### PR TITLE
[D2M] Match cmp rhs operand type to lhs operand type

### DIFF
--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccessShared.cpp
@@ -757,11 +757,9 @@ scf::IfOp createLoadLoopGuard(PatternRewriter &rewriter, Location loc,
   const auto cmpPredicate =
       isBcastGuard ? arith::CmpIPredicate::eq : arith::CmpIPredicate::ne;
 
-  auto zero = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getIndexType(),
-      rewriter.getIntegerAttr(rewriter.getIndexType(), 0));
-
   for (Value guardIV : guardIVs) {
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, guardIV.getType(), rewriter.getIntegerAttr(guardIV.getType(), 0));
     Value cmp =
         rewriter.create<arith::CmpIOp>(loc, cmpPredicate, guardIV, zero);
     if (isBcastGuard) {


### PR DESCRIPTION
In my frontend I generate loops with integer types - I'm not sure exactly why they are integers by the time we get to this stage of the pipeline, but they are integers here. This causes a cmp operand mismatch error. I don't think allowing integers should be a problem; the extra zero ops will get canonicalized together later in the pipeline. 