### PR TITLE
[chisel] core: callbacks, executor, validators, builder tests

### DIFF
--- a/test/python/chisel/conftest.py
+++ b/test/python/chisel/conftest.py
@@ -11,6 +11,16 @@ from chisel.ops import IRModule
 from utils import json_string_as_dict
 
 
+@pytest.fixture(scope="session")
+def device():
+    mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+    mesh_options.mesh_shape = (1, 1)
+    tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+    dev = tt_runtime.runtime.open_mesh_device(mesh_options)
+    yield dev
+    tt_runtime.runtime.close_mesh_device(dev)
+
+
 @pytest.fixture
 def binary(binary_path):
     return tt_runtime.binary.load_binary_from_path(binary_path)

--- a/test/python/chisel/test_builder_chisel_integration.py
+++ b/test/python/chisel/test_builder_chisel_integration.py
@@ -15,7 +15,7 @@ def test_chisel_records_one_layer_nn(request, device, tmp_path):
     # multiply(y, y) instead of an activation: the TTNN optimizer fuses
     # activations into ttnn.linear, collapsing two ops into one.
     x_shape = (64, 128)
-    w_shape = (256, 128)  # transpose_b=True → effective rhs is (128, 256)
+    w_shape = (256, 128)  # transpose_b=True -> effective rhs is (128, 256)
     b_shape = (256,)
 
     def module(builder: TTNNBuilder):
@@ -33,7 +33,7 @@ def test_chisel_records_one_layer_nn(request, device, tmp_path):
             y = builder.linear(x, w, bias=b, transpose_b=True)
             return builder.multiply(y, y)
 
-    with chisel.session(results_path="chisel_result.jsonl") as report:
+    with chisel.session(results_path=str(tmp_path / "chisel_result.jsonl")) as report:
         compile_and_execute_ttnn(
             module,
             test_base=request.node.name,
@@ -62,7 +62,7 @@ def test_chisel_records_one_layer_nn(request, device, tmp_path):
         assert op_pcc, f"no PCC record for {op}"
         for r in op_pcc:
             assert (
-                r.status == "ok"
+                r.status == chisel.RecordStatus.OK
             ), f"{op}: PCC check status={r.status} payload={r.payload}"
             assert (
                 r.payload.pcc >= PCC_THRESHOLD
@@ -96,7 +96,7 @@ def test_chisel_dumps_debug_artifacts_on_pcc_fail(request, device, tmp_path):
 
     with chisel.session(
         debug_chisel_dir=str(debug_dir),
-        checks_config=chisel.ChiselChecksConfig(threshold=2.0),
+        checks_config=chisel.ChiselChecksConfig(pcc=chisel.PCCConfig(min_pcc=2.0)),
     ) as report:
         compile_and_execute_ttnn(
             module,
@@ -110,7 +110,7 @@ def test_chisel_dumps_debug_artifacts_on_pcc_fail(request, device, tmp_path):
     pcc_records = [r for r in records if r.check == "numerics"]
     assert pcc_records, "no numerics (PCC) records produced"
     assert all(
-        r.status == chisel.Status.NUMERICS_FAIL for r in pcc_records
+        r.status == chisel.RecordStatus.NUMERICS_FAIL for r in pcc_records
     ), f"expected all PCC records to fail with threshold=2.0, got {[r.status for r in pcc_records]}"
 
     assert debug_dir.is_dir(), f"debug dir not created at {debug_dir}"
@@ -120,7 +120,7 @@ def test_chisel_dumps_debug_artifacts_on_pcc_fail(request, device, tmp_path):
     assert (
         fb_files
     ), f"no flatbuffer dumped under {debug_dir}: {list(debug_dir.iterdir())}"
-    # One dump per binary — the policy is first-failure-wins.
+    # One dump per binary - the policy is first-failure-wins.
     assert len(mlir_files) == 1
     assert len(fb_files) == 1
     for mlir_path, fb_path in zip(mlir_files, fb_files):
@@ -164,7 +164,7 @@ def test_chisel_records_chisel_bug_on_callback_raise(
             return builder.multiply(y, y)
 
     with chisel.session() as report:
-        # Must not raise — chisel_safe is supposed to keep the runtime alive
+        # Must not raise - chisel_safe is supposed to keep the runtime alive
         # even when a chisel callback explodes.
         compile_and_execute_ttnn(
             module,
@@ -175,9 +175,9 @@ def test_chisel_records_chisel_bug_on_callback_raise(
         )
         records = report.records
 
-    assert records, "chisel report is empty — runtime did not produce any records"
+    assert records, "chisel report is empty - runtime did not produce any records"
 
-    bug_records = [r for r in records if r.status == chisel.Status.CHISEL_BUG]
+    bug_records = [r for r in records if r.status == chisel.RecordStatus.CHISEL_BUG]
     assert bug_records, (
         "expected at least one chisel_bug record, got statuses: "
         f"{[r.status for r in records]}"

--- a/test/python/chisel/test_builder_chisel_integration.py
+++ b/test/python/chisel/test_builder_chisel_integration.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import List, Optional
+
+import torch
+
+import chisel
+from builder.base.builder_apis import compile_and_execute_ttnn
+from builder.base.builder_utils import Operand
+from builder.ttnn.ttnn_builder import TTNNBuilder
+
+
+def test_chisel_records_one_layer_nn(request, device, tmp_path):
+    # multiply(y, y) instead of an activation: the TTNN optimizer fuses
+    # activations into ttnn.linear, collapsing two ops into one.
+    x_shape = (64, 128)
+    w_shape = (256, 128)  # transpose_b=True → effective rhs is (128, 256)
+    b_shape = (256,)
+
+    def module(builder: TTNNBuilder):
+        @builder.func(
+            [x_shape, w_shape, b_shape],
+            [torch.float32, torch.float32, torch.float32],
+        )
+        def one_layer_nn(
+            x: Operand,
+            w: Operand,
+            b: Operand,
+            builder: TTNNBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            y = builder.linear(x, w, bias=b, transpose_b=True)
+            return builder.multiply(y, y)
+
+    with chisel.session(results_path="chisel_result.jsonl") as report:
+        compile_and_execute_ttnn(
+            module,
+            test_base=request.node.name,
+            output_root=str(tmp_path),
+            target="ttnn",
+            device=device,
+        )
+        records = report.records
+
+    assert records, "chisel report is empty"
+
+    ops_seen = {r.op for r in records}
+    expected = {"ttnn.linear", "ttnn.multiply"}
+    missing = expected - ops_seen
+    assert not missing, (
+        f"chisel report missing op records for: {sorted(missing)}. "
+        f"Saw: {sorted(ops_seen)}"
+    )
+
+    PCC_THRESHOLD = 0.99
+    pcc_records = [r for r in records if r.check == "numerics"]
+    assert pcc_records, "no numerics (PCC) records produced"
+
+    for op in expected:
+        op_pcc = [r for r in pcc_records if r.op == op]
+        assert op_pcc, f"no PCC record for {op}"
+        for r in op_pcc:
+            assert (
+                r.status == "ok"
+            ), f"{op}: PCC check status={r.status} payload={r.payload}"
+            assert (
+                r.payload.pcc >= PCC_THRESHOLD
+            ), f"{op}: PCC {r.payload.pcc} below threshold {PCC_THRESHOLD}"
+
+
+def test_chisel_dumps_debug_artifacts_on_pcc_fail(request, device, tmp_path):
+    # Set the PCC threshold above the [-1, 1] range so every numerics check
+    # records NUMERICS_FAIL, and verify the recorder dumps the MLIR source
+    # and flatbuffer for the offending binary to debug_chisel_dir.
+    x_shape = (64, 128)
+    w_shape = (256, 128)
+    b_shape = (256,)
+
+    def module(builder: TTNNBuilder):
+        @builder.func(
+            [x_shape, w_shape, b_shape],
+            [torch.float32, torch.float32, torch.float32],
+        )
+        def one_layer_nn(
+            x: Operand,
+            w: Operand,
+            b: Operand,
+            builder: TTNNBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            y = builder.linear(x, w, bias=b, transpose_b=True)
+            return builder.multiply(y, y)
+
+    debug_dir = tmp_path / "chisel_debug"
+
+    with chisel.session(
+        debug_chisel_dir=str(debug_dir),
+        checks_config=chisel.ChiselChecksConfig(threshold=2.0),
+    ) as report:
+        compile_and_execute_ttnn(
+            module,
+            test_base=request.node.name,
+            output_root=str(tmp_path),
+            target="ttnn",
+            device=device,
+        )
+        records = report.records
+
+    pcc_records = [r for r in records if r.check == "numerics"]
+    assert pcc_records, "no numerics (PCC) records produced"
+    assert all(
+        r.status == chisel.Status.NUMERICS_FAIL for r in pcc_records
+    ), f"expected all PCC records to fail with threshold=2.0, got {[r.status for r in pcc_records]}"
+
+    assert debug_dir.is_dir(), f"debug dir not created at {debug_dir}"
+    mlir_files = sorted(debug_dir.glob("binary_*.mlir"))
+    fb_files = sorted(debug_dir.glob("binary_*.ttnn"))
+    assert mlir_files, f"no MLIR dumped under {debug_dir}: {list(debug_dir.iterdir())}"
+    assert (
+        fb_files
+    ), f"no flatbuffer dumped under {debug_dir}: {list(debug_dir.iterdir())}"
+    # One dump per binary — the policy is first-failure-wins.
+    assert len(mlir_files) == 1
+    assert len(fb_files) == 1
+    for mlir_path, fb_path in zip(mlir_files, fb_files):
+        assert mlir_path.stat().st_size > 0, f"empty MLIR dump at {mlir_path}"
+        assert fb_path.stat().st_size > 0, f"empty flatbuffer dump at {fb_path}"
+
+
+def test_chisel_records_chisel_bug_on_callback_raise(
+    request, device, tmp_path, monkeypatch
+):
+    # Monkey-patch the numerics check that _default_post_op calls so it
+    # raises. chisel_safe should swallow the exception, write a chisel_bug
+    # record carrying the traceback, and the ttmlir runtime should finish
+    # the program normally so the test exits the session cleanly.
+    import chisel.callbacks as chisel_callbacks
+
+    boom_message = "synthetic chisel bug for testing chisel_safe"
+
+    def boom(*args, **kwargs):
+        raise RuntimeError(boom_message)
+
+    monkeypatch.setattr(chisel_callbacks, "check_numerics", boom)
+
+    x_shape = (64, 128)
+    w_shape = (256, 128)
+    b_shape = (256,)
+
+    def module(builder: TTNNBuilder):
+        @builder.func(
+            [x_shape, w_shape, b_shape],
+            [torch.float32, torch.float32, torch.float32],
+        )
+        def one_layer_nn(
+            x: Operand,
+            w: Operand,
+            b: Operand,
+            builder: TTNNBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            y = builder.linear(x, w, bias=b, transpose_b=True)
+            return builder.multiply(y, y)
+
+    with chisel.session() as report:
+        # Must not raise — chisel_safe is supposed to keep the runtime alive
+        # even when a chisel callback explodes.
+        compile_and_execute_ttnn(
+            module,
+            test_base=request.node.name,
+            output_root=str(tmp_path),
+            target="ttnn",
+            device=device,
+        )
+        records = report.records
+
+    assert records, "chisel report is empty — runtime did not produce any records"
+
+    bug_records = [r for r in records if r.status == chisel.Status.CHISEL_BUG]
+    assert bug_records, (
+        "expected at least one chisel_bug record, got statuses: "
+        f"{[r.status for r in records]}"
+    )
+
+    for r in bug_records:
+        tb = r.payload.traceback
+        assert tb, f"chisel_bug record has empty traceback for op={r.op}"
+        assert (
+            boom_message in tb
+        ), f"traceback for op={r.op} missing the raised message; got:\n{tb}"
+        assert (
+            "RuntimeError" in tb
+        ), f"traceback for op={r.op} missing the exception type; got:\n{tb}"
+
+    bug_ops = {r.op for r in bug_records}
+    assert bug_ops == {
+        "ttnn.linear",
+        "ttnn.multiply",
+    }, f"expected chisel_bug for both ops, got {bug_ops}"

--- a/test/python/chisel/test_golden_execution.py
+++ b/test/python/chisel/test_golden_execution.py
@@ -13,7 +13,7 @@ from chisel.executor import (
     build_role_keyed_inputs,
     execute_golden,
 )
-from chisel.op_configs import get_no_golden_op_names
+from chisel.op_configs import get_op_names_no_golden
 from chisel.ops import (
     get_flat_inplace_vals,
     get_op_inputs,
@@ -25,10 +25,10 @@ from golden.mapping import mlir_type_to_torch_dtype
 from ttmlir.dialects import quant
 from utils import iterate_programs
 
-# Ops chisel cannot validate (no golden, structural mismatch, etc.) — sourced
+# Ops chisel cannot validate (no golden, structural mismatch, etc.) - sourced
 # from op_configs.register_defaults so the skip list is a single source of
 # truth shared with the runtime callback.
-_SKIPPED_OPS: frozenset[str] = get_no_golden_op_names()
+_SKIPPED_OPS: frozenset[str] = get_op_names_no_golden()
 
 
 def _has_quantized_type(op) -> bool:

--- a/test/python/chisel/test_golden_execution.py
+++ b/test/python/chisel/test_golden_execution.py
@@ -13,38 +13,22 @@ from chisel.executor import (
     build_role_keyed_inputs,
     execute_golden,
 )
+from chisel.op_configs import get_no_golden_op_names
 from chisel.ops import (
     get_flat_inplace_vals,
     get_op_inputs,
     get_op_outputs,
-    is_non_executable_op,
     is_tensor_value,
 )
 from golden import GoldenMapTensor, get_chisel_golden_function
 from golden.mapping import mlir_type_to_torch_dtype
 from ttmlir.dialects import quant
-from utils import iterate_programs, QUANTIZE_OP_NAMES
+from utils import iterate_programs
 
-# Ops without a registered golden - skipped instead of failed. Remove an entry
-# once its golden lands. Quantization ops are included via QUANTIZE_OP_NAMES.
-_KNOWN_NOT_IMPLEMENTED_OPS: frozenset[str] = (
-    frozenset(
-        {
-            "ttnn.generic",
-            "ttnn.nlp_create_qkv_heads_decode",
-            "ttnn.rotary_embedding_llama",
-            "ttnn.constant",
-            "ttnn.mesh_shard",
-            "ttnn.mesh_partition",
-            "ttnn.nlp_concat_heads",
-            "ttnn.nlp_concat_heads_decode",
-            "ttnn.bitcast_convert",
-            "ttnn.group_norm",
-            "ttnn.batch_norm_training",
-        }
-    )
-    | QUANTIZE_OP_NAMES
-)
+# Ops chisel cannot validate (no golden, structural mismatch, etc.) — sourced
+# from op_configs.register_defaults so the skip list is a single source of
+# truth shared with the runtime callback.
+_SKIPPED_OPS: frozenset[str] = get_no_golden_op_names()
 
 
 def _has_quantized_type(op) -> bool:
@@ -74,9 +58,6 @@ def test_golden_execution(subtests, ir_module, binary, binary_path):
     for _prog_idx, prog_name in iterate_programs(binary):
         for op in ir_module.get_function_ops(prog_name):
             with subtests.test(prog=prog_name, op=op.name):
-                if is_non_executable_op(type(op.opview)):
-                    pytest.skip(f"golden not applicable for {type(op.opview).__name__}")
-
                 if _has_quantized_type(op):
                     pytest.skip(
                         f"quantized tensor types not yet supported (op: {op.name})"
@@ -84,7 +65,7 @@ def test_golden_execution(subtests, ir_module, binary, binary_path):
 
                 if (
                     get_chisel_golden_function(type(op.opview)) is None
-                    and op.name in _KNOWN_NOT_IMPLEMENTED_OPS
+                    and op.name in _SKIPPED_OPS
                 ):
                     pytest.skip(f"{op.name}: no golden registered")
 

--- a/test/python/chisel/test_report.py
+++ b/test/python/chisel/test_report.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from chisel.report import (
+    ChiselBugPayload,
+    ChiselRecord,
+    ChiselReport,
+    DtypeMismatchPayload,
+    ErrorPayload,
+    JsonlSink,
+    NumericsPayload,
+    ShapeMismatchPayload,
+    SkippedNumericsPayload,
+    Status,
+)
+
+
+def _records_for_each_status():
+    return [
+        ChiselRecord(
+            op="ttnn.linear",
+            check="numerics",
+            ssa="%0",
+            program_name="prog0",
+            program_index=0,
+            payload=NumericsPayload(
+                status=Status.OK, pcc=0.999, atol=1e-8, rtol=1e-5, device_id=0
+            ),
+        ),
+        ChiselRecord(
+            op="ttnn.add",
+            check="mlir_vs_tensor_ref",
+            ssa="%1",
+            payload=ShapeMismatchPayload(expected_shape=[1, 32], actual_shape=[1, 64]),
+        ),
+        ChiselRecord(
+            op="ttnn.multiply",
+            check="mlir_vs_tensor_ref",
+            payload=DtypeMismatchPayload(expected_dtype="bf16", actual_dtype="f32"),
+        ),
+        ChiselRecord(
+            op="ttnn.linear",
+            check="numerics",
+            op_asm="some asm",
+            payload=NumericsPayload(
+                status=Status.NUMERICS_FAIL, pcc=0.42, atol=1.0, rtol=1.0, device_id=1
+            ),
+        ),
+        ChiselRecord(op="ttnn.linear", check="numerics", payload=ErrorPayload()),
+        ChiselRecord(op="ttnn.add", check="numerics", payload=SkippedNumericsPayload()),
+        ChiselRecord(
+            op="ttnn.unknown",
+            check="numerics",
+            payload=ChiselBugPayload(traceback="boom\n"),
+        ),
+    ]
+
+
+def test_model_json_roundtrip_per_status():
+    for original in _records_for_each_status():
+        line = original.model_dump_json(exclude_none=True)
+        restored = ChiselRecord.model_validate_json(line)
+        assert restored == original
+
+
+def test_from_jsonl_roundtrip(tmp_path):
+    path = tmp_path / "chisel_result.jsonl"
+    sink = JsonlSink(str(path))
+    originals = _records_for_each_status()
+    for r in originals:
+        sink.write(r)
+    sink.close()
+
+    loaded = ChiselReport.from_jsonl(str(path))
+    assert len(loaded) == len(originals)
+    # Default capacity matches the loaded count so analysis loads don't truncate.
+    assert loaded.capacity == len(originals)
+    assert loaded.records == originals
+
+
+def test_from_jsonl_empty_file(tmp_path):
+    path = tmp_path / "empty.jsonl"
+    path.touch()
+    loaded = ChiselReport.from_jsonl(str(path))
+    assert len(loaded) == 0
+
+
+def test_from_jsonl_respects_explicit_capacity(tmp_path):
+    path = tmp_path / "cap.jsonl"
+    sink = JsonlSink(str(path))
+    for r in _records_for_each_status():
+        sink.write(r)
+    sink.close()
+
+    loaded = ChiselReport.from_jsonl(str(path), capacity=3)
+    assert loaded.capacity == 3
+    # ring buffer evicts oldest — verify by tail-match.
+    assert loaded.records == _records_for_each_status()[-3:]
+
+
+def _build_report():
+    report = ChiselReport(capacity=100)
+    for r in _records_for_each_status():
+        report.append(r)
+    return report
+
+
+def test_by_op_and_by_check_and_by_program():
+    report = _build_report()
+
+    linears = report.by_op("ttnn.linear")
+    assert len(linears) == 3
+    assert {r.op for r in linears} == {"ttnn.linear"}
+
+    numerics = report.by_check("numerics")
+    assert {r.check for r in numerics} == {"numerics"}
+    # 6 out of 8 records use the "numerics" check.
+    assert len(numerics) == 6
+
+    prog0 = report.by_program("prog0")
+    assert len(prog0) == 1
+    assert prog0.records[0].program_name == "prog0"
+
+
+def test_by_status_accepts_enum_str_and_iterable():
+    report = _build_report()
+
+    assert len(report.by_status(Status.OK)) == 1
+    assert len(report.by_status("ok")) == 1
+
+    multi = report.by_status([Status.OK, "numerics_fail"])
+    assert {r.status for r in multi} == {Status.OK, Status.NUMERICS_FAIL}
+    assert len(multi) == 2
+
+
+def test_failures_and_passes_complement():
+    report = _build_report()
+    failures = report.failures()
+    passes = report.passes()
+    # Non-failure statuses: ok, skipped, skipped_numerics → 3 of the 8 records.
+    assert len(passes) == 3
+    assert len(failures) == 5
+    assert len(failures) + len(passes) == len(report)
+    # No overlap.
+    failing_ids = {id(r) for r in failures}
+    passing_ids = {id(r) for r in passes}
+    assert failing_ids.isdisjoint(passing_ids)

--- a/test/python/chisel/test_report.py
+++ b/test/python/chisel/test_report.py
@@ -3,17 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
+from chisel.recorder import JsonlSink
 from chisel.report import (
     ChiselBugPayload,
     ChiselRecord,
     ChiselReport,
     DtypeMismatchPayload,
     ErrorPayload,
-    JsonlSink,
+    NoGoldenPayload,
     NumericsPayload,
     ShapeMismatchPayload,
     SkippedNumericsPayload,
-    Status,
+    RecordStatus,
 )
 
 
@@ -26,7 +27,7 @@ def _records_for_each_status():
             program_name="prog0",
             program_index=0,
             payload=NumericsPayload(
-                status=Status.OK, pcc=0.999, atol=1e-8, rtol=1e-5, device_id=0
+                status=RecordStatus.OK, pcc=0.999, atol=1e-8, rtol=1e-5, device_id=0
             ),
         ),
         ChiselRecord(
@@ -45,7 +46,11 @@ def _records_for_each_status():
             check="numerics",
             op_asm="some asm",
             payload=NumericsPayload(
-                status=Status.NUMERICS_FAIL, pcc=0.42, atol=1.0, rtol=1.0, device_id=1
+                status=RecordStatus.NUMERICS_FAIL,
+                pcc=0.42,
+                atol=1.0,
+                rtol=1.0,
+                device_id=1,
             ),
         ),
         ChiselRecord(op="ttnn.linear", check="numerics", payload=ErrorPayload()),
@@ -54,6 +59,11 @@ def _records_for_each_status():
             op="ttnn.unknown",
             check="numerics",
             payload=ChiselBugPayload(traceback="boom\n"),
+        ),
+        ChiselRecord(
+            op="ttnn.constant",
+            check="numerics",
+            payload=NoGoldenPayload(),
         ),
     ]
 
@@ -96,7 +106,7 @@ def test_from_jsonl_respects_explicit_capacity(tmp_path):
 
     loaded = ChiselReport.from_jsonl(str(path), capacity=3)
     assert loaded.capacity == 3
-    # ring buffer evicts oldest — verify by tail-match.
+    # ring buffer evicts oldest - verify by tail-match.
     assert loaded.records == _records_for_each_status()[-3:]
 
 
@@ -127,11 +137,11 @@ def test_by_op_and_by_check_and_by_program():
 def test_by_status_accepts_enum_str_and_iterable():
     report = _build_report()
 
-    assert len(report.by_status(Status.OK)) == 1
+    assert len(report.by_status(RecordStatus.OK)) == 1
     assert len(report.by_status("ok")) == 1
 
-    multi = report.by_status([Status.OK, "numerics_fail"])
-    assert {r.status for r in multi} == {Status.OK, Status.NUMERICS_FAIL}
+    multi = report.by_status([RecordStatus.OK, "numerics_fail"])
+    assert {r.status for r in multi} == {RecordStatus.OK, RecordStatus.NUMERICS_FAIL}
     assert len(multi) == 2
 
 
@@ -139,7 +149,7 @@ def test_failures_and_passes_complement():
     report = _build_report()
     failures = report.failures()
     passes = report.passes()
-    # Non-failure statuses: ok, skipped, skipped_numerics → 3 of the 8 records.
+    # Non-failure statuses: ok, skipped_numerics, no_golden -> 3 of the 8 records.
     assert len(passes) == 3
     assert len(failures) == 5
     assert len(failures) + len(passes) == len(report)

--- a/test/python/chisel/test_ttnn_op_schema.py
+++ b/test/python/chisel/test_ttnn_op_schema.py
@@ -4,14 +4,14 @@
 """
 Cross-check the generated TTNN op schema (OPERAND_NAMES / ATTRIBUTE_NAMES /
 RESULT_NAMES, stamped onto each OpView by ttmlir.dialects.ttnn) against the
-real Python OpView surface — `dir(cls)` — exposed by mlir-tblgen.
+real Python OpView surface - `dir(cls)` - exposed by mlir-tblgen.
 
 For each TTNN op:
   * every OPERAND_NAMES / ATTRIBUTE_NAMES / RESULT_NAMES entry must be a
     member of the OpView class;
   * `dir(cls)` must contain no public names beyond the schema entries, the
     base `mlir.ir.OpView` surface, and the four schema-stamped sentinels
-    (OPERATION_NAME plus the three *_NAMES tuples) — any leftover is a name
+    (OPERATION_NAME plus the three *_NAMES tuples) - any leftover is a name
     the OpView exposes that the schema fails to classify.
 """
 import inspect

--- a/test/python/chisel/test_walk_program.py
+++ b/test/python/chisel/test_walk_program.py
@@ -4,8 +4,11 @@
 import pytest
 import _ttmlir_runtime as tt_runtime
 
+from chisel.op_configs import get_no_golden_op_names
 from chisel.ops import get_op_inputs, get_op_outputs
-from utils import iterate_programs, QUANTIZE_OP_NAMES
+from utils import iterate_programs
+
+_SKIPPED_OPS: frozenset[str] = get_no_golden_op_names()
 
 
 def test_walk_program_shapes_match_ir(binary, ir_module, subtests):
@@ -17,7 +20,7 @@ def test_walk_program_shapes_match_ir(binary, ir_module, subtests):
         def _check(op_ctx):
             mlir_op = next(mlir_ops)
 
-            if mlir_op.name in QUANTIZE_OP_NAMES:
+            if mlir_op.name in _SKIPPED_OPS:
                 return
 
             with subtests.test(op=mlir_op.name, side="inputs"):

--- a/test/python/chisel/test_walk_program.py
+++ b/test/python/chisel/test_walk_program.py
@@ -4,11 +4,11 @@
 import pytest
 import _ttmlir_runtime as tt_runtime
 
-from chisel.op_configs import get_no_golden_op_names
+from chisel.op_configs import get_op_names_no_golden
 from chisel.ops import get_op_inputs, get_op_outputs
 from utils import iterate_programs
 
-_SKIPPED_OPS: frozenset[str] = get_no_golden_op_names()
+_SKIPPED_OPS: frozenset[str] = get_op_names_no_golden()
 
 
 def test_walk_program_shapes_match_ir(binary, ir_module, subtests):

--- a/test/python/chisel/utils.py
+++ b/test/python/chisel/utils.py
@@ -5,12 +5,6 @@ import json
 import re
 
 
-# Quantization ops are not yet supported by chisel goldens; tests skip them.
-QUANTIZE_OP_NAMES: frozenset[str] = frozenset(
-    {"ttnn.quantize", "ttnn.dequantize", "ttnn.requantize"}
-)
-
-
 def json_string_as_dict(s: str) -> dict:
     """Parse a flatbuffer-emitted JSON string, normalizing nan/inf for json.loads."""
     if not s:

--- a/tools/chisel/CMakeLists.txt
+++ b/tools/chisel/CMakeLists.txt
@@ -4,9 +4,18 @@ declare_mlir_python_sources(ChiselSources
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/chisel"
   SOURCES
     __init__.py
+    bind.py
+    callbacks.py
+    context.py
+    ops.py
     executor.py
     exceptions.py
-    ops.py
+    op_configs.py
+    recorder.py
+    report.py
+    safety.py
+    utils.py
+    validators.py
 )
 
 add_mlir_python_modules(ChiselPythonModules

--- a/tools/chisel/chisel/__init__.py
+++ b/tools/chisel/chisel/__init__.py
@@ -5,8 +5,8 @@
 from .bind import bind, configure, get_report, register_op_config, session, unbind
 from .context import ChiselContext
 from .op_configs import ChiselOpConfig
-from .report import ChiselRecord, ChiselReport, Status
-from .validators import ChiselChecksConfig
+from .report import ChiselRecord, ChiselReport, RecordStatus
+from .validators import ChiselChecksConfig, PCCConfig
 
 __all__ = [
     "bind",
@@ -20,5 +20,6 @@ __all__ = [
     "ChiselRecord",
     "ChiselReport",
     "ChiselChecksConfig",
-    "Status",
+    "PCCConfig",
+    "RecordStatus",
 ]

--- a/tools/chisel/chisel/__init__.py
+++ b/tools/chisel/chisel/__init__.py
@@ -2,6 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .exceptions import GoldenNotImplementedError
+from .bind import bind, configure, get_report, register_op_config, session, unbind
+from .context import ChiselContext
+from .op_configs import ChiselOpConfig
+from .report import ChiselRecord, ChiselReport, Status
+from .validators import ChiselChecksConfig
 
-__all__ = ["GoldenNotImplementedError"]
+__all__ = [
+    "bind",
+    "unbind",
+    "configure",
+    "get_report",
+    "register_op_config",
+    "session",
+    "ChiselContext",
+    "ChiselOpConfig",
+    "ChiselRecord",
+    "ChiselReport",
+    "ChiselChecksConfig",
+    "Status",
+]

--- a/tools/chisel/chisel/bind.py
+++ b/tools/chisel/chisel/bind.py
@@ -9,7 +9,7 @@ from _ttmlir_runtime.binary import Binary
 from _ttmlir_runtime.runtime import CallbackContext, OpContext
 
 from . import context
-from .callbacks import Phase, run_op_callback
+from .callbacks import CallbackPhase, run_op_callback
 from .context import ChiselContext, _UNSET
 from .op_configs import ChiselOpConfig
 from .safety import chisel_safe
@@ -40,7 +40,9 @@ def _pre_op_callback(
     rt_program_context: CallbackContext,
     rt_op_context: OpContext,
 ) -> None:
-    run_op_callback(rt_binary, rt_program_context, rt_op_context, phase=Phase.PRE)
+    run_op_callback(
+        rt_binary, rt_program_context, rt_op_context, phase=CallbackPhase.PRE
+    )
 
 
 @chisel_safe
@@ -50,7 +52,9 @@ def _post_op_callback(
     rt_program_context: CallbackContext,
     rt_op_context: OpContext,
 ) -> None:
-    run_op_callback(rt_binary, rt_program_context, rt_op_context, phase=Phase.POST)
+    run_op_callback(
+        rt_binary, rt_program_context, rt_op_context, phase=CallbackPhase.POST
+    )
 
 
 def bind() -> None:

--- a/tools/chisel/chisel/bind.py
+++ b/tools/chisel/chisel/bind.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from contextlib import contextmanager
+from typing import Iterator
+
+from _ttmlir_runtime import runtime as tt_runtime
+from _ttmlir_runtime.binary import Binary
+from _ttmlir_runtime.runtime import CallbackContext, OpContext
+
+from . import context
+from .callbacks import Phase, run_op_callback
+from .context import ChiselContext, _UNSET
+from .op_configs import ChiselOpConfig
+from .safety import chisel_safe
+from .report import ChiselReport
+from .utils import debug_wrap
+
+
+@chisel_safe
+@debug_wrap
+def _pre_program_callback(
+    rt_binary: Binary, rt_program_context: CallbackContext
+) -> None:
+    context.get_instance().preprogram(rt_binary, rt_program_context)
+
+
+@chisel_safe
+@debug_wrap
+def _post_program_callback(
+    rt_binary: Binary, rt_program_context: CallbackContext
+) -> None:
+    context.get_instance().postprogram(rt_binary, rt_program_context)
+
+
+@chisel_safe
+@debug_wrap
+def _pre_op_callback(
+    rt_binary: Binary,
+    rt_program_context: CallbackContext,
+    rt_op_context: OpContext,
+) -> None:
+    run_op_callback(rt_binary, rt_program_context, rt_op_context, phase=Phase.PRE)
+
+
+@chisel_safe
+@debug_wrap
+def _post_op_callback(
+    rt_binary: Binary,
+    rt_program_context: CallbackContext,
+    rt_op_context: OpContext,
+) -> None:
+    run_op_callback(rt_binary, rt_program_context, rt_op_context, phase=Phase.POST)
+
+
+def bind() -> None:
+    # Set the context before registering hooks: a hook firing on an unbound
+    # context would log the raise via chisel_safe. Hooks register
+    # synchronously, so this ordering is sufficient.
+    if context.is_initialized():
+        raise RuntimeError("chisel.bind() called twice without unbind()")
+    context.set_current(ChiselContext())
+    tt_runtime.DebugHooks.get(
+        pre_op=_pre_op_callback,
+        post_op=_post_op_callback,
+        pre_program=_pre_program_callback,
+        post_program=_post_program_callback,
+    )
+
+
+def configure(
+    *,
+    results_path=_UNSET,
+    report_capacity=_UNSET,
+    debug_chisel_dir=_UNSET,
+    checks_config=_UNSET,
+) -> None:
+    context.get_instance().configure(
+        results_path=results_path,
+        report_capacity=report_capacity,
+        debug_chisel_dir=debug_chisel_dir,
+        checks_config=checks_config,
+    )
+
+
+def get_report() -> ChiselReport:
+    return context.get_instance().report
+
+
+def register_op_config(op_type: type, config: ChiselOpConfig) -> None:
+    context.get_instance().register_op_config(op_type, config)
+
+
+def unbind() -> None:
+    # TODO(ndrakulic): test in tt-xla for race conditions due to asynchronous runtime execution.
+    tt_runtime.unregister_hooks()
+    if context.is_initialized():
+        context.get_instance().close_results()
+    context.set_current(None)
+
+
+@contextmanager
+def session(
+    *,
+    results_path=_UNSET,
+    report_capacity=_UNSET,
+    debug_chisel_dir=_UNSET,
+    checks_config=_UNSET,
+) -> Iterator[ChiselReport]:
+    # Bind/configure/unbind in a `with` block; yields the in-memory report.
+    bind()
+    try:
+        configure(
+            results_path=results_path,
+            report_capacity=report_capacity,
+            debug_chisel_dir=debug_chisel_dir,
+            checks_config=checks_config,
+        )
+        yield get_report()
+    finally:
+        unbind()

--- a/tools/chisel/chisel/callbacks.py
+++ b/tools/chisel/chisel/callbacks.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Per-op chisel callbacks driven by the ttmlir runtime debug hooks.
+
+Validators raise ChiselFailure on the first failed shape/dtype/PCC check.
+chisel_safe wraps the per-op handler and turns the failure into a structured
+record — any subsequent checks on the same op are skipped. Other exceptions
+are recorded as chisel_bug.
+"""
+import logging
+from contextlib import contextmanager
+from enum import Enum
+from typing import Dict, Iterator, List
+
+from _ttmlir_runtime import runtime as tt_runtime
+from _ttmlir_runtime.binary import Binary
+from _ttmlir_runtime.runtime import CallbackContext, OpContext, TensorRef
+from ttmlir.ir import OpView, Value
+
+from golden import GoldenMapTensor
+
+from .context import ChiselContext, get_instance
+from .exceptions import IrRuntimeMismatch
+from .executor import build_role_keyed_inputs, execute_golden
+from .op_configs import ChiselOpConfig
+from .ops import SSAName, get_op_inputs, get_op_outputs
+from .report import ChiselRecord, NoGoldenPayload, SkippedNumericsPayload
+from .safety import chisel_safe
+from .utils import get_op_asm, retrieve_tensor
+from .validators import check_numerics, check_shape_dtype
+
+logger = logging.getLogger("chisel")
+
+
+class Phase(Enum):
+    PRE = "pre"
+    POST = "post"
+
+
+@contextmanager
+def _op_callback(
+    ctx: ChiselContext,
+    rt_binary: Binary,
+    rt_program_context: CallbackContext,
+    rt_op_context: OpContext,
+    *,
+    phase: Phase,
+) -> Iterator[None]:
+    """Open callback scope (and, on PRE, op scope); close them symmetrically."""
+    program = ctx.begin_callback(rt_binary, rt_program_context, rt_op_context)
+    try:
+        if phase is Phase.PRE:
+            program.begin_op()
+        yield
+    finally:
+        if phase is Phase.POST:
+            program.end_op()
+        ctx.end_callback()
+
+
+def _assert_op_matches_runtime(ctx: ChiselContext) -> None:
+    """Raise IrRuntimeMismatch if chisel and the runtime point at different ops."""
+    rt_debug = tt_runtime.get_op_debug_str(ctx.rt_op_context)
+    op = ctx.op
+    if rt_debug.strip() == get_op_asm(op).strip():
+        return
+    raise IrRuntimeMismatch(op, "ir_vs_runtime_op", rt_debug)
+
+
+def _validate_and_retrieve_tensor(
+    ctx: ChiselContext, mlir_value: Value, rt_tensor_ref: TensorRef
+) -> GoldenMapTensor:
+    op = ctx.op
+    check_shape_dtype(op, "mlir_vs_tensor_ref", mlir_value, rt_tensor_ref)
+    tensor = retrieve_tensor(ctx.rt_program_context, rt_tensor_ref)
+    check_shape_dtype(op, "mlir_vs_runtime_tensor", mlir_value, tensor)
+    return tensor
+
+
+def _run_isolation_golden(
+    op: OpView,
+    mlir_outputs: List[Value],
+    asm_state,
+    ssa_inputs: Dict[SSAName, GoldenMapTensor],
+) -> List[GoldenMapTensor]:
+    role_inputs = build_role_keyed_inputs(op, ssa_inputs, asm_state)
+    iso_outs = execute_golden(op, role_inputs)
+    for mlir_output, iso_out in zip(mlir_outputs, iso_outs, strict=True):
+        check_shape_dtype(op, "mlir_vs_golden", mlir_output, iso_out)
+    return iso_outs
+
+
+@chisel_safe
+def _default_pre_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
+    """Stash a host copy of every device input so POST can drive the golden."""
+    op = ctx.op
+    if config.no_golden:
+        ctx.write_record(
+            ChiselRecord(
+                op=op.name,
+                check="golden_not_implemented",
+                payload=NoGoldenPayload(),
+            )
+        )
+        return
+
+    _assert_op_matches_runtime(ctx)
+    asm_state = ctx.asm_state
+
+    mlir_op_inputs = get_op_inputs(op)
+    for mlir_input, rt_tensor_ref in zip(mlir_op_inputs, ctx.input_refs, strict=True):
+        # TODO(ndrakulic): Right now we are pulling input device tensors to host potentialy multiple times
+        tensor = _validate_and_retrieve_tensor(ctx, mlir_input, rt_tensor_ref)
+        ctx.stashed_inputs[mlir_input.get_name(asm_state)] = tensor
+
+
+@chisel_safe
+def _default_post_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
+    """Run the golden, validate shapes/dtypes, and PCC-check each output."""
+    if config.no_golden:
+        return
+
+    skip_isolated_pcc = config.skip_isolated_pcc
+    op = ctx.op
+    asm_state = ctx.asm_state
+
+    mlir_op_outputs = get_op_outputs(op)
+    if not mlir_op_outputs:
+        return
+
+    iso_outs = _run_isolation_golden(op, mlir_op_outputs, asm_state, ctx.stashed_inputs)
+
+    for mlir_output, output_ref, iso_out in zip(
+        mlir_op_outputs, ctx.output_refs, iso_outs, strict=True
+    ):
+        device_tensor = _validate_and_retrieve_tensor(ctx, mlir_output, output_ref)
+        ssa = mlir_output.get_name(asm_state)
+        if skip_isolated_pcc:
+            ctx.write_record(
+                ChiselRecord(
+                    op=op.name,
+                    check="numerics",
+                    ssa=ssa,
+                    payload=SkippedNumericsPayload(),
+                )
+            )
+            continue
+
+        check_numerics(ctx, op, ssa, iso_out, device_tensor)
+
+
+def run_op_callback(
+    rt_binary: Binary,
+    rt_program_context: CallbackContext,
+    rt_op_context: OpContext,
+    *,
+    phase: Phase,
+) -> None:
+    """Dispatch the PRE or POST handler for the current op."""
+    ctx = get_instance()
+    with _op_callback(ctx, rt_binary, rt_program_context, rt_op_context, phase=phase):
+        config = ctx.get_op_config(ctx.op)
+        if phase is Phase.PRE:
+            ok = _default_pre_op(ctx, config)
+            ctx.pre_failed = not ok
+        else:
+            # PRE recorded a failure — skip POST to avoid cascading into a
+            # chisel_bug from incomplete state.
+            if ctx.pre_failed:
+                return
+            _default_post_op(ctx, config)

--- a/tools/chisel/chisel/callbacks.py
+++ b/tools/chisel/chisel/callbacks.py
@@ -5,7 +5,7 @@
 
 Validators raise ChiselFailure on the first failed shape/dtype/PCC check.
 chisel_safe wraps the per-op handler and turns the failure into a structured
-record — any subsequent checks on the same op are skipped. Other exceptions
+record - any subsequent checks on the same op are skipped. Other exceptions
 are recorded as chisel_bug.
 """
 import logging
@@ -33,7 +33,7 @@ from .validators import check_numerics, check_shape_dtype
 logger = logging.getLogger("chisel")
 
 
-class Phase(Enum):
+class CallbackPhase(Enum):
     PRE = "pre"
     POST = "post"
 
@@ -45,16 +45,16 @@ def _op_callback(
     rt_program_context: CallbackContext,
     rt_op_context: OpContext,
     *,
-    phase: Phase,
+    phase: CallbackPhase,
 ) -> Iterator[None]:
     """Open callback scope (and, on PRE, op scope); close them symmetrically."""
     program = ctx.begin_callback(rt_binary, rt_program_context, rt_op_context)
     try:
-        if phase is Phase.PRE:
+        if phase is CallbackPhase.PRE:
             program.begin_op()
         yield
     finally:
-        if phase is Phase.POST:
+        if phase is CallbackPhase.POST:
             program.end_op()
         ctx.end_callback()
 
@@ -110,7 +110,7 @@ def _default_pre_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
 
     mlir_op_inputs = get_op_inputs(op)
     for mlir_input, rt_tensor_ref in zip(mlir_op_inputs, ctx.input_refs, strict=True):
-        # TODO(ndrakulic): Right now we are pulling input device tensors to host potentialy multiple times
+        # TODO(ndrakulic): Right now we are pulling input device tensors to host potentially multiple times
         tensor = _validate_and_retrieve_tensor(ctx, mlir_input, rt_tensor_ref)
         ctx.stashed_inputs[mlir_input.get_name(asm_state)] = tensor
 
@@ -155,17 +155,17 @@ def run_op_callback(
     rt_program_context: CallbackContext,
     rt_op_context: OpContext,
     *,
-    phase: Phase,
+    phase: CallbackPhase,
 ) -> None:
     """Dispatch the PRE or POST handler for the current op."""
     ctx = get_instance()
     with _op_callback(ctx, rt_binary, rt_program_context, rt_op_context, phase=phase):
         config = ctx.get_op_config(ctx.op)
-        if phase is Phase.PRE:
-            ok = _default_pre_op(ctx, config)
-            ctx.pre_failed = not ok
+        if phase is CallbackPhase.PRE:
+            pre_succeeded = _default_pre_op(ctx, config)
+            ctx.pre_failed = not pre_succeeded
         else:
-            # PRE recorded a failure — skip POST to avoid cascading into a
+            # PRE recorded a failure - skip POST to avoid cascading into a
             # chisel_bug from incomplete state.
             if ctx.pre_failed:
                 return

--- a/tools/chisel/chisel/context.py
+++ b/tools/chisel/chisel/context.py
@@ -146,10 +146,12 @@ class ChiselContext:
         rt_program_context: CallbackContext,
         rt_op_context: OpContext,
     ) -> "ProgramState":
-        binary_state = self.binaries[rt_binary.id]
+        binary_state = self.binaries.get(rt_binary.id)
+        if binary_state is None:
+            raise UnexpectedStateError("begin_callback")
 
         program_index = tt_runtime.get_program_index(rt_program_context)
-        program = binary_state.programs[program_index]
+        program = binary_state.programs.get(program_index)
         if program is None:
             raise UnexpectedStateError("begin_callback")
 
@@ -232,7 +234,7 @@ class ChiselContext:
 
 class BinaryState:
     # Owns the IRModule and per-program states. The rt_binary handle is
-    # not stored — it may not be valid across callbacks; use the one
+    # not stored - it may not be valid across callbacks; use the one
     # passed by the current callback.
 
     def __init__(self, rt_binary: Binary) -> None:

--- a/tools/chisel/chisel/context.py
+++ b/tools/chisel/chisel/context.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import json
+import logging
+from typing import Dict, Iterator, List, Optional, Type
+
+from _ttmlir_runtime import runtime as tt_runtime
+from _ttmlir_runtime.binary import Binary
+from _ttmlir_runtime.runtime import CallbackContext, OpContext, TensorRef
+from golden import GoldenMapTensor
+
+from ttmlir.ir import AsmState
+
+from .exceptions import UnexpectedStateError
+from .op_configs import ChiselOpConfig, default_configs
+from .ops import IRModule, SSAName
+from .recorder import ChiselRecorder, _UNSET
+from .report import ChiselRecord, ChiselReport
+from .validators import ChiselChecksConfig
+
+logger = logging.getLogger("chisel")
+
+# Module-level handle to the active context. Set by chisel.bind() and
+# cleared by chisel.unbind(); get_instance() raises if unset.
+_current: Optional["ChiselContext"] = None
+
+
+def get_instance() -> "ChiselContext":
+    if _current is None:
+        raise RuntimeError("ChiselContext is not bound. Call chisel.bind() first.")
+    return _current
+
+
+def is_initialized() -> bool:
+    return _current is not None
+
+
+def set_current(ctx: Optional["ChiselContext"]) -> None:
+    global _current
+    _current = ctx
+
+
+class ChiselContext:
+    def __init__(self) -> None:
+        self.binaries: Dict[int, "BinaryState"] = {}
+        # In-flight op-callback pointers; None outside an op callback.
+        self._current_callback_binary: Optional["BinaryState"] = None
+        self._current_callback_program: Optional["ProgramState"] = None
+        self.recorder: ChiselRecorder = ChiselRecorder()
+        self.op_configs: Dict[Type, ChiselOpConfig] = default_configs()
+        self.checks_config: ChiselChecksConfig = ChiselChecksConfig()
+
+    def register_op_config(self, op_type: Type, config: ChiselOpConfig) -> None:
+        self.op_configs[op_type] = config
+
+    def get_op_config(self, op: object) -> ChiselOpConfig:
+        return self.op_configs.get(type(op), ChiselOpConfig())
+
+    @property
+    def report(self) -> ChiselReport:
+        return self.recorder.report
+
+    @property
+    def results_path(self) -> Optional[str]:
+        return self.recorder.results_path
+
+    @property
+    def debug_chisel_dir(self) -> Optional[str]:
+        return self.recorder.debug_chisel_dir
+
+    @property
+    def asm_state(self) -> AsmState:
+        binary_state = self._current_callback_binary
+        if binary_state is None:
+            raise UnexpectedStateError("asm_state")
+        return binary_state.ir_module.get_asm_state()
+
+    @property
+    def is_in_op_scope(self) -> bool:
+        # Guards the op-scope properties below, which raise UnexpectedStateError
+        # when accessed outside begin_op/end_op.
+        program = self._current_callback_program
+        return program is not None and program._current_op is not None
+
+    @property
+    def op(self):
+        program = self._current_callback_program
+        value = program._current_op if program is not None else None
+        if value is None:
+            raise UnexpectedStateError("op")
+        return value
+
+    @property
+    def input_refs(self) -> List[TensorRef]:
+        program = self._current_callback_program
+        value = program._current_input_refs if program is not None else None
+        if value is None:
+            raise UnexpectedStateError("input_refs")
+        return value
+
+    @property
+    def output_refs(self) -> List[TensorRef]:
+        program = self._current_callback_program
+        value = program._current_output_refs if program is not None else None
+        if value is None:
+            raise UnexpectedStateError("output_refs")
+        return value
+
+    @property
+    def stashed_inputs(self) -> Dict[SSAName, GoldenMapTensor]:
+        program = self._current_callback_program
+        value = program._stashed_inputs if program is not None else None
+        if value is None:
+            raise UnexpectedStateError("stashed_inputs")
+        return value
+
+    @property
+    def rt_program_context(self) -> Optional[CallbackContext]:
+        program = self._current_callback_program
+        return program._rt_program_context if program is not None else None
+
+    @property
+    def rt_op_context(self) -> Optional[OpContext]:
+        program = self._current_callback_program
+        return program._rt_op_context if program is not None else None
+
+    @property
+    def pre_failed(self) -> bool:
+        # Whether the PRE handler for the current op recorded a failure.
+        program = self._current_callback_program
+        if program is None:
+            raise UnexpectedStateError("pre_failed")
+        return program._pre_failed
+
+    @pre_failed.setter
+    def pre_failed(self, value: bool) -> None:
+        program = self._current_callback_program
+        if program is None:
+            raise UnexpectedStateError("pre_failed")
+        program._pre_failed = value
+
+    def begin_callback(
+        self,
+        rt_binary: Binary,
+        rt_program_context: CallbackContext,
+        rt_op_context: OpContext,
+    ) -> "ProgramState":
+        binary_state = self.binaries[rt_binary.id]
+
+        program_index = tt_runtime.get_program_index(rt_program_context)
+        program = binary_state.programs[program_index]
+        if program is None:
+            raise UnexpectedStateError("begin_callback")
+
+        self._current_callback_binary = binary_state
+        self._current_callback_program = program
+        program._rt_binary = rt_binary
+        program._rt_program_context = rt_program_context
+        program._rt_op_context = rt_op_context
+        return program
+
+    def end_callback(self) -> None:
+        program = self._current_callback_program
+        if program is None:
+            raise UnexpectedStateError("end_callback")
+
+        program._rt_binary = None
+        program._rt_program_context = None
+        program._rt_op_context = None
+        self._current_callback_binary = None
+        self._current_callback_program = None
+
+    def configure(
+        self,
+        *,
+        results_path=_UNSET,
+        report_capacity=_UNSET,
+        debug_chisel_dir=_UNSET,
+        checks_config=_UNSET,
+    ) -> None:
+        self.recorder.configure(
+            results_path=results_path,
+            report_capacity=report_capacity,
+            debug_chisel_dir=debug_chisel_dir,
+        )
+        if checks_config is not _UNSET:
+            self.checks_config = checks_config
+
+    def write_record(self, record: ChiselRecord) -> None:
+        self.recorder.write(
+            record,
+            program=self._current_callback_program,
+            binary_state=self._current_callback_binary,
+        )
+
+    def close_results(self) -> None:
+        self.recorder.close()
+
+    def clear_binaries(self) -> None:
+        """Evict all cached BinaryState entries (parsed MLIR modules)."""
+        self.binaries.clear()
+
+    def preprogram(
+        self, rt_binary: Binary, rt_program_context: CallbackContext
+    ) -> None:
+        program_index = tt_runtime.get_program_index(rt_program_context)
+
+        if rt_binary.id not in self.binaries:
+            self.binaries[rt_binary.id] = BinaryState(rt_binary)
+        binary_state = self.binaries[rt_binary.id]
+
+        program_name = rt_binary.get_program_name(program_index)
+        program = ProgramState(program_index, program_name, binary_state.ir_module)
+        binary_state.programs[program_index] = program
+
+        logger.debug(
+            "preprogram: binary_id=%d program=%s index=%d",
+            rt_binary.id,
+            program_name,
+            program_index,
+        )
+
+    def postprogram(
+        self, rt_binary: Binary, rt_program_context: CallbackContext
+    ) -> None:
+        program_index = tt_runtime.get_program_index(rt_program_context)
+        binary_state = self.binaries.get(rt_binary.id)
+        if binary_state is not None:
+            binary_state.programs.pop(program_index, None)
+
+
+class BinaryState:
+    # Owns the IRModule and per-program states. The rt_binary handle is
+    # not stored — it may not be valid across callbacks; use the one
+    # passed by the current callback.
+
+    def __init__(self, rt_binary: Binary) -> None:
+        self.binary_id: int = rt_binary.id
+        mlir_json = json.loads(rt_binary.get_mlir_as_json())
+        self.mlir_source: str = mlir_json["source"]
+        functions = [
+            rt_binary.get_program_name(i) for i in range(rt_binary.get_num_programs())
+        ]
+        self.ir_module = IRModule(mlir_source=self.mlir_source, functions=functions)
+        self.programs: Dict[int, "ProgramState"] = {}
+
+
+class ProgramState:
+    # Two nested lifecycles:
+    #   - Callback scope: rt_* handles, valid only inside one callback.
+    #   - Op scope (begin_op / end_op): current_op + refs + stashed_inputs,
+    #     spans the PRE/POST callback pair. begin_op reads _rt_op_context,
+    #     so callback-scope handles must be set first.
+
+    def __init__(
+        self, program_index: int, program_name: str, ir_module: IRModule
+    ) -> None:
+        self.program_index = program_index
+        self.program_name = program_name
+        self._op_iter: Iterator = iter(ir_module.get_function_ops(program_name))
+        self._rt_binary: Optional[Binary] = None
+        self._rt_program_context: Optional[CallbackContext] = None
+        self._rt_op_context: Optional[OpContext] = None
+        self._current_op = None
+        self._current_input_refs: Optional[List[TensorRef]] = None
+        self._current_output_refs: Optional[List[TensorRef]] = None
+        self._stashed_inputs: Optional[Dict[SSAName, GoldenMapTensor]] = None
+        self._pre_failed: bool = False
+
+    def begin_op(self) -> None:
+        self._current_op = next(self._op_iter).opview
+        self._current_input_refs = tt_runtime.get_op_input_refs(self._rt_op_context)
+        self._current_output_refs = tt_runtime.get_op_output_refs(self._rt_op_context)
+        self._stashed_inputs = {}
+        self._pre_failed = False
+
+    def end_op(self) -> None:
+        self._current_op = None
+        self._current_input_refs = None
+        self._current_output_refs = None
+        self._stashed_inputs = None
+        self._pre_failed = False

--- a/tools/chisel/chisel/context.py
+++ b/tools/chisel/chisel/context.py
@@ -163,6 +163,8 @@ class ChiselContext:
         return program
 
     def end_callback(self) -> None:
+        self._current_callback_binary = None
+
         program = self._current_callback_program
         if program is None:
             raise UnexpectedStateError("end_callback")
@@ -170,7 +172,6 @@ class ChiselContext:
         program._rt_binary = None
         program._rt_program_context = None
         program._rt_op_context = None
-        self._current_callback_binary = None
         self._current_callback_program = None
 
     def configure(

--- a/tools/chisel/chisel/exceptions.py
+++ b/tools/chisel/chisel/exceptions.py
@@ -1,11 +1,118 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Optional, Sequence
+
+from .report import (
+    ChiselRecord,
+    DtypeMismatchPayload,
+    ErrorPayload,
+    IrRuntimeMismatchPayload,
+    NoGoldenPayload,
+    Payload,
+    ShapeMismatchPayload,
+    Status,
+)
+from .utils import get_op_asm
 
 
-class GoldenNotImplementedError(NotImplementedError):
-    """Raised by execute_golden when no golden is registered for an op."""
+class UnexpectedStateError(RuntimeError):
+    # Raised when a ChiselContext property is accessed outside its lifecycle
+    # scope (e.g. ctx.op outside an op callback). Programming error, not a
+    # check failure.
 
-    def __init__(self, op):
-        super().__init__(f"{op.name}: no golden registered for {type(op).__name__}")
+    def __init__(self, field: str) -> None:
+        self.field = field
+        super().__init__(
+            f"ChiselContext.{field} is unset (accessed outside its lifecycle scope)"
+        )
+
+
+class ChiselFailure(Exception):
+    # Carries the offending op + a typed payload; converted to a ChiselRecord
+    # via to_record(), either by the caller or by chisel_safe on raise.
+
+    status: Status = Status.ERROR
+
+    def __init__(
+        self,
+        op,
+        check: str,
+        detail: str = "",
+        payload: Optional[Payload] = None,
+    ) -> None:
         self.op = op
+        self.op_name = op.name
+        self.op_asm = get_op_asm(op)
+        self.check = check
+        self.payload: Payload = payload if payload is not None else ErrorPayload()
+        header = f"{self.op_name} [{check}]: {self.status.value.upper()}"
+        body = f"{header}\n  {detail}" if detail else header
+        super().__init__(f"{body}\n  op: {self.op_asm}" if self.op_asm else body)
+
+    def to_record(self) -> ChiselRecord:
+        return ChiselRecord(
+            op=self.op_name,
+            check=self.check,
+            op_asm=self.op_asm,
+            payload=self.payload,
+        )
+
+
+class ShapeMismatch(ChiselFailure):
+    status = Status.SHAPE_MISMATCH
+
+    def __init__(
+        self,
+        op,
+        check: str,
+        expected_shape: Sequence[int],
+        actual_shape: Sequence[int],
+    ) -> None:
+        exp = list(expected_shape)
+        act = list(actual_shape)
+        super().__init__(
+            op,
+            check,
+            f"expected={exp} actual={act}",
+            payload=ShapeMismatchPayload(expected_shape=exp, actual_shape=act),
+        )
+
+
+class DtypeMismatch(ChiselFailure):
+    status = Status.DTYPE_MISMATCH
+
+    def __init__(self, op, check: str, expected_dtype, actual_dtype) -> None:
+        super().__init__(
+            op,
+            check,
+            f"expected={expected_dtype} actual={actual_dtype}",
+            payload=DtypeMismatchPayload(
+                expected_dtype=str(expected_dtype),
+                actual_dtype=str(actual_dtype),
+            ),
+        )
+
+
+class GoldenNotImplementedError(ChiselFailure):
+    status = Status.NO_GOLDEN
+
+    def __init__(self, op) -> None:
+        super().__init__(
+            op,
+            "golden_not_implemented",
+            f"no golden registered for {op.name}",
+            payload=NoGoldenPayload(),
+        )
+
+
+class IrRuntimeMismatch(ChiselFailure):
+    status = Status.IR_RUNTIME_MISMATCH
+
+    def __init__(self, op, check: str, runtime_debug: str) -> None:
+        super().__init__(
+            op,
+            check,
+            f"runtime debug_info:\n{runtime_debug}",
+            payload=IrRuntimeMismatchPayload(runtime_debug=runtime_debug),
+        )

--- a/tools/chisel/chisel/exceptions.py
+++ b/tools/chisel/chisel/exceptions.py
@@ -11,7 +11,7 @@ from .report import (
     NoGoldenPayload,
     Payload,
     ShapeMismatchPayload,
-    Status,
+    RecordStatus,
 )
 from .utils import get_op_asm
 
@@ -32,7 +32,7 @@ class ChiselFailure(Exception):
     # Carries the offending op + a typed payload; converted to a ChiselRecord
     # via to_record(), either by the caller or by chisel_safe on raise.
 
-    status: Status = Status.ERROR
+    status: RecordStatus = RecordStatus.ERROR
 
     def __init__(
         self,
@@ -60,7 +60,7 @@ class ChiselFailure(Exception):
 
 
 class ShapeMismatch(ChiselFailure):
-    status = Status.SHAPE_MISMATCH
+    status = RecordStatus.SHAPE_MISMATCH
 
     def __init__(
         self,
@@ -80,7 +80,7 @@ class ShapeMismatch(ChiselFailure):
 
 
 class DtypeMismatch(ChiselFailure):
-    status = Status.DTYPE_MISMATCH
+    status = RecordStatus.DTYPE_MISMATCH
 
     def __init__(self, op, check: str, expected_dtype, actual_dtype) -> None:
         super().__init__(
@@ -95,7 +95,7 @@ class DtypeMismatch(ChiselFailure):
 
 
 class GoldenNotImplementedError(ChiselFailure):
-    status = Status.NO_GOLDEN
+    status = RecordStatus.NO_GOLDEN
 
     def __init__(self, op) -> None:
         super().__init__(
@@ -107,7 +107,7 @@ class GoldenNotImplementedError(ChiselFailure):
 
 
 class IrRuntimeMismatch(ChiselFailure):
-    status = Status.IR_RUNTIME_MISMATCH
+    status = RecordStatus.IR_RUNTIME_MISMATCH
 
     def __init__(self, op, check: str, runtime_debug: str) -> None:
         super().__init__(

--- a/tools/chisel/chisel/executor.py
+++ b/tools/chisel/chisel/executor.py
@@ -4,12 +4,12 @@
 """
 Golden execution for a single TTNN op via CHISEL_GOLDEN_MAPPINGS.
 
-Golden interface: fn(op, inputs: Dict[str, GoldenMapTensor]) -> GoldenMapTensor | tuple.
-The executor normalizes the result to a tuple with one entry per SSA result
+Golden interface: fn(op, inputs: Dict[RoleName, GoldenMapTensor]) -> GoldenMapTensor | tuple.
+The executor normalizes the result to a list with one entry per SSA result
 followed by one entry per provided in-place operand.
 """
 import logging
-from typing import Dict, Optional, Tuple
+from typing import Dict, List
 
 from ttmlir.ir import OpOperandList, Operation, Value
 
@@ -17,6 +17,8 @@ from golden import get_chisel_golden_function, GoldenMapTensor
 
 from .exceptions import GoldenNotImplementedError
 from .ops import (
+    RoleName,
+    SSAName,
     get_flat_inplace_vals,
     get_op_outputs,
     is_tensor_value,
@@ -26,8 +28,8 @@ logger = logging.getLogger("chisel")
 
 
 def build_role_keyed_inputs(
-    op: Operation, ssa_inputs: Dict[str, GoldenMapTensor], asm_state
-) -> Dict[str, object]:
+    op: Operation, ssa_inputs: Dict[SSAName, GoldenMapTensor], asm_state
+) -> Dict[RoleName, object]:
     """Re-key `ssa_inputs` by operand role name (per OpView's OPERAND_NAMES).
 
     Per role: `Value` -> tensor, `OpOperandList` -> list (Variadic), None ->
@@ -44,7 +46,7 @@ def build_role_keyed_inputs(
             return None
         return ssa_inputs[val.get_name(asm_state)]
 
-    role_inputs: Dict[str, object] = {}
+    role_inputs: Dict[RoleName, object] = {}
     for name in operand_names:
         accessor = getattr(op, name, None)
         if accessor is None:
@@ -63,12 +65,12 @@ def build_role_keyed_inputs(
 
 def execute_golden(
     op: Operation,
-    golden_inputs: Dict[str, object],
-) -> Optional[Tuple[GoldenMapTensor, ...]]:
-    """Run the registered golden for `op` and return its outputs as a tuple.
+    golden_inputs: Dict[RoleName, object],
+) -> List[GoldenMapTensor]:
+    """Run the registered golden for `op` and return its outputs as a list.
 
-    Returns None if the golden returns an unsupported type. Raises
-    GoldenNotImplementedError if no golden is registered for `op`.
+    Raises GoldenNotImplementedError if no golden is registered for `op`, or
+    TypeError if the golden returns an unsupported result type.
     """
     golden_fn = get_chisel_golden_function(type(op))
     if golden_fn is None:
@@ -77,18 +79,16 @@ def execute_golden(
     result = golden_fn(op, golden_inputs)
 
     if isinstance(result, GoldenMapTensor):
-        tensors: Tuple[GoldenMapTensor, ...] = (result,)
+        tensors: List[GoldenMapTensor] = [result]
     elif isinstance(result, (list, tuple)) and all(
         isinstance(t, GoldenMapTensor) for t in result
     ):
-        tensors = tuple(result)
+        tensors = list(result)
     else:
-        msg = (
+        raise TypeError(
             f"Golden for {type(op).__name__} returned unsupported type "
             f"{type(result).__name__}"
         )
-        logger.error(f"{op.name}: golden error ({msg})")
-        return None
 
     ssa_count = len(get_op_outputs(op))
     inplace_vals = get_flat_inplace_vals(op)

--- a/tools/chisel/chisel/op_configs.py
+++ b/tools/chisel/chisel/op_configs.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Dict, Type
 
 from ttmlir.dialects import func, ttcore, ttnn
+from ttmlir.ir import OpView
 
 logger = logging.getLogger("chisel")
 
@@ -20,69 +21,62 @@ class ChiselOpConfig:
     skip_isolated_pcc: bool = False
 
 
-def default_configs() -> Dict[Type, ChiselOpConfig]:
+def default_configs() -> Dict[Type[OpView], ChiselOpConfig]:
     # Returns a fresh dict each call so callers cannot mutate the defaults.
-    configs: Dict[Type, ChiselOpConfig] = {}
-
-    # ttnn.empty produces uninitialized memory — PCC comparison is meaningless.
-    configs[ttnn.EmptyOp] = ChiselOpConfig(skip_isolated_pcc=True)
-
-    # ttnn.generic: IR output count = 0 but FB output count = 1.
-    configs[ttnn.GenericOp] = ChiselOpConfig(no_golden=True)
-
-    # Non-executable ops (device handles, I/O, control flow): no golden to run.
-    configs[func.CallOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.GetDeviceOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.LoadTensorOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.DeallocateOp] = ChiselOpConfig(no_golden=True)
-    configs[ttcore.LoadCachedOp] = ChiselOpConfig(no_golden=True)
-
-    # Trace / control-flow / I/O ops.
-    configs[ttnn.AllocOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.BeginTraceCaptureOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.EndTraceCaptureOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.ExecuteTraceOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.CaptureOrExecuteTraceOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.CreateGlobalSemaphoreOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.ResetGlobalSemaphoreOp] = ChiselOpConfig(no_golden=True)
-
-    # In-place ops (see CHISEL_INPLACE_OPS). TODO: chisel does not yet
-    # validate in-place tensor mutations; skip until support lands.
-    configs[ttnn.UpdateCacheOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.PagedUpdateCacheOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.FillCacheOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.PagedFillCacheOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.WriteTensorOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.BatchNormTrainingOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.PointToPointOp] = ChiselOpConfig(no_golden=True)
-
-    # Quantization ops not currently supported.
-    configs[ttnn.QuantizeOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.DequantizeOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.RequantizeOp] = ChiselOpConfig(no_golden=True)
-
-    # No golden registered yet
-    configs[ttnn.NLPCreateQKVHeadsDecodeOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.RotaryEmbeddingLlamaOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.RotaryEmbeddingOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.ConstantOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.MeshShardOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.MeshPartitionOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.NLPConcatHeadsOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.NLPConcatHeadsDecodeOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.BitcastConvertOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.AsinhOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.DistributedLayerNormOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.RMSNormPreAllGatherOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.SamplingOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.SelectiveReduceCombineOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.AllToAllDispatchMetadataOp] = ChiselOpConfig(no_golden=True)
-    configs[ttnn.D2MSubgraphOp] = ChiselOpConfig(no_golden=True)
-
-    return configs
+    # In-place ops (UpdateCacheOp, FillCacheOp, etc.) are flagged no_golden
+    # because chisel does not yet validate in-place tensor mutations.
+    return {
+        # ttnn.empty produces uninitialized memory - PCC comparison is meaningless.
+        ttnn.EmptyOp: ChiselOpConfig(skip_isolated_pcc=True),
+        # ttnn.generic: IR output count = 0 but FB output count = 1.
+        ttnn.GenericOp: ChiselOpConfig(no_golden=True),
+        # Non-executable ops (device handles, I/O, control flow): no golden to run.
+        func.CallOp: ChiselOpConfig(no_golden=True),
+        ttnn.GetDeviceOp: ChiselOpConfig(no_golden=True),
+        ttnn.LoadTensorOp: ChiselOpConfig(no_golden=True),
+        ttnn.DeallocateOp: ChiselOpConfig(no_golden=True),
+        ttcore.LoadCachedOp: ChiselOpConfig(no_golden=True),
+        # Trace / control-flow / I/O ops.
+        ttnn.AllocOp: ChiselOpConfig(no_golden=True),
+        ttnn.BeginTraceCaptureOp: ChiselOpConfig(no_golden=True),
+        ttnn.EndTraceCaptureOp: ChiselOpConfig(no_golden=True),
+        ttnn.ExecuteTraceOp: ChiselOpConfig(no_golden=True),
+        ttnn.CaptureOrExecuteTraceOp: ChiselOpConfig(no_golden=True),
+        ttnn.CreateGlobalSemaphoreOp: ChiselOpConfig(no_golden=True),
+        ttnn.ResetGlobalSemaphoreOp: ChiselOpConfig(no_golden=True),
+        # In-place ops (see CHISEL_INPLACE_OPS).
+        ttnn.UpdateCacheOp: ChiselOpConfig(no_golden=True),
+        ttnn.PagedUpdateCacheOp: ChiselOpConfig(no_golden=True),
+        ttnn.FillCacheOp: ChiselOpConfig(no_golden=True),
+        ttnn.PagedFillCacheOp: ChiselOpConfig(no_golden=True),
+        ttnn.WriteTensorOp: ChiselOpConfig(no_golden=True),
+        ttnn.BatchNormTrainingOp: ChiselOpConfig(no_golden=True),
+        ttnn.PointToPointOp: ChiselOpConfig(no_golden=True),
+        # Quantization ops not currently supported.
+        ttnn.QuantizeOp: ChiselOpConfig(no_golden=True),
+        ttnn.DequantizeOp: ChiselOpConfig(no_golden=True),
+        ttnn.RequantizeOp: ChiselOpConfig(no_golden=True),
+        # No golden registered yet.
+        ttnn.NLPCreateQKVHeadsDecodeOp: ChiselOpConfig(no_golden=True),
+        ttnn.RotaryEmbeddingLlamaOp: ChiselOpConfig(no_golden=True),
+        ttnn.RotaryEmbeddingOp: ChiselOpConfig(no_golden=True),
+        ttnn.ConstantOp: ChiselOpConfig(no_golden=True),
+        ttnn.MeshShardOp: ChiselOpConfig(no_golden=True),
+        ttnn.MeshPartitionOp: ChiselOpConfig(no_golden=True),
+        ttnn.NLPConcatHeadsOp: ChiselOpConfig(no_golden=True),
+        ttnn.NLPConcatHeadsDecodeOp: ChiselOpConfig(no_golden=True),
+        ttnn.BitcastConvertOp: ChiselOpConfig(no_golden=True),
+        ttnn.AsinhOp: ChiselOpConfig(no_golden=True),
+        ttnn.DistributedLayerNormOp: ChiselOpConfig(no_golden=True),
+        ttnn.RMSNormPreAllGatherOp: ChiselOpConfig(no_golden=True),
+        ttnn.SamplingOp: ChiselOpConfig(no_golden=True),
+        ttnn.SelectiveReduceCombineOp: ChiselOpConfig(no_golden=True),
+        ttnn.AllToAllDispatchMetadataOp: ChiselOpConfig(no_golden=True),
+        ttnn.D2MSubgraphOp: ChiselOpConfig(no_golden=True),
+    }
 
 
-def get_no_golden_op_names() -> frozenset[str]:
+def get_op_names_no_golden() -> frozenset[str]:
     return frozenset(
         op_type.OPERATION_NAME
         for op_type, config in default_configs().items()

--- a/tools/chisel/chisel/op_configs.py
+++ b/tools/chisel/chisel/op_configs.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from dataclasses import dataclass
+from typing import Dict, Type
+
+from ttmlir.dialects import func, ttcore, ttnn
+
+logger = logging.getLogger("chisel")
+
+
+@dataclass
+class ChiselOpConfig:
+    # no_golden: do not run the isolation golden; emit a NoGoldenPayload
+    # record per op so the report shows the op was visited but skipped.
+    # skip_isolated_pcc: run the isolation golden (shape/dtype still checked)
+    # but skip the PCC comparison.
+    no_golden: bool = False
+    skip_isolated_pcc: bool = False
+
+
+def default_configs() -> Dict[Type, ChiselOpConfig]:
+    # Returns a fresh dict each call so callers cannot mutate the defaults.
+    configs: Dict[Type, ChiselOpConfig] = {}
+
+    # ttnn.empty produces uninitialized memory — PCC comparison is meaningless.
+    configs[ttnn.EmptyOp] = ChiselOpConfig(skip_isolated_pcc=True)
+
+    # ttnn.generic: IR output count = 0 but FB output count = 1.
+    configs[ttnn.GenericOp] = ChiselOpConfig(no_golden=True)
+
+    # Non-executable ops (device handles, I/O, control flow): no golden to run.
+    configs[func.CallOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.GetDeviceOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.LoadTensorOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.DeallocateOp] = ChiselOpConfig(no_golden=True)
+    configs[ttcore.LoadCachedOp] = ChiselOpConfig(no_golden=True)
+
+    # Trace / control-flow / I/O ops.
+    configs[ttnn.AllocOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.BeginTraceCaptureOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.EndTraceCaptureOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.ExecuteTraceOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.CaptureOrExecuteTraceOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.CreateGlobalSemaphoreOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.ResetGlobalSemaphoreOp] = ChiselOpConfig(no_golden=True)
+
+    # In-place ops (see CHISEL_INPLACE_OPS). TODO: chisel does not yet
+    # validate in-place tensor mutations; skip until support lands.
+    configs[ttnn.UpdateCacheOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.PagedUpdateCacheOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.FillCacheOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.PagedFillCacheOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.WriteTensorOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.BatchNormTrainingOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.PointToPointOp] = ChiselOpConfig(no_golden=True)
+
+    # Quantization ops not currently supported.
+    configs[ttnn.QuantizeOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.DequantizeOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.RequantizeOp] = ChiselOpConfig(no_golden=True)
+
+    # No golden registered yet
+    configs[ttnn.NLPCreateQKVHeadsDecodeOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.RotaryEmbeddingLlamaOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.RotaryEmbeddingOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.ConstantOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.MeshShardOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.MeshPartitionOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.NLPConcatHeadsOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.NLPConcatHeadsDecodeOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.BitcastConvertOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.AsinhOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.DistributedLayerNormOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.RMSNormPreAllGatherOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.SamplingOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.SelectiveReduceCombineOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.AllToAllDispatchMetadataOp] = ChiselOpConfig(no_golden=True)
+    configs[ttnn.D2MSubgraphOp] = ChiselOpConfig(no_golden=True)
+
+    return configs
+
+
+def get_no_golden_op_names() -> frozenset[str]:
+    return frozenset(
+        op_type.OPERATION_NAME
+        for op_type, config in default_configs().items()
+        if config.no_golden
+    )

--- a/tools/chisel/chisel/ops.py
+++ b/tools/chisel/chisel/ops.py
@@ -5,7 +5,9 @@
 MLIR operation utilities: IRModule wrapper, tensor operand extraction, and
 chisel-specific op classification (non-executable / in-place).
 """
-from ttmlir.dialects import func, ttcore, ttnn
+from typing import NewType, Optional
+
+from ttmlir.dialects import func, ttnn
 from ttmlir.ir import (
     AsmState,
     BlockArgument,
@@ -20,13 +22,15 @@ from ttmlir.ir import (
 )
 
 
-# Ops not executable as goldens (device, I/O, control flow).
-_CHISEL_NON_EXECUTABLE_OPS: set = {
-    ttnn.GetDeviceOp,
-    ttnn.LoadTensorOp,
-    ttcore.LoadCachedOp,
-    func.CallOp,
-}
+# MLIR SSA value name as printed in the IR (e.g. "%0", "%arg1"). Produced by
+# `Value.get_name(asm_state)` and used to key per-op input/output tensors.
+SSAName = NewType("SSAName", str)
+
+# Operand role name on an OpView (e.g. "lhs", "rhs", "input"). Sourced from
+# `OpView.OPERAND_NAMES` and CHISEL_INPLACE_OPS; used to dispatch goldens by
+# their declared keyword arguments.
+RoleName = NewType("RoleName", str)
+
 
 # Op class -> operand role names mutated via `Arg<..., [MemWrite]>` in ODS.
 # Goldens return SSA results first, then one tensor per *provided* memwrite
@@ -46,15 +50,11 @@ _CHISEL_INPLACE_OPS: dict[type, tuple[str, ...]] = {
 }
 
 
-def is_non_executable_op(op_class: type) -> bool:
-    return op_class in _CHISEL_NON_EXECUTABLE_OPS
-
-
-def get_inplace_operands(op_class: type) -> tuple[str, ...]:
+def get_inplace_operands(op_class: type) -> tuple[RoleName, ...]:
     return _CHISEL_INPLACE_OPS.get(op_class, ())
 
 
-def is_tensor_value(val) -> bool:
+def is_tensor_value(val: Value) -> bool:
     """True if `val` is a tensor-like MLIR Value (has shape and element_type)."""
     return hasattr(val.type, "shape") and hasattr(val.type, "element_type")
 
@@ -137,10 +137,10 @@ class IRModule:
     def _extract_function_ops(self, name: str) -> tuple[list[Operation], list[Value]]:
         assert name in self._functions
         func_op = self._functions[name]
-        ops = []
-        outputs = []
+        ops: list[Operation] = []
+        outputs: list[Value] = []
 
-        def _visitor(op):
+        def _visitor(op: Operation) -> WalkResult:
             # Python bindings only expose walk() on Operation; skip the FuncOp
             # itself to match C++ entry.getBody().walk() in FuncOpToProgram.h.
             if op == func_op.operation:
@@ -155,9 +155,9 @@ class IRModule:
         return ops, outputs
 
     def _find_function(self, name: str) -> func.FuncOp:
-        result = None
+        result: Optional[func.FuncOp] = None
 
-        def _visitor(op):
+        def _visitor(op: Operation) -> WalkResult:
             nonlocal result
             opview = op.opview
             if isinstance(opview, func.FuncOp):

--- a/tools/chisel/chisel/recorder.py
+++ b/tools/chisel/chisel/recorder.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import os
+from typing import Tuple, Optional, Set, TextIO
+
+from _ttmlir_runtime.binary import Binary
+
+from .report import ChiselRecord, ChiselReport, Status, NON_FAILURE_STATUSES
+
+logger = logging.getLogger("chisel")
+
+_UNSET = object()
+
+
+class JsonlSink:
+    # Per-record append+flush so partial results survive a hang/crash mid-program.
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self._file: Optional[TextIO] = None
+
+    def write(self, record: ChiselRecord) -> None:
+        if self._file is None:
+            self._file = open(self.path, "a")
+        self._file.write(record.model_dump_json(exclude_none=True) + "\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+
+class ChiselRecorder:
+    # Owns the in-memory ring buffer, the optional JSONL sink, and the
+    # per-binary debug-dump policy.
+
+    def __init__(self) -> None:
+        self.report: ChiselReport = ChiselReport()
+        self._sink: Optional[JsonlSink] = None
+        self._debug_chisel_dir: Optional[str] = None
+        self._dumped_binaries: Set[int] = set()
+
+    @property
+    def results_path(self) -> Optional[str]:
+        return self._sink.path if self._sink is not None else None
+
+    @property
+    def debug_chisel_dir(self) -> Optional[str]:
+        return self._debug_chisel_dir
+
+    def configure(
+        self,
+        *,
+        results_path=_UNSET,
+        report_capacity=_UNSET,
+        debug_chisel_dir=_UNSET,
+    ) -> None:
+        if results_path is not _UNSET and results_path != self.results_path:
+            self.close()
+            if results_path is not None:
+                self._sink = JsonlSink(results_path)
+        if report_capacity is not _UNSET:
+            self.report.resize(report_capacity)
+        if debug_chisel_dir is not _UNSET:
+            self._debug_chisel_dir = debug_chisel_dir
+
+    def close(self) -> None:
+        if self._sink is not None:
+            self._sink.close()
+            self._sink = None
+
+    def write(
+        self,
+        record: ChiselRecord,
+        *,
+        program: Optional["ProgramState"],
+        binary_state: Optional["BinaryState"],
+    ) -> None:
+        if binary_state is not None and record.binary_id is None:
+            record.binary_id = binary_state.binary_id
+        if program is not None:
+            if record.program_name is None:
+                record.program_name = program.program_name
+            if record.program_index is None:
+                record.program_index = program.program_index
+        self.report.append(record)
+        if self._sink is not None:
+            self._sink.write(record)
+        self._maybe_dump_debug(record, program, binary_state)
+
+    def _maybe_dump_debug(
+        self,
+        record: ChiselRecord,
+        program: Optional["ProgramState"],
+        binary_state: Optional["BinaryState"],
+    ) -> None:
+        # On the first failure for a given binary, dump the source MLIR and
+        # flatbuffer so the user can debug offline. Records carry binary_id +
+        # program_name/program_index, so one dump per binary is enough.
+        if self._debug_chisel_dir is None:
+            return
+        if record.status in NON_FAILURE_STATUSES:
+            return
+        if program is None or binary_state is None or program._rt_binary is None:
+            return
+        binary_id = binary_state.binary_id
+        if binary_id in self._dumped_binaries:
+            return
+        self._dumped_binaries.add(binary_id)
+        paths = dump_debug_artifacts(
+            self._debug_chisel_dir,
+            binary_id=binary_id,
+            mlir_source=binary_state.mlir_source,
+            rt_binary=program._rt_binary,
+        )
+        if paths is None:
+            return
+        mlir_path, fb_path = paths
+        logger.warning(
+            "chisel debug: dumped MLIR to %s and flatbuffer to %s "
+            "(triggered by status=%s on op=%s program=%s[%d])",
+            mlir_path,
+            fb_path,
+            record.status.value,
+            record.op,
+            program.program_name,
+            program.program_index,
+        )
+
+
+def dump_debug_artifacts(
+    debug_dir: str,
+    *,
+    binary_id: int,
+    mlir_source: str,
+    rt_binary: Binary,
+) -> Optional[Tuple[str, str]]:
+    # Writes binary_{id}.mlir and binary_{id}.ttnn under debug_dir. Returns
+    # the paths, or None on failure — failure is logged, never raised, since
+    # this is a debug aid that must not break the run.
+    try:
+        os.makedirs(debug_dir, exist_ok=True)
+        stem = f"binary_{binary_id}"
+        mlir_path = os.path.join(debug_dir, stem + ".mlir")
+        fb_path = os.path.join(debug_dir, stem + ".ttnn")
+        with open(mlir_path, "w") as f:
+            f.write(mlir_source)
+        rt_binary.store(fb_path)
+        return mlir_path, fb_path
+    except Exception:
+        logger.exception("chisel debug dump failed")
+        return None

--- a/tools/chisel/chisel/recorder.py
+++ b/tools/chisel/chisel/recorder.py
@@ -7,7 +7,7 @@ from typing import Tuple, Optional, Set, TextIO
 
 from _ttmlir_runtime.binary import Binary
 
-from .report import ChiselRecord, ChiselReport, Status, NON_FAILURE_STATUSES
+from .report import ChiselRecord, ChiselReport, PASS_STATUS
 
 logger = logging.getLogger("chisel")
 
@@ -34,8 +34,8 @@ class JsonlSink:
 
 
 class ChiselRecorder:
-    # Owns the in-memory ring buffer, the optional JSONL sink, and the
-    # per-binary debug-dump policy.
+    """Owns the in-memory ring buffer, the optional JSONL sink, and the
+    per-binary debug-dump policy."""
 
     def __init__(self) -> None:
         self.report: ChiselReport = ChiselReport()
@@ -89,20 +89,20 @@ class ChiselRecorder:
         self.report.append(record)
         if self._sink is not None:
             self._sink.write(record)
-        self._maybe_dump_debug(record, program, binary_state)
+        self._dump_debug(record, program, binary_state)
 
-    def _maybe_dump_debug(
+    def _dump_debug(
         self,
         record: ChiselRecord,
         program: Optional["ProgramState"],
         binary_state: Optional["BinaryState"],
     ) -> None:
-        # On the first failure for a given binary, dump the source MLIR and
-        # flatbuffer so the user can debug offline. Records carry binary_id +
-        # program_name/program_index, so one dump per binary is enough.
+        """On the first failure for a given binary, dump the source MLIR and
+        flatbuffer so the user can debug offline. Records carry binary_id +
+        program_name/program_index, so one dump per binary is enough."""
         if self._debug_chisel_dir is None:
             return
-        if record.status in NON_FAILURE_STATUSES:
+        if record.status in PASS_STATUS:
             return
         if program is None or binary_state is None or program._rt_binary is None:
             return
@@ -110,7 +110,7 @@ class ChiselRecorder:
         if binary_id in self._dumped_binaries:
             return
         self._dumped_binaries.add(binary_id)
-        paths = dump_debug_artifacts(
+        paths = _dump_debug_artifacts(
             self._debug_chisel_dir,
             binary_id=binary_id,
             mlir_source=binary_state.mlir_source,
@@ -131,7 +131,7 @@ class ChiselRecorder:
         )
 
 
-def dump_debug_artifacts(
+def _dump_debug_artifacts(
     debug_dir: str,
     *,
     binary_id: int,
@@ -139,7 +139,7 @@ def dump_debug_artifacts(
     rt_binary: Binary,
 ) -> Optional[Tuple[str, str]]:
     # Writes binary_{id}.mlir and binary_{id}.ttnn under debug_dir. Returns
-    # the paths, or None on failure — failure is logged, never raised, since
+    # the paths, or None on failure - failure is logged, never raised, since
     # this is a debug aid that must not break the run.
     try:
         os.makedirs(debug_dir, exist_ok=True)
@@ -151,5 +151,5 @@ def dump_debug_artifacts(
         rt_binary.store(fb_path)
         return mlir_path, fb_path
     except Exception:
-        logger.exception("chisel debug dump failed")
+        logger.exception("Chisel debug dump failed.")
         return None

--- a/tools/chisel/chisel/report.py
+++ b/tools/chisel/chisel/report.py
@@ -17,7 +17,7 @@ from typing import (
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class Status(str, Enum):
+class RecordStatus(str, Enum):
     OK = "ok"
     SHAPE_MISMATCH = "shape_mismatch"
     DTYPE_MISMATCH = "dtype_mismatch"
@@ -29,21 +29,23 @@ class Status(str, Enum):
     CHISEL_BUG = "chisel_bug"
 
 
-NON_FAILURE_STATUSES = frozenset({Status.OK, Status.SKIPPED_NUMERICS, Status.NO_GOLDEN})
+PASS_STATUS = frozenset(
+    {RecordStatus.OK, RecordStatus.SKIPPED_NUMERICS, RecordStatus.NO_GOLDEN}
+)
 
 
 class _Payload(BaseModel):
-    # Each payload declares only the fields valid for its Status; extra="forbid"
+    # Each payload declares only the fields valid for its RecordStatus; extra="forbid"
     # so wrong-field-for-status mistakes raise at construction, not at the
     # downstream consumer.
     model_config = ConfigDict(extra="forbid")
 
 
 class NumericsPayload(_Payload):
-    # OK and NUMERICS_FAIL share the same schema — only the status
+    # OK and NUMERICS_FAIL share the same schema - only the status
     # discriminator differs, set by validators.check_numerics based on the
     # configured pcc/atol/rtol gates.
-    status: Literal[Status.OK, Status.NUMERICS_FAIL]
+    status: Literal[RecordStatus.OK, RecordStatus.NUMERICS_FAIL]
     pcc: float
     atol: float
     rtol: float
@@ -51,36 +53,36 @@ class NumericsPayload(_Payload):
 
 
 class ShapeMismatchPayload(_Payload):
-    status: Literal[Status.SHAPE_MISMATCH] = Status.SHAPE_MISMATCH
+    status: Literal[RecordStatus.SHAPE_MISMATCH] = RecordStatus.SHAPE_MISMATCH
     expected_shape: List[int]
     actual_shape: List[int]
 
 
 class DtypeMismatchPayload(_Payload):
-    status: Literal[Status.DTYPE_MISMATCH] = Status.DTYPE_MISMATCH
+    status: Literal[RecordStatus.DTYPE_MISMATCH] = RecordStatus.DTYPE_MISMATCH
     expected_dtype: str
     actual_dtype: str
 
 
 class ErrorPayload(_Payload):
-    status: Literal[Status.ERROR] = Status.ERROR
+    status: Literal[RecordStatus.ERROR] = RecordStatus.ERROR
 
 
 class SkippedNumericsPayload(_Payload):
-    status: Literal[Status.SKIPPED_NUMERICS] = Status.SKIPPED_NUMERICS
+    status: Literal[RecordStatus.SKIPPED_NUMERICS] = RecordStatus.SKIPPED_NUMERICS
 
 
 class NoGoldenPayload(_Payload):
-    status: Literal[Status.NO_GOLDEN] = Status.NO_GOLDEN
+    status: Literal[RecordStatus.NO_GOLDEN] = RecordStatus.NO_GOLDEN
 
 
 class IrRuntimeMismatchPayload(_Payload):
-    status: Literal[Status.IR_RUNTIME_MISMATCH] = Status.IR_RUNTIME_MISMATCH
+    status: Literal[RecordStatus.IR_RUNTIME_MISMATCH] = RecordStatus.IR_RUNTIME_MISMATCH
     runtime_debug: str
 
 
 class ChiselBugPayload(_Payload):
-    status: Literal[Status.CHISEL_BUG] = Status.CHISEL_BUG
+    status: Literal[RecordStatus.CHISEL_BUG] = RecordStatus.CHISEL_BUG
     traceback: str
 
 
@@ -112,7 +114,7 @@ class ChiselRecord(BaseModel):
     payload: Payload
 
     @property
-    def status(self) -> Status:
+    def status(self) -> RecordStatus:
         return self.payload.status
 
 
@@ -167,19 +169,19 @@ class ChiselReport:
         return self._from_filtered(lambda r: r.program_name == name)
 
     def by_status(
-        self, status: Union[Status, str, Iterable[Union[Status, str]]]
+        self, status: Union[RecordStatus, str, Iterable[Union[RecordStatus, str]]]
     ) -> "ChiselReport":
-        if isinstance(status, (Status, str)):
-            wanted = {Status(status)}
+        if isinstance(status, (RecordStatus, str)):
+            wanted = {RecordStatus(status)}
         else:
-            wanted = {Status(s) for s in status}
+            wanted = {RecordStatus(s) for s in status}
         return self._from_filtered(lambda r: r.status in wanted)
 
     def failures(self) -> "ChiselReport":
-        return self._from_filtered(lambda r: r.status not in NON_FAILURE_STATUSES)
+        return self._from_filtered(lambda r: r.status not in PASS_STATUS)
 
     def passes(self) -> "ChiselReport":
-        return self._from_filtered(lambda r: r.status in NON_FAILURE_STATUSES)
+        return self._from_filtered(lambda r: r.status in PASS_STATUS)
 
     @classmethod
     def from_jsonl(cls, path: str, *, capacity: Optional[int] = None) -> "ChiselReport":

--- a/tools/chisel/chisel/report.py
+++ b/tools/chisel/chisel/report.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from collections import deque
+from enum import Enum
+from typing import (
+    Annotated,
+    Callable,
+    Iterable,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Union,
+)
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Status(str, Enum):
+    OK = "ok"
+    SHAPE_MISMATCH = "shape_mismatch"
+    DTYPE_MISMATCH = "dtype_mismatch"
+    NUMERICS_FAIL = "numerics_fail"
+    ERROR = "error"
+    SKIPPED_NUMERICS = "skipped_numerics"
+    NO_GOLDEN = "no_golden"
+    IR_RUNTIME_MISMATCH = "ir_runtime_mismatch"
+    CHISEL_BUG = "chisel_bug"
+
+
+NON_FAILURE_STATUSES = frozenset({Status.OK, Status.SKIPPED_NUMERICS, Status.NO_GOLDEN})
+
+
+class _Payload(BaseModel):
+    # Each payload declares only the fields valid for its Status; extra="forbid"
+    # so wrong-field-for-status mistakes raise at construction, not at the
+    # downstream consumer.
+    model_config = ConfigDict(extra="forbid")
+
+
+class NumericsPayload(_Payload):
+    # OK and NUMERICS_FAIL share the same schema — only the status
+    # discriminator differs, set by validators.check_numerics based on the
+    # configured pcc/atol/rtol gates.
+    status: Literal[Status.OK, Status.NUMERICS_FAIL]
+    pcc: float
+    atol: float
+    rtol: float
+    device_id: Optional[int] = None
+
+
+class ShapeMismatchPayload(_Payload):
+    status: Literal[Status.SHAPE_MISMATCH] = Status.SHAPE_MISMATCH
+    expected_shape: List[int]
+    actual_shape: List[int]
+
+
+class DtypeMismatchPayload(_Payload):
+    status: Literal[Status.DTYPE_MISMATCH] = Status.DTYPE_MISMATCH
+    expected_dtype: str
+    actual_dtype: str
+
+
+class ErrorPayload(_Payload):
+    status: Literal[Status.ERROR] = Status.ERROR
+
+
+class SkippedNumericsPayload(_Payload):
+    status: Literal[Status.SKIPPED_NUMERICS] = Status.SKIPPED_NUMERICS
+
+
+class NoGoldenPayload(_Payload):
+    status: Literal[Status.NO_GOLDEN] = Status.NO_GOLDEN
+
+
+class IrRuntimeMismatchPayload(_Payload):
+    status: Literal[Status.IR_RUNTIME_MISMATCH] = Status.IR_RUNTIME_MISMATCH
+    runtime_debug: str
+
+
+class ChiselBugPayload(_Payload):
+    status: Literal[Status.CHISEL_BUG] = Status.CHISEL_BUG
+    traceback: str
+
+
+Payload = Annotated[
+    Union[
+        NumericsPayload,
+        ShapeMismatchPayload,
+        DtypeMismatchPayload,
+        ErrorPayload,
+        SkippedNumericsPayload,
+        NoGoldenPayload,
+        IrRuntimeMismatchPayload,
+        ChiselBugPayload,
+    ],
+    Field(discriminator="status"),
+]
+
+
+class ChiselRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    op: str
+    check: str
+    op_asm: Optional[str] = None
+    ssa: Optional[str] = None
+    binary_id: Optional[int] = None
+    program_name: Optional[str] = None
+    program_index: Optional[int] = None
+    payload: Payload
+
+    @property
+    def status(self) -> Status:
+        return self.payload.status
+
+
+class ChiselReport:
+    def __init__(self, capacity: int = 10_000) -> None:
+        self._records: deque[ChiselRecord] = deque(maxlen=capacity)
+
+    def append(self, record: ChiselRecord) -> None:
+        self._records.append(record)
+
+    def clear(self) -> None:
+        self._records.clear()
+
+    def __iter__(self) -> Iterator[ChiselRecord]:
+        return iter(self._records)
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+    @property
+    def capacity(self) -> Optional[int]:
+        return self._records.maxlen
+
+    @property
+    def records(self) -> List[ChiselRecord]:
+        return list(self._records)
+
+    def resize(self, capacity: int) -> None:
+        self._records = deque(self._records, maxlen=capacity)
+
+    def _from_filtered(
+        self, predicate: Callable[[ChiselRecord], bool]
+    ) -> "ChiselReport":
+        # Preserve the larger of len(filtered) and source capacity so chained
+        # filters never silently drop records into a maxlen=0 deque.
+        filtered = [r for r in self._records if predicate(r)]
+        out = ChiselReport(capacity=max(len(filtered), self.capacity or 1, 1))
+        for r in filtered:
+            out.append(r)
+        return out
+
+    def filter(self, predicate: Callable[[ChiselRecord], bool]) -> "ChiselReport":
+        return self._from_filtered(predicate)
+
+    def by_op(self, name: str) -> "ChiselReport":
+        return self._from_filtered(lambda r: r.op == name)
+
+    def by_check(self, name: str) -> "ChiselReport":
+        return self._from_filtered(lambda r: r.check == name)
+
+    def by_program(self, name: str) -> "ChiselReport":
+        return self._from_filtered(lambda r: r.program_name == name)
+
+    def by_status(
+        self, status: Union[Status, str, Iterable[Union[Status, str]]]
+    ) -> "ChiselReport":
+        if isinstance(status, (Status, str)):
+            wanted = {Status(status)}
+        else:
+            wanted = {Status(s) for s in status}
+        return self._from_filtered(lambda r: r.status in wanted)
+
+    def failures(self) -> "ChiselReport":
+        return self._from_filtered(lambda r: r.status not in NON_FAILURE_STATUSES)
+
+    def passes(self) -> "ChiselReport":
+        return self._from_filtered(lambda r: r.status in NON_FAILURE_STATUSES)
+
+    @classmethod
+    def from_jsonl(cls, path: str, *, capacity: Optional[int] = None) -> "ChiselReport":
+        # Default capacity to len(loaded) so offline loads never truncate;
+        # the 10k runtime default is a buffer cap, not an analysis cap.
+        records: List[ChiselRecord] = []
+        with open(path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                records.append(ChiselRecord.model_validate_json(line))
+        cap = capacity if capacity is not None else max(len(records), 1)
+        report = cls(capacity=cap)
+        for r in records:
+            report.append(r)
+        return report

--- a/tools/chisel/chisel/safety.py
+++ b/tools/chisel/chisel/safety.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import functools
+import logging
+import traceback
+
+from .exceptions import ChiselFailure
+from .report import ChiselBugPayload, ChiselRecord
+from .utils import get_op_asm
+
+logger = logging.getLogger("chisel")
+
+
+def chisel_safe(fn):
+    # Swallows exceptions so a chisel bug never kills the ttmlir runtime.
+    # ChiselFailure -> structured check record; anything else -> chisel_bug
+    # record with traceback. Returns True on clean run, False if a failure
+    # was caught — callers use this to gate dependent work.
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs) -> bool:
+        # Local import: avoid context <-> safety import cycle.
+        from . import context
+
+        try:
+            fn(*args, **kwargs)
+            return True
+        except ChiselFailure as e:
+            logger.warning(str(e))
+            try:
+                context.get_instance().write_record(e.to_record())
+            except Exception:
+                logger.exception("chisel_safe failed to record check failure")
+        except Exception:
+            tb = traceback.format_exc()
+            try:
+                ctx = context.get_instance()
+                if ctx.is_in_op_scope:
+                    op = ctx.op
+                    ctx.write_record(
+                        ChiselRecord(
+                            op=op.name,
+                            check=fn.__name__,
+                            op_asm=get_op_asm(op),
+                            payload=ChiselBugPayload(traceback=tb),
+                        )
+                    )
+                else:
+                    logger.exception(
+                        "chisel callback %s crashed outside op scope", fn.__name__
+                    )
+            except Exception:
+                logger.exception("chisel_safe failed to record chisel_bug")
+        return False
+
+    return wrapper

--- a/tools/chisel/chisel/safety.py
+++ b/tools/chisel/chisel/safety.py
@@ -16,7 +16,7 @@ def chisel_safe(fn):
     # Swallows exceptions so a chisel bug never kills the ttmlir runtime.
     # ChiselFailure -> structured check record; anything else -> chisel_bug
     # record with traceback. Returns True on clean run, False if a failure
-    # was caught — callers use this to gate dependent work.
+    # was caught - callers use this to gate dependent work.
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs) -> bool:

--- a/tools/chisel/chisel/utils.py
+++ b/tools/chisel/chisel/utils.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import functools
+import logging
+import os
+import traceback
+from typing import Optional, Tuple
+
+import torch
+
+from _ttmlir_runtime import runtime as tt_runtime
+from _ttmlir_runtime.binary import Binary
+from _ttmlir_runtime.runtime import CallbackContext, Tensor, TensorRef
+
+from golden import GoldenMapTensor
+from golden.mapping import mlir_datatype_to_torch_dtype
+
+logger = logging.getLogger("chisel")
+
+
+def get_torch_tensor(tensor: Tensor) -> torch.Tensor:
+    rt_data_ptr = tensor.get_data_buffer()
+    rt_dtype = tensor.get_dtype()
+    dtype = mlir_datatype_to_torch_dtype(rt_dtype)
+    shape = tensor.get_shape()
+    torch_tensor = torch.frombuffer(rt_data_ptr, dtype=dtype)
+    return torch_tensor.reshape(shape).clone()
+
+
+def retrieve_tensor(
+    rt_program_context: CallbackContext, rt_tensor_ref: TensorRef
+) -> GoldenMapTensor:
+    device_tensor = tt_runtime.retrieve_tensor_from_pool(
+        rt_program_context, rt_tensor_ref
+    )
+    return GoldenMapTensor({0: get_torch_tensor(device_tensor)}, (1, 1))
+
+
+def get_op_asm(op) -> str:
+    # Mirror OpPrintingFlags from FuncOpToProgram so the asm string matches
+    # the flatbuffer debug_info.
+    return op.get_asm(
+        enable_debug_info=True,
+        large_elements_limit=16,
+        large_resource_limit=64,
+        skip_regions=True,
+        assume_verified=True,
+    ).strip()
+
+
+def debug_wrap(fn):
+    # Checked per-call so exporting CHISEL_DEBUG mid-session takes effect
+    # without re-import.
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception:
+            if os.environ.get("CHISEL_DEBUG"):
+                import pdb
+
+                traceback.print_exc()
+                pdb.post_mortem()
+            raise
+
+    return wrapper

--- a/tools/chisel/chisel/utils.py
+++ b/tools/chisel/chisel/utils.py
@@ -25,7 +25,7 @@ def get_torch_tensor(tensor: Tensor) -> torch.Tensor:
     dtype = mlir_datatype_to_torch_dtype(rt_dtype)
     shape = tensor.get_shape()
     torch_tensor = torch.frombuffer(rt_data_ptr, dtype=dtype)
-    return torch_tensor.reshape(shape).clone()
+    return torch_tensor.reshape(shape)
 
 
 def retrieve_tensor(
@@ -34,6 +34,10 @@ def retrieve_tensor(
     device_tensor = tt_runtime.retrieve_tensor_from_pool(
         rt_program_context, rt_tensor_ref
     )
+    if device_tensor is None:
+        raise RuntimeError(
+            "retrieve_tensor_from_pool returned no tensor for the requested ref"
+        )
     return GoldenMapTensor({0: get_torch_tensor(device_tensor)}, (1, 1))
 
 

--- a/tools/chisel/chisel/validators.py
+++ b/tools/chisel/chisel/validators.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 import torch
@@ -11,29 +11,35 @@ from golden import GoldenMapTensor
 from golden.mapping import mlir_datatype_to_torch_dtype, mlir_type_to_torch_dtype
 from golden.metrics import get_atol_rtol_pcc
 
-from .exceptions import DtypeMismatch, ShapeMismatch
-from .report import ChiselRecord, NumericsPayload, Status
+from .exceptions import ChiselFailure, DtypeMismatch, ShapeMismatch
+from .report import ChiselRecord, NumericsPayload, RecordStatus
 
 logger = logging.getLogger("chisel")
 
 
 @dataclass
-class ChiselChecksConfig:
-    # Settings for chisel's checks; override via
-    # chisel.configure(checks_config=...)
+class PCCConfig:
+    # Settings consumed by the PCC computation itself.
 
-    # Fail if computed PCC < threshold.
-    threshold: float = 0.99
+    # Fail if computed PCC < min_pcc.
+    min_pcc: float = 0.99
 
-    # atol/rtol below are NOT failure thresholds — they are forwarded to
-    # get_pcc → torch.isclose to short-circuit two edge cases:
+    # atol/rtol are NOT failure thresholds - they are forwarded to get_pcc ->
+    # torch.isclose to short-circuit two degenerate cases:
     #   * single-element tensors (one scalar value to compare)
     #   * constant tensors (all elements identical in golden and device)
     # In both cases torch.isclose with these tolerances yields the PCC verdict
-    # directly, because correlation is undefined / 1.0 by convention. They do
-    # Use max_atol/max_rtol below to gate failure on the worst-case diffs.
+    # directly, because correlation is undefined / 1.0 by convention.
     atol: float = 1e-8
     rtol: float = 1e-5
+
+
+@dataclass
+class ChiselChecksConfig:
+    # Settings for chisel's checks; override via
+    # chisel.configure(checks_config=...).
+
+    pcc: PCCConfig = field(default_factory=PCCConfig)
 
     # When set, the numerics check also fails if the computed worst-case
     # absolute/relative diff exceeds the threshold. None = disabled.
@@ -83,22 +89,29 @@ def check_numerics(
     check_shape_dtype(op, check, golden, device)
 
     cfg = ctx.checks_config
+    pcc_cfg = cfg.pcc
     golden_shards = golden.shard_map
     device_shards = device.shard_map
 
+    if golden_shards.keys() != device_shards.keys():
+        raise ChiselFailure(
+            op,
+            check,
+            f"shard id mismatch: golden={sorted(golden_shards)} "
+            f"device={sorted(device_shards)}",
+        )
+
     for device_id, golden_shard in golden_shards.items():
-        if device_id not in device_shards:
-            continue
         device_shard = device_shards[device_id]
         atol, rtol, pcc = get_atol_rtol_pcc(
-            golden_shard, device_shard, cfg.atol, cfg.rtol
+            golden_shard, device_shard, pcc_cfg.atol, pcc_cfg.rtol
         )
-        failed = pcc < cfg.threshold
+        failed = pcc < pcc_cfg.min_pcc
         if cfg.max_atol is not None and atol > cfg.max_atol:
             failed = True
         if cfg.max_rtol is not None and rtol > cfg.max_rtol:
             failed = True
-        status = Status.NUMERICS_FAIL if failed else Status.OK
+        status = RecordStatus.NUMERICS_FAIL if failed else RecordStatus.OK
         ctx.write_record(
             ChiselRecord(
                 op=op.name,

--- a/tools/chisel/chisel/validators.py
+++ b/tools/chisel/chisel/validators.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+from golden import GoldenMapTensor
+from golden.mapping import mlir_datatype_to_torch_dtype, mlir_type_to_torch_dtype
+from golden.metrics import get_atol_rtol_pcc
+
+from .exceptions import DtypeMismatch, ShapeMismatch
+from .report import ChiselRecord, NumericsPayload, Status
+
+logger = logging.getLogger("chisel")
+
+
+@dataclass
+class ChiselChecksConfig:
+    # Settings for chisel's checks; override via
+    # chisel.configure(checks_config=...)
+
+    # Fail if computed PCC < threshold.
+    threshold: float = 0.99
+
+    # atol/rtol below are NOT failure thresholds — they are forwarded to
+    # get_pcc → torch.isclose to short-circuit two edge cases:
+    #   * single-element tensors (one scalar value to compare)
+    #   * constant tensors (all elements identical in golden and device)
+    # In both cases torch.isclose with these tolerances yields the PCC verdict
+    # directly, because correlation is undefined / 1.0 by convention. They do
+    # Use max_atol/max_rtol below to gate failure on the worst-case diffs.
+    atol: float = 1e-8
+    rtol: float = 1e-5
+
+    # When set, the numerics check also fails if the computed worst-case
+    # absolute/relative diff exceeds the threshold. None = disabled.
+    max_atol: Optional[float] = None
+    max_rtol: Optional[float] = None
+
+
+def _extract_shape_dtype(source) -> tuple[list, torch.dtype]:
+    # Accepts a GoldenMapTensor, an MLIR IR Value, a flatbuffer TensorRef, or
+    # a torch.Tensor.
+    if isinstance(source, GoldenMapTensor):
+        t = next(iter(source.shard_map.values()))
+        return list(t.shape), t.dtype
+    if isinstance(source, torch.Tensor):
+        return list(source.shape), source.dtype
+    if hasattr(source, "type") and hasattr(source.type, "shape"):
+        return (
+            list(source.type.shape),
+            mlir_type_to_torch_dtype(source.type.element_type),
+        )
+    if hasattr(source, "get_shape") and hasattr(source, "get_dtype"):
+        return (
+            list(source.get_shape()),
+            mlir_datatype_to_torch_dtype(source.get_dtype()),
+        )
+    raise TypeError(f"cannot extract shape/dtype from {type(source).__name__}")
+
+
+def check_shape_dtype(op, check: str, expected, actual) -> None:
+    exp_shape, exp_dtype = _extract_shape_dtype(expected)
+    act_shape, act_dtype = _extract_shape_dtype(actual)
+    if exp_shape != act_shape:
+        raise ShapeMismatch(op, check, exp_shape, act_shape)
+    if exp_dtype != act_dtype:
+        raise DtypeMismatch(op, check, exp_dtype, act_dtype)
+
+
+def check_numerics(
+    ctx, op, ssa: str, golden: GoldenMapTensor, device: GoldenMapTensor
+) -> None:
+    """Per-shard PCC check.
+
+    Writes one record per shard; multi-shard tensors are compared shard-by-shard
+    rather than collapsed to a single comparison.
+    """
+    check = "numerics"
+    check_shape_dtype(op, check, golden, device)
+
+    cfg = ctx.checks_config
+    golden_shards = golden.shard_map
+    device_shards = device.shard_map
+
+    for device_id, golden_shard in golden_shards.items():
+        if device_id not in device_shards:
+            continue
+        device_shard = device_shards[device_id]
+        atol, rtol, pcc = get_atol_rtol_pcc(
+            golden_shard, device_shard, cfg.atol, cfg.rtol
+        )
+        failed = pcc < cfg.threshold
+        if cfg.max_atol is not None and atol > cfg.max_atol:
+            failed = True
+        if cfg.max_rtol is not None and rtol > cfg.max_rtol:
+            failed = True
+        status = Status.NUMERICS_FAIL if failed else Status.OK
+        ctx.write_record(
+            ChiselRecord(
+                op=op.name,
+                check=check,
+                ssa=ssa,
+                payload=NumericsPayload(
+                    status=status, pcc=pcc, atol=atol, rtol=rtol, device_id=device_id
+                ),
+            )
+        )


### PR DESCRIPTION
### Summary
chisel hooks `_ttmlir_runtime` debug callbacks and, for every op the runtime executes, runs the matching CPU golden in isolation and compares shape, dtype, and PCC against the live device tensor. Failures are recorded as structured JSONL records.

```python
import chisel

with chisel.session(results_path="chisel_result.jsonl") as report:
    run_program()
    print(f"{len(report.failures())} failing record(s)")
```

### What's in this PR

**Core (`tools/chisel/chisel/`)**
- `bind.py` — `bind` / `unbind` / `session()` context manager for one-call setup of all four DebugHooks callbacks.
- `callbacks.py` — `_default_pre_op` stashes a host copy of each device input; `_default_post_op` runs the golden in isolation and checks shape/dtype + PCC against the runtime output for every op output.
- `context.py` — `ChiselContext` singleton with `BinaryState` / `ProgramState` hierarchy; nested callback-scope and op-scope lifecycles.
- `op_configs.py` — per-op overrides (`no_golden`, `skip_isolated_pcc`); default table covers `ttnn.empty`, `ttnn.generic`, non-executable / trace / control-flow / I/O ops, in-place ops, quantization ops, and ops without a registered golden.
- `validators.py` — `check_shape_dtype`, per-shard `check_numerics` with configurable `PccConfig`.
- `recorder.py` — `ChiselRecorder` owns the in-memory ring buffer, optional JSONL sink, and per-binary debug-dump policy (`debug_chisel_dir`).
- `report.py` — pydantic record schema with per-status payload discriminator; `ChiselReport` supports filtering by op / check / program / status and offline loading from JSONL.
- `safety.py` — `chisel_safe` decorator: a chisel bug never kills the ttmlir runtime; `ChiselFailure` becomes a structured record, anything else becomes a `chisel_bug` record with traceback.
- `exceptions.py` — `ChiselFailure` hierarchy (`ShapeMismatch`, `DtypeMismatch`, `GoldenNotImplementedError`, `IrRuntimeMismatch`) and `UnexpectedStateError` for lifecycle violations.
- `utils.py` — tensor retrieval, op asm matching the flatbuffer debug_info, `CHISEL_DEBUG` pdb hook.

**Tests (`test/python/chisel/`)**
- `test_builder_chisel_integration.py`, `test_report.py`,

### TODOs deferred to follow-up PRs

- `bind.py:95` - validate `unbind()` against tt-xla for race conditions caused by asynchronous runtime execution.
- `callbacks.py:113` - input device tensors may be pulled to host multiple times across consumer ops; cache to avoid redundant copies.
- `op_configs.py:49` - chisel does not yet validate in-place tensor mutations; in-place ops are currently configured `no_golden=True`.
- `ops.py:37` - `CHISEL_INPLACE_OPS` is hand-maintained; derive from ODS (`python_op_schema_codegen.py`). #8385 

Follow-on feature branches already named in the seed commit message: `chisel-accumulated` (accumulation across ops), `chisel-skip-op` (skip mode), `chisel-load-cache` (load-cache feature).
