### PR TITLE
[ttkernel] Add EmitC lowering for arith.minsi / arith.maxsi

### DIFF
--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1537,6 +1537,42 @@ public:
     return success();
   }
 };
+
+// Arith MaxSIOp / MinSIOp don't have an emitc lowering. Lower to
+// std::max<int32_t> / std::min<int32_t>, mirroring the unsigned versions.
+class ArithMaxSIRewriter : public OpConversionPattern<arith::MaxSIOp> {
+public:
+  using OpConversionPattern<arith::MaxSIOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arith::MaxSIOp op, arith::MaxSIOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, resultType, "std::max<int32_t>", adaptor.getOperands());
+    return success();
+  }
+};
+
+class ArithMinSIRewriter : public OpConversionPattern<arith::MinSIOp> {
+public:
+  using OpConversionPattern<arith::MinSIOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arith::MinSIOp op, arith::MinSIOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, resultType, "std::min<int32_t>", adaptor.getOperands());
+    return success();
+  }
+};
 } // namespace
 
 namespace {
@@ -1926,9 +1962,10 @@ public:
             ttkernel::InterleavedAddrGenFastGetNocAddrOp>>(typeConverter,
                                                            funcOp.getContext());
 
-    patterns.add<ArithFloorDivRewriter, ArithBitcastRewriter,
-                 ArithMaxUIRewriter, ArithMinUIRewriter>(typeConverter,
-                                                         funcOp.getContext());
+    patterns
+        .add<ArithFloorDivRewriter, ArithBitcastRewriter, ArithMaxUIRewriter,
+             ArithMinUIRewriter, ArithMaxSIRewriter, ArithMinSIRewriter>(
+            typeConverter, funcOp.getContext());
 
     return applyFullConversion(funcOp, target, std::move(patterns));
   }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/minsi_maxsi.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/minsi_maxsi.mlir
@@ -1,0 +1,24 @@
+// RUN: ttmlir-opt --convert-ttkernel-to-emitc -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Arith MinSIOp / MaxSIOp don't have a built-in emitc lowering. The
+// TTKernelToEmitC pass rewrites them to std::min<int32_t> / std::max<int32_t>
+// CallOpaqueOps, mirroring the unsigned variants.
+
+// CHECK-LABEL: func @minsi
+func.func @minsi() -> i32 attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+  %0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> i32
+  %1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> i32
+  // CHECK: emitc.call_opaque "std::min<int32_t>"
+  %2 = arith.minsi %0, %1 : i32
+  return %2 : i32
+}
+
+// CHECK-LABEL: func @maxsi
+func.func @maxsi() -> i32 attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+  %0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> i32
+  %1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> i32
+  // CHECK: emitc.call_opaque "std::max<int32_t>"
+  %2 = arith.maxsi %0, %1 : i32
+  return %2 : i32
+}


### PR DESCRIPTION
Mirrors the existing MinUI/MaxUI rewriters but uses `std::min<int32_t>` / `std::max<int32_t>` for the signed-integer variants. Needed by index arithmetic (group_size_m = min(num_pid_m - group_id, group_size_m) and similar) that lowers through the d2m-to-ttkernel pipeline.

Includes a lit test exercising both rewriters.