### PR TITLE
ConcatOpRewritePattern: reserve 20% L1 headroom in chunk-size formula

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpRewritePattern.cpp
@@ -107,9 +107,7 @@ ConcatOpRewritePattern::matchAndRewrite(ttnn::ConcatOp srcOp,
   uint64_t cbSizeAfterTranspose =
       static_cast<uint64_t>(dimMinusTwo) * elemSizeBytes * 2;
 
-  uint64_t l1UsableSize = ttcore::getCurrentScopeSystemDesc(srcOp)
-                              .getChipDescs()[0]
-                              .getUsableL1Size();
+  uint64_t l1UsableSize = utils::getUsableL1PerCore(srcOp);
 
   if (cbSizeAfterTranspose <= l1UsableSize) {
     // Existing path fits in L1, no workaround needed.


### PR DESCRIPTION
### Ticket
Follow-up to [#8237](https://github.com/tenstorrent/tt-mlir/pull/8237) 

### Problem description
PR [#8237](https://github.com/tenstorrent/tt-mlir/pull/8237) added the ConcatOpRewritePattern workaround to fix the original CB-overflow on ttnn.concat. The workaround chunks the concat along dim[-2] so each per-chunk CB region fits in usable L1.

The chunk-size formula at lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpRewritePattern.cpp:128-130:
```
int64_t maxC = static_cast<int64_t>(l1UsableSize / (elemSizeBytes * 2));
int64_t chunkSize = (maxC / TILE_HEIGHT) * TILE_HEIGHT;
```
sizes each chunk's CB region at 100% of usable L1. For si32 with l1UsableSize ≈ 1,499,136 B this gives chunkSize = 187,392 and per-chunk CB after the internal transpose = 187,392 × 4 × 2 = 1,499,136 B — exactly the full L1 budget, with zero headroom for any other L1-resident tensor on the same cores.

In real model graphs, surrounding ops produce L1-resident intermediates on the workaround's target cores, and the CB region overlaps them at runtime:

```
TT_THROW: Statically allocated circular buffers in program 590 clash with L1
buffers on core range [0-0 - 0-2]. L1 buffer allocated at 1,433,280 and
static circular buffer region ends at 1,498,912
```
### What's changed
Cap the chunk-size at 80% of usable L1, leaving headroom on each core for co-resident allocations:

// Reserve ~20% L1 headroom so the per-chunk CB doesn't crowd out
// co-resident L1 tensors on the same cores 
int64_t maxC = static_cast<int64_t>(l1UsableSize * 0.8 / (elemSizeBytes * 2));
int64_t chunkSize = (maxC / TILE_HEIGHT) * TILE_HEIGHT;

### Logs
[qwen_3_5_concat_error.log](https://github.com/user-attachments/files/27714641/qwen_3_5_concat_error.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
