### PR TITLE
unsqueeze attention sink too

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
@@ -519,6 +519,9 @@ bool SDPAFusing::prepareInputsForSDPA(SDPAComponents &c,
   c.query = unsqueezeTo4D(c.query);
   c.key = unsqueezeTo4D(c.key);
   c.value = unsqueezeTo4D(c.value);
+  if (c.attentionSink) {
+    c.attentionSink = unsqueezeTo4D(c.attentionSink);
+  }
 
   return true;
 }


### PR DESCRIPTION
### Ticket
Required for https://github.com/tenstorrent/tt-xla/pull/3795 to land

### Problem description
With AOTAutograd, attention sinks too can get squeezed to 3D

### What's changed
Add the unsqueeze on sink too

### Checklist
- [ ] New/Existing tests provide coverage for changes
