### PR TITLE
[CI] Autosplit support for builder jobs

### DIFF
--- a/.github/scripts/python/generate_test_matrix.py
+++ b/.github/scripts/python/generate_test_matrix.py
@@ -182,7 +182,7 @@ def calc_test_duration(arch):
         durations_file = Path(".test_durations") / f"{arch}.json"
         if not durations_file.exists():
             print(f"Durations file not found: {durations_file}", file=sys.stderr)
-            return 0
+            return default_duration
 
     with durations_file.open() as f:
         durations = json.load(f)
@@ -266,7 +266,10 @@ def main(input_filename, target_duration, component_filter):
             if split_into_groups > 1:
                 for m in range(1, split_into_groups + 1):
                     split_copy = test_copy.copy()
-                    split_copy["args"] = list(split_copy.get("args", [])) + [
+                    existing_args = split_copy.get("args", [])
+                    if isinstance(existing_args, str):
+                        existing_args = [existing_args]
+                    split_copy["args"] = existing_args + [
                         f"split={m}/{split_into_groups}"
                     ]
                     split_copy["duration"] = duration / split_into_groups

--- a/.github/scripts/python/generate_test_matrix.py
+++ b/.github/scripts/python/generate_test_matrix.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from pathlib import Path
 import sys
 import test_common
 from itertools import product
@@ -171,6 +172,24 @@ def civ2_offload(test_matrix):
     return test_matrix
 
 
+def calc_test_duration(arch):
+    durations_file = Path(".test_durations") / f"{arch}.json"
+    if not durations_file.exists():
+        if arch == "llmbox":
+            arch = "n300-llmbox"
+        elif arch == "p150":
+            arch = "p150b"
+        durations_file = Path(".test_durations") / f"{arch}.json"
+        if not durations_file.exists():
+            print(f"Durations file not found: {durations_file}", file=sys.stderr)
+            return 0
+
+    with durations_file.open() as f:
+        durations = json.load(f)
+
+    return sum(durations.values())
+
+
 def main(input_filename, target_duration, component_filter):
     # Load the input JSON file
     with open(input_filename, "r") as f:
@@ -233,9 +252,34 @@ def main(input_filename, target_duration, component_filter):
         }
         hash, hash_string = test_common.compute_hash(test_copy, runs_on, image)
         duration = durations.get(hash, default_duration)
-        test_copy["duration"] = duration
-        test_matrix[key]["tests"].append(test_copy)
-        test_matrix[key]["total_duration"] += duration
+        if test_copy.get("autosplit", None) is not None:
+            duration = calc_test_duration(runs_on)
+            td = (
+                target_duration * 0.9
+            )  # pytest-split can be a bit imprecise, so we use a slightly lower target to avoid overshooting
+            split_into_groups = int((duration + td - 1.0) / td)
+            print(
+                f"Autosplitting group {key} with total duration {duration:.2f}s into {split_into_groups} batches of {td:.2f}s"
+            )
+            split_into_groups = int(split_into_groups)
+            test_copy.pop("autosplit")
+            if split_into_groups > 1:
+                for m in range(1, split_into_groups + 1):
+                    split_copy = test_copy.copy()
+                    split_copy["args"] = list(split_copy.get("args", [])) + [
+                        f"split={m}/{split_into_groups}"
+                    ]
+                    split_copy["duration"] = duration / split_into_groups
+                    test_matrix[key]["tests"].append(split_copy)
+                test_matrix[key]["total_duration"] += duration
+            else:
+                test_copy["duration"] = duration
+                test_matrix[key]["tests"].append(test_copy)
+                test_matrix[key]["total_duration"] += duration
+        else:
+            test_copy["duration"] = duration
+            test_matrix[key]["tests"].append(test_copy)
+            test_matrix[key]["total_duration"] += duration
         if shrun:
             test_matrix[key]["sh-run"] = True
         if runs_on == "builder":

--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -19,19 +19,9 @@
 
     { "runs-on": "n150",   "image": "tracy",  "script": "pytest.sh", "args": "tools/explorer/test/run_tests.py", "reqs": "--force-reinstall $BUILD_DIR/bin/wheels/tt_adapter*.whl $BUILD_DIR/bin/wheels/ai_edge_model_explorer*.whl" },
 
-    { "runs-on": ["n150","p150"],
+    { "runs-on": ["llmbox","n300","n150","p150"],
           "image": "tracy",
-              "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt", "split=1/3"] },
-    { "runs-on": ["n150","p150"],
-          "image": "tracy",
-              "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt", "split=2/3"] },
-    { "runs-on": ["n150","p150"],
-          "image": "tracy",
-              "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt", "split=3/3"] },
-
-    { "runs-on": ["llmbox","n300"],
-          "image": "tracy",
-              "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt"] },
+              "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt"], "autosplit": "builder" },
 
     { "runs-on": "n150",   "image": "tracy",  "script": "op_model_ttrt.sh", "args": "perf" },
     { "runs-on": "n150",   "image": "speedy",  "script": "op_model_ttrt.sh", "args": "run" },


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8355

### Problem description
Builder tests are manually split. Auto splitting is better choice.

### What's changed
Added "autosplit" param to tests.json which will take saved test durations and calculate the best splitting scheme for each hw architecture. Currently only "builder" tests are supported. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
