### PR TITLE
Uplift third_party/tt-metal to c5ebc6351098dfb68ce913eedcc20ee5abd1509f 2026-05-19

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "5a8026599e2638db1feb1c98256a62894809748a")
+set(TT_METAL_VERSION "c5ebc6351098dfb68ce913eedcc20ee5abd1509f")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the c5ebc6351098dfb68ce913eedcc20ee5abd1509f



### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/26097661977
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/26098014831
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):