### PR TITLE
Moving RoPE fusing from TTNN to TTIR

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -3236,6 +3236,35 @@ def TTIR_SoftmaxOp : TTIR_NamedOp<"softmax"> {
     let hasVerifier = 1;
 }
 
+def TTIR_RotaryEmbeddingOp : TTIR_NamedOp<"rotary_embedding"> {
+  let summary = "Rotary position embedding operation.";
+  let description = [{
+    Applies rotary position embedding (RoPE) to the input tensor using
+    precomputed cosine and sine caches.
+
+    Formula:
+      result = x * cos + rotate_half(x) * sin
+      where rotate_half(x) = concat(neg(x[D/2:]), x[:D/2])
+
+    The input tensor must be 4D [batch, heads, seq_len, head_dim].
+    cos_cache and sin_cache must be 4D and broadcastable to the input shape,
+    with the last dimension (head_dim) matching the input exactly.
+
+    Example:
+      %result = "ttir.rotary_embedding"(%input, %cos_cache, %sin_cache)
+        : (tensor<1x32x128x64xbf16>, tensor<1x1x128x64xbf16>,
+           tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       AnyRankedTensor:$cos_cache,
+                       AnyRankedTensor:$sin_cache);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 1;
+}
+
 def TTIR_SortOp : TTIR_NamedOp<"sort"> {
   let summary = "Sort operation.";
   let description = [{

--- a/include/ttmlir/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_TRANSFORMS_FUSING_ROPEFUSINGPATTERN_H
+#define TTMLIR_DIALECT_TTIR_TRANSFORMS_FUSING_ROPEFUSINGPATTERN_H
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttir::fusing {
+
+// Fuses: (x * cos) + (rotate_half(x) * sin) -> rotary_embedding(x, cos, sin)
+//   where rotate_half(x) = concat(neg(x[D/2:]), x[:D/2])
+//
+// Anchors on AddOp. Handles commuted operand orders for both add and multiply.
+// Traces cos/sin through TM chains (TypecastOp, ReshapeOp, BroadcastOp).
+//
+// This pattern is unconditional — no op-model validation is performed.
+// Validation happens later at the TTNN level via
+// RotaryEmbeddingDecompositionRewritePattern.
+class RoPERotateHalfFusingPattern : public mlir::OpRewritePattern<AddOp> {
+public:
+  using OpRewritePattern<AddOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(AddOp srcOp, mlir::PatternRewriter &rewriter) const override;
+};
+
+// Fuses: concat(sub(x1*cos, x2*sin), add(x2*cos, x1*sin))
+//        -> rotary_embedding(x, concat(cos_h, cos_h), concat(sin_h, sin_h))
+//   where x1 = x[:D/2], x2 = x[D/2:]
+//
+// Anchors on ConcatOp. Handles optional pre-scaling of cos/sin (the scaled
+// values are absorbed as the cache inputs).
+//
+// This pattern is unconditional — no op-model validation is performed.
+class RoPEComplexRotationFusingPattern
+    : public mlir::OpRewritePattern<ConcatOp> {
+public:
+  using OpRewritePattern<ConcatOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ConcatOp srcOp,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttir::fusing
+
+#endif // TTMLIR_DIALECT_TTIR_TRANSFORMS_FUSING_ROPEFUSINGPATTERN_H

--- a/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_ROTARYEMBEDDINGDECOMPOSITIONREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_ROTARYEMBEDDINGDECOMPOSITIONREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+#include <optional>
+
+namespace mlir::tt::ttnn::decomposition {
+
+// Decomposes ttnn::RotaryEmbeddingOp back into primitive TTNN ops.
+// When validationConfig is provided, decomposition only occurs if op-model
+// validation fails. When validationConfig is std::nullopt, decomposition
+// is unconditional.
+//
+// Decomposition formula:
+//   x1 = slice(x, [:D/2])
+//   x2 = slice(x, [D/2:])
+//   rotated = concat(neg(x2), x1)
+//   result = add(mul(x, cos), mul(rotated, sin))
+class RotaryEmbeddingDecompositionRewritePattern
+    : public OpRewritePattern<ttnn::RotaryEmbeddingOp> {
+public:
+  RotaryEmbeddingDecompositionRewritePattern(mlir::MLIRContext *context)
+      : OpRewritePattern<ttnn::RotaryEmbeddingOp>(context) {}
+
+  RotaryEmbeddingDecompositionRewritePattern(
+      mlir::MLIRContext *context, const OpValidationConfig &validationConfig)
+      : OpRewritePattern<ttnn::RotaryEmbeddingOp>(context),
+        validationConfig(validationConfig) {}
+
+  LogicalResult matchAndRewrite(ttnn::RotaryEmbeddingOp ropeOp,
+                                PatternRewriter &rewriter) const override;
+
+private:
+  std::optional<OpValidationConfig> validationConfig;
+};
+
+} // namespace mlir::tt::ttnn::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_ROTARYEMBEDDINGDECOMPOSITIONREWRITEPATTERN_H

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -333,7 +333,12 @@ def TTNNFusing: Pass<"ttnn-fusing", "::mlir::ModuleOp">
             "uint32_t", /*default=*/"10000",
             "Maximum number of fallback configurations to try before "
             "giving up (0 = unlimited). Only used when "
-            "enable-op-constraints is true.">
+            "enable-op-constraints is true.">,
+    Option<"enableRoPEFusion",
+            "enable-rope-fusion",
+            "bool", /*default=*/"false",
+            "Enable RoPE fusion patterns at the TTNN level. Disabled by "
+            "default since RoPE fusion is handled at the TTIR level.">
   ];
 }
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3595,6 +3595,28 @@ public:
   }
 };
 
+class RotaryEmbeddingOpConversionPattern
+    : public OpConversionPattern<ttir::RotaryEmbeddingOp> {
+public:
+  using OpConversionPattern<ttir::RotaryEmbeddingOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::RotaryEmbeddingOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resultType =
+        this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<ttnn::RotaryEmbeddingOp>(
+        op, resultType, adaptor.getInput(), adaptor.getCosCache(),
+        adaptor.getSinCache(),
+        /*token_index=*/mlir::IntegerAttr(),
+        /*compute_config=*/nullptr);
+    return success();
+  }
+};
+
 class TopKOpConversionPattern : public OpConversionPattern<ttir::TopKOp> {
 public:
   using OpConversionPattern<ttir::TopKOp>::OpConversionPattern;
@@ -3764,6 +3786,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            GeluBackwardOpConversionPattern,
            DropoutOpConversionPattern,
            DebugOpConversionPattern<debug::DumpOp, ttnn::DumpTensorOp>,
+           RotaryEmbeddingOpConversionPattern,
            TopKOpConversionPattern,
            TopKRouterGptOpConversionPattern
            >(typeConverter, ctx);

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -5363,6 +5363,52 @@ mlir::OpFoldResult mlir::tt::ttir::RepeatInterleaveOp::fold(FoldAdaptor fold) {
 }
 
 //===----------------------------------------------------------------------===//
+// RotaryEmbeddingOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttir::RotaryEmbeddingOp::verify() {
+  auto inputType = mlir::cast<RankedTensorType>(getInput().getType());
+  auto cosType = mlir::cast<RankedTensorType>(getCosCache().getType());
+  auto sinType = mlir::cast<RankedTensorType>(getSinCache().getType());
+  auto resultType = mlir::cast<RankedTensorType>(getResult().getType());
+
+  // All tensors must be rank 4.
+  if (inputType.getRank() != 4) {
+    return emitOpError("input tensor must be rank 4, got rank ")
+           << inputType.getRank();
+  }
+  if (cosType.getRank() != 4) {
+    return emitOpError("cos_cache tensor must be rank 4, got rank ")
+           << cosType.getRank();
+  }
+  if (sinType.getRank() != 4) {
+    return emitOpError("sin_cache tensor must be rank 4, got rank ")
+           << sinType.getRank();
+  }
+
+  // cos and sin must have the same shape.
+  if (cosType.getShape() != sinType.getShape()) {
+    return emitOpError("cos_cache and sin_cache must have the same shape, got ")
+           << cosType.getShape() << " and " << sinType.getShape();
+  }
+
+  // Last dimension (head_dim) must match between input and cos/sin.
+  auto inputShape = inputType.getShape();
+  auto cosShape = cosType.getShape();
+  if (inputShape[3] != cosShape[3]) {
+    return emitOpError("head_dim mismatch: input has ")
+           << inputShape[3] << " but cos/sin caches have " << cosShape[3];
+  }
+
+  // Result shape must match input shape.
+  if (inputType.getShape() != resultType.getShape()) {
+    return emitOpError("result shape must match input shape");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // SortOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         RankNormalization.cpp
         Transforms.cpp
         TTIRFusing.cpp
+        Fusing/RoPEFusingPattern.cpp
         Fusing/TopKFusingPattern.cpp
         MultiDeviceTensorAnnotation.cpp
 

--- a/lib/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.cpp
@@ -1,0 +1,453 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.h"
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::tt::ttir::fusing {
+
+namespace {
+
+// Walk backward through transparent TM ops to find the original value.
+// These ops don't change the semantic content, just type/shape/layout.
+Value skipTMs(Value v) {
+  while (Operation *defOp = v.getDefiningOp()) {
+    if (isa<TypecastOp, ReshapeOp, BroadcastOp>(defOp)) {
+      v = defOp->getOperand(0);
+    } else {
+      break;
+    }
+  }
+  return v;
+}
+
+// Walk backward through BroadcastOp only, keeping typecast/reshape.
+// This gives us a 4D value suitable as an op input.
+Value skipBroadcastOnly(Value v) {
+  while (auto *defOp = v.getDefiningOp()) {
+    if (isa<BroadcastOp>(defOp)) {
+      v = defOp->getOperand(0);
+    } else {
+      break;
+    }
+  }
+  return v;
+}
+
+// Get slice parameters for a SliceStaticOp on a specific dimension.
+// Returns (begin, end) on that dimension if the slice is identity on all
+// other dimensions (begin=0, end=dimSize, step=1).
+std::optional<std::pair<int64_t, int64_t>> getSliceOnDim(SliceStaticOp sliceOp,
+                                                         int64_t targetDim) {
+  auto inputType = mlir::cast<RankedTensorType>(sliceOp.getOperand().getType());
+  auto inputShape = inputType.getShape();
+  int64_t rank = inputType.getRank();
+
+  auto begins = sliceOp.getBegins();
+  auto ends = sliceOp.getEnds();
+  auto steps = sliceOp.getStep();
+
+  for (int64_t i = 0; i < rank; ++i) {
+    auto begin = mlir::cast<IntegerAttr>(begins[i]).getInt();
+    auto end = mlir::cast<IntegerAttr>(ends[i]).getInt();
+    auto step = mlir::cast<IntegerAttr>(steps[i]).getInt();
+
+    if (step != 1) {
+      return std::nullopt;
+    }
+
+    if (i == targetDim) {
+      continue;
+    }
+
+    // Non-target dimensions must be identity slices.
+    if (begin != 0 || end != inputShape[i]) {
+      return std::nullopt;
+    }
+  }
+
+  auto begin = mlir::cast<IntegerAttr>(begins[targetDim]).getInt();
+  auto end = mlir::cast<IntegerAttr>(ends[targetDim]).getInt();
+  return std::make_pair(begin, end);
+}
+
+// Check that a slice takes the first half [0, D/2) on the last dimension.
+bool isFirstHalfSlice(SliceStaticOp sliceOp) {
+  auto inputType = mlir::cast<RankedTensorType>(sliceOp.getOperand().getType());
+  if (inputType.getRank() < 1) {
+    return false;
+  }
+  int64_t lastDim = inputType.getRank() - 1;
+  int64_t fullSize = inputType.getShape()[lastDim];
+  if (fullSize % 2 != 0) {
+    return false;
+  }
+  int64_t halfSize = fullSize / 2;
+  auto params = getSliceOnDim(sliceOp, lastDim);
+  return params && params->first == 0 && params->second == halfSize;
+}
+
+// Check that a slice takes the second half [D/2, D) on the last dimension.
+bool isSecondHalfSlice(SliceStaticOp sliceOp) {
+  auto inputType = mlir::cast<RankedTensorType>(sliceOp.getOperand().getType());
+  if (inputType.getRank() < 1) {
+    return false;
+  }
+  int64_t lastDim = inputType.getRank() - 1;
+  int64_t fullSize = inputType.getShape()[lastDim];
+  if (fullSize % 2 != 0) {
+    return false;
+  }
+  int64_t halfSize = fullSize / 2;
+  auto params = getSliceOnDim(sliceOp, lastDim);
+  return params && params->first == halfSize && params->second == fullSize;
+}
+
+// Result of matching the rotate_half subgraph.
+struct RotateHalfMatch {
+  Value xSource;         // The original input tensor before slicing.
+  ConcatOp concatOp;     // The concat that reassembles the rotated halves.
+  SliceStaticOp hiSlice; // slice(x, D/2:)
+  SliceStaticOp loSlice; // slice(x, :D/2)
+  NegOp negOp;           // neg(slice(x, D/2:))
+};
+
+// Try to match the rotate_half subgraph:
+//   concat(neg(slice(x, D/2:)), slice(x, :D/2))
+std::optional<RotateHalfMatch> matchRotateHalf(Value rotatedValue) {
+  auto concatOp = dyn_cast_or_null<ConcatOp>(rotatedValue.getDefiningOp());
+  if (!concatOp) {
+    return std::nullopt;
+  }
+
+  // Must concat on the last dimension with exactly 2 operands.
+  auto resultType = mlir::cast<RankedTensorType>(concatOp.getType());
+  if (concatOp.getDim() != resultType.getRank() - 1) {
+    return std::nullopt;
+  }
+  if (concatOp.getNumOperands() != 2) {
+    return std::nullopt;
+  }
+
+  Value firstArg = concatOp.getOperand(0);
+  Value secondArg = concatOp.getOperand(1);
+
+  // First operand must be neg(slice(x, D/2:)).
+  auto negOp = dyn_cast_or_null<NegOp>(firstArg.getDefiningOp());
+  if (!negOp) {
+    return std::nullopt;
+  }
+
+  auto hiSlice =
+      dyn_cast_or_null<SliceStaticOp>(negOp.getOperand().getDefiningOp());
+  if (!hiSlice) {
+    return std::nullopt;
+  }
+
+  // Second operand must be slice(x, :D/2).
+  auto loSlice = dyn_cast_or_null<SliceStaticOp>(secondArg.getDefiningOp());
+  if (!loSlice) {
+    return std::nullopt;
+  }
+
+  // Both slices must come from the same source.
+  if (hiSlice.getOperand() != loSlice.getOperand()) {
+    return std::nullopt;
+  }
+
+  // hiSlice must be [D/2, D), loSlice must be [0, D/2).
+  if (!isSecondHalfSlice(hiSlice) || !isFirstHalfSlice(loSlice)) {
+    return std::nullopt;
+  }
+
+  RotateHalfMatch match;
+  match.xSource = hiSlice.getOperand();
+  match.concatOp = concatOp;
+  match.hiSlice = hiSlice;
+  match.loSlice = loSlice;
+  match.negOp = negOp;
+  return match;
+}
+
+// Given a MulOp, try to identify which operand is x (matching expectedXSource)
+// and which is the cos/sin embedding.
+// Checks direct equality first (x is often used directly), then falls back
+// to walking through TMs. This mirrors TTNN's findCommonTMAncestor approach.
+// Returns (x_operand, embedding_operand) or nullopt.
+std::optional<std::pair<Value, Value>>
+identifyXAndEmbedding(MultiplyOp mulOp, Value expectedXSource) {
+  Value op0 = mulOp.getOperand(0);
+  Value op1 = mulOp.getOperand(1);
+
+  // Direct match first — handles the common case where x is used as-is
+  // (even if it's the output of a reshape/typecast).
+  if (op0 == expectedXSource) {
+    return std::make_pair(op0, op1);
+  }
+  if (op1 == expectedXSource) {
+    return std::make_pair(op1, op0);
+  }
+
+  // Fall back to tracing through TMs for cases where x is behind a
+  // typecast in the cos branch (e.g. x_bf16 -> typecast -> x_f32).
+  Value src0 = skipTMs(op0);
+  Value src1 = skipTMs(op1);
+
+  if (src0 == expectedXSource) {
+    return std::make_pair(op0, op1);
+  }
+  if (src1 == expectedXSource) {
+    return std::make_pair(op1, op0);
+  }
+  return std::nullopt;
+}
+
+// Get a 4D cos/sin input value suitable for the RotaryEmbeddingOp.
+// Walks back past broadcast but keeps typecast/reshape to ensure 4D.
+Value get4DEmbeddingInput(Value embValue) {
+  Value candidate = skipBroadcastOnly(embValue);
+  auto candidateType = mlir::dyn_cast<RankedTensorType>(candidate.getType());
+  if (candidateType && candidateType.getRank() == 4) {
+    return candidate;
+  }
+  // If not 4D after skipping broadcast, use the broadcast output.
+  return embValue;
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// RoPERotateHalfFusingPattern
+//===----------------------------------------------------------------------===//
+
+mlir::LogicalResult RoPERotateHalfFusingPattern::matchAndRewrite(
+    AddOp srcOp, mlir::PatternRewriter &rewriter) const {
+
+  // Both operands of the add must be multiplies.
+  auto mul0 = dyn_cast_or_null<MultiplyOp>(srcOp.getOperand(0).getDefiningOp());
+  auto mul1 = dyn_cast_or_null<MultiplyOp>(srcOp.getOperand(1).getDefiningOp());
+  if (!mul0 || !mul1) {
+    return failure();
+  }
+
+  // One multiply is x*cos, the other is rotate_half(x)*sin.
+  // Try both orderings for which mul is the sin branch.
+  MultiplyOp cosMul = nullptr;
+  MultiplyOp sinMul = nullptr;
+  std::optional<RotateHalfMatch> rotMatch;
+
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    MultiplyOp candidateSinMul = (attempt == 0) ? mul1 : mul0;
+    MultiplyOp candidateCosMul = (attempt == 0) ? mul0 : mul1;
+
+    // Check both operands of candidateSinMul for rotate_half.
+    for (int i = 0; i < 2; ++i) {
+      rotMatch = matchRotateHalf(candidateSinMul->getOperand(i));
+      if (rotMatch) {
+        break;
+      }
+    }
+
+    if (rotMatch) {
+      sinMul = candidateSinMul;
+      cosMul = candidateCosMul;
+      break;
+    }
+  }
+
+  if (!rotMatch) {
+    return failure();
+  }
+
+  Value xSource = rotMatch->xSource;
+
+  // Input must be 4D.
+  auto inputType = mlir::cast<RankedTensorType>(xSource.getType());
+  if (inputType.getRank() != 4) {
+    return failure();
+  }
+
+  // In the cos branch, identify x and cos.
+  auto cosXAndEmb = identifyXAndEmbedding(cosMul, xSource);
+  if (!cosXAndEmb) {
+    return failure();
+  }
+  auto [cosX, cosEmb] = *cosXAndEmb;
+
+  // In the sin branch, the embedding is the operand that is NOT rotate_half.
+  Value sinEmb;
+  if (sinMul->getOperand(0) == rotMatch->concatOp.getResult()) {
+    sinEmb = sinMul->getOperand(1);
+  } else if (sinMul->getOperand(1) == rotMatch->concatOp.getResult()) {
+    sinEmb = sinMul->getOperand(0);
+  } else {
+    return failure();
+  }
+
+  // Check single-use on critical intermediate ops to avoid incorrect fusion.
+  if (!cosMul->hasOneUse() || !sinMul->hasOneUse() ||
+      !rotMatch->concatOp->hasOneUse() || !rotMatch->negOp->hasOneUse()) {
+    return failure();
+  }
+
+  // Get 4D cos/sin inputs for the op.
+  Value cosInput = get4DEmbeddingInput(cosEmb);
+  Value sinInput = get4DEmbeddingInput(sinEmb);
+
+  auto resultType = mlir::cast<RankedTensorType>(srcOp.getType());
+  rewriter.replaceOpWithNewOp<RotaryEmbeddingOp>(srcOp, resultType, xSource,
+                                                 cosInput, sinInput);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// RoPEComplexRotationFusingPattern
+//===----------------------------------------------------------------------===//
+
+mlir::LogicalResult RoPEComplexRotationFusingPattern::matchAndRewrite(
+    ConcatOp srcOp, mlir::PatternRewriter &rewriter) const {
+
+  // Must concat on last dimension with exactly 2 operands.
+  auto resultType = mlir::cast<RankedTensorType>(srcOp.getType());
+  if (resultType.getRank() != 4) {
+    return failure();
+  }
+  if (srcOp.getDim() != resultType.getRank() - 1) {
+    return failure();
+  }
+  if (srcOp.getNumOperands() != 2) {
+    return failure();
+  }
+
+  // Operand 0: subtract(x1*cos, x2*sin)
+  auto subOp =
+      dyn_cast_or_null<SubtractOp>(srcOp.getOperand(0).getDefiningOp());
+  if (!subOp) {
+    return failure();
+  }
+
+  // Operand 1: add(x2*cos, x1*sin)
+  auto addOp = dyn_cast_or_null<AddOp>(srcOp.getOperand(1).getDefiningOp());
+  if (!addOp) {
+    return failure();
+  }
+
+  // All 4 operands of sub and add must be multiplies.
+  auto subMul0 =
+      dyn_cast_or_null<MultiplyOp>(subOp.getOperand(0).getDefiningOp());
+  auto subMul1 =
+      dyn_cast_or_null<MultiplyOp>(subOp.getOperand(1).getDefiningOp());
+  auto addMul0 =
+      dyn_cast_or_null<MultiplyOp>(addOp.getOperand(0).getDefiningOp());
+  auto addMul1 =
+      dyn_cast_or_null<MultiplyOp>(addOp.getOperand(1).getDefiningOp());
+  if (!subMul0 || !subMul1 || !addMul0 || !addMul1) {
+    return failure();
+  }
+
+  // Helper to find a SliceStaticOp operand of a MulOp.
+  auto findSlice =
+      [](MultiplyOp mulOp) -> std::optional<std::pair<SliceStaticOp, Value>> {
+    for (int i = 0; i < 2; ++i) {
+      Value op = mulOp->getOperand(i);
+      Value other = mulOp->getOperand(1 - i);
+      if (auto slice = dyn_cast_or_null<SliceStaticOp>(op.getDefiningOp())) {
+        return std::make_pair(slice, other);
+      }
+    }
+    return std::nullopt;
+  };
+
+  // Extract slice and embedding from each multiply.
+  auto subMul0Info = findSlice(subMul0);
+  auto subMul1Info = findSlice(subMul1);
+  auto addMul0Info = findSlice(addMul0);
+  auto addMul1Info = findSlice(addMul1);
+  if (!subMul0Info || !subMul1Info || !addMul0Info || !addMul1Info) {
+    return failure();
+  }
+
+  auto [subSlice0, subEmb0] = *subMul0Info;
+  auto [subSlice1, subEmb1] = *subMul1Info;
+  auto [addSlice0, addEmb0] = *addMul0Info;
+  auto [addSlice1, addEmb1] = *addMul1Info;
+
+  // All slices must come from the same source tensor.
+  Value xSource = subSlice0.getOperand();
+  if (subSlice1.getOperand() != xSource || addSlice0.getOperand() != xSource ||
+      addSlice1.getOperand() != xSource) {
+    return failure();
+  }
+
+  // Input must be 4D.
+  auto inputType = mlir::cast<RankedTensorType>(xSource.getType());
+  if (inputType.getRank() != 4) {
+    return failure();
+  }
+
+  // sub: x1*cos - x2*sin => subSlice0 = x1 (first half), subSlice1 = x2
+  // add: x2*cos + x1*sin => addSlice0 = x2, addSlice1 = x1
+  if (!isFirstHalfSlice(subSlice0) || !isSecondHalfSlice(subSlice1)) {
+    return failure();
+  }
+  if (!isSecondHalfSlice(addSlice0) || !isFirstHalfSlice(addSlice1)) {
+    return failure();
+  }
+
+  // Verify cos is shared: subEmb0 and addEmb0 should trace to same source.
+  Value cosSource = skipTMs(subEmb0);
+  Value cosSourceFromAdd = skipTMs(addEmb0);
+  if (cosSource != cosSourceFromAdd) {
+    return failure();
+  }
+
+  // Verify sin is shared: subEmb1 and addEmb1 should trace to same source.
+  Value sinSource = skipTMs(subEmb1);
+  Value sinSourceFromAdd = skipTMs(addEmb1);
+  if (sinSource != sinSourceFromAdd) {
+    return failure();
+  }
+
+  // Check single-use on critical intermediates.
+  if (!subOp->hasOneUse() || !addOp->hasOneUse() || !subMul0->hasOneUse() ||
+      !subMul1->hasOneUse() || !addMul0->hasOneUse() || !addMul1->hasOneUse()) {
+    return failure();
+  }
+
+  // cos/sin are half-dim. Double them to full-dim by concatenating with
+  // themselves.
+  Value cosHalf = get4DEmbeddingInput(subEmb0);
+  Value sinHalf = get4DEmbeddingInput(subEmb1);
+
+  auto cosHalfType = mlir::cast<RankedTensorType>(cosHalf.getType());
+  auto sinHalfType = mlir::cast<RankedTensorType>(sinHalf.getType());
+
+  int64_t lastDim = resultType.getRank() - 1;
+
+  SmallVector<int64_t> cosFullShape(cosHalfType.getShape());
+  cosFullShape[lastDim] *= 2;
+  auto cosFullType =
+      RankedTensorType::get(cosFullShape, cosHalfType.getElementType());
+
+  SmallVector<int64_t> sinFullShape(sinHalfType.getShape());
+  sinFullShape[lastDim] *= 2;
+  auto sinFullType =
+      RankedTensorType::get(sinFullShape, sinHalfType.getElementType());
+
+  auto cosFull = rewriter.create<ConcatOp>(
+      srcOp.getLoc(), cosFullType, ValueRange{cosHalf, cosHalf},
+      rewriter.getSI32IntegerAttr(lastDim));
+  auto sinFull = rewriter.create<ConcatOp>(
+      srcOp.getLoc(), sinFullType, ValueRange{sinHalf, sinHalf},
+      rewriter.getSI32IntegerAttr(lastDim));
+
+  rewriter.replaceOpWithNewOp<RotaryEmbeddingOp>(srcOp, resultType, xSource,
+                                                 cosFull, sinFull);
+  return success();
+}
+
+} // namespace mlir::tt::ttir::fusing

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Fusing/TopKFusingPattern.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTIR/Utils/Utils.h"
@@ -3051,6 +3052,8 @@ public:
       patterns.add<HardsigmoidFusionPattern>(&getContext());
       patterns.add<MishFusingPattern>(&getContext());
       patterns.add<ReshapeBroadcastReshapeToRepeatPattern>(&getContext());
+      patterns.add<fusing::RoPERotateHalfFusingPattern>(&getContext());
+      patterns.add<fusing::RoPEComplexRotationFusingPattern>(&getContext());
       patterns.add<fusing::TopKFusingPattern>(&getContext());
 
       GreedyRewriteConfig config;

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
         Decomposition/DistributedLayerNormDecompositionRewritePattern.cpp
         Decomposition/GroupNormDecompositionRewritePattern.cpp
+        Decomposition/RotaryEmbeddingDecompositionRewritePattern.cpp
         Decomposition/TopKDecompositionRewritePattern.cpp
         Decomposition/TTNNDecompositionPass.cpp
         OpValidator.cpp

--- a/lib/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.h"
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Support/Logger.h"
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::tt::ttnn::decomposition {
+
+LogicalResult RotaryEmbeddingDecompositionRewritePattern::matchAndRewrite(
+    ttnn::RotaryEmbeddingOp ropeOp, PatternRewriter &rewriter) const {
+
+  auto inputType = mlir::cast<RankedTensorType>(ropeOp.getInput().getType());
+  auto resultType = mlir::cast<RankedTensorType>(ropeOp.getResult().getType());
+
+  // When validation config is provided, validate first.
+  if (validationConfig.has_value()) {
+    IsolatedIRValidationWrapper validator(rewriter.getContext(),
+                                          *validationConfig);
+
+    auto validationResult = validator.validateOp<ttnn::RotaryEmbeddingOp>(
+        ropeOp.getOperation(), ropeOp.getLoc(), {resultType}, ropeOp.getInput(),
+        ropeOp.getCosCache(), ropeOp.getSinCache(), ropeOp.getTokenIndexAttr(),
+        /*compute_config=*/nullptr);
+
+    if (validationResult.isSuccess()) {
+      return failure(); // Op is valid, keep it.
+    }
+
+    TTMLIR_DEBUG(
+        ttmlir::LogComponent::IsolatedIRValidationWrapper,
+        "RotaryEmbedding decomposition triggered (validation failed): {0}",
+        validationResult.errorMessage);
+  }
+
+  // Decompose: result = x*cos + rotate_half(x)*sin
+  // where rotate_half(x) = concat(neg(x[D/2:]), x[:D/2])
+
+  auto loc = ropeOp.getLoc();
+  auto inputShape = inputType.getShape();
+  int64_t rank = inputType.getRank();
+  int64_t lastDim = rank - 1;
+  int64_t fullDim = inputShape[lastDim];
+  int64_t halfDim = fullDim / 2;
+
+  // Build slice attributes for first half [0, D/2) and second half [D/2, D).
+  SmallVector<Attribute> beginsLo, endsLo, beginsHi, endsHi, steps;
+  for (int64_t i = 0; i < rank; ++i) {
+    beginsLo.push_back(rewriter.getI32IntegerAttr(0));
+    beginsHi.push_back(rewriter.getI32IntegerAttr(i == lastDim ? halfDim : 0));
+    endsLo.push_back(
+        rewriter.getI32IntegerAttr(i == lastDim ? halfDim : inputShape[i]));
+    endsHi.push_back(rewriter.getI32IntegerAttr(inputShape[i]));
+    steps.push_back(rewriter.getI32IntegerAttr(1));
+  }
+
+  // Compute half-dim shape and type.
+  SmallVector<int64_t> halfShape(inputShape);
+  halfShape[lastDim] = halfDim;
+  auto halfType = utils::RankedTensorTypeFactory::create(resultType, halfShape);
+
+  auto stepsAttr = rewriter.getArrayAttr(steps);
+
+  // x_lo = x[:D/2], x_hi = x[D/2:]
+  auto xLo = rewriter.create<ttnn::SliceStaticOp>(
+      loc, halfType, ropeOp.getInput(), rewriter.getArrayAttr(beginsLo),
+      rewriter.getArrayAttr(endsLo), stepsAttr);
+  auto xHi = rewriter.create<ttnn::SliceStaticOp>(
+      loc, halfType, ropeOp.getInput(), rewriter.getArrayAttr(beginsHi),
+      rewriter.getArrayAttr(endsHi), stepsAttr);
+
+  // neg(x_hi)
+  auto negHi = rewriter.create<ttnn::NegOp>(loc, halfType, xHi.getResult());
+
+  // rotated = concat(neg(x_hi), x_lo) on last dim
+  auto rotated = rewriter.create<ttnn::ConcatOp>(
+      loc, resultType, ValueRange{negHi.getResult(), xLo.getResult()},
+      static_cast<int32_t>(lastDim));
+
+  // x * cos
+  auto xCos = rewriter.create<ttnn::MultiplyOp>(
+      loc, resultType, ropeOp.getInput(), ropeOp.getCosCache());
+
+  // rotated * sin
+  auto rotSin = rewriter.create<ttnn::MultiplyOp>(
+      loc, resultType, rotated.getResult(), ropeOp.getSinCache());
+
+  // result = x*cos + rotated*sin
+  auto result = rewriter.create<ttnn::AddOp>(loc, resultType, xCos.getResult(),
+                                             rotSin.getResult());
+
+  rewriter.replaceOp(ropeOp, result.getResult());
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::decomposition

--- a/lib/Dialect/TTNN/Transforms/Decomposition/TTNNDecompositionPass.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/TTNNDecompositionPass.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/DistributedLayerNormDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 
@@ -39,12 +40,16 @@ public:
           &getContext(), validationConfig);
       patterns.add<decomposition::GroupNormDecompositionRewritePattern>(
           &getContext(), validationConfig);
+      patterns.add<decomposition::RotaryEmbeddingDecompositionRewritePattern>(
+          &getContext(), validationConfig);
     } else {
       patterns.add<decomposition::TopKDecompositionRewritePattern>(
           &getContext());
       patterns.add<decomposition::ConcatenateHeadsDecompositionRewritePattern>(
           &getContext());
       patterns.add<decomposition::GroupNormDecompositionRewritePattern>(
+          &getContext());
+      patterns.add<decomposition::RotaryEmbeddingDecompositionRewritePattern>(
           &getContext());
     }
 

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -320,10 +320,13 @@ public:
       OpValidationConfig validationConfig;
       validationConfig.maxFallbackAttempts = maxFallbackAttempts;
 
-      patterns.add<fusing::RoPERotateHalfFusing>(&getContext(),
+      if (enableRoPEFusion) {
+        patterns.add<fusing::RoPERotateHalfFusing>(&getContext(),
+                                                   validationConfig);
+        patterns.add<fusing::RoPEExpandedFusing>(&getContext(),
                                                  validationConfig);
-      patterns.add<fusing::RoPEExpandedFusing>(&getContext(), validationConfig);
-      patterns.add<fusing::RoPEDecodeFusing>(&getContext());
+        patterns.add<fusing::RoPEDecodeFusing>(&getContext());
+      }
       patterns.add<fusing::SDPAFusing>(&getContext(), validationConfig);
       patterns.add<NLPConcatHeadsDecodeFusing>(&getContext());
       patterns.add<fusing::SplitQueryKeyValueAndSplitHeadsFusing<MatmulOp>>(

--- a/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
+++ b/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
@@ -4,8 +4,8 @@
 
 import pytest
 import torch
-from typing import List, Optional
-from builder.base.builder_utils import Operand, Shape
+from typing import List
+from builder.base.builder_utils import Operand
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir
 from conftest import get_request_kwargs
@@ -22,125 +22,235 @@ def check_op(mlir_file: str, op_name: str) -> bool:
     return False
 
 
-def rotate(x):
+def rotate_half(x):
     x1 = x[..., : x.shape[-1] // 2]
     x2 = x[..., x.shape[-1] // 2 :]
     return torch.cat((-x2, x1), dim=-1)
 
 
-def build_torch_golden(
-    input_data: torch.Tensor,
-    cos_data: torch.Tensor,
-    sin_data: torch.Tensor,
-) -> torch.Tensor:
-    # Unsqueeze cos and sin
-    cos_unsqueezed = torch.unsqueeze(cos_data, dim=0)
-    sin_unsqueezed = torch.unsqueeze(sin_data, dim=0)
-
-    # Rotate input
-    rotated = rotate(input_data)
-
-    # Final computation: input * cos + rotated * sin
-    return input_data * cos_unsqueezed + rotated * sin_unsqueezed
+def torch_rope(x, cos, sin):
+    """Golden reference for RoPE. Works for both patterns since they are
+    mathematically equivalent. cos/sin are broadcast over batch and heads."""
+    return x * cos + rotate_half(x) * sin
 
 
-def build_ttir(
+# ---------------------------------------------------------------------------
+# Pattern 1: rotate_half
+#   result = x * cos + rotate_half(x) * sin
+#   where rotate_half(x) = concat(neg(x[D/2:]), x[:D/2])
+# ---------------------------------------------------------------------------
+
+
+def build_rope_rotate_half(
     input: Operand,
     cos_input: Operand,
     sin_input: Operand,
     builder: TTIRBuilder,
-    unit_attrs: Optional[List[str]] = None,
 ):
-    unsqueezed_shape = [1] + sin_input.type.shape
-    cos_unsqueezed = builder.reshape(cos_input, shape=unsqueezed_shape)
+    """Build Pattern 1 (rotate_half) as a sequence of TTIR ops.
 
-    # Multiply input with sin
-    unrotated = builder.multiply(input, cos_unsqueezed)
+    cos/sin are 3D [1, seq, head_dim] and get reshaped to 4D [1, 1, seq, head_dim]
+    then broadcast to match the input [batch, heads, seq, head_dim].
+    This mirrors how tt-xla emits the pattern for llama, falcon, qwen, etc.
+    """
+    cos_4d_shape = [1, 1] + cos_input.type.shape[1:]
+    cos_reshaped = builder.reshape(cos_input, shape=cos_4d_shape)
+    sin_reshaped = builder.reshape(sin_input, shape=cos_4d_shape)
+
+    # x * cos (broadcast cos over batch and heads)
+    x_cos = builder.multiply(input, cos_reshaped)
 
     last_dim = input.type.shape[-1]
     half_dim = last_dim // 2
 
-    # Slice second half of input
-    begins = [0, 0, 0, half_dim]
-    ends = input.type.shape[:3] + [last_dim]
-    slice1 = builder.slice(input, begins=begins, ends=ends, step=[1, 1, 1, 1])
+    # rotate_half(x) = concat(neg(x[D/2:]), x[:D/2])
+    begins_hi = [0, 0, 0, half_dim]
+    ends_hi = list(input.type.shape[:3]) + [last_dim]
+    x_hi = builder.slice(input, begins=begins_hi, ends=ends_hi, step=[1, 1, 1, 1])
+    neg_hi = builder.neg(x_hi)
 
-    # Negate the second half
-    neg_slice = builder.neg(slice1, unit_attrs=unit_attrs)
+    begins_lo = [0, 0, 0, 0]
+    ends_lo = list(input.type.shape[:3]) + [half_dim]
+    x_lo = builder.slice(input, begins=begins_lo, ends=ends_lo, step=[1, 1, 1, 1])
 
-    # Slice first half of input
-    begins = [0, 0, 0, 0]
-    ends = input.type.shape[:3] + [half_dim]
-    slice2 = builder.slice(input, begins=begins, ends=ends, step=[1, 1, 1, 1])
+    rotated = builder.concat([neg_hi, x_lo], dim=3)
 
-    # Concat negated second half with first half
-    input_rotated = builder.concat([neg_slice, slice2], dim=3)
+    # rotate_half(x) * sin (broadcast sin over batch and heads)
+    rot_sin = builder.multiply(rotated, sin_reshaped)
 
-    # Unsqueeze sin
-    sin_unsqueezed = builder.reshape(sin_input, shape=unsqueezed_shape)
-
-    # Multiply rotated with broadcasted cos
-    rotated = builder.multiply(input_rotated, sin_unsqueezed)
-
-    # Add the two products
-    return builder.add(unrotated, rotated)
+    return builder.add(x_cos, rot_sin)
 
 
-@pytest.mark.skip(
-    "TTNN fusing is only available when optimizer is enabled, but currently optimizer isn't enabled in builder tests: https://github.com/tenstorrent/tt-mlir/issues/5909"
-)
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        # prefill
-        [
-            (1, 32, 1024, 64),  # input
-            (1, 1024, 64),  # cos input
-            (1, 1024, 64),  # sin input
-        ],
-        [
-            (1, 8, 1, 64),  # input
-            (1, 1, 64),  # cos input
-            (1, 1, 64),  # sin input
-        ],
-        # Phi decode: query path (seq=1, head_dim=32 partial rotary)
-        [
-            (32, 32, 1, 32),  # input [num_heads, batch, seq=1, head_dim/2]
-            (1, 1, 32),  # cos input
-            (1, 1, 32),  # sin input
-        ],
-        # Phi decode: key path after EIO commute pushes reshape back through
-        # RoPE, folding batch into seq: [1, nH=32, B*S=32, D/2=32].
-        # cos/sin seq=1 < input seq=32 so fusion is correctly rejected.
-        # Should fuse once RoPE fusion moves before EIO pass.
-        # https://github.com/tenstorrent/tt-mlir/issues/8341
-        pytest.param(
-            [
-                (1, 32, 32, 32),  # input [1, num_heads, batch, head_dim/2]
-                (1, 1, 32),  # cos input
-                (1, 1, 32),  # sin input
-            ],
-            marks=pytest.mark.xfail(
-                reason="cos/sin seq < input seq — fusion rejected until "
-                "RoPE fusion moves before EIO "
-                "(https://github.com/tenstorrent/tt-mlir/issues/8341)"
-            ),
-        ),
-    ],
-)
-@pytest.mark.parametrize("dtypes", [[torch.bfloat16] * 3])
-@pytest.mark.parametrize("target", ["ttnn"])
-def test_rotary_embedding(
-    shapes: List[Shape], dtypes: List[torch.dtype], target: str, request, device
+# ---------------------------------------------------------------------------
+# Pattern 2: complex rotation (expanded / trig-identity form)
+#   real = x1*cos - x2*sin
+#   imag = x2*cos + x1*sin
+#   result = concat(real, imag)
+#   where x1 = x[:D/2], x2 = x[D/2:]
+# Used by gpt_oss models. cos/sin are half-dim and get doubled.
+# ---------------------------------------------------------------------------
+
+
+def build_rope_complex_rotation(
+    input: Operand,
+    cos_half_input: Operand,
+    sin_half_input: Operand,
+    builder: TTIRBuilder,
 ):
+    """Build Pattern 2 (complex rotation) as a sequence of TTIR ops.
+
+    cos/sin are half-dim 3D [1, seq, head_dim/2] and get reshaped to 4D
+    then broadcast. This mirrors how tt-xla emits the gpt_oss pattern.
     """
-    Test rotary position embedding (RoPE) pattern.
-    This test implements the RoPE operation as a sequence of TTIR ops:
-    - Reshape cos/sin to unsqueeze first dimension
-    - Split input into two halves along last dimension
-    - Rotate: concat(neg(second_half), first_half)
-    - Multiply and add: input * cos + rotated * sin
+    cos_4d_shape = [1, 1] + cos_half_input.type.shape[1:]
+    cos_reshaped = builder.reshape(cos_half_input, shape=cos_4d_shape)
+    sin_reshaped = builder.reshape(sin_half_input, shape=cos_4d_shape)
+
+    last_dim = input.type.shape[-1]
+    half_dim = last_dim // 2
+
+    # x1 = x[:D/2], x2 = x[D/2:]
+    begins_lo = [0, 0, 0, 0]
+    ends_lo = list(input.type.shape[:3]) + [half_dim]
+    x1 = builder.slice(input, begins=begins_lo, ends=ends_lo, step=[1, 1, 1, 1])
+
+    begins_hi = [0, 0, 0, half_dim]
+    ends_hi = list(input.type.shape[:3]) + [last_dim]
+    x2 = builder.slice(input, begins=begins_hi, ends=ends_hi, step=[1, 1, 1, 1])
+
+    # real = x1*cos - x2*sin
+    x1_cos = builder.multiply(x1, cos_reshaped)
+    x2_sin = builder.multiply(x2, sin_reshaped)
+    real = builder.subtract(x1_cos, x2_sin)
+
+    # imag = x2*cos + x1*sin
+    x2_cos = builder.multiply(x2, cos_reshaped)
+    x1_sin = builder.multiply(x1, sin_reshaped)
+    imag = builder.add(x2_cos, x1_sin)
+
+    return builder.concat([real, imag], dim=3)
+
+
+# ---------------------------------------------------------------------------
+# Test parameters: shapes extracted from 40 LLM TTIR graphs (tt-xla CI)
+#
+# Pattern 1 (rotate_half):
+#   input: [B, H, S, D]  cos/sin: [1, S, D]  (3D, reshaped to 4D in builder)
+#
+# Pattern 2 (complex rotation):
+#   input: [B, H, S, D]  cos/sin: [1, S, D/2] (half-dim, 3D)
+# ---------------------------------------------------------------------------
+
+# Representative shapes per model family for Pattern 1
+ROTATE_HALF_SHAPES = [
+    # --- Prefill (seq > 1) ---
+    pytest.param(
+        (32, 8, 18, 128),
+        (1, 18, 128),
+        id="llama_3_1_8b-prefill",
+    ),
+    pytest.param(
+        (32, 8, 18, 64),
+        (1, 18, 64),
+        id="llama_3_2_1b-prefill",
+    ),
+    pytest.param(
+        (32, 4, 17, 256),
+        (1, 17, 256),
+        id="falcon3_1b-prefill",
+    ),
+    pytest.param(
+        (32, 32, 17, 32),
+        (1, 17, 32),
+        id="phi1_5-prefill",
+    ),
+    pytest.param(
+        (32, 2, 17, 128),
+        (1, 17, 128),
+        id="qwen_2_5_1_5b-prefill",
+    ),
+    pytest.param(
+        (32, 8, 18, 128),
+        (1, 18, 128),
+        id="mistral_7b-prefill",
+    ),
+    pytest.param(
+        (32, 1, 17, 256),
+        (1, 17, 256),
+        id="gemma_1_1_2b-prefill",
+    ),
+    # --- Decode (seq = 1) ---
+    pytest.param(
+        (32, 8, 1, 128),
+        (1, 1, 128),
+        id="llama_3_1_8b-decode",
+    ),
+    pytest.param(
+        (32, 8, 1, 64),
+        (1, 1, 64),
+        id="llama_3_2_1b-decode",
+    ),
+    pytest.param(
+        (32, 4, 1, 256),
+        (1, 1, 256),
+        id="falcon3_1b-decode",
+    ),
+    pytest.param(
+        (32, 32, 1, 32),
+        (1, 1, 32),
+        id="phi1_5-decode",
+    ),
+    pytest.param(
+        (32, 2, 1, 128),
+        (1, 1, 128),
+        id="qwen_2_5_1_5b-decode",
+    ),
+    pytest.param(
+        (32, 8, 1, 128),
+        (1, 1, 128),
+        id="ministral_8b-decode",
+    ),
+]
+
+# Representative shapes for Pattern 2 (complex rotation / expanded)
+COMPLEX_ROTATION_SHAPES = [
+    pytest.param(
+        (32, 8, 17, 64),
+        (1, 17, 32),
+        id="gpt_oss_20b_tp-prefill",
+    ),
+    pytest.param(
+        (32, 8, 1, 64),
+        (1, 1, 32),
+        id="gpt_oss_20b_tp-decode",
+    ),
+    pytest.param(
+        (64, 8, 17, 64),
+        (1, 17, 32),
+        id="gpt_oss_120b_tp_galaxy-prefill",
+    ),
+    pytest.param(
+        (1, 8, 17, 64),
+        (1, 17, 32),
+        id="gpt_oss_20b_tp_batch_size_1-prefill",
+    ),
+]
+
+
+@pytest.mark.parametrize("input_shape, cos_sin_shape", ROTATE_HALF_SHAPES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_rope_rotate_half(input_shape, cos_sin_shape, dtype, target, request, device):
     """
+    Pattern 1: rotate_half RoPE.
+    Used by llama, falcon, gemma, qwen, mistral, ministral, phi, kimi.
+
+    Shapes extracted from tt-xla CI artifacts (40 LLM models).
+    Verifies that the decomposed RoPE pattern fuses into ttnn.rotary_embedding
+    through the full pipeline.
+    """
+    shapes = [input_shape, cos_sin_shape, cos_sin_shape]
+    dtypes = [dtype] * 3
 
     def module(builder: TTIRBuilder):
         @builder.func(shapes, dtypes)
@@ -149,22 +259,20 @@ def test_rotary_embedding(
             cos_input: Operand,
             sin_input: Operand,
             builder: TTIRBuilder,
-            unit_attrs: Optional[List[str]] = None,
         ):
-            # Create input tensors
-            input_data = torch.randn(shapes[0], dtype=dtypes[1])
-            cos_data = torch.randn(shapes[1], dtype=dtypes[0])
-            sin_data = torch.randn(shapes[2], dtype=dtypes[2])
+            input_data = torch.randn(input_shape, dtype=dtype)
+            cos_data = torch.randn(cos_sin_shape, dtype=dtype)
+            sin_data = torch.randn(cos_sin_shape, dtype=dtype)
 
-            golden_output = build_torch_golden(input_data, cos_data, sin_data)
+            cos_4d = cos_data.unsqueeze(0)
+            sin_4d = sin_data.unsqueeze(0)
+            golden = torch_rope(input_data, cos_4d, sin_4d)
 
-            result = build_ttir(
-                input, cos_input, sin_input, builder, unit_attrs=unit_attrs
-            )
+            result = build_rope_rotate_half(input, cos_input, sin_input, builder)
 
             builder.set_goldens(
                 {input: input_data, cos_input: cos_data, sin_input: sin_data},
-                {result: golden_output},
+                {result: golden},
             )
             return result
 
@@ -173,71 +281,61 @@ def test_rotary_embedding(
         target=target,
         **get_request_kwargs(request),
         device=device,
+        pipeline_options=["enable-ttnn-decomposition-pass=false"],
+        save_artifacts=True,
     )
 
     assert check_op(output, "rotary_embedding")
-    if shapes[0][-2] % 32 != 0:
-        assert check_op(output, "slice_static")
 
 
-@pytest.mark.skip(
-    "Causes segfault during pipeline, see https://github.com/tenstorrent/tt-mlir/issues/5283"
-)
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        # decode
-        pytest.param(
-            [
-                (1, 8, 1, 64),  # input
-                (1, 1, 64),  # cos input
-                (1, 1, 64),  # sin input
-            ],
-            # Mark as fail because of https://github.com/tenstorrent/tt-metal/issues/31567
-            # I will follow up with decomposition to slice tensor until there is
-            # some resolution from metal team.
-            # Issue for decomposition https://github.com/tenstorrent/tt-mlir/issues/5621
-            marks=pytest.mark.xfail,
-        ),
-    ],
-)
-@pytest.mark.parametrize("dtypes", [[torch.bfloat16] * 3])
+@pytest.mark.parametrize("input_shape, cos_sin_half_shape", COMPLEX_ROTATION_SHAPES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("target", ["ttnn"])
-def test_rotary_embedding_failure(
-    shapes: List[Shape], dtypes: List[torch.dtype], target: str, request, device
+def test_rope_complex_rotation(
+    input_shape, cos_sin_half_shape, dtype, target, request, device
 ):
     """
-    Test rotary position embedding (RoPE) pattern.
-    This test implements the RoPE operation as a sequence of TTIR ops:
-    - Reshape cos/sin to unsqueeze first dimension
-    - Split input into two halves along last dimension
-    - Rotate: concat(neg(second_half), first_half)
-    - Multiply and add: input * cos + rotated * sin
+    Pattern 2: complex rotation (expanded / trig-identity) RoPE.
+    Used by gpt_oss_20b and gpt_oss_120b.
+
+    cos/sin are half-dim [1, S, D/2]. The fusion doubles them to full-dim
+    by concatenating with themselves before creating ttnn.rotary_embedding.
+
+    Previously unfused at TTNN level when cos/sin were pre-scaled (#8415).
+    Now fused at TTIR level where the scaled values are absorbed naturally.
     """
+    shapes = [input_shape, cos_sin_half_shape, cos_sin_half_shape]
+    dtypes = [dtype] * 3
 
     def module(builder: TTIRBuilder):
         @builder.func(shapes, dtypes)
         def rotary_embedding(
             input: Operand,
-            cos_input: Operand,
-            sin_input: Operand,
+            cos_half_input: Operand,
+            sin_half_input: Operand,
             builder: TTIRBuilder,
-            unit_attrs: Optional[List[str]] = None,
         ):
-            # Create input tensors
-            input_data = torch.randn(shapes[0], dtype=dtypes[1])
-            cos_data = torch.randn(shapes[1], dtype=dtypes[0])
-            sin_data = torch.randn(shapes[2], dtype=dtypes[2])
+            input_data = torch.randn(input_shape, dtype=dtype)
+            cos_half_data = torch.randn(cos_sin_half_shape, dtype=dtype)
+            sin_half_data = torch.randn(cos_sin_half_shape, dtype=dtype)
 
-            golden_output = build_torch_golden(input_data, cos_data, sin_data)
+            cos_full = torch.cat([cos_half_data, cos_half_data], dim=-1)
+            sin_full = torch.cat([sin_half_data, sin_half_data], dim=-1)
+            golden = torch_rope(
+                input_data, cos_full.unsqueeze(0), sin_full.unsqueeze(0)
+            )
 
-            result = build_ttir(
-                input, cos_input, sin_input, builder, unit_attrs=unit_attrs
+            result = build_rope_complex_rotation(
+                input, cos_half_input, sin_half_input, builder
             )
 
             builder.set_goldens(
-                {input: input_data, cos_input: cos_data, sin_input: sin_data},
-                {result: golden_output},
+                {
+                    input: input_data,
+                    cos_half_input: cos_half_data,
+                    sin_half_input: sin_half_data,
+                },
+                {result: golden},
             )
             return result
 
@@ -246,7 +344,8 @@ def test_rotary_embedding_failure(
         target=target,
         **get_request_kwargs(request),
         device=device,
-        pipeline_options=["disable-workarounds=true"],
+        pipeline_options=["enable-ttnn-decomposition-pass=false"],
+        save_artifacts=True,
     )
 
     assert check_op(output, "rotary_embedding")

--- a/test/ttmlir/Dialect/TTIR/fusing/rotary_embedding/rope.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/rotary_embedding/rope.mlir
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttir-fusing %s | FileCheck %s
+
+// =========================================================================
+// Pattern 1: rotate_half RoPE
+// =========================================================================
+
+// Basic rotate_half with 4D broadcast cos/sin.
+// CHECK-LABEL: @rope_rotate_half_basic
+// CHECK: "ttir.rotary_embedding"
+// CHECK-NOT: ttir.neg
+// CHECK-NOT: ttir.concat
+module {
+  func.func @rope_rotate_half_basic(%x: tensor<1x32x128x64xbf16>, %cos: tensor<1x1x128x64xbf16>, %sin: tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos) <{broadcast_dimensions = array<i64: 1, 32, 1, 1>}> : (tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %x_cos = "ttir.multiply"(%x, %cos_bc) : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+
+    %x_hi = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [1:i32, 32:i32, 128:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x128x64xbf16>) -> tensor<1x32x128x32xbf16>
+    %neg_hi = "ttir.neg"(%x_hi) : (tensor<1x32x128x32xbf16>) -> tensor<1x32x128x32xbf16>
+    %x_lo = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 32:i32, 128:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x128x64xbf16>) -> tensor<1x32x128x32xbf16>
+    %rotated = "ttir.concat"(%neg_hi, %x_lo) <{dim = 3 : si32}> : (tensor<1x32x128x32xbf16>, tensor<1x32x128x32xbf16>) -> tensor<1x32x128x64xbf16>
+
+    %sin_bc = "ttir.broadcast"(%sin) <{broadcast_dimensions = array<i64: 1, 32, 1, 1>}> : (tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %rot_sin = "ttir.multiply"(%rotated, %sin_bc) : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %result = "ttir.add"(%x_cos, %rot_sin) : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %result : tensor<1x32x128x64xbf16>
+  }
+}
+
+// Commuted add: sin branch on LHS.
+// CHECK-LABEL: @rope_rotate_half_commuted_add
+// CHECK: "ttir.rotary_embedding"
+module {
+  func.func @rope_rotate_half_commuted_add(%x: tensor<1x32x128x64xbf16>, %cos: tensor<1x1x128x64xbf16>, %sin: tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos) <{broadcast_dimensions = array<i64: 1, 32, 1, 1>}> : (tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %x_cos = "ttir.multiply"(%x, %cos_bc) : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+
+    %x_hi = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [1:i32, 32:i32, 128:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x128x64xbf16>) -> tensor<1x32x128x32xbf16>
+    %neg_hi = "ttir.neg"(%x_hi) : (tensor<1x32x128x32xbf16>) -> tensor<1x32x128x32xbf16>
+    %x_lo = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 32:i32, 128:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x128x64xbf16>) -> tensor<1x32x128x32xbf16>
+    %rotated = "ttir.concat"(%neg_hi, %x_lo) <{dim = 3 : si32}> : (tensor<1x32x128x32xbf16>, tensor<1x32x128x32xbf16>) -> tensor<1x32x128x64xbf16>
+
+    %sin_bc = "ttir.broadcast"(%sin) <{broadcast_dimensions = array<i64: 1, 32, 1, 1>}> : (tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %rot_sin = "ttir.multiply"(%rotated, %sin_bc) : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+
+    %result = "ttir.add"(%rot_sin, %x_cos) : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %result : tensor<1x32x128x64xbf16>
+  }
+}
+
+// Commuted multiply: cos * x instead of x * cos.
+// CHECK-LABEL: @rope_rotate_half_commuted_multiply
+// CHECK: "ttir.rotary_embedding"
+module {
+  func.func @rope_rotate_half_commuted_multiply(%x: tensor<1x32x128x64xbf16>, %cos: tensor<1x1x128x64xbf16>, %sin: tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos) <{broadcast_dimensions = array<i64: 1, 32, 1, 1>}> : (tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %x_cos = "ttir.multiply"(%cos_bc, %x) : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+
+    %x_hi = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [1:i32, 32:i32, 128:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x128x64xbf16>) -> tensor<1x32x128x32xbf16>
+    %neg_hi = "ttir.neg"(%x_hi) : (tensor<1x32x128x32xbf16>) -> tensor<1x32x128x32xbf16>
+    %x_lo = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 32:i32, 128:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x128x64xbf16>) -> tensor<1x32x128x32xbf16>
+    %rotated = "ttir.concat"(%neg_hi, %x_lo) <{dim = 3 : si32}> : (tensor<1x32x128x32xbf16>, tensor<1x32x128x32xbf16>) -> tensor<1x32x128x64xbf16>
+
+    %sin_bc = "ttir.broadcast"(%sin) <{broadcast_dimensions = array<i64: 1, 32, 1, 1>}> : (tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %rot_sin = "ttir.multiply"(%sin_bc, %rotated) : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %result = "ttir.add"(%x_cos, %rot_sin) : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %result : tensor<1x32x128x64xbf16>
+  }
+}
+
+// 3D cos/sin with reshape + broadcast TM chain.
+// CHECK-LABEL: @rope_rotate_half_3d_reshape
+// CHECK: "ttir.rotary_embedding"
+module {
+  func.func @rope_rotate_half_3d_reshape(%x: tensor<1x32x1024x64xbf16>, %sin: tensor<1x1024x64xbf16>, %cos: tensor<1x1024x64xbf16>) -> tensor<1x32x1024x64xbf16> {
+    %cos4d = "ttir.reshape"(%cos) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x1024x64xbf16>) -> tensor<1x1x1024x64xbf16>
+    %cos_bc = "ttir.broadcast"(%cos4d) <{broadcast_dimensions = array<i64: 1, 32, 1, 1>}> : (tensor<1x1x1024x64xbf16>) -> tensor<1x32x1024x64xbf16>
+    %x_cos = "ttir.multiply"(%x, %cos_bc) : (tensor<1x32x1024x64xbf16>, tensor<1x32x1024x64xbf16>) -> tensor<1x32x1024x64xbf16>
+
+    %x_hi = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [1:i32, 32:i32, 1024:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x1024x64xbf16>) -> tensor<1x32x1024x32xbf16>
+    %neg_hi = "ttir.neg"(%x_hi) : (tensor<1x32x1024x32xbf16>) -> tensor<1x32x1024x32xbf16>
+    %x_lo = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 32:i32, 1024:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x1024x64xbf16>) -> tensor<1x32x1024x32xbf16>
+    %rotated = "ttir.concat"(%neg_hi, %x_lo) <{dim = 3 : si32}> : (tensor<1x32x1024x32xbf16>, tensor<1x32x1024x32xbf16>) -> tensor<1x32x1024x64xbf16>
+
+    %sin4d = "ttir.reshape"(%sin) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x1024x64xbf16>) -> tensor<1x1x1024x64xbf16>
+    %sin_bc = "ttir.broadcast"(%sin4d) <{broadcast_dimensions = array<i64: 1, 32, 1, 1>}> : (tensor<1x1x1024x64xbf16>) -> tensor<1x32x1024x64xbf16>
+    %rot_sin = "ttir.multiply"(%rotated, %sin_bc) : (tensor<1x32x1024x64xbf16>, tensor<1x32x1024x64xbf16>) -> tensor<1x32x1024x64xbf16>
+
+    %result = "ttir.add"(%x_cos, %rot_sin) : (tensor<1x32x1024x64xbf16>, tensor<1x32x1024x64xbf16>) -> tensor<1x32x1024x64xbf16>
+    return %result : tensor<1x32x1024x64xbf16>
+  }
+}
+
+// =========================================================================
+// Pattern 2: complex rotation (expanded) RoPE
+// =========================================================================
+
+// Basic expanded RoPE with half-dim cos/sin.
+// CHECK-LABEL: @rope_expanded_basic
+// CHECK: "ttir.rotary_embedding"
+// CHECK-NOT: ttir.subtract
+module {
+  func.func @rope_expanded_basic(%x: tensor<16x8x1x64xbf16>, %cos_h: tensor<1x1x1x32xbf16>, %sin_h: tensor<1x1x1x32xbf16>) -> tensor<16x8x1x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %sin_bc = "ttir.broadcast"(%sin_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %first = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [16:i32, 8:i32, 1:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+    %second = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [16:i32, 8:i32, 1:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %fc = "ttir.multiply"(%first, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %ss = "ttir.multiply"(%second, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %sub = "ttir.subtract"(%fc, %ss) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %sc = "ttir.multiply"(%second, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %fs = "ttir.multiply"(%first, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %add = "ttir.add"(%sc, %fs) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %result = "ttir.concat"(%sub, %add) <{dim = 3 : si32}> : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x64xbf16>
+    return %result : tensor<16x8x1x64xbf16>
+  }
+}
+
+// =========================================================================
+// Negative tests
+// =========================================================================
+
+// Both halves negated — not valid rotate_half.
+// CHECK-LABEL: @rope_neg_both_halves_no_fuse
+// CHECK-NOT: "ttir.rotary_embedding"
+// CHECK: "ttir.add"
+module {
+  func.func @rope_neg_both_halves_no_fuse(%x: tensor<1x8x1x64xbf16>, %cos: tensor<1x1x1x64xbf16>, %sin: tensor<1x1x1x64xbf16>) -> tensor<1x8x1x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos) <{broadcast_dimensions = array<i64: 1, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    %x_cos = "ttir.multiply"(%x, %cos_bc) : (tensor<1x8x1x64xbf16>, tensor<1x8x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+
+    %x_hi = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [1:i32, 8:i32, 1:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x8x1x64xbf16>) -> tensor<1x8x1x32xbf16>
+    %neg_hi = "ttir.neg"(%x_hi) : (tensor<1x8x1x32xbf16>) -> tensor<1x8x1x32xbf16>
+    %x_lo = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 8:i32, 1:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x8x1x64xbf16>) -> tensor<1x8x1x32xbf16>
+    %neg_lo = "ttir.neg"(%x_lo) : (tensor<1x8x1x32xbf16>) -> tensor<1x8x1x32xbf16>
+    %rotated = "ttir.concat"(%neg_hi, %neg_lo) <{dim = 3 : si32}> : (tensor<1x8x1x32xbf16>, tensor<1x8x1x32xbf16>) -> tensor<1x8x1x64xbf16>
+
+    %sin_bc = "ttir.broadcast"(%sin) <{broadcast_dimensions = array<i64: 1, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    %rot_sin = "ttir.multiply"(%rotated, %sin_bc) : (tensor<1x8x1x64xbf16>, tensor<1x8x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    %result = "ttir.add"(%x_cos, %rot_sin) : (tensor<1x8x1x64xbf16>, tensor<1x8x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    return %result : tensor<1x8x1x64xbf16>
+  }
+}
+
+// Different x sources: cos branch uses %x, sin branch uses %y.
+// CHECK-LABEL: @rope_different_x_sources_no_fuse
+// CHECK-NOT: "ttir.rotary_embedding"
+// CHECK: "ttir.add"
+module {
+  func.func @rope_different_x_sources_no_fuse(%x: tensor<1x8x1x64xbf16>, %y: tensor<1x8x1x64xbf16>, %cos: tensor<1x1x1x64xbf16>, %sin: tensor<1x1x1x64xbf16>) -> tensor<1x8x1x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos) <{broadcast_dimensions = array<i64: 1, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    %x_cos = "ttir.multiply"(%x, %cos_bc) : (tensor<1x8x1x64xbf16>, tensor<1x8x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+
+    %y_hi = "ttir.slice_static"(%y) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [1:i32, 8:i32, 1:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x8x1x64xbf16>) -> tensor<1x8x1x32xbf16>
+    %neg_hi = "ttir.neg"(%y_hi) : (tensor<1x8x1x32xbf16>) -> tensor<1x8x1x32xbf16>
+    %y_lo = "ttir.slice_static"(%y) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 8:i32, 1:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x8x1x64xbf16>) -> tensor<1x8x1x32xbf16>
+    %rotated = "ttir.concat"(%neg_hi, %y_lo) <{dim = 3 : si32}> : (tensor<1x8x1x32xbf16>, tensor<1x8x1x32xbf16>) -> tensor<1x8x1x64xbf16>
+
+    %sin_bc = "ttir.broadcast"(%sin) <{broadcast_dimensions = array<i64: 1, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    %rot_sin = "ttir.multiply"(%rotated, %sin_bc) : (tensor<1x8x1x64xbf16>, tensor<1x8x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    %result = "ttir.add"(%x_cos, %rot_sin) : (tensor<1x8x1x64xbf16>, tensor<1x8x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    return %result : tensor<1x8x1x64xbf16>
+  }
+}
+
+// No rotate_half: sin branch multiplies x directly.
+// CHECK-LABEL: @rope_no_rotate_half_no_fuse
+// CHECK-NOT: "ttir.rotary_embedding"
+// CHECK: "ttir.add"
+module {
+  func.func @rope_no_rotate_half_no_fuse(%x: tensor<1x8x1x64xbf16>, %cos: tensor<1x1x1x64xbf16>, %sin: tensor<1x1x1x64xbf16>) -> tensor<1x8x1x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos) <{broadcast_dimensions = array<i64: 1, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    %x_cos = "ttir.multiply"(%x, %cos_bc) : (tensor<1x8x1x64xbf16>, tensor<1x8x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+
+    %sin_bc = "ttir.broadcast"(%sin) <{broadcast_dimensions = array<i64: 1, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    %x_sin = "ttir.multiply"(%x, %sin_bc) : (tensor<1x8x1x64xbf16>, tensor<1x8x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    %result = "ttir.add"(%x_cos, %x_sin) : (tensor<1x8x1x64xbf16>, tensor<1x8x1x64xbf16>) -> tensor<1x8x1x64xbf16>
+    return %result : tensor<1x8x1x64xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/8427
Closes https://github.com/tenstorrent/tt-mlir/issues/8341
Closes https://github.com/tenstorrent/tt-mlir/issues/8415

### Summary
- Add ttir.rotary_embedding op and fuse two RoPE patterns (rotate_half and complex rotation) at the TTIR level, before EraseInverseOps runs
- Lower ttir.rotary_embedding → ttnn.rotary_embedding in TTIR-to-TTNN conversion
- Add TTNN decomposition fallback that decomposes back to primitives when op-model validation fails
- Disable TTNN-level RoPE fusion by default (new --enable-rope-fusion flag to re-enable)

### Context
RoPE fusion previously ran at the TTNN level, after EraseInverseOps (EIO). This caused two problems:
1. EIO shape corruption (#8341): EIO pushes reshapes backward through decomposed RoPE elementwise ops, folding batch into the apparent seq dimension. This caused shape mismatches between cos/sin caches and the input's seq dim, preventing fusion on the key path (e.g., phi decode: PCC ≈ 0.17 when fused incorrectly).
2. Scaled cos/sin missed (#8415): The TTNN matcher couldn't look through the extra scaling multiply on cos/sin in gpt_oss models, leaving query RoPE unfused (24/48 per graph).

Moving fusion to TTIR (before EIO) avoids both problems — shapes are clean, scaled cos/sin are absorbed naturally, and EIO cannot break the fused op.

### Pattern matching
Two patterns are matched:

Pattern 1 — rotate_half (falcon, llama, gemma, qwen, mistral, ministral, phi, kimi):
x * cos + concat(neg(slice(x, D/2:)), slice(x, :D/2)) * sin

Pattern 2 — complex rotation (gpt_oss_20b, gpt_oss_120b):
concat(sub(x1*cos, x2*sin), add(x2*cos, x1*sin)) where x1, x2 are complementary half-slices

### Validation on 40 LLM TTIR graphs (tt-xla CI artifacts)

Model family | Graphs | Fused per layer | Pattern
-- | -- | -- | --
falcon3 (1b–10b) | 10 | 2 | rotate_half
gemma 1.1 2b | 2 | 2 | rotate_half
gpt_oss (20b, 120b) | 10 | 2 | complex rotation
llama 3.x (1b–70b) | 14 | 2 | rotate_half
ministral/mistral | 10 | 2 | rotate_half
phi (1, 1.5, 2) | 6 | 2 | rotate_half
qwen 2.5/3 (0.5b–32b) | 26 | 2 | rotate_half
kimi k2 | 4 | 2 | rotate_half
Total | 82 graphs | 2/layer | 100% fused

<br class="Apple-interchange-newline">
### Checklist
- [ ] New/Existing tests provide coverage for changes
