### PR TITLE
[d2m] Handle multi-level synchronized scopes in SplitUnifiedThread

### DIFF
--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -143,7 +143,7 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     return failure();
   }
 
-  // Expand and merge compute regions until we hit a syncrhonizable op on both
+  // Expand and merge compute regions until we hit a synchronizable op on both
   // ends.
   //
   // Beyond hitting a SynchronizableOpInterface op (which bounds the wrap),
@@ -249,42 +249,11 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
   // erases the shared op (B-1), leaving the second region's start iterator
   // dangling and triggering an ilist sentinel crash.
   if (!computeRegions.empty()) {
-    Block *block = computeRegions[0].first->getBlock();
-
-    // Position map: op → sequential index within the block.
-    DenseMap<Operation *, unsigned> posMap;
-    SmallVector<Block::iterator> posToIter;
-    {
-      unsigned pos = 0;
-      for (auto it = block->begin(); it != block->end(); ++it, ++pos) {
-        posMap[&*it] = pos;
-        posToIter.push_back(it);
-      }
-    }
-
-    // Convert regions to (startPos, endPosInclusive) pairs and sort.
-    SmallVector<std::pair<unsigned, unsigned>> posRegions;
-    posRegions.reserve(computeRegions.size());
-    for (auto [s, e] : computeRegions) {
-      posRegions.push_back({posMap[&*s], posMap[&*std::prev(e)]});
-    }
-    llvm::sort(posRegions,
-               [](const auto &a, const auto &b) { return a.first < b.first; });
-
-    // Merge overlapping intervals.
-    SmallVector<std::pair<unsigned, unsigned>> merged;
-    for (auto [s, e] : posRegions) {
-      if (!merged.empty() && s <= merged.back().second) {
-        merged.back().second = std::max(merged.back().second, e);
-      } else {
-        merged.push_back({s, e});
-      }
-    }
-
     // Purity cache mirroring isPurelyDerivedOp in wrapInSynchronizedRegion:
     // an op is purely derived if it is pure and every operand-defining op is
     // also purely derived.  Ops that are not purely derived will be erased by
     // wrapInSynchronizedRegion; their results must not escape the region.
+    // The cache is block-agnostic and shared across all per-block passes below.
     DenseMap<Operation *, bool> pureCache;
     auto isPurelyDerived = [&](auto &self, Operation *op) -> bool {
       auto it = pureCache.find(op);
@@ -305,97 +274,145 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
       return (pureCache[op] = result);
     };
 
-    // Fixpoint expansion: extend each merged region in both directions.
-    //
-    // Downward (end grows): a non-pure op in [startPos, endPos) has result
-    // users outside the range that would dangle after wrapInSynchronizedRegion
-    // erases the op.  Expand endPos to include those users.
-    //
-    // Upward (start shrinks): a non-pure op in the range has an operand
-    // defined by another non-pure op just before startPos.  Expand startPos
-    // to include that defining op so that CB-load detection (which walks ops
-    // inside [start, end)) can find the CB operand feeding the region.
-    //
-    // Both directions stop at SynchronizableOpInterface boundaries.
-    for (auto &[startPos, endPos] : merged) {
-      bool changed = true;
-      while (changed) {
-        changed = false;
-        for (unsigned p = startPos; p <= endPos; ++p) {
-          Operation *op = &*posToIter[p];
-          if (isPurelyDerived(isPurelyDerived, op)) {
-            continue;
-          }
-          // Downward: result users outside range.
-          for (Value result : op->getResults()) {
-            for (Operation *user : result.getUsers()) {
-              Operation *userInBlock = user;
-              while (userInBlock && userInBlock->getBlock() != block) {
-                userInBlock = userInBlock->getParentOp();
+    // Group regions by block: multi-level scopes can produce regions in
+    // different blocks (e.g. inner K-loop body vs. enclosing block).
+    // A stable insertion-order vector preserves deterministic processing.
+    SmallVector<Block *> blockOrder;
+    DenseMap<Block *, SmallVector<std::pair<Block::iterator, Block::iterator>>>
+        regionsByBlock;
+    for (auto [s, e] : computeRegions) {
+      Block *blk = s->getBlock();
+      if (!regionsByBlock.count(blk)) {
+        blockOrder.push_back(blk);
+      }
+      regionsByBlock[blk].push_back({s, e});
+    }
+
+    computeRegions.clear();
+    for (Block *block : blockOrder) {
+      auto &regions = regionsByBlock[block];
+
+      // Position map: op → sequential index within the block.
+      DenseMap<Operation *, unsigned> posMap;
+      SmallVector<Block::iterator> posToIter;
+      {
+        unsigned pos = 0;
+        for (auto it = block->begin(); it != block->end(); ++it, ++pos) {
+          posMap[&*it] = pos;
+          posToIter.push_back(it);
+        }
+      }
+
+      // Convert regions to (startPos, endPosInclusive) pairs and sort.
+      SmallVector<std::pair<unsigned, unsigned>> posRegions;
+      posRegions.reserve(regions.size());
+      for (auto [s, e] : regions) {
+        posRegions.push_back({posMap[&*s], posMap[&*std::prev(e)]});
+      }
+      llvm::sort(posRegions,
+                 [](const auto &a, const auto &b) { return a.first < b.first; });
+
+      // Merge overlapping intervals.
+      SmallVector<std::pair<unsigned, unsigned>> merged;
+      for (auto [s, e] : posRegions) {
+        if (!merged.empty() && s <= merged.back().second) {
+          merged.back().second = std::max(merged.back().second, e);
+        } else {
+          merged.push_back({s, e});
+        }
+      }
+
+      // Fixpoint expansion: extend each merged region in both directions.
+      //
+      // Downward (end grows): a non-pure op in [startPos, endPos) has result
+      // users outside the range that would dangle after wrapInSynchronizedRegion
+      // erases the op.  Expand endPos to include those users.
+      //
+      // Upward (start shrinks): a non-pure op in the range has an operand
+      // defined by another non-pure op just before startPos.  Expand startPos
+      // to include that defining op so that CB-load detection (which walks ops
+      // inside [start, end)) can find the CB operand feeding the region.
+      //
+      // Both directions stop at SynchronizableOpInterface boundaries.
+      for (auto &[startPos, endPos] : merged) {
+        bool changed = true;
+        while (changed) {
+          changed = false;
+          for (unsigned p = startPos; p <= endPos; ++p) {
+            Operation *op = &*posToIter[p];
+            if (isPurelyDerived(isPurelyDerived, op)) {
+              continue;
+            }
+            // Downward: result users outside range.
+            for (Value result : op->getResults()) {
+              for (Operation *user : result.getUsers()) {
+                Operation *userInBlock = user;
+                while (userInBlock && userInBlock->getBlock() != block) {
+                  userInBlock = userInBlock->getParentOp();
+                }
+                if (!userInBlock) {
+                  continue;
+                }
+                auto posIt = posMap.find(userInBlock);
+                if (posIt == posMap.end()) {
+                  continue;
+                }
+                unsigned userPos = posIt->second;
+                if (userPos <= endPos) {
+                  continue;
+                }
+                // Don't expand past a SynchronizableOpInterface boundary.
+                bool blocked = false;
+                for (unsigned q = endPos + 1; q <= userPos; ++q) {
+                  if (isa<SynchronizableOpInterface>(&*posToIter[q])) {
+                    blocked = true;
+                    break;
+                  }
+                }
+                if (!blocked) {
+                  endPos = userPos;
+                  changed = true;
+                }
               }
-              if (!userInBlock) {
+            }
+            // Upward: operands defined by non-pure ops before startPos.
+            for (Value operand : op->getOperands()) {
+              Operation *defOp = operand.getDefiningOp();
+              if (!defOp) {
                 continue;
               }
-              auto posIt = posMap.find(userInBlock);
+              auto posIt = posMap.find(defOp);
               if (posIt == posMap.end()) {
                 continue;
               }
-              unsigned userPos = posIt->second;
-              if (userPos <= endPos) {
-                continue;
+              unsigned defPos = posIt->second;
+              if (defPos >= startPos) {
+                continue; // already in range
+              }
+              if (isPurelyDerived(isPurelyDerived, defOp)) {
+                continue; // pure ops are not erased; no need to pull them in
               }
               // Don't expand past a SynchronizableOpInterface boundary.
               bool blocked = false;
-              for (unsigned q = endPos + 1; q <= userPos; ++q) {
+              for (unsigned q = defPos; q < startPos; ++q) {
                 if (isa<SynchronizableOpInterface>(&*posToIter[q])) {
                   blocked = true;
                   break;
                 }
               }
               if (!blocked) {
-                endPos = userPos;
+                startPos = defPos;
                 changed = true;
               }
             }
           }
-          // Upward: operands defined by non-pure ops before startPos.
-          for (Value operand : op->getOperands()) {
-            Operation *defOp = operand.getDefiningOp();
-            if (!defOp) {
-              continue;
-            }
-            auto posIt = posMap.find(defOp);
-            if (posIt == posMap.end()) {
-              continue;
-            }
-            unsigned defPos = posIt->second;
-            if (defPos >= startPos) {
-              continue; // already in range
-            }
-            if (isPurelyDerived(isPurelyDerived, defOp)) {
-              continue; // pure ops are not erased; no need to pull them in
-            }
-            // Don't expand past a SynchronizableOpInterface boundary.
-            bool blocked = false;
-            for (unsigned q = defPos; q < startPos; ++q) {
-              if (isa<SynchronizableOpInterface>(&*posToIter[q])) {
-                blocked = true;
-                break;
-              }
-            }
-            if (!blocked) {
-              startPos = defPos;
-              changed = true;
-            }
-          }
         }
       }
-    }
 
-    // Rebuild computeRegions from the merged+expanded positions.
-    computeRegions.clear();
-    for (auto [s, e] : merged) {
-      computeRegions.push_back({posToIter[s], std::next(posToIter[e])});
+      // Append this block's merged+expanded regions to computeRegions.
+      for (auto [s, e] : merged) {
+        computeRegions.push_back({posToIter[s], std::next(posToIter[e])});
+      }
     }
   }
 

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -309,8 +309,9 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
       for (auto [s, e] : regions) {
         posRegions.push_back({posMap[&*s], posMap[&*std::prev(e)]});
       }
-      llvm::sort(posRegions,
-                 [](const auto &a, const auto &b) { return a.first < b.first; });
+      llvm::sort(posRegions, [](const auto &a, const auto &b) {
+        return a.first < b.first;
+      });
 
       // Merge overlapping intervals.
       SmallVector<std::pair<unsigned, unsigned>> merged;
@@ -325,8 +326,9 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
       // Fixpoint expansion: extend each merged region in both directions.
       //
       // Downward (end grows): a non-pure op in [startPos, endPos) has result
-      // users outside the range that would dangle after wrapInSynchronizedRegion
-      // erases the op.  Expand endPos to include those users.
+      // users outside the range that would dangle after
+      // wrapInSynchronizedRegion erases the op.  Expand endPos to include those
+      // users.
       //
       // Upward (start shrinks): a non-pure op in the range has an operand
       // defined by another non-pure op just before startPos.  Expand startPos

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -72,6 +72,10 @@ Value traceComputeMemrefToCB(Value value, GenericOp genericOp) {
       value = subviewOp.getSource();
       continue;
     }
+    if (auto castOp = mlir::dyn_cast<memref::CastOp>(definingOp)) {
+      value = castOp.getSource();
+      continue;
+    }
     return nullptr;
   }
   return nullptr;
@@ -89,15 +93,17 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
   // Collect the ops that directly contain SynchronizableOpInterface ops.
   // These delimit the scope where compute is synchronized: the outermost
   // compute ancestor is a direct child of such an op, alongside the
-  // synchronizable ops that bound it.
+  // synchronizable ops that bound it. Multiple parents are allowed: each
+  // identifies an independent synchronized scope at its own nesting level
+  // (e.g. remote_loads in an accumulator loop bounding the matmul compute,
+  // while a remote_store in the enclosing loop bounds a separate compute
+  // region around the epilogue).
   DenseSet<Operation *> opsWithSynchronizableOps;
   genericOp.getRegion(0).walk([&](Operation *op) {
     if (dyn_cast<SynchronizableOpInterface>(op)) {
       opsWithSynchronizableOps.insert(op->getParentOp());
     }
   });
-  assert(opsWithSynchronizableOps.size() == 1 &&
-         "synchronized scope must be unambiguous");
 
   DenseSet<Operation *> outermostOps;
   bool walkFailed = false;
@@ -138,6 +144,48 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
 
   // Expand and merge compute regions until we hit a syncrhonizable op on both
   // ends.
+  //
+  // Beyond hitting a SynchronizableOpInterface op (which bounds the wrap),
+  // two additional stop conditions matter:
+  // (1) A sibling op already in `opsWithSynchronizableOps` hosts its own
+  //     synchronized scope at a deeper level; folding it in would nest
+  //     sync regions (e.g. an inner accumulator loop sitting next to a
+  //     remote_store in the outer loop's body).
+  // (2) Including an op whose result is consumed past the wrap would
+  //     violate `wrapInSynchronizedRegion`'s precondition: any op in
+  //     [start, end) whose operand chain reaches a non-pure op gets
+  //     erased after the wrap is created, so leaving an outside user
+  //     dangles. Check users unconditionally — an op like
+  //     `arith.index_cast` is itself Pure but is treated as non-pure
+  //     by the wrap utility once an ancestor like `arith.divsi` (which
+  //     can fault) enters the operand chain.
+  auto hasUserOutsideRange = [](Operation *op, Block::iterator s,
+                                Block::iterator e) {
+    Block *block = op->getBlock();
+    for (Value result : op->getResults()) {
+      for (Operation *user : result.getUsers()) {
+        Operation *userInBlock = user;
+        while (userInBlock && userInBlock->getBlock() != block) {
+          userInBlock = userInBlock->getParentOp();
+        }
+        if (!userInBlock) {
+          return true;
+        }
+        bool inRange = false;
+        for (auto it = s; it != e; ++it) {
+          if (&*it == userInBlock) {
+            inRange = true;
+            break;
+          }
+        }
+        if (!inRange) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
   SmallVector<std::pair<Block::iterator, Block::iterator>> computeRegions;
   while (!outermostOps.empty()) {
     Operation *outermostOp = *outermostOps.begin();
@@ -146,8 +194,17 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     Block::iterator end = outermostOp->getIterator();
 
     // Expand above.
-    while (start != outermostOp->getBlock()->begin() &&
-           !dyn_cast<SynchronizableOpInterface>(std::prev(start))) {
+    while (start != outermostOp->getBlock()->begin()) {
+      Operation *prev = &*std::prev(start);
+      if (dyn_cast<SynchronizableOpInterface>(prev)) {
+        break;
+      }
+      if (opsWithSynchronizableOps.contains(prev)) {
+        break;
+      }
+      if (hasUserOutsideRange(prev, std::prev(start), std::next(end))) {
+        break;
+      }
       start--;
       if (outermostOps.contains(&*start)) {
         outermostOps.erase(&*start);
@@ -155,8 +212,20 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     }
 
     // Expand below.
-    while (std::next(end) != outermostOp->getBlock()->end() &&
-           !dyn_cast<SynchronizableOpInterface>(std::next(end))) {
+    while (std::next(end) != outermostOp->getBlock()->end()) {
+      Operation *next = &*std::next(end);
+      if (next->hasTrait<OpTrait::IsTerminator>()) {
+        break;
+      }
+      if (dyn_cast<SynchronizableOpInterface>(next)) {
+        break;
+      }
+      if (opsWithSynchronizableOps.contains(next)) {
+        break;
+      }
+      if (hasUserOutsideRange(next, start, std::next(end, 2))) {
+        break;
+      }
       end++;
       if (outermostOps.contains(&*end)) {
         outermostOps.erase(&*end);
@@ -286,6 +355,27 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
     if (dyn_cast<SynchronizableOpInterface>(op) &&
         !op->hasTrait<D2MGenericRegionDatamovementOpTrait>()) {
       auto synchronizedOp = mlir::cast<SynchronizableOpInterface>(op);
+
+      // The CB ops we emit must fire once per DMA partner activation, not
+      // once per compute iteration. When the DMA partner sits in an outer
+      // block (e.g. a matmul accumulator: remote_loads inside the K loop,
+      // remote_store outside it), placing wait/pop or reserve/push around
+      // `synchronizedOp` would emit N pairs against a single DMA op. Climb
+      // synchronizedOp's ancestors until we reach one whose parent block
+      // matches the partner's; that ancestor is the anchor for the CB ops.
+      auto anchorForPartner = [&](Operation *partner) -> Operation * {
+        Block *targetBlock = partner->getBlock();
+        Operation *anchor = synchronizedOp;
+        while (anchor->getBlock() != targetBlock) {
+          Operation *parent = anchor->getParentOp();
+          if (!parent) {
+            return synchronizedOp;
+          }
+          anchor = parent;
+        }
+        return anchor;
+      };
+
       // get consumers and insert wait+pop
       for (auto &operand : synchronizedOp->getOpOperands()) {
         if (synchronizedOp.isConsumer(operand)) {
@@ -301,7 +391,8 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
                  cbUsageInfo[localBuffer].consumers.size() == 1 &&
                  "Expected exactly one producer and one consumer for CB");
           auto *associatedProducer = cbUsageInfo[localBuffer].producers.front();
-          rewriter.setInsertionPoint(synchronizedOp);
+          Operation *anchor = anchorForPartner(associatedProducer);
+          rewriter.setInsertionPoint(anchor);
           auto cb = d2m::getOrCreateCB(
               rewriter, synchronizedOp->getParentOfType<GenericOp>(),
               computeBlock, cbOperandIdx);
@@ -312,7 +403,7 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
             rewriter.create<PushOp>(loc, cb);
           }
           WaitOp waitOp = rewriter.create<WaitOp>(loc, cb);
-          rewriter.setInsertionPointAfter(synchronizedOp);
+          rewriter.setInsertionPointAfter(anchor);
           rewriter.create<PopOp>(loc, cb);
 
           // Replace uses of the local buffer in compute consumer
@@ -337,12 +428,13 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
                  cbUsageInfo[localBuffer].producers.size() == 1 &&
                  "Expected exactly one producer and one consumer for CB");
           auto *associatedConsumer = cbUsageInfo[localBuffer].consumers.front();
-          rewriter.setInsertionPoint(synchronizedOp);
+          Operation *anchor = anchorForPartner(associatedConsumer);
+          rewriter.setInsertionPoint(anchor);
           auto cb = d2m::getOrCreateCB(
               rewriter, synchronizedOp->getParentOfType<GenericOp>(),
               computeBlock, cbOperandIdx);
           auto reserveOp = rewriter.create<ReserveOp>(loc, cb);
-          rewriter.setInsertionPointAfter(synchronizedOp);
+          rewriter.setInsertionPointAfter(anchor);
           rewriter.create<PushOp>(loc, cb);
           if (mlir::isa<RemoteStoreOp>(associatedConsumer) &&
               isAliasedStore(mlir::cast<RemoteStoreOp>(associatedConsumer))) {

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -84,21 +84,12 @@ Value traceComputeMemrefToCB(Value value, GenericOp genericOp) {
 
 LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
                                               PatternRewriter &rewriter) {
-  // Look for a D2M_GenericRegionComputeOp, and collect the outermost ops that
-  // contain them in the generic op.
-  // Skip ops that have the SynchronizableOpInterface,
-  // such as TileTilizeBlockOp and TileUntilizeBlockOp ops since
-  // they haven't been lowered yet into non-synchronized ops
   OpBuilder::InsertionGuard guard(rewriter);
 
-  // Collect the ops that directly contain SynchronizableOpInterface ops.
-  // These delimit the scope where compute is synchronized: the outermost
-  // compute ancestor is a direct child of such an op, alongside the
-  // synchronizable ops that bound it. Multiple parents are allowed: each
-  // identifies an independent synchronized scope at its own nesting level
-  // (e.g. remote_loads in an accumulator loop bounding the matmul compute,
-  // while a remote_store in the enclosing loop bounds a separate compute
-  // region around the epilogue).
+  // Collect ops that directly contain a SynchronizableOpInterface op. Each
+  // such parent delimits an independent synchronized scope at its own nesting
+  // level (e.g. remote_loads in an accumulator loop bound the matmul compute,
+  // while a remote_store in the enclosing loop bounds the epilogue compute).
   DenseSet<Operation *> opsWithSynchronizableOps;
   genericOp.getRegion(0).walk([&](Operation *op) {
     if (dyn_cast<SynchronizableOpInterface>(op)) {
@@ -134,9 +125,8 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
       }
     }
 
-    // Skip ops that have the SynchronizableOpInterface,
-    // such as TileTilizeBlockOp and TileUntilizeBlockOp ops since
-    // they haven't been lowered yet into non-synchronized ops.
+    // Skip synchronizable ops (e.g. TileTilize/UntilizeBlockOp) not yet
+    // lowered to non-synchronized form.
     if (!dyn_cast<SynchronizableOpInterface>(outermostOp)) {
       outermostOps.insert(outermostOp);
     }
@@ -148,23 +138,14 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     return failure();
   }
 
-  // Expand and merge compute regions until we hit a synchronizable op on both
-  // ends.
-  //
-  // Beyond hitting a SynchronizableOpInterface op (which bounds the wrap),
-  // two additional stop conditions matter:
-  // (1) A sibling op already in `opsWithSynchronizableOps` hosts its own
-  //     synchronized scope at a deeper level; folding it in would nest
-  //     sync regions (e.g. an inner accumulator loop sitting next to a
-  //     remote_store in the outer loop's body).
-  // (2) Including an op whose result is consumed past the wrap would
-  //     violate `wrapInSynchronizedRegion`'s precondition: any op in
-  //     [start, end) whose operand chain reaches a non-pure op gets
-  //     erased after the wrap is created, so leaving an outside user
-  //     dangles. Check users unconditionally — an op like
-  //     `arith.index_cast` is itself Pure but is treated as non-pure
-  //     by the wrap utility once an ancestor like `arith.divsi` (which
-  //     can fault) enters the operand chain.
+  // Expand each compute region outward until it hits a boundary. Three stop
+  // conditions: (1) a SynchronizableOpInterface op, which bounds the wrap;
+  // (2) a sibling in `opsWithSynchronizableOps`, whose own deeper scope must
+  // not be nested inside this one; (3) an op whose result is used past the
+  // wrap — wrapInSynchronizedRegion erases non-pure ops in [start, end), so an
+  // outside user would dangle. Check users unconditionally: a Pure op like
+  // arith.index_cast is treated as non-pure once a faulting ancestor (e.g.
+  // arith.divsi) enters its operand chain.
   auto hasUserOutsideRange = [](Operation *op, Block::iterator s,
                                 Block::iterator e) {
     Block *block = op->getBlock();
@@ -241,24 +222,20 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     computeRegions.push_back({start, std::next(end)});
   }
 
-  // Merge overlapping compute regions and fixpoint-expand each merged region
-  // so wrapInSynchronizedRegion's precondition holds: no op that will be
-  // erased by that utility may have result users outside [start, end).
+  // Merge overlapping compute regions and fixpoint-expand each so
+  // wrapInSynchronizedRegion's precondition holds: no op it erases may have
+  // result users outside [start, end).
   //
-  // Overlaps arise when hasUserOutsideRange causes independent per-outermostOp
-  // expansions to produce regions that share ops.  For example, acquire_dst
-  // and tile_add form an interdependent value chain in a flat block: the
-  // acquire_dst expansion stops early because tile_add's result escapes, and
-  // tile_add's expansion starts one op after acquire_dst for the same reason,
-  // yielding overlapping [A, B) and [B-1, C).  Wrapping the first region then
-  // erases the shared op (B-1), leaving the second region's start iterator
-  // dangling and triggering an ilist sentinel crash.
+  // Overlaps arise when hasUserOutsideRange splits an interdependent value
+  // chain across per-outermostOp expansions. E.g. acquire_dst and tile_add in
+  // a flat block yield overlapping [A, B) and [B-1, C); wrapping the first
+  // erases the shared op B-1, leaving the second's start iterator dangling
+  // (ilist sentinel crash).
   if (!computeRegions.empty()) {
-    // Purity cache mirroring isPurelyDerivedOp in wrapInSynchronizedRegion:
-    // an op is purely derived if it is pure and every operand-defining op is
-    // also purely derived.  Ops that are not purely derived will be erased by
-    // wrapInSynchronizedRegion; their results must not escape the region.
-    // The cache is block-agnostic and shared across all per-block passes below.
+    // Purity cache mirroring isPurelyDerivedOp in wrapInSynchronizedRegion: an
+    // op is purely derived if it is pure and all operand-defining ops are too.
+    // Non-purely-derived ops get erased there, so their results must not escape
+    // the region. Block-agnostic; shared across all per-block passes below.
     DenseMap<Operation *, bool> pureCache;
     auto isPurelyDerived = [&](auto &self, Operation *op) -> bool {
       auto it = pureCache.find(op);
@@ -280,8 +257,8 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     };
 
     // Group regions by block: multi-level scopes can produce regions in
-    // different blocks (e.g. inner K-loop body vs. enclosing block).
-    // A stable insertion-order vector preserves deterministic processing.
+    // different blocks (e.g. inner K-loop body vs. enclosing block). The
+    // insertion-order vector keeps processing deterministic.
     SmallVector<Block *> blockOrder;
     DenseMap<Block *, SmallVector<std::pair<Block::iterator, Block::iterator>>>
         regionsByBlock;
@@ -328,19 +305,14 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
         }
       }
 
-      // Fixpoint expansion: extend each merged region in both directions.
+      // Fixpoint-expand each merged region in both directions, stopping at
+      // SynchronizableOpInterface boundaries.
       //
-      // Downward (end grows): a non-pure op in [startPos, endPos) has result
-      // users outside the range that would dangle after
-      // wrapInSynchronizedRegion erases the op.  Expand endPos to include those
-      // users.
-      //
-      // Upward (start shrinks): a non-pure op in the range has an operand
-      // defined by another non-pure op just before startPos.  Expand startPos
-      // to include that defining op so that CB-load detection (which walks ops
-      // inside [start, end)) can find the CB operand feeding the region.
-      //
-      // Both directions stop at SynchronizableOpInterface boundaries.
+      // Downward: a non-pure op in range has result users past endPos that
+      // would dangle once wrapInSynchronizedRegion erases it — pull them in.
+      // Upward: a non-pure op has an operand defined by a non-pure op before
+      // startPos — pull it in so CB-load detection (which walks [start, end))
+      // can see the CB operand feeding the region.
       for (auto &[startPos, endPos] : merged) {
         bool changed = true;
         while (changed) {
@@ -544,13 +516,12 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
         !op->hasTrait<D2MGenericRegionDatamovementOpTrait>()) {
       auto synchronizedOp = mlir::cast<SynchronizableOpInterface>(op);
 
-      // The CB ops we emit must fire once per DMA partner activation, not
-      // once per compute iteration. When the DMA partner sits in an outer
-      // block (e.g. a matmul accumulator: remote_loads inside the K loop,
-      // remote_store outside it), placing wait/pop or reserve/push around
-      // `synchronizedOp` would emit N pairs against a single DMA op. Climb
-      // synchronizedOp's ancestors until we reach one whose parent block
-      // matches the partner's; that ancestor is the anchor for the CB ops.
+      // CB ops must fire once per DMA partner activation, not once per compute
+      // iteration. When the partner sits in an outer block (e.g. a matmul
+      // accumulator: remote_loads in the K loop, remote_store outside it),
+      // wrapping `synchronizedOp` would emit N pairs against one DMA op. Climb
+      // synchronizedOp's ancestors until one shares the partner's block; that
+      // ancestor anchors the CB ops.
       auto anchorForPartner = [&](Operation *partner) -> Operation * {
         Block *targetBlock = partner->getBlock();
         Operation *anchor = synchronizedOp;

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -106,6 +106,11 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     }
   });
 
+  // Early exit if there are no synchronizable ops.
+  if (opsWithSynchronizableOps.empty()) {
+    return success();
+  }
+
   DenseSet<Operation *> outermostOps;
   bool walkFailed = false;
   genericOp.getRegion(0).walk([&](Operation *op) {
@@ -551,9 +556,8 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
         Operation *anchor = synchronizedOp;
         while (anchor->getBlock() != targetBlock) {
           Operation *parent = anchor->getParentOp();
-          if (!parent) {
-            return synchronizedOp;
-          }
+          assert(parent &&
+                 "Unexpected ancestor-less op while looking for anchor");
           anchor = parent;
         }
         return anchor;

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -233,6 +234,169 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     }
 
     computeRegions.push_back({start, std::next(end)});
+  }
+
+  // Merge overlapping compute regions and fixpoint-expand each merged region
+  // so wrapInSynchronizedRegion's precondition holds: no op that will be
+  // erased by that utility may have result users outside [start, end).
+  //
+  // Overlaps arise when hasUserOutsideRange causes independent per-outermostOp
+  // expansions to produce regions that share ops.  For example, acquire_dst
+  // and tile_add form an interdependent value chain in a flat block: the
+  // acquire_dst expansion stops early because tile_add's result escapes, and
+  // tile_add's expansion starts one op after acquire_dst for the same reason,
+  // yielding overlapping [A, B) and [B-1, C).  Wrapping the first region then
+  // erases the shared op (B-1), leaving the second region's start iterator
+  // dangling and triggering an ilist sentinel crash.
+  if (!computeRegions.empty()) {
+    Block *block = computeRegions[0].first->getBlock();
+
+    // Position map: op → sequential index within the block.
+    DenseMap<Operation *, unsigned> posMap;
+    SmallVector<Block::iterator> posToIter;
+    {
+      unsigned pos = 0;
+      for (auto it = block->begin(); it != block->end(); ++it, ++pos) {
+        posMap[&*it] = pos;
+        posToIter.push_back(it);
+      }
+    }
+
+    // Convert regions to (startPos, endPosInclusive) pairs and sort.
+    SmallVector<std::pair<unsigned, unsigned>> posRegions;
+    posRegions.reserve(computeRegions.size());
+    for (auto [s, e] : computeRegions) {
+      posRegions.push_back({posMap[&*s], posMap[&*std::prev(e)]});
+    }
+    llvm::sort(posRegions,
+               [](const auto &a, const auto &b) { return a.first < b.first; });
+
+    // Merge overlapping intervals.
+    SmallVector<std::pair<unsigned, unsigned>> merged;
+    for (auto [s, e] : posRegions) {
+      if (!merged.empty() && s <= merged.back().second) {
+        merged.back().second = std::max(merged.back().second, e);
+      } else {
+        merged.push_back({s, e});
+      }
+    }
+
+    // Purity cache mirroring isPurelyDerivedOp in wrapInSynchronizedRegion:
+    // an op is purely derived if it is pure and every operand-defining op is
+    // also purely derived.  Ops that are not purely derived will be erased by
+    // wrapInSynchronizedRegion; their results must not escape the region.
+    DenseMap<Operation *, bool> pureCache;
+    auto isPurelyDerived = [&](auto &self, Operation *op) -> bool {
+      auto it = pureCache.find(op);
+      if (it != pureCache.end()) {
+        return it->second;
+      }
+      bool result = mlir::isPure(op);
+      if (result) {
+        for (Value operand : op->getOperands()) {
+          if (Operation *defOp = operand.getDefiningOp()) {
+            if (!self(self, defOp)) {
+              result = false;
+              break;
+            }
+          }
+        }
+      }
+      return (pureCache[op] = result);
+    };
+
+    // Fixpoint expansion: extend each merged region in both directions.
+    //
+    // Downward (end grows): a non-pure op in [startPos, endPos) has result
+    // users outside the range that would dangle after wrapInSynchronizedRegion
+    // erases the op.  Expand endPos to include those users.
+    //
+    // Upward (start shrinks): a non-pure op in the range has an operand
+    // defined by another non-pure op just before startPos.  Expand startPos
+    // to include that defining op so that CB-load detection (which walks ops
+    // inside [start, end)) can find the CB operand feeding the region.
+    //
+    // Both directions stop at SynchronizableOpInterface boundaries.
+    for (auto &[startPos, endPos] : merged) {
+      bool changed = true;
+      while (changed) {
+        changed = false;
+        for (unsigned p = startPos; p <= endPos; ++p) {
+          Operation *op = &*posToIter[p];
+          if (isPurelyDerived(isPurelyDerived, op)) {
+            continue;
+          }
+          // Downward: result users outside range.
+          for (Value result : op->getResults()) {
+            for (Operation *user : result.getUsers()) {
+              Operation *userInBlock = user;
+              while (userInBlock && userInBlock->getBlock() != block) {
+                userInBlock = userInBlock->getParentOp();
+              }
+              if (!userInBlock) {
+                continue;
+              }
+              auto posIt = posMap.find(userInBlock);
+              if (posIt == posMap.end()) {
+                continue;
+              }
+              unsigned userPos = posIt->second;
+              if (userPos <= endPos) {
+                continue;
+              }
+              // Don't expand past a SynchronizableOpInterface boundary.
+              bool blocked = false;
+              for (unsigned q = endPos + 1; q <= userPos; ++q) {
+                if (isa<SynchronizableOpInterface>(&*posToIter[q])) {
+                  blocked = true;
+                  break;
+                }
+              }
+              if (!blocked) {
+                endPos = userPos;
+                changed = true;
+              }
+            }
+          }
+          // Upward: operands defined by non-pure ops before startPos.
+          for (Value operand : op->getOperands()) {
+            Operation *defOp = operand.getDefiningOp();
+            if (!defOp) {
+              continue;
+            }
+            auto posIt = posMap.find(defOp);
+            if (posIt == posMap.end()) {
+              continue;
+            }
+            unsigned defPos = posIt->second;
+            if (defPos >= startPos) {
+              continue; // already in range
+            }
+            if (isPurelyDerived(isPurelyDerived, defOp)) {
+              continue; // pure ops are not erased; no need to pull them in
+            }
+            // Don't expand past a SynchronizableOpInterface boundary.
+            bool blocked = false;
+            for (unsigned q = defPos; q < startPos; ++q) {
+              if (isa<SynchronizableOpInterface>(&*posToIter[q])) {
+                blocked = true;
+                break;
+              }
+            }
+            if (!blocked) {
+              startPos = defPos;
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+
+    // Rebuild computeRegions from the merged+expanded positions.
+    computeRegions.clear();
+    for (auto [s, e] : merged) {
+      computeRegions.push_back({posToIter[s], std::next(posToIter[e])});
+    }
   }
 
   for (auto [start, end] : computeRegions) {

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
@@ -2,6 +2,7 @@
 
 #l1 = #ttcore.memory_space<l1>
 #dram = #ttcore.memory_space<dram>
+#dst = #ttcore.memory_space<dst>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #ttcore.iterator_type<parallel>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
@@ -793,6 +794,68 @@ module attributes {ttcore.system_desc = #system_desc} {
     memref.dealloc %cb_lhs : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     memref.dealloc %cb_rhs : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     memref.dealloc %cb_acc : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    return
+  }
+
+  // Test 16: Flat-block arange pattern — acquire_dst followed by tile_add,
+  // no surrounding loop.  Both ops have D2MGenericRegionComputeOpTrait, and
+  // acquire_dst's %dst result is used by the tile_add operand chain.
+  // hasUserOutsideRange previously produced overlapping compute regions
+  // [A, B) and [B-1, C), causing wrapInSynchronizedRegion to erase the start
+  // op of the second region, triggering an ilist sentinel crash.  Regression
+  // test: verify no crash and correct DM/compute split.
+  // CHECK-LABEL: func.func @test_arange_flat_acquire_dst_tile_add
+  func.func @test_arange_flat_acquire_dst_tile_add(
+      %arg0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>,
+      %arg1: memref<1x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    %alloc = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
+    %alias = d2m.operand_alias %arg1 : memref<1x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK: d2m.generic
+    // CHECK-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
+    // DMA thread: remote_load and remote_store; no compute ops.
+    // CHECK: d2m.remote_load
+    // CHECK-NOT: d2m.acquire_dst
+    // Compute thread: CB sync ops surrounding all compute.
+    // CHECK: }, {
+    // CHECK: d2m.wait
+    // CHECK: d2m.acquire_dst
+    // CHECK: "d2m.tile_add"
+    // CHECK: d2m.pop
+    // CHECK-NOT: d2m.remote_load
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x4>, indexing_maps = [],
+                 iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%arg0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%arg1 : memref<1x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        additionalArgs(%alloc, %alias :
+            memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>,
+            memref<1x1x!ttcore.tile<32x32, f32>, #l1>) {
+      %c4096 = arith.constant 4096 : index
+      %c32 = arith.constant 32 : index
+      %c0 = arith.constant 0 : index
+      d2m.remote_load %alloc %arg0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+      %flat_in = memref.collapse_shape %alloc [[0, 1]] : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1> into memref<1x!ttcore.tile<32x32, f32>, #l1>
+      %flat_out = memref.collapse_shape %alias [[0, 1]] : memref<1x1x!ttcore.tile<32x32, f32>, #l1> into memref<1x!ttcore.tile<32x32, f32>, #l1>
+      d2m.fill_arange_tile to %alloc : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
+      %core0 = d2m.core_index(0) : index
+      %core1 = d2m.core_index(1) : index
+      %tile_in = memref.load %flat_in[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
+      %dst = d2m.acquire_dst() : memref<4x!ttcore.tile<32x32, f32>, #dst>
+      memref.store %tile_in, %dst[%c0] : memref<4x!ttcore.tile<32x32, f32>, #dst>
+      %t0 = memref.load %dst[%c0] : memref<4x!ttcore.tile<32x32, f32>, #dst>
+      %p0 = arith.muli %core0, %c4096 : index
+      %p1 = arith.muli %core1, %c32 : index
+      %p2 = arith.addi %p0, %p1 : index
+      %p3 = arith.index_cast %p2 : index to i64
+      %p4 = arith.sitofp %p3 : i64 to f32
+      %t1 = "d2m.tile_add"(%t0, %p4) : (!ttcore.tile<32x32, f32>, f32) -> !ttcore.tile<32x32, f32>
+      memref.store %t1, %dst[%c0] : memref<4x!ttcore.tile<32x32, f32>, #dst>
+      %t2 = memref.load %dst[%c0] : memref<4x!ttcore.tile<32x32, f32>, #dst>
+      memref.store %t2, %flat_out[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
+      %out_core0 = d2m.core_index(0) : index
+      %out_core1 = d2m.core_index(1) : index
+      d2m.remote_store %arg1[%out_core0, %out_core1] %alias : memref<1x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    }
+    memref.dealloc %alloc : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
     return
   }
 }

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
@@ -730,4 +730,69 @@ module attributes {ttcore.system_desc = #system_desc} {
     memref.dealloc %cb_out : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     return
   }
+
+  // Test 15: Multi-level synchronized scopes (matmul-style K accumulator).
+  // The K loop hosts two remote_loads bounding the matmul compute, while the
+  // result remote_store lives in the enclosing unified block. Two parents end
+  // up in `opsWithSynchronizableOps` (the scf.for and the generic itself);
+  // the previous single-scope assertion rejected this shape. Expansion of
+  // the inner compute region must also stop at the sibling K-loop in the
+  // outer block rather than absorbing it.
+  // CHECK-LABEL: func.func @test_multi_level_sync_matmul
+  func.func @test_multi_level_sync_matmul(
+      %arg0: memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>,
+      %arg1: memref<2x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>) {
+    %alloc = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %stream_lhs = d2m.view_layout %arg0 remapping = #map4 : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram> -> memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+    %stream_rhs = d2m.view_layout %arg1 remapping = #map4 : memref<2x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram> -> memref<2x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+    %cb_lhs = memref.alloc() {address = 5120 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    %cb_rhs = memref.alloc() {address = 9216 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    %cb_acc = memref.alloc() {address = 13312 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+
+    // CHECK: d2m.generic
+    // CHECK-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
+    // DMA: K loop holds both remote_loads; remote_store sits in the outer block.
+    // CHECK: scf.for
+    // CHECK: d2m.remote_load %{{.*}} into %{{.*}}
+    // CHECK: d2m.remote_load %{{.*}} into %{{.*}}
+    // CHECK-NOT: d2m.tile_matmul_block
+    // CHECK-NOT: d2m.wait
+    // CHECK-NOT: d2m.pop
+    // CHECK: d2m.remote_store %{{.*}} from %{{.*}}
+    // Compute: reserve once before the K loop and push once after it (matching
+    // the single remote_store); wait/pop for the K-iterated loads stay inside
+    // the loop alongside the matmul.
+    // CHECK: }, {
+    // CHECK: d2m.reserve %{{.*}}
+    // CHECK: scf.for
+    // CHECK: d2m.wait %{{.*}}
+    // CHECK: d2m.wait %{{.*}}
+    // CHECK: d2m.tile_matmul_block
+    // CHECK: d2m.pop %{{.*}}
+    // CHECK: d2m.pop %{{.*}}
+    // CHECK: d2m.push %{{.*}}
+    // CHECK-NOT: d2m.remote_load
+    // CHECK-NOT: d2m.remote_store
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%stream_lhs, %stream_rhs : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>)
+        outs(%alloc : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+        additionalArgs(%cb_lhs, %cb_rhs, %cb_acc : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) {
+    ^unified0:
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %core0 = d2m.core_index(0) : index
+      %core1 = d2m.core_index(1) : index
+      scf.for %k = %c0 to %c2 step %c1 {
+        d2m.remote_load %cb_lhs %stream_lhs[%core0, %k] : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+        d2m.remote_load %cb_rhs %stream_rhs[%k, %core1] : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+        "d2m.tile_matmul_block"(%cb_lhs, %cb_rhs, %cb_acc) : (memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) -> ()
+      } {d2m.blocking_loop = 2}
+      d2m.remote_store %alloc[%core0, %core1] %cb_acc : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    }
+    memref.dealloc %cb_lhs : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    memref.dealloc %cb_rhs : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    memref.dealloc %cb_acc : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    return
+  }
 }


### PR DESCRIPTION
The previous algorithm assumed all SynchronizableOpInterface ops in a unified-thread generic sit at the same nesting level (a single parent), which it asserted. Some dsl generated matmul kernels violate that assumption: remote_loads live inside the K accumulator loop, while the remote_store of the result lives in the enclosing loop. Two synchronized scopes coexist, one per parent.

Drop the single-scope assertion and tighten the [start, end) expansion in two ways:

1. Stop at a sibling op already in `opsWithSynchronizableOps`. Such an op hosts its own synchronized scope at a deeper level (e.g. the inner accumulator loop next to the outer-loop remote_store); folding it in would nest sync regions.

2. Stop before pulling in any op whose result is consumed past the wrap. `wrapInSynchronizedRegion` erases every op in the range whose operand chain reaches a non-pure op, so any external user would dangle. The check has to be unconditional on purity: an op like arith.index_cast is itself Pure but is treated as non-pure by the wrap utility once arith.divsi (which can fault) enters its operand chain.