### PR TITLE
Prefer candidates with larger sharded input grid volume as tiebreaker

### DIFF
--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -11,6 +11,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TypecastRules.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Utils.h"
 
 #include "llvm/ADT/DenseMap.h"
 
@@ -55,7 +56,25 @@ bool OpRuleBook::preferCandidate(Operation * /*op*/, const BeamCandidate &a,
     }
     return count;
   };
-  return countShardedInputs(a) > countShardedInputs(b);
+  int64_t shardedA = countShardedInputs(a);
+  int64_t shardedB = countShardedInputs(b);
+  if (shardedA != shardedB) {
+    return shardedA > shardedB;
+  }
+  // Tied on sharded-input count: greedily prefer the candidate whose sharded
+  // inputs cover a larger total grid volume. This assumes ops benefit from
+  // inputs already distributed across more cores, not just sharded outputs.
+  auto shardedGridVolume = [](const BeamCandidate &c) -> int64_t {
+    int64_t total = 0;
+    for (const auto &layout : c.inputLayouts) {
+      auto ml = layout.getMemLayout();
+      if (ml && isShardedMemoryLayout(ml.getValue())) {
+        total += ttmlir::utils::volume(layout.getGridShape());
+      }
+    }
+    return total;
+  };
+  return shardedGridVolume(a) > shardedGridVolume(b);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

Extends `OpRuleBook::preferCandidate` with a second tiebreaker tier: when two candidates tie on sharded-input count, prefer the one with the larger total sharded grid volume across all inputs. This pulls more upstream parallelism through the op without overriding the existing sharding preference.

## Notes

The current heuristic counts grid volume for all sharded inputs regardless of whether they require resharding. It is important to note that reshard quantity is not considered here — this could be a more important tiebreaker: while `scoreCandidate` already penalizes candidates that have any input reshards vs. none, when multiple inputs are resharded the quantity is not accounted for anywhere, and preferring the candidate with fewer resharded inputs (or lower total reshard cost) could outweigh grid volume as a signal.

## Test plan
- [x] No significant regressions + some gains(?) on other perf benchmark tests (non-vllms)
  - on base commit: https://github.com/tenstorrent/tt-xla/actions/runs/26399822651
  - this change on top: https://github.com/tenstorrent/tt-xla/actions/runs/26399800083
 
<img width="1950" height="1680" alt="image" src="https://github.com/user-attachments/assets/d91dced7-52b5-46f7-aa56-9ff587ada410" />
