### PR TITLE
D2M: fix GenericOp DRAM D2H transfers

### DIFF
--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -139,6 +139,13 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
                      "(>=1). Default is 2."),
       llvm::cl::init(2)};
 
+  // Force all non-bound allocator variables to spill into DRAM.
+  Option<bool> forceSpillToDramIfLegal{
+      *this, "force-spill-to-dram-if-legal",
+      llvm::cl::desc(
+          "Force all non-bound allocator variables to spill into DRAM."),
+      llvm::cl::init(false)};
+
   // The allocator will not consider generic outputs eligible for spilling
   // unless this option is turned on.
   Option<bool> allowL1OutputSpilling{

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -164,6 +164,7 @@ void createD2MFrontendPipeline(OpPassManager &pm,
     allocateOptions.availableL1AddrRange.assign(
         options.availableL1AddrRange.begin(),
         options.availableL1AddrRange.end());
+    allocateOptions.forceSpillToDramIfLegal = options.forceSpillToDramIfLegal;
     allocateOptions.testAssumeL1Capacity = options.testAssumel1Capacity;
     allocateOptions.testBufferSizePolicy = options.testBufferSizePolicy;
   }
@@ -257,7 +258,6 @@ void createD2MBackendPipeline(OpPassManager &pm,
   // treat all arguments.
   pm.addPass(d2m::createD2MNormalizeThreadArgs());
 
-  pm.addPass(createCanonicalizerPassWithOptions(options));
   createOptimizationPasses(pm, options);
 
   pm.addPass(d2m::createD2MGenericRegionsToFuncs());

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -5,7 +5,6 @@
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 
-#include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/Analysis/Allocation/Planner.h"
 #include "ttmlir/Dialect/D2M/Analysis/Allocation/Utils.h"
@@ -21,7 +20,6 @@
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/OpDefinition.h"
-#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -1542,22 +1540,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
                                     ttcore::DeviceAttr device) {
     // A tighter size calculation is possible for memrefs that don't map to
     // CBs which we don't attempt here except to ignore `buffers` multiplier.
-    int64_t shardSizeBytes = device.getMemrefSizeBytes(bufferType, 0, false);
-
-    if (ttcore::getMemorySpace(bufferType) == MemorySpace::DeviceDRAM) {
-      if (auto shardLayout =
-              mlir::dyn_cast<ttcore::ShardLayoutAttr>(bufferType.getLayout())) {
-        int64_t gridVolume =
-            ttmlir::utils::volume(shardLayout.getGridShape(bufferType));
-        int64_t numDramBanks = ttmlir::utils::volume(
-            llvm::to_vector(device.getDramGrid().getShape()));
-        int64_t shardsPerBank =
-            ttmlir::utils::alignUp(gridVolume, numDramBanks) / numDramBanks;
-        return shardSizeBytes * shardsPerBank;
-      }
-    }
-
-    return shardSizeBytes;
+    return device.getMemrefSizeBytes(bufferType, 0, false);
   }
 
   /// @return aligned allocation sizes for a `type` buffer for different
@@ -1570,10 +1553,29 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     for (PlannerSpace placement = PlannerSpace::begin;
          placement < PlannerSpace::end; ++placement) {
       const MemorySpace memspace = asMemorySpace(placement);
+      MemRefType remapped = remap(rewriter, type, memspace);
+      int64_t sizeBytes = getMemrefSizeBytes(remapped, device);
+
+      // This function returns the aligned allocation size on each core.
+      // - For block-sharded L1 tensors it's the size of a single shard.
+      // - For DRAM tensors that live on the 1D DRAM core grid we should return
+      //   the per-bank memory footprint. Since shards are distributed to the
+      //   DRAM banks in the round-robin pattern, we align up the number of
+      //   shards to the number of DRAM banks (bank-aligned padding).
+      if (memspace == MemorySpace::DeviceDRAM) {
+        if (auto layout =
+                mlir::dyn_cast<ttcore::ShardLayoutAttr>(remapped.getLayout())) {
+          const int64_t nShards =
+              ttmlir::utils::volume(layout.getGridShape(remapped));
+          const int64_t nDramBanks = device.getDramGrid().getGridVolume();
+          const int64_t shardsPerBank =
+              ttmlir::utils::alignUp(nShards, nDramBanks) / nDramBanks;
+          sizeBytes *= shardsPerBank;
+        }
+      }
 
       sizes[ordinal(placement)] = ttmlir::utils::alignUp(
-          getMemrefSizeBytes(remap(rewriter, type, memspace), device),
-          memSpaces[ordinal(memspace)].alignment);
+          sizeBytes, memSpaces[ordinal(memspace)].alignment);
     }
 
     return sizes;

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
@@ -4,12 +4,8 @@
 
 #include "ttmlir/Dialect/D2M/Transforms/LowerToLayout/Plan.h"
 
-#include "ttmlir/AffineMapUtils.h"
-#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
-
-#include "llvm/ADT/STLExtras.h"
 
 #include <numeric>
 #include <optional>
@@ -333,35 +329,20 @@ Plan canonicalize(const PlanState &src, const PlanState &tgt,
     updateStateFromOutput(current, output, current.remapping);
   }
 
-  // DRAM → L1: DMA the tensor into an L1 buffer. For device-to-device layout
-  // changes, use the target layout. For device-to-host, mirror the
-  // host-to-device path by staging the current device layout through L1 before
-  // ToHostOp.
-  if (current.hasLayout() && current.isDRAM() &&
-      ((tgt.hasLayout() && !tgt.isDRAM()) || tgt.isSystem())) {
-    const bool hasTargetDeviceLayout = tgt.hasLayout();
-    ttcore::MetalLayoutAttr bounceLayout =
-        hasTargetDeviceLayout ? *tgt.getLayout() : *current.getLayout();
-    RankedTensorType bounceBaseType =
-        hasTargetDeviceLayout ? tgt.type : current.type;
-    AffineMap bounceRemapping =
-        hasTargetDeviceLayout ? AffineMap() : current.remapping;
+  // DRAM → L1: DMA the tensor into an L1 buffer with the target's layout.
+  if (current.hasLayout() && current.isDRAM() && tgt.hasLayout() &&
+      !tgt.isDRAM()) {
     const bool isDRAMInterleaved = current.getLayout()->getMemoryLayout() ==
                                    ttcore::TensorMemoryLayout::Interleaved;
-    auto bounceGrid = hasTargetDeviceLayout && isDRAMInterleaved
-                          ? llvm::to_vector(tgt.getGridShape())
-                          : llvm::to_vector(current.getGridShape());
+    auto bounceGrid = llvm::to_vector(
+        isDRAMInterleaved ? tgt.getGridShape() : current.getGridShape());
     auto l1Type =
-        modifyDeviceType(ctx, bounceBaseType, bounceLayout, targetGridShape,
-                         bounceRemapping, ttcore::MemorySpace::DeviceL1,
-                         bounceGrid, current.type.getElementType());
-    AffineMap outputVgmForward =
-        hasTargetDeviceLayout ? tgt.vgmForward : current.vgmForward;
-    AffineMap outputVgmInverse =
-        hasTargetDeviceLayout ? tgt.vgmInverse : current.vgmInverse;
-    auto output = makeOutputSpec(l1Type, outputVgmForward, outputVgmInverse);
+        modifyDeviceType(ctx, tgt.type, *tgt.getLayout(), targetGridShape,
+                         AffineMap(), ttcore::MemorySpace::DeviceL1, bounceGrid,
+                         current.type.getElementType());
+    auto output = makeOutputSpec(l1Type, tgt.vgmForward, tgt.vgmInverse);
     plan.push_back(DRAMToL1Step{output, AffineMap()});
-    updateStateFromOutput(current, output, bounceRemapping);
+    updateStateFromOutput(current, output);
   }
 
   // TILIZE with the current layout so subsequent mapping changes operate on

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Target/TTMetal/TTMetalToFlatbuffer.h"
-#include "ttmlir/AffineMapUtils.h"
+
 #include "ttmlir/Asserts.h"
-#include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
@@ -39,7 +38,6 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
@@ -199,45 +197,129 @@ static AffineMap extendMappingForHigherDimGrid(AffineMap originalMapping,
                         ctx);
 }
 
+// Convert logical shard dimensions to TT-Metal's page-domain distribution
+// shape.
+static std::vector<uint32_t>
+computeShardPageShapeForDistributionSpec(ArrayRef<int64_t> memrefShardShape,
+                                         target::Dim2d elementShape,
+                                         target::Dim2d pageShape) {
+  TT_assertv(memrefShardShape.size() >= 2u,
+             "Expected shard shape to have at least two dimensions");
+
+  std::vector<uint32_t> shardShapeInPages(memrefShardShape.size());
+
+  for (size_t i = 0; i < memrefShardShape.size(); i++) {
+    int64_t dim = memrefShardShape[i];
+    int64_t pageDim = 1;
+    // Only the innermost 2D plane is divided by the concrete page shape.
+    if (i == memrefShardShape.size() - 2) {
+      dim *= elementShape.y();
+      pageDim = pageShape.y();
+    } else if (i == memrefShardShape.size() - 1) {
+      dim *= elementShape.x();
+      pageDim = pageShape.x();
+    }
+
+    TT_assertv(pageDim > 0, "Expected positive page dimension");
+    shardShapeInPages[i] = static_cast<uint32_t>((dim + pageDim - 1) / pageDim);
+  }
+
+  return shardShapeInPages;
+}
+
 static flatbuffers::Offset<target::metal::ShardedBufferConfig>
 createShardedBufferConfigForDRAMMemref(FlatbufferObjectCache &cache,
                                        MemRefType memref,
                                        ttcore::DeviceAttr device,
                                        ttcore::SystemDescAttr systemDesc) {
-
-  // D2M DRAM shard-to-bank placement is cyclic, while ShardedBufferConfig can
-  // only model a contiguous sharded buffer. Emit placeholder sharding metadata
-  // with the correct byte footprint; it is exact only for the single-shard,
-  // single-bank case.
+  // D2M DRAM shard-to-bank placement is cyclic. Use the same page granularity
+  // as L1 (one element-row per page) so that the host-side read reassembles
+  // data in the row-major order.
+  target::Dim2d elementShape(1, 1);
+  if (auto tileType =
+          mlir::dyn_cast<ttcore::TileType>(memref.getElementType())) {
+    elementShape = target::Dim2d(tileType.getHeight(), tileType.getWidth());
+  }
 
   auto shardLayout = mlir::cast<ttcore::ShardLayoutAttr>(memref.getLayout());
+  ArrayRef<int64_t> stride = shardLayout.getStride();
+  const int64_t elementSize = stride[stride.size() - 1];
   auto memrefGridShape = shardLayout.getGridShape(memref);
-  uint64_t actualShardSize = device.getShardSizeInBytes(memref, 1, true);
-  uint64_t gridVolume = ttmlir::utils::volume(memrefGridShape);
+  auto memrefShardShape = shardLayout.getShardShape(memref);
+  const uint64_t gridVolume = ttmlir::utils::volume(memrefGridShape);
+
+  // Compute the outer-collapsed 2D shard shape (same as for L1 memref).
+  int32_t shardXElements = stride[stride.size() - 2] / elementSize;
+  int32_t collapsedShardYElements =
+      (memrefShardShape[0] * stride[0] / elementSize) / shardXElements;
+  TT_assert(collapsedShardYElements * shardXElements ==
+            ttmlir::utils::volume(memrefShardShape));
+  target::Dim2d shardShape(collapsedShardYElements * elementShape.y() *
+                               shardLayout.getBuffers(),
+                           shardXElements * elementShape.x());
+
+  // The page's width is the same as the memref's element's row width.
+  target::Dim2d pageShape(elementShape.y(), shardShape.x());
 
   // Determine how many DRAM banks are actually used by D2M.
   uint64_t numDramBanks =
       systemDesc.getChipDescs().front().getNumDramChannels();
   uint64_t numDRAMBanksUsed = std::min(numDramBanks, gridVolume);
+  // Important: the DRAM cores are distributed along the X dim on WH & BH.
   std::vector<target::Dim2dRange> coreRangeSet = {target::Dim2dRange(
-      target::Dim2d(0, 0), target::Dim2d(numDRAMBanksUsed, 1))};
-
-  uint64_t actualShardsPerBank =
-      ttmlir::utils::alignUp(gridVolume, numDramBanks) / numDramBanks;
-
-  // Compute placeholder shapes that occupy the actual D2M memref footprint.
-  target::Dim2d dummyShardShape(actualShardsPerBank, actualShardSize);
-  target::Dim2d dummyPageShape(actualShardsPerBank, actualShardSize);
-  uint64_t dummyShardSize = dummyShardShape.x() * dummyShardShape.y();
-  target::Dim2d dummyTensorShapeInPages(numDRAMBanksUsed, 1);
-  uint64_t dummyTensorSize = numDRAMBanksUsed * dummyShardSize;
+      target::Dim2d(0, 0), target::Dim2d(1, numDRAMBanksUsed))};
 
   auto shardSpec = target::metal::CreateShardSpecDirect(
-      *cache.fbb, &coreRangeSet, &dummyShardShape);
+      *cache.fbb, &coreRangeSet, &shardShape);
+
+  // Outer-collapsed tensor shape from the logical grid (not the DRAM grid).
+  int32_t gridY = 1;
+  for (size_t i = 0; i < memrefGridShape.size() - 1; i++) {
+    gridY *= memrefGridShape[i];
+  }
+  int32_t gridX = memrefGridShape.back();
+  int32_t tensorShape[2] = {gridY * shardShape.y(), gridX * shardShape.x()};
+  TT_assert(tensorShape[0] % pageShape.y() == 0);
+  TT_assert(tensorShape[1] % pageShape.x() == 0);
+  target::Dim2d tensorShapeInPages(tensorShape[0] / pageShape.y(),
+                                   tensorShape[1] / pageShape.x());
+
   auto shardSpecBuffer = target::metal::CreateShardSpecBuffer(
-      *cache.fbb, shardSpec, &dummyPageShape, &dummyTensorShapeInPages);
+      *cache.fbb, shardSpec, &pageShape, &tensorShapeInPages);
+
+  // Create BufferDistributionSpec on uncollapsed shapes and the default 1D
+  // round-robin DRAM bank assignment.
+  std::vector<uint32_t> shardShapeInPages =
+      computeShardPageShapeForDistributionSpec(memrefShardShape, elementShape,
+                                               pageShape);
+
+  std::vector<uint32_t> distTensorShape(shardShapeInPages.size());
+  for (size_t i = 0; i < shardShapeInPages.size(); i++) {
+    distTensorShape[i] = memrefGridShape[i] * shardShapeInPages[i];
+  }
+
+  std::vector<target::Dim2d> cores(numDRAMBanksUsed);
+  for (uint64_t i = 0; i < numDRAMBanksUsed; i++) {
+    cores[i] = target::Dim2d(0, i);
+  }
+
+  auto bufferDistributionSpec =
+      target::metal::CreateBufferDistributionSpecDirect(
+          *cache.fbb, &distTensorShape, &shardShapeInPages, &cores);
+
+  // Page size in bytes and total buffer size (including bank-aligned padding).
+  TT_assert(pageShape.y() % elementShape.y() == 0);
+  TT_assert(pageShape.x() % elementShape.x() == 0);
+  int32_t pageShapeInElements[2] = {pageShape.y() / elementShape.y(),
+                                    pageShape.x() / elementShape.x()};
+  const uint64_t pageSize =
+      pageShapeInElements[0] * pageShapeInElements[1] * elementSize;
+  const uint64_t shardSize =
+      device.getMemrefSizeBytes(memref, pageSize, /*includeBuffers=*/true);
+  const uint64_t totalSize = gridVolume * shardSize;
+
   return target::metal::CreateShardedBufferConfig(
-      *cache.fbb, dummyTensorSize, dummyShardSize, shardSpecBuffer);
+      *cache.fbb, totalSize, pageSize, shardSpecBuffer, bufferDistributionSpec);
 }
 
 // Virtual-grid serialization requires both inverse and forward maps.
@@ -280,38 +362,6 @@ getPhysicalGridShapeForVirtualGrid(ttcore::ShardLayoutAttr shardLayout,
   auto workerGridShape = device.getWorkerGrid().getShape();
   return ttmlir::d2m::utils::grids::getPhysicalGridExtent(gridShape,
                                                           workerGridShape);
-}
-
-// Convert logical shard dimensions to TT-Metal's page-domain distribution
-// shape.
-static std::vector<uint32_t>
-computeShardPageShapeForDistributionSpec(ArrayRef<int64_t> memrefShardShape,
-                                         target::Dim2d elementShape,
-                                         target::Dim2d pageShape) {
-  TT_assertv(memrefShardShape.size() >= 2u,
-             "Expected shard shape to have at least two dimensions");
-
-  std::vector<uint32_t> shardShapeInPages;
-  shardShapeInPages.reserve(memrefShardShape.size());
-
-  for (size_t i = 0; i < memrefShardShape.size(); ++i) {
-    int64_t dim = memrefShardShape[i];
-    int64_t pageDim = 1;
-    // Only the innermost 2D plane is divided by the concrete page shape.
-    if (i == memrefShardShape.size() - 2) {
-      dim *= elementShape.y();
-      pageDim = pageShape.y();
-    } else if (i == memrefShardShape.size() - 1) {
-      dim *= elementShape.x();
-      pageDim = pageShape.x();
-    }
-
-    TT_assertv(pageDim > 0, "Expected positive page dimension");
-    shardShapeInPages.push_back(
-        static_cast<uint32_t>((dim + pageDim - 1) / pageDim));
-  }
-
-  return shardShapeInPages;
 }
 
 static flatbuffers::Offset<target::metal::BufferDistributionSpec>
@@ -534,19 +584,32 @@ memrefTypeToCircularBufferConfigFlatbuffer(FlatbufferObjectCache &cache,
       toFlatbuffer(cache, workerGridShape, extendedMapping);
 
   uint64_t pageSize = 0;
+  uint64_t tilePageSize = device.getMemrefCBPageSizeBytes(memref);
   bool useScalarCBLayoutSizing =
       !mlir::isa<ttcore::TileType>(memref.getElementType()) &&
       shardLayout.getBuffers() > 1;
   if (!useScalarCBLayoutSizing) {
-    pageSize = device.getMemrefCBPageSizeBytes(memref);
+    pageSize = tilePageSize;
   } else {
     ArrayRef<int64_t> stride = shardLayout.getStride();
-    int64_t elementSize = stride.back();
-    pageSize = stride.size() < 2 ? elementSize : stride[stride.size() - 2];
+    const uint64_t elementSize = static_cast<uint64_t>(stride.back());
+    uint64_t scalarPageSize =
+        stride.size() < 2 ? elementSize : stride[stride.size() - 2];
     // Scalar CBs may be used as packet scratch buffers.  Keep the CB page at
     // least one NOC-aligned transfer so reserve/push/pop advance correctly.
-    pageSize =
-        std::max<uint64_t>(pageSize, systemDesc.getNocL1AddressAlignBytes());
+    scalarPageSize = std::max<uint64_t>(scalarPageSize,
+                                        systemDesc.getNocL1AddressAlignBytes());
+
+    // Both llk_pack_untilize and our experimental::pack_untilize_block use
+    // fifo_page_size to compute inter-tile-row strides to get the starting
+    // offset of the next row of tiles. So we make sure CB page size equals to
+    // the tile size whenever possible, to avoid inconsistencies with
+    // getMemrefCBNumPages (that counts tiles) and avoid wrong offset
+    // calculations.
+    const uint64_t rawShardBytes =
+        elementSize * ttmlir::utils::volume(memref.getShape());
+    const bool tileAligned = rawShardBytes % tilePageSize == 0;
+    pageSize = tileAligned ? tilePageSize : scalarPageSize;
   }
   uint64_t shardSize =
       device.getMemrefSizeBytes(memref, pageSize, /*includeBuffers=*/true);

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -478,7 +478,7 @@ void MCQExecutor::execute(
     const target::metal::EnqueueWriteBufferCommand *command) {
   ZoneScopedN("EnqueueWriteBufferCommand");
 
-  auto input = hostBuffers.at(command->src()->global_id());
+  auto &input = hostBuffers.at(command->src()->global_id());
   auto meshBuffer = meshBuffers.at(command->dst()->global_id());
   checkHostTensorSizeMatchWithMeshBufferSize(input, meshBuffer);
   writeHostTensorToMeshBuffer(mcq, input, meshBuffer, blockingCQ);
@@ -488,8 +488,8 @@ void MCQExecutor::execute(
     const target::metal::EnqueueReadBufferCommand *command) {
   ZoneScopedN("EnqueueReadBufferCommand");
 
+  auto &output = hostBuffers.at(command->dst()->global_id());
   auto meshBuffer = meshBuffers.at(command->src()->global_id());
-  auto output = hostBuffers.at(command->dst()->global_id());
   checkHostTensorSizeMatchWithMeshBufferSize(output, meshBuffer);
   readHostTensorFromMeshBuffer(mcq, meshBuffer, output, blockingCQ);
 }

--- a/test/python/golden/d2m/test_dma.py
+++ b/test/python/golden/d2m/test_dma.py
@@ -4,7 +4,7 @@
 
 import pytest
 import torch
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 from ttmlir.dialects import ttir, ttcore
 from ttmlir.ir import *
@@ -17,7 +17,7 @@ from conftest import get_request_kwargs
 pytestmark = pytest.mark.frontend("ttir")
 
 
-def compile_dma_test(test_func, shape, request, device):
+def compile_dma_test(test_func, request, device):
 
     # Back to back tolayout ops are normally folded during canonicalization into
     # a single ToLayoutOp representing the final result. The option
@@ -55,7 +55,7 @@ def test_host_interop_single_bank_dram_dma(
         def tilize(
             in0: Operand,
             builder: TTIRBuilder,
-            unit_attrs: List[str] = None,
+            unit_attrs: Optional[List[str]] = None,
         ):
 
             to_device = builder.to_layout(
@@ -74,7 +74,7 @@ def test_host_interop_single_bank_dram_dma(
 
             return system_out
 
-    compile_dma_test(module, shape, request, device=device)
+    compile_dma_test(module, request, device=device)
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -98,17 +98,15 @@ def test_roundtrip_dma_tiled(
         def tilize(
             in0: Operand,
             builder: TTIRBuilder,
-            unit_attrs: List[str] = None,
+            unit_attrs: Optional[List[str]] = None,
         ):
             # derive sharded shapes
             assert (shape[0] % start_grid[0] == 0) and (
                 shape[1] % start_grid[1] == 0
             ), "shape must be divisible by start_grid"
-            start_shard_shape = (shape[0] // start_grid[0], shape[1] // start_grid[1])
             assert (shape[0] % end_grid[0] == 0) and (
                 shape[1] % end_grid[1] == 0
             ), "shard_shape must be divisible by end_grid"
-            end_shard_shape = (shape[0] // end_grid[0], shape[1] // end_grid[1])
 
             # tilize the tensor on a single worker
             to_device = builder.tilize(
@@ -153,14 +151,11 @@ def test_roundtrip_dma_tiled(
 
             return untilize_out
 
-    compile_dma_test(module, shape, request, device=device)
+    compile_dma_test(module, request, device=device)
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize(
-    "shape",
-    [(128, 128)],
-)
+@pytest.mark.parametrize("shape", [(128, 128)])
 @pytest.mark.parametrize("start_grid", [(1, 1), (1, 2), (2, 1), (4, 4)])
 @pytest.mark.parametrize("end_grid", [(1, 1), (2, 2)])
 @pytest.mark.parametrize(
@@ -180,7 +175,7 @@ def test_roundtrip_dma_rowmajor(
         def dram_write(
             in0: Operand,
             builder: TTIRBuilder,
-            unit_attrs: List[str] = None,
+            unit_attrs: Optional[List[str]] = None,
         ):
 
             to_device = builder.to_layout(
@@ -199,7 +194,6 @@ def test_roundtrip_dma_rowmajor(
             assert (start_shard_shape[0] % end_grid[0] == 0) and (
                 start_shard_shape[1] % end_grid[1] == 0
             ), "start_shard_shape must be divisible by end_grid"
-            end_shard_shape = (shape[0] // end_grid[0], shape[1] // end_grid[1])
 
             # WRITE L1 to initial shard layout
             tensor_layoutA = builder.to_layout(
@@ -233,7 +227,7 @@ def test_roundtrip_dma_rowmajor(
 
             return system_out
 
-    compile_dma_test(module, shape, request, device=device)
+    compile_dma_test(module, request, device=device)
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -247,14 +241,13 @@ def test_interleaved_dma(
         def interleaved_dma(
             in0: Operand,
             builder: TTIRBuilder,
-            unit_attrs: List[str] = None,
+            unit_attrs: Optional[List[str]] = None,
         ):
             # derive sharded shapes
             assert (
                 (shape[0] % end_grid[0] == 0) and (shape[1] % end_grid[1] == 0),
                 "shard_shape must be divisible by end_grid",
             )
-            end_shard_shape = (shape[0] // end_grid[0], shape[1] // end_grid[1])
 
             # tilize the tensor on a single worker
             to_device = builder.tilize(
@@ -300,4 +293,4 @@ def test_interleaved_dma(
 
             return untilize_out
 
-    compile_dma_test(module, shape, request, device=device)
+    compile_dma_test(module, request, device=device)

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -2,19 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import itertools
 import pytest
 import torch
 from typing import List, Optional
 
-from conftest import get_request_kwargs
 from builder.base.builder_utils import Operand, Shape
-from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir
 from d2m.test_matmul import create_matmul_constrained_inputs
 from d2m.test_reductions import (
     _reduction_atol,
     create_reductions_constrained_inputs,
 )
+from builder.ttir.ttir_builder import TTIRBuilder
+from conftest import get_request_kwargs
 from test_utils import shape_str
 
 pytestmark = pytest.mark.frontend("ttir")
@@ -30,15 +31,15 @@ DRAM_FUSION_PIPELINE_OPTIONS = [
 ]
 
 DRAM_SHAPES = [
-    (1, 16),
-    (16, 16),
-    (32, 32),
-    (32, 64),
-    (64, 128),
-    (128, 128),
-    (256, 512),
-    (512, 1024),
+    (1, 15),
+    (17, 1),
+    (73, 467),
+    (449, 89),
+    (512, 8192),
+    (16384, 256),
     (2048, 2048),
+    (23, 383, 457),
+    (5, 3, 439, 373),
 ]
 
 
@@ -59,37 +60,13 @@ def shape_dtype_param(shape: Shape, dtype: torch.dtype):
 
 DRAM_FLOAT_CASES = [
     shape_dtype_param(shape, dtype)
-    for shape, dtype in zip(
-        DRAM_SHAPES,
-        [
-            torch.float32,
-            torch.bfloat16,
-            torch.float32,
-            torch.bfloat16,
-            torch.float32,
-            torch.bfloat16,
-            torch.float32,
-            torch.bfloat16,
-            torch.float32,
-        ],
-    )
+    for shape, dtype in itertools.product(DRAM_SHAPES, [torch.float32, torch.bfloat16])
 ]
 
 DRAM_NUMERIC_CASES = [
     shape_dtype_param(shape, dtype)
-    for shape, dtype in zip(
-        DRAM_SHAPES,
-        [
-            torch.float32,
-            torch.bfloat16,
-            torch.int32,
-            torch.float32,
-            torch.bfloat16,
-            torch.int32,
-            torch.float32,
-            torch.bfloat16,
-            torch.int32,
-        ],
+    for shape, dtype in itertools.product(
+        DRAM_SHAPES, [torch.float32, torch.bfloat16, torch.int32]
     )
 ]
 
@@ -107,7 +84,9 @@ def get_clamp_bounds(dtype: torch.dtype):
     return (0, 3) if dtype == torch.int32 else (-0.5, 0.8)
 
 
-def compile_dram_test(module, request, device, target: str, **compile_kwargs):
+def compile_and_execute_dram_test(
+    module, request, device, target: str, **compile_kwargs
+):
     compile_and_execute_ttir(
         module,
         **get_request_kwargs(request),
@@ -130,17 +109,15 @@ def compile_dram_fusion_test(module, request, device, target: str):
 
 @pytest.mark.parametrize("shape,dtype", DRAM_FLOAT_CASES)
 @pytest.mark.parametrize("target", ["ttmetal"])
-def test_dram_unary_relu(
-    shape: Shape, dtype: torch.dtype, target: str, request, device
-):
+def test_dram_unary_neg(shape: Shape, dtype: torch.dtype, target: str, request, device):
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
-        def relu(
-            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[list[str]] = None
+        def neg(
+            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
         ):
-            return builder.relu(in0, unit_attrs=unit_attrs)
+            return builder.neg(in0, unit_attrs=unit_attrs)
 
-    compile_dram_test(module, request, device, target)
+    compile_and_execute_dram_test(module, request, device, target)
 
 
 @pytest.mark.parametrize("shape,dtype", DRAM_FLOAT_CASES)
@@ -154,11 +131,11 @@ def test_dram_binary_add(
             in0: Operand,
             in1: Operand,
             builder: TTIRBuilder,
-            unit_attrs: Optional[list[str]] = None,
+            unit_attrs: Optional[List[str]] = None,
         ):
             return builder.add(in0, in1, unit_attrs=unit_attrs)
 
-    compile_dram_test(module, request, device, target)
+    compile_and_execute_dram_test(module, request, device, target)
 
 
 @pytest.mark.parametrize("shape,dtype", DRAM_FUSION_CASES)
@@ -173,7 +150,7 @@ def test_dram_fuse_add_relu_multiply(
             in1: Operand,
             in2: Operand,
             builder: TTIRBuilder,
-            unit_attrs: Optional[list[str]] = None,
+            unit_attrs: Optional[List[str]] = None,
         ):
             sum_result = builder.add(in0, in1, unit_attrs=unit_attrs)
             relu_result = builder.relu(sum_result, unit_attrs=unit_attrs)
@@ -194,7 +171,7 @@ def test_dram_fuse_converging_branches(
             in1: Operand,
             in2: Operand,
             builder: TTIRBuilder,
-            unit_attrs: Optional[list[str]] = None,
+            unit_attrs: Optional[List[str]] = None,
         ):
             lhs = builder.relu(in0, unit_attrs=unit_attrs)
             rhs = builder.add(in1, in2, unit_attrs=unit_attrs)
@@ -211,15 +188,13 @@ def test_dram_binary_add_scalar(
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
         def add_scalar(
-            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[list[str]] = None
+            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
         ):
             scalar_value = get_add_scalar_value(dtype)
-            scalar = builder.full(
-                list(shape), dtype, scalar_value, unit_attrs=unit_attrs
-            )
+            scalar = builder.full(shape, dtype, scalar_value, unit_attrs=unit_attrs)
             return builder.add(in0, scalar, unit_attrs=unit_attrs)
 
-    compile_dram_test(module, request, device, target)
+    compile_and_execute_dram_test(module, request, device, target)
 
 
 @pytest.mark.parametrize("shape,dtype", DRAM_NUMERIC_CASES)
@@ -234,7 +209,7 @@ def test_dram_ternary_clamp_tensor(
             min_tensor: Operand,
             max_tensor: Operand,
             builder: TTIRBuilder,
-            unit_attrs: Optional[list[str]] = None,
+            unit_attrs: Optional[List[str]] = None,
         ):
             if dtype == torch.int32:
                 input_golden = torch.randint(-5, 10, shape, dtype=dtype)
@@ -254,7 +229,7 @@ def test_dram_ternary_clamp_tensor(
                 in0, min_tensor, max_tensor, unit_attrs=unit_attrs
             )
 
-    compile_dram_test(module, request, device, target)
+    compile_and_execute_dram_test(module, request, device, target)
 
 
 @pytest.mark.parametrize("shape,dtype", DRAM_NUMERIC_CASES)
@@ -265,7 +240,7 @@ def test_dram_ternary_clamp_scalar(
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
         def clamp_scalar(
-            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[list[str]] = None
+            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
         ):
             if dtype == torch.int32:
                 input_golden = torch.randint(-5, 10, shape, dtype=dtype)
@@ -277,7 +252,7 @@ def test_dram_ternary_clamp_scalar(
                 in0, min_arg=min_value, max_arg=max_value, unit_attrs=unit_attrs
             )
 
-    compile_dram_test(module, request, device, target)
+    compile_and_execute_dram_test(module, request, device, target)
 
 
 DRAM_MATMUL_CASES = [
@@ -339,7 +314,7 @@ def test_dram_matmul(
     request,
     device,
 ):
-    compile_dram_test(
+    compile_and_execute_dram_test(
         create_matmul_constrained_inputs(lhs_shape, rhs_shape, dtype),
         request,
         device,
@@ -362,7 +337,7 @@ def test_dram_reduction(
     request,
     device,
 ):
-    compile_dram_test(
+    compile_and_execute_dram_test(
         create_reductions_constrained_inputs(
             shape, reduce_type, dim_arg, keep_dim, dtype
         ),

--- a/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
+++ b/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
@@ -65,21 +65,40 @@ func.func @untilize(%arg0: tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>) ->
   return %1 : tensor<1024x1024xf32>
 }
 
-// Test untilize from DRAM to host stages through L1 before d2m.to_host.
-func.func @untilize_dram_to_host_stages_l1(%arg0: tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout_dram>) -> tensor<1024x1024xf32> {
+func.func @tilize_dram_to_l1(%arg0: tensor<8x8x128x128xf32, #layout_dram>) -> tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout> {
+  // CHECK-LABEL: @tilize_dram_to_l1
+  // CHECK: %[[L1_TILED:.*]] = d2m.empty() : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #[[L1_LAYOUT:.*]]>
+  // CHECK: %[[L1_SCALAR:.*]] = d2m.empty() : tensor<8x8x128x128xf32, #[[L1_LAYOUT]]>
+  // CHECK: %[[DRAM_TO_L1:.*]] = d2m.generic
+  // CHECK-NEXT: ins(%arg0 : tensor<8x8x128x128xf32, #[[DRAM_LAYOUT:.*]]>)
+  // CHECK-NEXT: outs(%[[L1_SCALAR]] : tensor<8x8x128x128xf32, #[[L1_LAYOUT]]>)
+  // CHECK: d2m.remote_load
+  // CHECK: d2m.remote_store %[[L1_SCALAR]]
+  // CHECK: %[[TILIZE_L1:.*]] = d2m.generic
+  // CHECK-NEXT: ins(%[[DRAM_TO_L1]] : tensor<8x8x128x128xf32, #[[L1_LAYOUT]]>)
+  // CHECK-NEXT: outs(%[[L1_TILED]] : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #[[L1_LAYOUT]]>)
+  // CHECK: d2m.remote_load %{{.+}} %[[DRAM_TO_L1]]
+  // CHECK: d2m.tile_tilize_block
+  // CHECK: d2m.remote_store %[[L1_TILED]]
+  %0 = d2m.empty() : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
+  %1 = d2m.to_layout %arg0, %0 : tensor<8x8x128x128xf32, #layout_dram> into tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout> -> tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
+  return %1 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
+}
+
+// Test untilize from DRAM to host is a direct transfer.
+func.func @untilize_dram_to_host(%arg0: tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout_dram>) -> tensor<1024x1024xf32> {
   %0 = d2m.empty() : tensor<1024x1024xf32>
 
-  // CHECK-LABEL: @untilize_dram_to_host_stages_l1
-  // CHECK: %[[L1_TILED:.*]] = d2m.empty() : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}>
-  // CHECK: %[[DRAM_TO_L1:.*]] = d2m.generic
-  // CHECK-NEXT: ins(%arg0 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}>)
-  // CHECK-NEXT: outs(%[[L1_TILED]] : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}>)
+  // CHECK-LABEL: @untilize_dram_to_host
+  // CHECK: %[[DRAM_SCALAR:.*]] = d2m.empty() : tensor<8x8x128x128xf32, #[[DRAM_LAYOUT:.*]]>
+  // CHECK: %[[DRAM_TO_DRAM:.*]] = d2m.generic
+  // CHECK-NEXT: ins(%arg0 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #[[DRAM_LAYOUT]]>)
+  // CHECK-NEXT: outs(%[[DRAM_SCALAR]] : tensor<8x8x128x128xf32, #[[DRAM_LAYOUT]]>)
+  // CHECK-NOT: d2m.generic
   // CHECK: d2m.remote_load
-  // CHECK: d2m.remote_store %[[L1_TILED]]
-  // CHECK: %[[L1_SCALAR:.*]] = d2m.generic
-  // CHECK-NEXT: ins(%[[DRAM_TO_L1]] : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}>)
   // CHECK: d2m.tile_untilize_block
-  // CHECK: d2m.to_host %[[L1_SCALAR]]
+  // CHECK: d2m.remote_store %[[DRAM_SCALAR]]
+  // CHECK: d2m.to_host %[[DRAM_TO_DRAM]]
   %1 = d2m.to_layout %arg0, %0 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout_dram> into tensor<1024x1024xf32>
     -> tensor<1024x1024xf32>
 

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_add_dram.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_add_dram.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% default-input-memspace=dram default-output-memspace=dram" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir
+
+func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  // CHECK: "ttmetal.create_buffer"
+  // CHECK: "ttmetal.enqueue_program"
+  %1 = "ttir.add"(%arg0, %arg1) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  // CHECK: "ttmetal.enqueue_read_buffer"
+  // CHECK: "ttmetal.finish"
+  return %1 : tensor<64x128xf32>
+}


### PR DESCRIPTION
### Problem description
Supersedes #8398

### What's changed
- Instead of doing L1 bounce for DRAM D2H transfer, fix the MeshBuffer creation so enqueue_read/write works correctly.
- Move the DRAM shard size bank-alignment logic to `getAlignedAllocSizes()` as it's a better fit.
- In `TTMetalToFlatbuffer`, replace the dummy logic and implement proper DRAM sharding instructions.
  - The DRAM shard-to-bank assignment is round-robin, aligns with TTNN default.
- Bugfix: DRAM grid should be `y=1,x=N` on WH & BH, not the other way around.
- Update `test_dram_ops.py` to test unaligned shapes and N-D tensors.
- Expose the `force-spill-to-dram-if-legal` option of the allocator pass as a `ttmlir-opt` option.

### Checklist
- [x] New/Existing tests provide coverage for changes
