### PR TITLE
[d2m] Canonicalize nested linalg.generic inits to a fresh d2m.empty

### DIFF
--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -2064,7 +2064,8 @@ void GenericOp::getCanonicalizationPatterns(mlir::RewritePatternSet &patterns,
           }
 
           Operation *origDefiningOp = initOperand.get().getDefiningOp();
-          if (!origDefiningOp || mlir::isa<EmptyOp>(origDefiningOp)) {
+          if (!origDefiningOp ||
+              mlir::isa<EmptyOp, mlir::tensor::EmptyOp>(origDefiningOp)) {
             return false;
           }
 

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -2049,6 +2049,9 @@ void GenericOp::getCanonicalizationPatterns(mlir::RewritePatternSet &patterns,
         }
 
         // Only works on tensor types (pre-bufferization).
+        // Since generic op is DPS, we can check if the number of results is
+        // zero to determine if we're in a non-tensor-bufferized form, and skip
+        // this pattern in that case.
         if (op->getNumResults() == 0) {
           return mlir::failure();
         }

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -17,6 +17,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -2047,88 +2048,45 @@ void GenericOp::getCanonicalizationPatterns(mlir::RewritePatternSet &patterns,
           return mlir::failure();
         }
 
-        auto replaceWithOutputAlloc =
-            [op](PatternRewriter &rewriter, Region &region, Operation *regionOp,
-                 OpOperand &initOperand, int64_t dpsIOBoundary) -> bool {
+        // Only works on tensor types (pre-bufferization).
+        if (op->getNumResults() == 0) {
+          return mlir::failure();
+        }
+
+        auto replaceWithEmpty = [](PatternRewriter &rewriter, Region &region,
+                                   Operation *regionOp,
+                                   OpOperand &initOperand) -> bool {
+          if (!mlir::isa<RankedTensorType>(initOperand.get().getType())) {
+            return false;
+          }
+
           Operation *origDefiningOp = initOperand.get().getDefiningOp();
-          if (origDefiningOp &&
-              !mlir::isa<EmptyOp, mlir::tensor::EmptyOp>(origDefiningOp)) {
+          if (!origDefiningOp || mlir::isa<EmptyOp>(origDefiningOp)) {
             return false;
           }
 
-          // Find the output alloc by positional counting.
-          Value outputAlloc = GenericOp::getOperandAlloc(region, dpsIOBoundary);
-
-          if (!outputAlloc || outputAlloc.use_empty()) {
-            return false;
-          }
-
-          // Find a wait/reserve that dominates the DPS operation.
-          Operation *waitOrReserve = nullptr;
-
-          // Get the parent function to compute dominance.
-          Operation *parentOp = op->getParentOp();
-          while (parentOp && !mlir::isa<FunctionOpInterface>(parentOp)) {
-            parentOp = parentOp->getParentOp();
-          }
-
-          assert(parentOp && "d2m.generic must be nested within a function");
-
-          // Use DominanceInfo for cross-block dominance checking.
-          DominanceInfo domInfo(parentOp);
-          for (Operation *user : outputAlloc.getUsers()) {
-            if (!mlir::isa<d2m::WaitOp, d2m::ReserveOp>(user)) {
-              continue;
-            }
-            // Check if this wait/reserve dominates the regionOp.
-            if (domInfo.dominates(user, regionOp)) {
-              waitOrReserve = user;
-              break;
-            }
-          }
-
-          if (!waitOrReserve) {
-            return false;
-          }
-
-          rewriter.modifyOpInPlace(regionOp, [&]() {
-            initOperand.assign(waitOrReserve->getResult(0));
-          });
-
-          if (mlir::isa_and_nonnull<EmptyOp, mlir::tensor::EmptyOp>(
-                  origDefiningOp)) {
-            rewriter.replaceAllUsesWith(origDefiningOp->getResult(0),
-                                        initOperand.get());
-          }
+          rewriter.setInsertionPoint(regionOp);
+          auto empty = rewriter.create<EmptyOp>(regionOp->getLoc(),
+                                                initOperand.get().getType(),
+                                                nullptr, nullptr);
+          initOperand.assign(empty);
 
           return true;
         };
 
-        int64_t dpsIOBoundary = op.getNumDpsInputs();
         bool updated = false;
         for (Region &region : op->getRegions()) {
-          if (op.getRegionThreadType(region.getRegionNumber()) !=
-              ThreadType::Compute) {
-            continue;
-          }
-
           region.walk([&](Operation *regionOp) {
-            if (DestinationStyleOpInterface dps =
-                    mlir::dyn_cast<DestinationStyleOpInterface>(regionOp);
+            if (linalg::GenericOp dps =
+                    mlir::dyn_cast<linalg::GenericOp>(regionOp);
                 dps) {
               for (OpOperand &initOperand : dps.getDpsInitsMutable()) {
                 assert(op.getNumDpsInits() == dps.getNumDpsInits());
                 assert(op.getNumDpsInits() == 1);
 
-                updated |= replaceWithOutputAlloc(rewriter, region, regionOp,
-                                                  initOperand, dpsIOBoundary);
+                updated |=
+                    replaceWithEmpty(rewriter, region, regionOp, initOperand);
               }
-            } else if (TileMatmulBlockOp tmb =
-                           mlir::dyn_cast<TileMatmulBlockOp>(regionOp);
-                       tmb) {
-              updated |=
-                  replaceWithOutputAlloc(rewriter, region, regionOp,
-                                         tmb.getOutputMutable(), dpsIOBoundary);
             }
           });
         }

--- a/test/ttmlir/Dialect/D2M/generic/generic_canonicalize_nested_linalg_init.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_canonicalize_nested_linalg_init.mlir
@@ -1,0 +1,141 @@
+// RUN: ttmlir-opt --canonicalize %s --split-input-file | FileCheck %s
+//
+// Verifies the d2m.generic canonicalization that retargets nested linalg.generic
+// DPS init operands to a fresh d2m.empty when the init's defining op is anything
+// other than a d2m.empty. This catches cases where upstream linalg passes have
+// fused the d2m.generic's input into the linalg.generic's output (in-place),
+// which the backend does not support.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#l1 = #ttcore.memory_space<l1>
+
+// The linalg.generic outs is the d2m.reserve result; the canonicalization
+// should insert a fresh d2m.empty immediately before the linalg.generic and
+// rewire the outs.
+// CHECK-LABEL: func.func @nested_linalg_reserve_init_retargeted
+func.func @nested_linalg_reserve_init_retargeted(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %0 = d2m.empty() : tensor<64x128xf32>
+  // CHECK: d2m.generic
+  // CHECK: %[[RESERVE:.*]] = d2m.reserve
+  // CHECK: %[[EMPTY:.*]] = d2m.empty() : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK-NEXT: linalg.generic
+  // CHECK-SAME: outs(%[[EMPTY]] :
+  // CHECK: d2m.store %[[RESERVE]]
+  %1 = "d2m.generic"(%arg0, %arg1, %0) <{
+      block_factors = [1, 1],
+      grid = #ttcore.grid<1x1>,
+      indexing_maps = [#map, #map, #map],
+      iterator_types = [#parallel, #parallel],
+      threads = [#d2m.thread<compute>],
+      operandSegmentSizes = array<i32: 2, 1, 0>}> ({
+  ^bb0:
+    %cb0 = d2m.get_cb(0) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %cb1 = d2m.get_cb(1) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %cb2 = d2m.get_cb(2) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %a = d2m.wait %cb0 : <tensor<2x4x!ttcore.tile<32x32, f32>, #l1>> -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    %b = d2m.wait %cb1 : <tensor<2x4x!ttcore.tile<32x32, f32>, #l1>> -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    %out = d2m.reserve %cb2 : <tensor<2x4x!ttcore.tile<32x32, f32>, #l1>> -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    %result = linalg.generic {
+        indexing_maps = [#map, #map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%a, %b : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>, tensor<2x4x!ttcore.tile<32x32, f32>, #l1>)
+        outs(%out : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>) {
+    ^bb1(%aa: !ttcore.tile<32x32, f32>, %bb: !ttcore.tile<32x32, f32>, %cc: !ttcore.tile<32x32, f32>):
+      %s = "d2m.tile_add"(%aa, %bb) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+      linalg.yield %s : !ttcore.tile<32x32, f32>
+    } -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    d2m.store %out, %result : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    d2m.yield %0 : (tensor<64x128xf32>)
+  }) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %1 : tensor<64x128xf32>
+}
+
+// -----
+
+// The linalg.generic outs is the linalg.generic's own input (the d2m.wait
+// result), modelling the in-place pattern an upstream pass may produce. The
+// canonicalization should still insert a fresh d2m.empty for the outs.
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#l1 = #ttcore.memory_space<l1>
+
+// CHECK-LABEL: func.func @nested_linalg_inplace_input_retargeted
+func.func @nested_linalg_inplace_input_retargeted(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %0 = d2m.empty() : tensor<64x128xf32>
+  // CHECK: d2m.generic
+  // CHECK: %[[WAIT:.*]] = d2m.wait
+  // CHECK: %[[EMPTY:.*]] = d2m.empty() : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK-NEXT: linalg.generic
+  // CHECK-SAME: ins(%[[WAIT]] :
+  // CHECK-SAME: outs(%[[EMPTY]] :
+  %1 = "d2m.generic"(%arg0, %0) <{
+      block_factors = [1, 1],
+      grid = #ttcore.grid<1x1>,
+      indexing_maps = [#map, #map],
+      iterator_types = [#parallel, #parallel],
+      threads = [#d2m.thread<compute>],
+      operandSegmentSizes = array<i32: 1, 1, 0>}> ({
+  ^bb0:
+    %cb0 = d2m.get_cb(0) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %cb1 = d2m.get_cb(1) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %a = d2m.wait %cb0 : <tensor<2x4x!ttcore.tile<32x32, f32>, #l1>> -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    %out = d2m.reserve %cb1 : <tensor<2x4x!ttcore.tile<32x32, f32>, #l1>> -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    %result = linalg.generic {
+        indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%a : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>)
+        outs(%a : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>) {
+    ^bb1(%aa: !ttcore.tile<32x32, f32>, %cc: !ttcore.tile<32x32, f32>):
+      %s = "d2m.tile_abs"(%aa) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+      linalg.yield %s : !ttcore.tile<32x32, f32>
+    } -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    d2m.store %out, %result : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    d2m.yield %0 : (tensor<64x128xf32>)
+  }) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %1 : tensor<64x128xf32>
+}
+
+// -----
+
+// Negative: when the linalg.generic outs is already a d2m.empty, the
+// canonicalization must not insert a redundant one.
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#l1 = #ttcore.memory_space<l1>
+
+// CHECK-LABEL: func.func @nested_linalg_empty_init_unchanged
+func.func @nested_linalg_empty_init_unchanged(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %0 = d2m.empty() : tensor<64x128xf32>
+  // CHECK: d2m.generic
+  // CHECK: %[[EMPTY:.*]] = d2m.empty() : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK-NOT: d2m.empty() : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK: linalg.generic
+  // CHECK-SAME: outs(%[[EMPTY]] :
+  %1 = "d2m.generic"(%arg0, %0) <{
+      block_factors = [1, 1],
+      grid = #ttcore.grid<1x1>,
+      indexing_maps = [#map, #map],
+      iterator_types = [#parallel, #parallel],
+      threads = [#d2m.thread<compute>],
+      operandSegmentSizes = array<i32: 1, 1, 0>}> ({
+  ^bb0:
+    %cb0 = d2m.get_cb(0) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %cb1 = d2m.get_cb(1) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %a = d2m.wait %cb0 : <tensor<2x4x!ttcore.tile<32x32, f32>, #l1>> -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    %out = d2m.reserve %cb1 : <tensor<2x4x!ttcore.tile<32x32, f32>, #l1>> -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    %scratch = d2m.empty() : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    %result = linalg.generic {
+        indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%a : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>)
+        outs(%scratch : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>) {
+    ^bb1(%aa: !ttcore.tile<32x32, f32>, %cc: !ttcore.tile<32x32, f32>):
+      %s = "d2m.tile_abs"(%aa) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+      linalg.yield %s : !ttcore.tile<32x32, f32>
+    } -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    d2m.store %out, %result : tensor<2x4x!ttcore.tile<32x32, f32>, #l1>
+    d2m.yield %0 : (tensor<64x128xf32>)
+  }) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %1 : tensor<64x128xf32>
+}


### PR DESCRIPTION
Rework the GenericOp canonicalization that retargets DPS init operands inside compute regions. The previous version ran on bufferized IR: it located the output alloc by positional index and rerouted the init through a dominating d2m.wait/reserve. Replace that with a pre-bufferization tensor pattern that simply inserts a fresh d2m.empty for any init whose defining op is not already an EmptyOp.

Also narrows the match to linalg::GenericOp (dropping the generic DPS interface and TileMatmulBlockOp branches) and removes the ThreadType::Compute region filter, since the rewrite is now safe on tensors regardless of thread kind.