### PR TITLE
[EmitPy] Preserve scalar precision in CPU EmitPy pass

### DIFF
--- a/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
+++ b/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
@@ -755,8 +755,7 @@ public:
     if (denseAttr.isSplat()) {
       if (isa<FloatType>(elemType)) {
         b.addKwarg("fill_value",
-                   std::to_string(
-                       denseAttr.getSplatValue<APFloat>().convertToDouble()));
+                   formatAPFloat(denseAttr.getSplatValue<APFloat>()));
       } else {
         b.addKwarg(
             "fill_value",
@@ -772,7 +771,7 @@ public:
           if (!first) {
             os << ", ";
           }
-          os << v.convertToDouble();
+          os << formatAPFloat(v);
           first = false;
         }
       } else {

--- a/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
+++ b/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
@@ -115,9 +115,17 @@ static SmallVector<int32_t, 4> getI32Quad(Attribute attr) {
   return {val, val, val, val};
 }
 
+static std::string formatAPFloat(llvm::APFloat value) {
+  // Default precision (0) prints enough decimal digits that parsing the
+  // string back yields the exact same float bits.
+  llvm::SmallString<32> buf;
+  value.toString(buf);
+  return std::string(buf);
+}
+
 static std::string formatScalarAttr(Attribute attr) {
   if (auto fAttr = dyn_cast<FloatAttr>(attr)) {
-    return std::to_string(fAttr.getValueAsDouble());
+    return formatAPFloat(fAttr.getValue());
   }
   return std::to_string(cast<IntegerAttr>(attr).getInt());
 }
@@ -570,7 +578,7 @@ public:
     EmitPyCallBuilder b(op, getTypeConverter(), getCallee(op));
     b.addOperand(adaptor.getInput());
     b.addLiteral(formatI32List(adaptor.getPadding()));
-    b.addLiteral(std::to_string(adaptor.getValue().convertToFloat()));
+    b.addLiteral(formatAPFloat(adaptor.getValue()));
     b.replaceOp(rewriter);
     return success();
   }
@@ -716,8 +724,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     EmitPyCallBuilder b(op, getTypeConverter(), getCallee(op));
     b.addOperand(adaptor.getInput());
-    b.addKwarg("negative_slope",
-               std::to_string(adaptor.getParameter().convertToFloat()));
+    b.addKwarg("negative_slope", formatAPFloat(adaptor.getParameter()));
     b.replaceOp(rewriter);
     return success();
   }
@@ -893,8 +900,7 @@ public:
     } else {
       b.addKwarg("bias", "None");
     }
-    b.addKwarg("epsilon",
-               std::to_string(adaptor.getEpsilon().convertToFloat()));
+    b.addKwarg("epsilon", formatAPFloat(adaptor.getEpsilon()));
     b.replaceOp(rewriter);
     return success();
   }

--- a/test/ttmlir/EmitPy/cpu_hoisted_ops.mlir
+++ b/test/ttmlir/EmitPy/cpu_hoisted_ops.mlir
@@ -307,6 +307,9 @@ func.func @softmax_validation(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
 // LayerNorm
 // CHECK-LABEL: def cpu_hoisted_ttir_layer_{{.*}}
 // CHECK: ttir_cpu.layer_norm(
+// Regression for #8457: scalar FloatAttr must round-trip, not be
+// truncated by std::to_string to "epsilon=0.000010".
+// CHECK-SAME: epsilon=9.99999974E-6
 // CHECK-LABEL: def layer_norm_validation
 // CHECK: cpu_hoisted_ttir_layer_{{.*}}
 // CHECK: ttnn.layer_norm(


### PR DESCRIPTION
Fixes #8457 (partially)

## Summary
Format scalar `FloatAttr` values via `APFloat::toString` instead of `std::to_string(double/float)` in the TTIR-CPU EmitPy pass so emitted Python constants (e.g. `epsilon`, pad value, leaky-relu slope) round-trip to the exact same bits.



🤖 Generated with [Claude Code](https://claude.com/claude-code)