### PR TITLE
Flip gridW/gridH in DistributedRMSNormWidthShardInputRewritePattern for consistency with system desc

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
@@ -261,8 +261,8 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
   auto scalarShardShape = desiredInputLayout.getScalarShardShape();
   int64_t blockH = scalarShardShape[0] / tileWidth;
   int64_t blockW = scalarShardShape[1] / tileWidth;
-  int64_t gridW = std::min(numCores, physicalGrid[0]);
-  int64_t gridH = (numCores + physicalGrid[0] - 1) / physicalGrid[0];
+  int64_t gridW = std::min(numCores, physicalGrid[1]);
+  int64_t gridH = (numCores + physicalGrid[1] - 1) / physicalGrid[1];
   auto programConfigAttr =
       ttnn::LayerNormShardedMultiCoreProgramConfigAttr::get(
           rewriter.getContext(),


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4678

### Problem description

This change is AI generated.

DistributedRMSNormOp fails at runtime with the error:
TT_FATAL: Shard grid bounding box must fit within compute grid size

This occurs on blackhole architecture when the tensor width requires more cores than physicalGrid[0] (10) but fits within physicalGrid[1] (12). For example, a tensor with width 448 (14 tiles) width-sharded on blackhole produces core ranges spanning x=0..11, but the program_config incorrectly specifies compute_with_storage_grid_size = <10, 2> instead of <12, 2>.

The root cause is in DistributedRMSNormWidthShardInputRewritePattern.cpp where the program config grid size calculation uses physicalGrid[0] as the grid width. However, the system descriptor stores the grid as {rows,  cols} (10x12), so physicalGrid[0] is actually the row count (10), not the column count (12). Meanwhile, buildWithCanonicalCorePlacement correctly uses gridSize[1] as the width when placing cores, creating a mismatch.

### What's changed

Changed the program config grid size calculation to use physicalGrid[1] (columns) instead of physicalGrid[0] (rows) for the grid width, consistent with how buildRowMajorCoreRanges interprets the grid shape.

Before:
int64_t gridW = std::min(numCores, physicalGrid[0]);
int64_t gridH = (numCores + physicalGrid[0] - 1) / physicalGrid[0];

After:
int64_t gridW = std::min(numCores, physicalGrid[1]);
int64_t gridH = (numCores + physicalGrid[1] - 1) / physicalGrid[1];

### Checklist
- [ ]  New/Existing tests provide coverage for changes