### PR TITLE
Preserve core_range during d2m.spatial lowering

### DIFF
--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -558,7 +558,6 @@ public:
           op, "SpatialOp with results is not supported in TTMetal lowering");
     }
 
-    ArrayAttr gridRanges = op.getGridRanges();
     unsigned chipNumCbs = 0;
     bool foundSystemDesc = false;
     for (Operation *walk = op->getParentOp(); walk;
@@ -587,11 +586,7 @@ public:
     SmallVector<Operation *> preEnqueueOps;
     SmallVector<Operation *> postEnqueueOps;
 
-    for (auto [regionIndex, region] : llvm::enumerate(op.getRegions())) {
-      auto spatialCoreRange =
-          mlir::cast<ttcore::CoreRangeAttr>(gridRanges.getValue()[regionIndex]);
-      CoreRangeAttr spatialMetalRange =
-          ttCoreSpatialRangeToTtmetalCoreRange(rewriter, spatialCoreRange);
+    for (Region &region : op.getRegions()) {
       FailureOr<ttmetal::EnqueueProgramOp> maybeEnqueue =
           collectRegionOps(region, preEnqueueOps, postEnqueueOps);
       if (failed(maybeEnqueue)) {
@@ -615,9 +610,8 @@ public:
           llvm::seq<int64_t>(
               portBase, portBase + static_cast<int64_t>(regionCbPortCount)));
       for (Attribute kernelConfig : enqueueProgram.getKernelConfigs()) {
-        mergedKernelConfigs.push_back(
-            remapKernelConfig(kernelConfig, spatialMetalRange, enqueueProgram,
-                              remapTable, mergedCbSlotBase));
+        mergedKernelConfigs.push_back(remapKernelConfig(
+            kernelConfig, enqueueProgram, remapTable, mergedCbSlotBase));
       }
 
       auto enqueueFabricConfig = enqueueProgram.getFabricConnectionConfigAttr();
@@ -754,7 +748,6 @@ private:
   }
 
   static Attribute remapKernelConfig(Attribute kernelConfig,
-                                     CoreRangeAttr spatialCoreRange,
                                      ttmetal::EnqueueProgramOp enqueueProgram,
                                      const SpatialRemapTable &remapTable,
                                      size_t mergedCbSlotBase) {
@@ -763,7 +756,7 @@ private:
         .Case<ComputeConfigAttr>([&](ComputeConfigAttr computeConfig) {
           return ComputeConfigAttr::get(
               computeConfig.getContext(), computeConfig.getKernelSymbol(),
-              spatialCoreRange,
+              computeConfig.getCoreRange(),
               remapKernelArgs(builder, computeConfig.getKernelArgs(),
                               enqueueProgram, remapTable, mergedCbSlotBase),
               computeConfig.getMathFidelity(), computeConfig.getFp32DestAccEn(),
@@ -774,7 +767,7 @@ private:
         .Case<NocConfigAttr>([&](NocConfigAttr nocConfig) {
           return NocConfigAttr::get(
               nocConfig.getContext(), nocConfig.getKernelSymbol(),
-              spatialCoreRange,
+              nocConfig.getCoreRange(),
               remapKernelArgs(builder, nocConfig.getKernelArgs(),
                               enqueueProgram, remapTable, mergedCbSlotBase),
               nocConfig.getNocIndex());
@@ -782,7 +775,7 @@ private:
         .Case<EthernetConfigAttr>([&](EthernetConfigAttr ethernetConfig) {
           return EthernetConfigAttr::get(
               ethernetConfig.getContext(), ethernetConfig.getKernelSymbol(),
-              spatialCoreRange,
+              ethernetConfig.getCoreRange(),
               remapKernelArgs(builder, ethernetConfig.getKernelArgs(),
                               enqueueProgram, remapTable, mergedCbSlotBase),
               ethernetConfig.getEthType(), ethernetConfig.getNocIndex());
@@ -831,21 +824,7 @@ private:
     }
     return onlyEnqueue;
   }
-
-  static CoreRangeAttr
-  ttCoreSpatialRangeToTtmetalCoreRange(Builder &builder,
-                                       ttcore::CoreRangeAttr cr);
 };
-
-CoreRangeAttr SpatialOpRewriter::ttCoreSpatialRangeToTtmetalCoreRange(
-    Builder &builder, ttcore::CoreRangeAttr cr) {
-  auto sc = cr.getStartCoord();
-  auto ec = cr.getEndCoord();
-  SmallVector<int64_t> offset = {sc.getY(), sc.getX()};
-  SmallVector<int64_t> size = {ec.getY() - sc.getY() + 1,
-                               ec.getX() - sc.getX() + 1};
-  return CoreRangeAttr::get(builder.getContext(), offset, size);
-}
 
 } // namespace
 

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -157,6 +157,50 @@ convertMathFidelity(ttmetal::MathFidelity fidelity) {
   llvm_unreachable("Invalid MathFidelity");
 }
 
+static ttnn::CoreRangeSetAttr coreRangeSetFromGeneric(MLIRContext *ctx,
+                                                      d2m::GenericOp op) {
+  ttcore::GridAttr grid = op.getGrid();
+  AffineMap virtToPhysMap = grid.getVirtToPhysicalMap();
+  ArrayRef<int64_t> gridShape = grid.getShape();
+  if (virtToPhysMap.isEmpty()) {
+    auto physicalGridShape = op.getPhysicalGridShape();
+    return ttnn::CoreRangeSetAttr::get(
+        ctx, ttnn::CoreRangeAttr::get(
+                 ctx, ttnn::CoreCoordAttr::get(ctx, 0, 0),
+                 ttnn::CoreCoordAttr::get(ctx, physicalGridShape[1] - 1,
+                                          physicalGridShape[0] - 1)));
+  }
+
+  TT_assertv(gridShape.size() == virtToPhysMap.getNumDims(),
+             "virt_to_physical num dims {} must match grid rank {}",
+             virtToPhysMap.getNumDims(), gridShape.size());
+  TT_assertv((virtToPhysMap.getNumResults() == 2u ||
+              virtToPhysMap.getNumResults() == 3u),
+             "virt_to_physical must have 2 or 3 results (got {})",
+             virtToPhysMap.getNumResults());
+
+  if (virtToPhysMap.getNumResults() == 3u) {
+    virtToPhysMap = virtToPhysMap.getSubMap({1, 2});
+  }
+
+  llvm::SmallVector<int64_t> start(gridShape.size(), 0);
+  llvm::SmallVector<int64_t> end;
+  end.reserve(gridShape.size());
+  for (int64_t dim : gridShape) {
+    end.push_back(dim - 1);
+  }
+  d2m::utils::BoundingBox physBox = d2m::utils::getProjectedBoundingBox(
+      d2m::utils::BoundingBox{start, end}, virtToPhysMap);
+  auto coreStart =
+      ttnn::CoreCoordAttr::get(ctx, static_cast<uint64_t>(physBox.start[1]),
+                               static_cast<uint64_t>(physBox.start[0]));
+  auto coreEnd =
+      ttnn::CoreCoordAttr::get(ctx, static_cast<uint64_t>(physBox.end[1]),
+                               static_cast<uint64_t>(physBox.end[0]));
+  return ttnn::CoreRangeSetAttr::get(
+      ctx, llvm::ArrayRef{ttnn::CoreRangeAttr::get(ctx, coreStart, coreEnd)});
+}
+
 static mlir::Attribute
 convertKernelArg(Builder &builder, const ttkernel::ArgAttr &arg,
                  const llvm::DenseMap<size_t, size_t> &semIndexMap,
@@ -653,17 +697,7 @@ static LogicalResult convertSingleGeneric(d2m::GenericOp op,
   auto device = ttcore::lookupDevice(op->getParentOp());
   TT_assert(device);
 
-  // Compute core range set.
-  // Note: TTNN grids are (Width, Height), while D2M grids are (Height, Width).
-  auto physicalGridShape = op.getPhysicalGridShape();
-  llvm::SmallVector<int64_t> endCoreRange = {physicalGridShape[1] - 1,
-                                             physicalGridShape[0] - 1};
-
-  ttnn::CoreRangeSetAttr coreRangeSet = ttnn::CoreRangeSetAttr::get(
-      ctx,
-      ttnn::CoreRangeAttr::get(
-          ctx, ttnn::CoreCoordAttr::get(ctx, 0, 0),
-          ttnn::CoreCoordAttr::get(ctx, endCoreRange[0], endCoreRange[1])));
+  ttnn::CoreRangeSetAttr coreRangeSet = coreRangeSetFromGeneric(ctx, op);
 
   SmallVector<Value> ttnnGenericAdditionalArgs;
   // Additional args in the d2m.generic don't map 1:1 to the ttnn.generic's
@@ -748,20 +782,9 @@ static LogicalResult convertGenerics(ModuleOp moduleOp,
 // is built by walking regions in order and appending each input/output Value
 // the first time it is seen (dedupe by SSA Value identity). Additional operands
 // are concatenated per region. Kernel/CB attrs remap via SpatialRemapTable;
-// kernels, CBs, and semaphores use each region's spatial grid core_ranges.
+// kernels, CBs, and semaphores preserve per-region core_ranges from converted
+// ttnn.generics.
 // ===----------------------------------------------------------------------===//
-
-static ttnn::CoreRangeSetAttr
-ttCoreRangeToTtnnCoreRangeSet(MLIRContext *ctx, ttcore::CoreRangeAttr cr) {
-  auto sc = cr.getStartCoord();
-  auto ec = cr.getEndCoord();
-  auto tts = ttnn::CoreCoordAttr::get(ctx, static_cast<uint64_t>(sc.getX()),
-                                      static_cast<uint64_t>(sc.getY()));
-  auto tte = ttnn::CoreCoordAttr::get(ctx, static_cast<uint64_t>(ec.getX()),
-                                      static_cast<uint64_t>(ec.getY()));
-  return ttnn::CoreRangeSetAttr::get(
-      ctx, llvm::ArrayRef{ttnn::CoreRangeAttr::get(ctx, tts, tte)});
-}
 
 class SpatialRemapTable {
   using LocalKey = std::pair<ttnn::GenericOp, size_t>;
@@ -860,8 +883,7 @@ remapSpatialKernelArgs(MLIRContext *ctx, ArrayRef<Attribute> args,
 static Attribute
 remapSpatialKernelDescriptor(MLIRContext *ctx, Attribute kernelAttr,
                              ttnn::GenericOp generic,
-                             const SpatialRemapTable &remapTable,
-                             ttnn::CoreRangeSetAttr gridCoreRanges) {
+                             const SpatialRemapTable &remapTable) {
   auto iface = mlir::dyn_cast<ttnn::KernelInterface>(kernelAttr);
   if (!iface) {
     return kernelAttr;
@@ -875,23 +897,23 @@ remapSpatialKernelDescriptor(MLIRContext *ctx, Attribute kernelAttr,
   return llvm::TypeSwitch<Attribute, Attribute>(kernelAttr)
       .Case<ttnn::ComputeKernelAttr>([&](ttnn::ComputeKernelAttr compute) {
         return ttnn::ComputeKernelAttr::get(
-            ctx, compute.getSymbolRef(), gridCoreRanges,
+            ctx, compute.getSymbolRef(), compute.getCoreRanges(),
             compute.getMathFidelity(), compute.getFp32DestAccEn(),
             compute.getDstFullSyncEn(), compute.getUnpackToDestModes(),
             compute.getBfp8PackPrecise(), compute.getMathApproxMode(), crt, ct);
       })
       .Case<ttnn::DataMovementKernelAttr>([&](ttnn::DataMovementKernelAttr dm) {
         return ttnn::DataMovementKernelAttr::get(
-            ctx, dm.getSymbolRef(), gridCoreRanges, dm.getProcessor(),
+            ctx, dm.getSymbolRef(), dm.getCoreRanges(), dm.getProcessor(),
             dm.getNocIndex(), dm.getNocMode(), crt, ct);
       })
       .Case<ttnn::ReadKernelAttr>([&](ttnn::ReadKernelAttr read) {
         return ttnn::ReadKernelAttr::get(ctx, read.getSymbolRef(),
-                                         gridCoreRanges, crt, ct);
+                                         read.getCoreRanges(), crt, ct);
       })
       .Case<ttnn::WriteKernelAttr>([&](ttnn::WriteKernelAttr write) {
         return ttnn::WriteKernelAttr::get(ctx, write.getSymbolRef(),
-                                          gridCoreRanges, crt, ct);
+                                          write.getCoreRanges(), crt, ct);
       })
       .Default([](Attribute attr) { return attr; });
 }
@@ -899,8 +921,7 @@ remapSpatialKernelDescriptor(MLIRContext *ctx, Attribute kernelAttr,
 static ttnn::KernelCBAttr
 adjustSpatialCBDescriptor(MLIRContext *ctx, ttnn::KernelCBAttr cb,
                           ttnn::GenericOp generic,
-                          const SpatialRemapTable &remapTable,
-                          ttnn::CoreRangeSetAttr gridCoreRanges) {
+                          const SpatialRemapTable &remapTable) {
   SmallVector<ttnn::KernelCBFormatAttr> formats;
   formats.append(cb.getFormats().begin(), cb.getFormats().end());
   ttnn::KernelCBGlobalBufferAddressOfTensorAttr bufferToUse = cb.getBuffer();
@@ -911,7 +932,7 @@ adjustSpatialCBDescriptor(MLIRContext *ctx, ttnn::KernelCBAttr cb,
           ttnn::KernelCBGlobalBufferAddressOfTensorAttr::get(ctx, *unified);
     }
   }
-  return ttnn::KernelCBAttr::get(ctx, cb.getTotalSize(), gridCoreRanges,
+  return ttnn::KernelCBAttr::get(ctx, cb.getTotalSize(), cb.getCoreRanges(),
                                  formats, bufferToUse);
 }
 
@@ -967,27 +988,22 @@ static LogicalResult convertSingleSpatial(d2m::SpatialOp spatialOp,
     remapTable.addOperands(generic);
   }
 
-  mlir::ArrayAttr spatialGridRanges = spatialOp.getGridRanges();
   SmallVector<Attribute> mergedKernels;
   SmallVector<ttnn::KernelCBAttr> mergedCBs;
   SmallVector<ttnn::KernelSemaphoreAttr> mergedSemaphores;
-  for (const auto [regionIdx, generic] : llvm::enumerate(regionGenerics)) {
-    auto regionCoreRange =
-        mlir::cast<ttcore::CoreRangeAttr>(spatialGridRanges[regionIdx]);
-    ttnn::CoreRangeSetAttr gridCoreRanges =
-        ttCoreRangeToTtnnCoreRangeSet(ctx, regionCoreRange);
+  for (ttnn::GenericOp generic : regionGenerics) {
     auto program = llvm::cast<ttnn::ProgramAttr>(generic.getProgram());
     for (Attribute kernelAttr : program.getKernels()) {
-      mergedKernels.push_back(remapSpatialKernelDescriptor(
-          ctx, kernelAttr, generic, remapTable, gridCoreRanges));
+      mergedKernels.push_back(
+          remapSpatialKernelDescriptor(ctx, kernelAttr, generic, remapTable));
     }
     for (ttnn::KernelCBAttr cb : program.getCbs()) {
-      mergedCBs.push_back(adjustSpatialCBDescriptor(
-          ctx, cb, generic, remapTable, gridCoreRanges));
+      mergedCBs.push_back(
+          adjustSpatialCBDescriptor(ctx, cb, generic, remapTable));
     }
     for (ttnn::KernelSemaphoreAttr sem : program.getSemaphores()) {
       mergedSemaphores.push_back(ttnn::KernelSemaphoreAttr::get(
-          ctx, sem.getId(), sem.getCoreType(), gridCoreRanges,
+          ctx, sem.getId(), sem.getCoreType(), sem.getCoreRanges(),
           sem.getInitialValue()));
     }
   }

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -1,18 +1,18 @@
 // RUN: ttmlir-opt --split-input-file --ttcore-register-device --convert-d2m-to-ttkernel --convert-d2m-to-ttmetal -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 
-// Spatial lowering regression test for D2M -> TTMetal.
-// This test validates:
-// 1) Two nested region programs are merged into one ttmetal.enqueue_program.
-// 2) Per-region core ranges are preserved in merged kernel configs.
-// 3) Index-based kernel args (global_semaphore operand index) are remapped
-//    when args from multiple enqueues are concatenated.
-// 4) CBPort operand_idx remaps into the merged `cbs` list per region; hardware
-//    cb_ports are reassigned to sequential globally unique ids (temporary
-//    workaround for spatial merge).
+// Spatial lowering regression tests for D2M -> TTMetal.
+// This file validates independent concerns with separate test funcs:
+// 1) Region enqueue_programs merge into one ttmetal.enqueue_program.
+// 2) GlobalSemaphore arg index remap during spatial merge.
+// 3) Non-origin core-range derivation from d2m.generic grid maps.
+// 4) BufferAddress arg index remap.
+// 5) CBPort remap into merged cbs list (and sequential hardware cb_ports).
 
 // Single-region merge smoke test.
 #l1 = #ttcore.memory_space<l1>
+#vgm_11_inv = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#vgm_11_fwd = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
 module {
   ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
   // CHECK-LABEL: func.func @spatial_single_region_merge
@@ -47,22 +47,24 @@ module {
 // -----
 
 #l1 = #ttcore.memory_space<l1>
+#vgm_11_inv = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#vgm_11_fwd = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
 module {
   ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
-  // CHECK-LABEL: func.func @spatial_two_regions_global_semaphore_remap
+  // CHECK-LABEL: func.func @spatial_two_regions_global_semaphore_arg_remap
   // CHECK-COUNT-1: "ttmetal.enqueue_program"
   // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[2]>]>, noc0>
   // CHECK-SAME: #ttmetal.compute_config<@cp_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[2]>]>, hifi4, true, false, false, [default]>
   // CHECK-SAME: #ttmetal.noc_config<@dm_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>, <global_semaphore[5]>]>, noc0>
   // CHECK-SAME: #ttmetal.compute_config<@cp_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>, <global_semaphore[5]>]>, hifi4, true, false, false, [default]>]
   // CHECK-NOT: d2m.spatial
-  func.func @spatial_two_regions_global_semaphore_remap(
+  func.func @spatial_two_regions_global_semaphore_arg_remap(
       %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
       %arg1: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
       -> (memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
           memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
     %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1000} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
-    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2000} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2000, d2m.virtualGridInverseMapping = #vgm_11_inv, d2m.virtualGridForwardMapping = #vgm_11_fwd} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
     %sem_backing0 = memref.alloc() {alignment = 16 : i64, address = 0x3000} : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #l1>
     %sem_backing1 = memref.alloc() {alignment = 16 : i64, address = 0x3010} : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #l1>
     %sem0 = d2m.create_global_semaphore(%sem_backing0) {value = 0 : ui32} : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #l1> -> !d2m.global_semaphore
@@ -82,7 +84,7 @@ module {
             additionalArgs(%sem0, %cb_r0_0, %cb_r0_1 : !d2m.global_semaphore, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
       }, {
       ^region_1:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_r1, noc = 0>, #d2m.thread<compute, @cp_r1>]}
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_r1, noc = 0>, #d2m.thread<compute, @cp_r1>]}
             ins(%arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             outs(%out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             additionalArgs(%sem1, %cb_r1_0, %cb_r1_1 : !d2m.global_semaphore, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
@@ -111,8 +113,68 @@ module {
 
 // -----
 
+// Two-region non-origin core range from generic grid map.
+#l1 = #ttcore.memory_space<l1>
+#vgm_11_inv = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#vgm_11_fwd = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK-LABEL: func.func @spatial_two_regions_non_origin_core_range_from_grid_map
+  // CHECK-COUNT-1: "ttmetal.enqueue_program"
+  // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_core_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>
+  // CHECK-SAME: #ttmetal.compute_config<@cp_core_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, hifi4, true, false, false, [default]>
+  // CHECK-SAME: #ttmetal.noc_config<@dm_core_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>]>, noc0>
+  // CHECK-SAME: #ttmetal.compute_config<@cp_core_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>]>, hifi4, true, false, false, [default]>]
+  // CHECK-NOT: d2m.spatial
+  func.func @spatial_two_regions_non_origin_core_range_from_grid_map(
+      %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+      %arg1: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      -> (memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+          memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+    %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1400} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2400, d2m.virtualGridInverseMapping = #vgm_11_inv, d2m.virtualGridForwardMapping = #vgm_11_fwd} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %cb_core_r0_0 = memref.alloc() {address = 0x7000 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
+    %cb_core_r0_1 = memref.alloc() {address = 0x7100 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
+    %cb_core_r1_0 = memref.alloc() {address = 0x7200 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
+    %cb_core_r1_1 = memref.alloc() {address = 0x7300 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+        ins(%arg0, %arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+        outs(%out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_core_r0, noc = 0>, #d2m.thread<compute, @cp_core_r0>]}
+            ins(%arg0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            additionalArgs(%cb_core_r0_0, %cb_core_r0_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
+      }, {
+      ^region_1:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_core_r1, noc = 0>, #d2m.thread<compute, @cp_core_r1>]}
+            ins(%arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            additionalArgs(%cb_core_r1_0, %cb_core_r1_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
+      }
+    return %out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+  }
+
+  func.func private @dm_core_r0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @cp_core_r0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    return
+  }
+  func.func private @dm_core_r1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @cp_core_r1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    return
+  }
+}
+
+// -----
+
 // Two-region BufferAddress argsOffset remap test.
 #l1 = #ttcore.memory_space<l1>
+#vgm_11_inv = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#vgm_11_fwd = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
 module {
   ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
   // CHECK-LABEL: func.func @spatial_two_regions_buffer_address_remap
@@ -126,7 +188,7 @@ module {
       -> (memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
           memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
     %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1200} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
-    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2200} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2200, d2m.virtualGridInverseMapping = #vgm_11_inv, d2m.virtualGridForwardMapping = #vgm_11_fwd} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
     %cb_b0_0 = memref.alloc() {address = 0x5000 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
     %cb_b0_1 = memref.alloc() {address = 0x5100 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
     %cb_b1_0 = memref.alloc() {address = 0x5200 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
@@ -141,7 +203,7 @@ module {
             additionalArgs(%cb_b0_0, %cb_b0_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
       }, {
       ^region_1:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_b1, noc = 0>]}
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_b1, noc = 0>]}
             ins(%arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             outs(%out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             additionalArgs(%cb_b1_0, %cb_b1_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
@@ -162,6 +224,8 @@ module {
 // Two-region CBPort index remap: second region kernels must reference merged
 // cbs slots [2,3], not [0,1]. Hardware cb_ports are 0,1,2,3 after merge remap.
 #l1 = #ttcore.memory_space<l1>
+#vgm_11_inv = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#vgm_11_fwd = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
 module {
   ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
   // CHECK-LABEL: func.func @spatial_two_regions_cb_port_remap
@@ -178,7 +242,7 @@ module {
       -> (memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
           memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
     %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1300} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
-    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2300} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2300, d2m.virtualGridInverseMapping = #vgm_11_inv, d2m.virtualGridForwardMapping = #vgm_11_fwd} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
     %cb_cbp_r0_0 = memref.alloc() {address = 0x6000 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
     %cb_cbp_r0_1 = memref.alloc() {address = 0x6100 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
     %cb_cbp_r1_0 = memref.alloc() {address = 0x6200 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
@@ -193,7 +257,7 @@ module {
             additionalArgs(%cb_cbp_r0_0, %cb_cbp_r0_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
       }, {
       ^region_1:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_cbport_r1, noc = 0>]}
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_cbport_r1, noc = 0>]}
             ins(%arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             outs(%out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             additionalArgs(%cb_cbp_r1_0, %cb_cbp_r1_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -137,7 +137,7 @@ module {
     %cb_core_r0_1 = memref.alloc() {address = 0x7100 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
     %cb_core_r1_0 = memref.alloc() {address = 0x7200 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
     %cb_core_r1_1 = memref.alloc() {address = 0x7300 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
-    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 2)>]}
         ins(%arg0, %arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
         outs(%out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
       ^region_0:

--- a/test/ttmlir/Conversion/D2MToTTNN/spatial.mlir
+++ b/test/ttmlir/Conversion/D2MToTTNN/spatial.mlir
@@ -78,6 +78,47 @@ module {
 }
 
 // -----
+// TC7: spatial grid range is wider than generic VGM range.
+// The kernel core range must follow d2m.generic grid map.
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+#dram1 = #ttcore.memory_space<dram>
+#l1_1 = #ttcore.memory_space<l1>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(1, 1), (1, 1)>]>>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK-LABEL: func.func @spatial_generic_map_narrower_than_spatial_range
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK: #ttnn.data_movement_kernel<symbol_ref = @dm_narrow, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>
+  // CHECK: #ttnn.compute_kernel<symbol_ref = @cp_narrow, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>
+  func.func @spatial_generic_map_narrower_than_spatial_range(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x64xf32, #ttnn_layout3> {
+    %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<64x128xf32, #ttnn_layout> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>
+    %cast_0 = memref.alloc() {address = 0xa400 : i64, alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>, d2m.virtualGridInverseMapping = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
+    %view = d2m.view_layout %cast remapping = #map3 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
+    %cb_0 = memref.alloc() {address = 0xa000 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>
+    %cb_1 = d2m.operand_alias %cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1> -> memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (3, 3)>]}
+        ins(%cast : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>)
+        outs(%cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_narrow, noc = 0>, #d2m.thread<compute, @cp_narrow>]}
+            ins(%view : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>)
+            outs(%cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>)
+            additionalArgs(%cb_0, %cb_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
+    }
+    %cast_1 = ttir.ttnn_metal_layout_cast %cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1> -> tensor<64x64xf32, #ttnn_layout3>
+    return %cast_1 : tensor<64x64xf32, #ttnn_layout3>
+  }
+  func.func private @dm_narrow() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @cp_narrow() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    return
+  }
+}
+
+// -----
 // TC2: Multi-region, inputs NOT shared. Each region 1 in + 1 out. Global IOs: in0, in1, out0, out1. CB descriptors 2+2; ct_args CB 0,1 each region; address 0,1,2,3.
 #dram = #ttnn.buffer_type<dram>
 #l1 = #ttnn.buffer_type<l1>
@@ -123,7 +164,7 @@ module {
     %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<64x128xf32, #ttnn_layout> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>
     %cast_0 = ttir.ttnn_metal_layout_cast %arg1 : tensor<128x64xf32, #ttnn_layout1> -> memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.interleaved<8192x4096>, #dram1>
     %cast_1 = ttir.ttnn_metal_layout_cast %0 : tensor<64x64xf32, #ttnn_layout2> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
-    %cast_2 = ttir.ttnn_metal_layout_cast %1 : tensor<64x64xf32, #ttnn_layout3> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
+    %cast_2 = memref.alloc() {address = 0x5200 : i64, alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>, d2m.virtualGridInverseMapping = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
     %view_tc2_r0 = d2m.view_layout %cast remapping = #map3 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
     %view_tc2_r1 = d2m.view_layout %cast_0 remapping = #map3 : memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.interleaved<8192x4096>, #dram1> -> memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
     %cb_tc2_r0_0 = memref.alloc() {address = 0x5000 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>
@@ -140,7 +181,7 @@ module {
             additionalArgs(%cb_tc2_r0_0, %cb_tc2_r0_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
       }, {
       ^region_1:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_ns2, noc = 0>, #d2m.thread<datamovement, @dm_ns3, noc = 1>, #d2m.thread<compute, @cp_ns1>]}
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_ns2, noc = 0>, #d2m.thread<datamovement, @dm_ns3, noc = 1>, #d2m.thread<compute, @cp_ns1>]}
             ins(%view_tc2_r1 : memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>)
             outs(%cast_2 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>)
             additionalArgs(%cb_tc2_r1_0, %cb_tc2_r1_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
@@ -215,7 +256,7 @@ module {
     %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<64x128xf32, #ttnn_layout> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>
     %cast_0 = ttir.ttnn_metal_layout_cast %arg1 : tensor<128x64xf32, #ttnn_layout1> -> memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.interleaved<8192x4096>, #dram1>
     %cast_1 = ttir.ttnn_metal_layout_cast %0 : tensor<64x64xf32, #ttnn_layout2> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
-    %cast_2 = ttir.ttnn_metal_layout_cast %1 : tensor<64x64xf32, #ttnn_layout3> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
+    %cast_2 = memref.alloc() {address = 0x6300 : i64, alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>, d2m.virtualGridInverseMapping = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
     %view_tc3_r0 = d2m.view_layout %cast remapping = #map3 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
     %view_tc3_r1_0 = d2m.view_layout %cast remapping = #map3 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
     %view_tc3_r1_1 = d2m.view_layout %cast_0 remapping = #map3 : memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.interleaved<8192x4096>, #dram1> -> memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
@@ -234,7 +275,7 @@ module {
             additionalArgs(%cb_tc3_r0_0, %cb_tc3_r0_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
       }, {
       ^region_1:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_2p3_2, noc = 0>, #d2m.thread<datamovement, @dm_2p3_3, noc = 1>, #d2m.thread<compute, @cp_2p3_1>]}
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_2p3_2, noc = 0>, #d2m.thread<datamovement, @dm_2p3_3, noc = 1>, #d2m.thread<compute, @cp_2p3_1>]}
             ins(%view_tc3_r1_0, %view_tc3_r1_1 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>, memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>)
             outs(%cast_2 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>)
             additionalArgs(%cb_tc3_r1_0, %cb_tc3_r1_1, %cb_tc3_r1_2 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
@@ -293,7 +334,7 @@ module {
     %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<64x128xf32, #ttnn_layout> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>
     %cast_0 = ttir.ttnn_metal_layout_cast %arg1 : tensor<128x64xf32, #ttnn_layout1> -> memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.interleaved<8192x4096>, #dram1>
     %cast_1 = ttir.ttnn_metal_layout_cast %0 : tensor<64x64xf32, #ttnn_layout2> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
-    %cast_2 = ttir.ttnn_metal_layout_cast %1 : tensor<64x64xf32, #ttnn_layout3> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
+    %cast_2 = memref.alloc() {address = 0x7400 : i64, alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>, d2m.virtualGridInverseMapping = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
     %view_tc4_r0_0 = d2m.view_layout %cast remapping = #map3 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
     %view_tc4_r0_1 = d2m.view_layout %cast_0 remapping = #map3 : memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.interleaved<8192x4096>, #dram1> -> memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
     %view_tc4_r1_0 = d2m.view_layout %cast remapping = #map3 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
@@ -314,7 +355,7 @@ module {
             additionalArgs(%cb_tc4_r0_0, %cb_tc4_r0_1, %cb_tc4_r0_2 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
       }, {
       ^region_1:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_k2, noc = 0>, #d2m.thread<datamovement, @dm_k3, noc = 1>, #d2m.thread<compute, @cp_k1>]}
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_k2, noc = 0>, #d2m.thread<datamovement, @dm_k3, noc = 1>, #d2m.thread<compute, @cp_k1>]}
             ins(%view_tc4_r1_0, %view_tc4_r1_1 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>, memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>)
             outs(%cast_2 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>)
             additionalArgs(%cb_tc4_r1_0, %cb_tc4_r1_1, %cb_tc4_r1_2 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
@@ -371,7 +412,7 @@ module {
     %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<64x128xf32, #ttnn_layout> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>
     %cast_0 = ttir.ttnn_metal_layout_cast %arg1 : tensor<128x64xf32, #ttnn_layout1> -> memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.interleaved<8192x4096>, #dram1>
     %cast_1 = ttir.ttnn_metal_layout_cast %0 : tensor<64x64xf32, #ttnn_layout2> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
-    %cast_2 = ttir.ttnn_metal_layout_cast %1 : tensor<64x64xf32, #ttnn_layout3> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
+    %cast_2 = memref.alloc() {address = 0x8400 : i64, alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>, d2m.virtualGridInverseMapping = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
     %view_tc5_r0 = d2m.view_layout %cast remapping = #map3 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
     %view_tc5_r1 = d2m.view_layout %cast_0 remapping = #map3 : memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.interleaved<8192x4096>, #dram1> -> memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
     %cb_tc5_r0_0 = memref.alloc() {address = 0x8000 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>
@@ -388,7 +429,7 @@ module {
             additionalArgs(%cb_tc5_r0_0, %cb_tc5_r0_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
       }, {
       ^region_1:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_r1_sem, noc = 0>, #d2m.thread<datamovement, @dm_r1_nosem, noc = 1>, #d2m.thread<compute, @cp_r1>]}
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_r1_sem, noc = 0>, #d2m.thread<datamovement, @dm_r1_nosem, noc = 1>, #d2m.thread<compute, @cp_r1>]}
             ins(%view_tc5_r1 : memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>)
             outs(%cast_2 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>)
             additionalArgs(%cb_tc5_r1_0, %cb_tc5_r1_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)

--- a/test/ttmlir/Conversion/D2MToTTNN/spatial.mlir
+++ b/test/ttmlir/Conversion/D2MToTTNN/spatial.mlir
@@ -14,6 +14,7 @@
 // - multi_region: 2 regions, 2 shared inputs, 2 outputs; each region ct_args CB 0,1,2; address 0,1,2,3 (last).
 // - multi_region_semaphore: 2 regions; semaphore_at<0,1> per region; merged semaphores keep id 0,1 per region (listed twice).
 // - two_global_semaphores: 2 regions; each generic has one additional global semaphore; merged common_rt_args remap flat operand_index 2 to unified slots 4 and 5.
+// - generic_map_narrower_than_spatial_range: 1 region; spatial grid range is wider than d2m.generic VGM map; merged kernel/CB/semaphore core_ranges must follow the generic map (not spatial grid_ranges).
 
 // -----
 // TC1: Single region.
@@ -73,47 +74,6 @@ module {
     return
   }
   func.func private @cp_s0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 3>, <arg_type = cb_port, operand_index = 4>, <arg_type = cb_port, operand_index = 5>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-    return
-  }
-}
-
-// -----
-// TC7: spatial grid range is wider than generic VGM range.
-// The kernel core range must follow d2m.generic grid map.
-#dram = #ttnn.buffer_type<dram>
-#l1 = #ttnn.buffer_type<l1>
-#dram1 = #ttcore.memory_space<dram>
-#l1_1 = #ttcore.memory_space<l1>
-#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(1, 1), (1, 1)>]>>
-#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-// CHECK-LABEL: func.func @spatial_generic_map_narrower_than_spatial_range
-module {
-  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
-  // CHECK: #ttnn.data_movement_kernel<symbol_ref = @dm_narrow, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>
-  // CHECK: #ttnn.compute_kernel<symbol_ref = @cp_narrow, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>
-  func.func @spatial_generic_map_narrower_than_spatial_range(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x64xf32, #ttnn_layout3> {
-    %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<64x128xf32, #ttnn_layout> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>
-    %cast_0 = memref.alloc() {address = 0xa400 : i64, alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>, d2m.virtualGridInverseMapping = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
-    %view = d2m.view_layout %cast remapping = #map3 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
-    %cb_0 = memref.alloc() {address = 0xa000 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>
-    %cb_1 = d2m.operand_alias %cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1> -> memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>
-    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (3, 3)>]}
-        ins(%cast : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>)
-        outs(%cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>) {
-      ^region_0:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_narrow, noc = 0>, #d2m.thread<compute, @cp_narrow>]}
-            ins(%view : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>)
-            outs(%cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>)
-            additionalArgs(%cb_0, %cb_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
-    }
-    %cast_1 = ttir.ttnn_metal_layout_cast %cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1> -> tensor<64x64xf32, #ttnn_layout3>
-    return %cast_1 : tensor<64x64xf32, #ttnn_layout3>
-  }
-  func.func private @dm_narrow() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-    return
-  }
-  func.func private @cp_narrow() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<compute>} {
     return
   }
 }
@@ -539,6 +499,51 @@ module {
     return
   }
   func.func private @cp_g1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 3>, <arg_type = cb_port, operand_index = 4>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    return
+  }
+}
+
+// -----
+// TC7: spatial grid range is wider than generic VGM range.
+// The kernel core range must follow d2m.generic grid map.
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+#dram1 = #ttcore.memory_space<dram>
+#l1_1 = #ttcore.memory_space<l1>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(1, 1), (1, 1)>]>>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK-LABEL: func.func @spatial_generic_map_narrower_than_spatial_range
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK: #ttnn.data_movement_kernel<symbol_ref = @dm_narrow, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>, processor = riscv1, noc_index = noc0, noc_mode = dedicated_noc, ct_args = [#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>, #ttnn.kernel_arg_semaphore_at<0>, #ttnn.kernel_arg_semaphore_at<1>], common_rt_args = [#ttnn.kernel_arg_address_of_tensor<0>], rt_args = []>
+  // CHECK: #ttnn.compute_kernel<symbol_ref = @cp_narrow, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>
+  // CHECK: <total_size = 16384, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>, formats = [<buffer_index = 0, dtype = f32, page_size = 4096>]>
+  // CHECK: <total_size = 16384, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>, formats = [<buffer_index = 1, dtype = f32, page_size = 4096>], buffer = #ttnn.kernel_cb_global_buffer_address_of_tensor<1>>
+  // CHECK: semaphores = [<id = 0, core_type = worker, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>, initial_value = 0>
+  // CHECK: <id = 1, core_type = worker, core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>, initial_value = 0>]
+  func.func @spatial_generic_map_narrower_than_spatial_range(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x64xf32, #ttnn_layout3> {
+    %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<64x128xf32, #ttnn_layout> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>
+    %cast_0 = memref.alloc() {address = 0xa400 : i64, alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>, d2m.virtualGridInverseMapping = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>
+    %view = d2m.view_layout %cast remapping = #map3 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>
+    %cb_0 = memref.alloc() {address = 0xa000 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>
+    %cb_1 = d2m.operand_alias %cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1> -> memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (3, 3)>]}
+        ins(%cast : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #dram1>)
+        outs(%cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_narrow, noc = 0>, #d2m.thread<compute, @cp_narrow>]}
+            ins(%view : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram1>)
+            outs(%cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1>)
+            additionalArgs(%cb_0, %cb_1 : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_1>)
+    }
+    %cast_1 = ttir.ttnn_metal_layout_cast %cast_0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1> -> tensor<64x64xf32, #ttnn_layout3>
+    return %cast_1 : tensor<64x64xf32, #ttnn_layout3>
+  }
+  func.func private @dm_narrow() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>, <arg_type = local_semaphore, operand_index = 0>, <arg_type = local_semaphore, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @cp_narrow() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<compute>} {
     return
   }
 }


### PR DESCRIPTION
### Ticket
closes #8431 

### Problem description
During d2m.spatial lowering, core_range metadata can be overwritten by the op-level grid_ranges.
This can discard placement decisions made by earlier passes and expand resource usage beyond what those passes selected.

### What's changed
Updated D2MToTTNN lowering to preserve existing core_range instead of unconditionally replacing it with d2m.spatial.grid_ranges.
Applied the same preservation behavior in D2MToTTMetal lowering for consistency.
Added/updated spatial lowering tests for both backends to verify that precomputed core_range values are not overwritten.

### Checklist
- [ ] New/Existing tests provide coverage for changes
