### PR TITLE
Fix KV cache dtype conversion for TP models 

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNKVCacheDtypeConversion.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNKVCacheDtypeConversion.cpp
@@ -126,6 +126,13 @@ public:
       return;
     }
 
+    // Only propagate through mesh_shard since it is the only dtype-transparent 
+    // op expected between a kv_cache block argument and a write op in TP 
+    // models.
+    if (!mlir::isa<MeshShardOp>(value.getDefiningOp())) {
+      return;
+    }
+
     mlir::Type originalElemType = tensorType.getElementType();
     for (Value operand : value.getDefiningOp()->getOperands()) {
       auto operandType = mlir::dyn_cast<RankedTensorType>(operand.getType());

--- a/lib/Dialect/TTNN/Transforms/TTNNKVCacheDtypeConversion.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNKVCacheDtypeConversion.cpp
@@ -105,6 +105,36 @@ public:
         mlir::FunctionType::get(ctx, newArgTypes, newResultTypes));
   }
 
+  // Walk backward from `value`, updating the element dtype of every value
+  // along the cache path until reaching the target dtype or a block argument.
+  static void propagateDtypeTowardRoot(Value value,
+                                       ttcore::DataType targetDtype) {
+    auto tensorType = mlir::dyn_cast<RankedTensorType>(value.getType());
+    if (!tensorType) {
+      return;
+    }
+
+    auto newType =
+        ttnn::utils::RankedTensorTypeFactory::create(tensorType, targetDtype);
+    if (value.getType() == newType) {
+      return;
+    }
+
+    value.setType(newType);
+
+    if (mlir::isa<BlockArgument>(value)) {
+      return;
+    }
+
+    mlir::Type originalElemType = tensorType.getElementType();
+    for (Value operand : value.getDefiningOp()->getOperands()) {
+      auto operandType = mlir::dyn_cast<RankedTensorType>(operand.getType());
+      if (operandType && operandType.getElementType() == originalElemType) {
+        propagateDtypeTowardRoot(operand, targetDtype);
+      }
+    }
+  }
+
   // Inserts a ttnn.typecast before `op`'s input operand if it is not already
   // the target dtype.
   template <typename OpTy>
@@ -154,6 +184,7 @@ public:
         llvm::TypeSwitch<Operation *>(op)
             .Case<FillCacheOp, UpdateCacheOp, PagedFillCacheOp>(
                 [&](auto cacheOp) {
+                  propagateDtypeTowardRoot(cacheOp.getCache(), dtype);
                   insertTypecastIfNeeded(builder, cacheOp, dtype);
                 });
       });

--- a/lib/Dialect/TTNN/Transforms/TTNNKVCacheDtypeConversion.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNKVCacheDtypeConversion.cpp
@@ -35,31 +35,41 @@ public:
     return mlir::isa<MeshShardOp>(op);
   }
 
-  // Returns true if the chain from `value` back to a block argument consists
-  // only of isAllowedOnCachePath ops. Does not modify any types.
-  static bool canPropagateDtype(Value value) {
-    auto tensorType = mlir::dyn_cast<RankedTensorType>(value.getType());
-    if (!tensorType) {
-      return false;
-    }
-
-    if (mlir::isa<BlockArgument>(value)) {
-      return true;
-    }
-
-    Operation *defOp = value.getDefiningOp();
-    if (!isAllowedOnCachePath(defOp)) {
-      return false;
-    }
-
-    mlir::Type elemType = tensorType.getElementType();
-    for (Value operand : defOp->getOperands()) {
-      auto opType = mlir::dyn_cast<RankedTensorType>(operand.getType());
-      if (opType && opType.getElementType() == elemType) {
-        return canPropagateDtype(operand);
+  // Walks the linear tensor chain from `value` back through allowed ops,
+  // collecting intermediate tensor values into `chain`. Returns the
+  // terminating block argument, or nullptr if the chain is invalid
+  static BlockArgument collectChainToRoot(Value value,
+                                          llvm::SmallVectorImpl<Value> &chain) {
+    while (!mlir::isa<BlockArgument>(value)) {
+      chain.push_back(value);
+      Operation *defOp = value.getDefiningOp();
+      if (!isAllowedOnCachePath(defOp)) {
+        return nullptr;
       }
+      Value next;
+      for (Value operand : defOp->getOperands()) {
+        if (mlir::isa<RankedTensorType>(operand.getType())) {
+          if (next) {
+            return nullptr;
+          }
+          next = operand;
+        }
+      }
+      if (!next) {
+        return nullptr;
+      }
+      value = next;
     }
-    return true;
+    return mlir::cast<BlockArgument>(value);
+  }
+
+  // Returns true if the chain from `value` back through allowed ops terminates
+  // at a kv_cache-labeled block argument. Does not modify any types.
+  static bool canPropagateDtype(func::FuncOp funcOp, Value value) {
+    llvm::SmallVector<Value> chain;
+    BlockArgument blockArg = collectChainToRoot(value, chain);
+    return blockArg && funcOp.getArgAttr(blockArg.getArgNumber(),
+                                         ttcore::g_kvCacheAttrName);
   }
 
   static ttcore::LocalShapeAttr
@@ -136,34 +146,16 @@ public:
         mlir::FunctionType::get(ctx, newArgTypes, newResultTypes));
   }
 
-  // Walk backward from `value` through the chain, updating each value's element
-  // dtype. Only call this after canPropagateDtype confirms the chain is fully
-  // traversable.
+  // Updates the element dtype of each value on the chain from `value` back to
+  // its kv_cache block argument. Only call this if the chain is valid
   static void propagateDtypeTowardRoot(Value value,
                                        ttcore::DataType targetDtype) {
-    auto tensorType = mlir::dyn_cast<RankedTensorType>(value.getType());
-    if (!tensorType) {
-      return;
-    }
-
-    auto newType =
-        ttnn::utils::RankedTensorTypeFactory::create(tensorType, targetDtype);
-    if (value.getType() == newType) {
-      return;
-    }
-
-    value.setType(newType);
-
-    if (mlir::isa<BlockArgument>(value)) {
-      return;
-    }
-
-    mlir::Type originalElemType = tensorType.getElementType();
-    for (Value operand : value.getDefiningOp()->getOperands()) {
-      auto operandType = mlir::dyn_cast<RankedTensorType>(operand.getType());
-      if (operandType && operandType.getElementType() == originalElemType) {
-        propagateDtypeTowardRoot(operand, targetDtype);
-      }
+    llvm::SmallVector<Value> chain;
+    collectChainToRoot(value, chain);
+    for (Value v : chain) {
+      auto tensorType = mlir::cast<RankedTensorType>(v.getType());
+      v.setType(ttnn::utils::RankedTensorTypeFactory::create(tensorType,
+                                                             targetDtype));
     }
   }
 
@@ -215,7 +207,7 @@ public:
         llvm::TypeSwitch<Operation *>(op)
             .Case<FillCacheOp, UpdateCacheOp, PagedFillCacheOp,
                   PagedUpdateCacheOp>([&](auto cacheOp) {
-              if (!canPropagateDtype(cacheOp.getCache())) {
+              if (!canPropagateDtype(funcOp, cacheOp.getCache())) {
                 canConvert = false;
               }
             });

--- a/lib/Dialect/TTNN/Transforms/TTNNKVCacheDtypeConversion.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNKVCacheDtypeConversion.cpp
@@ -29,6 +29,39 @@ public:
   using impl::TTNNKVCacheDtypeConversionBase<
       TTNNKVCacheDtypeConversionPass>::TTNNKVCacheDtypeConversionBase;
 
+  // Ops that are safe to propagate dtype through on the kv_cache → cache_op
+  // path. Extend this list when new transparent ops appear on that path.
+  static bool isAllowedOnCachePath(Operation *op) {
+    return mlir::isa<MeshShardOp>(op);
+  }
+
+  // Returns true if the chain from `value` back to a block argument consists
+  // only of isAllowedOnCachePath ops. Does not modify any types.
+  static bool canPropagateDtype(Value value) {
+    auto tensorType = mlir::dyn_cast<RankedTensorType>(value.getType());
+    if (!tensorType) {
+      return false;
+    }
+
+    if (mlir::isa<BlockArgument>(value)) {
+      return true;
+    }
+
+    Operation *defOp = value.getDefiningOp();
+    if (!isAllowedOnCachePath(defOp)) {
+      return false;
+    }
+
+    mlir::Type elemType = tensorType.getElementType();
+    for (Value operand : defOp->getOperands()) {
+      auto opType = mlir::dyn_cast<RankedTensorType>(operand.getType());
+      if (opType && opType.getElementType() == elemType) {
+        return canPropagateDtype(operand);
+      }
+    }
+    return true;
+  }
+
   static ttcore::LocalShapeAttr
   convertLocalShapeAttr(MLIRContext *ctx, ttcore::LocalShapeAttr attr,
                         ttcore::DataType targetDtype) {
@@ -40,12 +73,10 @@ public:
     return ttcore::LocalShapeAttr::get(ctx, newLocalShapeType);
   }
 
-  static void changeCacheArgTypes(func::FuncOp funcOp,
-                                  ttcore::DataType targetDtype) {
-    if (!ttmlir::utils::isForwardDeviceFunc(funcOp)) {
-      return;
-    }
-
+  // Updates all kv_cache block arg types and the function signature to
+  // targetDtype. Only call this after all cache op paths have been validated.
+  static void convertCacheArgTypes(func::FuncOp funcOp,
+                                   ttcore::DataType targetDtype) {
     auto *ctx = funcOp.getContext();
     auto funcType = funcOp.getFunctionType();
     llvm::SmallVector<Type> newArgTypes(funcType.getInputs());
@@ -105,8 +136,9 @@ public:
         mlir::FunctionType::get(ctx, newArgTypes, newResultTypes));
   }
 
-  // Walk backward from `value`, updating the element dtype of every value
-  // along the cache path until reaching the target dtype or a block argument.
+  // Walk backward from `value` through the chain, updating each value's element
+  // dtype. Only call this after canPropagateDtype confirms the chain is fully
+  // traversable.
   static void propagateDtypeTowardRoot(Value value,
                                        ttcore::DataType targetDtype) {
     auto tensorType = mlir::dyn_cast<RankedTensorType>(value.getType());
@@ -123,13 +155,6 @@ public:
     value.setType(newType);
 
     if (mlir::isa<BlockArgument>(value)) {
-      return;
-    }
-
-    // Only propagate through mesh_shard since it is the only dtype-transparent 
-    // op expected between a kv_cache block argument and a write op in TP 
-    // models.
-    if (!mlir::isa<MeshShardOp>(value.getDefiningOp())) {
       return;
     }
 
@@ -175,23 +200,51 @@ public:
 
     ttcore::DataType dtype = bfpDtypeToDataType(targetDtype);
 
-    // Change kv_cache argument types to the target dtype and update the
-    // function signature. Insert typecast operations on the input operands of
-    // all cache ops so written data matches the new cache dtype.
-    // PagedUpdateCacheOp is excluded: tt-metal enforces FLOAT32/BFLOAT16 for
-    // that op and handles any dtype mismatch internally.
     mlir::OpBuilder builder(&getContext());
     getOperation().walk([&](func::FuncOp funcOp) {
-      changeCacheArgTypes(funcOp, dtype);
-
       if (!ttmlir::utils::isForwardDeviceFunc(funcOp)) {
         return;
       }
+
+      // Check that every cache op's path back to a block arg consists only of
+      // arg consists only of isAllowedOnCachePath ops. If any path contains
+      // an unsupported op, skip the entire function to avoid partial
+      // conversion.
+      bool canConvert = true;
+      funcOp.walk([&](Operation *op) {
+        llvm::TypeSwitch<Operation *>(op)
+            .Case<FillCacheOp, UpdateCacheOp, PagedFillCacheOp,
+                  PagedUpdateCacheOp>([&](auto cacheOp) {
+              if (!canPropagateDtype(cacheOp.getCache())) {
+                canConvert = false;
+              }
+            });
+      });
+
+      if (!canConvert) {
+        return;
+      }
+
+      // Update all kv_cache block arg types, the function
+      // signature, and propagate the new dtype through the chain.
+      convertCacheArgTypes(funcOp, dtype);
+      funcOp.walk([&](Operation *op) {
+        llvm::TypeSwitch<Operation *>(op)
+            .Case<FillCacheOp, UpdateCacheOp, PagedFillCacheOp,
+                  PagedUpdateCacheOp>([&](auto cacheOp) {
+              propagateDtypeTowardRoot(cacheOp.getCache(), dtype);
+            });
+      });
+
+      // Insert typecasts on the input (fill value) of each cache op
+      // so the written data matches the new cache dtype.
+      // PagedUpdateCacheOp is excluded since tt-metal enforces
+      // FLOAT32/BFLOAT16 for input dtype and handles dtype mismatch
+      // internally.
       funcOp.walk([&](Operation *op) {
         llvm::TypeSwitch<Operation *>(op)
             .Case<FillCacheOp, UpdateCacheOp, PagedFillCacheOp>(
                 [&](auto cacheOp) {
-                  propagateDtypeTowardRoot(cacheOp.getCache(), dtype);
                   insertTypecastIfNeeded(builder, cacheOp, dtype);
                 });
       });

--- a/test/ttmlir/Dialect/TTNN/kv_cache_conversion/fill_cache_bfp8_tp.mlir
+++ b/test/ttmlir/Dialect/TTNN/kv_cache_conversion/fill_cache_bfp8_tp.mlir
@@ -1,0 +1,34 @@
+// RUN: ttmlir-opt --ttnn-kv-cache-dtype-conversion="target-dtype=bfp_bf8" %s | FileCheck %s
+
+#dram = #ttnn.buffer_type<dram>
+
+#global_cache = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<128x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#local_cache = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<64x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#input = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 + d2, d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// CHECK-LABEL: func.func @test_fill_cache_bfp8_tp
+// CHECK-SAME: %arg0: tensor<2x32x64x128x!ttcore.tile<32x32, bfp_bf8>,
+// CHECK-SAME: %arg1: tensor<1x32x1x128xbf16,
+module attributes {} {
+  func.func @test_fill_cache_bfp8_tp(
+      %arg0: tensor<2x32x64x128xbf16, #global_cache> {ttcore.kv_cache},
+      %arg1: tensor<1x32x1x128xbf16, #input>
+  ) attributes {tt.function_type = "forward_device"} {
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+
+    // CHECK: %[[LOCAL:.*]] = "ttnn.mesh_shard"(%arg0,
+    // CHECK-SAME: -> tensor<1x32x64x128x!ttcore.tile<32x32, bfp_bf8>,
+    %local_cache = "ttnn.mesh_shard"(%arg0, %dev) <{shard_dims = array<i64: -1, 0>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 1, 1, 1>, shard_type = #ttcore.shard_type<identity>}> : (tensor<2x32x64x128xbf16, #global_cache>, !ttnn.device) -> tensor<1x32x64x128xbf16, #local_cache>
+
+    // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg1)
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf8>
+    // CHECK-SAME: -> tensor<1x32x1x128x!ttcore.tile<32x32, bfp_bf8>,
+    // CHECK: "ttnn.fill_cache"(%[[LOCAL]], %[[CAST]])
+    // CHECK-NOT: "ttnn.typecast"(%arg0)
+    "ttnn.fill_cache"(%local_cache, %arg1) <{batch_offset = 0 : i32}> : (
+        tensor<1x32x64x128xbf16, #local_cache>,
+        tensor<1x32x1x128xbf16, #input>
+    ) -> ()
+    return
+  }
+}


### PR DESCRIPTION
### Ticket
#8449 

### Problem description
`TTNNKVCacheDtypeConversion` did not update intermediate values between the function argument and fill_cache's cache operand, causing a dtype mismatch when mesh_shard sat between them in TP models.

### What's changed
- Added `propagateDtypeTowardRoot` to `TTNNKVCacheDtypeConversion`, which walks backward from fill_cache's cache operand through its defining ops, updating each intermediate tensor type to the target dtype. This is invoked before the existing typecast insertion so the full operand chain is consistently typed before validation.             
- Added new lit test `fill_cache_bfp8_tp.mlir` that covers the TP path, verifying that the `mesh_shard` result is retyped to the target dtype                                                                                                                          
                                                                                        
