### PR TITLE
PagedSdpaDecode: workaround pass attribute for large head_dim

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -110,6 +110,10 @@ struct Conv2dConfig;
 struct Conv2dSliceConfig;
 } // namespace conv::conv2d
 
+namespace transformer {
+struct SDPAProgramConfig;
+} // namespace transformer
+
 } // namespace operations
 } // namespace ttnn
 
@@ -255,6 +259,12 @@ template <>
 struct TypeName<::ttnn::prim::LayerNormShardedMultiCoreProgramConfig> {
   inline static const std::string value =
       "::ttnn::prim::LayerNormShardedMultiCoreProgramConfig";
+};
+
+template <>
+struct TypeName<::ttnn::operations::transformer::SDPAProgramConfig> {
+  inline static const std::string value =
+      "::ttnn::operations::transformer::SDPAProgramConfig";
 };
 
 // Marker type for MatmulMultiCoreReuseMultiCast1DProgramConfig (used by
@@ -1391,6 +1401,48 @@ struct EmitCTypeConverter<::ttnn::CoreRangeSet> {
   }
 };
 
+// Specialization for SDPAProgramConfig
+template <>
+struct EmitCTypeConverter<::ttnn::operations::transformer::SDPAProgramConfig> {
+  static std::optional<std::string> convert(mlir::Attribute attr) {
+    auto configAttr =
+        mlir::dyn_cast_if_present<ttnn::SDPAProgramConfigAttr>(attr);
+    if (!configAttr) {
+      return {};
+    }
+    return convert(configAttr);
+  }
+
+  static std::string convert(ttnn::SDPAProgramConfigAttr attr) {
+    std::string buf;
+    llvm::raw_string_ostream rso(buf);
+    rso << TypeNameV<::ttnn::operations::transformer::SDPAProgramConfig> << "{";
+
+    rso << ".compute_with_storage_grid_size = "
+        << EmitCTypeConverter<::ttnn::CoreCoord>::convert(
+               attr.getComputeWithStorageGridSize());
+    if (auto subCoreGrids = attr.getSubCoreGrids()) {
+      rso << ", .sub_core_grids = "
+          << EmitCTypeConverter<::ttnn::CoreRangeSet>::convert(subCoreGrids);
+    }
+    rso << ", .q_chunk_size = "
+        << EmitCTypeConverter<uint32_t>::convert(attr.getQChunkSize());
+    rso << ", .k_chunk_size = "
+        << EmitCTypeConverter<uint32_t>::convert(attr.getKChunkSize());
+    if (auto expApproxMode = attr.getExpApproxMode()) {
+      rso << ", .exp_approx_mode = "
+          << (expApproxMode.getValue() ? "true" : "false");
+    }
+    if (auto maxCores = attr.getMaxCoresPerHeadBatch()) {
+      rso << ", .max_cores_per_head_batch = "
+          << EmitCTypeConverter<uint32_t>::convert(*maxCores);
+    }
+
+    rso << "}";
+    return buf;
+  }
+};
+
 template <>
 struct EmitCTypeConverter<::ttnn::ShardSpec> {
   static std::optional<std::string> convert(mlir::Attribute attr) {
@@ -1901,6 +1953,11 @@ struct TTNNTarget<tt::ttnn::DeviceComputeKernelConfigAttr> {
 template <>
 struct TTNNTarget<tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr> {
   using type = ::ttnn::prim::LayerNormShardedMultiCoreProgramConfig;
+};
+
+template <>
+struct TTNNTarget<tt::ttnn::SDPAProgramConfigAttr> {
+  using type = ::ttnn::operations::transformer::SDPAProgramConfig;
 };
 
 template <typename T>

--- a/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
@@ -93,6 +93,10 @@ namespace prim {
 struct LayerNormShardedMultiCoreProgramConfig;
 } // namespace prim
 
+namespace operations::transformer {
+struct SDPAProgramConfig;
+} // namespace operations::transformer
+
 namespace experimental::prim {
 struct Conv3dConfig;
 } // namespace experimental::prim
@@ -187,6 +191,11 @@ template <>
 struct TypeName<::ttnn::prim::LayerNormShardedMultiCoreProgramConfig> {
   inline static const std::string value =
       "ttnn.LayerNormShardedMultiCoreProgramConfig";
+};
+
+template <>
+struct TypeName<::ttnn::operations::transformer::SDPAProgramConfig> {
+  inline static const std::string value = "ttnn.SDPAProgramConfig";
 };
 
 template <typename T>
@@ -1958,6 +1967,36 @@ struct EmitPyTypeConverter<
   }
 };
 
+// Specialization for SDPAProgramConfig
+template <>
+struct EmitPyTypeConverter<::ttnn::operations::transformer::SDPAProgramConfig> {
+  static std::optional<std::string> convert(ttnn::SDPAProgramConfigAttr attr) {
+    if (!attr) {
+      return std::nullopt;
+    }
+
+    std::string buf;
+    llvm::raw_string_ostream rso(buf);
+    rso << TypeNameV<::ttnn::operations::transformer::SDPAProgramConfig> << "(";
+
+    auto gridSize = attr.getComputeWithStorageGridSize();
+    rso << "compute_with_storage_grid_size=ttnn.CoreCoord(" << gridSize.getX()
+        << ", " << gridSize.getY() << ")";
+    rso << ", q_chunk_size=" << attr.getQChunkSize();
+    rso << ", k_chunk_size=" << attr.getKChunkSize();
+    if (auto expApproxMode = attr.getExpApproxMode()) {
+      rso << ", exp_approx_mode="
+          << (expApproxMode.getValue() ? "True" : "False");
+    }
+    if (auto maxCores = attr.getMaxCoresPerHeadBatch()) {
+      rso << ", max_cores_per_head_batch=" << *maxCores;
+    }
+
+    rso << ")";
+    return buf;
+  }
+};
+
 // This template struct retrieves the most relevant C++ type with a one-to-one
 // Python type correspondence for a given template type.
 template <typename T>
@@ -2061,6 +2100,11 @@ struct TTNNTarget<tt::ttnn::DeviceComputeKernelConfigAttr> {
 template <>
 struct TTNNTarget<tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr> {
   using type = ::ttnn::prim::LayerNormShardedMultiCoreProgramConfig;
+};
+
+template <>
+struct TTNNTarget<tt::ttnn::SDPAProgramConfigAttr> {
+  using type = ::ttnn::operations::transformer::SDPAProgramConfig;
 };
 
 // Marker type for matmul program config union (AnyAttrOf<[...]>)

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3640,7 +3640,8 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
                        Optional<AnyRankedTensor>:$cur_pos_tensor,
                        Optional<AnyRankedTensor>:$attention_sink,
                        OptionalAttr<F32Attr>:$scale,
-                       OptionalAttr<UI32Attr>:$sliding_window_size);
+                       OptionalAttr<UI32Attr>:$sliding_window_size,
+                       OptionalAttr<TTNN_SDPAProgramConfigAttr>:$program_config);
 
   let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_PAGEDSCALEDDOTPRODUCTATTENTIONDECODEPROGRAMCONFIGREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_PAGEDSCALEDDOTPRODUCTATTENTIONDECODEPROGRAMCONFIGREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// Sets an explicit SDPAProgramConfig on PagedScaledDotProductAttentionDecodeOp
+// for head_dim >= 256, where the default TTNN schedule overflows per-core L1.
+// Scoped to opt-level=0; at opt-level>=1 OpValidationAndFallback owns this
+// decision.
+//
+// Metal issue: https://github.com/tenstorrent/tt-metal/issues/44311
+class PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern
+    : public OpRewritePattern<ttnn::PagedScaledDotProductAttentionDecodeOp> {
+public:
+  PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern(
+      MLIRContext *context, int64_t optimizationLevel)
+      : OpRewritePattern<ttnn::PagedScaledDotProductAttentionDecodeOp>(context),
+        optimizationLevel(optimizationLevel) {}
+
+  LogicalResult
+  matchAndRewrite(ttnn::PagedScaledDotProductAttentionDecodeOp srcOp,
+                  PatternRewriter &rewriter) const override;
+
+private:
+  int64_t optimizationLevel;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_PAGEDSCALEDDOTPRODUCTATTENTIONDECODEPROGRAMCONFIGREWRITEPATTERN_H

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -774,21 +774,26 @@ struct OpModel<PagedScaledDotProductAttentionDecodeOp> {
       std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
       std::optional<TTNNLayoutAttr> attentionSinkLayout,
       std::optional<llvm::APFloat> scale,
-      std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout);
+      std::optional<uint32_t> slidingWindowSize,
+      std::optional<SDPAProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t> getOpRuntime(
-      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
-      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-      std::optional<TTNNLayoutAttr> attentionMaskLayout,
-      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
-      std::optional<TTNNLayoutAttr> curPosTensorLayout,
-      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-      std::optional<TTNNLayoutAttr> attentionSinkLayout,
-      std::optional<llvm::APFloat> scale,
-      std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+               llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+               llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+               llvm::ArrayRef<int64_t> pageTableShape,
+               TTNNLayoutAttr pageTableLayout, bool isCausal,
+               std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+               std::optional<TTNNLayoutAttr> attentionMaskLayout,
+               std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+               std::optional<TTNNLayoutAttr> curPosTensorLayout,
+               std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+               std::optional<TTNNLayoutAttr> attentionSinkLayout,
+               std::optional<llvm::APFloat> scale,
+               std::optional<uint32_t> slidingWindowSize,
+               std::optional<SDPAProgramConfigAttr> programConfig,
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTNN/operations/transformer.fbs
+++ b/include/ttmlir/Target/TTNN/operations/transformer.fbs
@@ -118,6 +118,7 @@ table PagedScaledDotProductAttentionDecodeOp {
   sliding_window_size: uint32 = null;
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
+  program_config: tt.target.ttnn.SDPAConfig;
 }
 
 table PagedFlashMultiLatentAttentionDecodeOp {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3298,7 +3298,8 @@ public:
         adaptor.getPageTable(), adaptor.getIsCausal(),
         adaptor.getAttentionMask(), adaptor.getCurPosTensor(),
         adaptor.getAttentionSink(), adaptor.getScaleAttr(),
-        adaptor.getSlidingWindowSizeAttr());
+        adaptor.getSlidingWindowSizeAttr(),
+        /*program_config=*/nullptr);
     return success();
   }
 };

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3417,7 +3417,7 @@ public:
         emitter.emit(srcOp.getScale()),
         emitter.emit(srcOp.getSlidingWindowSize()),
         emitter.emit(srcOp.getMemoryConfig()),
-        emitter.emit(/*program_config=*/std::nullopt),
+        emitter.emit(srcOp.getProgramConfig()),
         emitter.emit(/*compute_kernel_config=*/std::nullopt),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -4310,6 +4310,59 @@ public:
 };
 } // namespace
 
+// PagedScaledDotProductAttentionDecodeOp conversion pattern
+//
+namespace {
+class PagedScaledDotProductAttentionDecodeOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.paged_scaled_dot_product_attention_decode";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn.transformer.paged_scaled_dot_product_attention_decode";
+  }
+
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp>::
+      TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<
+        mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getQuery()),
+        emitter.emit(srcOp.getKey()),
+        emitter.emit(srcOp.getValue()),
+        emitter.emit(srcOp.getPageTable(), "page_table_tensor"),
+        emitter.emit(srcOp.getIsCausal(), "is_causal"),
+        emitter.emit(srcOp.getAttentionMask(), "attn_mask"),
+        emitter.emit(srcOp.getCurPosTensor(), "cur_pos_tensor"),
+        emitter.emit(srcOp.getAttentionSink(), "attention_sink"),
+        emitter.emit(srcOp.getScale(), "scale"),
+        emitter.emit(srcOp.getSlidingWindowSize(), "sliding_window_size"),
+        emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
+        emitter.emit(srcOp.getProgramConfig(), "program_config"),
+    };
+    // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // PagedFlashMultiLatentAttentionDecodeOp conversion pattern
 //
 namespace {
@@ -5198,6 +5251,8 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<ScaledDotProductAttentionOpConversionPattern>(typeConverter,
                                                              ctx);
   patterns.add<ScaledDotProductAttentionDecodeOpConversionPattern>(
+      typeConverter, ctx);
+  patterns.add<PagedScaledDotProductAttentionDecodeOpConversionPattern>(
       typeConverter, ctx);
   patterns.add<PagedFlashMultiLatentAttentionDecodeOpConversionPattern>(
       typeConverter, ctx);

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2097,6 +2097,7 @@ struct PagedScaledDotProductAttentionDecodeArgs {
   std::optional<TTNNLayoutAttr> attentionSinkLayout = std::nullopt;
   std::optional<llvm::APFloat> scale = std::nullopt;
   std::optional<uint32_t> slidingWindowSize = std::nullopt;
+  std::optional<SDPAProgramConfigAttr> programConfig = std::nullopt;
 };
 
 static PagedScaledDotProductAttentionDecodeArgs
@@ -2118,6 +2119,7 @@ unpackPagedScaledDotProductAttentionDecodeArgs(
   ret.isCausal = op.getIsCausal();
   ret.scale = op.getScale();
   ret.slidingWindowSize = op.getSlidingWindowSize();
+  ret.programConfig = op.getProgramConfig();
 
   TypedValue<RankedTensorType> attentionMask = op.getAttentionMask();
   TypedValue<RankedTensorType> curPosTensor = op.getCurPosTensor();
@@ -2179,7 +2181,7 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
       pagedSdpaArgs.curPosTensorShape, pagedSdpaArgs.curPosTensorLayout,
       pagedSdpaArgs.attentionSinkShape, pagedSdpaArgs.attentionSinkLayout,
       pagedSdpaArgs.scale, pagedSdpaArgs.slidingWindowSize,
-      opConfig.outputLayout);
+      pagedSdpaArgs.programConfig, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
@@ -2205,7 +2207,7 @@ llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
       pagedSdpaArgs.curPosTensorShape, pagedSdpaArgs.curPosTensorLayout,
       pagedSdpaArgs.attentionSinkShape, pagedSdpaArgs.attentionSinkLayout,
       pagedSdpaArgs.scale, pagedSdpaArgs.slidingWindowSize,
-      opConfig.outputLayout);
+      pagedSdpaArgs.programConfig, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -49,6 +49,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/AllToAllDispatchMetadataDrainCoreRewritePattern.cpp
         Workarounds/Decomposition/ArgMaxOpDimRewritePattern.cpp
         Workarounds/Decomposition/ConcatOpRewritePattern.cpp
+        Workarounds/Decomposition/PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern.cpp
         Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
         Workarounds/Decomposition/PointToPointOpRewritePattern.cpp
         Workarounds/Decomposition/SplitQueryKeyValueAndSplitHeadsOpRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern.h"
+
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+
+#include <algorithm>
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// SDPA decode allocates per-core CBs whose footprint scales with head_dim
+// (and num_cores_per_head for the tree-reduction partial-accumulator). For
+// head_dim >= 256 the default schedule overflows L1. Pin k_chunk_size=32
+// and cap max_cores_per_head_batch at 32.
+LogicalResult PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern::
+    matchAndRewrite(ttnn::PagedScaledDotProductAttentionDecodeOp srcOp,
+                    PatternRewriter &rewriter) const {
+  if (optimizationLevel != 0) {
+    return failure();
+  }
+
+  if (srcOp.getProgramConfigAttr()) {
+    return failure();
+  }
+
+  RankedTensorType queryType =
+      mlir::cast<RankedTensorType>(srcOp.getQuery().getType());
+  RankedTensorType pageTableType =
+      mlir::cast<RankedTensorType>(srcOp.getPageTable().getType());
+
+  // queryShape: [1, B, Hq, head_dim] -- pick head_dim from last dim.
+  const int64_t headDim = queryType.getShape().back();
+  constexpr int64_t kOverrideHeadDimThreshold = 256;
+  if (headDim < kOverrideHeadDimThreshold) {
+    return failure();
+  }
+
+  // pageTableShape: [B, num_blocks] -- pick block count from last dim.
+  const int64_t pageTableBlocks = pageTableType.getShape().back();
+
+  MLIRContext *context = srcOp.getContext();
+  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(srcOp.getOperation());
+  auto workerGridShape = deviceAttr.getWorkerGrid().getShape();
+  // workerGrid is [Y, X]; CoreCoord is (x, y).
+  const auto gridX = static_cast<uint32_t>(workerGridShape[1]);
+  const auto gridY = static_cast<uint32_t>(workerGridShape[0]);
+  const uint32_t totalCores = gridX * gridY;
+
+  constexpr uint32_t kMaxSdpaDecodeCoresPerHeadBatch = 64u;
+  constexpr uint32_t kOverrideCoresCap = 32u;
+  constexpr uint32_t kPageTokens = 32u;
+
+  const uint32_t coresCap =
+      std::min(totalCores, kMaxSdpaDecodeCoresPerHeadBatch);
+  const uint32_t overrideCap = std::min(coresCap, kOverrideCoresCap);
+  const uint32_t maxCoresPerHeadBatch =
+      std::min(static_cast<uint32_t>(pageTableBlocks), overrideCap);
+
+  auto computeGrid = CoreCoordAttr::get(context, /*x=*/gridX, /*y=*/gridY);
+  auto programConfig = SDPAProgramConfigAttr::get(
+      context, computeGrid, /*sub_core_grids=*/nullptr,
+      /*q_chunk_size=*/0u, /*k_chunk_size=*/kPageTokens,
+      /*exp_approx_mode=*/nullptr,
+      /*max_cores_per_head_batch=*/
+      std::optional<uint32_t>(maxCoresPerHeadBatch));
+
+  rewriter.replaceOpWithNewOp<ttnn::PagedScaledDotProductAttentionDecodeOp>(
+      srcOp, srcOp.getResult().getType(), srcOp.getQuery(), srcOp.getKey(),
+      srcOp.getValue(), srcOp.getPageTable(), srcOp.getIsCausalAttr(),
+      srcOp.getAttentionMask(), srcOp.getCurPosTensor(),
+      srcOp.getAttentionSink(), srcOp.getScaleAttr(),
+      srcOp.getSlidingWindowSizeAttr(), programConfig);
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -21,6 +21,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PadHighDimRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PointToPointOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/RMSNormConfigRewritePattern.h"
@@ -687,6 +688,11 @@ public:
             .add<workarounds::decomposition::PagedUpdateCacheOpRewritePattern>(
                 &getContext());
       }
+
+      patterns.add<
+          workarounds::decomposition::
+              PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern>(
+          &getContext(), optimizationLevel);
 
       runRewritePatterns(std::move(patterns),
                          GreedyRewriteConfig::kNoLimit /*maxIterations*/);

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2639,7 +2639,9 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
     std::optional<llvm::APFloat> scale,
-    std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout) {
+    std::optional<uint32_t> slidingWindowSize,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2669,6 +2671,8 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
 
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
 
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(
@@ -2676,7 +2680,7 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
         querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
         attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
         slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
+        sdpaProgramConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 
@@ -2701,7 +2705,9 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
     std::optional<llvm::APFloat> scale,
-    std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout) {
+    std::optional<uint32_t> slidingWindowSize,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2733,13 +2739,16 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
 
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
+
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
     return QUERY_OP_RUNTIME(
         ::ttnn::transformer::paged_scaled_dot_product_attention_decode, device,
         querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
         attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
         slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
+        sdpaProgramConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3184,9 +3184,13 @@ createOp(FlatbufferObjectCache &cache,
 
                                   /*local_shape*/ std::nullopt);
 
+  std::optional<::flatbuffers::Offset<::tt::target::ttnn::SDPAConfig>>
+      programConfig = toFlatbuffer(cache, op.getProgramConfig());
+
   return ::tt::target::ttnn::CreatePagedScaledDotProductAttentionDecodeOp(
       *cache.fbb, query, key, value, pageTable, isCausal, attentionMask,
-      curPosTensor, attentionSink, scale, slidingWindowSize, out, memoryConfig);
+      curPosTensor, attentionSink, scale, slidingWindowSize, out, memoryConfig,
+      programConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<

--- a/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
@@ -4,6 +4,7 @@
 
 #include "operations/transformer/paged_scaled_dot_product_attention_decode.h"
 
+#include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::transformer {
@@ -46,18 +47,24 @@ static void runPagedScaledDotProductAttentionDecodeOp(
 
   std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
       programConfig = std::nullopt;
-  if (!isCausal) {
+  if (op->program_config()) {
+    programConfig = utils::createSDPAProgramConfig(op->program_config());
+  } else if (!isCausal) {
     programConfig.emplace();
     programConfig->k_chunk_size = 32; // Required for non-causal
     programConfig->compute_with_storage_grid_size = computeGrid;
   } else if (query.device()->arch() == ::tt::ARCH::BLACKHOLE) {
-    // Preserve the existing causal decode scheduling while disabling the
-    // approximate exponential path on Blackhole.
     programConfig.emplace();
     programConfig->q_chunk_size = 0;
     programConfig->k_chunk_size = 0;
     programConfig->compute_with_storage_grid_size = computeGrid;
     programConfig->max_cores_per_head_batch = computeGrid.x * computeGrid.y;
+  }
+
+  // Blackhole's SDPA decode default approx-exp path fails SFPI compile
+  // (tt-metal #40301).
+  if (programConfig.has_value() &&
+      query.device()->arch() == ::tt::ARCH::BLACKHOLE) {
     programConfig->exp_approx_mode = false;
   }
 

--- a/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
+++ b/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
@@ -1111,3 +1111,190 @@ def test_slice_l1_cb_workaround_disabled(
         device=device,
         pipeline_options=["enable-decomposition-workaround-pass=false"],
     )
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        # Gemma-4 31B global attention shape on BHQB 4-chip TP=4, per-chip:
+        # num_heads=32/4=8, num_kv_heads=4/4=1, head_dim=512, max_model_len=1024,
+        # block_size=32 -> 32 page-table blocks. Triggers per-core L1 overflow
+        # on the default schedule.
+        # Q: [1, batch, num_heads, head_dim]
+        # K/V: [num_blocks, num_kv_heads, page_tokens, head_dim]
+        # page_table: [batch, num_blocks_per_user]
+        # output: same shape as Q
+        # cur_pos_tensor: [batch]
+        pytest.param(
+            [
+                (1, 1, 8, 512),
+                (32, 1, 32, 512),
+                (32, 1, 32, 512),
+                (1, 32),
+                (1, 1, 8, 512),
+                (1,),
+            ],
+            marks=pytest.mark.xfail(
+                reason="PagedSdpaDecode default schedule overflows per-core L1 "
+                "when head_dim >= 256. Metal issue: "
+                "https://github.com/tenstorrent/tt-metal/issues/44311"
+            ),
+        ),
+    ],
+    ids=shapes_list_str,
+)
+@pytest.mark.parametrize(
+    "dtypes",
+    [
+        [
+            torch.bfloat16,
+            torch.bfloat16,
+            torch.bfloat16,
+            torch.int32,
+            torch.bfloat16,
+            torch.int32,
+        ]
+    ],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_paged_sdpa_decode_l1_overflow_no_workaround(
+    shapes: List[Shape], dtypes: List[torch.dtype], target: str, request, device
+):
+    """
+    Test that PagedSdpaDecode with large head_dim (Gemma-4 31B global
+    attention) hits per-core L1 overflow under the default schedule with
+    the workaround disabled.  When tt-metal fixes the default schedule's
+    L1 footprint for head_dim >= 256, this xfail flips to xpass and the
+    PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern can be
+    removed.
+    """
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def paged_sdpa_decode_l1_overflow(
+            query: Operand,
+            key: Operand,
+            value: Operand,
+            page_table: Operand,
+            output: Operand,
+            cur_pos: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            head_dim = shapes[0][-1]
+            scale = 1.0 / math.sqrt(head_dim)
+            num_blocks_per_user = shapes[3][-1]
+            batch = shapes[3][0]
+            valid_page_table = (
+                torch.arange(num_blocks_per_user, dtype=torch.int32)
+                .unsqueeze(0)
+                .expand(batch, -1)
+                .contiguous()
+            )
+            valid_cur_pos = torch.zeros(batch, dtype=torch.int32)
+            builder.set_goldens(
+                {page_table: valid_page_table, cur_pos: valid_cur_pos}, {}
+            )
+            return builder.paged_scaled_dot_product_attention_decode(
+                query,
+                key,
+                value,
+                page_table,
+                output,
+                is_causal=True,
+                cur_pos_tensor=cur_pos,
+                scale=scale,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        pipeline_options=["disable-workarounds=true"],
+    )
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        # Same Gemma-4 31B global attention shape as the no-workaround case.
+        [
+            (1, 1, 8, 512),
+            (32, 1, 32, 512),
+            (32, 1, 32, 512),
+            (1, 32),
+            (1, 1, 8, 512),
+            (1,),
+        ],
+    ],
+    ids=shapes_list_str,
+)
+@pytest.mark.parametrize(
+    "dtypes",
+    [
+        [
+            torch.bfloat16,
+            torch.bfloat16,
+            torch.bfloat16,
+            torch.int32,
+            torch.bfloat16,
+            torch.int32,
+        ]
+    ],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_paged_sdpa_decode_l1_overflow_with_workaround(
+    shapes: List[Shape], dtypes: List[torch.dtype], target: str, request, device
+):
+    """
+    Positive coverage for the workaround: with the TTNN workarounds pass
+    enabled (default), the same shape that overflows L1 under the default
+    schedule must compile and run.
+    """
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def paged_sdpa_decode_with_workaround(
+            query: Operand,
+            key: Operand,
+            value: Operand,
+            page_table: Operand,
+            output: Operand,
+            cur_pos: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            head_dim = shapes[0][-1]
+            scale = 1.0 / math.sqrt(head_dim)
+            num_blocks_per_user = shapes[3][-1]
+            batch = shapes[3][0]
+            valid_page_table = (
+                torch.arange(num_blocks_per_user, dtype=torch.int32)
+                .unsqueeze(0)
+                .expand(batch, -1)
+                .contiguous()
+            )
+            valid_cur_pos = torch.zeros(batch, dtype=torch.int32)
+            builder.set_goldens(
+                {page_table: valid_page_table, cur_pos: valid_cur_pos}, {}
+            )
+            return builder.paged_scaled_dot_product_attention_decode(
+                query,
+                key,
+                value,
+                page_table,
+                output,
+                is_causal=True,
+                cur_pos_tensor=cur_pos,
+                scale=scale,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/paged_sdpa_decode_program_config_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/paged_sdpa_decode_program_config_workaround.mlir
@@ -1,0 +1,44 @@
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttnn-layout --ttnn-workaround -o %t %s
+// RUN: FileCheck %s --input-file=%t
+// At opt-level>=1 the workaround bails out; OpValidationAndFallback owns the
+// program_config decision in that path.
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttnn-layout --ttnn-workaround="ttnn-optimization-level=1" -o %t.opt1 %s
+// RUN: FileCheck %s --check-prefix=OPT1 --input-file=%t.opt1
+
+func.func @test_paged_sdpa_large_head_dim(
+    %arg0: tensor<1x1x4x512xbf16>,
+    %arg1: tensor<128x4x32x512xbf16>,
+    %arg2: tensor<128x4x32x512xbf16>,
+    %arg3: tensor<1x64xi32>,
+    %arg4: tensor<1xi32>) -> tensor<1x1x4x512xbf16> {
+  // CHECK-LABEL: func.func @test_paged_sdpa_large_head_dim
+  // CHECK: "ttnn.paged_scaled_dot_product_attention_decode"
+  // CHECK-SAME: program_config = #ttnn.sdpa_program_config
+  // CHECK-SAME: k_chunk_size = 32
+  // OPT1-LABEL: func.func @test_paged_sdpa_large_head_dim
+  // OPT1: "ttnn.paged_scaled_dot_product_attention_decode"
+  // OPT1-NOT: program_config
+  %result = "ttnn.paged_scaled_dot_product_attention_decode"(%arg0, %arg1, %arg2, %arg3, %arg4)
+      <{is_causal = true, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 1, 0>}>
+      : (tensor<1x1x4x512xbf16>, tensor<128x4x32x512xbf16>, tensor<128x4x32x512xbf16>,
+         tensor<1x64xi32>, tensor<1xi32>) -> tensor<1x1x4x512xbf16>
+  return %result : tensor<1x1x4x512xbf16>
+}
+
+// -----
+
+func.func @test_paged_sdpa_small_head_dim(
+    %arg0: tensor<1x1x12x128xbf16>,
+    %arg1: tensor<128x12x32x128xbf16>,
+    %arg2: tensor<128x12x32x128xbf16>,
+    %arg3: tensor<1x4xi32>,
+    %arg4: tensor<1xi32>) -> tensor<1x1x12x128xbf16> {
+  // CHECK-LABEL: func.func @test_paged_sdpa_small_head_dim
+  // CHECK: "ttnn.paged_scaled_dot_product_attention_decode"
+  // CHECK-NOT: program_config
+  %result = "ttnn.paged_scaled_dot_product_attention_decode"(%arg0, %arg1, %arg2, %arg3, %arg4)
+      <{is_causal = true, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 1, 0>}>
+      : (tensor<1x1x12x128xbf16>, tensor<128x12x32x128xbf16>, tensor<128x12x32x128xbf16>,
+         tensor<1x4xi32>, tensor<1xi32>) -> tensor<1x1x12x128xbf16>
+  return %result : tensor<1x1x12x128xbf16>
+}

--- a/test/ttmlir/EmitC/TTNN/transformer/paged_sdpa_decode_program_config_workaround.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/paged_sdpa_decode_program_config_workaround.mlir
@@ -1,0 +1,20 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround --convert-ttnn-to-emitc -o %t.mlir %s
+// RUN: ttmlir-translate --mlir-to-cpp %t.mlir | FileCheck %s
+
+func.func @test_paged_sdpa_emit_program_config(
+    %arg0: tensor<1x1x4x512xbf16>,
+    %arg1: tensor<128x4x32x512xbf16>,
+    %arg2: tensor<128x4x32x512xbf16>,
+    %arg3: tensor<1x64xi32>,
+    %arg4: tensor<1xi32>) -> tensor<1x1x4x512xbf16> {
+  // CHECK: ::ttnn::operations::transformer::SDPAProgramConfig{
+  // CHECK-SAME: .compute_with_storage_grid_size
+  // CHECK-SAME: .q_chunk_size
+  // CHECK-SAME: .k_chunk_size = 32
+  // CHECK-SAME: .max_cores_per_head_batch = 32
+  %result = "ttnn.paged_scaled_dot_product_attention_decode"(%arg0, %arg1, %arg2, %arg3, %arg4)
+      <{is_causal = true, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 1, 0>}>
+      : (tensor<1x1x4x512xbf16>, tensor<128x4x32x512xbf16>, tensor<128x4x32x512xbf16>,
+         tensor<1x64xi32>, tensor<1xi32>) -> tensor<1x1x4x512xbf16>
+  return %result : tensor<1x1x4x512xbf16>
+}

--- a/test/ttmlir/EmitPy/transformer/paged_sdpa_decode_program_config_workaround.mlir
+++ b/test/ttmlir/EmitPy/transformer/paged_sdpa_decode_program_config_workaround.mlir
@@ -1,0 +1,20 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround --convert-ttnn-to-emitpy -o %t.mlir %s
+// RUN: ttmlir-translate --mlir-to-python %t.mlir | FileCheck %s
+
+func.func @test_paged_sdpa_emit_program_config(
+    %arg0: tensor<1x1x4x512xbf16>,
+    %arg1: tensor<128x4x32x512xbf16>,
+    %arg2: tensor<128x4x32x512xbf16>,
+    %arg3: tensor<1x64xi32>,
+    %arg4: tensor<1xi32>) -> tensor<1x1x4x512xbf16> {
+  // CHECK: ttnn.SDPAProgramConfig(
+  // CHECK-SAME: compute_with_storage_grid_size=ttnn.CoreCoord(
+  // CHECK-SAME: q_chunk_size=
+  // CHECK-SAME: k_chunk_size=32
+  // CHECK-SAME: max_cores_per_head_batch=32
+  %result = "ttnn.paged_scaled_dot_product_attention_decode"(%arg0, %arg1, %arg2, %arg3, %arg4)
+      <{is_causal = true, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 1, 0>}>
+      : (tensor<1x1x4x512xbf16>, tensor<128x4x32x512xbf16>, tensor<128x4x32x512xbf16>,
+         tensor<1x64xi32>, tensor<1xi32>) -> tensor<1x1x4x512xbf16>
+  return %result : tensor<1x1x4x512xbf16>
+}

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -6535,6 +6535,7 @@ protected:
     std::optional<llvm::APFloat> scale = scaleAPFloat;
 
     std::optional<uint32_t> slidingWindowSize = std::nullopt;
+    std::optional<SDPAProgramConfigAttr> programConfig = std::nullopt;
 
     auto constraintsExp =
         OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
@@ -6542,7 +6543,7 @@ protected:
             valueShape, valueLayout, pageTableShape, pageTableLayout, isCausal,
             attentionMaskShape, attentionMaskLayout, curPosTensorShape,
             curPosTensorLayout, attentionSinkShape, attentionSinkLayout, scale,
-            slidingWindowSize, outputLayout);
+            slidingWindowSize, programConfig, outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -2162,7 +2162,8 @@ TEST_F(OpModelBase, DISABLED_PagedScaledDotProductAttentionDecodeOpInterface) {
           /*cur_pos_tensor=*/curPos,
           /*attention_sink=*/nullptr,
           /*scale=*/builder.getF32FloatAttr(0.125f),
-          /*sliding_window_size=*/nullptr);
+          /*sliding_window_size=*/nullptr,
+          /*program_config=*/nullptr);
 
   OpModel backend = dyn_cast<OpModel>(sdpAttentionDecode.getOperation());
   auto constraintsExp = backend.getOpConstraints(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4596#issuecomment-4426475057)

### Problem description
L1 OOM issue when running Gemma4 31b model which has head_dim >=256

### What's changed
Adds an optional program_config attribute on
ttnn.paged_scaled_dot_product_attention_decode and a TTNN workaround pattern that populates it when the default schedule overflows per-core L1. The runtime reads the attribute when set; the OpModel/validation path sees the same config that will execute.

This replaces the previous design that inlined the schedule into the runtime: by lifting the decision to a compile-time pattern, the runtime stays a thin executor and a future pass / external producer can supply its own program_config without forking the runtime heuristic.

Why head_dim is the discriminator
---------------------------------
tt-metal's SDPA decode program factory allocates per-core CBs whose footprint scales with DHt = head_dim / TILE_WIDTH (K/V tiles double- buffered) and with num_cores_per_head for the partial-accumulator CB:

  k_tiles               = Sk_chunk_t_cb_size * DHt  * 2
  v_tiles               = Sk_chunk_t_cb_size * vDHt * 2
  intermed_output_tiles = (PNHt * vDHt + 2 * PNHt) * (num_cores_per_head - 1)

For Gemma-4 31B (head_dim=512 global, head_dim=256 sliding-window) this overflows Blackhole's 1.5 MB usable L1 under the default schedule. Llama-class shapes (head_dim=128) with similar total K/V residency stay within budget, so the trigger is the per-CB scaling factor, not the aggregate K/V volume.

Override schedule
-----------------
When head_dim >= 256, set k_chunk_size=32 (one page, bounds Sk_chunk_t_cb_size) and cap max_cores_per_head_batch at min(32, blocks). The 32-core cap (vs the 64-core MAX_TREE_REDUCTION_ROUNDS limit) halves the intermed-output footprint, which is what keeps Gemma-4 31B at max_model_len >= 2048 (pageTableBlocks >= 64) inside per-core L1.

Components
----------
* IR: TTNN_PagedScaledDotProductAttentionDecodeOp gets an optional TTNN_SDPAProgramConfigAttr program_config.
* Flatbuffer: PagedScaledDotProductAttentionDecodeOp table carries a SDPAConfig program_config; TTNNToFlatbuffer serializes it from the attribute.
* Workaround pass: new PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern fires only when head_dim >= 256 and program_config is unset; it populates the attribute from the device worker grid and the page-table block count.
* Runtime: prefers op->program_config() via utils::createSDPAProgramConfig when present; otherwise keeps the existing non-causal / Blackhole-causal fallbacks unchanged.
* OpModel: reads the attribute through conversion::getSDPAProgramConfig so the validation/fallback pass sees the same program_config the runtime executes; falls back to the existing core_grid-driven default when the attribute is absent.

### Checklist
- [ ] New/Existing tests provide coverage for changes
