### PR TITLE
[d2m] Remove implicit CB release semantics

### DIFF
--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1917,38 +1917,6 @@ public:
 
   static_assert(std::is_same_v<D2MCBOp, d2m::WaitOp> ||
                 std::is_same_v<D2MCBOp, d2m::ReserveOp>);
-
-  // Check if there's an explicit push/pop for this CB in the enclosing block,
-  // including nested regions.
-  static bool hasExplicitRelease(D2MCBOp op) {
-    Block *block = op->getBlock();
-    Value cb = op.getCb();
-
-    bool found = false;
-    block->walk([&](Operation *blockOp) {
-      if (found) {
-        return WalkResult::interrupt();
-      }
-      if constexpr (std::is_same_v<D2MCBOp, d2m::ReserveOp>) {
-        if (auto pushOp = dyn_cast<d2m::PushOp>(blockOp)) {
-          if (pushOp.getCb() == cb) {
-            found = true;
-            return WalkResult::interrupt();
-          }
-        }
-      } else if constexpr (std::is_same_v<D2MCBOp, d2m::WaitOp>) {
-        if (auto popOp = dyn_cast<d2m::PopOp>(blockOp)) {
-          if (popOp.getCb() == cb) {
-            found = true;
-            return WalkResult::interrupt();
-          }
-        }
-      }
-      return WalkResult::advance();
-    });
-    return found;
-  }
-
   LogicalResult
   matchAndRewrite(D2MCBOp op, typename D2MCBOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
@@ -1973,18 +1941,6 @@ public:
     auto numPages = i32(rewriter, op->getLoc(), cbNumPages);
 
     rewriter.create<TTKernelAcquireOp>(op.getLoc(), adaptor.getCb(), numPages);
-
-    // Only insert automatic release if there's no explicit push/pop
-    if (!hasExplicitRelease(op)) {
-      Block *block = op->getBlock();
-      auto release = rewriter.create<TTKernelReleaseOp>(
-          op.getLoc(), adaptor.getCb(), numPages);
-      if (block->mightHaveTerminator()) {
-        rewriter.moveOpBefore(release, block->getTerminator());
-      } else {
-        rewriter.moveOpAfter(release, &block->back());
-      }
-    }
 
     rewriter.replaceOp(op, adaptor.getCb());
 


### PR DESCRIPTION
### Problem description/What's changed
We no longer use implicit CB release semantics, since CB insertion is done in SplitUnifiedThread and LowerLoadStoreOpsToDMA passes.

### Checklist
- [x] New/Existing tests provide coverage for changes
