### PR TITLE
[Optimizer] Fix L1 sharding non-determinism: stable sort + ordered maps in beam and reshard candidate generation

### DIFF
--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ADT/DenseSet.h"
 
 #include <algorithm>
+#include <map>
 
 namespace mlir::tt::ttnn {
 
@@ -534,14 +535,17 @@ MemoryLayoutPropagation::processOp(Operation *op) {
                "  processOp {0}: {1} valid candidates from cross-product",
                op->getName(), candidates.size());
 
-  // Step 4: Sort by score descending, keep top-K.
-  std::sort(candidates.begin(), candidates.end(),
-            [op](const BeamCandidate &a, const BeamCandidate &b) {
-              if (a.score != b.score) {
-                return a.score > b.score;
-              }
-              return preferCandidate(op, a, b);
-            });
+  // Step 4: Sort by score descending, keep top-K. Stable sort: when both
+  // LayoutScore and preferCandidate tie, fall back to insertion order so
+  // downstream consumers (e.g. L1-spill's first-fit walk) see a fixed
+  // beam-slot assignment across runs.
+  std::stable_sort(candidates.begin(), candidates.end(),
+                   [op](const BeamCandidate &a, const BeamCandidate &b) {
+                     if (a.score != b.score) {
+                       return a.score > b.score;
+                     }
+                     return preferCandidate(op, a, b);
+                   });
 
   if (candidates.size() > beamWidth) {
     candidates.resize(beamWidth);
@@ -1031,16 +1035,21 @@ std::vector<TTNNLayoutAttr> MemoryLayoutPropagation::generateReshardCandidates(
   // representation — without this, high-volume types (e.g., block_sharded)
   // would crowd out lower-volume types (e.g., height_sharded) when
   // candidates compete for a single global budget.
-  llvm::DenseMap<TensorMemoryLayout, std::vector<TTNNLayoutAttr>> buckets;
+  //
+  // std::map (sorted iteration) + std::stable_sort: layouts with equal
+  // grid volume keep their insertion order, and buckets are merged in a
+  // fixed enum order, so the final reshard-candidate list is
+  // reproducible across runs.
+  std::map<TensorMemoryLayout, std::vector<TTNNLayoutAttr>> buckets;
   for (const auto &layout : deduped) {
     buckets[layout.getMemLayout().getValue()].push_back(layout);
   }
   for (auto &[type, layouts] : buckets) {
-    std::sort(layouts.begin(), layouts.end(),
-              [](const TTNNLayoutAttr &a, const TTNNLayoutAttr &b) {
-                return ttmlir::utils::volume(a.getGridShape()) >
-                       ttmlir::utils::volume(b.getGridShape());
-              });
+    std::stable_sort(layouts.begin(), layouts.end(),
+                     [](const TTNNLayoutAttr &a, const TTNNLayoutAttr &b) {
+                       return ttmlir::utils::volume(a.getGridShape()) >
+                              ttmlir::utils::volume(b.getGridShape());
+                     });
     if (layouts.size() > maxReshardCandidatesPerType) {
       layouts.resize(maxReshardCandidatesPerType);
     }
@@ -1050,12 +1059,15 @@ std::vector<TTNNLayoutAttr> MemoryLayoutPropagation::generateReshardCandidates(
     deduped.insert(deduped.end(), layouts.begin(), layouts.end());
   }
 
-  // Final sort for deterministic ordering.
-  std::sort(deduped.begin(), deduped.end(),
-            [](const TTNNLayoutAttr &a, const TTNNLayoutAttr &b) {
-              return ttmlir::utils::volume(a.getGridShape()) >
-                     ttmlir::utils::volume(b.getGridShape());
-            });
+  // Final stable sort by grid volume. For layouts with equal grid volume,
+  // stable_sort preserves the concat order above (buckets in enum order),
+  // so same-volume layouts from different sharding types stay grouped
+  // consistently across runs rather than interleaving arbitrarily.
+  std::stable_sort(deduped.begin(), deduped.end(),
+                   [](const TTNNLayoutAttr &a, const TTNNLayoutAttr &b) {
+                     return ttmlir::utils::volume(a.getGridShape()) >
+                            ttmlir::utils::volume(b.getGridShape());
+                   });
 
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                "  generated {0} reshard candidates for {1}", deduped.size(),

--- a/lib/Dialect/TTNN/Utils/OptimizerUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/OptimizerUtils.cpp
@@ -13,11 +13,10 @@
 #include "mlir/IR/MLIRContext.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <cstdint>
-#include <unordered_map>
+#include <map>
 
 namespace mlir::tt::ttnn::optimizer_utils {
 
@@ -36,19 +35,14 @@ getUniqueOpSpecificAttrs(const std::vector<OpConfig> &configs) {
 
 llvm::SmallVector<OpConfig> getUniqueTestConfigsForMatmulLinear(
     const std::vector<OpConfig> &consumerConfigs) {
-  // Helper structs for tracking unique (bufferType, memLayout) pairs.
   struct BufferMemLayoutKey {
     BufferType bufferType;
     TensorMemoryLayout memLayout;
-
-    bool operator==(const BufferMemLayoutKey &other) const {
-      return bufferType == other.bufferType && memLayout == other.memLayout;
-    }
-  };
-
-  struct BufferMemLayoutKeyHash {
-    size_t operator()(const BufferMemLayoutKey &key) const {
-      return llvm::hash_combine(key.bufferType, key.memLayout);
+    bool operator<(const BufferMemLayoutKey &other) const {
+      if (bufferType != other.bufferType) {
+        return bufferType < other.bufferType;
+      }
+      return memLayout < other.memLayout;
     }
   };
 
@@ -67,8 +61,13 @@ llvm::SmallVector<OpConfig> getUniqueTestConfigsForMatmulLinear(
     llvm::DenseSet<OpConfig::OpSpecificAttrs> seenAttrs;
   };
 
-  std::unordered_map<BufferMemLayoutKey, LayoutGroup, BufferMemLayoutKeyHash>
-      groups;
+  // Iteration order must be deterministic: downstream tie-breaks
+  // (e.g., L1-spill's first-fit walk over fallback configs) commit to
+  // the first entry, so a shuffled order produces different IR across
+  // processes. std::unordered_map iteration depends on bucket layout
+  // and varies between processes; std::map iterates in key order
+  // (bufferType, then memLayout).
+  std::map<BufferMemLayoutKey, LayoutGroup> groups;
 
   for (const OpConfig &config : consumerConfigs) {
     assert(config.outputLayout &&
@@ -77,7 +76,7 @@ llvm::SmallVector<OpConfig> getUniqueTestConfigsForMatmulLinear(
     BufferMemLayoutKey key{config.outputLayout.getBufferType(),
                            config.outputLayout.getMemLayout().getValue()};
 
-    auto &group = groups[key];
+    LayoutGroup &group = groups[key];
     if (!group.partialLayout) {
       TTNNLayoutAttr layout = config.outputLayout;
       group.partialLayout = layout.withIgnorePhysicalLayout(true);

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_ttir_l1_input.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_ttir_l1_input.mlir
@@ -6,22 +6,29 @@
 
 // TTIR-level test: starting from ttir.relu → ttir.distributed_rms_norm,
 // verify that after the full TTIR→TTNN pipeline (workaround + greedy
-// optimizer including L1SpillManagement) the relu output is converted to
-// L1 width-sharded before reaching distributed_rms_norm with no
-// intermediate DRAM spill on the input path.
+// optimizer including L1SpillManagement) the input reaches
+// distributed_rms_norm as L1 width-sharded with no intermediate DRAM spill.
+//
+// The greedy optimizer assigns L1 width-sharded to relu directly, so the
+// workaround-inserted ToLayoutOp (added before MemoryLayoutPropagation when
+// relu was still DRAM) becomes a no-op and is eliminated by the canonicalizer.
+// L1SpillManagement sees the ToLayoutOp between relu and distributed_rms_norm
+// in its schedule, so relu's output is marked dead before distributed_rms_norm
+// is processed — liveValues is empty and evictAllFromL1 never fires.
 
-// relu → to_memory_config(L1 width-sharded) → distributed_rms_norm.
-// Verify no DRAM spill appears before the L1 conversion and none between
-// the L1 conversion and distributed_rms_norm (i.e. the input is never
-// bounced through DRAM on its way to the fused kernel).
+// to_memory_config(L1 width-sharded) → relu → distributed_rms_norm.
+// Verify no DRAM spill appears between the L1 conversion and
+// distributed_rms_norm (i.e. the input is never bounced through DRAM on
+// its way to the fused kernel).
 // Capture the DRAM and L1-width-sharded layouts so we can pattern-match
 // against the result tensor type of `ttnn.to_memory_config`
 // CHECK-DAG: #[[DRAM_LAYOUT:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
 // CHECK-DAG: #[[L1_WIDTH_SHARDED:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}bf16{{.*}}#l1>{{.*}}<width_sharded>
 // CHECK-LABEL: func.func @main
-// CHECK: "ttnn.relu"
 // CHECK-NOT: "ttnn.to_memory_config"{{.*}} -> tensor<{{.*}}, #[[DRAM_LAYOUT]]>
 // CHECK: "ttnn.to_memory_config"{{.*}} -> tensor<{{.*}}, #[[L1_WIDTH_SHARDED]]>
+// CHECK-NOT: "ttnn.to_memory_config"{{.*}} -> tensor<{{.*}}, #[[DRAM_LAYOUT]]>
+// CHECK: "ttnn.relu"
 // CHECK-NOT: "ttnn.to_memory_config"{{.*}} -> tensor<{{.*}}, #[[DRAM_LAYOUT]]>
 // CHECK: "ttnn.distributed_rms_norm"
 


### PR DESCRIPTION
## Summary

The greedy optimizer produced different output IR across processes for the same input model (observed on falcon3_7b_base n150). The root cause was three independent sites using hash-based containers and unstable sorts, causing tie-breaks in layout selection to depend on hash-bucket ordering, which varies per process.

### How the non-determinism manifested (falcon3_7b)

The rms_norm output layout (`layout50`) flipped between `6x8 block_sharded` and `6x7 block_sharded` across runs, causing the downstream matmul to receive different input shard shapes. Tracing the cause:

1. `getUniqueTestConfigsForMatmulLinear` used `std::unordered_map` to group matmul program configs by `(bufferType, memLayout)`. The iteration order of that map is bucket-layout-dependent and varies per process, so the 9 output hints (5 block + 3 width + 1 DRAM) appeared in a different group order each run.
2. The beam candidate sort used `std::sort` (unstable). The cross-product of `(rms_norm output candidates) × (matmul hints)` produced several candidates tied on all 6 `LayoutScore` fields. With unstable sort, tied candidates occupied different `BEAM[1..3]` slots depending on evaluation order — which depended on hint order.
3. L1-spill management walks beam slots in order and commits to the first valid candidate. Different slot occupants → different `MatmulProgramConfig` → different input shard-shape demand → rms_norm output rewritten differently.

### Fixes

**`OptimizerUtils.cpp` — `getUniqueTestConfigsForMatmulLinear`**
- Replace `std::unordered_map<BufferMemLayoutKey, LayoutGroup, Hash>` with `std::map<BufferMemLayoutKey, LayoutGroup>` using `operator<` on the key struct.
- Iteration is now deterministic by `(bufferType, memLayout)` enum value, so the group order in the emitted hint sequence is stable across processes.

**`MemoryLayoutPropagation.cpp` — beam sort**
- Replace `std::sort` with `std::stable_sort` on beam candidates.
- When `LayoutScore` and `preferCandidate` both tie, fall back to insertion order rather than pivot-dependent sort behavior.

**`MemoryLayoutPropagation.cpp` — `generateReshardCandidates`**
- Replace `llvm::DenseMap<TensorMemoryLayout, ...>` with `std::map<TensorMemoryLayout, ...>` for the per-sharding-type buckets. `DenseMap` iteration order depends on hash and allocation; `std::map` iterates by enum value.
- Replace both `std::sort` calls with `std::stable_sort` using `ttmlir::utils::volume(getGridShape())`. Equal-volume layouts within a bucket are deduped by `(memLayout, gridShape)` before reaching this point, so the comparator is a total order within each bucket.

### Validation

Verified by running the full falcon3_7b optimization pipeline 5 times and diffing the output IR — all 5 runs now produce bit-identical results. Previously this test would produce divergent `rms_norm` output layouts on a significant fraction of multi-run invocations.

 ### Side effect: relu now runs sharded in `distributed_rms_norm_ttir_l1_input` test

   The determinism fixes changed which tied candidate wins for relu ahead of `distributed_rms_norm`. The optimizer now generates two equally-scored candidates for relu:
   1. Interleaved relu → reshard output to L1 width_sharded before `distributed_rms_norm`
   2. L1 width_sharded relu → no reshard needed, output feeds directly into `distributed_rms_norm`

   Previously, unstable sort + `DenseMap` iteration happened to put candidate 1 first. With `stable_sort` + `std::map` (enum-ordered buckets), candidate 2 now wins. Candidate 2 is actually better — it avoids the reshard entirely. The test was updated to match the new ordering: `to_memory_config(L1 width_sharded)` → `relu` → `distributed_rms_norm`.


## Test plan
— 5-run diff on full falcon3_7b model: **PASS, all runs identical**
- [x] CI: existing optimizer lit tests and perf model tests
n150: https://github.com/tenstorrent/tt-xla/actions/runs/25919933376
n300-llmbox: https://github.com/tenstorrent/tt-xla/actions/runs/25925741122
galaxy-wh-6u: https://github.com/tenstorrent/tt-xla/actions/runs/25925837251
Possible to cause slight perf regression/improvement. But testing proved no obvious regressions (the base for this branch was a bit stale compared to the latest nightly it checked against, so the check for those was done manually).