### PR TITLE
[d2m] pipe clean dram to dram for reductions and matmuls

### DIFF
--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -9,6 +9,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 
+#include <utility>
 #include <variant>
 
 namespace mlir::tt::ttcore {
@@ -103,6 +104,12 @@ std::optional<AffineMap> getVirtualGridInverseMapping(Value val);
 // associated with a value, if any.  Traces the same def-use chain as
 // getVirtualGridInverseMapping but returns the forward map attribute.
 std::optional<AffineMap> getVirtualGridForwardMapping(Value val);
+
+// Derive GridAttr-compatible virtual grid maps for `gridShape` from the full
+// tensor/memref virtual grid mapping carried by `val`. Returns std::nullopt
+// when the stored mapping belongs to a different-rank view of the value.
+std::optional<std::pair<AffineMap, AffineMap>>
+getGridMapsFromVirtualGridMapping(Value val, ArrayRef<int64_t> gridShape);
 
 // Returns the effective affine map for a memref-typed value by resolving
 // ViewLayoutAttr remappings (via applyViews) and falling back to the layout's

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
@@ -363,23 +363,20 @@ public:
     ttcore::GridAttr grid;
     if (outputInfo.isDRAM()) {
       viewOutput = buildConcreteView(output, outputInfo.type, inputInfo.type);
-      if (auto invMap = utils::getVirtualGridInverseMapping(input)) {
-        auto gridShape = llvm::to_vector(inputInfo.getGridShape());
-
-        auto fwdMap = *utils::getVirtualGridForwardMapping(input);
-        size_t rank = gridShape.size();
-        fwdMap = ttmlir::utils::affineMapDropBackResults(fwdMap, rank);
-        for (int i = rank - 1; i >= 0; i--) {
-          fwdMap = ttmlir::utils::dropDim(fwdMap, rank + i);
-        }
-        fwdMap = fwdMap.insertResult(
-            getAffineConstantExpr(0, rewriter.getContext()), 0);
-
-        grid = rewriter.getAttr<ttcore::GridAttr>(gridShape, fwdMap, *invMap);
+      auto gridShape = llvm::to_vector(inputInfo.getGridShape());
+      if (auto maps =
+              utils::getGridMapsFromVirtualGridMapping(input, gridShape)) {
+        grid = rewriter.getAttr<ttcore::GridAttr>(gridShape, maps->first,
+                                                  maps->second);
       }
     }
 
-    const size_t gridRank = outputInfo.getGridShape().size();
+    auto viewOutputType = mlir::cast<RankedTensorType>(viewOutput.getType());
+    auto viewOutputLayout = mlir::dyn_cast_or_null<ttcore::MetalLayoutAttr>(
+        viewOutputType.getEncoding());
+    const size_t gridRank =
+        viewOutputLayout ? viewOutputLayout.getShardShape(viewOutputType).size()
+                         : viewOutputType.getShape().size();
 
     ArrayAttr indexingMaps, iteratorTypes;
     std::tie(indexingMaps, iteratorTypes) =
@@ -407,6 +404,11 @@ public:
                 },
                 ThreadType::Unified, grid)
             .getResult(0);
+    if (outputInfo.isDRAM() && result.getType() != output.getType()) {
+      return buildConcreteView(result,
+                               mlir::cast<RankedTensorType>(result.getType()),
+                               outputInfo.type);
+    }
     return result;
   }
 

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
@@ -105,6 +105,32 @@ bool canUseReinterpretLayoutView(const PlanState &current,
              target.getLayout()->getMemoryLayout();
 }
 
+// DRAM cannot be both the source and destination of a materializing generic.
+// Pure view-like DRAM changes are still legal, but anything requiring a copy or
+// format/grid mutation must bounce through L1 first.
+bool needsDramBounce(const PlanState &current, const PlanState &target) {
+  if (!current.hasLayout() || !target.hasLayout() || !current.isDRAM() ||
+      !target.isDRAM()) {
+    return false;
+  }
+
+  bool sameVgm = current.vgmForward == target.vgmForward &&
+                 current.vgmInverse == target.vgmInverse;
+  bool sameRemapping = current.remapping == target.remapping;
+  bool sameOrReinterpretableType = current.type == target.type ||
+                                   canUseReinterpretLayoutView(current, target);
+  if (sameVgm && sameRemapping && sameOrReinterpretableType) {
+    return false;
+  }
+
+  bool currentHasRemapping = current.remapping && !current.remapping.isEmpty();
+  bool targetHasRemapping = target.remapping && !target.remapping.isEmpty();
+  bool onlyApplyingTargetRemap = sameVgm && !currentHasRemapping &&
+                                 targetHasRemapping &&
+                                 sameOrReinterpretableType;
+  return !onlyApplyingTargetRemap;
+}
+
 // Collapse an ND virtual grid into a 2D bounce shape that fits within the
 // device grid. Used when staging data through interleaved DRAM on a unit grid.
 llvm::SmallVector<int64_t>
@@ -293,6 +319,20 @@ Plan canonicalize(const PlanState &src, const PlanState &tgt,
     updateStateFromOutput(current, output);
   }
 
+  // DRAM → DRAM materialization: stage through an equivalent L1 buffer before
+  // doing format/grid/VGM changes, then let the normal L1 → DRAM rule below
+  // write into the final target buffer.
+  if (needsDramBounce(current, tgt)) {
+    auto l1Type = modifyDeviceType(
+        ctx, current.type, *current.getLayout(), targetGridShape,
+        current.remapping, ttcore::MemorySpace::DeviceL1,
+        llvm::to_vector(current.getGridShape()), current.type.getElementType());
+    auto output =
+        makeOutputSpec(l1Type, current.vgmForward, current.vgmInverse);
+    plan.push_back(DRAMToL1Step{output, AffineMap()});
+    updateStateFromOutput(current, output, current.remapping);
+  }
+
   // DRAM → L1: DMA the tensor into an L1 buffer. For device-to-device layout
   // changes, use the target layout. For device-to-host, mirror the
   // host-to-device path by staging the current device layout through L1 before
@@ -354,10 +394,12 @@ Plan canonicalize(const PlanState &src, const PlanState &tgt,
     updateStateFromOutput(current, output, current.remapping);
   }
 
-  // L1 → DRAM: the DMA writes directly into the output DRAM buffer.
+  // L1 → DRAM: the DMA writes directly into the output DRAM buffer, including
+  // the target virtual-grid metadata. Otherwise a following VGM-only rebuffer
+  // would become an unsupported DRAM→DRAM copy.
   if (current.hasLayout() && !current.isDRAM() && tgt.hasLayout() &&
       tgt.isDRAM()) {
-    auto output = makeOutputSpec(tgt.type);
+    auto output = makeOutputSpec(tgt.type, tgt.vgmForward, tgt.vgmInverse);
     plan.push_back(L1ToDRAMStep{output, AffineMap()});
     updateStateFromOutput(current, output);
   }

--- a/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.h"
 
@@ -16,6 +17,25 @@ namespace mlir::tt::d2m {
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 namespace {
+
+static bool containsAccumulatingCompute(Operation *op) {
+  if (isa<d2m::TileMatmulOp, d2m::TileMatmulBlockOp, d2m::TileReduceSumOp,
+          d2m::TileReduceMaxOp, d2m::TileReduceMeanOp, d2m::TileSFPUReduceSumOp,
+          d2m::TileSFPUReduceMaxOp>(op)) {
+    return true;
+  }
+
+  return op
+      ->walk([](Operation *nestedOp) {
+        if (isa<d2m::TileMatmulOp, d2m::TileMatmulBlockOp, d2m::TileReduceSumOp,
+                d2m::TileReduceMaxOp, d2m::TileReduceMeanOp,
+                d2m::TileSFPUReduceSumOp, d2m::TileSFPUReduceMaxOp>(nestedOp)) {
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      })
+      .wasInterrupted();
+}
 
 class D2MMarkSynchronizedBuffers
     : public impl::D2MMarkSynchronizedBuffersBase<D2MMarkSynchronizedBuffers> {
@@ -32,8 +52,15 @@ public:
       for (auto &[cb, usageInfo] : cbUsageInfo) {
         if (auto allocOp =
                 mlir::dyn_cast<memref::AllocOp>(cb.getDefiningOp())) {
+          int32_t bufferCount = numStreamBuffers;
+          for (Operation *producer : usageInfo.producers) {
+            if (containsAccumulatingCompute(producer)) {
+              bufferCount = 1;
+              break;
+            }
+          }
           allocOp->setAttr("d2m.synchronized_buffer",
-                           rewriter.getI32IntegerAttr(numStreamBuffers));
+                           rewriter.getI32IntegerAttr(bufferCount));
 
           if (!usageInfo.consumers.empty() && !usageInfo.producers.empty()) {
             TT_assertv((usageInfo.consumers.size() == 1 &&

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -287,6 +287,20 @@ SmallVector<int64_t> getPhysicalGridShape(Value tensorOrMemref) {
     ttcore::DeviceAttr device = ttcore::lookupDevice(viewOp);
     auto deviceGridShape = device.getWorkerGrid().getShape();
     TT_assert(ttcore::hasDeviceLayout(tensorOrMemref));
+
+    if (auto fwdMap = utils::getVirtualGridForwardMapping(tensorOrMemref)) {
+      auto shapedType = dyn_cast<ShapedType>(tensorOrMemref.getType());
+      TT_assert(shapedType);
+      if (fwdMap->getNumDims() == shapedType.getRank()) {
+        auto physicalShape =
+            ttmlir::utils::evalShape(*fwdMap, shapedType.getShape());
+        TT_assert(physicalShape.size() >= deviceGridShape.size());
+        return SmallVector<int64_t>(physicalShape.begin(),
+                                    physicalShape.begin() +
+                                        deviceGridShape.size());
+      }
+    }
+
     SmallVector<int64_t> outputGridShape =
         llvm::to_vector(ttcore::getGridShape(tensorOrMemref));
 
@@ -308,11 +322,18 @@ SmallVector<int64_t> getPhysicalGridShape(Value tensorOrMemref) {
   if (auto fwdMap = utils::getVirtualGridForwardMapping(tensorOrMemref)) {
     auto shapedType = dyn_cast<ShapedType>(tensorOrMemref.getType());
     TT_assert(shapedType);
-    auto fullShape = shapedType.getShape();
-    auto physShape = ttmlir::utils::evalShape(*fwdMap, fullShape);
-    unsigned gridRank = fullShape.size() / 2;
-    return SmallVector<int64_t>(physShape.begin(),
-                                physShape.begin() + gridRank);
+    if (fwdMap->getNumDims() == shapedType.getRank()) {
+      auto fullShape = shapedType.getShape();
+      auto physShape = ttmlir::utils::evalShape(*fwdMap, fullShape);
+      unsigned physicalGridRank = 2;
+      if (auto *definingOp = tensorOrMemref.getDefiningOp()) {
+        physicalGridRank =
+            ttcore::lookupDevice(definingOp).getWorkerGrid().getShape().size();
+      }
+      TT_assert(physShape.size() >= physicalGridRank);
+      return SmallVector<int64_t>(physShape.begin(),
+                                  physShape.begin() + physicalGridRank);
+    }
   }
 
   // Check for a reblocking remapping on a view/stream op.
@@ -503,6 +524,41 @@ std::optional<AffineMap> getVirtualGridForwardMapping(Value val) {
   return std::nullopt;
 }
 
+std::optional<std::pair<AffineMap, AffineMap>>
+getGridMapsFromVirtualGridMapping(Value val, ArrayRef<int64_t> gridShape) {
+  auto invMap = getVirtualGridInverseMapping(val);
+  auto fwdMap = getVirtualGridForwardMapping(val);
+  if (!invMap || !fwdMap) {
+    return std::nullopt;
+  }
+
+  // Full VGM maps are shaped as:
+  //   (virtual grid dims, shard dims) -> (physical grid dims, shard dims)
+  // The generic grid only consumes the virtual grid dims. If a view has changed
+  // the apparent grid rank, the stored VGM describes the backing value instead
+  // and must not be attached to this GridAttr.
+  const unsigned rank = gridShape.size();
+  if (rank == 0 || fwdMap->getNumDims() != 2 * rank ||
+      fwdMap->getNumResults() != rank + 2 || invMap->getNumDims() != 2 ||
+      invMap->getNumResults() != rank + 1) {
+    return std::nullopt;
+  }
+
+  AffineMap gridFwdMap = *fwdMap;
+  gridFwdMap = ttmlir::utils::affineMapDropBackResults(gridFwdMap, rank);
+  for (int64_t i = static_cast<int64_t>(rank) - 1; i >= 0; --i) {
+    gridFwdMap =
+        ttmlir::utils::dropDim(gridFwdMap, rank + static_cast<unsigned>(i));
+  }
+  gridFwdMap = gridFwdMap.insertResult(
+      getAffineConstantExpr(0, gridFwdMap.getContext()), 0);
+
+  if (gridFwdMap.getNumDims() != rank || gridFwdMap.getNumResults() != 3) {
+    return std::nullopt;
+  }
+  return std::make_pair(gridFwdMap, *invMap);
+}
+
 std::optional<AffineMap> getAssociatedRemapping(Value val) {
   if (auto viewOp = val.getDefiningOp<ViewLayoutOp>()) {
     AffineMap map = viewOp.getRemapping();
@@ -525,6 +581,62 @@ AffineMap resolveEffectiveAffineMap(Value val, MemRefType memrefType) {
   }
   return AffineMap::getMultiDimIdentityMap(memrefType.getRank(),
                                            memrefType.getContext());
+}
+
+static void appendShapeCollapsedToRank(SmallVectorImpl<int64_t> &symbols,
+                                       ArrayRef<int64_t> shape, unsigned rank) {
+  if (rank == 0) {
+    return;
+  }
+
+  if (shape.size() < rank) {
+    symbols.append(rank - shape.size(), 1);
+    symbols.append(shape.begin(), shape.end());
+    return;
+  }
+
+  if (shape.size() == rank) {
+    symbols.append(shape.begin(), shape.end());
+    return;
+  }
+
+  symbols.push_back(ttmlir::utils::volume(shape.drop_back(rank - 1)));
+  symbols.append(shape.end() - (rank - 1), shape.end());
+}
+
+static SmallVector<int64_t>
+getDramMapShapeSymbols(ttcore::DeviceAttr device, MemRefType memrefType,
+                       ttcore::ShardLayoutAttr shardLayout,
+                       std::optional<AffineMap> storedForwardMap) {
+  unsigned workerRank = device.getWorkerGrid().getShape().size();
+  TT_assertv(device.getDramMap().getNumSymbols() == workerRank * 2 + 3,
+             "Unexpected DRAM map symbol count");
+
+  SmallVector<int64_t> gridShape;
+  SmallVector<int64_t> shardShape;
+  if (storedForwardMap && !storedForwardMap->isEmpty()) {
+    SmallVector<int64_t> physicalShape =
+        ttmlir::utils::evalShape(*storedForwardMap, memrefType.getShape());
+    TT_assert(physicalShape.size() >= workerRank);
+    gridShape.assign(physicalShape.begin(), physicalShape.begin() + workerRank);
+    shardShape.assign(physicalShape.begin() + workerRank, physicalShape.end());
+  } else {
+    unsigned shardRank = shardLayout.getRank();
+    unsigned gridRank = memrefType.getRank() - shardRank;
+    gridShape = llvm::to_vector(memrefType.getShape().take_front(gridRank));
+    shardShape = llvm::to_vector(memrefType.getShape().drop_front(gridRank));
+
+    if (ttmlir::d2m::utils::grids::requiresVirtualGrid(
+            gridShape, device.getWorkerGrid().getShape())) {
+      gridShape = llvm::to_vector(collapseToPhysicalGrid2D(
+          gridShape, device.getWorkerGrid().getShape()));
+    }
+  }
+
+  SmallVector<int64_t> symbols;
+  appendShapeCollapsedToRank(symbols, gridShape, workerRank);
+  appendShapeCollapsedToRank(symbols, shardShape, workerRank);
+  return symbols;
 }
 
 // Core implementation of getMemoryMap. When storedForwardMap is provided, it
@@ -604,7 +716,8 @@ getMemoryMapImpl(ttcore::DeviceAttr device, MemRefType memrefType,
     case ttcore::MemorySpace::DeviceDRAM: {
       pageSize = device.getMemrefSizeBytes(memrefType);
       assert(pageSize > 0 && "expected positive page size");
-      SmallVector<int64_t> symbols(memrefType.getShape());
+      SmallVector<int64_t> symbols = getDramMapShapeSymbols(
+          device, memrefType, shardLayout, storedForwardMap);
       symbols.push_back(static_cast<int64_t>(pageSize));
       symbols.push_back(static_cast<int64_t>(baseOffset));
       symbols.push_back(

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -4,12 +4,17 @@
 
 import pytest
 import torch
-from typing import Optional
+from typing import List, Optional
 
 from conftest import get_request_kwargs
 from builder.base.builder_utils import Operand, Shape
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir
+from d2m.test_matmul import create_matmul_constrained_inputs
+from d2m.test_reductions import (
+    _reduction_atol,
+    create_reductions_constrained_inputs,
+)
 from test_utils import shape_str
 
 pytestmark = pytest.mark.frontend("ttir")
@@ -102,13 +107,14 @@ def get_clamp_bounds(dtype: torch.dtype):
     return (0, 3) if dtype == torch.int32 else (-0.5, 0.8)
 
 
-def compile_dram_test(module, request, device, target: str):
+def compile_dram_test(module, request, device, target: str, **compile_kwargs):
     compile_and_execute_ttir(
         module,
         **get_request_kwargs(request),
         target=target,
         device=device,
         pipeline_options=list(DRAM_PIPELINE_OPTIONS),
+        **compile_kwargs,
     )
 
 
@@ -272,3 +278,97 @@ def test_dram_ternary_clamp_scalar(
             )
 
     compile_dram_test(module, request, device, target)
+
+
+DRAM_MATMUL_CASES = [
+    pytest.param(
+        (32, 128),
+        (128, 64),
+        torch.float32,
+        id="f32-32x128x64",
+    ),
+    pytest.param(
+        (128, 320),
+        (320, 768),
+        torch.bfloat16,
+        id="bf16-128x320x768",
+    ),
+    pytest.param(
+        (2, 64, 160),
+        (2, 160, 96),
+        torch.float32,
+        id="f32-batch2-64x160x96",
+    ),
+]
+
+DRAM_REDUCTION_CASES = [
+    pytest.param(
+        (1, 128, 320),
+        "sum",
+        [2],
+        False,
+        torch.float32,
+        id="f32-sum-1x128x320-dim2",
+    ),
+    pytest.param(
+        (2, 128, 160),
+        "mean",
+        [2],
+        True,
+        torch.float32,
+        id="f32-mean-2x128x160-dim2-keep",
+    ),
+    pytest.param(
+        (4, 64, 128),
+        "sum",
+        [1],
+        True,
+        torch.bfloat16,
+        id="bf16-sum-4x64x128-dim1-keep",
+    ),
+]
+
+
+@pytest.mark.parametrize("lhs_shape,rhs_shape,dtype", DRAM_MATMUL_CASES)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_matmul(
+    lhs_shape: Shape,
+    rhs_shape: Shape,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    compile_dram_test(
+        create_matmul_constrained_inputs(lhs_shape, rhs_shape, dtype),
+        request,
+        device,
+        target,
+        pcc=0.99,
+    )
+
+
+@pytest.mark.parametrize(
+    "shape,reduce_type,dim_arg,keep_dim,dtype", DRAM_REDUCTION_CASES
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_reduction(
+    shape: Shape,
+    reduce_type: str,
+    dim_arg: List[int],
+    keep_dim: bool,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    compile_dram_test(
+        create_reductions_constrained_inputs(
+            shape, reduce_type, dim_arg, keep_dim, dtype
+        ),
+        request,
+        device,
+        target,
+        atol=_reduction_atol(reduce_type, shape, dim_arg, dtype),
+        pcc=0.99,
+    )

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_to_layout_sharded_to_interleaved.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_to_layout_sharded_to_interleaved.mlir
@@ -48,7 +48,8 @@ func.func @sharded_to_interleaved_reblock() -> tensor<32x2048xbf16, #ttnn_dram_i
   // CHECK: d2m.remote_store %[[VIEW]][%{{.*}}, %{{.*}}] {{.*}} : tensor<1x64x1x1x!ttcore.tile<32x32, bf16>, #layout3>
   // CHECK: } : tensor<1x64x1x1x!ttcore.tile<32x32, bf16>, #layout3>
   // CHECK-NOT: d2m.generic
-  // CHECK: ttir.ttnn_metal_layout_cast %[[RESULT]]
+  // CHECK: %[[RESULT_VIEW:.*]] = d2m.view_layout %[[RESULT]] remapping = #map6 : tensor<1x64x1x1x!ttcore.tile<32x32, bf16>, #layout3> -> tensor<1x1x1x64x!ttcore.tile<32x32, bf16>, #layout3>
+  // CHECK: ttir.ttnn_metal_layout_cast %[[RESULT_VIEW]]
 
   %1 = d2m.to_layout %src, %dst : tensor<1x64x1x1x!ttcore.tile<32x32, bf16>, #l1_sharded_2> into tensor<1x1x1x64x!ttcore.tile<32x32, bf16>, #dram_interleaved_2>
     -> tensor<1x1x1x64x!ttcore.tile<32x32, bf16>, #dram_interleaved_2>

--- a/test/ttmlir/Dialect/D2M/generic/mark_synchronized_buffers.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/mark_synchronized_buffers.mlir
@@ -1,0 +1,71 @@
+// RUN: ttmlir-opt --d2m-mark-synchronized-buffers %s | FileCheck %s
+
+#l1 = #ttcore.memory_space<l1>
+#dram = #ttcore.memory_space<dram>
+
+module {
+  // CHECK-LABEL: func.func @test_matmul_output_stream_single_buffer()
+  // CHECK: d2m.generic
+  // CHECK: %[[CB_LHS:.*]] = memref.alloc() {d2m.synchronized_buffer = 2 : i32} : memref<2x3x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK: %[[CB_RHS:.*]] = memref.alloc() {d2m.synchronized_buffer = 2 : i32} : memref<3x4x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK: %[[CB_OUT:.*]] = memref.alloc() {d2m.synchronized_buffer = 1 : i32} : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK: d2m.synchronized_region consumers(%[[CB_LHS]], %[[CB_RHS]]) producers(%[[CB_OUT]])
+  // CHECK: "d2m.tile_matmul_block"
+  func.func @test_matmul_output_stream_single_buffer() {
+    %lhs = memref.alloc() : memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #dram>
+    %rhs = memref.alloc() : memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>
+    %out = memref.alloc() : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>
+
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%lhs, %rhs :
+            memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #dram>,
+            memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>)
+        outs(%out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>)  {
+    ^unified0:
+      %c0 = arith.constant 0 : index
+      %buffer_lhs = memref.alloc() : memref<2x3x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_load %buffer_lhs %lhs[%c0, %c0] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #dram>
+      %buffer_rhs = memref.alloc() : memref<3x4x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_load %buffer_rhs %rhs[%c0, %c0] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>
+      %buffer_out = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      d2m.synchronized_region consumers(%buffer_lhs, %buffer_rhs) producers(%buffer_out) {
+      ^bb0(%arg0: memref<2x3x!ttcore.tile<32x32, f32>, #l1>, %arg1: memref<3x4x!ttcore.tile<32x32, f32>, #l1>, %arg2: memref<2x4x!ttcore.tile<32x32, f32>, #l1>):
+        "d2m.tile_matmul_block"(%arg0, %arg1, %arg2) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
+      } : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_store %out[%c0, %c0] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+    }
+    return
+  }
+
+  // CHECK-LABEL: func.func @test_reduce_output_stream_single_buffer()
+  // CHECK: d2m.generic
+  // CHECK: %[[CB_IN:.*]] = memref.alloc() {d2m.synchronized_buffer = 2 : i32} : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK: d2m.remote_load %[[CB_IN]]
+  // CHECK: %[[CB_OUT:.*]] = memref.alloc() {d2m.synchronized_buffer = 1 : i32} : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK: d2m.synchronized_region consumers(%[[CB_IN]]) producers(%[[CB_OUT]])
+  // CHECK: "d2m.tile_reduce_sum"
+  func.func @test_reduce_output_stream_single_buffer() {
+    %in = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>
+    %out = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>
+
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%in : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>)
+        outs(%out : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>)  {
+    ^unified0:
+      %c0 = arith.constant 0 : index
+      %buffer_in = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_load %buffer_in %in[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>
+      %buffer_out = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      d2m.synchronized_region consumers(%buffer_in) producers(%buffer_out) {
+      ^bb0(%arg0: memref<1x1x!ttcore.tile<32x32, f32>, #l1>, %arg1: memref<1x1x!ttcore.tile<32x32, f32>, #l1>):
+        %a = memref.load %arg0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+        %b = memref.load %arg0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+        %c = memref.load %arg1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+        %r = "d2m.tile_reduce_sum"(%a, %b, %c) <{reduce_dim = #d2m<reduce_dim R>}> : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+        memref.store %r, %arg1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      } : memref<1x1x!ttcore.tile<32x32, f32>, #l1> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_store %out[%c0, %c0] %buffer_out : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    }
+    return
+  }
+}


### PR DESCRIPTION
### Problem description
Need to support dram to dram generics for reductions and matmuls

### What's changed
- Added DRAM-to-DRAM reblocking bouncing thru L1
- Mark synchronized buffers shouldn't double buffer the accumulation buffers for matmuls/reductions
- Added DRAM input/output matmul and reduction coverage in builder tests
- Added/updated lit tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
