### PR TITLE
Initial Quasar system descriptor support

### DIFF
--- a/.claude/skills/add-op/references/ttnn_type_mapping.md
+++ b/.claude/skills/add-op/references/ttnn_type_mapping.md
@@ -84,7 +84,7 @@ ops to understand how C++ parameter types translate to tablegen definitions.
 | `ttcore::MeshShardDirection` | `TTCore_MeshShardDirectionAttr` | `TTCoreOpsTypes.td` | Enum: FullToShard, ShardToFull |
 | `ttcore::MeshShardType` | `TTCore_MeshShardTypeAttr` | `TTCoreOpsTypes.td` | Enum: Identity, Replicate, Maximal, Devices |
 | `ttcore::OOBVal` | `TTCore_OOBValAttr` | `TTCoreOpsTypes.td` | Enum: Undef, Zero, One, Inf, NegInf |
-| `ttcore::Arch` | `TTCore_ArchAttr` | `TTCoreOpsTypes.td` | Enum: WormholeB0, Blackhole |
+| `ttcore::Arch` | `TTCore_ArchAttr` | `TTCoreOpsTypes.td` | Enum: WormholeB0, Blackhole, Quasar |
 
 ### C.4 Device & Synchronization Types
 

--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -49,7 +49,9 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
       llvm::cl::values(clEnumValN(ttcore::Arch::WormholeB0, "wormhole_b0",
                                   "Use mock wormhole_b0 system desc."),
                        clEnumValN(ttcore::Arch::Blackhole, "blackhole",
-                                  "Use mock blackhole system desc.")),
+                                  "Use mock blackhole system desc."),
+                       clEnumValN(ttcore::Arch::Quasar, "quasar",
+                                  "Use mock quasar system desc.")),
       llvm::cl::init(ttcore::Arch::WormholeB0)};
 
   Option<unsigned> maxDstPhysicalSizeTiles{

--- a/include/ttmlir/Dialect/SFPI/IR/SFPIOpsTypes.td
+++ b/include/ttmlir/Dialect/SFPI/IR/SFPIOpsTypes.td
@@ -68,7 +68,8 @@ def SFPI_CmpPredicateAttr : I32EnumAttr<"CmpPredicate", "SFPI comparison predica
 def SFPI_ArchVariantAttr : I32EnumAttr<"ArchVariant", "SFPI architecture variant",
   [
     I32EnumAttrCase<"wormhole", 0, "wormhole">,
-    I32EnumAttrCase<"blackhole", 1, "blackhole">
+    I32EnumAttrCase<"blackhole", 1, "blackhole">,
+    I32EnumAttrCase<"quasar", 2, "quasar">
   ]> {
   let cppNamespace = "::mlir::tt::sfpi";
 }

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsEnums.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsEnums.td
@@ -47,11 +47,13 @@ def TTCore_DataType : I32EnumAttr<"DataType", "TT DataTypes",
 
 def TTCore_WormholeB0 : I32EnumAttrCase<"WormholeB0", 1, "wormhole_b0">;
 def TTCore_Blackhole : I32EnumAttrCase<"Blackhole", 2, "blackhole">;
+def TTCore_Quasar : I32EnumAttrCase<"Quasar", 3, "quasar">;
 
 def TTCore_Arch : I32EnumAttr<"Arch", "TT Arch",
                            [
                             TTCore_WormholeB0,
                             TTCore_Blackhole,
+                            TTCore_Quasar,
                            ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt::ttcore";

--- a/include/ttmlir/Dialect/TTCore/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTCore/Transforms/Passes.td
@@ -65,7 +65,9 @@ def TTCoreRegisterDevicePass : Pass<"ttcore-register-device", "::mlir::ModuleOp"
               clEnumValN(ttcore::Arch::WormholeB0, "wormhole_b0",
                "Use mock wormhole_b0 system desc."),
               clEnumValN(ttcore::Arch::Blackhole, "blackhole",
-               "Use mock blackhole system desc.")
+               "Use mock blackhole system desc."),
+              clEnumValN(ttcore::Arch::Quasar, "quasar",
+               "Use mock quasar system desc.")
              )}]>,
         Option<"systemDescPath", "system-desc-path", "std::string", "", "System desc path">,
         ListOption<"meshShape", "mesh-shape", "int64_t", "Set the mesh shape">,

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -214,7 +214,9 @@ struct TTIRToTTNNCommonPipelineOptions
       llvm::cl::values(clEnumValN(ttcore::Arch::WormholeB0, "wormhole_b0",
                                   "Use mock wormhole_b0 system desc."),
                        clEnumValN(ttcore::Arch::Blackhole, "blackhole",
-                                  "Use mock blackhole system desc.")),
+                                  "Use mock blackhole system desc."),
+                       clEnumValN(ttcore::Arch::Quasar, "quasar",
+                                  "Use mock quasar system desc.")),
       llvm::cl::init(ttcore::Arch::WormholeB0)};
 
   // Option to override maximum number of sharded layouts to be generated

--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -12,7 +12,8 @@ struct Dim2dRange {
 
 enum Arch: uint {
   Wormhole_b0,
-  Blackhole
+  Blackhole,
+  Quasar
 }
 
 enum DataType: uint16 {

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -304,6 +304,8 @@ inline ::tt::target::Arch toFlatbuffer(FlatbufferObjectCache &,
     return ::tt::target::Arch::Wormhole_b0;
   case ttcore::Arch::Blackhole:
     return ::tt::target::Arch::Blackhole;
+  case ttcore::Arch::Quasar:
+    return ::tt::target::Arch::Quasar;
   }
 }
 

--- a/lib/Dialect/D2M/Utils/DstRegisterAnalysis.cpp
+++ b/lib/Dialect/D2M/Utils/DstRegisterAnalysis.cpp
@@ -138,8 +138,8 @@ getLargestCommonNumOuterLoopIters(ArrayRef<int64_t> numDstFlipsPerOp) {
 
   // Pick the largest legal factor so the common outer loop iteration count is
   // maximized.
-  for (int64_t factor :
-       llvm::reverse(ttmlir::utils::getFactors(gcdNumDstFlips))) {
+  const auto factors = ttmlir::utils::getFactors(gcdNumDstFlips);
+  for (int64_t factor : llvm::reverse(factors)) {
     if (factor <= maxCandidate) {
       return factor;
     }
@@ -217,7 +217,8 @@ trySharedParallelChunking(d2m::GenericOp /*generic*/,
 
   // Try R values from largest valid factor down. R must be a proper factor
   // (< commonRowDim) and >= 2 so that per-iteration shards remain multi-tile.
-  for (int64_t R : llvm::reverse(ttmlir::utils::getFactors(commonRowDim))) {
+  const auto rowFactors = ttmlir::utils::getFactors(commonRowDim);
+  for (int64_t R : llvm::reverse(rowFactors)) {
     if (R >= commonRowDim || R < 2) {
       continue;
     }

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -39,6 +39,31 @@
 namespace mlir::tt::ttcore {
 
 namespace {
+SystemDescAttr
+createDefaultQuasarSystemDesc(mlir::MLIRContext *context,
+                              const ::llvm::SmallVector<int64_t> &meshShape) {
+  llvm::SmallVector<ChipDescAttr> chipDescs;
+  llvm::SmallVector<uint32_t> chipIndicesList;
+  llvm::SmallVector<ChipCapabilityAttr> chipCapabilities;
+  llvm::SmallVector<ChipChannelAttr> chipChannelList;
+
+  return SystemDescAttr::get(
+      context,
+      // CPU Descriptors.
+      {CPUDescAttr::get(context, CPURole::Host,
+                        mlir::StringAttr::get(context, "x86_64-pc-linux-gnu"))},
+      // Chip Descriptors.
+      chipDescs,
+      // Chip Descriptor Indices.
+      chipIndicesList,
+      // Chip Capabilities.
+      chipCapabilities,
+      // Chip Mesh Coordinates.
+      {ChipCoordAttr::get(context, 0, 0, 0, 0)},
+      // Chip Channel Connections.
+      chipChannelList);
+}
+
 SystemDescAttr createDefaultBlackholeSystemDesc(
     mlir::MLIRContext *context, const ::llvm::SmallVector<int64_t> &meshShape) {
   // Set default values
@@ -297,6 +322,8 @@ SystemDescAttr::getDefault(MLIRContext *context, Arch arch,
     return createDefaultWormholeSystemDesc(context, meshShape);
   case Arch::Blackhole:
     return createDefaultBlackholeSystemDesc(context, meshShape);
+  case Arch::Quasar:
+    return createDefaultQuasarSystemDesc(context, meshShape);
   }
 }
 
@@ -377,6 +404,9 @@ mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromBuffer(
       break;
     case ::tt::target::Arch::Blackhole:
       arch = Arch::Blackhole;
+      break;
+    case ::tt::target::Arch::Quasar:
+      arch = Arch::Quasar;
       break;
     }
 

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -97,6 +97,9 @@ void SingletonDeviceContext::openDevice(
     case ttcore::Arch::Blackhole:
       metalArch = ::tt::ARCH::BLACKHOLE;
       break;
+    case ttcore::Arch::Quasar:
+      metalArch = ::tt::ARCH::QUASAR;
+      break;
     }
     ::tt::tt_metal::experimental::configure_mock_mode(metalArch, numChips);
   }

--- a/runtime/include/tt/runtime/detail/common/common.h
+++ b/runtime/include/tt/runtime/detail/common/common.h
@@ -120,7 +120,7 @@ inline ::tt::target::Arch toTargetArch(::tt::ARCH arch) {
   case ::tt::ARCH::BLACKHOLE:
     return ::tt::target::Arch::Blackhole;
   case ::tt::ARCH::QUASAR:
-    LOG_FATAL("Quasar architecture is not supported");
+    return ::tt::target::Arch::Quasar;
   case ::tt::ARCH::Invalid:
     LOG_FATAL("Invalid architecture");
   }

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -38,6 +38,8 @@ static ::tt::target::Arch toFlatbuffer(::tt::ARCH arch) {
     return ::tt::target::Arch::Wormhole_b0;
   case ::tt::ARCH::BLACKHOLE:
     return ::tt::target::Arch::Blackhole;
+  case ::tt::ARCH::QUASAR:
+    return ::tt::target::Arch::Quasar;
   default:
     break;
   }
@@ -202,12 +204,14 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
 
     auto buildBankToWorkerVec =
         [&](::tt::tt_metal::NOC noc) -> std::vector<::tt::target::Dim2d> {
-      std::vector<::tt::tt_metal::CoreCoord> assignment =
-          device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
       std::vector<::tt::target::Dim2d> result;
-      result.reserve(assignment.size());
-      for (const auto &core : assignment) {
-        result.emplace_back(core.y, core.x);
+      if (tt::tt_metal::hal::get_arch() != tt::ARCH::QUASAR) {
+        std::vector<::tt::tt_metal::CoreCoord> assignment =
+            device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+        result.reserve(assignment.size());
+        for (const auto &core : assignment) {
+          result.emplace_back(core.y, core.x);
+        }
       }
       return result;
     };
@@ -217,8 +221,13 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
         buildBankToWorkerVec(::tt::tt_metal::NOC::NOC_1);
 
     constexpr std::uint32_t kDstPhysicalSizeTiles = 16;
-    constexpr std::uint32_t kNumComputeThreads = 1;
-    constexpr std::uint32_t kNumDatamovementThreads = 2;
+    std::uint32_t kNumComputeThreads = 1;
+    std::uint32_t kNumDatamovementThreads = 2;
+    if (tt::tt_metal::hal::get_arch() == tt::ARCH::QUASAR) {
+      kNumComputeThreads = 4;
+      // QSR DM cores: 6 programmable v.s. 8 physical.
+      kNumDatamovementThreads = 6;
+    }
     chipDescs.emplace_back(::tt::target::CreateChipDesc(
         fbb, toFlatbuffer(device->arch()), &deviceGrid,
         &coordTranslationOffsets, device->l1_size_per_core(),

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -322,7 +322,8 @@ void registerRuntimeBindings(nb::module_ &m) {
 
   nb::enum_<::tt::target::Arch>(m, "Arch")
       .value("WORMHOLE_B0", ::tt::target::Arch::Wormhole_b0)
-      .value("BLACKHOLE", ::tt::target::Arch::Blackhole);
+      .value("BLACKHOLE", ::tt::target::Arch::Blackhole)
+      .value("QUASAR", ::tt::target::Arch::Quasar);
 
   nb::enum_<::tt::runtime::MemoryLogLevel>(m, "MemoryLogLevel", nb::is_flag())
       .value("NONE", ::tt::runtime::MemoryLogLevel::NONE)

--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -484,6 +484,8 @@ def get_board_id(system_desc) -> str:
     num_chips = len(system_desc["chip_desc_indices"])
 
     match arch, num_chips:
+        case "Quasar", 1:
+            return "qsremu"
         case "Blackhole", 1:
             return "p150"
         case "Blackhole", 2:

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -70,15 +70,12 @@ set(TTMETAL_INCLUDE_DIRS
   ${TTMETAL_SOURCE_DIR}
   ${TTMETAL_SOURCE_DIR}/tt_metal
   ${TTMETAL_SOURCE_DIR}/tt_metal/api
-  ${TTMETAL_SOURCE_DIR}/tt_metal/include
   ${TTMETAL_SOURCE_DIR}/tt_metal/hostdevcommon/api
   ${TTMETAL_SOURCE_DIR}/tt_metal/third_party/umd
   ${TTMETAL_SOURCE_DIR}/tt_metal/third_party/umd/device/api
   ${TTMETAL_SOURCE_DIR}/tt_metal/hw/inc
-  ${TTMETAL_SOURCE_DIR}/tt_metal/third_party/taskflow
   ${TTMETAL_SOURCE_DIR}/tt_stl
   ${TTMETAL_SOURCE_DIR}/tt_stl/tt_stl
-  ${TTMETAL_SOURCE_DIR}/tt_eager
   ${TTMETAL_BUILD_SYMLINK}/include
   ${CPM_SOURCE_CACHE}/reflect/f93e77475670eaeacf332927dfe8b50e3f3812e0
   ${CPM_SOURCE_CACHE}/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
@@ -229,7 +226,7 @@ install(
 )
 
 # `tt_metal` directory is installed with two commands, since we need special handling of `third_party` directory.
-# We only need `tt_llk" and `umd` files from `third_party` directory.
+# We only need `umd` files from `third_party` directory.
 install(
   DIRECTORY
     ${TTMETAL_SOURCE_DIR}/tt_metal
@@ -247,9 +244,6 @@ install(
   COMPONENT SharedLib
   EXCLUDE_FROM_ALL
   FILES_MATCHING
-  REGEX "third_party/tt_llk/tt_llk_blackhole/"
-  REGEX "third_party/tt_llk/tt_llk_wormhole_b0/"
-  REGEX "third_party/tt_llk/common"
   REGEX "third_party/umd/"
 )
 

--- a/tools/tt-alchemist/templates/cpp/local/CMakeLists.txt
+++ b/tools/tt-alchemist/templates/cpp/local/CMakeLists.txt
@@ -72,15 +72,8 @@ set(INCLUDE_DIRS
     ${METAL_SRC_DIR}/tt_metal/api
     ${METAL_SRC_DIR}/tt_metal/hostdevcommon/api
     ${METAL_SRC_DIR}/tt_metal/hw/inc
-    ${METAL_SRC_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines
-    ${METAL_SRC_DIR}/tt_metal/hw/inc/wormhole
-    ${METAL_SRC_DIR}/tt_metal/hw/inc/blackhole
-    ${METAL_SRC_DIR}/tt_metal/include
     ${METAL_SRC_DIR}/tt_stl
     ${METAL_SRC_DIR}/tt_stl/tt_stl
-    ${METAL_SRC_DIR}/tt_metal/third_party/fmt
-    ${METAL_SRC_DIR}/tt_metal/third_party/enchantum
-    ${METAL_SRC_DIR}/tt_metal/third_party/taskflow
     ${METAL_SRC_DIR}/tt_metal/third_party/tracy/public
     ${METAL_SRC_DIR}/tt_metal/third_party/umd
     ${METAL_SRC_DIR}/tt_metal/third_party/umd/device/api

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -93,15 +93,8 @@ set(INCLUDE_DIRS
     ${METAL_SRC_DIR}/tt_metal/api
     ${METAL_SRC_DIR}/tt_metal/hostdevcommon/api
     ${METAL_SRC_DIR}/tt_metal/hw/inc
-    ${METAL_SRC_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines
-    ${METAL_SRC_DIR}/tt_metal/hw/inc/wormhole
-    ${METAL_SRC_DIR}/tt_metal/hw/inc/blackhole
-    ${METAL_SRC_DIR}/tt_metal/include
     ${METAL_SRC_DIR}/tt_stl
     ${METAL_SRC_DIR}/tt_stl/tt_stl
-    ${METAL_SRC_DIR}/tt_metal/third_party/fmt
-    ${METAL_SRC_DIR}/tt_metal/third_party/enchantum
-    ${METAL_SRC_DIR}/tt_metal/third_party/taskflow
     ${METAL_SRC_DIR}/tt_metal/third_party/tracy/public
     ${METAL_SRC_DIR}/tt_metal/third_party/umd
     ${METAL_SRC_DIR}/tt_metal/third_party/umd/device/api


### PR DESCRIPTION
Add minimal Quasar system descriptor support.
Also remove some non-existent include paths and fix ASan failure caused by `llvm::reverse`.