### PR TITLE
Descend into compute loops in GenericOp::getOperandAlloc

### DIFF
--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -3115,17 +3115,26 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
 
   GenericOp generic = region.getParentOfType<GenericOp>();
 
-  // Walk the region looking for tensor.empty/memref.alloc/d2m.get_cb ops,
-  // stepping into blocking loops only. Do NOT walk into compute loops
-  // (scf.for without d2m.blocking_loop) — allocs inside those are local
-  // working buffers, not operand allocations.
+  // Walk the region looking for tensor.empty/memref.alloc/d2m.get_cb ops.
+  //
+  // Descent into nested scf.for/affine.for is unconditional, but matching
+  // rules differ by context:
+  //  - At the top level or inside a blocking loop (tagged `d2m.blocking_loop`):
+  //    allocs match either by remote_load/remote_store association
+  //    (`assoc.hasRemoteUse`) or by positional declaration order.
+  //  - Inside a compute loop (scf.for/affine.for without `d2m.blocking_loop`):
+  //    only allocs with a direct remote_load/remote_store association are
+  //    considered operand allocs. Positional matching is disabled because
+  //    declaration order inside a compute loop has no relation to operand
+  //    declaration order; allocs without remote use there are local working
+  //    buffers, not operand allocations.
   //
   // d2m.get_cb ops are matched by operand_index when present, otherwise by
-  // their remote_load/remote_store binding. tensor.empty/memref.alloc ops are
-  // matched by positional order.
+  // their remote_load/remote_store binding.
   Value result;
   unsigned idx = 0;
-  std::function<void(Block &)> scanBlock = [&](Block &block) {
+  std::function<void(Block &, bool)> scanBlock = [&](Block &block,
+                                                     bool insideComputeLoop) {
     for (Operation &op : block) {
       if (result) {
         return;
@@ -3134,14 +3143,14 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
         LocalBufferAssociation assoc = analyzeLocalBufferAssociation(
             emptyOp.getResult(),
             generic ? generic.getOutputs().front() : Value());
-        if (assoc.hasRemoteUse || assoc.operand) {
+        if (assoc.hasRemoteUse || (assoc.operand && !insideComputeLoop)) {
           if (generic && assoc.operand &&
               generic.getOperandIndex(assoc.operand) ==
                   static_cast<int64_t>(operandIndex)) {
             result = emptyOp.getResult();
             return;
           }
-        } else {
+        } else if (!insideComputeLoop) {
           if (idx == operandIndex) {
             result = emptyOp.getResult();
             return;
@@ -3166,7 +3175,7 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
             result = allocOp.getResult();
             return;
           }
-        } else {
+        } else if (!insideComputeLoop) {
           if (idx == operandIndex) {
             result = allocOp.getResult();
             return;
@@ -3174,17 +3183,15 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
           ++idx;
         }
       } else if (auto forOp = mlir::dyn_cast<mlir::affine::AffineForOp>(&op)) {
-        if (forOp->hasAttr("d2m.blocking_loop")) {
-          scanBlock(*forOp.getBody());
-        }
+        bool isBlocking = forOp->hasAttr("d2m.blocking_loop");
+        scanBlock(*forOp.getBody(), insideComputeLoop || !isBlocking);
       } else if (auto forOp = mlir::dyn_cast<mlir::scf::ForOp>(&op)) {
-        if (forOp->hasAttr("d2m.blocking_loop")) {
-          scanBlock(*forOp.getBody());
-        }
+        bool isBlocking = forOp->hasAttr("d2m.blocking_loop");
+        scanBlock(*forOp.getBody(), insideComputeLoop || !isBlocking);
       }
     }
   };
-  scanBlock(region.front());
+  scanBlock(region.front(), /*insideComputeLoop=*/false);
 
   return result;
 }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_output_alloc_in_compute_loop.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_output_alloc_in_compute_loop.mlir
@@ -1,0 +1,74 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-allocate -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verify that an alloc inside a compute loop (`scf.for` / `affine.for`
+// without `d2m.blocking_loop`) is recognized as the output operand alloc
+// when it backs the localBuffer of a `d2m.remote_store` for the output.
+//
+// Before the fix, d2m.GenericOp::getOperandAlloc refused to descend into
+// compute loops, so the alloc was never stamped with CBLayoutAttr/address.
+// Downstream HoistCBAllocs then left it inside the generic and
+// SplitUnifiedThread crashed.
+
+#l1 = #ttcore.memory_space<l1>
+#dram = #ttcore.memory_space<dram>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+
+module {
+  // The output alloc lives inside a compute `scf.for` (no `d2m.blocking_loop`)
+  // and is the localBuffer of the output's `d2m.remote_store`. Allocate
+  // must stamp it with `address` and a `cb_layout` so HoistCBAllocs can
+  // later hoist it.
+  // CHECK-LABEL: func.func @scf_output_alloc_in_compute_loop
+  func.func @scf_output_alloc_in_compute_loop(
+      %in: memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>,
+      %out: memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>) {
+    %out_stream = d2m.view_layout %out remapping = #map4 : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram> -> memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+
+    // CHECK: d2m.generic
+    d2m.generic {block_factors = [], grid = #ttcore.grid<2x2>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%in : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>)
+        outs(%out_stream : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>) {
+    ^unified0():
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %core0 = d2m.core_index(0) : index
+      %core1 = d2m.core_index(1) : index
+      // CHECK: scf.for
+      // CHECK-NOT: d2m.blocking_loop
+      scf.for %iv = %c0 to %c1 step %c1 {
+        // CHECK: memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<{{[0-9]+}}x{{[0-9]+}}, {{[0-9]+}}>, #l1>
+        %alloc = memref.alloc() {alignment = 16 : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+        // CHECK: d2m.remote_store
+        %0 = d2m.remote_store %out_stream[%core0, %core1] %alloc : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<4x4x!ttcore.tile<32x32, f32>, #l1> -> memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+      }
+    }
+    return
+  }
+
+  // Same shape, with `affine.for` instead of `scf.for`.
+  // CHECK-LABEL: func.func @affine_output_alloc_in_compute_loop
+  func.func @affine_output_alloc_in_compute_loop(
+      %in: memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>,
+      %out: memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>) {
+    %out_stream = d2m.view_layout %out remapping = #map4 : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram> -> memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+
+    // CHECK: d2m.generic
+    d2m.generic {block_factors = [], grid = #ttcore.grid<2x2>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%in : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>)
+        outs(%out_stream : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>) {
+    ^unified0():
+      %core0 = d2m.core_index(0) : index
+      %core1 = d2m.core_index(1) : index
+      // CHECK: affine.for
+      // CHECK-NOT: d2m.blocking_loop
+      affine.for %iv = 0 to 1 {
+        // CHECK: memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<{{[0-9]+}}x{{[0-9]+}}, {{[0-9]+}}>, #l1>
+        %alloc = memref.alloc() {alignment = 16 : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+        // CHECK: d2m.remote_store
+        %0 = d2m.remote_store %out_stream[%core0, %core1] %alloc : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<4x4x!ttcore.tile<32x32, f32>, #l1> -> memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+      }
+    }
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_output_alloc_in_compute_loop.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_output_alloc_in_compute_loop.mlir
@@ -40,7 +40,7 @@ module {
         // CHECK: memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<{{[0-9]+}}x{{[0-9]+}}, {{[0-9]+}}>, #l1>
         %alloc = memref.alloc() {alignment = 16 : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
         // CHECK: d2m.remote_store
-        %0 = d2m.remote_store %out_stream[%core0, %core1] %alloc : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<4x4x!ttcore.tile<32x32, f32>, #l1> -> memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+        d2m.remote_store %out_stream[%core0, %core1] %alloc : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>
       }
     }
     return
@@ -66,7 +66,7 @@ module {
         // CHECK: memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<{{[0-9]+}}x{{[0-9]+}}, {{[0-9]+}}>, #l1>
         %alloc = memref.alloc() {alignment = 16 : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
         // CHECK: d2m.remote_store
-        %0 = d2m.remote_store %out_stream[%core0, %core1] %alloc : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<4x4x!ttcore.tile<32x32, f32>, #l1> -> memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+        d2m.remote_store %out_stream[%core0, %core1] %alloc : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>
       }
     }
     return


### PR DESCRIPTION
Previously getOperandAlloc only walked into scf.for/affine.for loops tagged with `d2m.blocking_loop`, on the assumption that allocs inside untagged ("compute") loops are always working buffers rather than operand allocs. That misses the case where the kernel itself allocates its operand-backing local buffer inside a user-written compute loop, e.g. an `%alloc_8` used as the `localBuffer` of a `d2m.remote_store` for the generic's output. Without this match, Allocate fails to stamp the alloc with a CBLayoutAttr, HoistCBAllocs leaves it inside the generic, and SplitUnifiedThread aborts with "Found use of non-pure op result outside the range of ops being wrapped".

Now scanBlock descends unconditionally and carries an insideComputeLoop flag. Inside compute loops only allocs with `assoc.hasRemoteUse == true` (a direct remote_load/remote_store binding) are considered operand allocs; positional `idx` matching stays gated to the top level and blocking loops, which preserves the original invariant that working buffers can't be mistaken for operand allocs.