### PR TITLE
[EmitPy] Fix targetModule path 

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -587,7 +587,7 @@ struct TTNNCommonToEmitCPipelineOptions
       *this, "tuplify-input-if-empty",
       llvm::cl::desc("Whether to create an empty tuple if no inputs to forward "
                      "function. This should only be used if the `target-dylib` "
-                     "or the `target-module` option is set to `true`"),
+                     "option is set to `true`."),
       llvm::cl::init(false)};
 
   Option<bool> loadInputTensorsFromDisk{
@@ -615,6 +615,14 @@ struct TTNNCommonToEmitPyPipelineOptions
       llvm::cl::desc("Tailor passes for Python module target. When enabled, "
                      "the entry function is named 'forward' with tuple of "
                      "tensors and device as inputs."),
+      llvm::cl::init(false)};
+
+  Option<bool> tuplifyInputIfEmpty{
+      *this, "tuplify-input-if-empty",
+      llvm::cl::desc(
+          "Whether to create an empty tuple if no inputs to forward "
+          "function. This should only be used if the `target-module` "
+          "option is set to `true`."),
       llvm::cl::init(false)};
 
   Option<bool> loadInputTensorsFromDisk{

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -587,7 +587,7 @@ struct TTNNCommonToEmitCPipelineOptions
       *this, "tuplify-input-if-empty",
       llvm::cl::desc("Whether to create an empty tuple if no inputs to forward "
                      "function. This should only be used if the `target-dylib` "
-                     "option is set to `true`"),
+                     "or the `target-module` option is set to `true`"),
       llvm::cl::init(false)};
 
   Option<bool> loadInputTensorsFromDisk{

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -263,18 +263,20 @@ def TTNNTuplifyTensors: Pass<"ttnn-tuplify-tensors", "::mlir::ModuleOp"> {
     Option<"tuplifyInputIfEmpty",
             "tuplify-input-if-empty",
             "bool", /*default=*/"false",
-            "If input arg is originally empty, force create an empty tuple arg. This is useful for scenarios where "
-            "signatures are required have tuples on the input, like the EmitC dylib path.">
+            "If forward function input arg is originally empty, force create an empty tuple arg. This is useful for scenarios where "
+            "signatures are required to have tuples on the input, like the EmitC dylib or EmitPy targetModule path.">
   ];
 }
 
 def TTNNPrepareModuleForExport : Pass<"ttnn-prepare-module-for-export", "::mlir::ModuleOp"> {
   let summary = "Prepare module for Python module export.";
   let description = [{
-    This pass prepares the module for export as a Python module by:
-    1. Renaming the first public (non-private, non-const-eval) function to "forward"
+    Reshapes the first forward device function into the canonical entry-point
+    signature consumed by the frontends by:
+    1. Renaming the first forward device function to "forward"
     2. Adding a device argument to the function signature
     3. Replacing all ttnn.get_device ops with the device function argument
+    4. Preparing the forward function input tensors to be in the right form (host/device, layout, dtype)
 
     Given a forward function like this:
 
@@ -283,8 +285,8 @@ def TTNNPrepareModuleForExport : Pass<"ttnn-prepare-module-for-export", "::mlir:
       %0 = ttcore.get_tuple_element %arg0[0] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
       %1 = ttcore.get_tuple_element %arg0[1] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
       %2 = "ttnn.get_device"() : () -> !ttnn.device
-      %3 = "ttnn.to_device"(%0, %2) : (tensor<32x32xbf16, !ttnn.device) -> tensor<32x32xbf16>
-      %4 = "ttnn.to_device"(%1, %2) : (tensor<32x32xbf16, !ttnn.device) -> tensor<32x32xbf16>
+      %3 = "ttnn.to_device"(%0, %2) : (tensor<32x32xbf16>, !ttnn.device) -> tensor<32x32xbf16>
+      %4 = "ttnn.to_device"(%1, %2) : (tensor<32x32xbf16>, !ttnn.device) -> tensor<32x32xbf16>
       %5 = "ttnn.add"(%3, %4) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
       %6 = ttcore.tuple %5 : tuple<tensor<32x32xbf16>>
       return %6 : tuple<tensor<32x32xbf16>>
@@ -294,15 +296,41 @@ def TTNNPrepareModuleForExport : Pass<"ttnn-prepare-module-for-export", "::mlir:
     The pass will return:
 
     ```mlir
-    func.func @forward(%arg0: tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>, %arg1: !ttnn.device) -> tuple<tensor<32x32xbf16>> {
+    func.func @forward(%arg0: tuple<tensor<32x32xbf16>, tensor<32x32xbf16>> {emitpy.name = "input"},
+                       %arg1: !ttnn.device {emitpy.name = "device"}) -> tuple<tensor<32x32xbf16>> {
       %0 = ttcore.get_tuple_element %arg0[0] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
       %1 = ttcore.get_tuple_element %arg0[1] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
-      %2 = "ttnn.to_device"(%0, %arg1) : (tensor<32x32xbf16, !ttnn.device) -> tensor<32x32xbf16>
-      %3 = "ttnn.to_device"(%1, %arg1) : (tensor<32x32xbf16, !ttnn.device) -> tensor<32x32xbf16>
+      %2 = "ttnn.to_device"(%0, %arg1) : (tensor<32x32xbf16>, !ttnn.device) -> tensor<32x32xbf16>
+      %3 = "ttnn.to_device"(%1, %arg1) : (tensor<32x32xbf16>, !ttnn.device) -> tensor<32x32xbf16>
       %4 = "ttnn.add"(%2, %3) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
       %5 = ttcore.tuple %4 : tuple<tensor<32x32xbf16>>
       return %5 : tuple<tensor<32x32xbf16>>
     }
+    ```
+
+    The example above shows the trivial case where tuple elements have no
+    device-buffer layout and step 4 is a no-op. When a tuple element does
+    carry a device-buffer layout, step 4 additionally retypes it to a host
+    layout in the signature and stages each `ttcore.get_tuple_element`
+    host -> device via a `ttnn.to_layout` followed by a `ttnn.to_device`.
+    The target memory config (buffer type, memory layout, shard spec) is
+    conveyed via the result tensor type's `TTNNLayoutAttr` encoding
+    (`#device` below; `#host` is `SystemMemory + RowMajor`, `#host_staged`
+    is `SystemMemory` carrying the target tile/dtype):
+
+    ```mlir
+    // Before:
+    %0 = ttcore.get_tuple_element %arg0[0]
+        : (tuple<tensor<32x32xbf16, #device>, ...>) -> tensor<32x32xbf16, #device>
+
+    // After:
+    %0 = ttcore.get_tuple_element %arg0[0]
+        : (tuple<tensor<32x32xbf16, #host>, ...>)   -> tensor<32x32xbf16, #host>
+    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<tile>, dtype = bf16}>
+        : (tensor<32x32xbf16, #host>) -> tensor<32x32xbf16, #host_staged>
+    %2 = "ttnn.to_device"(%1, %arg1)
+        : (tensor<32x32xbf16, #host_staged>, !ttnn.device)
+          -> tensor<32x32xbf16, #device>
     ```
   }];
 }

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -519,8 +519,9 @@ void createTTNNCommonToEmitCPipeline(
 
   if (options.targetDylib) {
     // In dylib path, only run tuplification with forced settings.
-    // This ensures tensor inputs are always tuplified even when the input is
-    // empty, which is necessary for proper dylib interface generation.
+    // This ensures that forward function input tensors are always tuplified
+    // even when the input is empty, which is necessary for proper dylib
+    // interface generation.
     //
     TTNNTuplifyTensorsOptions tuplifyOptions;
     tuplifyOptions.tuplifyInputIfEmpty = true;
@@ -563,9 +564,9 @@ void createTTNNCommonToEmitPyPipeline(
 
   if (options.targetModule) {
     // In module path, run tuplification with forced settings and add device
-    // argument. This ensures tensor inputs are always tuplified even when the
-    // input is empty, which is necessary for proper module interface
-    // generation.
+    // argument. This ensures forward function input tensors are always
+    // tuplified even when the input is empty, which is necessary for proper
+    // module interface generation.
     //
     TTNNTuplifyTensorsOptions tuplifyOptions;
     tuplifyOptions.tuplifyInputIfEmpty = true;

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -578,7 +578,9 @@ void createTTNNCommonToEmitPyPipeline(
     // weights first. Then tuplify everything else.
     //
     devicePm.addPass(createTTNNSplitForwardFuncArgsByType());
-    devicePm.addPass(createTTNNTuplifyTensors());
+    TTNNTuplifyTensorsOptions tuplifyOptions;
+    tuplifyOptions.tuplifyInputIfEmpty = options.tuplifyInputIfEmpty;
+    devicePm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
 
     if (options.loadInputTensorsFromDisk) {
       TTNNLoadInputTensorsOptions loadOptions;

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -1211,18 +1211,18 @@ public:
 
       mlir::FunctionType functionType = funcOp.getFunctionType();
 
-      // Check that input is not empty and that all args are of type
-      // RankedTensorType.
+      // Tuplify when either the function has at least one input, or when
+      // `tuplifyInputIfEmpty` is set and the function is a forward device
+      // function (in which case an empty input tuple is forced). In both
+      // cases, all inputs must be `RankedTensorType`.
       //
-      // If `tuplifyInputIfEmpty` option is set and the function is a forward
-      // device function, tuplify the input even if the
-      // function has no inputs.
-      //
-      if (((tuplifyInputIfEmpty &&
-            ttmlir::utils::isForwardDeviceFunc(funcOp)) ||
-           !functionType.getInputs().empty()) &&
+      const bool forceTuplifyForward =
+          tuplifyInputIfEmpty && ttmlir::utils::isForwardDeviceFunc(funcOp);
+      const bool hasInputs = !functionType.getInputs().empty();
+      const bool allInputsAreTensors =
           llvm::all_of(functionType.getInputs(),
-                       [](Type t) { return mlir::isa<RankedTensorType>(t); })) {
+                       [](Type t) { return mlir::isa<RankedTensorType>(t); });
+      if ((forceTuplifyForward || hasInputs) && allInputsAreTensors) {
         targetFuncOpsInput.push_back(funcOp);
       }
 

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -1214,10 +1214,13 @@ public:
       // Check that input is not empty and that all args are of type
       // RankedTensorType.
       //
-      // If `tuplifyInputIfEmpty` option is set, tuplify the input even if the
+      // If `tuplifyInputIfEmpty` option is set and the function is a forward
+      // device function, tuplify the input even if the
       // function has no inputs.
       //
-      if ((tuplifyInputIfEmpty || !functionType.getInputs().empty()) &&
+      if (((tuplifyInputIfEmpty &&
+            ttmlir::utils::isForwardDeviceFunc(funcOp)) ||
+           !functionType.getInputs().empty()) &&
           llvm::all_of(functionType.getInputs(),
                        [](Type t) { return mlir::isa<RankedTensorType>(t); })) {
         targetFuncOpsInput.push_back(funcOp);
@@ -1372,46 +1375,198 @@ public:
     rewriter.modifyOpInPlace(targetFuncOp,
                              [&]() { targetFuncOp.setSymName("forward"); });
 
-    // Add device argument to the function signature.
+    // The pipeline runs TTNNTuplifyTensors with `tuplifyInputIfEmpty=true`
+    // before this pass, so the forward function is guaranteed to have at
+    // least one argument (the input tuple) at this point.
     //
-    DeviceType deviceType = DeviceType::get(&getContext());
-    Block &entryBlock = targetFuncOp.getBlocks().front();
-    BlockArgument deviceArg =
-        entryBlock.addArgument(deviceType, targetFuncOp.getLoc());
-
-    // Update function type to include device argument.
-    //
-    mlir::FunctionType originalFuncType = targetFuncOp.getFunctionType();
-    SmallVector<Type> newInputTypes(originalFuncType.getInputs().begin(),
-                                    originalFuncType.getInputs().end());
-    newInputTypes.push_back(deviceType);
-    FunctionType newFuncType = FunctionType::get(&getContext(), newInputTypes,
-                                                 originalFuncType.getResults());
-
-    rewriter.modifyOpInPlace(targetFuncOp,
-                             [&]() { targetFuncOp.setType(newFuncType); });
-
-    // Set the emitpy.name attribute for the input tuple and device arguments.
-    // The input tuple should be named "input" and the device should be named
-    // "device".
-    //
-    if (!newInputTypes.empty()) {
-      targetFuncOp.setArgAttr(0, "emitpy.name",
-                              rewriter.getStringAttr("input"));
+    if (targetFuncOp.getNumArguments() == 0) {
+      targetFuncOp.emitOpError(
+          "expected forward function to have at least one (tuple) input; run "
+          "`-ttnn-tuplify-tensors=tuplify-input-if-empty=true` before this "
+          "pass");
+      signalPassFailure();
+      return;
     }
-    targetFuncOp.setArgAttr(newInputTypes.size() - 1, "emitpy.name",
-                            rewriter.getStringAttr("device"));
 
-    // Find all GetDeviceOp operations and replace their uses with the device
-    // argument.
+    // Add a device argument to the function and replace all GetDeviceOp uses
+    // with it.
     //
-    SmallVector<ttnn::GetDeviceOp> getDeviceOps;
-    targetFuncOp.walk(
-        [&](ttnn::GetDeviceOp op) { getDeviceOps.push_back(op); });
+    if (failed(injectDeviceArg(rewriter, targetFuncOp))) {
+      signalPassFailure();
+      return;
+    }
 
-    for (ttnn::GetDeviceOp getDeviceOp : getDeviceOps) {
+    // The forward function must have exactly two
+    // arguments: the input tuple from tuplification and the device argument
+    // just injected.
+    //
+    if (targetFuncOp.getNumArguments() != 2) {
+      targetFuncOp.emitOpError(
+          "expected forward function to have exactly (tuple, device) "
+          "arguments after device injection; got ")
+          << targetFuncOp.getNumArguments() << " arguments";
+      signalPassFailure();
+      return;
+    }
+
+    // Set `emitpy.name` attributes for the forward function's arguments.
+    //
+    targetFuncOp.setArgAttr(0, "emitpy.name", rewriter.getStringAttr("input"));
+    targetFuncOp.setArgAttr(1, "emitpy.name", rewriter.getStringAttr("device"));
+
+    // Prepare the forward function input tensors to be in the right form
+    // (host/device, layout, dtype).
+    //
+    prepareForwardFuncInputTensors(rewriter, targetFuncOp);
+  }
+
+private:
+  // Adds a trailing device argument to the function's signature and
+  // rewrites every GetDeviceOp inside the function to use it. Fails if
+  // the argument could not be inserted.
+  //
+  LogicalResult injectDeviceArg(IRRewriter &rewriter, func::FuncOp funcOp) {
+    DeviceType deviceType = DeviceType::get(rewriter.getContext());
+    unsigned deviceArgIndex = funcOp.getNumArguments();
+    if (failed(funcOp.insertArgument(deviceArgIndex, deviceType,
+                                     /*argAttrs=*/DictionaryAttr{},
+                                     funcOp.getLoc()))) {
+      return funcOp.emitOpError(
+          "failed to inject device argument into the function's signature!");
+    }
+
+    // Replace all GetDeviceOp operations with the new device argument.
+    //
+    BlockArgument deviceArg = funcOp.getArgument(deviceArgIndex);
+    SmallVector<ttnn::GetDeviceOp> getDeviceOps;
+    funcOp.walk([&](ttnn::GetDeviceOp op) { getDeviceOps.push_back(op); });
+    for (auto getDeviceOp : getDeviceOps) {
       rewriter.replaceOp(getDeviceOp, deviceArg);
     }
+    return success();
+  }
+
+  // Re-type every forward function input tensor to the appropriate form
+  // (host/device, layout, dtype).
+  //
+  void prepareForwardFuncInputTensors(IRRewriter &rewriter,
+                                      func::FuncOp forwardFuncOp) {
+    MLIRContext *ctx = rewriter.getContext();
+    Value inputTuple = forwardFuncOp.getArgument(0);
+    Value deviceArg = forwardFuncOp.getArgument(1);
+    auto inputTupleType = mlir::cast<mlir::TupleType>(inputTuple.getType());
+
+    // The tt-xla/codegen entry-point contract is that the forward function
+    // always receives each tensor on host in row-major form. However,
+    // TTNNLayout pass rewrites the FuncOp inputs to device layout (with some
+    // minor exceptions, e.g. Conv2d weights), and relies on the function caller
+    // to prepare input tensors in the right form. For that reason, this pass
+    // uses the proper host counterparts of the device-bound input tensors and
+    // applies ToLayoutOp and ToDeviceOp to them.
+    llvm::DenseMap<int64_t, RankedTensorType> hostTypesByIndex;
+    for (size_t idx = 0; idx < inputTupleType.size(); ++idx) {
+      auto tensorType =
+          mlir::cast<RankedTensorType>(inputTupleType.getType(idx));
+      auto targetLayout = mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
+
+      // System-memory inputs are already declared as host row-major.
+      //
+      if (!targetLayout.isDeviceBufferType()) {
+        continue;
+      }
+
+      // For each device-bound tensor type, create the host row-major tensor
+      // type that preserves the target shape and element type.
+      //
+      auto hostLayoutAttr = TTNNLayoutAttr::Builder(tensorType)
+                                .setBufferType(BufferType::SystemMemory)
+                                .setLayout(Layout::RowMajor)
+                                .build();
+      hostTypesByIndex[idx] = RankedTensorType::get(
+          tensorType.getShape(), tensorType.getElementType(), hostLayoutAttr);
+    }
+
+    if (hostTypesByIndex.empty()) {
+      return;
+    }
+
+    // Patch GetTupleElementOp results to a proper type.
+    //
+    SmallVector<ttcore::GetTupleElementOp> getElemOps;
+    forwardFuncOp.walk([&](ttcore::GetTupleElementOp getElemOp) {
+      if (getElemOp.getOperand() == inputTuple) {
+        getElemOps.push_back(getElemOp);
+      }
+    });
+
+    for (auto getElemOp : getElemOps) {
+      int64_t idx = getElemOp.getIndex();
+      auto it = hostTypesByIndex.find(idx);
+      if (it == hostTypesByIndex.end()) {
+        continue;
+      }
+
+      RankedTensorType hostTensorType = it->second;
+      auto deviceTensorType =
+          mlir::cast<RankedTensorType>(inputTupleType.getType(idx));
+      auto targetLayout =
+          mlir::cast<TTNNLayoutAttr>(deviceTensorType.getEncoding());
+
+      auto oldTupleElemResult = getElemOp.getResult();
+      oldTupleElemResult.setType(hostTensorType);
+
+      rewriter.setInsertionPointAfter(getElemOp);
+      // Build the intermediate host-staged type that
+      // carries the target layout and element type.
+      //
+      auto hostStagedLayoutAttr = TTNNLayoutAttr::Builder(deviceTensorType)
+                                      .setBufferType(BufferType::SystemMemory)
+                                      .setLayout(targetLayout.getLayout())
+                                      .build();
+      auto hostStagedTensorType = RankedTensorType::get(
+          deviceTensorType.getShape(), deviceTensorType.getElementType(),
+          hostStagedLayoutAttr);
+
+      // On-host layout/dtype conversion. If this is an
+      // identity conversion the folder collapses the op to its input.
+      //
+      auto toLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
+          getElemOp.getLoc(), hostStagedTensorType, oldTupleElemResult,
+          LayoutAttr::get(ctx, targetLayout.getLayout()),
+          ttcore::DataTypeAttr::get(ctx, targetLayout.getDataType()));
+
+      // Host-to-device transfer. The target memory config is conveyed via the
+      // result tensor type's `TTNNLayoutAttr` encoding.
+      //
+      auto toDeviceOp = rewriter.create<ttnn::ToDeviceOp>(
+          getElemOp.getLoc(), deviceTensorType, toLayoutOp.getResult(),
+          deviceArg);
+
+      // Replace the original tuple element with the device tensor produced by
+      // ToDeviceOp. The only use of the original tuple element preserved is
+      // the one inside the ToLayoutOp itself.
+      //
+      rewriter.replaceAllUsesExcept(oldTupleElemResult, toDeviceOp.getResult(),
+                                    toLayoutOp);
+    }
+
+    // Patch the tuple type and the forward function's input type so the IR
+    // is internally consistent with the retyped tuple element results.
+    //
+    SmallVector<Type> newTupleElementTypes(inputTupleType.getTypes().begin(),
+                                           inputTupleType.getTypes().end());
+    for (auto &[idx, hostType] : hostTypesByIndex) {
+      newTupleElementTypes[idx] = hostType;
+    }
+    auto newTupleType = mlir::TupleType::get(ctx, newTupleElementTypes);
+    inputTuple.setType(newTupleType);
+
+    FunctionType forwardFuncType = forwardFuncOp.getFunctionType();
+    SmallVector<Type> newInputTypes(forwardFuncType.getInputs().begin(),
+                                    forwardFuncType.getInputs().end());
+    newInputTypes[0] = newTupleType;
+    forwardFuncOp.setType(
+        FunctionType::get(ctx, newInputTypes, forwardFuncType.getResults()));
   }
 };
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_prepare_module_for_export.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_prepare_module_for_export.mlir
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt \
+// RUN:   --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" \
+// RUN:   --ttcore-unwrap-device-module \
+// RUN:   --ttnn-tuplify-tensors="tuplify-input-if-empty=true" \
+// RUN:   --ttnn-prepare-module-for-export \
+// RUN:   -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verify that TTNNPrepareModuleForExport reshapes the forward function into
+// the canonical entry-point expected on the tt-xla / codegen boundary:
+// - the forward function is renamed to `forward`;
+// - a trailing `!ttnn.device` argument is injected;
+// - each device-bound input tuple element is retyped to host row-major and
+//   staged onto the device via `ttnn.to_layout` followed by `ttnn.to_device`;
+// - the first and second arguments carry `emitpy.name = "input"` and
+//   `"device"` respectively.
+
+// CHECK-DAG: #[[HOST:[a-zA-Z0-9_]+]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xbf16, #system_memory>>
+
+// CHECK: func.func @forward(
+// CHECK-SAME: tuple<tensor<32x32xbf16, #[[HOST]]>, tensor<32x32xbf16, #[[HOST]]>> {emitpy.name = "input"}
+// CHECK-SAME: !ttnn.device {emitpy.name = "device"}
+
+// CHECK: %[[E0:.+]] = ttcore.get_tuple_element {{.*}}[0]
+// CHECK-SAME: -> tensor<32x32xbf16, #[[HOST]]>
+// CHECK-NEXT: %[[L0:.+]] = "ttnn.to_layout"(%[[E0]])
+// CHECK-NEXT: %{{.+}} = "ttnn.to_device"(%[[L0]]
+//
+// CHECK: %[[E1:.+]] = ttcore.get_tuple_element {{.*}}[1]
+// CHECK-SAME: -> tensor<32x32xbf16, #[[HOST]]>
+// CHECK-NEXT: %[[L1:.+]] = "ttnn.to_layout"(%[[E1]])
+// CHECK-NEXT: %{{.+}} = "ttnn.to_device"(%[[L1]]
+
+module {
+  func.func @add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %0 : tensor<32x32xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Part of #8258

### Problem description
Previously, two different paths in the TTNN-to-EmitPy pipeline served the same purpose of exporting a Python module for end-to-end testing: `targetModule` path and `TTNNCreateMainForTest` pass. On the frontend side, only the latter is used. However, there are a few points in favour of the `targetModule` path:
- `targetModule` was made as a completely separate path from the canonical one, whereas `TTNNCreateMainForTest` is part of the canonical codegen path
- `TTNNCreateMainForTest` leaves the input generator functions present in the generated code, which are redundant for testing since inputs are provided by the frontend
- `TTNNCreateMainForTest` pass conflicts with the recently added `TTNNSplitForwardFuncArgsByType` pass since they are both part of the canonical codegen path (the hot-fix is done in #8323, but this has to be properly addressed otherwise). However, `TTNNSplitForwardFuncArgsByType` pass that splits the forward function inputs into activations and weights is not really relevant for the testing

To reconcile these two, the agreement is to only use the `targetModule` path, and make a frontend/codegen contract on the tt-xla side that the forward function input tensors will always come as host, row-major. 
### What's changed
This PR refactors the `targetModule` path to work accordingly by: 
- fixing `TTNNTuplifyTensors` pass to perform forced tuplification (creating an empty tuple when input is empty) only on the forward function (this was previously applied to all funcOps, e.g., consteval funcs, and has caused errors in the emitted code)
- refactor `TTNNPrepareModuleForExport` to ensure that forward function input tensors are in the right form (host/device, layout, dtype) and that IR contains the true layout info

With these changes, `TTNNCreateMainForTest` pass can now be safely removed, provided that `targetModule` is set to be used on the frontend side. 
Workflows to prove the test parity: 
[Before (TTNNCreateMainForTest pass)](https://github.com/tenstorrent/tt-xla/actions/runs/25662480589)
[Now (targetModule path)](https://github.com/tenstorrent/tt-xla/actions/runs/26105781326)
### Checklist
- [ ] New/Existing tests provide coverage for changes
