### PR TITLE
[Logger] Add FusionValidator logger type

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
@@ -885,7 +885,7 @@ createAndReplaceWithRoPEOp(mlir::PatternRewriter &rewriter, Operation *srcOp,
     int64_t inputSeq = xType.getShape()[xRank - 2];
     int64_t cosSeq = cosType.getShape()[cosRank - 2];
     if (cosSeq < inputSeq) {
-      TTMLIR_DEBUG(ttmlir::LogComponent::FusionValidator,
+      TTMLIR_DEBUG(ttmlir::LogComponent::IsolatedIRValidationWrapper,
                    "RoPE fusion rejected: cos/sin seq dim ({0}) < input seq "
                    "dim ({1}) — kernel would read padding garbage",
                    cosSeq, inputSeq);


### PR DESCRIPTION
### Problem description
Debug build fails if TTMLIR_ENABLE_OPMODEL is set due to missing type

### What's changed
Add missing type for LogComponent.