### PR TITLE
Uplift third_party/tt-metal to ab59a2ea9e894b73011e918aed1c78622d02a647 2026-05-17

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=58959914b35566efc8079a02add5428478adb30c
+ARG TT_METAL_DEPENDENCIES_COMMIT=ab59a2ea9e894b73011e918aed1c78622d02a647
 
 # Install dependencies
 RUN <<EOT

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -5993,9 +5993,9 @@ void mlir::tt::ttir::UpdateCacheOp::getCanonicalizationPatterns(
                        std::to_string(blockSize));
   }
 
-  if (numInputHeads % numCacheHeads != 0) {
-    return emitOpError("Input must have a number of heads that is a multiple "
-                       "of the number of heads in the cache.");
+  if (numInputHeads != numCacheHeads) {
+    return emitOpError(
+        "Input must have the same number of heads as the cache.");
   }
 
   if (inputShape[3] != headDim) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -4013,9 +4013,9 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
                        std::to_string(blockSize));
   }
 
-  if (numInputHeads % numCacheHeads != 0) {
-    return emitOpError("Input must have a number of heads that is a multiple "
-                       "of the number of heads in the cache.");
+  if (numInputHeads != numCacheHeads) {
+    return emitOpError(
+        "Input must have the same number of heads as the cache.");
   }
 
   if (inputShape[3] != headDim) {

--- a/test/ttmlir/Conversion/StableHLOToTTIR/transformer/paged_fill_cache.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/transformer/paged_fill_cache.mlir
@@ -4,9 +4,9 @@
 // RUN: FileCheck %s --input-file=%t
 
 module {
-  func.func @paged_fill_cache(%cache: tensor<128x4x32x256xbf16>, %fill_value: tensor<1x12x65x256xbf16>, %page_table: tensor<8x16xi32>, %batch_offset: tensor<1xi64>) -> tensor<128x4x32x256xbf16> {
+  func.func @paged_fill_cache(%cache: tensor<128x12x32x256xbf16>, %fill_value: tensor<1x12x65x256xbf16>, %page_table: tensor<8x16xi32>, %batch_offset: tensor<1xi64>) -> tensor<128x12x32x256xbf16> {
     // CHECK: "ttir.paged_fill_cache"
-    %0 = stablehlo.custom_call @tt.paged_fill_cache(%cache, %fill_value, %page_table, %batch_offset) : (tensor<128x4x32x256xbf16>, tensor<1x12x65x256xbf16>, tensor<8x16xi32>, tensor<1xi64>) -> tensor<128x4x32x256xbf16>
-    return %0 : tensor<128x4x32x256xbf16>
+    %0 = stablehlo.custom_call @tt.paged_fill_cache(%cache, %fill_value, %page_table, %batch_offset) : (tensor<128x12x32x256xbf16>, tensor<1x12x65x256xbf16>, tensor<8x16xi32>, tensor<1xi64>) -> tensor<128x12x32x256xbf16>
+    return %0 : tensor<128x12x32x256xbf16>
   }
 }

--- a/test/ttmlir/EmitC/TTNN/kv_cache/paged_fill_cache.mlir
+++ b/test/ttmlir/EmitC/TTNN/kv_cache/paged_fill_cache.mlir
@@ -10,10 +10,10 @@
 module {
   ttcore.device_module {
     builtin.module {
-      func.func @paged_fill_cache(%cache: tensor<128x4x32x256xbf16>, %input: tensor<1x12x65x256xbf16>, %page_table: tensor<8x16xi32>, %batch_idx_tensor: tensor<1xi64>) -> tensor<128x4x32x256xbf16> {
+      func.func @paged_fill_cache(%cache: tensor<128x12x32x256xbf16>, %input: tensor<1x12x65x256xbf16>, %page_table: tensor<8x16xi32>, %batch_idx_tensor: tensor<1xi64>) -> tensor<128x12x32x256xbf16> {
         // CHECK: "ttnn.paged_fill_cache"
-        %0 = "ttir.paged_fill_cache"(%cache, %input, %page_table, %batch_idx_tensor) : (tensor<128x4x32x256xbf16>, tensor<1x12x65x256xbf16>, tensor<8x16xi32>, tensor<1xi64>) -> tensor<128x4x32x256xbf16>
-        return %0 : tensor<128x4x32x256xbf16>
+        %0 = "ttir.paged_fill_cache"(%cache, %input, %page_table, %batch_idx_tensor) : (tensor<128x12x32x256xbf16>, tensor<1x12x65x256xbf16>, tensor<8x16xi32>, tensor<1xi64>) -> tensor<128x12x32x256xbf16>
+        return %0 : tensor<128x12x32x256xbf16>
       }
     }
   }

--- a/test/ttmlir/Silicon/TTNN/n150/transformer/paged_fill_cache.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/transformer/paged_fill_cache.mlir
@@ -5,10 +5,10 @@
 module {
   ttcore.device_module {
     builtin.module {
-      func.func @paged_fill_cache(%cache: tensor<128x4x32x256xbf16>, %input: tensor<1x12x65x256xbf16>, %page_table: tensor<8x16xi32>, %batch_idx_tensor: tensor<1xi64>) -> tensor<128x4x32x256xbf16> {
+      func.func @paged_fill_cache(%cache: tensor<128x12x32x256xbf16>, %input: tensor<1x12x65x256xbf16>, %page_table: tensor<8x16xi32>, %batch_idx_tensor: tensor<1xi64>) -> tensor<128x12x32x256xbf16> {
         // CHECK: "ttnn.paged_fill_cache"
-        %0 = "ttir.paged_fill_cache"(%cache, %input, %page_table, %batch_idx_tensor) : (tensor<128x4x32x256xbf16>, tensor<1x12x65x256xbf16>, tensor<8x16xi32>, tensor<1xi64>) -> tensor<128x4x32x256xbf16>
-        return %0 : tensor<128x4x32x256xbf16>
+        %0 = "ttir.paged_fill_cache"(%cache, %input, %page_table, %batch_idx_tensor) : (tensor<128x12x32x256xbf16>, tensor<1x12x65x256xbf16>, tensor<8x16xi32>, tensor<1xi64>) -> tensor<128x12x32x256xbf16>
+        return %0 : tensor<128x12x32x256xbf16>
       }
     }
   }

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -5605,7 +5605,7 @@ TEST_F(OpModelTest, PagedUpdateCacheOpWithoutPageTable) {
 TEST_F(OpModelTest, PagedFillCacheOp) {
   // Test basic PagedUpdateCacheOp with DRAM cache, input, update_index, and
   // page_table tensors
-  const llvm::SmallVector<int64_t> cacheShape = {128, 4, 32, 256};
+  const llvm::SmallVector<int64_t> cacheShape = {128, 12, 32, 256};
   const llvm::SmallVector<int64_t> inputShape = {1, 12, 65, 256};
   const llvm::SmallVector<int64_t> batchOffsetShape = {1};
   const llvm::SmallVector<int64_t> pageTableShape = {8, 16};

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -5611,7 +5611,7 @@ TEST_F(OpModelBase, PagedUpdateCacheOpInterface) {
 TEST_F(OpModelBase, PagedFillCacheOpInterface) {
   // Test PagedUpdateCacheOp with cache, input, update_index, and page_table
   // tensors
-  llvm::SmallVector<int64_t> cacheShape = {128, 4, 32, 256};
+  llvm::SmallVector<int64_t> cacheShape = {128, 12, 32, 256};
   llvm::SmallVector<int64_t> inputShape = {1, 12, 65, 256};
   llvm::SmallVector<int64_t> batchOffsetShape = {1};
   llvm::SmallVector<int64_t> pageTableShape = {8, 16};

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "58959914b35566efc8079a02add5428478adb30c")
+set(TT_METAL_VERSION "ab59a2ea9e894b73011e918aed1c78622d02a647")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the ab59a2ea9e894b73011e918aed1c78622d02a647

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25999606882
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/25998903114
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [x] **Frontend fix PRs** ready (if needed by this uplift):