### PR TITLE
[d2m] pipe clean dram to dram flow and add elementwise op tests

### DIFF
--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1522,6 +1522,12 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
                   }
                 }
               })
+              .Case([&](d2m::TileTilizeBlockOp op) {
+                op.getResult().setType(op.getOutput().getType());
+              })
+              .Case([&](d2m::TileUntilizeBlockOp op) {
+                op.getResult().setType(op.getOutput().getType());
+              })
               .Case([&](d2m::RemoteStoreOp op) {
                 Value oldMemref = op.getMemref();
                 std::optional<int32_t> operandIndex;

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -2060,7 +2060,22 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
                                     ttcore::DeviceAttr device) {
     // A tighter size calculation is possible for memrefs that don't map to
     // CBs which we don't attempt here except to ignore `buffers` multiplier.
-    return device.getMemrefSizeBytes(bufferType, 0, false);
+    int64_t shardSizeBytes = device.getMemrefSizeBytes(bufferType, 0, false);
+
+    if (ttcore::getMemorySpace(bufferType) == MemorySpace::DeviceDRAM) {
+      if (auto shardLayout =
+              mlir::dyn_cast<ttcore::ShardLayoutAttr>(bufferType.getLayout())) {
+        int64_t gridVolume =
+            ttmlir::utils::volume(shardLayout.getGridShape(bufferType));
+        int64_t numDramBanks = ttmlir::utils::volume(
+            llvm::to_vector(device.getDramGrid().getShape()));
+        int64_t shardsPerBank =
+            ttmlir::utils::alignUp(gridVolume, numDramBanks) / numDramBanks;
+        return shardSizeBytes * shardsPerBank;
+      }
+    }
+
+    return shardSizeBytes;
   }
 
   /// @return aligned allocation sizes for a `type` buffer for different

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
@@ -321,7 +321,7 @@ Plan canonicalize(const PlanState &src, const PlanState &tgt,
         hasTargetDeviceLayout ? tgt.vgmInverse : current.vgmInverse;
     auto output = makeOutputSpec(l1Type, outputVgmForward, outputVgmInverse);
     plan.push_back(DRAMToL1Step{output, AffineMap()});
-    updateStateFromOutput(current, output);
+    updateStateFromOutput(current, output, bounceRemapping);
   }
 
   // TILIZE with the current layout so subsequent mapping changes operate on

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
@@ -293,18 +293,33 @@ Plan canonicalize(const PlanState &src, const PlanState &tgt,
     updateStateFromOutput(current, output);
   }
 
-  // DRAM → L1: DMA the tensor into an L1 buffer with the target's layout.
-  if (current.hasLayout() && current.isDRAM() && tgt.hasLayout() &&
-      !tgt.isDRAM()) {
+  // DRAM → L1: DMA the tensor into an L1 buffer. For device-to-device layout
+  // changes, use the target layout. For device-to-host, mirror the
+  // host-to-device path by staging the current device layout through L1 before
+  // ToHostOp.
+  if (current.hasLayout() && current.isDRAM() &&
+      ((tgt.hasLayout() && !tgt.isDRAM()) || tgt.isSystem())) {
+    const bool hasTargetDeviceLayout = tgt.hasLayout();
+    ttcore::MetalLayoutAttr bounceLayout =
+        hasTargetDeviceLayout ? *tgt.getLayout() : *current.getLayout();
+    RankedTensorType bounceBaseType =
+        hasTargetDeviceLayout ? tgt.type : current.type;
+    AffineMap bounceRemapping =
+        hasTargetDeviceLayout ? AffineMap() : current.remapping;
     const bool isDRAMInterleaved = current.getLayout()->getMemoryLayout() ==
                                    ttcore::TensorMemoryLayout::Interleaved;
-    auto bounceGrid = llvm::to_vector(
-        isDRAMInterleaved ? tgt.getGridShape() : current.getGridShape());
+    auto bounceGrid = hasTargetDeviceLayout && isDRAMInterleaved
+                          ? llvm::to_vector(tgt.getGridShape())
+                          : llvm::to_vector(current.getGridShape());
     auto l1Type =
-        modifyDeviceType(ctx, tgt.type, *tgt.getLayout(), targetGridShape,
-                         AffineMap(), ttcore::MemorySpace::DeviceL1, bounceGrid,
-                         current.type.getElementType());
-    auto output = makeOutputSpec(l1Type, tgt.vgmForward, tgt.vgmInverse);
+        modifyDeviceType(ctx, bounceBaseType, bounceLayout, targetGridShape,
+                         bounceRemapping, ttcore::MemorySpace::DeviceL1,
+                         bounceGrid, current.type.getElementType());
+    AffineMap outputVgmForward =
+        hasTargetDeviceLayout ? tgt.vgmForward : current.vgmForward;
+    AffineMap outputVgmInverse =
+        hasTargetDeviceLayout ? tgt.vgmInverse : current.vgmInverse;
+    auto output = makeOutputSpec(l1Type, outputVgmForward, outputVgmInverse);
     plan.push_back(DRAMToL1Step{output, AffineMap()});
     updateStateFromOutput(current, output);
   }

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -208,7 +208,9 @@ def test_dram_binary_add_scalar(
             in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[list[str]] = None
         ):
             scalar_value = get_add_scalar_value(dtype)
-            scalar = builder.constant(torch.full(shape, scalar_value, dtype=dtype))
+            scalar = builder.full(
+                list(shape), dtype, scalar_value, unit_attrs=unit_attrs
+            )
             return builder.add(in0, scalar, unit_attrs=unit_attrs)
 
     compile_dram_test(module, request, device, target)

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -32,6 +32,66 @@ DRAM_SHAPES = [
 ]
 
 
+def dtype_str(dtype: torch.dtype):
+    return {
+        torch.float32: "f32",
+        torch.bfloat16: "bf16",
+        torch.int32: "i32",
+    }[dtype]
+
+
+def shape_dtype_param(shape: Shape, dtype: torch.dtype):
+    marks = [pytest.mark.skip_config(["sim"])] if dtype == torch.int32 else []
+    return pytest.param(
+        shape, dtype, marks=marks, id=f"{dtype_str(dtype)}-{shape_str(shape)}"
+    )
+
+
+DRAM_FLOAT_CASES = [
+    shape_dtype_param(shape, dtype)
+    for shape, dtype in zip(
+        DRAM_SHAPES,
+        [
+            torch.float32,
+            torch.bfloat16,
+            torch.float32,
+            torch.bfloat16,
+            torch.float32,
+            torch.bfloat16,
+            torch.float32,
+            torch.bfloat16,
+            torch.float32,
+        ],
+    )
+]
+
+DRAM_NUMERIC_CASES = [
+    shape_dtype_param(shape, dtype)
+    for shape, dtype in zip(
+        DRAM_SHAPES,
+        [
+            torch.float32,
+            torch.bfloat16,
+            torch.int32,
+            torch.float32,
+            torch.bfloat16,
+            torch.int32,
+            torch.float32,
+            torch.bfloat16,
+            torch.int32,
+        ],
+    )
+]
+
+
+def get_add_scalar_value(dtype: torch.dtype):
+    return 5 if dtype == torch.int32 else 5.0 if dtype == torch.bfloat16 else 2.5
+
+
+def get_clamp_bounds(dtype: torch.dtype):
+    return (0, 3) if dtype == torch.int32 else (-0.5, 0.8)
+
+
 def compile_dram_test(module, request, device, target: str):
     compile_and_execute_ttir(
         module,
@@ -42,8 +102,7 @@ def compile_dram_test(module, request, device, target: str):
     )
 
 
-@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("shape,dtype", DRAM_FLOAT_CASES)
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_dram_unary_relu(
     shape: Shape, dtype: torch.dtype, target: str, request, device
@@ -58,8 +117,7 @@ def test_dram_unary_relu(
     compile_dram_test(module, request, device, target)
 
 
-@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("shape,dtype", DRAM_FLOAT_CASES)
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_dram_binary_add(
     shape: Shape, dtype: torch.dtype, target: str, request, device
@@ -77,44 +135,27 @@ def test_dram_binary_add(
     compile_dram_test(module, request, device, target)
 
 
-@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
-@pytest.mark.parametrize(
-    "dtype,scalar_value",
-    [
-        (torch.float32, 2.5),
-        (torch.bfloat16, 5.0),
-        pytest.param(torch.int32, 5, marks=pytest.mark.skip_config(["sim"])),
-    ],
-    ids=["f32", "bf16", "i32"],
-)
+@pytest.mark.parametrize("shape,dtype", DRAM_NUMERIC_CASES)
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_dram_binary_add_scalar(
-    shape: Shape, dtype: torch.dtype, scalar_value, target: str, request, device
+    shape: Shape, dtype: torch.dtype, target: str, request, device
 ):
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
         def add_scalar(
             in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[list[str]] = None
         ):
+            scalar_value = get_add_scalar_value(dtype)
             scalar = builder.constant(torch.full(shape, scalar_value, dtype=dtype))
             return builder.add(in0, scalar, unit_attrs=unit_attrs)
 
     compile_dram_test(module, request, device, target)
 
 
-@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
-@pytest.mark.parametrize(
-    "dtype,min_value,max_value",
-    [
-        (torch.float32, -0.5, 0.8),
-        (torch.bfloat16, -0.5, 0.8),
-        pytest.param(torch.int32, 0, 3, marks=pytest.mark.skip_config(["sim"])),
-    ],
-    ids=["f32", "bf16", "i32"],
-)
+@pytest.mark.parametrize("shape,dtype", DRAM_NUMERIC_CASES)
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_dram_ternary_clamp_tensor(
-    shape: Shape, dtype: torch.dtype, min_value, max_value, target: str, request, device
+    shape: Shape, dtype: torch.dtype, target: str, request, device
 ):
     def module(builder: TTIRBuilder):
         @builder.func([shape, shape, shape], [dtype, dtype, dtype])
@@ -129,6 +170,7 @@ def test_dram_ternary_clamp_tensor(
                 input_golden = torch.randint(-5, 10, shape, dtype=dtype)
             else:
                 input_golden = torch.rand(shape, dtype=dtype) * 2 - 1
+            min_value, max_value = get_clamp_bounds(dtype)
             min_golden = torch.full(shape, min_value, dtype=dtype)
             max_golden = torch.full(shape, max_value, dtype=dtype)
             builder.set_goldens(
@@ -145,19 +187,10 @@ def test_dram_ternary_clamp_tensor(
     compile_dram_test(module, request, device, target)
 
 
-@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
-@pytest.mark.parametrize(
-    "dtype,min_value,max_value",
-    [
-        (torch.float32, -0.5, 0.8),
-        (torch.bfloat16, -0.5, 0.8),
-        pytest.param(torch.int32, 0, 3, marks=pytest.mark.skip_config(["sim"])),
-    ],
-    ids=["f32", "bf16", "i32"],
-)
+@pytest.mark.parametrize("shape,dtype", DRAM_NUMERIC_CASES)
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_dram_ternary_clamp_scalar(
-    shape: Shape, dtype: torch.dtype, min_value, max_value, target: str, request, device
+    shape: Shape, dtype: torch.dtype, target: str, request, device
 ):
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
@@ -169,6 +202,7 @@ def test_dram_ternary_clamp_scalar(
             else:
                 input_golden = torch.rand(shape, dtype=dtype) * 2 - 1
             builder.set_goldens(inputs={in0: input_golden})
+            min_value, max_value = get_clamp_bounds(dtype)
             return builder.clamp_scalar(
                 in0, min_arg=min_value, max_arg=max_value, unit_attrs=unit_attrs
             )

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from typing import Optional
+
+from conftest import get_request_kwargs
+from builder.base.builder_utils import Operand, Shape
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_and_execute_ttir
+from test_utils import shape_str
+
+pytestmark = pytest.mark.frontend("ttir")
+
+DRAM_PIPELINE_OPTIONS = [
+    "default-input-memspace=dram",
+    "default-output-memspace=dram",
+]
+
+DRAM_SHAPES = [
+    (1, 16),
+    (16, 16),
+    (32, 32),
+    (32, 64),
+    (64, 128),
+    (128, 128),
+    (256, 512),
+    (512, 1024),
+    (2048, 2048),
+]
+
+
+def compile_dram_test(module, request, device, target: str):
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        pipeline_options=list(DRAM_PIPELINE_OPTIONS),
+    )
+
+
+@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_unary_relu(
+    shape: Shape, dtype: torch.dtype, target: str, request, device
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [dtype])
+        def relu(
+            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[list[str]] = None
+        ):
+            return builder.relu(in0, unit_attrs=unit_attrs)
+
+    compile_dram_test(module, request, device, target)
+
+
+@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_binary_add(
+    shape: Shape, dtype: torch.dtype, target: str, request, device
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, shape], [dtype, dtype])
+        def add(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[list[str]] = None,
+        ):
+            return builder.add(in0, in1, unit_attrs=unit_attrs)
+
+    compile_dram_test(module, request, device, target)
+
+
+@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
+@pytest.mark.parametrize(
+    "dtype,scalar_value",
+    [
+        (torch.float32, 2.5),
+        (torch.bfloat16, 5.0),
+        pytest.param(torch.int32, 5, marks=pytest.mark.skip_config(["sim"])),
+    ],
+    ids=["f32", "bf16", "i32"],
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_binary_add_scalar(
+    shape: Shape, dtype: torch.dtype, scalar_value, target: str, request, device
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [dtype])
+        def add_scalar(
+            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[list[str]] = None
+        ):
+            scalar = builder.constant(torch.full(shape, scalar_value, dtype=dtype))
+            return builder.add(in0, scalar, unit_attrs=unit_attrs)
+
+    compile_dram_test(module, request, device, target)
+
+
+@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
+@pytest.mark.parametrize(
+    "dtype,min_value,max_value",
+    [
+        (torch.float32, -0.5, 0.8),
+        (torch.bfloat16, -0.5, 0.8),
+        pytest.param(torch.int32, 0, 3, marks=pytest.mark.skip_config(["sim"])),
+    ],
+    ids=["f32", "bf16", "i32"],
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_ternary_clamp_tensor(
+    shape: Shape, dtype: torch.dtype, min_value, max_value, target: str, request, device
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, shape, shape], [dtype, dtype, dtype])
+        def clamp_tensor(
+            in0: Operand,
+            min_tensor: Operand,
+            max_tensor: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[list[str]] = None,
+        ):
+            if dtype == torch.int32:
+                input_golden = torch.randint(-5, 10, shape, dtype=dtype)
+            else:
+                input_golden = torch.rand(shape, dtype=dtype) * 2 - 1
+            min_golden = torch.full(shape, min_value, dtype=dtype)
+            max_golden = torch.full(shape, max_value, dtype=dtype)
+            builder.set_goldens(
+                inputs={
+                    in0: input_golden,
+                    min_tensor: min_golden,
+                    max_tensor: max_golden,
+                }
+            )
+            return builder.clamp_tensor(
+                in0, min_tensor, max_tensor, unit_attrs=unit_attrs
+            )
+
+    compile_dram_test(module, request, device, target)
+
+
+@pytest.mark.parametrize("shape", DRAM_SHAPES, ids=shape_str)
+@pytest.mark.parametrize(
+    "dtype,min_value,max_value",
+    [
+        (torch.float32, -0.5, 0.8),
+        (torch.bfloat16, -0.5, 0.8),
+        pytest.param(torch.int32, 0, 3, marks=pytest.mark.skip_config(["sim"])),
+    ],
+    ids=["f32", "bf16", "i32"],
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_ternary_clamp_scalar(
+    shape: Shape, dtype: torch.dtype, min_value, max_value, target: str, request, device
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [dtype])
+        def clamp_scalar(
+            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[list[str]] = None
+        ):
+            if dtype == torch.int32:
+                input_golden = torch.randint(-5, 10, shape, dtype=dtype)
+            else:
+                input_golden = torch.rand(shape, dtype=dtype) * 2 - 1
+            builder.set_goldens(inputs={in0: input_golden})
+            return builder.clamp_scalar(
+                in0, min_arg=min_value, max_arg=max_value, unit_attrs=unit_attrs
+            )
+
+    compile_dram_test(module, request, device, target)

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -19,6 +19,11 @@ DRAM_PIPELINE_OPTIONS = [
     "default-output-memspace=dram",
 ]
 
+DRAM_FUSION_PIPELINE_OPTIONS = [
+    *DRAM_PIPELINE_OPTIONS,
+    "enable-elementwise-fusion=true",
+]
+
 DRAM_SHAPES = [
     (1, 16),
     (16, 16),
@@ -83,6 +88,11 @@ DRAM_NUMERIC_CASES = [
     )
 ]
 
+DRAM_FUSION_CASES = [
+    shape_dtype_param((32, 32), torch.float32),
+    shape_dtype_param((128, 128), torch.bfloat16),
+]
+
 
 def get_add_scalar_value(dtype: torch.dtype):
     return 5 if dtype == torch.int32 else 5.0 if dtype == torch.bfloat16 else 2.5
@@ -99,6 +109,16 @@ def compile_dram_test(module, request, device, target: str):
         target=target,
         device=device,
         pipeline_options=list(DRAM_PIPELINE_OPTIONS),
+    )
+
+
+def compile_dram_fusion_test(module, request, device, target: str):
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        pipeline_options=list(DRAM_FUSION_PIPELINE_OPTIONS),
     )
 
 
@@ -133,6 +153,48 @@ def test_dram_binary_add(
             return builder.add(in0, in1, unit_attrs=unit_attrs)
 
     compile_dram_test(module, request, device, target)
+
+
+@pytest.mark.parametrize("shape,dtype", DRAM_FUSION_CASES)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_fuse_add_relu_multiply(
+    shape: Shape, dtype: torch.dtype, target: str, request, device
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, shape, shape], [dtype, dtype, dtype])
+        def add_relu_multiply(
+            in0: Operand,
+            in1: Operand,
+            in2: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[list[str]] = None,
+        ):
+            sum_result = builder.add(in0, in1, unit_attrs=unit_attrs)
+            relu_result = builder.relu(sum_result, unit_attrs=unit_attrs)
+            return builder.multiply(relu_result, in2, unit_attrs=unit_attrs)
+
+    compile_dram_fusion_test(module, request, device, target)
+
+
+@pytest.mark.parametrize("shape,dtype", DRAM_FUSION_CASES)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_fuse_converging_branches(
+    shape: Shape, dtype: torch.dtype, target: str, request, device
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, shape, shape], [dtype, dtype, dtype])
+        def converging_branches(
+            in0: Operand,
+            in1: Operand,
+            in2: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[list[str]] = None,
+        ):
+            lhs = builder.relu(in0, unit_attrs=unit_attrs)
+            rhs = builder.add(in1, in2, unit_attrs=unit_attrs)
+            return builder.multiply(lhs, rhs, unit_attrs=unit_attrs)
+
+    compile_dram_fusion_test(module, request, device, target)
 
 
 @pytest.mark.parametrize("shape,dtype", DRAM_NUMERIC_CASES)

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_tile_untilize_result_type.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_tile_untilize_result_type.mlir
@@ -1,0 +1,41 @@
+// RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=stream-insert-policy=infer test-buffer-size-policy=max" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#l1 = #ttcore.memory_space<l1>
+#dram = #ttcore.memory_space<dram>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+
+module {
+  // CHECK-LABEL: func.func @untilize_result_matches_cb_output
+  // CHECK: %[[SCALAR:.*]] = memref.alloc(){{.*}} : memref<32x32xf32, #ttcore.cb_layout<{{[^>]+}}>, #l1>
+  // CHECK: "d2m.tile_untilize_block"(%{{.*}}, %[[SCALAR]]) : (memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<{{[^>]+}}>, #l1>, memref<32x32xf32, #ttcore.cb_layout<{{[^>]+}}>, #l1>) -> memref<32x32xf32, #ttcore.cb_layout<{{[^>]+}}>, #l1>
+  func.func @untilize_result_matches_cb_output(
+      %arg0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>,
+      %arg1: memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #dram>) {
+    d2m.generic {
+        block_factors = [1, 1],
+        grid = #ttcore.grid<1x1>,
+        indexing_maps = [#map, #map],
+        iterator_types = [#parallel, #parallel],
+        threads = [#d2m.thread<unified>]}
+        ins(%arg0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>)
+        outs(%arg1 : memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #dram>) {
+    ^bb0:
+      %bf0 = d2m.get_block_factor(0) : index
+      %bf1 = d2m.get_block_factor(1) : index
+      affine.for %i = 0 to %bf0 {
+        affine.for %j = 0 to %bf1 {
+          %tile = memref.alloc() {alignment = 64 : i64} : memref<1x1x!ttcore.tile<32x32, f32>>
+          %loaded = d2m.remote_load %tile %arg0[%i, %j] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+
+          %scalar = memref.alloc() {alignment = 64 : i64} : memref<32x32xf32>
+          %untilized = "d2m.tile_untilize_block"(%tile, %scalar) : (memref<1x1x!ttcore.tile<32x32, f32>>, memref<32x32xf32>) -> memref<32x32xf32>
+
+          d2m.remote_store %arg1[%i, %j] %scalar : memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #dram>, memref<32x32xf32> -> memref<32x32xf32>
+        } {d2m.blocking_loop = 1 : i64}
+      } {d2m.blocking_loop = 0 : i64}
+    }
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_tile_untilize_result_type.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_tile_untilize_result_type.mlir
@@ -27,12 +27,12 @@ module {
       affine.for %i = 0 to %bf0 {
         affine.for %j = 0 to %bf1 {
           %tile = memref.alloc() {alignment = 64 : i64} : memref<1x1x!ttcore.tile<32x32, f32>>
-          %loaded = d2m.remote_load %tile %arg0[%i, %j] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_load %tile %arg0[%i, %j] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>
 
           %scalar = memref.alloc() {alignment = 64 : i64} : memref<32x32xf32>
           %untilized = "d2m.tile_untilize_block"(%tile, %scalar) : (memref<1x1x!ttcore.tile<32x32, f32>>, memref<32x32xf32>) -> memref<32x32xf32>
 
-          d2m.remote_store %arg1[%i, %j] %scalar : memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #dram>, memref<32x32xf32> -> memref<32x32xf32>
+          d2m.remote_store %arg1[%i, %j] %scalar : memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #dram>, memref<32x32xf32>
         } {d2m.blocking_loop = 1 : i64}
       } {d2m.blocking_loop = 0 : i64}
     }

--- a/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
+++ b/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
@@ -2,6 +2,7 @@
 // RUN: FileCheck %s --input-file=%t
 
 #layout = #ttcore.metal_layout<logical_shape = 1024x1024, dim_alignments = 256x256, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+#layout_dram = #ttcore.metal_layout<logical_shape = 1024x1024, dim_alignments = 256x256, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, dram, sharded>
 #layout2 = #ttcore.metal_layout<logical_shape = 256x768, dim_alignments = 32x256, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
 
 // Distribute to the target grid before tilization.
@@ -59,6 +60,27 @@ func.func @untilize(%arg0: tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>) ->
   // CHECK: d2m.to_host %[[UNTILIZED]], %[[HOST]] layout = #layout{{[0-9]*}} : tensor<8x8x128x128xf32, #layout{{[0-9]*}}> into tensor<1024x1024xf32>
 
   %1 = d2m.to_layout %arg0, %0 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout> into tensor<1024x1024xf32>
+    -> tensor<1024x1024xf32>
+
+  return %1 : tensor<1024x1024xf32>
+}
+
+// Test untilize from DRAM to host stages through L1 before d2m.to_host.
+func.func @untilize_dram_to_host_stages_l1(%arg0: tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout_dram>) -> tensor<1024x1024xf32> {
+  %0 = d2m.empty() : tensor<1024x1024xf32>
+
+  // CHECK-LABEL: @untilize_dram_to_host_stages_l1
+  // CHECK: %[[L1_TILED:.*]] = d2m.empty() : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}>
+  // CHECK: %[[DRAM_TO_L1:.*]] = d2m.generic
+  // CHECK-NEXT: ins(%arg0 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}>)
+  // CHECK-NEXT: outs(%[[L1_TILED]] : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}>)
+  // CHECK: d2m.remote_load
+  // CHECK: d2m.remote_store %[[L1_TILED]]
+  // CHECK: %[[L1_SCALAR:.*]] = d2m.generic
+  // CHECK-NEXT: ins(%[[DRAM_TO_L1]] : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}>)
+  // CHECK: d2m.tile_untilize_block
+  // CHECK: d2m.to_host %[[L1_SCALAR]]
+  %1 = d2m.to_layout %arg0, %0 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout_dram> into tensor<1024x1024xf32>
     -> tensor<1024x1024xf32>
 
   return %1 : tensor<1024x1024xf32>


### PR DESCRIPTION
### Problem description
Need to add support for ops running e2e thru dram

### What's changed
- Added a bounce buffer for device dram to host to go through l1 like it does for host to device
- Added logic in allocator for correctly getting the right number of shards per dram bank instead of assuming 1 to get the right size needed for allocation.
- Properly update tilize/untilize block result types
- Added lit tests exercising changes to allocator and lower to layout
- Added builder tests for unary, binary and ternary ops that go from dram to dram and eltwise fusion tests
### Checklist
- [ ] New/Existing tests provide coverage for changes
