### PR TITLE
[TTIR] Narrow RankNormalization scoping to skip only const_eval helpers

### DIFF
--- a/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
@@ -58,9 +58,10 @@ static bool needsRankExpansion(Type type) {
   return false;
 }
 
-/// Collects functions that participate in rank normalization. A function
-/// participates if it is external and its signature needs rank expansion, or
-/// if its body contains at least one TTIR-dialect op.
+/// Collects functions that participate in rank normalization:
+///   - external functions whose signature needs rank expansion;
+///   - all other non-external functions, except const_eval helpers (which are
+///     intentionally TTNN-only with rank<2 signatures).
 static DenseSet<func::FuncOp> collectParticipatingFuncs(ModuleOp module) {
   DenseSet<func::FuncOp> result;
   module.walk([&](func::FuncOp funcOp) {
@@ -72,9 +73,6 @@ static DenseSet<func::FuncOp> collectParticipatingFuncs(ModuleOp module) {
       return;
     }
 
-    // Skip only const_eval helpers; they are intentionally TTNN-only with
-    // rank<2 signatures. Every other function (forward, trace, D2M
-    // subgraph, forward CPU, ...) participates as in the pre-#8248 logic.
     if (ttmlir::utils::isConstEvalFunc(funcOp)) {
       return;
     }

--- a/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
@@ -72,17 +72,13 @@ static DenseSet<func::FuncOp> collectParticipatingFuncs(ModuleOp module) {
       return;
     }
 
-    bool hasTTIROp = false;
-    funcOp.walk([&](Operation *inner) {
-      if (isa<ttir::TTIRDialect>(inner->getDialect())) {
-        hasTTIROp = true;
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
-    });
-    if (hasTTIROp) {
-      result.insert(funcOp);
+    // Skip only const_eval helpers; they are intentionally TTNN-only with
+    // rank<2 signatures. Every other function (forward, trace, D2M
+    // subgraph, forward CPU, ...) participates as in the pre-#8248 logic.
+    if (ttmlir::utils::isConstEvalFunc(funcOp)) {
+      return;
     }
+    result.insert(funcOp);
   });
   return result;
 }

--- a/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization_scoping.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization_scoping.mlir
@@ -75,6 +75,18 @@ func.func private @cpu_hoisted_decl(tensor<32xf32>) -> tensor<32xf32>
     attributes {tt.function_type = "ForwardCPUDeclaration"}
 
 // =============================================================================
+// Non-const_eval function with no TTIR ops in its body but rank-1 tensors in
+// its signature must participate so the signature is promoted to rank-2.
+// =============================================================================
+
+// CHECK-LABEL: func.func @forward_rank1_no_ttir_op
+// CHECK-SAME: (%arg0: tensor<1x32xf32>) -> tensor<1x32xf32>
+// CHECK: return %{{.*}} : tensor<1x32xf32>
+func.func @forward_rank1_no_ttir_op(%arg0: tensor<32xf32>) -> tensor<32xf32> {
+  return %arg0 : tensor<32xf32>
+}
+
+// =============================================================================
 // Function with rank-2 TTIR ops which should be left untouched.
 // =============================================================================
 


### PR DESCRIPTION
### Problem description

Found during the **tt-mlir uplift in tt-xla**: `gpt_oss_120b_tp_dp_galaxy` (batch 128) OOMs after #8248 lands.

#8248 scoped `TTIRRankNormalization` to functions with at least one TTIR op in the body, as a proxy for "skip TTNN-only function bodies" (its tests are all `const_eval` helpers, mentioned as *e.g.* in the test comment). In the D2M + Optimizer path:

```
ConvertTTNNToTTIRPass -> D2MFrontend -> TTIRRankNormalization
```

a forward function can have **no TTIR ops in its body** yet carry **rank-1 tensors in its signature** (layer norm scales, `self_attn.sinks`). The proxy wrongly skipped it → rank-1 weights stayed rank-1 → TTNN picked a `<1x1>` single-core layout → DRAM fragmentation → OOM:

```
Out of Memory: Not enough space to allocate 3294625792 B DRAM buffer
... largest free block 215 MB
```

### What's changed

Replace the body-walk proxy with the precise predicate the test cases actually rely on:

- **Skip iff** `tt.function_type = "const_eval"`.
- Otherwise participate (pre-#8248 behavior).

`addLegalDialect<TTNNDialect>()` is kept, so any surviving TTNN ops are still non-candidates for rewriting and #7735 cannot regress.

**Test:** added `@forward_rank1_no_ttir_op` in `rank_normalization_scoping.mlir` — non-`const_eval` func, no TTIR op in body, rank-1 signature. Fails pre-PR, passes post-PR. The existing `@main_const_eval_*` cases continue to pin the `const_eval` skip behavior, so both halves of the predicate are locked in.

**Validation (local):**

| tt-mlir pin                | `gpt_oss_120b_tp_dp_galaxy` (batch 128) |
| -------------------------- | --------------------------------------- |
| `d61eba8f0^` (`9dcd8f5cc`) | passes                                  |
| `d61eba8f0`                | OOM                                     |

### Checklist
- [ ] [perf benchmark for gpt oss](https://github.com/tenstorrent/tt-xla/actions/runs/25800198765/job/75788059529)
