### PR TITLE
[StableHLOToTTIR] Handle 3D attention_mask in SDPA composite lowering

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -811,7 +811,26 @@ public:
                                        adaptor.getOperands()[1],
                                        adaptor.getOperands()[2]};
     if (hasAttnMask) {
-      sdpaOperands.push_back(adaptor.getOperands()[3]);
+      // Left-pad mask with unit dims to 4D — matches PyTorch broadcast
+      // semantics.
+      Value mask = adaptor.getOperands()[3];
+      auto maskType = mlir::cast<RankedTensorType>(mask.getType());
+      int64_t maskRank = maskType.getRank();
+      if (maskRank > 4) {
+        return rewriter.notifyMatchFailure(srcOp,
+                                           "attention_mask rank must be <= 4");
+      }
+      if (maskRank < 4) {
+        SmallVector<int64_t> paddedShape(4 - maskRank, 1);
+        paddedShape.append(maskType.getShape().begin(),
+                           maskType.getShape().end());
+        auto paddedType =
+            RankedTensorType::get(paddedShape, maskType.getElementType());
+        mask = rewriter.create<ttir::ReshapeOp>(
+            srcOp.getLoc(), paddedType, mask,
+            rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(paddedShape)));
+      }
+      sdpaOperands.push_back(mask);
     }
 
     // ttir.scaled_dot_product_attention has AttrSizedOperandSegments:

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdpa.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdpa.mlir
@@ -1,0 +1,52 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // 3D mask must be left-padded to 4D before ttir.scaled_dot_product_attention.
+  func.func @sdpa_3d_mask(
+      %q: tensor<1x1x1280x1024xbf16>,
+      %k: tensor<1x1x1280x1024xbf16>,
+      %v: tensor<1x1x1280x1024xbf16>,
+      %mask: tensor<1x1280x1280xbf16>) -> tensor<1x1x1280x1024xbf16> {
+    // CHECK-LABEL: func.func @sdpa_3d_mask
+    // CHECK: %[[MASK4D:[0-9]+]] = "ttir.reshape"(%arg3)
+    // CHECK-SAME: shape = [1 : i32, 1 : i32, 1280 : i32, 1280 : i32]
+    // CHECK-SAME: (tensor<1x1280x1280xbf16>{{.*}}) -> tensor<1x1x1280x1280xbf16>
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: %[[MASK4D]]
+    %0 = stablehlo.composite "tenstorrent.scaled_dot_product_attention" %q, %k, %v, %mask {
+        composite_attributes = {is_causal = false},
+        decomposition = @sdpa_impl_3d
+    } : (tensor<1x1x1280x1024xbf16>, tensor<1x1x1280x1024xbf16>, tensor<1x1x1280x1024xbf16>, tensor<1x1280x1280xbf16>) -> tensor<1x1x1280x1024xbf16>
+    return %0 : tensor<1x1x1280x1024xbf16>
+  }
+
+  // 4D mask must pass through unchanged — no extra reshape inserted.
+  func.func @sdpa_4d_mask(
+      %q: tensor<1x1x1280x1024xbf16>,
+      %k: tensor<1x1x1280x1024xbf16>,
+      %v: tensor<1x1x1280x1024xbf16>,
+      %mask: tensor<1x1x1280x1280xbf16>) -> tensor<1x1x1280x1024xbf16> {
+    // CHECK-LABEL: func.func @sdpa_4d_mask
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: "ttir.scaled_dot_product_attention"
+    %0 = stablehlo.composite "tenstorrent.scaled_dot_product_attention" %q, %k, %v, %mask {
+        composite_attributes = {is_causal = false},
+        decomposition = @sdpa_impl_4d
+    } : (tensor<1x1x1280x1024xbf16>, tensor<1x1x1280x1024xbf16>, tensor<1x1x1280x1024xbf16>, tensor<1x1x1280x1280xbf16>) -> tensor<1x1x1280x1024xbf16>
+    return %0 : tensor<1x1x1280x1024xbf16>
+  }
+
+  func.func private @sdpa_impl_3d(
+      %arg0: tensor<1x1x1280x1024xbf16>, %arg1: tensor<1x1x1280x1024xbf16>,
+      %arg2: tensor<1x1x1280x1024xbf16>, %arg3: tensor<1x1280x1280xbf16>) -> tensor<1x1x1280x1024xbf16> {
+    return %arg0 : tensor<1x1x1280x1024xbf16>
+  }
+
+  func.func private @sdpa_impl_4d(
+      %arg0: tensor<1x1x1280x1024xbf16>, %arg1: tensor<1x1x1280x1024xbf16>,
+      %arg2: tensor<1x1x1280x1024xbf16>, %arg3: tensor<1x1x1280x1280xbf16>) -> tensor<1x1x1280x1024xbf16> {
+    return %arg0 : tensor<1x1x1280x1024xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-mlir/issues/8362

### Problem description

- The `stablehlo.composite "tenstorrent.scaled_dot_product_attention"` lowering passes the attention mask through unchanged. `torch.nn.functional.scaled_dot_product_attention` accepts a 3D mask (broadcast against 4D Q/K/V), but `ttir.scaled_dot_product_attention` requires a 4D mask, so the conversion fails with `Attention mask must be a 4D tensor`.

### What's changed

- In `TenstorrentScaledDotProductAttentionConversionPattern`, left-pad the mask with unit dims when its rank is `< 4` before constructing the TTIR op. Ranks `> 4` are rejected via `notifyMatchFailure`. 4D masks are unchanged (no extra reshape) — pre-existing callers are unaffected.
- Added `test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdpa.mlir` covering both the 3D→4D promotion and the 4D pass-through regression guard.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs

- [may13_sdpa_before_fix.log](https://github.com/user-attachments/files/27720134/may13_sdpa_before_fix.log)
- [may13_sdpa_after_fix.log](https://github.com/user-attachments/files/27720132/may13_sdpa_after_fix.log)
