### PR TITLE
[D2M] enable l1 acc by default

### DIFF
--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -210,7 +210,7 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
 
   Option<bool> enableL1Acc{*this, "enable-l1-acc",
                            llvm::cl::desc("Enable L1 accumulation."),
-                           llvm::cl::init(false)};
+                           llvm::cl::init(true)};
 };
 
 void createTTIRBufferizationPipeline(OpPassManager &pm,

--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -208,9 +208,11 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
                      "prints debug output comparing them."),
       llvm::cl::init(false)};
 
-  Option<bool> enableL1Acc{*this, "enable-l1-acc",
-                           llvm::cl::desc("Enable L1 accumulation."),
-                           llvm::cl::init(true)};
+  Option<bool> disableL1Acc{
+      *this, "disable-l1-acc",
+      llvm::cl::desc("Disable L1 accumulation (force reloading from L1 to DST "
+                     "instead of accumulating partials in L1)."),
+      llvm::cl::init(false)};
 };
 
 void createTTIRBufferizationPipeline(OpPassManager &pm,

--- a/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.h
+++ b/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.h
@@ -118,6 +118,33 @@ bool hasTileMatmul(Operation *op);
 // True iff `op` is any tile-level reduction op (FPU or SFPU variant).
 bool isTileReductionOp(Operation *op);
 
+// Returns true iff the packer hardware supports L1 accumulation when packing
+// into an output buffer of element type `dt`. The packer L1-acc path goes
+// through a fixed set of native formats; block-float (Bfp*) outputs are NOT
+// supported and would silently produce garbage results.
+//
+// Supported set follows tt-llk `PACK_L1_ACC_FORMATS`:
+//   Float32, Float16, BFloat16 (Float16_b), Int32, UInt8.
+bool isPackerL1AccumulationSupportedDataType(ttcore::DataType dt);
+
+// Returns true iff every `d2m.tile_matmul` in `loopOp` has a result tile
+// element type that is supported by the packer L1-accumulation path. Returns
+// true if there are no `d2m.tile_matmul` ops (caller is responsible for
+// gating on `hasTileMatmul`).
+bool allTileMatmulOutputsSupportPackerL1Acc(Operation *loopOp);
+
+// Find the outermost ancestor reduction loop IV of `acquireDst`, where
+// "reduction" means: no output store recorded in `copyInfos` depends on the
+// loop's induction variable. This is the loop whose iterations accumulate
+// into the same output L1 slot, and is therefore the correct trigger for
+// switching the packer to L1-acc mode.
+//
+// Returns nullptr if there is no such reduction loop, or if the candidate
+// reduction loop has a constant trip count <= 1 (in which case L1-acc is
+// not needed and the trigger comparison would never fire correctly).
+Value findOutermostReductionLoopIVForL1Acc(Operation *acquireDstOp,
+                                           const CopyInfoMap &copyInfos);
+
 // Stamp a pass-allocated scratch slice onto the op's `dst_scratch_index`
 // attribute for the TTKernel lowering to consume.  Today only supports ops
 // that need exactly one scratch slice.

--- a/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.h
+++ b/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.h
@@ -230,8 +230,8 @@ cloneAffineLoopSkeleton(PatternRewriter &rewriter, Operation *loopNestOrOp);
 //   2. Rewrites the original load/store via `accessReplacer` so it now
 //      goes through the DST register.
 //
-// `enableL1Acc=true` skips the upfront copy nest entirely (the L1 acc
-// guard preserves the running tile).
+// `disableL1Acc=false` (i.e. L1 acc on) skips the upfront copy nest
+// entirely (the L1 acc guard preserves the running tile).
 template <typename LoadOrStoreTy>
 void emitDstCopyNest(
     PatternRewriter &rewriter, Operation *loopNestOrOp,
@@ -242,7 +242,7 @@ void emitDstCopyNest(
     llvm::function_ref<void(PatternRewriter &, LoadStoreRecord<LoadOrStoreTy>,
                             AffineMap, ValueRange)>
         accessReplacer,
-    bool enableL1Acc = false);
+    bool disableL1Acc = true);
 
 std::pair<AffineMap, SmallVector<Value>>
 buildLinearizedDstAccess(PatternRewriter &rewriter, Operation *op, int dstSlice,
@@ -277,7 +277,7 @@ void insertPackerL1AccGuard(PatternRewriter &rewriter, Location loc,
 bool insertDstRegisterAccessFinalize(
     PatternRewriter &rewriter, GenericOp gOp, Region &region,
     unsigned dstCapacity, Operation *outermostInnerComputeLoop,
-    bool enableL1Acc, CopyInfoMap &copyInfos,
+    bool disableL1Acc, CopyInfoMap &copyInfos,
     DstIntermediatesMap &dstIntermediates,
     llvm::function_ref<void(PatternRewriter &, Location, Value,
                             const CopyInfoMap &, bool)>

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -326,7 +326,7 @@ def D2MInsertDstRegisterAccessUnscheduled : Pass<"d2m-insert-dst-register-access
   ];
   let options = [
     Option<"maxDstPhysicalSizeTiles", "max-dst-physical-size-tiles", "unsigned", "0", "Override the max dst physical size tiles or 0 if unset.">,
-    Option<"enableL1Acc", "enable-l1-acc", "bool", /*default=*/"false", "Enable accumulating partials in L1 instead of reloading from L1 to DST.">,
+    Option<"enableL1Acc", "enable-l1-acc", "bool", /*default=*/"true", "Enable accumulating partials in L1 instead of reloading from L1 to DST.">,
   ];
 }
 
@@ -401,7 +401,7 @@ def D2MInsertDstRegisterAccessScheduled : Pass<"d2m-insert-dst-register-access-s
   ];
   let options = [
     Option<"maxDstPhysicalSizeTiles", "max-dst-physical-size-tiles", "unsigned", "0", "Override the max dst physical size tiles or 0 if unset.">,
-    Option<"enableL1Acc", "enable-l1-acc", "bool", /*default=*/"false", "Enable accumulating partials in L1 instead of reloading from L1 to DST.">,
+    Option<"enableL1Acc", "enable-l1-acc", "bool", /*default=*/"true", "Enable accumulating partials in L1 instead of reloading from L1 to DST.">,
   ];
 }
 

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -326,7 +326,7 @@ def D2MInsertDstRegisterAccessUnscheduled : Pass<"d2m-insert-dst-register-access
   ];
   let options = [
     Option<"maxDstPhysicalSizeTiles", "max-dst-physical-size-tiles", "unsigned", "0", "Override the max dst physical size tiles or 0 if unset.">,
-    Option<"enableL1Acc", "enable-l1-acc", "bool", /*default=*/"true", "Enable accumulating partials in L1 instead of reloading from L1 to DST.">,
+    Option<"disableL1Acc", "disable-l1-acc", "bool", /*default=*/"false", "Disable accumulating partials in L1 (force reloading from L1 to DST instead).">,
   ];
 }
 
@@ -401,7 +401,7 @@ def D2MInsertDstRegisterAccessScheduled : Pass<"d2m-insert-dst-register-access-s
   ];
   let options = [
     Option<"maxDstPhysicalSizeTiles", "max-dst-physical-size-tiles", "unsigned", "0", "Override the max dst physical size tiles or 0 if unset.">,
-    Option<"enableL1Acc", "enable-l1-acc", "bool", /*default=*/"true", "Enable accumulating partials in L1 instead of reloading from L1 to DST.">,
+    Option<"disableL1Acc", "disable-l1-acc", "bool", /*default=*/"false", "Disable accumulating partials in L1 (force reloading from L1 to DST instead).">,
   ];
 }
 

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -197,13 +197,13 @@ void createD2MBackendPipeline(OpPassManager &pm,
   d2m::D2MInsertDstRegisterAccessUnscheduledOptions unschedDstOpts;
   {
     unschedDstOpts.maxDstPhysicalSizeTiles = options.maxDstPhysicalSizeTiles;
-    unschedDstOpts.enableL1Acc = options.enableL1Acc;
+    unschedDstOpts.disableL1Acc = options.disableL1Acc;
   }
   pm.addPass(d2m::createD2MInsertDstRegisterAccessUnscheduled(unschedDstOpts));
   d2m::D2MInsertDstRegisterAccessScheduledOptions schedDstOpts;
   {
     schedDstOpts.maxDstPhysicalSizeTiles = options.maxDstPhysicalSizeTiles;
-    schedDstOpts.enableL1Acc = options.enableL1Acc;
+    schedDstOpts.disableL1Acc = options.disableL1Acc;
   }
   pm.addPass(d2m::createD2MInsertDstRegisterAccessScheduled(schedDstOpts));
   d2m::D2MInsertTileMatmulBlockOptions insertTileMatmulBlockOptions;

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessScheduled.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessScheduled.cpp
@@ -176,7 +176,7 @@ static void dataCopyGenerateScheduledInPlace(
     llvm::function_ref<void(PatternRewriter &, LoadStoreOpTy, AffineMap,
                             ValueRange)>
         dstAccessReplacement,
-    bool enableL1Acc = false) {
+    bool disableL1Acc = true) {
   if (loadStoreOps.empty()) {
     return;
   }
@@ -195,7 +195,7 @@ static void dataCopyGenerateScheduledInPlace(
 
     rewriter.setInsertionPoint(loadStore);
 
-    if (!enableL1Acc) {
+    if (disableL1Acc) {
       loadStoreDstAccessGenerator(
           rewriter, loadStore.getLoc(), loadStore.getMemRef(), l1AccessMap,
           l1AccessIndices, dstAccessMap, dstAccessIndices);
@@ -236,7 +236,7 @@ static void dataCopyGenerateWithClone(
         dstAccessReplacement(rw, record.loadStore, dstAccessMap,
                              dstAccessIndices);
       },
-      /*enableL1Acc=*/false);
+      /*disableL1Acc=*/true);
 }
 
 // ---------------------------------------------------------------------------
@@ -404,7 +404,7 @@ collectDstAccessesScheduled(GenericOp op, Region &region,
 static void dataCopyGenerateScheduledAll(PatternRewriter &rewriter,
                                          Location loc, Value dst,
                                          const CopyInfoMap &copyInfos,
-                                         bool enableL1Acc = false) {
+                                         bool disableL1Acc = true) {
   for (const auto &[loopNestOrOp, copyInfo] : copyInfos) {
     rewriter.setInsertionPointAfter(loopNestOrOp);
     auto insertionPointAfterLoopNest = rewriter.saveInsertionPoint();
@@ -427,7 +427,7 @@ static void dataCopyGenerateScheduledAll(PatternRewriter &rewriter,
           rewriter.replaceOpWithNewOp<affine::AffineLoadOp>(
               op, dst, dstAccessMap, dstAccessIndices);
         },
-        /*enableL1Acc=*/enableL1Acc);
+        /*disableL1Acc=*/disableL1Acc);
 
     // Process memref loads (scheduled path with scf.for loops).
     for (auto [loadOp, bcast, dstSliceIndex, guardIVs] : copyInfo.memrefLoads) {
@@ -436,7 +436,7 @@ static void dataCopyGenerateScheduledAll(PatternRewriter &rewriter,
 
       rewriter.setInsertionPoint(loadOp);
 
-      if (!enableL1Acc) {
+      if (disableL1Acc) {
         auto cbLoad = rewriter.create<memref::LoadOp>(
             loadOp.getLoc(), loadOp.getMemRef(), loadOp.getIndices());
         rewriter.create<affine::AffineStoreOp>(loadOp.getLoc(),
@@ -535,10 +535,10 @@ struct D2MInsertDstRegisterAccessScheduledRewriter final
     : public OpRewritePattern<GenericOp> {
   D2MInsertDstRegisterAccessScheduledRewriter(mlir::MLIRContext *ctx,
                                               unsigned maxDstPhysicalSizeTiles,
-                                              bool enableL1Acc)
+                                              bool disableL1Acc)
       : OpRewritePattern<GenericOp>(ctx),
         maxDstPhysicalSizeTiles(maxDstPhysicalSizeTiles),
-        enableL1Acc(enableL1Acc) {}
+        disableL1Acc(disableL1Acc) {}
 
   LogicalResult matchAndRewrite(GenericOp gOp,
                                 PatternRewriter &rewriter) const final {
@@ -602,22 +602,24 @@ struct D2MInsertDstRegisterAccessScheduledRewriter final
         // Consume the scheduled attribute.
         loopOp->removeAttr("d2m.scheduled");
 
-        // L1 accumulation requires (a) a tile_matmul that hits the packer
-        // L1-acc path, and (b) the matmul output element type to be one of
-        // the packer-supported native formats (block-float outputs like
+        // Disable packer L1 accumulation when (a) the user disabled it,
+        // (b) there is no tile_matmul that hits the packer L1-acc path,
+        // or (c) the matmul output element type is not one of the
+        // packer-supported native formats (block-float outputs like
         // bfp_bf8 are not supported and would silently corrupt results).
-        bool packerL1Acc = enableL1Acc && hasTileMatmul(loopOp) &&
-                           allTileMatmulOutputsSupportPackerL1Acc(loopOp);
+        bool disablePackerL1Acc =
+            disableL1Acc || !hasTileMatmul(loopOp) ||
+            !allTileMatmulOutputsSupportPackerL1Acc(loopOp);
 
         auto [copyInfos, dstIntermediates] =
             collectDstAccessesScheduled(gOp, *loopRegion, loopOp, dstCapacity);
 
         modified |= insertDstRegisterAccessFinalize(
-            rewriter, gOp, *loopRegion, dstCapacity, loopOp, packerL1Acc,
+            rewriter, gOp, *loopRegion, dstCapacity, loopOp, disablePackerL1Acc,
             copyInfos, dstIntermediates,
             [](PatternRewriter &rw, Location loc, Value dst,
-               const CopyInfoMap &ci, bool l1Acc) {
-              dataCopyGenerateScheduledAll(rw, loc, dst, ci, l1Acc);
+               const CopyInfoMap &ci, bool disableL1Acc) {
+              dataCopyGenerateScheduledAll(rw, loc, dst, ci, disableL1Acc);
             });
 
         return WalkResult::advance();
@@ -633,11 +635,11 @@ struct D2MInsertDstRegisterAccessScheduledRewriter final
 
         modified |= insertDstRegisterAccessFinalize(
             rewriter, gOp, *genericRegion, dstCapacity,
-            /*outermostInnerComputeLoop=*/nullptr, /*enableL1Acc=*/false,
+            /*outermostInnerComputeLoop=*/nullptr, /*disableL1Acc=*/true,
             copyInfos, dstIntermediates,
             [](PatternRewriter &rw, Location loc, Value dst,
-               const CopyInfoMap &ci, bool l1Acc) {
-              dataCopyGenerateScheduledAll(rw, loc, dst, ci, l1Acc);
+               const CopyInfoMap &ci, bool disableL1Acc) {
+              dataCopyGenerateScheduledAll(rw, loc, dst, ci, disableL1Acc);
             });
       }
     }
@@ -645,7 +647,7 @@ struct D2MInsertDstRegisterAccessScheduledRewriter final
   }
 
   unsigned maxDstPhysicalSizeTiles = 0;
-  bool enableL1Acc = false;
+  bool disableL1Acc = true;
 };
 
 // ---------------------------------------------------------------------------
@@ -669,7 +671,7 @@ public:
     MLIRContext *ctx = moduleOp.getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<D2MInsertDstRegisterAccessScheduledRewriter>(
-        ctx, maxDstPhysicalSizeTiles.getValue(), enableL1Acc);
+        ctx, maxDstPhysicalSizeTiles.getValue(), disableL1Acc);
 
     if (failed(applyPatternsGreedily(moduleOp, std::move(patterns)))) {
       signalPassFailure();

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessScheduled.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessScheduled.cpp
@@ -602,7 +602,12 @@ struct D2MInsertDstRegisterAccessScheduledRewriter final
         // Consume the scheduled attribute.
         loopOp->removeAttr("d2m.scheduled");
 
-        bool packerL1Acc = enableL1Acc && hasTileMatmul(loopOp);
+        // L1 accumulation requires (a) a tile_matmul that hits the packer
+        // L1-acc path, and (b) the matmul output element type to be one of
+        // the packer-supported native formats (block-float outputs like
+        // bfp_bf8 are not supported and would silently corrupt results).
+        bool packerL1Acc = enableL1Acc && hasTileMatmul(loopOp) &&
+                           allTileMatmulOutputsSupportPackerL1Acc(loopOp);
 
         auto [copyInfos, dstIntermediates] =
             collectDstAccessesScheduled(gOp, *loopRegion, loopOp, dstCapacity);

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.cpp
@@ -767,7 +767,7 @@ void emitDstCopyNest(
     llvm::function_ref<void(PatternRewriter &, LoadStoreRecord<LoadOrStoreTy>,
                             AffineMap, ValueRange)>
         accessReplacer,
-    bool enableL1Acc) {
+    bool disableL1Acc) {
   if (loadStoreRecords.empty()) {
     return;
   }
@@ -776,7 +776,7 @@ void emitDstCopyNest(
   // need a per-IV guard).
   Operation *copyLoop = nullptr;
   mlir::IRMapping copyLoopMapper;
-  if (!enableL1Acc) {
+  if (disableL1Acc) {
     std::tie(copyLoop, copyLoopMapper) =
         cloneAffineLoopSkeleton(rewriter, loopNestOrOp);
   }
@@ -787,7 +787,7 @@ void emitDstCopyNest(
     auto loadStoreMap = record.loadStore.getMap();
     auto loadStoreMemRefType = record.loadStore.getMemRefType();
 
-    if (!enableL1Acc) {
+    if (disableL1Acc) {
       mlir::IRMapping irMapper = copyLoopMapper;
       if (!record.guardIVs.empty()) {
         const bool isBcastGuard = record.bcast.has_value();
@@ -1107,7 +1107,7 @@ void insertPackerL1AccGuard(PatternRewriter &rewriter, Location loc,
 bool insertDstRegisterAccessFinalize(
     PatternRewriter &rewriter, GenericOp gOp, Region &region,
     unsigned dstCapacity, Operation *outermostInnerComputeLoop,
-    bool enableL1Acc, CopyInfoMap &copyInfos,
+    bool disableL1Acc, CopyInfoMap &copyInfos,
     DstIntermediatesMap &dstIntermediates,
     llvm::function_ref<void(PatternRewriter &, Location, Value,
                             const CopyInfoMap &, bool)>
@@ -1131,7 +1131,7 @@ bool insertDstRegisterAccessFinalize(
   Value dst = acquireDst.getResult();
 
   Value l1AccLoopIV = nullptr;
-  if (enableL1Acc) {
+  if (!disableL1Acc) {
     // L1-acc must be triggered by the outermost ancestor *reduction* loop --
     // i.e. an outer loop that does NOT index the output store. Using the
     // outermost ancestor unconditionally is incorrect for batched matmuls,
@@ -1144,15 +1144,15 @@ bool insertDstRegisterAccessFinalize(
     if (!l1AccLoopIV) {
       LDBG() << "Skipping L1 accumulation insertion: no outer reduction loop "
                 "with trip count > 1";
-      enableL1Acc = false;
+      disableL1Acc = true;
     }
   }
 
   // Emit path-specific data copy loops.
-  emitDataCopies(rewriter, loc, dst, copyInfos, enableL1Acc);
+  emitDataCopies(rewriter, loc, dst, copyInfos, disableL1Acc);
 
   // Insert optional L1 accumulation guard.
-  if (enableL1Acc) {
+  if (!disableL1Acc) {
     insertPackerL1AccGuard(rewriter, loc, acquireDst, l1AccLoopIV);
   }
 

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.cpp
@@ -182,6 +182,131 @@ bool isTileReductionOp(Operation *op) {
                    d2m::TileSFPUReduceSumOp>(op);
 }
 
+bool isPackerL1AccumulationSupportedDataType(ttcore::DataType dt) {
+  // The packer L1-acc path on Wormhole/Blackhole only operates on a fixed set
+  // of native formats. Block-float (bfp_*) outputs do NOT support L1
+  // accumulation: enabling it for those formats produces silently incorrect
+  // (catastrophic-PCC) results on hardware.
+  //
+  // Source of truth: tt-llk's `PACK_L1_ACC_FORMATS` in
+  // `tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py`:
+  //   { Float16_b, Float16, Float32, Int32, Int8, UInt8 }
+  // (we don't have an Int8 enum in TTCore, so it is absent here).
+  switch (dt) {
+  case ttcore::DataType::Float32:
+  case ttcore::DataType::Float16:
+  case ttcore::DataType::BFloat16:
+  case ttcore::DataType::Int32:
+  case ttcore::DataType::UInt8:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool allTileMatmulOutputsSupportPackerL1Acc(Operation *loopOp) {
+  bool allSupported = true;
+  loopOp->walk([&](d2m::TileMatmulOp matmul) {
+    auto tileType =
+        mlir::dyn_cast<ttcore::TileType>(matmul.getResult().getType());
+    if (!tileType) {
+      // Be conservative: if we can't determine the tile element type, do not
+      // enable L1-acc.
+      allSupported = false;
+      return WalkResult::interrupt();
+    }
+    if (!isPackerL1AccumulationSupportedDataType(tileType.getDataType())) {
+      allSupported = false;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return allSupported;
+}
+
+// Returns true iff any AffineStore (in `copyInfos.stores`) or memref::StoreOp
+// (in `copyInfos.memrefStores`) recorded for this region depends on `iv`.
+// "Depends on" includes transitive dependence through subview indices.
+static bool anyOutputStoreDependsOnIV(const CopyInfoMap &copyInfos, Value iv) {
+  for (const auto &[loopOrOp, copyInfo] : copyInfos) {
+    for (const auto &record : copyInfo.stores) {
+      if (record.loadStore && accessDependsOnIV(record.loadStore, iv)) {
+        return true;
+      }
+    }
+    for (const auto &record : copyInfo.memrefStores) {
+      if (record.loadStore && accessDependsOnIV(record.loadStore, iv)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Compute the static trip count of an affine.for / scf.for loop body by
+// using its constant lower/upper bound and step. Returns std::nullopt if the
+// loop is not constant-bounded (in which case we conservatively allow L1-acc
+// at runtime, matching legacy behavior for non-constant K loops).
+static std::optional<int64_t> tryGetConstantTripCount(Operation *loopOp) {
+  if (auto affineFor = mlir::dyn_cast<affine::AffineForOp>(loopOp)) {
+    if (!affineFor.hasConstantBounds()) {
+      return std::nullopt;
+    }
+    int64_t lb = affineFor.getConstantLowerBound();
+    int64_t ub = affineFor.getConstantUpperBound();
+    int64_t step = affineFor.getStepAsInt();
+    if (step <= 0) {
+      return std::nullopt;
+    }
+    return llvm::divideCeil(std::max<int64_t>(0, ub - lb), step);
+  }
+  if (auto scfFor = mlir::dyn_cast<scf::ForOp>(loopOp)) {
+    auto lbCst = scfFor.getLowerBound().getDefiningOp<arith::ConstantIndexOp>();
+    auto ubCst = scfFor.getUpperBound().getDefiningOp<arith::ConstantIndexOp>();
+    auto stepCst = scfFor.getStep().getDefiningOp<arith::ConstantIndexOp>();
+    if (!lbCst || !ubCst || !stepCst) {
+      return std::nullopt;
+    }
+    int64_t lb = lbCst.value();
+    int64_t ub = ubCst.value();
+    int64_t step = stepCst.value();
+    if (step <= 0) {
+      return std::nullopt;
+    }
+    return llvm::divideCeil(std::max<int64_t>(0, ub - lb), step);
+  }
+  return std::nullopt;
+}
+
+Value findOutermostReductionLoopIVForL1Acc(Operation *acquireDstOp,
+                                           const CopyInfoMap &copyInfos) {
+  // `collectAncestorLoopIVs` returns IVs in outermost-to-innermost order
+  // (it reverses the upward walk).
+  SmallVector<Value> ancestorIVs = collectAncestorLoopIVs(acquireDstOp);
+  for (Value iv : ancestorIVs) {
+    if (anyOutputStoreDependsOnIV(copyInfos, iv)) {
+      // This loop indexes the output -- it is parallel, not a reduction.
+      continue;
+    }
+    // Found the outermost reduction loop. Only enable L1-acc if the loop
+    // actually iterates more than once (otherwise the per-iteration
+    // accumulation guard would never fire and we'd just emit dead code).
+    Operation *loopOp = nullptr;
+    if (auto blockArg = mlir::dyn_cast<BlockArgument>(iv)) {
+      loopOp = blockArg.getOwner()->getParentOp();
+    }
+    if (!loopOp) {
+      return nullptr;
+    }
+    std::optional<int64_t> tripCount = tryGetConstantTripCount(loopOp);
+    if (tripCount.has_value() && *tripCount <= 1) {
+      return nullptr;
+    }
+    return iv;
+  }
+  return nullptr;
+}
+
 void setDstScratchIndex(OperandLoadStoreRegisterOpInterface computeOp,
                         int scratchSlice) {
   TT_assertv(computeOp.getNumDstScratchSlices() == 1,
@@ -1007,13 +1132,18 @@ bool insertDstRegisterAccessFinalize(
 
   Value l1AccLoopIV = nullptr;
   if (enableL1Acc) {
-    SmallVector<Value> loopIVsInScope =
-        collectAncestorLoopIVs(acquireDst.getOperation());
-    if (!loopIVsInScope.empty()) {
-      l1AccLoopIV = loopIVsInScope.front();
-    }
+    // L1-acc must be triggered by the outermost ancestor *reduction* loop --
+    // i.e. an outer loop that does NOT index the output store. Using the
+    // outermost ancestor unconditionally is incorrect for batched matmuls,
+    // where the outermost loop is parallel (e.g. the batch dim) and turning
+    // on L1-acc on its second iteration would cause the packer to accumulate
+    // a fresh batch's tile into uninitialized L1 contents at a different
+    // output address.
+    l1AccLoopIV = findOutermostReductionLoopIVForL1Acc(
+        acquireDst.getOperation(), copyInfos);
     if (!l1AccLoopIV) {
-      LDBG() << "Skipping L1 accumulation insertion: no in-scope loop IV";
+      LDBG() << "Skipping L1 accumulation insertion: no outer reduction loop "
+                "with trip count > 1";
       enableL1Acc = false;
     }
   }

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessUnscheduled.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessUnscheduled.cpp
@@ -390,7 +390,12 @@ struct D2MInsertDstRegisterAccessUnscheduledRewriter final
 
         loopOp->setAttr("d2m.dst_access_inserted", rewriter.getUnitAttr());
 
-        bool packerL1Acc = enableL1Acc && hasTileMatmul(loopOp);
+        // L1 accumulation requires (a) a tile_matmul that hits the packer
+        // L1-acc path, and (b) the matmul output element type to be one of
+        // the packer-supported native formats (block-float outputs like
+        // bfp_bf8 are not supported and would silently corrupt results).
+        bool packerL1Acc = enableL1Acc && hasTileMatmul(loopOp) &&
+                           allTileMatmulOutputsSupportPackerL1Acc(loopOp);
 
         auto [copyInfos, dstIntermediates] =
             collectDstAccesses(gOp, *loopRegion, loopOp);

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessUnscheduled.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessUnscheduled.cpp
@@ -223,7 +223,7 @@ collectDstAccesses(GenericOp gOp, Region &region,
 // in place and rewritten to access DST instead of CB.
 static void dataCopyGenerate(PatternRewriter &rewriter, Location loc, Value dst,
                              const CopyInfoMap &copyInfos,
-                             bool enableL1Acc = false) {
+                             bool disableL1Acc = true) {
   for (const auto &[loopNestOrOp, copyInfo] : copyInfos) {
     rewriter.setInsertionPointAfter(loopNestOrOp);
     auto insertionPointAfterLoopNest = rewriter.saveInsertionPoint();
@@ -271,7 +271,7 @@ static void dataCopyGenerate(PatternRewriter &rewriter, Location loc, Value dst,
     emitDstCopyNest<affine::AffineLoadOp>(rewriter, loopNestOrOp,
                                           copyInfo.loads, loadAccessGenerator,
                                           loadAccessRewriter,
-                                          /*enableL1Acc=*/enableL1Acc);
+                                          /*disableL1Acc=*/disableL1Acc);
 
     // Step 2: store copy loop.
     rewriter.restoreInsertionPoint(insertionPointAfterLoopNest);
@@ -330,10 +330,10 @@ struct D2MInsertDstRegisterAccessUnscheduledRewriter final
     : public OpRewritePattern<GenericOp> {
   D2MInsertDstRegisterAccessUnscheduledRewriter(
       mlir::MLIRContext *ctx, unsigned maxDstPhysicalSizeTiles,
-      bool enableL1Acc)
+      bool disableL1Acc)
       : OpRewritePattern<GenericOp>(ctx),
         maxDstPhysicalSizeTiles(maxDstPhysicalSizeTiles),
-        enableL1Acc(enableL1Acc) {}
+        disableL1Acc(disableL1Acc) {}
 
   LogicalResult matchAndRewrite(GenericOp gOp,
                                 PatternRewriter &rewriter) const final {
@@ -390,22 +390,25 @@ struct D2MInsertDstRegisterAccessUnscheduledRewriter final
 
         loopOp->setAttr("d2m.dst_access_inserted", rewriter.getUnitAttr());
 
-        // L1 accumulation requires (a) a tile_matmul that hits the packer
-        // L1-acc path, and (b) the matmul output element type to be one of
-        // the packer-supported native formats (block-float outputs like
+        // Disable packer L1 accumulation when (a) the user disabled it,
+        // (b) there is no tile_matmul that hits the packer L1-acc path,
+        // or (c) the matmul output element type is not one of the
+        // packer-supported native formats (block-float outputs like
         // bfp_bf8 are not supported and would silently corrupt results).
-        bool packerL1Acc = enableL1Acc && hasTileMatmul(loopOp) &&
-                           allTileMatmulOutputsSupportPackerL1Acc(loopOp);
+        bool disablePackerL1Acc =
+            disableL1Acc || !hasTileMatmul(loopOp) ||
+            !allTileMatmulOutputsSupportPackerL1Acc(loopOp);
 
         auto [copyInfos, dstIntermediates] =
             collectDstAccesses(gOp, *loopRegion, loopOp);
 
         modified |= insertDstRegisterAccessFinalize(
-            rewriter, gOp, *loopRegion, dstCapacity, loopOp, packerL1Acc,
+            rewriter, gOp, *loopRegion, dstCapacity, loopOp, disablePackerL1Acc,
             copyInfos, dstIntermediates,
             [](PatternRewriter &rw, Location loc, Value dst,
-               const CopyInfoMap &ci,
-               bool l1Acc) { dataCopyGenerate(rw, loc, dst, ci, l1Acc); });
+               const CopyInfoMap &ci, bool disableL1Acc) {
+              dataCopyGenerate(rw, loc, dst, ci, disableL1Acc);
+            });
 
         return WalkResult::advance();
       });
@@ -414,7 +417,7 @@ struct D2MInsertDstRegisterAccessUnscheduledRewriter final
   }
 
   unsigned maxDstPhysicalSizeTiles = 0;
-  bool enableL1Acc = false;
+  bool disableL1Acc = true;
 };
 
 // ---------------------------------------------------------------------------
@@ -438,7 +441,7 @@ public:
     MLIRContext *ctx = moduleOp.getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<D2MInsertDstRegisterAccessUnscheduledRewriter>(
-        ctx, maxDstPhysicalSizeTiles.getValue(), enableL1Acc);
+        ctx, maxDstPhysicalSizeTiles.getValue(), disableL1Acc);
 
     if (failed(applyPatternsGreedily(moduleOp, std::move(patterns)))) {
       signalPassFailure();

--- a/test/python/golden/d2m/test_generic.py
+++ b/test/python/golden/d2m/test_generic.py
@@ -60,7 +60,6 @@ def read_artifact(output_root: Path, test_base: str, filename: str) -> str:
     ],
 )
 @pytest.mark.parametrize("dtype", ["bf16"])
-@pytest.mark.parametrize("enable_l1_acc", [True])
 @pytest.mark.parametrize("use_tile_matmul", [False])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_generic(
@@ -69,7 +68,6 @@ def test_generic(
     block_factors,
     interchange,
     dtype,
-    enable_l1_acc,
     use_tile_matmul,
     target: str,
     request,
@@ -204,7 +202,6 @@ def test_generic(
 
     options = [
         f"use-tile-matmul={use_tile_matmul}",
-        f"enable-l1-acc={enable_l1_acc}",
     ]
     compile_and_execute_d2m(
         generic_module,
@@ -341,7 +338,7 @@ def test_generic_allocator_reblock_policy(
         custom_pipeline=(
             "ttir-to-ttmetal-pipeline{"
             f"test-buffer-size-policy={buffer_policy} "
-            "use-tile-matmul=false enable-l1-acc=false}"
+            "use-tile-matmul=false disable-l1-acc=true}"
         ),
         check_pcc=True,
         print_ir=False,

--- a/test/python/golden/d2m/test_matmul.py
+++ b/test/python/golden/d2m/test_matmul.py
@@ -53,11 +53,17 @@ def get_allocator_policy_override(
     if (
         dtype == torch.bfloat16
         and enable_l1_acc
-        and shape in ((1024, 2048, 2048), (2048, 2048, 2048))
+        and shape
+        in (
+            (1024, 2048, 2048),
+            (2048, 2048, 2048),
+        )
     ):
         # `auto` over-splits the reduction panel for these large bf16 matmuls,
-        # which increases partial accumulations and hurts PCC.
-        # TODO (anuragsingh): Revert this to the default allocator policy once precision issues are fixed.
+        # which increases the number of partial accumulations through the L1
+        # panel and degrades PCC even with L1-acc enabled.
+        # TODO (anuragsingh): Revert this to the default allocator policy
+        # once precision issues are fixed.
         # Issue here: https://github.com/tenstorrent/tt-mlir/issues/7656
         return ["test-buffer-size-policy=max"]
     return []
@@ -152,6 +158,22 @@ def test_matmul_ttnn_shapes_single_buffered(
     device,
 ):
     pcc = 0.99 if dtype == torch.float32 else 0.96
+    if (
+        dtype == torch.bfloat16
+        and not enable_l1_acc
+        and shape
+        in (
+            (1024, 2048, 2048),
+            (2048, 2048, 2048),
+        )
+    ):
+        # Without L1-acc, each K-block boundary requires DST(fp32) -> L1(bf16)
+        # -> DST(fp32) round-trips through the partial-sum CB. For these large
+        # bf16 matmuls the cumulative bf16 truncation drops PCC below 0.96
+        # even after forcing the largest K-block (test-buffer-size-policy=max).
+        # The proper fix (e.g. fp32_dest_acc_en or an fp32 partial-sum CB) is
+        # tracked here: https://github.com/tenstorrent/tt-mlir/issues/7656
+        pytest.xfail(reason="bf16 no-L1-acc PCC below threshold for these shapes")
 
     lhs = (
         shape[0],
@@ -213,6 +235,22 @@ def test_matmul_ttnn_shapes_double_buffered(
     pcc = 0.99 if dtype == torch.float32 else 0.96
     if dtype == torch.float32 and shape == (2048, 2048, 2048):
         pytest.xfail(reason="Too large for f32.")
+    if (
+        dtype == torch.bfloat16
+        and not enable_l1_acc
+        and shape
+        in (
+            (1024, 2048, 2048),
+            (2048, 2048, 2048),
+        )
+    ):
+        # Without L1-acc, each K-block boundary requires DST(fp32) -> L1(bf16)
+        # -> DST(fp32) round-trips through the partial-sum CB. For these large
+        # bf16 matmuls the cumulative bf16 truncation drops PCC below 0.96
+        # even after forcing the largest K-block (test-buffer-size-policy=max).
+        # The proper fix (e.g. fp32_dest_acc_en or an fp32 partial-sum CB) is
+        # tracked here: https://github.com/tenstorrent/tt-mlir/issues/7656
+        pytest.xfail(reason="bf16 no-L1-acc PCC below threshold for these shapes")
 
     lhs = (
         shape[0],

--- a/test/python/golden/d2m/test_matmul.py
+++ b/test/python/golden/d2m/test_matmul.py
@@ -48,11 +48,11 @@ def create_matmul_constrained_inputs(lhs_shape, rhs_shape, dtype=torch.float32):
 
 
 def get_allocator_policy_override(
-    shape: tuple[int, ...], dtype: torch.dtype, enable_l1_acc: bool
+    shape: tuple[int, ...], dtype: torch.dtype, disable_l1_acc: bool
 ) -> list[str]:
     if (
         dtype == torch.bfloat16
-        and enable_l1_acc
+        and not disable_l1_acc
         and shape
         in (
             (1024, 2048, 2048),
@@ -145,14 +145,14 @@ def test_matmul_multi_core_8otpc(m: int, k: int, n: int, target: str, request, d
 @pytest.mark.parametrize(
     "use_tile_matmul", [True, False], ids=["matmul_tile", "matmul_block"]
 )
-@pytest.mark.parametrize("enable_l1_acc", [True, False], ids=["l1_acc", "no_l1_acc"])
+@pytest.mark.parametrize("disable_l1_acc", [False, True], ids=["l1_acc", "no_l1_acc"])
 @pytest.mark.parametrize("target", ["ttmetal"])
 # Large matmuls, based on ttnn's matmul benchmarks
 def test_matmul_ttnn_shapes_single_buffered(
     shape: tuple[int, ...],
     dtype: torch.dtype,
     use_tile_matmul: bool,
-    enable_l1_acc: bool,
+    disable_l1_acc: bool,
     target: str,
     request,
     device,
@@ -160,7 +160,7 @@ def test_matmul_ttnn_shapes_single_buffered(
     pcc = 0.99 if dtype == torch.float32 else 0.96
     if (
         dtype == torch.bfloat16
-        and not enable_l1_acc
+        and disable_l1_acc
         and shape
         in (
             (1024, 2048, 2048),
@@ -188,9 +188,9 @@ def test_matmul_ttnn_shapes_single_buffered(
         f"matmul-interchange=2,0,1",
         f"num-stream-buffers=1",
         f"use-tile-matmul={use_tile_matmul}",
-        f"enable-l1-acc={enable_l1_acc}",
+        f"disable-l1-acc={disable_l1_acc}",
     ]
-    options.extend(get_allocator_policy_override(shape, dtype, enable_l1_acc))
+    options.extend(get_allocator_policy_override(shape, dtype, disable_l1_acc))
     compile_and_execute_ttir(
         create_matmul_constrained_inputs(lhs, rhs, dtype),
         target=target,
@@ -220,14 +220,14 @@ def test_matmul_ttnn_shapes_single_buffered(
 @pytest.mark.parametrize(
     "use_tile_matmul", [True, False], ids=["matmul_tile", "matmul_block"]
 )
-@pytest.mark.parametrize("enable_l1_acc", [True, False], ids=["l1_acc", "no_l1_acc"])
+@pytest.mark.parametrize("disable_l1_acc", [False, True], ids=["l1_acc", "no_l1_acc"])
 @pytest.mark.parametrize("target", ["ttmetal"])
 # Large matmuls, based on ttnn's matmul benchmarks
 def test_matmul_ttnn_shapes_double_buffered(
     shape: tuple[int, ...],
     dtype: torch.dtype,
     use_tile_matmul: bool,
-    enable_l1_acc: bool,
+    disable_l1_acc: bool,
     target: str,
     request,
     device,
@@ -237,7 +237,7 @@ def test_matmul_ttnn_shapes_double_buffered(
         pytest.xfail(reason="Too large for f32.")
     if (
         dtype == torch.bfloat16
-        and not enable_l1_acc
+        and disable_l1_acc
         and shape
         in (
             (1024, 2048, 2048),
@@ -264,9 +264,9 @@ def test_matmul_ttnn_shapes_double_buffered(
     options = [
         f"matmul-interchange=2,0,1",
         f"use-tile-matmul={use_tile_matmul}",
-        f"enable-l1-acc={enable_l1_acc}",
+        f"disable-l1-acc={disable_l1_acc}",
     ]
-    options.extend(get_allocator_policy_override(shape, dtype, enable_l1_acc))
+    options.extend(get_allocator_policy_override(shape, dtype, disable_l1_acc))
     compile_and_execute_ttir(
         create_matmul_constrained_inputs(lhs, rhs, dtype),
         target=target,

--- a/test/python/golden/d2m/test_matmul.py
+++ b/test/python/golden/d2m/test_matmul.py
@@ -152,16 +152,6 @@ def test_matmul_ttnn_shapes_single_buffered(
     device,
 ):
     pcc = 0.99 if dtype == torch.float32 else 0.96
-    if (
-        dtype == torch.bfloat16
-        and not enable_l1_acc
-        and shape
-        in (
-            (2048, 2048, 2048),
-            (1024, 2048, 2048),
-        )
-    ):
-        pytest.xfail(reason="bf16 PCC below threshold for these shapes")
 
     lhs = (
         shape[0],
@@ -223,17 +213,6 @@ def test_matmul_ttnn_shapes_double_buffered(
     pcc = 0.99 if dtype == torch.float32 else 0.96
     if dtype == torch.float32 and shape == (2048, 2048, 2048):
         pytest.xfail(reason="Too large for f32.")
-
-    if (
-        dtype == torch.bfloat16
-        and not enable_l1_acc
-        and shape
-        in (
-            (2048, 2048, 2048),
-            (1024, 2048, 2048),
-        )
-    ):
-        pytest.xfail(reason="bf16 PCC below threshold for these shapes")
 
     lhs = (
         shape[0],

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_l1_acc.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_l1_acc.mlir
@@ -2,15 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// RUN: ttmlir-opt --ttcore-register-device --d2m-insert-dst-register-access-unscheduled="enable-l1-acc=true" --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-insert-dst-register-access-unscheduled --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// Tests L1 accumulation guard insertion in the unscheduled pass:
+// Tests L1 accumulation guard insertion in the unscheduled pass (with the
+// default disable-l1-acc=false, i.e. L1 accumulation enabled):
 //
-// 1. `matmul_l1_acc`: with enable-l1-acc=true and an outer K-block
-//    reduction loop wrapping a tile_matmul root, expect a
-//    d2m.set_l1_accumulate guarded by an scf.if on the K-block IV (the
-//    outermost ancestor whose IV the output store does NOT depend on).
+// 1. `matmul_l1_acc`: with an outer K-block reduction loop wrapping a
+//    tile_matmul root, expect a d2m.set_l1_accumulate guarded by an
+//    scf.if on the K-block IV (the outermost ancestor whose IV the
+//    output store does NOT depend on).
 //
 // 2. `matmul_no_outer_reduction`: when the only ancestor loops of
 //    acquire_dst are *parallel* (output indexed by them), L1-acc must

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_l1_acc.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_l1_acc.mlir
@@ -5,9 +5,18 @@
 // RUN: ttmlir-opt --ttcore-register-device --d2m-insert-dst-register-access-unscheduled="enable-l1-acc=true" --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// Tests L1 accumulation guard insertion in the unscheduled pass: with
-// enable-l1-acc=true and a tile_matmul root, expect a d2m.set_l1_accumulate
-// guarded by scf.if on the outer tiling IV.
+// Tests L1 accumulation guard insertion in the unscheduled pass:
+//
+// 1. `matmul_l1_acc`: with enable-l1-acc=true and an outer K-block
+//    reduction loop wrapping a tile_matmul root, expect a
+//    d2m.set_l1_accumulate guarded by an scf.if on the K-block IV (the
+//    outermost ancestor whose IV the output store does NOT depend on).
+//
+// 2. `matmul_no_outer_reduction`: when the only ancestor loops of
+//    acquire_dst are *parallel* (output indexed by them), L1-acc must
+//    NOT be enabled. Using the outermost loop unconditionally is
+//    incorrect for cases like batched matmuls where the outermost loop
+//    is parallel.
 
 #l1_ = #ttcore.memory_space<l1>
 #dst_ = #ttcore.memory_space<dst>
@@ -15,6 +24,60 @@
 module {
   // CHECK-LABEL: func.func @matmul_l1_acc
   func.func @matmul_l1_acc(
+      %in0: memref<1x1x4x4x!ttcore.tile<32x32, f16>, #ttcore.shard<8192x2048, 1>, #l1_>,
+      %in1: memref<1x1x4x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048, 1>, #l1_>,
+      %out0: memref<1x1x2x2x!ttcore.tile<32x32, f16>, #ttcore.shard<2048x2048, 1>, #l1_>) {
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%in0, %in1 : memref<1x1x4x4x!ttcore.tile<32x32, f16>, #ttcore.shard<8192x2048, 1>, #l1_>, memref<1x1x4x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048, 1>, #l1_>)
+        outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f16>, #ttcore.shard<2048x2048, 1>, #l1_>) {
+    ^unified0:
+      %cb0_raw = d2m.get_cb(0) : !d2m.cb<memref<4x4x!ttcore.tile<32x32, f16>, #l1_>>
+      %cb1_raw = d2m.get_cb(1) : !d2m.cb<memref<4x2x!ttcore.tile<32x32, f16>, #l1_>>
+      %cb2_raw = d2m.get_cb(2) : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f16>, #l1_>>
+      %cb0 = d2m.wait %cb0_raw : !d2m.cb<memref<4x4x!ttcore.tile<32x32, f16>, #l1_>> -> memref<4x4x!ttcore.tile<32x32, f16>, #l1_>
+      %cb1 = d2m.wait %cb1_raw : !d2m.cb<memref<4x2x!ttcore.tile<32x32, f16>, #l1_>> -> memref<4x2x!ttcore.tile<32x32, f16>, #l1_>
+      %cb2 = d2m.reserve %cb2_raw : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f16>, #l1_>> -> memref<2x2x!ttcore.tile<32x32, f16>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      %c4 = arith.constant 4 : index
+      // Outer K-block reduction loop with 2 iterations (K0=0, K0=2). Note:
+      // the output (sv2 = subview of cb2) does NOT depend on %k_block, so
+      // this is the correct reduction loop to use as the L1-acc trigger.
+      scf.for %k_block = %c0 to %c4 step %c2 {
+        %sv0 = memref.subview %cb0[%c0, %k_block] [2, 2] [1, 1] : memref<4x4x!ttcore.tile<32x32, f16>, #l1_> to memref<2x2x!ttcore.tile<32x32, f16>, strided<[4, 1], offset: ?>, #l1_>
+        %sv1 = memref.subview %cb1[%k_block, %c0] [2, 2] [1, 1] : memref<4x2x!ttcore.tile<32x32, f16>, #l1_> to memref<2x2x!ttcore.tile<32x32, f16>, strided<[2, 1], offset: ?>, #l1_>
+        %sv2 = memref.subview %cb2[%c0, %c0] [2, 2] [1, 1] : memref<2x2x!ttcore.tile<32x32, f16>, #l1_> to memref<2x2x!ttcore.tile<32x32, f16>, strided<[2, 1], offset: ?>, #l1_>
+        affine.for %i = 0 to 2 {
+          affine.for %j = 0 to 2 {
+            affine.for %k = 0 to 2 {
+              %a = affine.load %sv0[%i, %k] : memref<2x2x!ttcore.tile<32x32, f16>, strided<[4, 1], offset: ?>, #l1_>
+              %b = affine.load %sv1[%k, %j] : memref<2x2x!ttcore.tile<32x32, f16>, strided<[2, 1], offset: ?>, #l1_>
+              %c = affine.load %sv2[%i, %j] : memref<2x2x!ttcore.tile<32x32, f16>, strided<[2, 1], offset: ?>, #l1_>
+              %r = "d2m.tile_matmul"(%a, %b, %c) : (!ttcore.tile<32x32, f16>, !ttcore.tile<32x32, f16>, !ttcore.tile<32x32, f16>) -> !ttcore.tile<32x32, f16>
+              affine.store %r, %sv2[%i, %j] : memref<2x2x!ttcore.tile<32x32, f16>, strided<[2, 1], offset: ?>, #l1_>
+            }
+          }
+        } {d2m.linalg_root}
+      }
+    }
+    return
+  }
+  // acquire_dst placed inside the K-block scf.for:
+  // CHECK: scf.for %[[K_BLOCK:.*]] = %c0
+  // CHECK:   %[[DST:.*]] = d2m.acquire_dst() : memref<{{[0-9]+}}x!ttcore.tile<32x32, f16>, #dst>
+  // L1 accumulation guard: triggers when %k_block != 0 (i.e. on second
+  // iteration of the K-block reduction loop):
+  // CHECK:   %[[CMP:.*]] = arith.cmpi eq, %[[K_BLOCK]]
+  // CHECK:   scf.if %[[CMP]]
+  // CHECK:     d2m.set_l1_accumulate
+  // Compute loop with matmul:
+  // CHECK:   affine.for
+  // CHECK:     affine.for
+  // CHECK:       affine.for
+  // CHECK:         "d2m.tile_matmul"
+
+  // CHECK-LABEL: func.func @matmul_no_outer_reduction
+  func.func @matmul_no_outer_reduction(
       %in0: memref<1x1x4x4x!ttcore.tile<32x32, f16>, #ttcore.shard<8192x2048, 1>, #l1_>,
       %in1: memref<1x1x4x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048, 1>, #l1_>,
       %out0: memref<1x1x4x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048, 1>, #l1_>) {
@@ -31,7 +94,9 @@ module {
       %c0 = arith.constant 0 : index
       %c2 = arith.constant 2 : index
       %c4 = arith.constant 4 : index
-      // Outer tiling loop with 2 iterations (0, 2):
+      // Outer parallel tiling loop over M positions: the output cb2 IS
+      // indexed by %tile_i, so %tile_i is a *parallel* loop, not a
+      // reduction loop. L1-acc must NOT be enabled here.
       scf.for %tile_i = %c0 to %c4 step %c2 {
         scf.for %tile_j = %c0 to %c2 step %c2 {
           %sv0 = memref.subview %cb0[%tile_i, %c0] [2, 4] [1, 1] : memref<4x4x!ttcore.tile<32x32, f16>, #l1_> to memref<2x4x!ttcore.tile<32x32, f16>, strided<[4, 1], offset: ?>, #l1_>
@@ -53,16 +118,5 @@ module {
     }
     return
   }
-  // acquire_dst placed inside the scf.for:
-  // CHECK: scf.for %[[TILE_I:.*]] =
-  // CHECK:   %[[DST:.*]] = d2m.acquire_dst() : memref<8x!ttcore.tile<32x32, f16>, #dst>
-  // L1 accumulation guard: checks if %tile_i == second_iteration_value:
-  // CHECK:   %[[CMP:.*]] = arith.cmpi eq, %[[TILE_I]]
-  // CHECK:   scf.if %[[CMP]]
-  // CHECK:     d2m.set_l1_accumulate
-  // Compute loop with matmul:
-  // CHECK:   affine.for
-  // CHECK:     affine.for
-  // CHECK:       affine.for
-  // CHECK:         "d2m.tile_matmul"
+  // CHECK-NOT: d2m.set_l1_accumulate
 }

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled --d2m-insert-tile-matmul-block --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="enable-l1-acc=false" --d2m-insert-tile-matmul-block --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="enable-l1-acc=false" --d2m-insert-tile-matmul-block --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="disable-l1-acc=true" --d2m-insert-tile-matmul-block --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="max-dst-physical-size-tiles=32 enable-l1-acc=false" --d2m-insert-tile-matmul-block --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="max-dst-physical-size-tiles=32 disable-l1-acc=true" --d2m-insert-tile-matmul-block --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="max-dst-physical-size-tiles=32" --d2m-insert-tile-matmul-block --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="max-dst-physical-size-tiles=32 enable-l1-acc=false" --d2m-insert-tile-matmul-block --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled --d2m-insert-tile-matmul-block="use-tile-matmul=true" --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="enable-l1-acc=false" --d2m-insert-tile-matmul-block="use-tile-matmul=true" --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="enable-l1-acc=false" --d2m-insert-tile-matmul-block="use-tile-matmul=true" --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="disable-l1-acc=true" --d2m-insert-tile-matmul-block="use-tile-matmul=true" --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="max-dst-physical-size-tiles=32" --d2m-insert-tile-matmul-block="use-tile-matmul=true" --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="max-dst-physical-size-tiles=32 enable-l1-acc=false" --d2m-insert-tile-matmul-block="use-tile-matmul=true" --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="max-dst-physical-size-tiles=32 enable-l1-acc=false" --d2m-insert-tile-matmul-block="use-tile-matmul=true" --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access-unscheduled="max-dst-physical-size-tiles=32 disable-l1-acc=true" --d2m-insert-tile-matmul-block="use-tile-matmul=true" --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8366

### Problem description
l1-accumulation was turned off by default in d2m.

### What's changed
1. **Enable L1-accumulation by default in D2M** (the main goal of this PR). The user-facing knob is now `disable-l1-acc` (default `false`); to opt out, pass `disable-l1-acc=true`. The previous `enable-l1-acc` option (default `false`) has been removed; `disableL1Acc` is now the single source of truth across pass/pipeline options, internal C++ (`InsertDstRegisterAccess{Shared,Unscheduled,Scheduled}.{h,cpp}`), MLIR lit tests, and Python golden tests.
2. **Correctness fixes required to safely enable L1-acc by default** (gated in `InsertDstRegisterAccess{Unscheduled,Scheduled}`):
   - **Skip L1-acc when the matmul output element type is not in the packer's L1-acc supported set.** Per tt-llk's `PACK_L1_ACC_FORMATS`, only `Float32 / Float16 / BFloat16 / Int32 / UInt8` are supported. Block-float outputs (e.g. `bfp_bf8`) would silently produce garbage results (PCC ~0).
   - **Trigger the L1-acc guard on the outermost reduction loop, not the outermost ancestor loop.** A "reduction" loop here is an ancestor loop whose IV no recorded output store depends on. The previous unconditional outermost-ancestor behavior was wrong for batched matmuls — the outermost loop is the parallel batch dimension, so turning on L1-acc on the second batch iteration would accumulate into uninitialized L1 at a different output address (e.g. PCC ~0.31 for `test_matmul_3d_single_core[batch2_small]`).
   - **Skip L1-acc when the candidate reduction loop has constant trip count ≤ 1** (accumulation is a no-op anyway).
3. **Test updates:**
   - Restored `pytest.xfail` for `bf16 + no_l1_acc + (1024|2048)x2048x2048` matmul tests, with a comment linking to [#7656](https://github.com/tenstorrent/tt-mlir/issues/7656). These cases test the no-L1-acc path which has fundamental bf16 precision limitations from cumulative round-trips through the partial-sum CB; the proper fix (e.g. `fp32_dest_acc_en` or an fp32 partial-sum CB) is tracked in #7656.
   - Updated `insert_dst_register_access_l1_acc.mlir` to validate (a) the corrected L1-acc trigger on a real outer K-block reduction loop, and (b) that L1-acc is correctly **not** inserted when only parallel ancestor loops exist.

### Why no profitability analysis ?
The selective gating above is **correctness-based**, not profitability-based — it disables L1-acc only in cases where the packer cannot honor it or the trigger loop is not actually a reduction. We do **not** gate L1-acc on a profitability heuristic: based on the following evidence, matmul kernels almost always benefit from it.

**Evidence 1:**
<img width="1540" height="728" alt="image" src="https://github.com/user-attachments/assets/77eb3916-2e0c-4230-a051-0350350efffe" />

**Evidence 2:**
This PR should also have positive effect on the [ttnn-jit dashboard](https://superset.tenstorrent.com/superset/dashboard/479/).  

| shape (M×K×N)   | dtype   | mem              | math fid. | L1 ON µs | L1 OFF µs | speedup |
|-----------------|---------|------------------|-----------|---------:|----------:|--------:|
| 2048×2048×2048  | bf16    | dram_interleaved | HiFi4     |    325.1 |     523.9 | 1.61x |
| 2048×2048×2048  | bf16    | l1_dram          | HiFi4     |    323.4 |     522.2 | 1.61x |
| 2048×2048×2048  | bfp8_b  | dram_interleaved | HiFi2     |    180.8 |     339.7 | 1.88x |
| 2048×2048×2048  | bfp8_b  | l1_dram          | HiFi2     |    180.2 |     336.8 | 1.87x |
| 2048×2048×1024  | bf16    | dram_interleaved | HiFi4     |    213.4 |     289.0 | 1.35x   |
| 2048×2048×1024  | bf16    | l1_dram          | HiFi4     |    180.0 |     285.7 | 1.59x   |
| 2048×2048×1024  | bfp8_b  | dram_interleaved | HiFi2     |    122.9 |     197.0 | 1.60x   |
| 2048×2048×1024  | bfp8_b  | l1_dram          | HiFi2     |    103.9 |     196.0 | 1.89x |
| 1024×2048×2048  | bf16    | dram_interleaved | HiFi4     |    179.6 |     281.0 | 1.56x   |
| 1024×2048×2048  | bf16    | l1_dram          | HiFi4     |    179.7 |     279.9 | 1.56x   |
| 1024×2048×2048  | bfp8_b  | dram_interleaved | HiFi2     |    104.2 |     186.8 | 1.79x   |
| 1024×2048×2048  | bfp8_b  | l1_dram          | HiFi2     |    103.9 |     186.2 | 1.79x   |
| 2048×1024×1024  | bf16    | dram_interleaved | HiFi4     |    111.2 |     147.7 | 1.33x   |
| 2048×1024×1024  | bf16    | l1_dram          | HiFi4     |     91.5 |     143.1 | 1.56x   |
| 2048×1024×1024  | bfp8_b  | dram_interleaved | HiFi2     |     62.5 |     100.3 | 1.60x   |
| 2048×1024×1024  | bfp8_b  | l1_dram          | HiFi2     |     52.8 |      98.4 | 1.86x   |
| 1024×1024×2048  | bf16    | dram_interleaved | HiFi4     |     91.8 |     141.0 | 1.54x   |
| 1024×1024×2048  | bf16    | l1_dram          | HiFi4     |     91.4 |     140.2 | 1.53x   |
| 1024×1024×2048  | bfp8_b  | dram_interleaved | HiFi2     |     53.5 |      94.2 | 1.76x   |
| 1024×1024×2048  | bfp8_b  | l1_dram          | HiFi2     |     53.1 |      93.6 | 1.76x   |
| 1024×1024×1024  | bf16    | dram_interleaved | HiFi4     |     58.3 |      83.2 | 1.43x   |
| 1024×1024×1024  | bf16    | l1_dram          | HiFi4     |     55.8 |      82.5 | 1.48x   |
| 1024×1024×1024  | bfp8_b  | dram_interleaved | HiFi2     |     35.4 |      57.8 | 1.63x   |
| 1024×1024×1024  | bfp8_b  | l1_dram          | HiFi2     |     34.8 |      57.9 | 1.67x   |
| 2048×1024×512   | bf16    | dram_interleaved | HiFi4     |    109.0 |     108.9 | 1.00x   |
| 2048×1024×512   | bf16    | l1_dram          | HiFi4     |     55.6 |      62.3 | 1.12x   |
| 2048×1024×512   | bfp8_b  | dram_interleaved | HiFi2     |     62.7 |      62.8 | 1.00x   |
| 2048×1024×512   | bfp8_b  | l1_dram          | HiFi2     |     33.5 |      40.5 | 1.21x   |
| 1024×1024×512   | bf16    | dram_interleaved | HiFi4     |     54.5 |      55.0 | 1.01x   |
| 1024×1024×512   | bf16    | l1_dram          | HiFi4     |     29.4 |      36.2 | 1.23x   |
| 1024×1024×512   | bfp8_b  | dram_interleaved | HiFi2     |     30.7 |      32.7 | 1.07x   |
| 1024×1024×512   | bfp8_b  | l1_dram          | HiFi2     |     20.2 |      24.7 | 1.22x   |
| 512×1024×2048   | bf16    | dram_interleaved | HiFi4     |     56.3 |      60.9 | 1.08x   |
| 512×1024×2048   | bf16    | l1_dram          | HiFi4     |     56.2 |      60.5 | 1.08x   |
| 512×1024×2048   | bfp8_b  | dram_interleaved | HiFi2     |     35.5 |      38.5 | 1.08x   |
| 512×1024×2048   | bfp8_b  | l1_dram          | HiFi2     |     34.8 |      38.3 | 1.10x   |
| 512×1024×1024   | bf16    | dram_interleaved | HiFi4     |     30.7 |      35.2 | 1.15x   |
| 512×1024×1024   | bf16    | l1_dram          | HiFi4     |     29.4 |      35.0 | 1.19x   |
| 512×1024×1024   | bfp8_b  | dram_interleaved | HiFi2     |     22.4 |      23.4 | 1.05x   |
| 512×1024×1024   | bfp8_b  | l1_dram          | HiFi2     |     21.5 |      23.1 | 1.07x   |
| 512×512×512     | bf16    | dram_interleaved | HiFi4     |     11.8 |      13.4 | 1.14x   |
| 512×512×512     | bf16    | l1_dram          | HiFi4     |     11.0 |      12.2 | 1.11x   |
| 512×512×512     | bfp8_b  | dram_interleaved | HiFi2     |      9.0 |       9.5 | 1.05x   |
| 512×512×512     | bfp8_b  | l1_dram          | HiFi2     |      8.3 |       8.8 | 1.05x   |

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] [Nightly](https://github.com/tenstorrent/tt-mlir/actions/runs/25811793178) 
