### PR TITLE
d2m: beam search on eltwise op reblocking to restrict search space

### DIFF
--- a/include/ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h
@@ -18,7 +18,7 @@ namespace mlir::tt::d2m {
 /// explicit-datamovement form), this analysis computes reblocked block
 /// factors according to the configured buffer size policy.
 struct BlockFactorAnalysis {
-  enum class BufferSizePolicy { Auto, Exhaustive, Min, Max };
+  enum class BufferSizePolicy { Auto, Bounded, Min, Max };
 
   struct Options {
     BufferSizePolicy policy = BufferSizePolicy::Auto;

--- a/include/ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h
@@ -18,7 +18,7 @@ namespace mlir::tt::d2m {
 /// explicit-datamovement form), this analysis computes reblocked block
 /// factors according to the configured buffer size policy.
 struct BlockFactorAnalysis {
-  enum class BufferSizePolicy { Auto, Min, Max };
+  enum class BufferSizePolicy { Auto, Exhaustive, Min, Max };
 
   struct Options {
     BufferSizePolicy policy = BufferSizePolicy::Auto;

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -653,7 +653,7 @@ def D2MAllocate: Pass<"d2m-allocate", "::mlir::ModuleOp"> {
     Option<"testBufferSizePolicy",
           "test-buffer-size-policy",
           "std::string", /*default=*/"\"auto\"",
-          "Set policy for sizing stream buffers ('auto', 'min', 'max').">,
+          "Set policy for sizing stream buffers ('auto', 'exhaustive', 'min', 'max').">,
   ];
 }
 

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -653,7 +653,7 @@ def D2MAllocate: Pass<"d2m-allocate", "::mlir::ModuleOp"> {
     Option<"testBufferSizePolicy",
           "test-buffer-size-policy",
           "std::string", /*default=*/"\"auto\"",
-          "Set policy for sizing stream buffers ('auto', 'exhaustive', 'min', 'max').">,
+          "Set policy for sizing stream buffers ('auto', 'bounded', 'min', 'max').">,
   ];
 }
 

--- a/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
@@ -517,11 +517,11 @@ static SmallVector<int64_t> chooseReblockedFactors(
   case BlockFactorAnalysis::BufferSizePolicy::Auto:
     return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
                            shardExtents, shardFactors, device, l1Attr,
-                           numBuffers, /*useBoundedEltwiseSearch=*/true);
-  case BlockFactorAnalysis::BufferSizePolicy::Exhaustive:
+                           numBuffers, /*useBoundedEltwiseSearch=*/false);
+  case BlockFactorAnalysis::BufferSizePolicy::Bounded:
     return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
                            shardExtents, shardFactors, device, l1Attr,
-                           numBuffers, /*useBoundedEltwiseSearch=*/false);
+                           numBuffers, /*useBoundedEltwiseSearch=*/true);
   }
 
   llvm_unreachable("unknown buffer size policy");

--- a/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
@@ -40,6 +40,7 @@ struct CandidateScore {
   uint64_t cbBytes = 0;
 };
 
+// Beam-search state before a full candidate legality and CB cost evaluation.
 struct PartialCandidate {
   SmallVector<int64_t> dimScales;
   uint64_t blockingVolume = 1;
@@ -154,7 +155,7 @@ static SmallVector<int64_t> buildEltwiseScaleSearchOrder(int64_t shardFactor) {
   });
 
   SmallVector<int64_t> limited;
-  // Always include 1 in the search order.
+  // Always include scale factor 1 so bounded search can leave a dim unchanged.
   limited.reserve(std::min(factors.size(), kEltwiseScalesPerDim));
   for (int64_t factor : factors) {
     if (limited.size() == kEltwiseScalesPerDim) {
@@ -372,7 +373,7 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
                 ArrayRef<int64_t> gridExtents, ArrayRef<int64_t> shardExtents,
                 ArrayRef<int64_t> shardFactors, ttcore::DeviceAttr device,
                 ttcore::MemorySpaceAttr l1Attr, uint32_t numBuffers,
-                bool useBoundedEltwiseSearch = true) {
+                bool useBoundedEltwiseSearch) {
   const SmallVector<int64_t> originalBlockFactors =
       genericOp.getBlockFactorsValue();
 
@@ -420,9 +421,7 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
     beam.push_back(
         PartialCandidate{SmallVector<int64_t>(currentDimScales), 1, 0});
 
-    for (std::size_t dimIndex = 0; dimIndex < config->candidateDims.size();
-         ++dimIndex) {
-      const std::size_t dim = config->candidateDims[dimIndex];
+    for (auto [dimIndex, dim] : llvm::enumerate(config->candidateDims)) {
       SmallVector<PartialCandidate> expanded;
       expanded.reserve(beam.size() * legalScales[dimIndex].size());
       for (const PartialCandidate &partial : beam) {
@@ -439,7 +438,7 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
     }
 
     for (const PartialCandidate &candidate : beam) {
-      auto score = evaluateCandidate(
+      std::optional<CandidateScore> score = evaluateCandidate(
           genericOp, config->candidateDims, indexingMaps, gridExtents,
           shardExtents, shardFactors, originalBlockFactors, candidate.dimScales,
           device, l1Attr, numBuffers);

--- a/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "llvm/ADT/DenseMap.h"
 
 #include <functional>
 
@@ -38,6 +39,15 @@ struct CandidateScore {
   uint64_t blockingVolume = 1;
   uint64_t cbBytes = 0;
 };
+
+struct PartialCandidate {
+  SmallVector<int64_t> dimScales;
+  uint64_t blockingVolume = 1;
+  uint64_t moderationPenalty = 0;
+};
+
+constexpr std::size_t kEltwiseBeamWidth = 64;
+constexpr std::size_t kEltwiseScalesPerDim = 5;
 
 static llvm::BitVector getDimMask(std::size_t rank,
                                   ArrayRef<std::size_t> dims) {
@@ -117,6 +127,67 @@ static bool isLexicographicallyLarger(ArrayRef<int64_t> lhs,
     }
   }
   return false;
+}
+
+static SmallVector<int64_t> buildEltwiseScaleSearchOrder(int64_t shardFactor) {
+  SmallVector<int64_t> factors = ttmlir::utils::getFactors(shardFactor);
+  llvm::SmallDenseMap<int64_t, int64_t, 8> factorRanks;
+  factorRanks.reserve(factors.size());
+  for (auto [index, factor] : llvm::enumerate(factors)) {
+    factorRanks[factor] = index;
+  }
+  // Visit moderate divisors first.
+  const auto midpoint = static_cast<int64_t>(factors.size() - 1) / 2;
+  llvm::stable_sort(factors, [&](int64_t lhs, int64_t rhs) {
+    if (lhs == rhs) {
+      return false;
+    }
+    const int64_t lhsPenalty = std::abs(factorRanks[lhs] - midpoint);
+    const int64_t rhsPenalty = std::abs(factorRanks[rhs] - midpoint);
+    if (lhsPenalty != rhsPenalty) {
+      return lhsPenalty < rhsPenalty;
+    }
+    if ((lhs == 1) != (rhs == 1)) {
+      return rhs == 1;
+    }
+    return lhs > rhs;
+  });
+
+  SmallVector<int64_t> limited;
+  // Always include 1 in the search order.
+  limited.reserve(std::min(factors.size(), kEltwiseScalesPerDim));
+  for (int64_t factor : factors) {
+    if (limited.size() == kEltwiseScalesPerDim) {
+      break;
+    }
+    limited.push_back(factor);
+  }
+  if (!llvm::is_contained(limited, int64_t{1})) {
+    limited.pop_back();
+    limited.push_back(1);
+  }
+  return limited;
+}
+
+static bool isBetterPartialCandidate(const PartialCandidate &lhs,
+                                     const PartialCandidate &rhs) {
+  if (lhs.moderationPenalty != rhs.moderationPenalty) {
+    return lhs.moderationPenalty < rhs.moderationPenalty;
+  }
+  if (lhs.blockingVolume != rhs.blockingVolume) {
+    return lhs.blockingVolume > rhs.blockingVolume;
+  }
+  return isLexicographicallyLarger(lhs.dimScales, rhs.dimScales);
+}
+
+static void trimPartialBeam(SmallVectorImpl<PartialCandidate> &beam) {
+  llvm::stable_sort(
+      beam, [&](const PartialCandidate &lhs, const PartialCandidate &rhs) {
+        return isBetterPartialCandidate(lhs, rhs);
+      });
+  if (beam.size() > kEltwiseBeamWidth) {
+    beam.resize(kEltwiseBeamWidth);
+  }
 }
 
 // Compare two automatic-reblocking candidates for the same generic op.
@@ -300,7 +371,8 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
                 ArrayRef<ttcore::IteratorType> iteratorTypes,
                 ArrayRef<int64_t> gridExtents, ArrayRef<int64_t> shardExtents,
                 ArrayRef<int64_t> shardFactors, ttcore::DeviceAttr device,
-                ttcore::MemorySpaceAttr l1Attr, uint32_t numBuffers) {
+                ttcore::MemorySpaceAttr l1Attr, uint32_t numBuffers,
+                bool useBoundedEltwiseSearch = true) {
   const SmallVector<int64_t> originalBlockFactors =
       genericOp.getBlockFactorsValue();
 
@@ -317,8 +389,14 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
   //===------------------------------------------------------------------===//
   SmallVector<SmallVector<int64_t>> legalScales;
   legalScales.reserve(config->candidateDims.size());
+  uint64_t boundedSearchSpace = 1;
   for (std::size_t dim : config->candidateDims) {
-    legalScales.push_back(ttmlir::utils::getFactors(shardFactors[dim]));
+    SmallVector<int64_t> dimScales =
+        config->shapeClass == AutoShapeClass::AllParallelEltwise
+            ? buildEltwiseScaleSearchOrder(shardFactors[dim])
+            : ttmlir::utils::getFactors(shardFactors[dim]);
+    boundedSearchSpace *= dimScales.size();
+    legalScales.push_back(std::move(dimScales));
   }
 
   //===------------------------------------------------------------------===//
@@ -331,6 +409,56 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
         genericOp, config->candidateDims, indexingMaps, gridExtents,
         shardExtents, shardFactors, originalBlockFactors, currentDimScales,
         device, l1Attr, numBuffers, /*allowIdentityCandidate=*/true);
+  }
+
+  // Restrict the large eltwise search space to the top kEltwiseBeamWidth
+  // candidates unless the caller explicitly requests exhaustive search.
+  if (useBoundedEltwiseSearch &&
+      config->shapeClass == AutoShapeClass::AllParallelEltwise &&
+      boundedSearchSpace > kEltwiseBeamWidth) {
+    SmallVector<PartialCandidate> beam;
+    beam.push_back(
+        PartialCandidate{SmallVector<int64_t>(currentDimScales), 1, 0});
+
+    for (std::size_t dimIndex = 0; dimIndex < config->candidateDims.size();
+         ++dimIndex) {
+      const std::size_t dim = config->candidateDims[dimIndex];
+      SmallVector<PartialCandidate> expanded;
+      expanded.reserve(beam.size() * legalScales[dimIndex].size());
+      for (const PartialCandidate &partial : beam) {
+        for (auto [scaleRank, scale] : llvm::enumerate(legalScales[dimIndex])) {
+          PartialCandidate candidate = partial;
+          candidate.dimScales[dim] = scale;
+          candidate.blockingVolume *= scale;
+          candidate.moderationPenalty += scaleRank;
+          expanded.push_back(std::move(candidate));
+        }
+      }
+      trimPartialBeam(expanded);
+      beam = std::move(expanded);
+    }
+
+    for (const PartialCandidate &candidate : beam) {
+      auto score = evaluateCandidate(
+          genericOp, config->candidateDims, indexingMaps, gridExtents,
+          shardExtents, shardFactors, originalBlockFactors, candidate.dimScales,
+          device, l1Attr, numBuffers);
+      if (score &&
+          (!bestCandidate ||
+           isBetterCandidate(config->shapeClass, *score, *bestCandidate))) {
+        bestCandidate = std::move(score);
+      }
+    }
+
+    if (!bestCandidate) {
+      return originalBlockFactors;
+    }
+
+    TT_ALLOC_DEBUG("applying auto policy scales {}, new block factors {}, CB "
+                   "bytes {}",
+                   asSeq(bestCandidate->dimScales),
+                   asSeq(bestCandidate->blockFactors), bestCandidate->cbBytes);
+    return bestCandidate->blockFactors;
   }
 
   std::function<void(std::size_t)> enumerateCandidates =
@@ -389,7 +517,11 @@ static SmallVector<int64_t> chooseReblockedFactors(
   case BlockFactorAnalysis::BufferSizePolicy::Auto:
     return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
                            shardExtents, shardFactors, device, l1Attr,
-                           numBuffers);
+                           numBuffers, /*useBoundedEltwiseSearch=*/true);
+  case BlockFactorAnalysis::BufferSizePolicy::Exhaustive:
+    return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
+                           shardExtents, shardFactors, device, l1Attr,
+                           numBuffers, /*useBoundedEltwiseSearch=*/false);
   }
 
   llvm_unreachable("unknown buffer size policy");

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -294,6 +294,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
   parseBufferSizePolicy(StringRef policy) {
     return llvm::StringSwitch<std::optional<BufferSizePolicy>>(policy)
         .Case("auto", BufferSizePolicy::Auto)
+        .Case("exhaustive", BufferSizePolicy::Exhaustive)
         .Case("min", BufferSizePolicy::Min)
         .Case("max", BufferSizePolicy::Max)
         .Default(std::nullopt);
@@ -311,7 +312,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     if (!parsedBufferSizePolicy.has_value()) {
       moduleOp.emitOpError()
           << "invalid test-buffer-size-policy '" << testBufferSizePolicy
-          << "' (expected one of: auto, min, max)";
+          << "' (expected one of: auto, exhaustive, min, max)";
       return signalPassFailure();
     }
     bufferSizePolicy = *parsedBufferSizePolicy;

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -294,7 +294,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
   parseBufferSizePolicy(StringRef policy) {
     return llvm::StringSwitch<std::optional<BufferSizePolicy>>(policy)
         .Case("auto", BufferSizePolicy::Auto)
-        .Case("exhaustive", BufferSizePolicy::Exhaustive)
+        .Case("bounded", BufferSizePolicy::Bounded)
         .Case("min", BufferSizePolicy::Min)
         .Case("max", BufferSizePolicy::Max)
         .Default(std::nullopt);
@@ -312,7 +312,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     if (!parsedBufferSizePolicy.has_value()) {
       moduleOp.emitOpError()
           << "invalid test-buffer-size-policy '" << testBufferSizePolicy
-          << "' (expected one of: auto, exhaustive, min, max)";
+          << "' (expected one of: auto, bounded, min, max)";
       return signalPassFailure();
     }
     bufferSizePolicy = *parsedBufferSizePolicy;

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
@@ -2,6 +2,8 @@
 // RUN: FileCheck %s --check-prefix=CHECK-MAX --input-file=%t.max
 // RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=test-assume-l1-capacity=8388608" -o %t.auto %s
 // RUN: FileCheck %s --check-prefix=CHECK-AUTO --input-file=%t.auto
+// RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=test-assume-l1-capacity=8388608 test-buffer-size-policy=exhaustive" -o %t.exhaustive %s
+// RUN: FileCheck %s --check-prefix=CHECK-EXHAUSTIVE --input-file=%t.exhaustive
 
 #l1 = #ttcore.memory_space<l1>
 #dram = #ttcore.memory_space<dram>
@@ -9,6 +11,7 @@
 #mapR = affine_map<(d0, d1, d2) -> (d2, d1)>
 #mapO = affine_map<(d0, d1, d2) -> (d0, d1)>
 #eltwise = affine_map<(d0, d1) -> (d0, d1)>
+#eltwise4d = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #eltwisePermuted = affine_map<(d0, d1) -> (d1, d0)>
 #eltwise3d = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #tail3d = affine_map<(d0, d1, d2) -> (d1, d2)>
@@ -223,5 +226,32 @@ module {
       %add = "d2m.tile_add"(%t0, %t1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     }
     return %out : memref<1x1x1x4x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x8192x8192, 1>, #dram>
+  }
+
+  // Large all-parallel factor spaces should use the bounded eltwise search in
+  // auto mode, while exhaustive mode expands the full candidate space.
+  // CHECK-AUTO-LABEL: func.func @eltwise_auto_vs_exhaustive_large_search_space()
+  // CHECK-AUTO: d2m.generic {block_factors = [4, 2, 2, 2], grid = #ttcore.grid<1x1x1x1>
+  // CHECK-AUTO-COUNT-3: memref.alloc() {{.*}} : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<32768x16384x8192x4096, 2>, #l1>
+  // CHECK-EXHAUSTIVE-LABEL: func.func @eltwise_auto_vs_exhaustive_large_search_space()
+  // CHECK-EXHAUSTIVE: d2m.generic {block_factors = [4, 4, 4, 1], grid = #ttcore.grid<1x1x1x1>
+  // CHECK-EXHAUSTIVE-COUNT-3: memref.alloc() {{.*}} : memref<1x1x1x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x16384x16384x4096, 2>, #l1>
+  func.func @eltwise_auto_vs_exhaustive_large_search_space() -> memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #dram> {
+    %lhs = memref.alloc() : memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #l1>
+    %rhs = memref.alloc() : memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #l1>
+    %out = memref.alloc() : memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #dram>
+    d2m.generic {block_factors = [1, 1, 1, 1], grid = #ttcore.grid<1x1x1x1>, indexing_maps = [#eltwise4d, #eltwise4d, #eltwise4d], iterator_types = [#parallel, #parallel, #parallel, #parallel], threads = [#d2m.thread<compute>]}
+        ins(%lhs, %rhs : memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #l1>, memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #l1>)
+        outs(%out : memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #dram>) {
+    ^compute0():
+      %tmp_in0 = memref.alloc() : memref<4x4x4x4x!ttcore.tile<32x32, f32>, #l1>
+      %tmp_in1 = memref.alloc() : memref<4x4x4x4x!ttcore.tile<32x32, f32>, #l1>
+      %tmp_out = memref.alloc() : memref<4x4x4x4x!ttcore.tile<32x32, f32>, #l1>
+      %c0 = arith.constant 0 : index
+      %t0 = memref.load %tmp_in0[%c0, %c0, %c0, %c0] : memref<4x4x4x4x!ttcore.tile<32x32, f32>, #l1>
+      %t1 = memref.load %tmp_in1[%c0, %c0, %c0, %c0] : memref<4x4x4x4x!ttcore.tile<32x32, f32>, #l1>
+      %add = "d2m.tile_add"(%t0, %t1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+    }
+    return %out : memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #dram>
   }
 }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
@@ -2,8 +2,8 @@
 // RUN: FileCheck %s --check-prefix=CHECK-MAX --input-file=%t.max
 // RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=test-assume-l1-capacity=8388608" -o %t.auto %s
 // RUN: FileCheck %s --check-prefix=CHECK-AUTO --input-file=%t.auto
-// RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=test-assume-l1-capacity=8388608 test-buffer-size-policy=exhaustive" -o %t.exhaustive %s
-// RUN: FileCheck %s --check-prefix=CHECK-EXHAUSTIVE --input-file=%t.exhaustive
+// RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=test-assume-l1-capacity=8388608 test-buffer-size-policy=bounded" -o %t.bounded %s
+// RUN: FileCheck %s --check-prefix=CHECK-BOUNDED --input-file=%t.bounded
 
 #l1 = #ttcore.memory_space<l1>
 #dram = #ttcore.memory_space<dram>
@@ -228,15 +228,15 @@ module {
     return %out : memref<1x1x1x4x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x8192x8192, 1>, #dram>
   }
 
-  // Large all-parallel factor spaces should use the bounded eltwise search in
-  // auto mode, while exhaustive mode expands the full candidate space.
-  // CHECK-AUTO-LABEL: func.func @eltwise_auto_vs_exhaustive_large_search_space()
-  // CHECK-AUTO: d2m.generic {block_factors = [4, 2, 2, 2], grid = #ttcore.grid<1x1x1x1>
-  // CHECK-AUTO-COUNT-3: memref.alloc() {{.*}} : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<32768x16384x8192x4096, 2>, #l1>
-  // CHECK-EXHAUSTIVE-LABEL: func.func @eltwise_auto_vs_exhaustive_large_search_space()
-  // CHECK-EXHAUSTIVE: d2m.generic {block_factors = [4, 4, 4, 1], grid = #ttcore.grid<1x1x1x1>
-  // CHECK-EXHAUSTIVE-COUNT-3: memref.alloc() {{.*}} : memref<1x1x1x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x16384x16384x4096, 2>, #l1>
-  func.func @eltwise_auto_vs_exhaustive_large_search_space() -> memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #dram> {
+  // Large all-parallel factor spaces use full search in auto mode, while
+  // bounded mode uses the restricted beam search.
+  // CHECK-AUTO-LABEL: func.func @eltwise_auto_vs_bounded_large_search_space()
+  // CHECK-AUTO: d2m.generic {block_factors = [4, 4, 4, 1], grid = #ttcore.grid<1x1x1x1>
+  // CHECK-AUTO-COUNT-3: memref.alloc() {{.*}} : memref<1x1x1x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x16384x16384x4096, 2>, #l1>
+  // CHECK-BOUNDED-LABEL: func.func @eltwise_auto_vs_bounded_large_search_space()
+  // CHECK-BOUNDED: d2m.generic {block_factors = [4, 2, 2, 2], grid = #ttcore.grid<1x1x1x1>
+  // CHECK-BOUNDED-COUNT-3: memref.alloc() {{.*}} : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<32768x16384x8192x4096, 2>, #l1>
+  func.func @eltwise_auto_vs_bounded_large_search_space() -> memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #dram> {
     %lhs = memref.alloc() : memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #l1>
     %rhs = memref.alloc() : memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #l1>
     %out = memref.alloc() : memref<1x1x1x1x4x4x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x16384x16384x16384, 1>, #dram>


### PR DESCRIPTION
New policy for eltwise op reblocking (bounded) now prioritizes moderate reblocking (best tradeoff between latency/memory) and performs beam search on a restricted search space set (top 64 candidates for now). Matmul policy remains as is for now (only one dimension is reblocked at this time--reduction--so the search space is quite limited). 

Follow up work is to enable reblocking for different ops at which point the names (AllParallel, Reduction) will change to better reflect true distinction. 
 
<img width="2631" height="3178" alt="image" src="https://github.com/user-attachments/assets/4680d4df-96bf-4273-9ce4-88d55a320354" />

Edit:
The timing data on some full model compilations for the Allocate pass doesn't suggest a need to restrict the current search space right now, so I will keep the exhaustive search as the default policy. What is justified is a bias towards "moderate" reblocking which the "bounded" policy does pick. Keeping the flag for now but will re-orient cost model so moderate factors are biased even for full search. 