### PR TITLE
[d2m] scratch buffer & fusion fixes

### DIFF
--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -21,23 +21,8 @@ namespace mlir::tt::d2m {
 
 namespace {
 
-// Fixed scratch buffer size in bytes used for every fused d2m.generic that
-// needs intermediate spills. We intentionally do NOT size the scratch buffer
-// based on the DST packing analysis, even though that analysis can produce a
-// tighter per-op estimate. The DST estimate is not a safe upper bound after
-// later passes (BlockFactorAnalysis / D2MGenerateOuterLoops) reshape the
-// per-iteration block: the scratch chunk emitted at codegen time can be larger
-// than what the DST analysis predicted at this point in the pipeline,
-// producing peak-scratch overflows in D2MLowerScratchAllocate (e.g. the
-// blackhole binary_tree[f32-2048x1024] regression: 9-tile buffer vs 14-tile
-// demand). Liveness-based slot reuse in D2MLowerScratchAllocate keeps the
-// effective L1 usage close to the true working set even when this nominal cap
-// is generous.
-//
-// TO-DO (ckaravasilis): replace this constant with a real upper-bound
-// computed here from each contained linalg op's worst-case per-core shard, or
-// move scratch sizing after D2MGenerateOuterLoops where the actual block
-// granularity is known.
+// Fixed scratch buffer size used for every fused d2m.generic that needs
+// intermediate spills.
 constexpr size_t kScratchSizeBytes = 128 * 1024;
 
 // Get the tile type from a memref type, if it has one.
@@ -82,10 +67,7 @@ static unsigned countLinalgGenerics(GenericOp genericOp) {
   return linalgCount;
 }
 
-// Compute the number of scratch tiles to allocate for a d2m.generic, in units
-// of `tileType`. Always returns the fixed kScratchSizeBytes converted to
-// tiles. See the comment on kScratchSizeBytes for why this is a fixed size
-// rather than an analysis-driven estimate.
+// Return kScratchSizeBytes expressed in tiles of `tileType` (at least 1).
 static size_t computeScratchNumTiles(ttcore::TileType tileType) {
   return std::max<size_t>(kScratchSizeBytes / tileType.getSizeBytes(), 1);
 }

--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -101,7 +101,6 @@ static void transferBlockingMaps(GenericOp genericOp) {
 // (post-bufferization). Creates a memref.alloc + scratch_init at the start of
 // the region body.
 static void addScratchToGeneric(GenericOp genericOp) {
-static void addScratchToGeneric(GenericOp genericOp) {
   // Skip if not in compute-only form.
   if (!genericOp.isComputeOnlyForm()) {
     return;

--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -119,7 +119,8 @@ computeScratchNumTiles(GenericOp genericOp, ttcore::TileType tileType,
   if (analysisNumTiles == 0) {
     return fallbackNumTiles;
   }
-  return std::min(analysisNumTiles, fallbackNumTiles);
+  //return std::min(analysisNumTiles, fallbackNumTiles);
+  return fallbackNumTiles;
 }
 
 // Transfer d2m.blocking_map attributes from inner linalg ops (set during

--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -38,7 +38,7 @@ namespace {
 // D2MLowerScratchAllocate (PR #7395) the per-producer slots can collapse and
 // this cap can drop back. Issue #7796 (subview offsets lost in DMA->CB
 // lowering) is a related latent bug that becomes observable once #7395 lands.
-constexpr size_t kFallbackScratchSizeBytes = 192 * 1024; // 192KB
+constexpr size_t kFallbackScratchSizeBytes = 128 * 1024; // 128KB!!
 
 // Get the tile type from a memref type, if it has one.
 static ttcore::TileType getTileType(MemRefType memrefType) {

--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -5,7 +5,6 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
-#include "ttmlir/Dialect/D2M/Utils/DstRegisterAnalysis.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
@@ -22,23 +21,24 @@ namespace mlir::tt::d2m {
 
 namespace {
 
-// Fallback scratch buffer size in bytes, used as an upper bound, and when the
-// DST packing analysis does not produce results for a given generic.
+// Fixed scratch buffer size in bytes used for every fused d2m.generic that
+// needs intermediate spills. We intentionally do NOT size the scratch buffer
+// based on the DST packing analysis, even though that analysis can produce a
+// tighter per-op estimate. The DST estimate is not a safe upper bound after
+// later passes (BlockFactorAnalysis / D2MGenerateOuterLoops) reshape the
+// per-iteration block: the scratch chunk emitted at codegen time can be larger
+// than what the DST analysis predicted at this point in the pipeline,
+// producing peak-scratch overflows in D2MLowerScratchAllocate (e.g. the
+// blackhole binary_tree[f32-2048x1024] regression: 9-tile buffer vs 14-tile
+// demand). Liveness-based slot reuse in D2MLowerScratchAllocate keeps the
+// effective L1 usage close to the true working set even when this nominal cap
+// is generous.
 //
-// The cap was bumped from 128KB to 192KB so that long fused elementwise chains
-// fit. After the D2MElementwiseFusion fix that gives every producer in a fused
-// d2m.generic its own intermediate tensor.empty (required to avoid a real
-// read-after-write hazard when aliasing producer outputs onto the consumer's
-// output CB), D2MInsertSpillAndScratch allocates one scratch slot per
-// producer with no liveness-based reuse (slotIndex++). For an N-op linear
-// chain that yields N-1 distinct slots; the 20-op test_eltwise_fuse_unary_chain
-// at 1x1 needs 76 tiles (152KB) and at 2x2 needs 72 tiles (144KB), both of
-// which overflow the old 128KB / 64-tile cap. 192KB accommodates these chains
-// with headroom; once liveness-based scratch slot reuse lands in
-// D2MLowerScratchAllocate (PR #7395) the per-producer slots can collapse and
-// this cap can drop back. Issue #7796 (subview offsets lost in DMA->CB
-// lowering) is a related latent bug that becomes observable once #7395 lands.
-constexpr size_t kFallbackScratchSizeBytes = 128 * 1024; // 128KB!!
+// TO-DO (ckaravasilis): replace this constant with a real upper-bound
+// computed here from each contained linalg op's worst-case per-core shard, or
+// move scratch sizing after D2MGenerateOuterLoops where the actual block
+// granularity is known.
+constexpr size_t kScratchSizeBytes = 128 * 1024;
 
 // Get the tile type from a memref type, if it has one.
 static ttcore::TileType getTileType(MemRefType memrefType) {
@@ -82,45 +82,12 @@ static unsigned countLinalgGenerics(GenericOp genericOp) {
   return linalgCount;
 }
 
-// Compute the number of scratch tiles needed for a d2m.generic. Sums the
-// per-result numTilesPerResult reported by the DST packing analysis for each
-// top-level linalg.generic in the region, skipping ops the analysis did not
-// size. Returns kFallbackScratchSizeBytes / tileSizeBytes when the analysis
-// produces no usable information. The result is capped at that fallback.
-static size_t
-computeScratchNumTiles(GenericOp genericOp, ttcore::TileType tileType,
-                       const utils::DstRegisterAnalysis &dstAnalysis) {
-  const size_t tileSizeBytes = tileType.getSizeBytes();
-  const size_t fallbackNumTiles =
-      std::max<size_t>(kFallbackScratchSizeBytes / tileSizeBytes, 1);
-
-  const utils::DSTPackingInfo *packingInfo = dstAnalysis.lookup(genericOp);
-  if (!packingInfo) {
-    return fallbackNumTiles;
-  }
-  const utils::DSTPackingRegionInfo *regionInfo =
-      packingInfo->lookup(&genericOp.getRegion(0));
-  if (!regionInfo) {
-    return fallbackNumTiles;
-  }
-
-  // Sum each top-level linalg.generic's own numTilesPerResult. Per-op entries
-  // are looked up by the linalg's single output value; ops not covered by the
-  // analysis are skipped and contribute 0 tiles.
-  size_t analysisNumTiles = 0;
-  for (linalg::GenericOp linalgOp :
-       genericOp.getRegion(0).front().getOps<linalg::GenericOp>()) {
-    auto it = regionInfo->perResult.find(linalgOp.getOutputs().front());
-    if (it == regionInfo->perResult.end()) {
-      continue;
-    }
-    analysisNumTiles += static_cast<size_t>(it->second.numTilesPerResult);
-  }
-  if (analysisNumTiles == 0) {
-    return fallbackNumTiles;
-  }
-  //return std::min(analysisNumTiles, fallbackNumTiles);
-  return fallbackNumTiles;
+// Compute the number of scratch tiles to allocate for a d2m.generic, in units
+// of `tileType`. Always returns the fixed kScratchSizeBytes converted to
+// tiles. See the comment on kScratchSizeBytes for why this is a fixed size
+// rather than an analysis-driven estimate.
+static size_t computeScratchNumTiles(ttcore::TileType tileType) {
+  return std::max<size_t>(kScratchSizeBytes / tileType.getSizeBytes(), 1);
 }
 
 // Transfer d2m.blocking_map attributes from inner linalg ops (set during
@@ -152,6 +119,7 @@ static void transferBlockingMaps(GenericOp genericOp) {
 // (post-bufferization). Creates a memref.alloc + scratch_init at the start of
 // the region body.
 static void addScratchToGeneric(GenericOp genericOp) {
+static void addScratchToGeneric(GenericOp genericOp) {
   // Skip if not in compute-only form.
   if (!genericOp.isComputeOnlyForm()) {
     return;
@@ -172,9 +140,7 @@ static void addScratchToGeneric(GenericOp genericOp) {
 
   ttcore::TileType tileType = getTileType(refMemRefType);
 
-  // Calculate number of scratch tiles using the DST packing analysis.
-  utils::DstRegisterAnalysis dstAnalysis(genericOp);
-  size_t numTiles = computeScratchNumTiles(genericOp, tileType, dstAnalysis);
+  size_t numTiles = computeScratchNumTiles(tileType);
 
   // Build scratch shard shape: [1, numTiles].
   SmallVector<int64_t> scratchShardShape = {1, static_cast<int64_t>(numTiles)};

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -943,18 +943,6 @@ private:
       return success();
     }
 
-    // Regather scratch loops after `fuseOuterScfLoops`. Sibling scratch-loop
-    // fusion as a capacity-saving rewrite is intentionally not driven from
-    // here: the previous demand estimate summed per-producer scratch volumes
-    // assuming no slot reuse, which over-counts by an order of magnitude on
-    // long chains and used to force `fuseScratchLoopSiblings` to run even
-    // when the chain would have fit. Partial sibling fusion left producer
-    // and consumer scratch shapes with different ranks, which
-    // `getConsumerScratchAccessMap`'s cross-step branch is not written to
-    // handle and produced ill-typed `affine.load`s. `D2MLowerScratchAllocate`
-    // now performs liveness-aware first-fit-decreasing packing of scratch
-    // slots and emits a clean diagnostic if peak usage actually exceeds the
-    // scratch buffer, so the conservative pre-check here is unnecessary.
     scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
 
     // Collect structural information for each scratch_space_loop.

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -14,10 +14,7 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/SmallPtrSet.h"
-
-#include <optional>
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MINSERTSPILLANDSCRATCH
@@ -68,50 +65,6 @@ struct IntermediateAllocInfo {
       consumers; // all consumer loop nests that read from it
   SmallVector<affine::AffineStoreOp> stores; // Stores to this alloc
 };
-
-// Compute the static capacity of the single scratch buffer owned by a
-// GenericOp.
-//
-// LowerScratchAllocate lays out d2m.scratch_allocate slots sequentially into
-// this buffer, so total slot demand must fit within this capacity.
-static FailureOr<std::optional<int64_t>>
-getScratchCapacity(GenericOp genericOp) {
-  std::optional<int64_t> capacity;
-  WalkResult result = genericOp.walk([&](ScratchInitOp scratchInit) {
-    if (capacity) {
-      return WalkResult::interrupt();
-    }
-
-    auto memrefType =
-        mlir::cast<MemRefType>(scratchInit.getScratch().getType());
-    ArrayRef<int64_t> shape = memrefType.getShape();
-    if (llvm::is_contained(shape, ShapedType::kDynamic)) {
-      return WalkResult::interrupt();
-    }
-
-    capacity = ttmlir::utils::volume<int64_t>(shape);
-    return WalkResult::advance();
-  });
-  if (result.wasInterrupted()) {
-    return failure();
-  }
-  return capacity;
-}
-
-// Estimate total scratch memory demand from intermediate allocations.
-static int64_t estimateScratchDemand(ArrayRef<IntermediateAllocInfo> infos) {
-  int64_t demand = 0;
-  for (auto &info : infos) {
-    if (!info.producer) {
-      continue;
-    }
-    if (llvm::is_contained(info.producer->scratchShape, ShapedType::kDynamic)) {
-      return ShapedType::kDynamic;
-    }
-    demand += ttmlir::utils::volume<int64_t>(info.producer->scratchShape);
-  }
-  return demand;
-}
 
 /// Find the innermost affine.for loop with d2m.linalg_root attribute.
 ///
@@ -251,52 +204,6 @@ static void collectLoadsInLoop(Value memref, ScratchLoopInfo &loopInfo,
   });
 }
 
-/// Check whether two affine loops have identical static iteration spaces.
-static bool haveMatchingConstantBounds(affine::AffineForOp lhs,
-                                       affine::AffineForOp rhs) {
-  if (!lhs.hasConstantBounds() || !rhs.hasConstantBounds()) {
-    return false;
-  }
-  return lhs.getConstantLowerBound() == rhs.getConstantLowerBound() &&
-         lhs.getConstantUpperBound() == rhs.getConstantUpperBound() &&
-         lhs.getStepAsInt() == rhs.getStepAsInt();
-}
-
-/// Return the single top-level affine child in a loop body, if one exists.
-static affine::AffineForOp
-getSingleTopLevelAffineChild(affine::AffineForOp loop) {
-  affine::AffineForOp child = nullptr;
-  for (Operation &op : *loop.getBody()) {
-    if (isa<affine::AffineYieldOp>(op)) {
-      continue;
-    }
-    auto innerFor = dyn_cast<affine::AffineForOp>(op);
-    if (!innerFor || child) {
-      return nullptr;
-    }
-    child = innerFor;
-  }
-  return child;
-}
-
-/// Return true if an op uses any value from the provided set.
-static bool usesAnyValue(Operation *op, ArrayRef<Value> values) {
-  return llvm::any_of(op->getOperands(), [&](Value operand) {
-    return llvm::is_contained(values, operand);
-  });
-}
-
-static bool hasNoMemoryEffects(Operation *op) {
-  auto effectOp = dyn_cast<MemoryEffectOpInterface>(op);
-  if (!effectOp) {
-    return false;
-  }
-
-  SmallVector<MemoryEffects::EffectInstance> effects;
-  effectOp.getEffects(effects);
-  return effects.empty();
-}
-
 static UnpackStallOnPackOp
 getUnpackStallImmediatelyBefore(Operation *consumerLoop) {
   Operation *previous = consumerLoop->getPrevNode();
@@ -331,101 +238,6 @@ static void ensureUnpackStallBeforeConsumer(
 
   rewriter.setInsertionPoint(consumerLoop);
   rewriter.create<UnpackStallOnPackOp>(consumerLoop->getLoc());
-}
-
-/// Fuse a dependence-related group of sibling scratch loops under one shared
-/// affine prefix.
-static bool manuallyFuseScratchLoopGroup(ArrayRef<affine::AffineForOp> loops,
-                                         IRRewriter &rewriter) {
-  if (loops.size() < 2) {
-    return false;
-  }
-
-  Block *parentBlock = loops.front()->getBlock();
-  SmallVector<Value> oldIvs;
-  oldIvs.reserve(loops.size());
-  for (auto loop : loops) {
-    if (loop->getBlock() != parentBlock ||
-        !haveMatchingConstantBounds(loops.front(), loop)) {
-      return false;
-    }
-
-    affine::AffineForOp inner = getSingleTopLevelAffineChild(loop);
-    // Hoist exactly one common affine prefix. The inner loop becomes the new
-    // scratch boundary and must still contain a nested linalg root.
-    if (!inner || inner->hasAttr("d2m.linalg_root")) {
-      return false;
-    }
-    oldIvs.push_back(loop.getInductionVar());
-  }
-
-  for (size_t i = 1; i < loops.size(); ++i) {
-    if (!loops[i - 1]->isBeforeInBlock(loops[i])) {
-      return false;
-    }
-  }
-
-  SmallVector<SmallVector<Operation *>> setupOpsBeforeLoop(loops.size());
-  SmallVector<Operation *> staleStalls;
-  for (size_t i = 1; i < loops.size(); ++i) {
-    for (auto it = std::next(loops[i - 1]->getIterator());
-         it != loops[i]->getIterator(); ++it) {
-      Operation *op = &*it;
-      if (isa<UnpackStallOnPackOp>(op)) {
-        staleStalls.push_back(op);
-        continue;
-      }
-
-      if (usesAnyValue(op, oldIvs) || !hasNoMemoryEffects(op)) {
-        return false;
-      }
-      setupOpsBeforeLoop[i].push_back(op);
-    }
-  }
-
-  rewriter.setInsertionPoint(loops.front());
-  affine::AffineForOp firstLoop = loops.front();
-  auto sharedLoop = rewriter.create<affine::AffineForOp>(
-      firstLoop.getLoc(), firstLoop.getConstantLowerBound(),
-      firstLoop.getConstantUpperBound(), firstLoop.getStepAsInt());
-
-  for (auto loop : loops) {
-    loop.getInductionVar().replaceAllUsesWith(sharedLoop.getInductionVar());
-  }
-
-  Operation *sharedYield = sharedLoop.getBody()->getTerminator();
-  for (auto &ops : setupOpsBeforeLoop) {
-    for (Operation *op : ops) {
-      op->moveBefore(sharedLoop);
-    }
-  }
-
-  for (auto indexedLoop : llvm::enumerate(loops)) {
-    affine::AffineForOp loop = indexedLoop.value();
-    auto &ops = loop.getBody()->getOperations();
-    sharedLoop.getBody()->getOperations().splice(
-        sharedYield->getIterator(), ops, ops.begin(), std::prev(ops.end()));
-  }
-
-  for (Operation *stallOp : staleStalls) {
-    rewriter.eraseOp(stallOp);
-  }
-
-  for (Operation &op : *sharedLoop.getBody()) {
-    auto innerFor = dyn_cast<affine::AffineForOp>(&op);
-    if (!innerFor) {
-      continue;
-    }
-    innerFor->setAttr("d2m.scratch_space_loop",
-                      UnitAttr::get(rewriter.getContext()));
-    innerFor->removeAttr("d2m.scratch_inserted");
-  }
-
-  for (auto loop : loops) {
-    rewriter.eraseOp(loop);
-  }
-
-  return true;
 }
 
 /// Build an affine map and operands for accessing the scratch buffer.
@@ -993,20 +805,6 @@ static bool fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
   return true;
 }
 
-static bool containsUnsafeFusedConsumer(ArrayRef<affine::AffineForOp> loops) {
-  // TODO (anuragsingh): Investigate the TileDivOp/TileWhereOp DST allocation
-  // failures and remove this guard once sibling fusion is safe for these ops.
-  // Issue: https://github.com/tenstorrent/tt-mlir/issues/8198
-  return llvm::any_of(loops, [](affine::AffineForOp loop) {
-    return loop
-        .walk([](Operation *op) {
-          return isa<TileDivOp, TileWhereOp>(op) ? WalkResult::interrupt()
-                                                 : WalkResult::advance();
-        })
-        .wasInterrupted();
-  });
-}
-
 static SmallVector<IntermediateAllocInfo>
 findIntermediates(GenericOp genericOp,
                   SmallVectorImpl<ScratchLoopInfo> &scratchLoops) {
@@ -1104,78 +902,6 @@ findIntermediates(GenericOp genericOp,
   return intermediates;
 }
 
-/// Repeatedly fuse dependence-related sibling scratch loops.
-static bool
-fuseScratchLoopSiblings(GenericOp genericOp,
-                        SmallVector<affine::AffineForOp> &scratchSpaceLoops,
-                        IRRewriter &rewriter) {
-  bool changed = false;
-  bool madeProgress = true;
-
-  while (madeProgress) {
-    madeProgress = false;
-
-    SmallVector<ScratchLoopInfo> loopShells;
-    loopShells.reserve(scratchSpaceLoops.size());
-    for (auto scratchLoop : scratchSpaceLoops) {
-      ScratchLoopInfo info;
-      info.scratchLoop = scratchLoop;
-      loopShells.push_back(info);
-    }
-
-    SmallVector<IntermediateAllocInfo> intermediates =
-        findIntermediates(genericOp, loopShells);
-    if (intermediates.empty()) {
-      break;
-    }
-
-    size_t bestBegin = scratchSpaceLoops.size();
-    size_t bestEnd = 0;
-    // Pick the widest producer->consumer span so one fusion covers the whole
-    // chain.
-    for (auto &intermediate : intermediates) {
-      size_t producerIdx =
-          static_cast<size_t>(intermediate.producer - loopShells.data());
-      for (auto &consumer : intermediate.consumers) {
-        if (consumer.loop == intermediate.producer) {
-          continue;
-        }
-        size_t consumerIdx =
-            static_cast<size_t>(consumer.loop - loopShells.data());
-        if (consumerIdx <= producerIdx ||
-            consumerIdx > intermediate.lastConsumerIndex) {
-          continue;
-        }
-        if (bestBegin == scratchSpaceLoops.size() ||
-            consumerIdx - producerIdx > bestEnd - bestBegin) {
-          bestBegin = producerIdx;
-          bestEnd = consumerIdx;
-        }
-      }
-    }
-
-    if (bestBegin == scratchSpaceLoops.size()) {
-      break;
-    }
-
-    SmallVector<affine::AffineForOp> loopsToFuse;
-    for (size_t i = bestBegin; i <= bestEnd; ++i) {
-      loopsToFuse.push_back(scratchSpaceLoops[i]);
-    }
-
-    if (containsUnsafeFusedConsumer(loopsToFuse)) {
-      break;
-    }
-
-    if (manuallyFuseScratchLoopGroup(loopsToFuse, rewriter)) {
-      scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
-      changed = madeProgress = true;
-    }
-  }
-
-  return changed;
-}
-
 /// Main pass implementation
 class D2MInsertSpillAndScratch
     : public impl::D2MInsertSpillAndScratchBase<D2MInsertSpillAndScratch> {
@@ -1217,41 +943,19 @@ private:
       return success();
     }
 
-    // Regather, then only fuse sibling scratch loops when the unfused scratch
-    // demand cannot fit in the available scratch buffer.
+    // Regather scratch loops after `fuseOuterScfLoops`. Sibling scratch-loop
+    // fusion as a capacity-saving rewrite is intentionally not driven from
+    // here: the previous demand estimate summed per-producer scratch volumes
+    // assuming no slot reuse, which over-counts by an order of magnitude on
+    // long chains and used to force `fuseScratchLoopSiblings` to run even
+    // when the chain would have fit. Partial sibling fusion left producer
+    // and consumer scratch shapes with different ranks, which
+    // `getConsumerScratchAccessMap`'s cross-step branch is not written to
+    // handle and produced ill-typed `affine.load`s. `D2MLowerScratchAllocate`
+    // now performs liveness-aware first-fit-decreasing packing of scratch
+    // slots and emits a clean diagnostic if peak usage actually exceeds the
+    // scratch buffer, so the conservative pre-check here is unnecessary.
     scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
-    bool needsSiblingFusionForCapacity = true;
-    FailureOr<std::optional<int64_t>> capacityOr =
-        getScratchCapacity(genericOp);
-    if (failed(capacityOr)) {
-      return genericOp.emitOpError()
-             << "expected at most one statically-shaped scratch_init";
-    }
-    if (std::optional<int64_t> capacity = *capacityOr) {
-      SmallVector<ScratchLoopInfo> preSiblingFusionScratchLoops;
-      for (auto scratchLoop : scratchSpaceLoops) {
-        ScratchLoopInfo info;
-        info.scratchLoop = scratchLoop;
-        info.linalgRoot = findLinalgRootLoop(scratchLoop);
-        if (!info.linalgRoot) {
-          continue;
-        }
-        collectAllInnerLoops(scratchLoop, info.allLoops);
-        if (computeScratchShape(info)) {
-          preSiblingFusionScratchLoops.push_back(info);
-        }
-      }
-
-      int64_t demand = estimateScratchDemand(
-          findIntermediates(genericOp, preSiblingFusionScratchLoops));
-      needsSiblingFusionForCapacity =
-          demand == ShapedType::kDynamic || demand > *capacity;
-    }
-
-    if (needsSiblingFusionForCapacity) {
-      fuseScratchLoopSiblings(genericOp, scratchSpaceLoops, rewriter);
-      scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
-    }
 
     // Collect structural information for each scratch_space_loop.
     //

--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -10,6 +10,9 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Visitors.h"
+
+#include <limits>
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MLOWERSCRATCHALLOCATE
@@ -109,8 +112,7 @@ private:
       return a.slotId < b.slotId;
     });
 
-    Block &block = region.front();
-    computeLiveness(allocations, block);
+    computeLiveness(allocations, region);
     int64_t peakUsage = assignOffsets(allocations);
 
     // Verify allocations fit in the scratch buffer.
@@ -139,33 +141,50 @@ private:
 
   // Compute liveness ranges for scratch allocations.
   //
-  // Each allocation's live range spans from its definition to its last use.
+  // Each allocation's live range is the textual span of its uses inside the
+  // generic's region. Two things matter for getting useful ranges:
+  //
+  // 1. Positions are assigned by a pre-order walk over the entire region, so
+  //    ops nested inside loops/blocks (e.g. affine.store/affine.load inside
+  //    a `scratch_space_loop` nest) receive distinct sequential positions.
+  //    A previous block-level numbering collapsed every nested store/load
+  //    onto the position of its outer `scf.for` and made every allocation
+  //    appear to overlap with every other one.
+  //
+  // 2. The live range is taken over uses, not the definition op. The
+  //    `d2m.scratch_allocate` op itself is a pure type annotation -- its
+  //    physical lifetime starts at the first store into the buffer and
+  //    ends at the last load. Long fused chains tend to batch every
+  //    `scratch_allocate` at the top of the enclosing loop before any
+  //    `scratch_space_loop` runs, so seeding `startPosition` from the
+  //    definition would clamp it before every use and prevent reuse
+  //    between intermediates with disjoint use spans (e.g. alternating
+  //    producers/consumers in a unary chain).
   void computeLiveness(SmallVectorImpl<ScratchAllocationInfo> &allocations,
-                       Block &block) {
-    // Assign sequential position indices to top-level operations in the block.
+                       Region &region) {
     DenseMap<Operation *, int64_t> opPositions;
     int64_t pos = 0;
-    for (Operation &op : block) {
-      opPositions[&op] = pos++;
-    }
-
-    auto getTopLevelOp = [&](Operation *op) -> Operation * {
-      return block.findAncestorOpInBlock(*op);
-    };
+    region.walk<WalkOrder::PreOrder>(
+        [&](Operation *op) { opPositions[op] = pos++; });
 
     for (auto &info : allocations) {
-      Operation *topLevelDef = getTopLevelOp(info.op.getOperation());
-      assert(opPositions.contains(topLevelDef) &&
-             "scratch allocation must have a top-level position");
-      info.startPosition = opPositions[topLevelDef];
-      info.endPosition = info.startPosition;
+      Operation *defOp = info.op.getOperation();
+      assert(opPositions.contains(defOp) &&
+             "scratch allocation must have a position");
 
+      info.startPosition = std::numeric_limits<int64_t>::max();
+      info.endPosition = std::numeric_limits<int64_t>::min();
       for (OpOperand &use : info.op.getResult().getUses()) {
-        Operation *topLevelUser = getTopLevelOp(use.getOwner());
-        assert(opPositions.contains(topLevelUser) &&
-               "scratch allocation user must have a top-level position");
-        int64_t userPos = opPositions[topLevelUser];
-        info.endPosition = std::max(info.endPosition, userPos);
+        auto it = opPositions.find(use.getOwner());
+        assert(it != opPositions.end() &&
+               "scratch allocation user must have a position");
+        info.startPosition = std::min(info.startPosition, it->second);
+        info.endPosition = std::max(info.endPosition, it->second);
+      }
+      if (info.startPosition > info.endPosition) {
+        // No users: collapse the live range to the definition position so the
+        // allocation still gets a valid (and trivially packable) offset.
+        info.startPosition = info.endPosition = opPositions[defOp];
       }
     }
   }

--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -209,9 +209,16 @@ private:
     return currentOffset;
   }
 
-  // Replace a scratch_allocate with a rank-reducing subview at the assigned
-  // offset of the scratch memref (shape [1, N] from InsertScratchBuffers),
-  // followed by an expand_shape if the requested type is multi-dimensional.
+  // Replace a scratch_allocate with a rank-reducing subview of the scratch
+  // memref, followed by an expand_shape if the requested type is
+  // multi-dimensional.
+  //
+  // The scratch buffer has shape [1, N] from InsertScratchBuffers.
+  // Each scratch_allocate requests a memref with numElements total tiles.
+  // We emit:
+  //   1. subview [0, offset][1, M][1, 1] : memref<1xN> -> memref<M>  (flat 1D)
+  //   2. expand_shape memref<M> [[0,1,...,rank-1]] -> memref<requested shape>
+  //      (only if the requested type has rank > 1)
   void replaceScratchAllocate(ScratchAllocationInfo &info,
                               Value scratchMemRef) {
     ScratchAllocateOp allocOp = info.op;
@@ -249,7 +256,7 @@ private:
       for (int64_t i = 0; i < requestedType.getRank(); ++i) {
         allDims.push_back(i);
       }
-      SmallVector<ReassociationIndices> reassociation = {allDims};
+      ƒ SmallVector<ReassociationIndices> reassociation = {allDims};
 
       auto subviewType = mlir::cast<MemRefType>(result.getType());
       auto expandedType = memref::ExpandShapeOp::computeExpandedType(

--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -256,7 +256,7 @@ private:
       for (int64_t i = 0; i < requestedType.getRank(); ++i) {
         allDims.push_back(i);
       }
-      ƒ SmallVector<ReassociationIndices> reassociation = {allDims};
+      SmallVector<ReassociationIndices> reassociation = {allDims};
 
       auto subviewType = mlir::cast<MemRefType>(result.getType());
       auto expandedType = memref::ExpandShapeOp::computeExpandedType(

--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -27,8 +27,8 @@ struct ScratchAllocationInfo {
   int64_t numElements;   // Number of elements (tiles) requested.
   int64_t elementOffset; // Starting element offset in scratch buffer.
 
-  // Liveness range: positions of the definition and last use within the
-  // top-level operation ordering of the entry block.
+  // Liveness range, as positions in a region-wide pre-order walk over the
+  // owning d2m.generic, taken across the slot's uses (first/last store/load).
   int64_t startPosition = -1;
   int64_t endPosition = -1;
 
@@ -141,25 +141,8 @@ private:
 
   // Compute liveness ranges for scratch allocations.
   //
-  // Each allocation's live range is the textual span of its uses inside the
-  // generic's region. Two things matter for getting useful ranges:
-  //
-  // 1. Positions are assigned by a pre-order walk over the entire region, so
-  //    ops nested inside loops/blocks (e.g. affine.store/affine.load inside
-  //    a `scratch_space_loop` nest) receive distinct sequential positions.
-  //    A previous block-level numbering collapsed every nested store/load
-  //    onto the position of its outer `scf.for` and made every allocation
-  //    appear to overlap with every other one.
-  //
-  // 2. The live range is taken over uses, not the definition op. The
-  //    `d2m.scratch_allocate` op itself is a pure type annotation -- its
-  //    physical lifetime starts at the first store into the buffer and
-  //    ends at the last load. Long fused chains tend to batch every
-  //    `scratch_allocate` at the top of the enclosing loop before any
-  //    `scratch_space_loop` runs, so seeding `startPosition` from the
-  //    definition would clamp it before every use and prevent reuse
-  //    between intermediates with disjoint use spans (e.g. alternating
-  //    producers/consumers in a unary chain).
+  // Positions come from a region-wide pre-order walk so that ops nested in
+  // `scratch_space_loop` nests get distinct indices.
   void computeLiveness(SmallVectorImpl<ScratchAllocationInfo> &allocations,
                        Region &region) {
     DenseMap<Operation *, int64_t> opPositions;
@@ -168,22 +151,18 @@ private:
         [&](Operation *op) { opPositions[op] = pos++; });
 
     for (auto &info : allocations) {
-      Operation *defOp = info.op.getOperation();
-      assert(opPositions.contains(defOp) &&
-             "scratch allocation must have a position");
-
       info.startPosition = std::numeric_limits<int64_t>::max();
       info.endPosition = std::numeric_limits<int64_t>::min();
       for (OpOperand &use : info.op.getResult().getUses()) {
         auto it = opPositions.find(use.getOwner());
-        assert(it != opPositions.end() &&
-               "scratch allocation user must have a position");
+        assert(it != opPositions.end() && "use is outside scratch region");
         info.startPosition = std::min(info.startPosition, it->second);
         info.endPosition = std::max(info.endPosition, it->second);
       }
       if (info.startPosition > info.endPosition) {
-        // No users: collapse the live range to the definition position so the
-        // allocation still gets a valid (and trivially packable) offset.
+        // Unused slot: pin the range to the def so it still gets an offset.
+        Operation *defOp = info.op.getOperation();
+        assert(opPositions.contains(defOp) && "def is outside scratch region");
         info.startPosition = info.endPosition = opPositions[defOp];
       }
     }
@@ -230,16 +209,9 @@ private:
     return currentOffset;
   }
 
-  /// Replace a scratch_allocate with a rank-reducing subview of the scratch
-  /// memref, followed by an expand_shape if the requested type is
-  /// multi-dimensional.
-  ///
-  /// The scratch buffer has shape [1, N] from InsertScratchBuffers.
-  /// Each scratch_allocate requests a memref with numElements total tiles.
-  /// We emit:
-  ///   1. subview [0, offset][1, M][1, 1] : memref<1xN> -> memref<M>  (flat 1D)
-  ///   2. expand_shape memref<M> [[0,1,...,rank-1]] -> memref<requested shape>
-  ///      (only if the requested type has rank > 1)
+  // Replace a scratch_allocate with a rank-reducing subview at the assigned
+  // offset of the scratch memref (shape [1, N] from InsertScratchBuffers),
+  // followed by an expand_shape if the requested type is multi-dimensional.
   void replaceScratchAllocate(ScratchAllocationInfo &info,
                               Value scratchMemRef) {
     ScratchAllocateOp allocOp = info.op;
@@ -248,14 +220,13 @@ private:
     OpBuilder builder(allocOp);
     Location loc = allocOp.getLoc();
 
-    // Always extract a flat 1D slice from the 2D scratch buffer.
     SmallVector<int64_t> flatShape = {info.numElements};
     SmallVector<int64_t> staticOffsets = {0, info.elementOffset};
     SmallVector<int64_t> staticSizes = {1, info.numElements};
     SmallVector<int64_t> staticStrides = {1, 1};
 
-    // Infer the correct rank-reduced result type. For non-zero offsets, the
-    // inferred type includes a strided layout (e.g. strided<[1], offset: N>).
+    // For non-zero offsets the inferred type carries a strided layout
+    // (e.g. strided<[1], offset: N>), which the requested type does not.
     auto sourceType = mlir::cast<MemRefType>(scratchMemRef.getType());
     auto inferredType = memref::SubViewOp::inferRankReducedResultType(
         flatShape, sourceType, staticOffsets, staticSizes, staticStrides);
@@ -273,16 +244,12 @@ private:
 
     Value result = subviewOp.getResult();
 
-    // If the requested type is multi-dimensional, reshape the flat 1D slice.
-    // We must compute the correct expanded type (preserving any strided layout
-    // from the subview) rather than using requestedType directly.
     if (requestedType.getRank() > 1) {
-      SmallVector<ReassociationIndices> reassociation;
       ReassociationIndices allDims;
       for (int64_t i = 0; i < requestedType.getRank(); ++i) {
         allDims.push_back(i);
       }
-      reassociation.push_back(allDims);
+      SmallVector<ReassociationIndices> reassociation = {allDims};
 
       auto subviewType = mlir::cast<MemRefType>(result.getType());
       auto expandedType = memref::ExpandShapeOp::computeExpandedType(

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
@@ -560,21 +560,10 @@ func.func @outer_scf_loops_get_fused(
 }
 
 // ---------------------------------------------------------------------------
-// Test: dependence-related sibling scratch_space_loop nests at the top of a
-//       generic body (no enclosing scf.for) are NOT fused at the affine level.
-//       Each producer keeps its own outer affine loop, the scratch shape
-//       retains the full row dimension, and the original unpack_stall_on_pack
-//       between producers and consumer is preserved as-is.
-//
-// Affine-level sibling fusion was previously driven from this pass as a
-// capacity-saving rewrite, but it was fragile (partial fusion left producer
-// and consumer scratch shapes with different ranks, breaking
-// `getConsumerScratchAccessMap`). Capacity is now enforced in
-// `D2MLowerScratchAllocate`, which packs slots with use-based liveness and
-// emits a clean diagnostic if peak demand actually exceeds the scratch
-// buffer. The scf.for-level fusion below (`outer_scf_loops_get_fused`) still
-// shares the outer iteration space across nests, which is what production
-// pipelines rely on.
+// Test: sibling scratch_space_loop nests at the top of a generic body stay
+//       separate affine nests (no affine-level fusion). Each producer keeps
+//       its full-rank scratch shape and the inter-loop unpack_stall_on_pack
+//       is preserved. Capacity sharing is delegated to D2MLowerScratchAllocate.
 // ---------------------------------------------------------------------------
 
 // CHECK-LABEL: func.func @dependent_sibling_scratch_loops_not_fused_at_affine_level

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
@@ -560,28 +560,41 @@ func.func @outer_scf_loops_get_fused(
 }
 
 // ---------------------------------------------------------------------------
-// Test: dependence-related sibling scratch_space_loop nests with a matching
-//       affine prefix are fused under one shared prefix before spill insertion.
-//       Scratch shapes must omit that shared row dimension, and inter-loop
-//       unpack_stall_on_pack ordering must be preserved inside the fused loop.
+// Test: dependence-related sibling scratch_space_loop nests at the top of a
+//       generic body (no enclosing scf.for) are NOT fused at the affine level.
+//       Each producer keeps its own outer affine loop, the scratch shape
+//       retains the full row dimension, and the original unpack_stall_on_pack
+//       between producers and consumer is preserved as-is.
+//
+// Affine-level sibling fusion was previously driven from this pass as a
+// capacity-saving rewrite, but it was fragile (partial fusion left producer
+// and consumer scratch shapes with different ranks, breaking
+// `getConsumerScratchAccessMap`). Capacity is now enforced in
+// `D2MLowerScratchAllocate`, which packs slots with use-based liveness and
+// emits a clean diagnostic if peak demand actually exceeds the scratch
+// buffer. The scf.for-level fusion below (`outer_scf_loops_get_fused`) still
+// shares the outer iteration space across nests, which is what production
+// pipelines rely on.
 // ---------------------------------------------------------------------------
 
-// CHECK-LABEL: func.func @dependent_sibling_scratch_loops_get_fused
-// CHECK-DAG:   %[[SCRATCH_A:.*]] = d2m.scratch_allocate {slot = 0 : i64} : memref<1x1x!ttcore.tile<32x32, bf16>, #l1>
-// CHECK-DAG:   %[[SCRATCH_B:.*]] = d2m.scratch_allocate {slot = 1 : i64} : memref<1x1x!ttcore.tile<32x32, bf16>, #l1>
-// CHECK-NOT:   memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+// CHECK-LABEL: func.func @dependent_sibling_scratch_loops_not_fused_at_affine_level
+// CHECK-DAG:   %[[SCRATCH_A:.*]] = d2m.scratch_allocate {slot = 0 : i64} : memref<2x1x1x!ttcore.tile<32x32, bf16>, #l1>
+// CHECK-DAG:   %[[SCRATCH_B:.*]] = d2m.scratch_allocate {slot = 1 : i64} : memref<2x1x1x!ttcore.tile<32x32, bf16>, #l1>
 // CHECK:       affine.for {{.*}} = 0 to 2
 // CHECK:       "d2m.tile_exp"
 // CHECK:       affine.store {{.*}}, %[[SCRATCH_A]]
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+// CHECK:       affine.for {{.*}} = 0 to 2
 // CHECK:       "d2m.tile_sin"
 // CHECK:       affine.store {{.*}}, %[[SCRATCH_B]]
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
 // CHECK:       d2m.unpack_stall_on_pack
-// CHECK-NOT:   d2m.unpack_stall_on_pack
+// CHECK:       affine.for {{.*}} = 0 to 2
 // CHECK:       affine.load %[[SCRATCH_A]]
 // CHECK:       affine.load %[[SCRATCH_B]]
 // CHECK:       "d2m.tile_add"
 // CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
-func.func @dependent_sibling_scratch_loops_get_fused(
+func.func @dependent_sibling_scratch_loops_not_fused_at_affine_level(
     %in0  : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
     %in1  : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
     %out0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>) {

--- a/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
@@ -41,7 +41,8 @@ func.func @single_scratch_store_load() {
 }
 
 // --- Test 2: Two conflicting scratch_allocates ---
-// Both slots are alive at the same time, so they cannot be packed together.
+// Both slots are written then read with interleaved use ranges, so their live
+// ranges genuinely overlap and they cannot be packed together.
 // Sorted by size descending: slot 1 (2 tiles) then slot 0 (1 tile).
 // slot 1 -> offset 0, slot 0 -> offset 2.
 
@@ -65,11 +66,11 @@ func.func @two_scratch_conflicting() {
     %scratch = memref.alloc() {d2m.scratch_buffer} : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
     d2m.scratch_init %scratch : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
     %c0 = arith.constant 0 : index
+    %seed = memref.load %alloc_cb3[%c0, %c0] : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
 
-    // Slot 0 (1 tile) is defined first and last-used before slot 1's last use,
-    // but their live ranges overlap so they cannot share storage.
-    // Sorted by size descending: slot 1 (2 tiles) gets offset 0,
-    // slot 0 (1 tile) cannot pack inside it and gets offset 2.
+    // Sorted by size descending: slot 1 (2 tiles) gets offset 0, slot 0
+    // (1 tile) cannot pack inside it because their use spans interleave
+    // (store s0, store s1, load s0, load s1) and gets offset 2.
     // CHECK: %[[SV0:.*]] = memref.subview %[[SCRATCH]][0, 2] [1, 1] [1, 1]
     // CHECK-SAME: to memref<1x!ttcore.tile<32x32, f32>
     %s0 = d2m.scratch_allocate {slot = 0 : i64} : memref<1x!ttcore.tile<32x32, f32>, #l1>
@@ -78,9 +79,12 @@ func.func @two_scratch_conflicting() {
     // CHECK-SAME: to memref<2x!ttcore.tile<32x32, f32>
     %s1 = d2m.scratch_allocate {slot = 1 : i64} : memref<2x!ttcore.tile<32x32, f32>, #l1>
 
-    %tile = memref.load %s0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
-    memref.store %tile, %s0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
-    memref.store %tile, %s1[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %seed, %s0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %seed, %s1[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+    %t0 = memref.load %s0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
+    %t1 = memref.load %s1[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %t1, %alloc_cb4[%c0, %c0] : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %t0, %alloc_cb4[%c0, %c0] : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
   }
   // CHECK-NOT: d2m.scratch_allocate
   return
@@ -138,10 +142,10 @@ func.func @packing_non_conflicting() {
 }
 
 // --- Test 4: Allocation between in-place read and write ---
-// Slot 0 is read, then slot 1 is allocated before slot 0 is written in place.
-// The two equal-sized slots cannot share storage because slot 0 remains live
-// across slot 1's allocation.
-// Tie-breaking by slot id makes slot 0 offset 0 and slot 1 offset 2.
+// Slot 0 is read, then slot 1 is allocated and used before slot 0 is written
+// in place. Slot 0's last store happens after slot 1's only use, so under
+// use-based liveness the two equal-sized slots overlap and cannot share
+// storage. Tie-breaking by slot id makes slot 0 offset 0 and slot 1 offset 2.
 
 // CHECK-LABEL: func.func @allocation_between_in_place_read_write
 func.func @allocation_between_in_place_read_write() {
@@ -178,10 +182,12 @@ func.func @allocation_between_in_place_read_write() {
     // CHECK-SAME: to memref<2x!ttcore.tile<32x32, f32>
     %s1 = d2m.scratch_allocate {slot = 1 : i64} : memref<2x!ttcore.tile<32x32, f32>, #l1>
 
-    // CHECK: memref.store %[[TILE]], %[[SV0]][%{{.*}}]
+    // s1 is stored to first, then s0 receives its in-place write, so
+    // s0's live range strictly contains s1's.
     // CHECK: memref.store %[[TILE]], %[[SV1]][%{{.*}}]
-    memref.store %tile, %s0[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK: memref.store %[[TILE]], %[[SV0]][%{{.*}}]
     memref.store %tile, %s1[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %tile, %s0[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
   }
   // CHECK-NOT: d2m.scratch_allocate
   return

--- a/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate_oom.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate_oom.mlir
@@ -28,10 +28,13 @@ func.func @scratch_overflow() {
     %c0 = arith.constant 0 : index
     %s0 = d2m.scratch_allocate {slot = 0 : i64} : memref<5x!ttcore.tile<32x32, f32>, #l1>
     %s1 = d2m.scratch_allocate {slot = 1 : i64} : memref<5x!ttcore.tile<32x32, f32>, #l1>
-    // Both slots are used after both are defined, so their live ranges overlap
-    // and they cannot be packed together. Total = 10 > capacity 8.
+    // Interleaved use spans (load s0, store s1, load s1, store s0) make the
+    // two slots' live ranges genuinely overlap, so they cannot be packed
+    // together. Total = 10 > capacity 8.
     %t0 = memref.load %s0[%c0] : memref<5x!ttcore.tile<32x32, f32>, #l1>
     memref.store %t0, %s1[%c0] : memref<5x!ttcore.tile<32x32, f32>, #l1>
+    %t1 = memref.load %s1[%c0] : memref<5x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %t1, %s0[%c0] : memref<5x!ttcore.tile<32x32, f32>, #l1>
   }
   return
 }

--- a/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
@@ -16,7 +16,7 @@
 // CHECK-LABEL: func.func @two_adds_gets_scratch
 // CHECK: d2m.generic
 // CHECK: ins(%{{.*}}, %{{.*}} :
-// CHECK: memref.alloc() {d2m.scratch_buffer} : memref<1x32x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<131072x4096, 1>, #l1>
+// CHECK: memref.alloc() {d2m.scratch_buffer} : memref<1x32x!ttcore.tile<32x32, f32>, #l1>
 // CHECK-NEXT: d2m.scratch_init
 func.func @two_adds_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
   %out = memref.alloc() : !memref_tiled
@@ -64,7 +64,7 @@ func.func @two_adds_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
 
 // CHECK-LABEL: func.func @add_and_mul_gets_scratch
 // CHECK: d2m.generic
-// CHECK: memref.alloc() {d2m.scratch_buffer} : memref<1x32x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<131072x4096, 1>, #l1>
+// CHECK: memref.alloc() {d2m.scratch_buffer} : memref<1x32x!ttcore.tile<32x32, f32>, #l1>
 // CHECK-NEXT: d2m.scratch_init
 func.func @add_and_mul_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
   %out = memref.alloc() : !memref_tiled

--- a/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
@@ -10,12 +10,13 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
 // Two tile_add ops in a fused generic → scratch_init should be inserted.
-// Verify: memref.alloc sized by DST packing analysis + scratch_init inside region.
+// Verify: memref.alloc sized at the fixed scratch-buffer size (128KB,
+// = 32 f32 tiles), plus scratch_init inside the region.
 
 // CHECK-LABEL: func.func @two_adds_gets_scratch
 // CHECK: d2m.generic
 // CHECK: ins(%{{.*}}, %{{.*}} :
-// CHECK: memref.alloc() {d2m.scratch_buffer} : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+// CHECK: memref.alloc() {d2m.scratch_buffer} : memref<1x32x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<131072x4096, 1>, #l1>
 // CHECK-NEXT: d2m.scratch_init
 func.func @two_adds_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
   %out = memref.alloc() : !memref_tiled
@@ -63,7 +64,7 @@ func.func @two_adds_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
 
 // CHECK-LABEL: func.func @add_and_mul_gets_scratch
 // CHECK: d2m.generic
-// CHECK: memref.alloc() {d2m.scratch_buffer} : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+// CHECK: memref.alloc() {d2m.scratch_buffer} : memref<1x32x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<131072x4096, 1>, #l1>
 // CHECK-NEXT: d2m.scratch_init
 func.func @add_and_mul_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
   %out = memref.alloc() : !memref_tiled


### PR DESCRIPTION
### Problem description
Affine-level sibling fusion in `SpillAndScratch` would get triggered if all `scratch_allocates` did not fit sequentially inside the scratch buffer. This ignored heuristic allocation within scratch that would take place afterwards in `LowerScratchAllocate`.

### What's changed

- `InsertSpillAndScratch`: Removed affine-level sibling fusion (introduced in #8143). This was originally introduced to deal with cases where the intermediates would not fit in the scratch. Smaller intermediates could also result in reduced performance. The fitting issue should be dealt with by the heuristic allocation, but a similar type of fusion might be re-introduced later on.
- `InsertScratchBuffers`: We no longer try to get a tighter scratch estimate using `DstRegisterAnalysis`, as potential reblocking afterwards might invalidate this bound. Revert to using the default 128K size for now.
- `LowerScratchAllocate`: Small improvements to get a more accurate liveness range for each scratch_allocate.