### PR TITLE
Add canonicalization after WA and LayoutDecomp

### DIFF
--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -417,6 +417,10 @@ void createTTIRToTTNNCommonPipeline(
 
     createTTNNPipelineLayoutDecompositionPass(devicePm, options);
 
+    // Workarounds pass and Layout decompositions can leave behind redundant
+    // typecast->typecast chains. Canonicalize them away to save memory.
+    devicePm.addPass(mlir::createCanonicalizerPass());
+
     // Fold ttcore.optimization_barrier ops before deallocation.
     devicePm.addPass(ttcore::createTTCoreOptimizationBarrierFold());
 


### PR DESCRIPTION
### Ticket
Required to land https://github.com/tenstorrent/tt-xla/pull/3795

### Problem description
Typecast->typecast chains can appear because of workarounds and cause OOM issues

### What's changed
Added the canonicalizer pass in another place in the TTNN pipeline

### Checklist
- [ ] New/Existing tests provide coverage for changes

This is a risky change, I'm running xla nightly https://github.com/tenstorrent/tt-xla/actions/runs/25736679580
