### PR TITLE
[D2M] Populate argMapping for scalar additional args

### DIFF
--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -185,10 +185,11 @@ public:
     for (unsigned i = 0; i < op.getAdditionalArgs().size(); ++i) {
       auto operandIndex = ioSize + i;
       auto operand = adaptor.getOperands()[operandIndex];
-      argMapping[operandIndex] = args.size();
       if (mlir::isa<ttmetal::GlobalSemaphoreType>(operand.getType())) {
+        argMapping[operandIndex] = args.size();
         args.push_back(operand);
       } else if (mlir::isa<ttmetal::LocalSemaphoreType>(operand.getType())) {
+        argMapping[operandIndex] = args.size();
         args.push_back(operand);
       } else if (auto memrefType =
                      mlir::dyn_cast_if_present<MemRefType>(operand.getType());
@@ -217,6 +218,7 @@ public:
         }
       } else if (mlir::isa<IntegerType, IndexType, FloatType>(
                      operand.getType())) {
+        argMapping[operandIndex] = args.size();
         args.push_back(operand);
       } else {
         op.emitOpError(

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -185,11 +185,10 @@ public:
     for (unsigned i = 0; i < op.getAdditionalArgs().size(); ++i) {
       auto operandIndex = ioSize + i;
       auto operand = adaptor.getOperands()[operandIndex];
+      argMapping[operandIndex] = args.size();
       if (mlir::isa<ttmetal::GlobalSemaphoreType>(operand.getType())) {
-        argMapping[operandIndex] = args.size();
         args.push_back(operand);
       } else if (mlir::isa<ttmetal::LocalSemaphoreType>(operand.getType())) {
-        argMapping[operandIndex] = args.size();
         args.push_back(operand);
       } else if (auto memrefType =
                      mlir::dyn_cast_if_present<MemRefType>(operand.getType());

--- a/test/ttmlir/Conversion/D2MToTTMetal/generic_scalar_additional_arg.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/generic_scalar_additional_arg.mlir
@@ -1,0 +1,37 @@
+// RUN: ttmlir-opt --ttcore-register-device --convert-d2m-to-ttkernel --convert-d2m-to-ttmetal -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// Regression test for D2MToTTMetal additional-arg mapping. Previously,
+// argMapping was only populated for semaphore-typed entries of
+// d2m.generic.additionalArgs; scalar (integer / index / float) entries were
+// pushed into `args` but skipped in the map, so evalKernelArgsFromSpec hit
+// argMapping.at() for the scalar arg_spec entry and crashed.
+
+#l1_ = #ttcore.memory_space<l1>
+module {
+  func.func @generic_with_scalar_additional_arg(
+      %arg0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+      %scalar: i32)
+      -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_> {
+    %alloc = memref.alloc() {alignment = 64 : i64, address = 0x1000} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>
+    %cb_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>
+    %cb_1 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>
+
+    // CHECK: "ttmetal.enqueue_program"
+    // CHECK-SAME: cb_ports = array<i64: 0, 1>
+    // CHECK-SAME: compute_config<@compute_kernel
+    // CHECK-SAME: ct_args = [<cb_port[0]>, <cb_port[1]>, <scalar[2]>]
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<compute, @compute_kernel>]}
+        ins(%arg0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)
+        outs(%alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)
+        additionalArgs(%cb_0, %cb_1, %scalar : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>, i32)
+    return %alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>
+  }
+
+  func.func private @compute_kernel() attributes {d2m.thread = #d2m.thread<compute>} {
+    %cb0 = d2m.get_cb(2) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>>
+    %cb1 = d2m.get_cb(3) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>>
+    %s = d2m.get_arg(4) : i32
+    return
+  }
+}


### PR DESCRIPTION
D2MGenericRewriter only set `argMapping[operandIndex] = args.size()` inside the GlobalSemaphore / LocalSemaphore branches when walking `d2m.generic`'s additionalArgs. Scalar (integer / index / float) entries were pushed onto `args` without updating the map, so a kernel arg_spec with `<arg_type = scalar, operand_index = N>` crashed `evalKernelArgsFromSpec` at `argMapping.at(N)`:

    Assertion failed: (Iter != this->end() &&
    "DenseMap::at failed due to a missing key"),
    function at, file DenseMap.h, line 215.

Hoist the assignment out of the type dispatch so scalars are covered. CB memrefs don't go into `args` (they go to `cbs` and are looked up via `cbOperandIndexToPort`), so the now-stale `argMapping` entry for them is harmless.

Add a regression lit test mixing CB memref + scalar additionalArgs.