### PR TITLE
Fix fused linear output rank for matmul-typed outputs (Pi0 action_in_proj / concat)

### DIFF
--- a/docs/evidence/pi0_linear_workaround_bisect/README.md
+++ b/docs/evidence/pi0_linear_workaround_bisect/README.md
@@ -1,0 +1,78 @@
+# Pi0 e2e bisect: `LinearOpOutputShapeRewritePattern` workaround
+
+Evidence for closing [tt-mlir#8459](https://github.com/tenstorrent/tt-mlir/pull/8459) without merge.
+
+Related issues: [tt-xla#4633](https://github.com/tenstorrent/tt-xla/issues/4633), [tt-metal#44094](https://github.com/tenstorrent/tt-metal/issues/44094).
+
+## Summary
+
+Three **tt-mlir** commits were built into the **same tt-xla** tree (`main` at `f491c9dd1`) using:
+
+```bash
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release \
+  -DUSE_CUSTOM_TT_MLIR_VERSION=ON \
+  -DTT_MLIR_VERSION=<commit>
+cmake --build build
+```
+
+Test (whole-model Pi0 e2e):
+
+```bash
+pytest -svv tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+```
+
+| Run | tt-mlir commit | `LinearOpOutputShapeRewritePattern` | Pi0 `pi0_base` result |
+|-----|----------------|-------------------------------------|------------------------|
+| 1 | `bb1deb417cef0e2c60147072cf7b6926a49ccca7` | **Present** (pre-#8328) | **FAILED** — `ttnn::concat` / `ShapeBase[] index out of range` |
+| 2 | `142346d3697b7f963dcf039584b5371e91835a5f` | **Removed** ([#8328](https://github.com/tenstorrent/tt-mlir/pull/8328)) | **PASSED** |
+| 3 | `eb9005fa360a80e44607e2dfd4404137b510092e` | **Removed** (current tt-xla pin) | **PASSED** |
+
+**Conclusion:** The `LinearOpOutputShapeRewritePattern` workaround is the culprit for this Pi0 e2e failure. Removing it in #8328 fixes the regression; current main remains healthy. **Do not re-land the workaround** via #8459.
+
+## Root cause (recap)
+
+- On Pi0’s fused TT graph (biased `action_in_proj` in `embed_suffix`), rank-mismatched operands reached `ttnn.concat` → `ShapeBase[] index out of range. 2 not in [-4, 2)`.
+- The workaround reshaped fused-linear outputs in ways that disagreed with downstream concat expectations on this graph.
+- #8328 removed the invalid workaround; Pi0 e2e passes on the removal commit and on latest main.
+
+## Key log excerpts
+
+### Run 1 — FAIL (`bb1deb417`, workaround present)
+
+```
+TT_THROW: ShapeBase[] index out of range. 2 not in [-4, 2)
+ --- ttnn::concat(...)
+...
+FAILED ... RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13
+```
+
+Full log: [logs/pi0_base_bb1deb41.log](logs/pi0_base_bb1deb41.log)
+
+### Run 2 — PASS (`142346d36`, #8328 removal)
+
+```
+| e2e_perf-avg_time: 0.016693990968633443
+PASSED
+```
+
+Full log: [logs/pi0_base_142346d3.log](logs/pi0_base_142346d3.log)
+
+### Run 3 — PASS (`eb9005fa3`, current main pin)
+
+```
+| e2e_perf-avg_time: 0.016800821060314775
+PASSED
+```
+
+Full log: [logs/pi0_base_eb9005fa.log](logs/pi0_base_eb9005fa.log)
+
+## Environment
+
+
+- **tt-xla:** `f491c9dd16f42271549e66343484dcedb72521ab` (main)
+- **Hardware:** Wormhole (single device)
+- **Date:** 2026-05-18 / 2026-05-19
+
+## Close #8459
+
+PR [#8459](https://github.com/tenstorrent/tt-mlir/pull/8459) re-extends `LinearOpOutputShapeRewritePattern` for Pi0. This bisect shows Pi0 **fails with the workaround** and **passes after #8328 removal** and on **current main**. Close as **not needed** — issue resolved on main by removing the workaround, not by restoring it.

--- a/docs/evidence/pi0_linear_workaround_bisect/logs/pi0_base_142346d3.log
+++ b/docs/evidence/pi0_linear_workaround_bisect/logs/pi0_base_142346d3.log
@@ -1,0 +1,294 @@
+2026-05-19 08:42:25.567 | WARNING  | torch_plugin_tt:__init__:40 - TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly.
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/bin/python
+cachedir: .pytest_cache
+metadata: {'Python': '3.12.3', 'Platform': 'Linux-5.4.0-212-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.3', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'metadata': '3.1.1', 'jaxtyping': '0.3.9', 'split': '0.11.0', 'forked': '1.6.0', 'anyio': '4.13.0'}}
+rootdir: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla
+configfile: pytest.ini
+plugins: json-report-1.5.0, metadata-3.1.1, jaxtyping-0.3.9, split-0.11.0, forked-1.6.0, anyio-4.13.0
+collecting ... 2026-05-19 08:42:42.186 | WARNING  | tests.runner.utils.dynamic_loader:discover_loader_paths:482 - Workaround to exclude model: suryaocr from discovery. Issue #1166
+Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
+Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
+2026-05-19 08:43:01.307 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov12/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-19 08:43:01.594 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov11/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-19 08:43:03.469 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov5/pytorch/loader.py: No module named 'pkg_resources'
+2026-05-19 08:43:12.932 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/sentencizer/pytorch/loader.py: cannot import name 'is_remote_url' from 'transformers.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/utils/__init__.py)
+2026-05-19 08:43:14.838 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov10/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-19 08:43:16.663 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov8/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-19 08:43:17.010 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/albert/masked_lm/jax/loader.py: cannot import name 'FlaxAlbertForMaskedLM' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+2026-05-19 08:43:17.015 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/t5/summarization/jax/loader.py: No module named 'transformers.models.t5.modeling_flax_t5'
+2026-05-19 08:43:17.033 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/mt5/nlp_summarization/jax/loader.py: No module named 'transformers.models.mt5.modeling_flax_mt5'
+2026-05-19 08:43:17.159 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/beit/image_classification/jax/loader.py: cannot import name 'FlaxBeitForImageClassification' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+2026-05-19 08:43:17.182 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/longt5/text_classification/jax/loader.py: No module named 'transformers.models.longt5.modeling_flax_longt5'
+2026-05-19 08:43:17.227 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/bert/masked_lm/jax/loader.py: cannot import name 'FlaxBertForMaskedLM' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+2026-05-19 08:43:17.241 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/bart/causal_lm/jax/loader.py: cannot import name 'FlaxBartForCausalLM' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+collected 1 item
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference] Running tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference] - pytorch_pi_0_pi0_base_mm_action_prediction_huggingface
+Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
+Collecting transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1))
+  Cloning https://github.com/huggingface/transformers.git (to revision fix/lerobot_openpi) to /tmp/pip-install-1j5k_zbz/transformers_9029e267dc484819bb608273402dad0d
+  Running command git clone --filter=blob:none --quiet https://github.com/huggingface/transformers.git /tmp/pip-install-1j5k_zbz/transformers_9029e267dc484819bb608273402dad0d
+  Running command git checkout -b fix/lerobot_openpi --track origin/fix/lerobot_openpi
+  Switched to a new branch 'fix/lerobot_openpi'
+  branch 'fix/lerobot_openpi' set up to track 'origin/fix/lerobot_openpi'.
+  Resolved https://github.com/huggingface/transformers.git to commit dcddb970176382c0fcf4521b0c0e6fc15894dfe0
+  Installing build dependencies: started
+  Installing build dependencies: finished with status 'done'
+  Getting requirements to build wheel: started
+  Getting requirements to build wheel: finished with status 'done'
+  Preparing metadata (pyproject.toml): started
+  Preparing metadata (pyproject.toml): finished with status 'done'
+Collecting tokenizers==0.21.1 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 2))
+  Using cached tokenizers-0.21.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.8 kB)
+Collecting draccus==0.10.0 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached draccus-0.10.0-py3-none-any.whl.metadata (24 kB)
+Collecting gymnasium==1.2.3 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4))
+  Using cached gymnasium-1.2.3-py3-none-any.whl.metadata (10 kB)
+Collecting torchcodec==0.10.0 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 5))
+  Using cached torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (11 kB)
+Collecting pyserial==3.5 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 6))
+  Using cached pyserial-3.5-py2.py3-none-any.whl.metadata (1.6 kB)
+Collecting deepdiff==8.6.1 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 7))
+  Using cached deepdiff-8.6.1-py3-none-any.whl.metadata (8.6 kB)
+Collecting av==15.0.0 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 8))
+  Using cached av-15.0.0-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (4.6 kB)
+Requirement already satisfied: filelock in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (3.29.0)
+Collecting huggingface-hub<1.0,>=0.30.0 (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1))
+  Using cached huggingface_hub-0.36.2-py3-none-any.whl.metadata (15 kB)
+Requirement already satisfied: numpy>=1.17 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2.1.2)
+Requirement already satisfied: packaging>=20.0 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (26.2)
+Requirement already satisfied: pyyaml>=5.1 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (6.0.1)
+Requirement already satisfied: regex!=2019.12.17 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2026.5.9)
+Requirement already satisfied: requests in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2.34.2)
+Requirement already satisfied: safetensors>=0.4.3 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (0.8.0rc0)
+Requirement already satisfied: tqdm>=4.27 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (4.67.3)
+Collecting mergedeep~=1.3 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached mergedeep-1.3.4-py3-none-any.whl.metadata (4.3 kB)
+Collecting pyyaml-include~=1.4 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached pyyaml_include-1.4.1-py3-none-any.whl.metadata (1.3 kB)
+Collecting toml~=0.10 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached toml-0.10.2-py2.py3-none-any.whl.metadata (7.1 kB)
+Collecting typing-inspect~=0.9.0 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached typing_inspect-0.9.0-py3-none-any.whl (8.8 kB)
+Collecting cloudpickle>=1.2.0 (from gymnasium==1.2.3->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4))
+  Using cached cloudpickle-3.1.2-py3-none-any.whl.metadata (7.1 kB)
+Requirement already satisfied: typing-extensions>=4.3.0 in ./venv/lib/python3.12/site-packages (from gymnasium==1.2.3->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4)) (4.15.0)
+Collecting farama-notifications>=0.0.1 (from gymnasium==1.2.3->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4))
+  Using cached farama_notifications-0.0.6-py3-none-any.whl.metadata (729 bytes)
+Collecting orderly-set<6,>=5.4.1 (from deepdiff==8.6.1->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 7))
+  Using cached orderly_set-5.5.0-py3-none-any.whl.metadata (6.6 kB)
+Requirement already satisfied: fsspec>=2023.5.0 in ./venv/lib/python3.12/site-packages (from huggingface-hub<1.0,>=0.30.0->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2025.10.0)
+Requirement already satisfied: hf-xet<2.0.0,>=1.1.3 in ./venv/lib/python3.12/site-packages (from huggingface-hub<1.0,>=0.30.0->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (1.5.0)
+Requirement already satisfied: mypy-extensions>=0.3.0 in ./venv/lib/python3.12/site-packages (from typing-inspect~=0.9.0->draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3)) (1.1.0)
+Requirement already satisfied: charset_normalizer<4,>=2 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (3.4.7)
+Requirement already satisfied: idna<4,>=2.5 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (3.15)
+Requirement already satisfied: urllib3<3,>=1.26 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2.7.0)
+Requirement already satisfied: certifi>=2023.5.7 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2026.4.22)
+Using cached tokenizers-0.21.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.0 MB)
+Using cached draccus-0.10.0-py3-none-any.whl (71 kB)
+Using cached gymnasium-1.2.3-py3-none-any.whl (952 kB)
+Using cached torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl (2.1 MB)
+Using cached pyserial-3.5-py2.py3-none-any.whl (90 kB)
+Using cached deepdiff-8.6.1-py3-none-any.whl (91 kB)
+Using cached av-15.0.0-cp312-cp312-manylinux_2_28_x86_64.whl (40.0 MB)
+Using cached huggingface_hub-0.36.2-py3-none-any.whl (566 kB)
+Using cached mergedeep-1.3.4-py3-none-any.whl (6.4 kB)
+Using cached orderly_set-5.5.0-py3-none-any.whl (13 kB)
+Using cached pyyaml_include-1.4.1-py3-none-any.whl (19 kB)
+Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
+Using cached cloudpickle-3.1.2-py3-none-any.whl (22 kB)
+Using cached farama_notifications-0.0.6-py3-none-any.whl (2.9 kB)
+Building wheels for collected packages: transformers
+  Building wheel for transformers (pyproject.toml): started
+  Building wheel for transformers (pyproject.toml): finished with status 'done'
+  Created wheel for transformers: filename=transformers-4.53.3-py3-none-any.whl size=10827916 sha256=d88ed46fbe8cb8a806321bf3088d125941856ffbf92081e17eaf2874859bd192
+  Stored in directory: /tmp/pip-ephem-wheel-cache-cmqdkibo/wheels/29/9c/af/9393d4342ca3b00939f0143419b1708e3d31ed8980de898431
+Successfully built transformers
+Installing collected packages: pyserial, farama-notifications, typing-inspect, torchcodec, toml, pyyaml-include, orderly-set, mergedeep, cloudpickle, av, huggingface-hub, gymnasium, draccus, deepdiff, tokenizers, transformers
+  Attempting uninstall: torchcodec
+    Found existing installation: torchcodec 0.12.0+cpu
+    Uninstalling torchcodec-0.12.0+cpu:
+      Successfully uninstalled torchcodec-0.12.0+cpu
+  Attempting uninstall: huggingface-hub
+    Found existing installation: huggingface_hub 1.15.0
+    Uninstalling huggingface_hub-1.15.0:
+      Successfully uninstalled huggingface_hub-1.15.0
+  Attempting uninstall: tokenizers
+    Found existing installation: tokenizers 0.22.2
+    Uninstalling tokenizers-0.22.2:
+      Successfully uninstalled tokenizers-0.22.2
+  WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~.kenizers'.
+  You can safely remove it manually.
+  Attempting uninstall: transformers
+    Found existing installation: transformers 5.2.0
+    Uninstalling transformers-5.2.0:
+      Successfully uninstalled transformers-5.2.0
+
+ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
+surya-ocr 0.17.1 requires transformers>=4.56.1, but you have transformers 4.53.3 which is incompatible.
+Successfully installed av-15.0.0 cloudpickle-3.1.2 deepdiff-8.6.1 draccus-0.10.0 farama-notifications-0.0.6 gymnasium-1.2.3 huggingface-hub-0.36.2 mergedeep-1.3.4 orderly-set-5.5.0 pyserial-3.5 pyyaml-include-1.4.1 tokenizers-0.21.1 toml-0.10.2 torchcodec-0.10.0 transformers-4.53.3 typing-inspect-0.9.0
+Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
+Collecting lerobot==0.4.3 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.nodeps.txt (line 1))
+  Using cached lerobot-0.4.3-py3-none-any.whl.metadata (17 kB)
+Using cached lerobot-0.4.3-py3-none-any.whl (993 kB)
+Installing collected packages: lerobot
+Successfully installed lerobot-0.4.3
+WARNING:root:No accelerated backend detected. Using default cpu, this will be slow.
+WARNING:lerobot.configs.policies:Device 'cuda' is not available. Switching to 'cpu'.
+WARNING:root:No accelerated backend detected. Using default cpu, this will be slow.
+WARNING:lerobot.configs.policies:Device 'cuda' is not available. Switching to 'cpu'.
+WARNING:root:Vision embedding key might need handling: paligemma_with_expert.paligemma.model.vision_tower.vision_model.embeddings.patch_embedding.bias
+WARNING:root:Vision embedding key might need handling: paligemma_with_expert.paligemma.model.vision_tower.vision_model.embeddings.patch_embedding.weight
+2026-05-19 08:47:35.841044: W torch_xla/csrc/runtime/profiler.cpp:88] Profiler API not found for PJRT plugin
+Found existing installation: av 15.0.0
+Uninstalling av-15.0.0:
+  Successfully uninstalled av-15.0.0
+WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~..libs'.
+You can safely remove it manually.
+WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~~av'.
+You can safely remove it manually.
+Found existing installation: cloudpickle 3.1.2
+Uninstalling cloudpickle-3.1.2:
+  Successfully uninstalled cloudpickle-3.1.2
+Found existing installation: deepdiff 8.6.1
+Uninstalling deepdiff-8.6.1:
+  Successfully uninstalled deepdiff-8.6.1
+Found existing installation: draccus 0.10.0
+Uninstalling draccus-0.10.0:
+  Successfully uninstalled draccus-0.10.0
+Found existing installation: Farama-Notifications 0.0.6
+Uninstalling Farama-Notifications-0.0.6:
+  Successfully uninstalled Farama-Notifications-0.0.6
+Found existing installation: gymnasium 1.2.3
+Uninstalling gymnasium-1.2.3:
+  Successfully uninstalled gymnasium-1.2.3
+Found existing installation: lerobot 0.4.3
+Uninstalling lerobot-0.4.3:
+  Successfully uninstalled lerobot-0.4.3
+Found existing installation: mergedeep 1.3.4
+Uninstalling mergedeep-1.3.4:
+  Successfully uninstalled mergedeep-1.3.4
+Found existing installation: orderly-set 5.5.0
+Uninstalling orderly-set-5.5.0:
+  Successfully uninstalled orderly-set-5.5.0
+Found existing installation: pyserial 3.5
+Uninstalling pyserial-3.5:
+  Successfully uninstalled pyserial-3.5
+Found existing installation: pyyaml-include 1.4.1
+Uninstalling pyyaml-include-1.4.1:
+  Successfully uninstalled pyyaml-include-1.4.1
+Found existing installation: toml 0.10.2
+Uninstalling toml-0.10.2:
+  Successfully uninstalled toml-0.10.2
+Found existing installation: typing-inspect 0.9.0
+Uninstalling typing-inspect-0.9.0:
+  Successfully uninstalled typing-inspect-0.9.0
+Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
+Collecting huggingface_hub==1.15.0 (from -r /tmp/tt_xla_restore_9kuleedj.txt (line 1))
+  Using cached huggingface_hub-1.15.0-py3-none-any.whl.metadata (14 kB)
+Collecting tokenizers==0.22.2 (from -r /tmp/tt_xla_restore_9kuleedj.txt (line 2))
+  Using cached tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (7.3 kB)
+Collecting torchcodec==0.12.0+cpu (from -r /tmp/tt_xla_restore_9kuleedj.txt (line 3))
+  Using cached torchcodec-0.12.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (11 kB)
+Collecting transformers==5.2.0 (from -r /tmp/tt_xla_restore_9kuleedj.txt (line 4))
+  Using cached transformers-5.2.0-py3-none-any.whl.metadata (32 kB)
+Requirement already satisfied: filelock>=3.10.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (3.29.0)
+Requirement already satisfied: fsspec>=2023.5.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (2025.10.0)
+Requirement already satisfied: hf-xet<2.0.0,>=1.4.3 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (1.5.0)
+Requirement already satisfied: httpx<1,>=0.23.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (0.28.1)
+Requirement already satisfied: packaging>=20.9 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (26.2)
+Requirement already satisfied: pyyaml>=5.1 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (6.0.1)
+Requirement already satisfied: tqdm>=4.42.1 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (4.67.3)
+Requirement already satisfied: typer>=0.20.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (0.25.1)
+Requirement already satisfied: typing-extensions>=4.1.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (4.15.0)
+Requirement already satisfied: numpy>=1.17 in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 4)) (2.1.2)
+Requirement already satisfied: regex!=2019.12.17 in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 4)) (2026.5.9)
+Requirement already satisfied: typer-slim in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 4)) (0.24.0)
+Requirement already satisfied: safetensors>=0.4.3 in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 4)) (0.8.0rc0)
+Requirement already satisfied: anyio in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (4.13.0)
+Requirement already satisfied: certifi in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (2026.4.22)
+Requirement already satisfied: httpcore==1.* in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (1.0.9)
+Requirement already satisfied: idna in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (3.15)
+Requirement already satisfied: h11>=0.16 in ./venv/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (0.16.0)
+Requirement already satisfied: click>=8.2.1 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (8.3.1)
+Requirement already satisfied: shellingham>=1.3.0 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (1.5.4)
+Requirement already satisfied: rich>=13.8.0 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (15.0.0)
+Requirement already satisfied: annotated-doc>=0.0.2 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (0.0.4)
+Requirement already satisfied: markdown-it-py>=2.2.0 in ./venv/lib/python3.12/site-packages (from rich>=13.8.0->typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (4.2.0)
+Requirement already satisfied: pygments<3.0.0,>=2.13.0 in ./venv/lib/python3.12/site-packages (from rich>=13.8.0->typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (2.20.0)
+Requirement already satisfied: mdurl~=0.1 in ./venv/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=13.8.0->typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_9kuleedj.txt (line 1)) (0.1.2)
+Using cached huggingface_hub-1.15.0-py3-none-any.whl (663 kB)
+Using cached tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.3 MB)
+Using cached torchcodec-0.12.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl (2.4 MB)
+Using cached transformers-5.2.0-py3-none-any.whl (10.4 MB)
+Installing collected packages: torchcodec, huggingface_hub, tokenizers, transformers
+  Attempting uninstall: torchcodec
+    Found existing installation: torchcodec 0.10.0
+    Uninstalling torchcodec-0.10.0:
+      Successfully uninstalled torchcodec-0.10.0
+  WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~.rchcodec'.
+  You can safely remove it manually.
+  Attempting uninstall: huggingface_hub
+    Found existing installation: huggingface_hub 0.36.2
+    Uninstalling huggingface_hub-0.36.2:
+      Successfully uninstalled huggingface_hub-0.36.2
+  Attempting uninstall: tokenizers
+    Found existing installation: tokenizers 0.21.1
+    Uninstalling tokenizers-0.21.1:
+      Successfully uninstalled tokenizers-0.21.1
+  Attempting uninstall: transformers
+    Found existing installation: transformers 4.53.3
+    Uninstalling transformers-4.53.3:
+      Successfully uninstalled transformers-4.53.3
+
+Successfully installed huggingface_hub-1.15.0 tokenizers-0.22.2 torchcodec-0.12.0+cpu transformers-5.2.0
+The PI0 model is a direct port of the OpenPI implementation. 
+This implementation follows the original OpenPI structure for compatibility. 
+Original implementation: https://github.com/Physical-Intelligence/openpi
+Loading model from: lerobot/pi0_base
+✓ Loaded state dict from model.safetensors
+Remapped 777 state dict keys
+Warning: Could not remap state dict keys: Error(s) in loading state_dict for PI0Policy:
+	Missing key(s) in state_dict: "model.paligemma_with_expert.paligemma.model.language_model.embed_tokens.weight". 
+====================================================================
+| pytorch_pi_0_pi0_base_mm_action_prediction_huggingface BENCHMARK:  
+--------------------------------------------------------------------
+| e2e_perf-total_samples: 2
+| e2e_perf-total_time: 0.033387981937266886
+| e2e_perf-avg_time: 0.016693990968633443
+| e2e_perf-perf_time_1: 0.016772227943874896
+| e2e_perf-perf_time_2: 0.01661575399339199
+====================================================================
+PASSED
+
+=============================== warnings summary ===============================
+venv/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+    warnings.warn(
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+
+venv/lib/python3.12/site-packages/torch/jit/_script.py:1480
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/torch/jit/_script.py:1480: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
+    warnings.warn(
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /home/ctr-akannan/.local/python/lib/python3.12/copyreg.py:99: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
+    return cls.__new__(cls, *args)
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/tests/conftest.py:524: FutureWarning: `torch.distributed.reduce_op` is deprecated, please use `torch.distributed.ReduceOp` instead
+    if isinstance(obj, torch.fx.GraphModule):
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/tests/conftest.py:528: FutureWarning: `torch.distributed.reduce_op` is deprecated, please use `torch.distributed.ReduceOp` instead
+    if isinstance(obj, GraphInputMatcher):
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+================= 1 passed, 20 warnings in 1252.31s (0:20:52) ==================
+sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

--- a/docs/evidence/pi0_linear_workaround_bisect/logs/pi0_base_bb1deb41.log
+++ b/docs/evidence/pi0_linear_workaround_bisect/logs/pi0_base_bb1deb41.log
@@ -1,0 +1,412 @@
+2026-05-18 19:57:07.929 | WARNING  | torch_plugin_tt:__init__:40 - TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly.
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/bin/python
+cachedir: .pytest_cache
+metadata: {'Python': '3.12.3', 'Platform': 'Linux-5.4.0-212-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.3', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'metadata': '3.1.1', 'jaxtyping': '0.3.9', 'split': '0.11.0', 'forked': '1.6.0', 'anyio': '4.13.0'}}
+rootdir: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla
+configfile: pytest.ini
+plugins: json-report-1.5.0, metadata-3.1.1, jaxtyping-0.3.9, split-0.11.0, forked-1.6.0, anyio-4.13.0
+collecting ... 2026-05-18 19:57:23.049 | WARNING  | tests.runner.utils.dynamic_loader:discover_loader_paths:482 - Workaround to exclude model: suryaocr from discovery. Issue #1166
+Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
+Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
+2026-05-18 19:57:37.257 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov12/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-18 19:57:37.556 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov11/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-18 19:57:40.134 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov5/pytorch/loader.py: No module named 'pkg_resources'
+2026-05-18 19:57:49.474 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/sentencizer/pytorch/loader.py: cannot import name 'is_remote_url' from 'transformers.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/utils/__init__.py)
+2026-05-18 19:57:52.734 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov10/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-18 19:57:54.674 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov8/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-18 19:57:54.913 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/albert/masked_lm/jax/loader.py: cannot import name 'FlaxAlbertForMaskedLM' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+2026-05-18 19:57:54.919 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/t5/summarization/jax/loader.py: No module named 'transformers.models.t5.modeling_flax_t5'
+2026-05-18 19:57:54.934 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/mt5/nlp_summarization/jax/loader.py: No module named 'transformers.models.mt5.modeling_flax_mt5'
+2026-05-18 19:57:55.018 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/beit/image_classification/jax/loader.py: cannot import name 'FlaxBeitForImageClassification' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+2026-05-18 19:57:55.042 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/longt5/text_classification/jax/loader.py: No module named 'transformers.models.longt5.modeling_flax_longt5'
+2026-05-18 19:57:55.090 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/bert/masked_lm/jax/loader.py: cannot import name 'FlaxBertForMaskedLM' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+2026-05-18 19:57:55.104 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/bart/causal_lm/jax/loader.py: cannot import name 'FlaxBartForCausalLM' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+collected 1 item
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference] Running tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference] - pytorch_pi_0_pi0_base_mm_action_prediction_huggingface
+Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
+Collecting transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1))
+  Cloning https://github.com/huggingface/transformers.git (to revision fix/lerobot_openpi) to /tmp/pip-install-ckv2mzz3/transformers_c17f3b6e093440b3b2d93dcece09797b
+  Running command git clone --filter=blob:none --quiet https://github.com/huggingface/transformers.git /tmp/pip-install-ckv2mzz3/transformers_c17f3b6e093440b3b2d93dcece09797b
+  Running command git checkout -b fix/lerobot_openpi --track origin/fix/lerobot_openpi
+  Switched to a new branch 'fix/lerobot_openpi'
+  branch 'fix/lerobot_openpi' set up to track 'origin/fix/lerobot_openpi'.
+  Resolved https://github.com/huggingface/transformers.git to commit dcddb970176382c0fcf4521b0c0e6fc15894dfe0
+  Installing build dependencies: started
+  Installing build dependencies: finished with status 'done'
+  Getting requirements to build wheel: started
+  Getting requirements to build wheel: finished with status 'done'
+  Preparing metadata (pyproject.toml): started
+  Preparing metadata (pyproject.toml): finished with status 'done'
+Collecting tokenizers==0.21.1 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 2))
+  Using cached tokenizers-0.21.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.8 kB)
+Collecting draccus==0.10.0 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached draccus-0.10.0-py3-none-any.whl.metadata (24 kB)
+Collecting gymnasium==1.2.3 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4))
+  Using cached gymnasium-1.2.3-py3-none-any.whl.metadata (10 kB)
+Collecting torchcodec==0.10.0 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 5))
+  Using cached torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (11 kB)
+Collecting pyserial==3.5 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 6))
+  Using cached pyserial-3.5-py2.py3-none-any.whl.metadata (1.6 kB)
+Collecting deepdiff==8.6.1 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 7))
+  Using cached deepdiff-8.6.1-py3-none-any.whl.metadata (8.6 kB)
+Collecting av==15.0.0 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 8))
+  Using cached av-15.0.0-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (4.6 kB)
+Requirement already satisfied: filelock in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (3.29.0)
+Collecting huggingface-hub<1.0,>=0.30.0 (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1))
+  Using cached huggingface_hub-0.36.2-py3-none-any.whl.metadata (15 kB)
+Requirement already satisfied: numpy>=1.17 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2.1.2)
+Requirement already satisfied: packaging>=20.0 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (26.2)
+Requirement already satisfied: pyyaml>=5.1 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (6.0.1)
+Requirement already satisfied: regex!=2019.12.17 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2026.5.9)
+Requirement already satisfied: requests in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2.34.2)
+Requirement already satisfied: safetensors>=0.4.3 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (0.8.0rc0)
+Requirement already satisfied: tqdm>=4.27 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (4.67.3)
+Collecting mergedeep~=1.3 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached mergedeep-1.3.4-py3-none-any.whl.metadata (4.3 kB)
+Collecting pyyaml-include~=1.4 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached pyyaml_include-1.4.1-py3-none-any.whl.metadata (1.3 kB)
+Collecting toml~=0.10 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached toml-0.10.2-py2.py3-none-any.whl.metadata (7.1 kB)
+Collecting typing-inspect~=0.9.0 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached typing_inspect-0.9.0-py3-none-any.whl (8.8 kB)
+Collecting cloudpickle>=1.2.0 (from gymnasium==1.2.3->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4))
+  Using cached cloudpickle-3.1.2-py3-none-any.whl.metadata (7.1 kB)
+Requirement already satisfied: typing-extensions>=4.3.0 in ./venv/lib/python3.12/site-packages (from gymnasium==1.2.3->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4)) (4.15.0)
+Collecting farama-notifications>=0.0.1 (from gymnasium==1.2.3->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4))
+  Using cached farama_notifications-0.0.6-py3-none-any.whl.metadata (729 bytes)
+Collecting orderly-set<6,>=5.4.1 (from deepdiff==8.6.1->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 7))
+  Using cached orderly_set-5.5.0-py3-none-any.whl.metadata (6.6 kB)
+Requirement already satisfied: fsspec>=2023.5.0 in ./venv/lib/python3.12/site-packages (from huggingface-hub<1.0,>=0.30.0->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2025.10.0)
+Requirement already satisfied: hf-xet<2.0.0,>=1.1.3 in ./venv/lib/python3.12/site-packages (from huggingface-hub<1.0,>=0.30.0->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (1.5.0)
+Requirement already satisfied: mypy-extensions>=0.3.0 in ./venv/lib/python3.12/site-packages (from typing-inspect~=0.9.0->draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3)) (1.1.0)
+Requirement already satisfied: charset_normalizer<4,>=2 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (3.4.7)
+Requirement already satisfied: idna<4,>=2.5 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (3.15)
+Requirement already satisfied: urllib3<3,>=1.26 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2.7.0)
+Requirement already satisfied: certifi>=2023.5.7 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2026.4.22)
+Using cached tokenizers-0.21.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.0 MB)
+Using cached draccus-0.10.0-py3-none-any.whl (71 kB)
+Using cached gymnasium-1.2.3-py3-none-any.whl (952 kB)
+Using cached torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl (2.1 MB)
+Using cached pyserial-3.5-py2.py3-none-any.whl (90 kB)
+Using cached deepdiff-8.6.1-py3-none-any.whl (91 kB)
+Using cached av-15.0.0-cp312-cp312-manylinux_2_28_x86_64.whl (40.0 MB)
+Using cached huggingface_hub-0.36.2-py3-none-any.whl (566 kB)
+Using cached mergedeep-1.3.4-py3-none-any.whl (6.4 kB)
+Using cached orderly_set-5.5.0-py3-none-any.whl (13 kB)
+Using cached pyyaml_include-1.4.1-py3-none-any.whl (19 kB)
+Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
+Using cached cloudpickle-3.1.2-py3-none-any.whl (22 kB)
+Using cached farama_notifications-0.0.6-py3-none-any.whl (2.9 kB)
+Building wheels for collected packages: transformers
+  Building wheel for transformers (pyproject.toml): started
+  Building wheel for transformers (pyproject.toml): finished with status 'done'
+  Created wheel for transformers: filename=transformers-4.53.3-py3-none-any.whl size=10827916 sha256=28d2e50d82f4d38c6b92fe50aca6ce7904fe4c36598beafcf9c17cc5de11b157
+  Stored in directory: /tmp/pip-ephem-wheel-cache-4olwzote/wheels/29/9c/af/9393d4342ca3b00939f0143419b1708e3d31ed8980de898431
+Successfully built transformers
+Installing collected packages: pyserial, farama-notifications, typing-inspect, torchcodec, toml, pyyaml-include, orderly-set, mergedeep, cloudpickle, av, huggingface-hub, gymnasium, draccus, deepdiff, tokenizers, transformers
+  Attempting uninstall: torchcodec
+    Found existing installation: torchcodec 0.12.0+cpu
+    Uninstalling torchcodec-0.12.0+cpu:
+      Successfully uninstalled torchcodec-0.12.0+cpu
+  Attempting uninstall: huggingface-hub
+    Found existing installation: huggingface_hub 1.15.0
+    Uninstalling huggingface_hub-1.15.0:
+      Successfully uninstalled huggingface_hub-1.15.0
+  Attempting uninstall: tokenizers
+    Found existing installation: tokenizers 0.22.2
+    Uninstalling tokenizers-0.22.2:
+      Successfully uninstalled tokenizers-0.22.2
+  WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~~kenizers'.
+  You can safely remove it manually.
+  Attempting uninstall: transformers
+    Found existing installation: transformers 5.2.0
+    Uninstalling transformers-5.2.0:
+      Successfully uninstalled transformers-5.2.0
+
+ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
+surya-ocr 0.17.1 requires transformers>=4.56.1, but you have transformers 4.53.3 which is incompatible.
+Successfully installed av-15.0.0 cloudpickle-3.1.2 deepdiff-8.6.1 draccus-0.10.0 farama-notifications-0.0.6 gymnasium-1.2.3 huggingface-hub-0.36.2 mergedeep-1.3.4 orderly-set-5.5.0 pyserial-3.5 pyyaml-include-1.4.1 tokenizers-0.21.1 toml-0.10.2 torchcodec-0.10.0 transformers-4.53.3 typing-inspect-0.9.0
+Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
+Collecting lerobot==0.4.3 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.nodeps.txt (line 1))
+  Using cached lerobot-0.4.3-py3-none-any.whl.metadata (17 kB)
+Using cached lerobot-0.4.3-py3-none-any.whl (993 kB)
+Installing collected packages: lerobot
+Successfully installed lerobot-0.4.3
+WARNING:root:No accelerated backend detected. Using default cpu, this will be slow.
+WARNING:lerobot.configs.policies:Device 'cuda' is not available. Switching to 'cpu'.
+WARNING:root:No accelerated backend detected. Using default cpu, this will be slow.
+WARNING:lerobot.configs.policies:Device 'cuda' is not available. Switching to 'cpu'.
+WARNING:root:Vision embedding key might need handling: paligemma_with_expert.paligemma.model.vision_tower.vision_model.embeddings.patch_embedding.bias
+WARNING:root:Vision embedding key might need handling: paligemma_with_expert.paligemma.model.vision_tower.vision_model.embeddings.patch_embedding.weight
+2026-05-18 20:01:18.492278: W torch_xla/csrc/runtime/profiler.cpp:88] Profiler API not found for PJRT plugin
+2026-05-18 20:12:58.899 | critical |          Always | TT_THROW: ShapeBase[] index out of range. 2 not in [-4, 2) (assert.hpp:104)
+2026-05-18 20:12:59.295 ( 951.367s) [        DE7F86C0]                utils.h:62     ERR| Exception:
+{TT_THROW @ /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/common/shape_base.cpp:16: tt::exception
+info:
+ShapeBase[] index out of range. 2 not in [-4, 2)
+backtrace:
+ --- /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt-mlir/install/lib/libtt_metal.so(+0x96e8ea) [0x7f83c54598ea]
+ --- /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt-mlir/install/lib/libtt_metal.so(+0x967e04) [0x7f83c5452e04]
+ --- /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt-mlir/install/lib/_ttnncpp.so(+0xbcda9f) [0x7f83c3aa4a9f]
+ --- ttnn::concat(std::vector<tt::tt_metal::Tensor, std::allocator<tt::tt_metal::Tensor> > const&, int, std::optional<tt::tt_metal::MemoryConfig> const&, std::optional<tt::tt_metal::Tensor> const&, unsigned int, std::optional<tt::tt_metal::CoreRangeSet> const&)
+ --- tt::runtime::ttnn::operations::data_movement::run(tt::target::ttnn::ConcatOp const*, tt::runtime::ttnn::ProgramContext&)
+ --- tt::runtime::ttnn::ProgramExecutor::runOperation(tt::target::ttnn::Operation const*)
+ --- tt::runtime::ttnn::ProgramExecutor::execute()
+ --- tt::runtime::ttnn::submit(tt::runtime::Device, tt::runtime::Binary, unsigned int, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&)
+ --- tt::runtime::submit(tt::runtime::Device, tt::runtime::Binary, unsigned int, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&)
+ --- std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> > std::__invoke_impl<std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> > (&)(tt::runtime::Device, tt::runtime::Binary, unsigned int, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&), tt::runtime::Device&, tt::runtime::Binary const&, unsigned int&, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&>(std::__invoke_other, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> > (&)(tt::runtime::Device, tt::runtime::Binary, unsigned int, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&), tt::runtime::Device&, tt::runtime::Binary const&, unsigned int&, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&)
+ --- std::optional<std::conditional<std::is_same_v<std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >, void>, std::monostate, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> > >::type> tt::pjrt::utils::invoke_noexcept<std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> > (&)(tt::runtime::Device, tt::runtime::Binary, unsigned int, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&), tt::runtime::Device&, tt::runtime::Binary const&, unsigned int&, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> > >(std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> > (&)(tt::runtime::Device, tt::runtime::Binary, unsigned int, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&), tt::runtime::Device&, tt::runtime::Binary const&, unsigned int&, std::vector<tt::runtime::Tensor, std::allocator<tt::runtime::Tensor> >&)
+ --- tt::pjrt::FlatbufferLoadedExecutableInstance::execute(PJRT_LoadedExecutable_Execute_Args*)
+ --- tt::pjrt::internal::onLoadedExecutableExecute(PJRT_LoadedExecutable_Execute_Args*)
+ --- xla::PjRtCApiLoadedExecutable::ExecuteWithSingleDevice(absl::lts_20230802::Span<xla::PjRtBuffer* const>, xla::PjRtDevice*, xla::ExecuteOptions const&, std::optional<xla::PjRtFuture<void> >&, bool)
+ --- xla::PjRtCApiLoadedExecutable::ExecutePortable(absl::lts_20230802::Span<xla::PjRtBuffer* const>, xla::PjRtDevice*, xla::ExecuteOptions const&, std::optional<xla::PjRtFuture<void> >&, bool)
+ --- torch_xla::runtime::PjRtComputationClient::ExecuteComputation(torch_xla::runtime::ComputationClient::Computation const&, absl::lts_20230802::Span<std::shared_ptr<torch_xla::runtime::ComputationClient::Data> const>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, torch_xla::runtime::ComputationClient::ExecuteComputationOptions const&)
+ --- torch_xla::XlaBackendImpl::ExecuteComputation(std::shared_ptr<torch::lazy::Computation>, c10::ArrayRef<std::shared_ptr<torch::lazy::BackendData> >, torch::lazy::BackendDevice const&) const
+ --- /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/_XLAC.cpython-312-x86_64-linux-gnu.so(+0x6dff560) [0x7f8408278560]
+ --- torch::lazy::MultiWait::Complete(std::function<void ()> const&)
+ --- Eigen::ThreadPoolTempl<tsl::thread::EigenEnvironment>::WorkerLoop(int)
+ --- void absl::lts_20230802::internal_any_invocable::RemoteInvoker<false, void, tsl::thread::EigenEnvironment::CreateThread(std::function<void ()>)::{lambda()#1}&>(absl::lts_20230802::internal_any_invocable::TypeErasedState*)
+ --- /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/_XLAC.cpython-312-x86_64-linux-gnu.so(+0x116a3112) [0x7f8412b1c112]
+ --- /lib/x86_64-linux-gnu/libc.so.6(+0x9caa4) [0x7f84446b5aa4]
+ --- /lib/x86_64-linux-gnu/libc.so.6(+0x129c6c) [0x7f8444742c6c]
+}
+
+Found existing installation: av 15.0.0
+Uninstalling av-15.0.0:
+  Successfully uninstalled av-15.0.0
+WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~~.libs'.
+You can safely remove it manually.
+WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~-av'.
+You can safely remove it manually.
+Found existing installation: cloudpickle 3.1.2
+Uninstalling cloudpickle-3.1.2:
+  Successfully uninstalled cloudpickle-3.1.2
+Found existing installation: deepdiff 8.6.1
+Uninstalling deepdiff-8.6.1:
+  Successfully uninstalled deepdiff-8.6.1
+Found existing installation: draccus 0.10.0
+Uninstalling draccus-0.10.0:
+  Successfully uninstalled draccus-0.10.0
+Found existing installation: Farama-Notifications 0.0.6
+Uninstalling Farama-Notifications-0.0.6:
+  Successfully uninstalled Farama-Notifications-0.0.6
+Found existing installation: gymnasium 1.2.3
+Uninstalling gymnasium-1.2.3:
+  Successfully uninstalled gymnasium-1.2.3
+Found existing installation: lerobot 0.4.3
+Uninstalling lerobot-0.4.3:
+  Successfully uninstalled lerobot-0.4.3
+Found existing installation: mergedeep 1.3.4
+Uninstalling mergedeep-1.3.4:
+  Successfully uninstalled mergedeep-1.3.4
+Found existing installation: orderly-set 5.5.0
+Uninstalling orderly-set-5.5.0:
+  Successfully uninstalled orderly-set-5.5.0
+Found existing installation: pyserial 3.5
+Uninstalling pyserial-3.5:
+  Successfully uninstalled pyserial-3.5
+Found existing installation: pyyaml-include 1.4.1
+Uninstalling pyyaml-include-1.4.1:
+  Successfully uninstalled pyyaml-include-1.4.1
+Found existing installation: toml 0.10.2
+Uninstalling toml-0.10.2:
+  Successfully uninstalled toml-0.10.2
+Found existing installation: typing-inspect 0.9.0
+Uninstalling typing-inspect-0.9.0:
+  Successfully uninstalled typing-inspect-0.9.0
+Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
+Collecting huggingface_hub==1.15.0 (from -r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1))
+  Using cached huggingface_hub-1.15.0-py3-none-any.whl.metadata (14 kB)
+Collecting tokenizers==0.22.2 (from -r /tmp/tt_xla_restore_cfl1o3ff.txt (line 2))
+  Using cached tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (7.3 kB)
+Collecting torchcodec==0.12.0+cpu (from -r /tmp/tt_xla_restore_cfl1o3ff.txt (line 3))
+  Using cached torchcodec-0.12.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (11 kB)
+Collecting transformers==5.2.0 (from -r /tmp/tt_xla_restore_cfl1o3ff.txt (line 4))
+  Using cached transformers-5.2.0-py3-none-any.whl.metadata (32 kB)
+Requirement already satisfied: filelock>=3.10.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (3.29.0)
+Requirement already satisfied: fsspec>=2023.5.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (2025.10.0)
+Requirement already satisfied: hf-xet<2.0.0,>=1.4.3 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (1.5.0)
+Requirement already satisfied: httpx<1,>=0.23.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (0.28.1)
+Requirement already satisfied: packaging>=20.9 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (26.2)
+Requirement already satisfied: pyyaml>=5.1 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (6.0.1)
+Requirement already satisfied: tqdm>=4.42.1 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (4.67.3)
+Requirement already satisfied: typer>=0.20.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (0.25.1)
+Requirement already satisfied: typing-extensions>=4.1.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (4.15.0)
+Requirement already satisfied: numpy>=1.17 in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 4)) (2.1.2)
+Requirement already satisfied: regex!=2019.12.17 in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 4)) (2026.5.9)
+Requirement already satisfied: typer-slim in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 4)) (0.24.0)
+Requirement already satisfied: safetensors>=0.4.3 in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 4)) (0.8.0rc0)
+Requirement already satisfied: anyio in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (4.13.0)
+Requirement already satisfied: certifi in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (2026.4.22)
+Requirement already satisfied: httpcore==1.* in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (1.0.9)
+Requirement already satisfied: idna in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (3.15)
+Requirement already satisfied: h11>=0.16 in ./venv/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (0.16.0)
+Requirement already satisfied: click>=8.2.1 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (8.3.1)
+Requirement already satisfied: shellingham>=1.3.0 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (1.5.4)
+Requirement already satisfied: rich>=13.8.0 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (15.0.0)
+Requirement already satisfied: annotated-doc>=0.0.2 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (0.0.4)
+Requirement already satisfied: markdown-it-py>=2.2.0 in ./venv/lib/python3.12/site-packages (from rich>=13.8.0->typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (4.2.0)
+Requirement already satisfied: pygments<3.0.0,>=2.13.0 in ./venv/lib/python3.12/site-packages (from rich>=13.8.0->typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (2.20.0)
+Requirement already satisfied: mdurl~=0.1 in ./venv/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=13.8.0->typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_cfl1o3ff.txt (line 1)) (0.1.2)
+Using cached huggingface_hub-1.15.0-py3-none-any.whl (663 kB)
+Using cached tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.3 MB)
+Using cached torchcodec-0.12.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl (2.4 MB)
+Using cached transformers-5.2.0-py3-none-any.whl (10.4 MB)
+Installing collected packages: torchcodec, huggingface_hub, tokenizers, transformers
+  Attempting uninstall: torchcodec
+    Found existing installation: torchcodec 0.10.0
+    Uninstalling torchcodec-0.10.0:
+      Successfully uninstalled torchcodec-0.10.0
+  WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~~rchcodec'.
+  You can safely remove it manually.
+  Attempting uninstall: huggingface_hub
+    Found existing installation: huggingface_hub 0.36.2
+    Uninstalling huggingface_hub-0.36.2:
+      Successfully uninstalled huggingface_hub-0.36.2
+  Attempting uninstall: tokenizers
+    Found existing installation: tokenizers 0.21.1
+    Uninstalling tokenizers-0.21.1:
+      Successfully uninstalled tokenizers-0.21.1
+  Attempting uninstall: transformers
+    Found existing installation: transformers 4.53.3
+    Uninstalling transformers-4.53.3:
+      Successfully uninstalled transformers-4.53.3
+
+Successfully installed huggingface_hub-1.15.0 tokenizers-0.22.2 torchcodec-0.12.0+cpu transformers-5.2.0
+The PI0 model is a direct port of the OpenPI implementation. 
+This implementation follows the original OpenPI structure for compatibility. 
+Original implementation: https://github.com/Physical-Intelligence/openpi
+Loading model from: lerobot/pi0_base
+✓ Loaded state dict from model.safetensors
+Remapped 777 state dict keys
+Warning: Could not remap state dict keys: Error(s) in loading state_dict for PI0Policy:
+	Missing key(s) in state_dict: "model.paligemma_with_expert.paligemma.model.language_model.embed_tokens.weight". 
+====================================================================
+| pytorch_pi_0_pi0_base_mm_action_prediction_huggingface BENCHMARK:  
+--------------------------------------------------------------------
+| e2e_perf-total_samples: -1
+| e2e_perf-total_time: -1
+====================================================================
+FAILED
+
+=================================== FAILURES ===================================
+_____ test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference] _____
+tests/runner/test_models.py:340: in test_all_models_torch
+    _run_model_test_impl(
+tests/runner/test_models.py:195: in _run_model_test_impl
+    comparison_result, tt_result = tester.test(request=request)
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infra/testers/single_chip/model/model_tester.py:160: in test
+    return self._test_inference(request=request)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infra/testers/single_chip/model/model_tester.py:179: in _test_inference
+    e2e_perf_stats = self._test_e2e_perf()
+                     ^^^^^^^^^^^^^^^^^^^^^
+tests/infra/testers/single_chip/model/model_tester.py:200: in _test_e2e_perf
+    _ = self._run_on_tt_device(self._workload)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infra/testers/single_chip/model/model_tester.py:229: in _run_on_tt_device
+    return self._device_runner.run_on_tt_device(compiled_workload)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infra/runners/device_runner.py:30: in run_on_tt_device
+    return self.run_on_device(workload, DeviceType.TT, device_num)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infra/runners/device_runner.py:40: in run_on_device
+    return self._run_on_device(device_workload, device)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infra/runners/torch_device_runner.py:105: in _run_on_device
+    return workload.execute()
+           ^^^^^^^^^^^^^^^^^^
+tests/infra/workloads/workload.py:71: in execute
+    return self.compiled_executable(*self.args, **self.kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py:465: in __call__
+    return super().__call__(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1776: in _wrapped_call_impl
+    return self._call_impl(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1787: in _call_impl
+    return forward_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py:953: in compile_wrapper
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_dynamo/external_utils.py:69: in inner
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1776: in _wrapped_call_impl
+    return self._call_impl(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1787: in _call_impl
+    return forward_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/utils/_contextlib.py:123: in decorate_context
+    with ctx_factory():
+venv/lib/python3.12/site-packages/torch/autograd/grad_mode.py:82: in __enter__
+    torch.set_grad_enabled(False)
+venv/lib/python3.12/site-packages/torch/autograd/grad_mode.py:187: in __init__
+    torch._C._set_grad_enabled(mode)
+python_package/tt_torch/torch_overrides.py:9: in __torch_function__
+    def __torch_function__(self, func, types, args, kwargs=None):
+venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py:1181: in _fn
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+python_package/tt_torch/backend/backend.py:226: in __call__
+    return self._call_experimental_compile(*args)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+python_package/tt_torch/backend/backend.py:201: in _call_experimental_compile
+    self.compiled_graph = bridge.extract_compiled_graph(
+venv/lib/python3.12/site-packages/torch_xla/_dynamo/dynamo_bridge.py:737: in extract_compiled_graph
+    return extract_compiled_graph_helper(xla_model, xla_args)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch_xla/_dynamo/dynamo_bridge.py:826: in extract_compiled_graph_helper
+    torch_xla.sync(reset_scope=False)
+venv/lib/python3.12/site-packages/torch_xla/torch_xla.py:87: in sync
+    torch_xla._XLAC._xla_step_marker(
+E   RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13
+------------------------------ Captured log call -------------------------------
+WARNING  root:utils.py:52 No accelerated backend detected. Using default cpu, this will be slow.
+WARNING  lerobot.configs.policies:policies.py:86 Device 'cuda' is not available. Switching to 'cpu'.
+WARNING  root:utils.py:52 No accelerated backend detected. Using default cpu, this will be slow.
+WARNING  lerobot.configs.policies:policies.py:86 Device 'cuda' is not available. Switching to 'cpu'.
+WARNING  root:modeling_pi0.py:1121 Vision embedding key might need handling: paligemma_with_expert.paligemma.model.vision_tower.vision_model.embeddings.patch_embedding.bias
+WARNING  root:modeling_pi0.py:1121 Vision embedding key might need handling: paligemma_with_expert.paligemma.model.vision_tower.vision_model.embeddings.patch_embedding.weight
+=============================== warnings summary ===============================
+venv/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+    warnings.warn(
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+
+venv/lib/python3.12/site-packages/torch/jit/_script.py:1480
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/torch/jit/_script.py:1480: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
+    warnings.warn(
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /home/ctr-akannan/.local/python/lib/python3.12/copyreg.py:99: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
+    return cls.__new__(cls, *args)
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/tests/infra/utilities/failing_reasons/utils.py:230: PytestDeprecationWarning: A private pytest class or function was used.
+    long_repr = ExceptionInfo(exc_info).getrepr(style="long")
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/tests/conftest.py:524: FutureWarning: `torch.distributed.reduce_op` is deprecated, please use `torch.distributed.ReduceOp` instead
+    if isinstance(obj, torch.fx.GraphModule):
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/tests/conftest.py:528: FutureWarning: `torch.distributed.reduce_op` is deprecated, please use `torch.distributed.ReduceOp` instead
+    if isinstance(obj, GraphInputMatcher):
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+FAILED tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference] - RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13
+================= 1 failed, 21 warnings in 1011.06s (0:16:51) ==================
+sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

--- a/docs/evidence/pi0_linear_workaround_bisect/logs/pi0_base_eb9005fa.log
+++ b/docs/evidence/pi0_linear_workaround_bisect/logs/pi0_base_eb9005fa.log
@@ -1,0 +1,294 @@
+2026-05-19 11:42:35.743 | WARNING  | torch_plugin_tt:__init__:40 - TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly.
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/bin/python
+cachedir: .pytest_cache
+metadata: {'Python': '3.12.3', 'Platform': 'Linux-5.4.0-212-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.3', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'metadata': '3.1.1', 'jaxtyping': '0.3.9', 'split': '0.11.0', 'forked': '1.6.0', 'anyio': '4.13.0'}}
+rootdir: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla
+configfile: pytest.ini
+plugins: json-report-1.5.0, metadata-3.1.1, jaxtyping-0.3.9, split-0.11.0, forked-1.6.0, anyio-4.13.0
+collecting ... 2026-05-19 11:42:43.231 | WARNING  | tests.runner.utils.dynamic_loader:discover_loader_paths:482 - Workaround to exclude model: suryaocr from discovery. Issue #1166
+Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
+Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
+2026-05-19 11:42:50.726 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov12/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-19 11:42:50.909 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov11/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-19 11:42:51.402 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov5/pytorch/loader.py: No module named 'pkg_resources'
+2026-05-19 11:43:00.096 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/sentencizer/pytorch/loader.py: cannot import name 'is_remote_url' from 'transformers.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/utils/__init__.py)
+2026-05-19 11:43:00.789 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov10/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-19 11:43:01.465 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/yolov8/pytorch/loader.py: cannot import name 'yolo_postprocess' from 'tt_forge_models.tools.utils' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/tools/utils.py)
+2026-05-19 11:43:01.970 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/albert/masked_lm/jax/loader.py: cannot import name 'FlaxAlbertForMaskedLM' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+2026-05-19 11:43:01.975 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/t5/summarization/jax/loader.py: No module named 'transformers.models.t5.modeling_flax_t5'
+2026-05-19 11:43:01.979 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/mt5/nlp_summarization/jax/loader.py: No module named 'transformers.models.mt5.modeling_flax_mt5'
+2026-05-19 11:43:02.012 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/beit/image_classification/jax/loader.py: cannot import name 'FlaxBeitForImageClassification' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+2026-05-19 11:43:02.020 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/longt5/text_classification/jax/loader.py: No module named 'transformers.models.longt5.modeling_flax_longt5'
+2026-05-19 11:43:02.034 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/bert/masked_lm/jax/loader.py: cannot import name 'FlaxBertForMaskedLM' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+2026-05-19 11:43:02.048 | WARNING  | tests.runner.utils.dynamic_loader:get_model_variants:290 - Cannot import path: /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/bart/causal_lm/jax/loader.py: cannot import name 'FlaxBartForCausalLM' from 'transformers' (/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/transformers/__init__.py)
+collected 1 item
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference] Running tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference] - pytorch_pi_0_pi0_base_mm_action_prediction_huggingface
+Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
+Collecting transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1))
+  Cloning https://github.com/huggingface/transformers.git (to revision fix/lerobot_openpi) to /tmp/pip-install-m7ocvk_g/transformers_7ef577b37f284b1c89a326aa0ea9d837
+  Running command git clone --filter=blob:none --quiet https://github.com/huggingface/transformers.git /tmp/pip-install-m7ocvk_g/transformers_7ef577b37f284b1c89a326aa0ea9d837
+  Running command git checkout -b fix/lerobot_openpi --track origin/fix/lerobot_openpi
+  Switched to a new branch 'fix/lerobot_openpi'
+  branch 'fix/lerobot_openpi' set up to track 'origin/fix/lerobot_openpi'.
+  Resolved https://github.com/huggingface/transformers.git to commit dcddb970176382c0fcf4521b0c0e6fc15894dfe0
+  Installing build dependencies: started
+  Installing build dependencies: finished with status 'done'
+  Getting requirements to build wheel: started
+  Getting requirements to build wheel: finished with status 'done'
+  Preparing metadata (pyproject.toml): started
+  Preparing metadata (pyproject.toml): finished with status 'done'
+Collecting tokenizers==0.21.1 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 2))
+  Using cached tokenizers-0.21.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.8 kB)
+Collecting draccus==0.10.0 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached draccus-0.10.0-py3-none-any.whl.metadata (24 kB)
+Collecting gymnasium==1.2.3 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4))
+  Using cached gymnasium-1.2.3-py3-none-any.whl.metadata (10 kB)
+Collecting torchcodec==0.10.0 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 5))
+  Using cached torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (11 kB)
+Collecting pyserial==3.5 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 6))
+  Using cached pyserial-3.5-py2.py3-none-any.whl.metadata (1.6 kB)
+Collecting deepdiff==8.6.1 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 7))
+  Using cached deepdiff-8.6.1-py3-none-any.whl.metadata (8.6 kB)
+Collecting av==15.0.0 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 8))
+  Using cached av-15.0.0-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (4.6 kB)
+Requirement already satisfied: filelock in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (3.29.0)
+Collecting huggingface-hub<1.0,>=0.30.0 (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1))
+  Using cached huggingface_hub-0.36.2-py3-none-any.whl.metadata (15 kB)
+Requirement already satisfied: numpy>=1.17 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2.1.2)
+Requirement already satisfied: packaging>=20.0 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (26.2)
+Requirement already satisfied: pyyaml>=5.1 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (6.0.1)
+Requirement already satisfied: regex!=2019.12.17 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2026.5.9)
+Requirement already satisfied: requests in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2.34.2)
+Requirement already satisfied: safetensors>=0.4.3 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (0.8.0rc0)
+Requirement already satisfied: tqdm>=4.27 in ./venv/lib/python3.12/site-packages (from transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (4.67.3)
+Collecting mergedeep~=1.3 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached mergedeep-1.3.4-py3-none-any.whl.metadata (4.3 kB)
+Collecting pyyaml-include~=1.4 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached pyyaml_include-1.4.1-py3-none-any.whl.metadata (1.3 kB)
+Collecting toml~=0.10 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached toml-0.10.2-py2.py3-none-any.whl.metadata (7.1 kB)
+Collecting typing-inspect~=0.9.0 (from draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3))
+  Using cached typing_inspect-0.9.0-py3-none-any.whl (8.8 kB)
+Collecting cloudpickle>=1.2.0 (from gymnasium==1.2.3->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4))
+  Using cached cloudpickle-3.1.2-py3-none-any.whl.metadata (7.1 kB)
+Requirement already satisfied: typing-extensions>=4.3.0 in ./venv/lib/python3.12/site-packages (from gymnasium==1.2.3->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4)) (4.15.0)
+Collecting farama-notifications>=0.0.1 (from gymnasium==1.2.3->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 4))
+  Using cached farama_notifications-0.0.6-py3-none-any.whl.metadata (729 bytes)
+Collecting orderly-set<6,>=5.4.1 (from deepdiff==8.6.1->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 7))
+  Using cached orderly_set-5.5.0-py3-none-any.whl.metadata (6.6 kB)
+Requirement already satisfied: fsspec>=2023.5.0 in ./venv/lib/python3.12/site-packages (from huggingface-hub<1.0,>=0.30.0->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2025.10.0)
+Requirement already satisfied: hf-xet<2.0.0,>=1.1.3 in ./venv/lib/python3.12/site-packages (from huggingface-hub<1.0,>=0.30.0->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (1.5.0)
+Requirement already satisfied: mypy-extensions>=0.3.0 in ./venv/lib/python3.12/site-packages (from typing-inspect~=0.9.0->draccus==0.10.0->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 3)) (1.1.0)
+Requirement already satisfied: charset_normalizer<4,>=2 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (3.4.7)
+Requirement already satisfied: idna<4,>=2.5 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (3.15)
+Requirement already satisfied: urllib3<3,>=1.26 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2.7.0)
+Requirement already satisfied: certifi>=2023.5.7 in ./venv/lib/python3.12/site-packages (from requests->transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi->-r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.txt (line 1)) (2026.4.22)
+Using cached tokenizers-0.21.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.0 MB)
+Using cached draccus-0.10.0-py3-none-any.whl (71 kB)
+Using cached gymnasium-1.2.3-py3-none-any.whl (952 kB)
+Using cached torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl (2.1 MB)
+Using cached pyserial-3.5-py2.py3-none-any.whl (90 kB)
+Using cached deepdiff-8.6.1-py3-none-any.whl (91 kB)
+Using cached av-15.0.0-cp312-cp312-manylinux_2_28_x86_64.whl (40.0 MB)
+Using cached huggingface_hub-0.36.2-py3-none-any.whl (566 kB)
+Using cached mergedeep-1.3.4-py3-none-any.whl (6.4 kB)
+Using cached orderly_set-5.5.0-py3-none-any.whl (13 kB)
+Using cached pyyaml_include-1.4.1-py3-none-any.whl (19 kB)
+Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
+Using cached cloudpickle-3.1.2-py3-none-any.whl (22 kB)
+Using cached farama_notifications-0.0.6-py3-none-any.whl (2.9 kB)
+Building wheels for collected packages: transformers
+  Building wheel for transformers (pyproject.toml): started
+  Building wheel for transformers (pyproject.toml): finished with status 'done'
+  Created wheel for transformers: filename=transformers-4.53.3-py3-none-any.whl size=10827916 sha256=6763f5b6a93485af10137d87057e4e005bca087708cbb3ee30125059b7796077
+  Stored in directory: /tmp/pip-ephem-wheel-cache-lirxh7vk/wheels/29/9c/af/9393d4342ca3b00939f0143419b1708e3d31ed8980de898431
+Successfully built transformers
+Installing collected packages: pyserial, farama-notifications, typing-inspect, torchcodec, toml, pyyaml-include, orderly-set, mergedeep, cloudpickle, av, huggingface-hub, gymnasium, draccus, deepdiff, tokenizers, transformers
+  Attempting uninstall: torchcodec
+    Found existing installation: torchcodec 0.12.0+cpu
+    Uninstalling torchcodec-0.12.0+cpu:
+      Successfully uninstalled torchcodec-0.12.0+cpu
+  Attempting uninstall: huggingface-hub
+    Found existing installation: huggingface_hub 1.15.0
+    Uninstalling huggingface_hub-1.15.0:
+      Successfully uninstalled huggingface_hub-1.15.0
+  Attempting uninstall: tokenizers
+    Found existing installation: tokenizers 0.22.2
+    Uninstalling tokenizers-0.22.2:
+      Successfully uninstalled tokenizers-0.22.2
+  WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~=kenizers'.
+  You can safely remove it manually.
+  Attempting uninstall: transformers
+    Found existing installation: transformers 5.2.0
+    Uninstalling transformers-5.2.0:
+      Successfully uninstalled transformers-5.2.0
+
+ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
+surya-ocr 0.17.1 requires transformers>=4.56.1, but you have transformers 4.53.3 which is incompatible.
+Successfully installed av-15.0.0 cloudpickle-3.1.2 deepdiff-8.6.1 draccus-0.10.0 farama-notifications-0.0.6 gymnasium-1.2.3 huggingface-hub-0.36.2 mergedeep-1.3.4 orderly-set-5.5.0 pyserial-3.5 pyyaml-include-1.4.1 tokenizers-0.21.1 toml-0.10.2 torchcodec-0.10.0 transformers-4.53.3 typing-inspect-0.9.0
+Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
+Collecting lerobot==0.4.3 (from -r /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/third_party/tt_forge_models/pi_0/pytorch/requirements.nodeps.txt (line 1))
+  Using cached lerobot-0.4.3-py3-none-any.whl.metadata (17 kB)
+Using cached lerobot-0.4.3-py3-none-any.whl (993 kB)
+Installing collected packages: lerobot
+Successfully installed lerobot-0.4.3
+WARNING:root:No accelerated backend detected. Using default cpu, this will be slow.
+WARNING:lerobot.configs.policies:Device 'cuda' is not available. Switching to 'cpu'.
+WARNING:root:No accelerated backend detected. Using default cpu, this will be slow.
+WARNING:lerobot.configs.policies:Device 'cuda' is not available. Switching to 'cpu'.
+WARNING:root:Vision embedding key might need handling: paligemma_with_expert.paligemma.model.vision_tower.vision_model.embeddings.patch_embedding.bias
+WARNING:root:Vision embedding key might need handling: paligemma_with_expert.paligemma.model.vision_tower.vision_model.embeddings.patch_embedding.weight
+2026-05-19 11:47:36.561236: W torch_xla/csrc/runtime/profiler.cpp:88] Profiler API not found for PJRT plugin
+Found existing installation: av 15.0.0
+Uninstalling av-15.0.0:
+  Successfully uninstalled av-15.0.0
+WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~=.libs'.
+You can safely remove it manually.
+WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~.av'.
+You can safely remove it manually.
+Found existing installation: cloudpickle 3.1.2
+Uninstalling cloudpickle-3.1.2:
+  Successfully uninstalled cloudpickle-3.1.2
+Found existing installation: deepdiff 8.6.1
+Uninstalling deepdiff-8.6.1:
+  Successfully uninstalled deepdiff-8.6.1
+Found existing installation: draccus 0.10.0
+Uninstalling draccus-0.10.0:
+  Successfully uninstalled draccus-0.10.0
+Found existing installation: Farama-Notifications 0.0.6
+Uninstalling Farama-Notifications-0.0.6:
+  Successfully uninstalled Farama-Notifications-0.0.6
+Found existing installation: gymnasium 1.2.3
+Uninstalling gymnasium-1.2.3:
+  Successfully uninstalled gymnasium-1.2.3
+Found existing installation: lerobot 0.4.3
+Uninstalling lerobot-0.4.3:
+  Successfully uninstalled lerobot-0.4.3
+Found existing installation: mergedeep 1.3.4
+Uninstalling mergedeep-1.3.4:
+  Successfully uninstalled mergedeep-1.3.4
+Found existing installation: orderly-set 5.5.0
+Uninstalling orderly-set-5.5.0:
+  Successfully uninstalled orderly-set-5.5.0
+Found existing installation: pyserial 3.5
+Uninstalling pyserial-3.5:
+  Successfully uninstalled pyserial-3.5
+Found existing installation: pyyaml-include 1.4.1
+Uninstalling pyyaml-include-1.4.1:
+  Successfully uninstalled pyyaml-include-1.4.1
+Found existing installation: toml 0.10.2
+Uninstalling toml-0.10.2:
+  Successfully uninstalled toml-0.10.2
+Found existing installation: typing-inspect 0.9.0
+Uninstalling typing-inspect-0.9.0:
+  Successfully uninstalled typing-inspect-0.9.0
+Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
+Collecting huggingface_hub==1.15.0 (from -r /tmp/tt_xla_restore_j0wqara1.txt (line 1))
+  Using cached huggingface_hub-1.15.0-py3-none-any.whl.metadata (14 kB)
+Collecting tokenizers==0.22.2 (from -r /tmp/tt_xla_restore_j0wqara1.txt (line 2))
+  Using cached tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (7.3 kB)
+Collecting torchcodec==0.12.0+cpu (from -r /tmp/tt_xla_restore_j0wqara1.txt (line 3))
+  Using cached torchcodec-0.12.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (11 kB)
+Collecting transformers==5.2.0 (from -r /tmp/tt_xla_restore_j0wqara1.txt (line 4))
+  Using cached transformers-5.2.0-py3-none-any.whl.metadata (32 kB)
+Requirement already satisfied: filelock>=3.10.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (3.29.0)
+Requirement already satisfied: fsspec>=2023.5.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (2025.10.0)
+Requirement already satisfied: hf-xet<2.0.0,>=1.4.3 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (1.5.0)
+Requirement already satisfied: httpx<1,>=0.23.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (0.28.1)
+Requirement already satisfied: packaging>=20.9 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (26.2)
+Requirement already satisfied: pyyaml>=5.1 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (6.0.1)
+Requirement already satisfied: tqdm>=4.42.1 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (4.67.3)
+Requirement already satisfied: typer>=0.20.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (0.25.1)
+Requirement already satisfied: typing-extensions>=4.1.0 in ./venv/lib/python3.12/site-packages (from huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (4.15.0)
+Requirement already satisfied: numpy>=1.17 in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 4)) (2.1.2)
+Requirement already satisfied: regex!=2019.12.17 in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 4)) (2026.5.9)
+Requirement already satisfied: typer-slim in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 4)) (0.24.0)
+Requirement already satisfied: safetensors>=0.4.3 in ./venv/lib/python3.12/site-packages (from transformers==5.2.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 4)) (0.8.0rc0)
+Requirement already satisfied: anyio in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (4.13.0)
+Requirement already satisfied: certifi in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (2026.4.22)
+Requirement already satisfied: httpcore==1.* in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (1.0.9)
+Requirement already satisfied: idna in ./venv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (3.15)
+Requirement already satisfied: h11>=0.16 in ./venv/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (0.16.0)
+Requirement already satisfied: click>=8.2.1 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (8.3.1)
+Requirement already satisfied: shellingham>=1.3.0 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (1.5.4)
+Requirement already satisfied: rich>=13.8.0 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (15.0.0)
+Requirement already satisfied: annotated-doc>=0.0.2 in ./venv/lib/python3.12/site-packages (from typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (0.0.4)
+Requirement already satisfied: markdown-it-py>=2.2.0 in ./venv/lib/python3.12/site-packages (from rich>=13.8.0->typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (4.2.0)
+Requirement already satisfied: pygments<3.0.0,>=2.13.0 in ./venv/lib/python3.12/site-packages (from rich>=13.8.0->typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (2.20.0)
+Requirement already satisfied: mdurl~=0.1 in ./venv/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=13.8.0->typer>=0.20.0->huggingface_hub==1.15.0->-r /tmp/tt_xla_restore_j0wqara1.txt (line 1)) (0.1.2)
+Using cached huggingface_hub-1.15.0-py3-none-any.whl (663 kB)
+Using cached tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.3 MB)
+Using cached torchcodec-0.12.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl (2.4 MB)
+Using cached transformers-5.2.0-py3-none-any.whl (10.4 MB)
+Installing collected packages: torchcodec, huggingface_hub, tokenizers, transformers
+  Attempting uninstall: torchcodec
+    Found existing installation: torchcodec 0.10.0
+    Uninstalling torchcodec-0.10.0:
+      Successfully uninstalled torchcodec-0.10.0
+  WARNING: Failed to remove contents in a temporary directory '/proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/~=rchcodec'.
+  You can safely remove it manually.
+  Attempting uninstall: huggingface_hub
+    Found existing installation: huggingface_hub 0.36.2
+    Uninstalling huggingface_hub-0.36.2:
+      Successfully uninstalled huggingface_hub-0.36.2
+  Attempting uninstall: tokenizers
+    Found existing installation: tokenizers 0.21.1
+    Uninstalling tokenizers-0.21.1:
+      Successfully uninstalled tokenizers-0.21.1
+  Attempting uninstall: transformers
+    Found existing installation: transformers 4.53.3
+    Uninstalling transformers-4.53.3:
+      Successfully uninstalled transformers-4.53.3
+
+Successfully installed huggingface_hub-1.15.0 tokenizers-0.22.2 torchcodec-0.12.0+cpu transformers-5.2.0
+The PI0 model is a direct port of the OpenPI implementation. 
+This implementation follows the original OpenPI structure for compatibility. 
+Original implementation: https://github.com/Physical-Intelligence/openpi
+Loading model from: lerobot/pi0_base
+✓ Loaded state dict from model.safetensors
+Remapped 777 state dict keys
+Warning: Could not remap state dict keys: Error(s) in loading state_dict for PI0Policy:
+	Missing key(s) in state_dict: "model.paligemma_with_expert.paligemma.model.language_model.embed_tokens.weight". 
+====================================================================
+| pytorch_pi_0_pi0_base_mm_action_prediction_huggingface BENCHMARK:  
+--------------------------------------------------------------------
+| e2e_perf-total_samples: 2
+| e2e_perf-total_time: 0.03360164212062955
+| e2e_perf-avg_time: 0.016800821060314775
+| e2e_perf-perf_time_1: 0.01683826104272157
+| e2e_perf-perf_time_2: 0.01676338107790798
+====================================================================
+PASSED
+
+=============================== warnings summary ===============================
+venv/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+    warnings.warn(
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+
+venv/lib/python3.12/site-packages/torch/jit/_script.py:1480
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/venv/lib/python3.12/site-packages/torch/jit/_script.py:1480: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
+    warnings.warn(
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /home/ctr-akannan/.local/python/lib/python3.12/copyreg.py:99: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
+    return cls.__new__(cls, *args)
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/tests/conftest.py:524: FutureWarning: `torch.distributed.reduce_op` is deprecated, please use `torch.distributed.ReduceOp` instead
+    if isinstance(obj, torch.fx.GraphModule):
+
+tests/runner/test_models.py::test_all_models_torch[pi_0/pytorch-pi0_base-single_device-inference]
+  /proj_sw/user_dev/ctr-akannan/18_new_may_gd/tt-xla/tests/conftest.py:528: FutureWarning: `torch.distributed.reduce_op` is deprecated, please use `torch.distributed.ReduceOp` instead
+    if isinstance(obj, GraphInputMatcher):
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+================= 1 passed, 20 warnings in 1101.39s (0:18:21) ==================
+sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpOutputShapeRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpOutputShapeRewritePattern.h
@@ -13,11 +13,14 @@
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
 // When the fused LinearOp kernel is used (padded bias second-to-last dim ==
-// TILE_HEIGHT), the hardware output shape is the matmul shape, not the
-// broadcasted shape. This pattern adjusts the LinearOp output from the
-// broadcasted shape to the matmul shape and inserts a ReshapeOp to restore the
-// original shape.
+// TILE_HEIGHT), tt-metal may return the matmul rank or the bias-broadcast rank
+// depending on how the op was typed. This pattern inserts an explicit
+// linear + reshape so downstream consumers (e.g. ttnn.concat) always see the
+// rank declared in the IR:
+//   - broadcast-typed linear: linear(matmul rank) -> reshape(broadcast rank)
+//   - matmul-typed linear:    linear(broadcast rank) -> reshape(matmul rank)
 // See: https://github.com/tenstorrent/tt-metal/issues/39392
+//      https://github.com/tenstorrent/tt-xla/issues/4633
 class LinearOpOutputShapeRewritePattern
     : public OpRewritePattern<ttnn::LinearOp> {
 public:

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpOutputShapeRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpOutputShapeRewritePattern.cpp
@@ -4,7 +4,6 @@
 
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpOutputShapeRewritePattern.h"
 
-#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Utils.h"
@@ -55,6 +54,25 @@ computeMatmulOutputShape(llvm::ArrayRef<int64_t> shapeA, bool transposeA,
   return outputShape;
 }
 
+static RankedTensorType createTensorTypeWithShape(RankedTensorType tensorType,
+                                                  ArrayRef<int64_t> shape) {
+  if (mlir::isa<ttnn::TTNNLayoutAttr>(tensorType.getEncoding())) {
+    return utils::RankedTensorTypeFactory::create(tensorType, shape);
+  }
+  return RankedTensorType::get(shape, tensorType.getElementType());
+}
+
+static ttnn::ReshapeOp createReshapeWithShape(
+    mlir::TypedValue<RankedTensorType> input, ArrayRef<int64_t> newShape,
+    PatternRewriter &rewriter, mlir::Location loc) {
+  RankedTensorType outputType =
+      createTensorTypeWithShape(input.getType(), newShape);
+  llvm::SmallVector<int32_t> newShapeI32(newShape.begin(), newShape.end());
+  return rewriter.create<ttnn::ReshapeOp>(loc, outputType, input,
+                                          rewriter.getI32ArrayAttr(newShapeI32),
+                                          /*memory_config=*/nullptr);
+}
+
 LogicalResult LinearOpOutputShapeRewritePattern::matchAndRewrite(
     ttnn::LinearOp srcOp, PatternRewriter &rewriter) const {
 
@@ -93,20 +111,55 @@ LogicalResult LinearOpOutputShapeRewritePattern::matchAndRewrite(
       computeMatmulOutputShape(inputAType.getShape(), srcOp.getTransposeA(),
                                inputBType.getShape(), srcOp.getTransposeB());
 
-  RankedTensorType currentOutputType = srcOp.getResult().getType();
-  ArrayRef<int64_t> currentOutputShape = currentOutputType.getShape();
-
-  // If the output shape already equals the matmul shape, nothing to do.
-  if (llvm::equal(currentOutputShape, matmulShape)) {
+  llvm::SmallVector<int64_t> broadcastShape;
+  if (!mlir::OpTrait::util::getBroadcastedShape(matmulShape, biasShape,
+                                                broadcastShape)) {
     return failure();
   }
 
-  // Replace LinearOp with matmul-shaped output + ReshapeOp.
-  auto matmulOutputType =
-      utils::RankedTensorTypeFactory::create(currentOutputType, matmulShape);
+  // No rank mismatch between matmul and bias-broadcast results.
+  if (llvm::equal(matmulShape, broadcastShape)) {
+    return failure();
+  }
+
+  RankedTensorType currentOutputType = srcOp.getResult().getType();
+  ArrayRef<int64_t> currentOutputShape = currentOutputType.getShape();
+
+  const bool outputIsMatmul = llvm::equal(currentOutputShape, matmulShape);
+  const bool outputIsBroadcast =
+      llvm::equal(currentOutputShape, broadcastShape);
+
+  // Only handle graphs where consumers expect one of the two valid linear
+  // output shapes (see LinearOp::verify).
+  if (!outputIsMatmul && !outputIsBroadcast) {
+    return failure();
+  }
+
+  // Already rewritten: linear(intermediate) -> reshape(final). Greedy rewrite
+  // has no iteration limit, so without this check the pattern oscillates.
+  if (srcOp.getResult().hasOneUse()) {
+    if (auto reshapeOp =
+            dyn_cast<ttnn::ReshapeOp>(*srcOp.getResult().user_begin())) {
+      ArrayRef<int64_t> reshapeOut =
+          reshapeOp.getResult().getType().getShape();
+      if ((outputIsBroadcast && llvm::equal(reshapeOut, matmulShape)) ||
+          (outputIsMatmul && llvm::equal(reshapeOut, broadcastShape))) {
+        return failure();
+      }
+    }
+  }
+
+  // Fused linear may return the broadcast rank at runtime while the IR types the
+  // op as matmul rank (or vice versa). Insert linear + explicit reshape so
+  // downstream ops (e.g. ttnn.concat) see a consistent rank.
+  // - broadcast-typed output: linear(matmul) -> reshape(broadcast)
+  // - matmul-typed output:    linear(broadcast) -> reshape(matmul)
+  const auto linearOutputType = createTensorTypeWithShape(
+      currentOutputType,
+      outputIsBroadcast ? matmulShape : broadcastShape);
 
   auto newLinearOp = rewriter.create<ttnn::LinearOp>(
-      srcOp.getLoc(), matmulOutputType, srcOp.getA(), srcOp.getB(),
+      srcOp.getLoc(), linearOutputType, srcOp.getA(), srcOp.getB(),
       srcOp.getBias(), srcOp.getTransposeA(), srcOp.getTransposeB(),
       /*matmul_program_config=*/nullptr, srcOp.getActivationAttr(),
       /*compute_config=*/srcOp.getComputeConfigAttr());
@@ -115,8 +168,7 @@ LogicalResult LinearOpOutputShapeRewritePattern::matchAndRewrite(
     newLinearOp->setAttr("ttcore.weight_dtype", weightDtype);
   }
 
-  // Reshape back to the original broadcasted shape.
-  ttnn::ReshapeOp reshapeOp = ttir_to_ttnn::utils::generateReshape(
+  ttnn::ReshapeOp reshapeOp = createReshapeWithShape(
       newLinearOp.getResult(), currentOutputShape, rewriter,
       ttmlir::utils::appendLocationSuffix(srcOp.getLoc(),
                                           "_output_shape_workaround"));

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/linear_op_output_shape_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/linear_op_output_shape_workaround.mlir
@@ -55,6 +55,19 @@ module {
     return %result : tensor<1x256x512xbf16>
   }
 
+  // Pi0 action_in_proj: matmul shape [50, 1024], bias [1, 1, 1024], output typed as matmul.
+  // Broadcast shape is [1, 50, 1024]. Pattern inserts linear(broadcast) + reshape(matmul).
+  // See: https://github.com/tenstorrent/tt-xla/issues/4633
+  func.func @pi0_action_in_proj_matmul_typed_output(%arg0: tensor<50x32xbf16>, %arg1: tensor<1024x32xbf16>, %bias: tensor<1x1x1024xbf16>) -> tensor<50x1024xbf16> {
+    // CHECK-LABEL: func.func @pi0_action_in_proj_matmul_typed_output
+    // CHECK: "ttnn.linear"
+    // CHECK-SAME: -> tensor<1x50x1024xbf16
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: -> tensor<50x1024xbf16
+    %result = "ttnn.linear"(%arg0, %arg1, %bias) <{transpose_a = false, transpose_b = true}> : (tensor<50x32xbf16>, tensor<1024x32xbf16>, tensor<1x1x1024xbf16>) -> tensor<50x1024xbf16>
+    return %result : tensor<50x1024xbf16>
+  }
+
   // No bias. Pattern should NOT fire.
   func.func @linear_no_bias_no_change(%arg0: tensor<256x1024xbf16>, %arg1: tensor<1024x512xbf16>) -> tensor<256x512xbf16> {
     // CHECK-LABEL: func.func @linear_no_bias_no_change


### PR DESCRIPTION
### Ticket
[tt-xla#4633](https://github.com/tenstorrent/tt-xla/issues/4633) — Pi0: `ttnn::concat` / `ShapeBase[]` on XLA graph for second denoise with `action_in_proj` bias
[tt-metal#44094](https://github.com/tenstorrent/tt-metal/issues/44094) — `ttnn.concat` throws on Pi0 / `action_in_proj` bias path (rank-mismatched operands)

### Problem description
- On Pi0, a fused TT graph through the second denoise step fails when action_in_proj uses bias. The fused ttnn.linear path can return 3D (1, 50, 1024) while sibling tensors and the IR stay 2D (50, 1024), so the first embed_suffix ttnn.concat hits ShapeBase[] index out of range.
- Matmul-only (bias=None) and isolated biased linear on TT pass; the bug needs the full fused stem. Existing LinearOpOutputShapeRewritePattern only handled broadcast-typed outputs (matmul at runtime → reshape to broadcast). Pi0 types the output as matmul rank while the kernel returns broadcast rank, so the workaround never ran.

### What's changed
- Extend `LinearOpOutputShapeRewritePattern` to handle both fused-linear rank mismatches via explicit linear + reshape:
   a) Broadcast-typed output: linear(matmul rank) → reshape(broadcast rank)
   b) Matmul-typed output (Pi0): linear(broadcast rank) → reshape(matmul rank)
- Also add a rewrite oscillation guard and MLIR FileCheck for the Pi0 action_in_proj shape case.
- Impact: Downstream ttnn.concat sees consistent ranks per the IR, fixing the Pi0 biased-linear / concat failure at the mlir lowering layer.

### Checklist
- [x] Validated the changes


### Logs
- Before Fix - [pi_0_failure.log](https://github.com/user-attachments/files/27903770/pi_0_failure.log)
- After Fix - [pi0_base.log](https://github.com/user-attachments/files/27903774/pi0_base.log)
