### PR TITLE
Group norm decomposition

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_GROUPNORMDECOMPOSITIONREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_GROUPNORMDECOMPOSITIONREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+#include <optional>
+
+namespace mlir::tt::ttnn::decomposition {
+
+// Decomposes ttnn::GroupNormOp into a sequence of primitive TTNN ops
+// (reshape / mean / subtract / multiply / add / rsqrt / multiply / reshape,
+// plus optional weight*+bias broadcast tail).
+//
+// When validationConfig is provided, decomposition only occurs if op-model
+// validation of the fused ttnn.group_norm fails (e.g. the kernel's L1 /
+// circular-buffer requirements cannot be satisfied with any layout the
+// validator's fallback search produces). When validationConfig is
+// std::nullopt, decomposition is unconditional.
+
+class GroupNormDecompositionRewritePattern
+    : public OpRewritePattern<ttnn::GroupNormOp> {
+public:
+  GroupNormDecompositionRewritePattern(mlir::MLIRContext *context)
+      : OpRewritePattern<ttnn::GroupNormOp>(context) {}
+
+  GroupNormDecompositionRewritePattern(
+      mlir::MLIRContext *context, const OpValidationConfig &validationConfig)
+      : OpRewritePattern<ttnn::GroupNormOp>(context),
+        validationConfig(validationConfig) {}
+
+  LogicalResult matchAndRewrite(ttnn::GroupNormOp op,
+                                PatternRewriter &rewriter) const override;
+
+private:
+  std::optional<OpValidationConfig> validationConfig;
+};
+
+} // namespace mlir::tt::ttnn::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_GROUPNORMDECOMPOSITIONREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Decomposition/ConcatenateHeadsDecompositionRewritePattern.cpp
         Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
         Decomposition/DistributedLayerNormDecompositionRewritePattern.cpp
+        Decomposition/GroupNormDecompositionRewritePattern.cpp
         Decomposition/TopKDecompositionRewritePattern.cpp
         Decomposition/TTNNDecompositionPass.cpp
         OpValidator.cpp

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -4,8 +4,8 @@
 
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.h"
 
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
-#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
@@ -46,18 +46,6 @@ bool isAlreadyCanonicalShape(ArrayRef<int64_t> shape) {
   return shape.size() == 4 && shape[0] == 1 && shape[1] == 1;
 }
 
-mlir::Value reshapeTo(PatternRewriter &rewriter, Location loc, mlir::Value v,
-                      ArrayRef<int64_t> targetShape) {
-  auto srcType = mlir::cast<RankedTensorType>(v.getType());
-  RankedTensorType targetType =
-      utils::RankedTensorTypeFactory::create(srcType, targetShape);
-  SmallVector<int32_t> targetShapeI32(targetShape.begin(), targetShape.end());
-  return rewriter
-      .create<ttnn::ReshapeOp>(loc, targetType, v,
-                               rewriter.getI32ArrayAttr(targetShapeI32))
-      .getResult();
-}
-
 } // namespace
 
 LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
@@ -81,12 +69,18 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
     SmallVector<int64_t> canonicalShape = {1, 1, 32, inputShape.back()};
 
     mlir::Value reshapedInput =
-        reshapeTo(rewriter, loc, op.getInput(), canonicalShape);
+        ttir_to_ttnn::utils::generateReshape(
+            mlir::cast<mlir::TypedValue<RankedTensorType>>(op.getInput()),
+            canonicalShape, rewriter, loc)
+            .getResult();
 
     mlir::Value reshapedResidual = op.getResidual();
     if (reshapedResidual) {
       reshapedResidual =
-          reshapeTo(rewriter, loc, reshapedResidual, canonicalShape);
+          ttir_to_ttnn::utils::generateReshape(
+              mlir::cast<mlir::TypedValue<RankedTensorType>>(reshapedResidual),
+              canonicalShape, rewriter, loc)
+              .getResult();
     }
 
     RankedTensorType canonicalResultType =
@@ -100,7 +94,9 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
         op.getProgramConfigAttr());
 
     mlir::Value reshapedResult =
-        reshapeTo(rewriter, loc, newOp.getResult(), resultType.getShape());
+        ttir_to_ttnn::utils::generateReshape(
+            newOp.getResult(), resultType.getShape(), rewriter, loc)
+            .getResult();
 
     rewriter.replaceOp(op, reshapedResult);
     return success();

--- a/lib/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.h"
+
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Support/Logger.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::tt::ttnn::decomposition {
+
+LogicalResult GroupNormDecompositionRewritePattern::matchAndRewrite(
+    ttnn::GroupNormOp op, PatternRewriter &rewriter) const {
+
+  RankedTensorType inputType =
+      mlir::cast<RankedTensorType>(op.getInput().getType());
+  RankedTensorType resultType =
+      mlir::cast<RankedTensorType>(op.getResult().getType());
+
+  // When validation config is provided, validate the GroupNorm operation using
+  // IsolatedIRValidationWrapper. If validation succeeds, keep the op as-is.
+  if (validationConfig.has_value()) {
+    IsolatedIRValidationWrapper validator(rewriter.getContext(),
+                                          *validationConfig);
+
+    auto validationResult = validator.validateOp<ttnn::GroupNormOp>(
+        op.getOperation(), op.getLoc(), {resultType}, op.getInput(),
+        op.getInputMask(), op.getWeight(), op.getBias(), op.getNumGroupsAttr(),
+        op.getEpsilonAttr(), op.getCoreGridAttr());
+
+    if (validationResult.isSuccess()) {
+      return failure();
+    }
+
+    TTMLIR_DEBUG(ttmlir::LogComponent::IsolatedIRValidationWrapper,
+                 "GroupNorm decomposition triggered (validation failed): {0}",
+                 validationResult.errorMessage);
+  }
+
+  // The TTIRToTTNN conversion places GroupNorm inputs in [N, 1, H*W, C] form
+  // (channels in the last dim). If we ever see something different, bail out
+  // and leave the op as-is rather than emit an incorrect decomposition.
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  if (inputShape.size() != 4) {
+    return rewriter.notifyMatchFailure(
+        op, "expected rank-4 input in canonical [N, 1, H*W, C] form");
+  }
+
+  const int64_t N = inputShape[0];
+  const int64_t S = inputShape[2];
+  const int64_t C = inputShape[3];
+  const int64_t G = op.getNumGroups();
+  if (G <= 0 || C % G != 0) {
+    return rewriter.notifyMatchFailure(
+        op, "num_groups must evenly divide the channel dimension");
+  }
+  const int64_t Cpg = C / G;
+
+  Location loc = op.getLoc();
+
+  // Reshape [N, 1, S, C] -> [N, S, G, Cpg] so per-group reductions can happen
+  // over a contiguous (S, Cpg) sub-tensor.
+  SmallVector<int64_t> groupedShape = {N, S, G, Cpg};
+  mlir::Value grouped =
+      ttir_to_ttnn::utils::generateReshape(
+          mlir::cast<mlir::TypedValue<RankedTensorType>>(op.getInput()),
+          groupedShape, rewriter,
+          ttmlir::utils::appendLocationSuffix(loc, "_group_reshape"))
+          .getResult();
+  RankedTensorType groupedType =
+      mlir::cast<RankedTensorType>(grouped.getType());
+
+  SmallVector<int64_t> statsShape = {N, 1, G, 1};
+  RankedTensorType statsType =
+      utils::RankedTensorTypeFactory::create(inputType, statsShape);
+  ArrayAttr reduceDims = rewriter.getI32ArrayAttr({1, 3});
+
+  // mean = mean(grouped, dims=[1,3], keep_dim=true)
+  auto meanOp = rewriter.create<ttnn::MeanOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_mean"), statsType, grouped,
+      /*keep_dim=*/true, reduceDims);
+
+  // centered = grouped - mean  (broadcasts dims 1 and 3 of mean)
+  auto centeredOp = rewriter.create<ttnn::SubtractOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_center"), groupedType, grouped,
+      meanOp.getResult());
+
+  // variance = mean(centered * centered, dims=[1,3], keep_dim=true)
+  auto squaredOp = rewriter.create<ttnn::MultiplyOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_square"), groupedType,
+      centeredOp.getResult(), centeredOp.getResult());
+  auto varianceOp = rewriter.create<ttnn::MeanOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_variance"), statsType,
+      squaredOp.getResult(), /*keep_dim=*/true, reduceDims);
+
+  // eps tensor: ttnn.full of stats shape filled with epsilon.
+  auto deviceOp = utils::getOrInsertDevice(rewriter, op);
+  auto epsTensor = rewriter.create<ttnn::FullOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_eps"), statsType,
+      rewriter.getF32FloatAttr(op.getEpsilon().convertToFloat()),
+      deviceOp.getResult());
+
+  // inv_std = rsqrt(variance + eps)
+  auto stabilizedOp = rewriter.create<ttnn::AddOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_add_eps"), statsType,
+      varianceOp.getResult(), epsTensor.getResult());
+  auto invStdOp = rewriter.create<ttnn::RsqrtOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_rsqrt"), statsType,
+      stabilizedOp.getResult());
+
+  // normalized = centered * inv_std (broadcasts)
+  auto normalizedOp = rewriter.create<ttnn::MultiplyOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_normalize"), groupedType,
+      centeredOp.getResult(), invStdOp.getResult());
+
+  // Restore the original [N, 1, S, C] shape.
+  mlir::Value result =
+      ttir_to_ttnn::utils::generateReshape(
+          normalizedOp.getResult(), inputShape, rewriter,
+          ttmlir::utils::appendLocationSuffix(loc, "_unreshape"))
+          .getResult();
+
+  // Per-channel affine parameters. After TTIRToTTNN they are materialized as
+  // 1-D tensors of shape [C]; we reshape to [1, 1, 1, C] so that the broadcast
+  // is explicit and unambiguous to downstream layout selection.
+  SmallVector<int64_t> affineShape = {1, 1, 1, C};
+
+  // Optional weight: result = result * reshape(weight, [1,1,1,C]).
+  if (op.getWeight()) {
+    mlir::Value reshapedWeight =
+        ttir_to_ttnn::utils::generateReshape(
+            mlir::cast<mlir::TypedValue<RankedTensorType>>(op.getWeight()),
+            affineShape, rewriter,
+            ttmlir::utils::appendLocationSuffix(loc, "_weight_reshape"))
+            .getResult();
+    result = rewriter
+                 .create<ttnn::MultiplyOp>(
+                     ttmlir::utils::appendLocationSuffix(loc, "_weight_mul"),
+                     resultType, result, reshapedWeight)
+                 .getResult();
+  }
+
+  // Optional bias: result = result + reshape(bias, [1,1,1,C]).
+  if (op.getBias()) {
+    mlir::Value reshapedBias =
+        ttir_to_ttnn::utils::generateReshape(
+            mlir::cast<mlir::TypedValue<RankedTensorType>>(op.getBias()),
+            affineShape, rewriter,
+            ttmlir::utils::appendLocationSuffix(loc, "_bias_reshape"))
+            .getResult();
+    result = rewriter
+                 .create<ttnn::AddOp>(
+                     ttmlir::utils::appendLocationSuffix(loc, "_bias_add"),
+                     resultType, result, reshapedBias)
+                 .getResult();
+  }
+
+  rewriter.replaceOp(op, result);
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::decomposition

--- a/lib/Dialect/TTNN/Transforms/Decomposition/TTNNDecompositionPass.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/TTNNDecompositionPass.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/ConcatenateHeadsDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/DistributedLayerNormDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 
@@ -36,10 +37,14 @@ public:
           &getContext(), validationConfig);
       patterns.add<decomposition::ConcatenateHeadsDecompositionRewritePattern>(
           &getContext(), validationConfig);
+      patterns.add<decomposition::GroupNormDecompositionRewritePattern>(
+          &getContext(), validationConfig);
     } else {
       patterns.add<decomposition::TopKDecompositionRewritePattern>(
           &getContext());
       patterns.add<decomposition::ConcatenateHeadsDecompositionRewritePattern>(
+          &getContext());
+      patterns.add<decomposition::GroupNormDecompositionRewritePattern>(
           &getContext());
     }
 

--- a/test/python/golden/ttir_ops/normalization/test_normalization.py
+++ b/test/python/golden/ttir_ops/normalization/test_normalization.py
@@ -663,7 +663,7 @@ def test_distributed_layer_norm(
 
 
 @pytest.mark.parametrize("num_groups", [8, 32])
-@pytest.mark.parametrize("shape", [(1, 8, 8, 480), (2, 32, 32, 320)])
+@pytest.mark.parametrize("shape", [(1, 8, 8, 480), (2, 32, 32, 320), (8, 32, 32, 128)])
 @pytest.mark.parametrize("has_weight", [True, False])
 @pytest.mark.parametrize("has_bias", [True, False])
 @pytest.mark.parametrize(
@@ -724,4 +724,7 @@ def test_group_norm(
         **get_request_kwargs(request),
         device=device,
         target=target,
+        pipeline_options=["enable-ttnn-decomposition-pass=false"]
+        if shape != (8, 32, 32, 128)
+        else None,
     )

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/group_norm_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/group_norm_decomposition.mlir
@@ -1,0 +1,73 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-decomposition -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 9216 + d1 * 9216 + d2, d3), <1x1>, memref<73728x128xf32, #dram>, <interleaved>>
+#ttnn_layout_affine = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x128xf32, #dram>, <interleaved>>
+
+// Test: full group_norm with weight and bias decomposes to primitives.
+// CHECK-LABEL: func.func @group_norm_weight_bias
+// CHECK-NOT: "ttnn.group_norm"
+// Reshape input from [N, 1, S, C] to [N, S, G, Cpg].
+// CHECK: "ttnn.reshape"
+// CHECK-SAME: shape = [8 : i32, 9216 : i32, 32 : i32, 4 : i32]
+// Per-group mean over (S, Cpg) = dims [1, 3].
+// CHECK: "ttnn.mean"
+// CHECK-SAME: dim_arg = [1 : i32, 3 : i32], keep_dim = true
+// Centering.
+// CHECK: "ttnn.subtract"
+// Square and variance.
+// CHECK: "ttnn.multiply"
+// CHECK: "ttnn.mean"
+// CHECK-SAME: dim_arg = [1 : i32, 3 : i32], keep_dim = true
+// eps tensor + (var + eps) + rsqrt.
+// CHECK: "ttnn.full"
+// CHECK: "ttnn.add"
+// CHECK: "ttnn.rsqrt"
+// Normalize and restore canonical [N, 1, S, C] shape.
+// CHECK: "ttnn.multiply"
+// CHECK: "ttnn.reshape"
+// CHECK-SAME: shape = [8 : i32, 1 : i32, 9216 : i32, 128 : i32]
+// Affine tail: weight reshape [C] -> [1, 1, 1, C], multiply.
+// CHECK: "ttnn.reshape"
+// CHECK-SAME: shape = [1 : i32, 1 : i32, 1 : i32, 128 : i32]
+// CHECK: "ttnn.multiply"
+// Affine tail: bias reshape [C] -> [1, 1, 1, C], add.
+// CHECK: "ttnn.reshape"
+// CHECK-SAME: shape = [1 : i32, 1 : i32, 1 : i32, 128 : i32]
+// CHECK: "ttnn.add"
+func.func @group_norm_weight_bias(
+    %arg0: tensor<8x1x9216x128xf32, #ttnn_layout>,
+    %arg1: tensor<128xf32, #ttnn_layout_affine>,
+    %arg2: tensor<128xf32, #ttnn_layout_affine>) -> tensor<8x1x9216x128xf32, #ttnn_layout> {
+  %0 = "ttnn.group_norm"(%arg0, %arg1, %arg2) <{num_groups = 32 : i64, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 1, 1>}> : (tensor<8x1x9216x128xf32, #ttnn_layout>, tensor<128xf32, #ttnn_layout_affine>, tensor<128xf32, #ttnn_layout_affine>) -> tensor<8x1x9216x128xf32, #ttnn_layout>
+  return %0 : tensor<8x1x9216x128xf32, #ttnn_layout>
+}
+
+// Test: group_norm without weight or bias still decomposes; no affine tail
+// is emitted.
+// CHECK-LABEL: func.func @group_norm_no_affine
+// CHECK-NOT: "ttnn.group_norm"
+// Group-split reshape, two means (mean and variance), and the normalize tail.
+// CHECK: "ttnn.reshape"
+// CHECK-SAME: shape = [8 : i32, 9216 : i32, 32 : i32, 4 : i32]
+// CHECK: "ttnn.mean"
+// CHECK: "ttnn.subtract"
+// CHECK: "ttnn.multiply"
+// CHECK: "ttnn.mean"
+// CHECK: "ttnn.full"
+// CHECK: "ttnn.add"
+// CHECK: "ttnn.rsqrt"
+// CHECK: "ttnn.multiply"
+// Restoring reshape is the LAST reshape - there must be no affine multiply or
+// affine reshape after it.
+// CHECK: "ttnn.reshape"
+// CHECK-SAME: shape = [8 : i32, 1 : i32, 9216 : i32, 128 : i32]
+// CHECK-NOT: "ttnn.multiply"
+// CHECK-NOT: "ttnn.add"
+// CHECK: return
+func.func @group_norm_no_affine(
+    %arg0: tensor<8x1x9216x128xf32, #ttnn_layout>) -> tensor<8x1x9216x128xf32, #ttnn_layout> {
+  %0 = "ttnn.group_norm"(%arg0) <{num_groups = 32 : i64, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<8x1x9216x128xf32, #ttnn_layout>) -> tensor<8x1x9216x128xf32, #ttnn_layout>
+  return %0 : tensor<8x1x9216x128xf32, #ttnn_layout>
+}

--- a/test/ttmlir/Dialect/TTNN/group_norm/simple_group_norm.mlir
+++ b/test/ttmlir/Dialect/TTNN/group_norm/simple_group_norm.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-ttnn-decomposition-pass=false" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 module {


### PR DESCRIPTION
 ### Problem description
Group norm can have problematic configurations that cannot be always executed on TT-device when coming directly from composite ops.

### What's changed
Added decomposition to primitive ops if optimizer is not enabled or if it cannot be verified to work. Simplified some decomposition logic to use existing helpers instead of duplicating them.

### Checklist
- [x] New/Existing tests provide coverage for changes
