### PR TITLE
[d2m] more vgm fixes for dram ops

### DIFF
--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1468,18 +1468,10 @@ void d2m::GenericOp::build(
       // 1. Check for an explicit virtualGridInverseMapping (inverse map) on the
       //    output's EmptyOp.  Use the stored map directly — it encodes the
       //    correct physical grid from the TTNN layout.
-      if (auto invMap = utils::getVirtualGridInverseMapping(output)) {
-        // Get virtual to physical map from output as well.
-        auto fwdMap = *utils::getVirtualGridForwardMapping(output);
-        size_t rank = gridShape.size();
-        fwdMap = ttmlir::utils::affineMapDropBackResults(fwdMap, rank);
-        for (int i = rank - 1; i >= 0; i--) {
-          fwdMap = ttmlir::utils::dropDim(fwdMap, rank + i);
-        }
-        fwdMap = fwdMap.insertResult(
-            getAffineConstantExpr(0, builder.getContext()), 0);
-
-        grid = builder.getAttr<ttcore::GridAttr>(gridShape, fwdMap, *invMap);
+      if (auto maps =
+              utils::getGridMapsFromVirtualGridMapping(output, gridShape)) {
+        grid = builder.getAttr<ttcore::GridAttr>(gridShape, maps->first,
+                                                 maps->second);
       }
 
       // 2. Check for a 2D→2D permutation reblocking on a ViewLayoutOp.
@@ -1873,42 +1865,42 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
       }
       return false;
     };
-    // Verify per-output VGM consistency:
-    // 1. For non-DRAM outputs, the output's inverse VGM must match the
-    // GridAttr's inverse map.
-    // 2. The inverse map applied to the physical grid shape must produce
-    //    a virtual grid shape matching the output's grid shape.
+    // For non-DRAM outputs, verify that:
+    // 1. The output operand's inverse VGM matches the GenericOp GridAttr's
+    //    inverse map.
+    // 2. The inverse map applied to the physical grid shape produces a virtual
+    //    grid shape matching the output's grid shape.
+    // DRAM outputs may carry VGM attrs used for address calculation, but they
+    // are not constrained by the GenericOp's L1 execution grid.
     AffineMap gridInvMap = getGrid().getPhysicalToVirtMap();
     for (Value output : getOutputs()) {
       if (!isDRAM(output)) {
         auto outputInvMap = utils::getVirtualGridInverseMapping(output);
         if (outputInvMap && *outputInvMap != gridInvMap) {
-          return emitOpError("grid inverse map does not match output operand's "
-                             "inverse VGM");
+          return emitOpError(
+              "grid inverse map does not match output operand's inverse VGM");
         }
         if (!outputInvMap && !gridInvMap.isEmpty()) {
           return emitOpError("grid has an inverse map but output operand "
                              "does not have a VGM");
         }
-      }
 
-      SmallVector<int64_t> physicalGridShape =
-          d2m::utils::getPhysicalGridShape(output);
-      // Drop the deviceID result (first result) from the inverse map.
-      AffineMap invMapNoDevice = gridInvMap.dropResult(0);
+        SmallVector<int64_t> physicalGridShape =
+            d2m::utils::getPhysicalGridShape(output);
+        // Drop the deviceID result (first result) from the inverse map.
+        AffineMap invMapNoDevice = gridInvMap.dropResult(0);
 
-      SmallVector<int64_t> impliedVirtShape =
-          ttmlir::utils::evalShape(invMapNoDevice, physicalGridShape);
+        SmallVector<int64_t> impliedVirtShape =
+            ttmlir::utils::evalShape(invMapNoDevice, physicalGridShape);
 
-      SmallVector<int64_t> outputGridShape =
-          llvm::to_vector(ttcore::getGridShape(output));
+        SmallVector<int64_t> outputGridShape =
+            llvm::to_vector(ttcore::getGridShape(output));
 
-      if (auto memrefType = mlir::dyn_cast<MemRefType>(output.getType())) {
-        if (auto viewOp = output.getDefiningOp<d2m::ViewOpInterface>()) {
-          if (!viewOp.isComposite()) {
-            auto [baseMemrefType, viewMap] = applyViews(viewOp.getOperation());
-            if (ttcore::isL1MemorySpace(
-                    ttcore::getMemorySpace(baseMemrefType))) {
+        if (auto memrefType = mlir::dyn_cast<MemRefType>(output.getType())) {
+          if (auto viewOp = output.getDefiningOp<d2m::ViewOpInterface>()) {
+            if (!viewOp.isComposite()) {
+              auto [baseMemrefType, viewMap] =
+                  applyViews(viewOp.getOperation());
               SmallVector<int64_t> baseGridShape =
                   getGridAndShardFromShapedType(baseMemrefType).first;
               AffineMap gridViewMap = ttmlir::utils::affineMapTakeFrontResults(
@@ -1918,11 +1910,12 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
             }
           }
         }
-      }
 
-      if (outputGridShape != impliedVirtShape) {
-        return emitOpError("output grid shape does not match implied virtual "
-                           "grid shape from physical grid and inverse mapping");
+        if (outputGridShape != impliedVirtShape) {
+          return emitOpError(
+              "output grid shape does not match implied virtual "
+              "grid shape from physical grid and inverse mapping");
+        }
       }
     }
   }

--- a/lib/Dialect/D2M/Transforms/DecomposeMasking.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeMasking.cpp
@@ -83,25 +83,11 @@ static TypedAttr getFillValueAttr(Builder &builder, Type elemType,
 
 static ttcore::GridAttr getMaskGridAttr(OpBuilder &builder, Value output,
                                         ArrayRef<int64_t> gridShape) {
-  auto invMap = utils::getVirtualGridInverseMapping(output);
-  auto fwdMap = utils::getVirtualGridForwardMapping(output);
-  if (!invMap || !fwdMap) {
-    return ttcore::GridAttr::get(builder.getContext(), gridShape);
+  if (auto maps = utils::getGridMapsFromVirtualGridMapping(output, gridShape)) {
+    return ttcore::GridAttr::get(builder.getContext(), gridShape, maps->first,
+                                 maps->second);
   }
-
-  AffineMap gridFwdMap = *fwdMap;
-  size_t rank = gridShape.size();
-  gridFwdMap = ttmlir::utils::affineMapDropBackResults(gridFwdMap, rank);
-  for (int64_t i = static_cast<int64_t>(rank) - 1; i >= 0; --i) {
-    unsigned dimToDrop = static_cast<unsigned>(rank + static_cast<size_t>(i));
-    gridFwdMap = ttmlir::utils::dropDim(gridFwdMap, dimToDrop);
-  }
-  gridFwdMap =
-      gridFwdMap.insertResult(getAffineConstantExpr(0, builder.getContext()),
-                              /*resultPos=*/0);
-
-  return ttcore::GridAttr::get(builder.getContext(), gridShape, gridFwdMap,
-                               *invMap);
+  return ttcore::GridAttr::get(builder.getContext(), gridShape);
 }
 
 /// Decompose MaskOp with multi-core support.

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -568,18 +568,9 @@ static ttcore::GridAttr deriveGridAttrForOutput(Value output,
     return builder.getAttr<ttcore::GridAttr>(gridShape);
   }
 
-  if (auto invMap = utils::getVirtualGridInverseMapping(output)) {
-    // Get virtual to physical map from output as well.
-    auto fwdMap = *utils::getVirtualGridForwardMapping(output);
-    size_t rank = gridShape.size();
-    fwdMap = ttmlir::utils::affineMapDropBackResults(fwdMap, rank);
-    for (int i = rank - 1; i >= 0; i--) {
-      fwdMap = ttmlir::utils::dropDim(fwdMap, rank + i);
-    }
-    fwdMap =
-        fwdMap.insertResult(getAffineConstantExpr(0, builder.getContext()), 0);
-
-    return builder.getAttr<ttcore::GridAttr>(gridShape, fwdMap, *invMap);
+  if (auto maps = utils::getGridMapsFromVirtualGridMapping(output, gridShape)) {
+    return builder.getAttr<ttcore::GridAttr>(gridShape, maps->first,
+                                             maps->second);
   }
 
   auto existingRemapping = utils::getAssociatedRemapping(output);

--- a/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
+++ b/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
@@ -315,6 +315,8 @@ func.func @tilize_ignores_rank_incompatible_input_vgm() -> tensor<8x4x16x1x!ttco
   // CHECK-LABEL: @tilize_ignores_rank_incompatible_input_vgm
   // CHECK: d2m.empty() {virtualGridForwardMapping = #map{{[0-9]+}}, virtualGridInverseMapping = #map{{[0-9]+}}} : tensor<1x1x1x1x128x4096xf32, #layout{{[0-9]+}}>
   // CHECK: d2m.empty() : tensor<8x4x512x32xf32, #layout{{[0-9]+}}>
+  // CHECK: d2m.generic
+  // CHECK-SAME: grid = #ttcore.grid<8x4>
   // CHECK: d2m.tile_tilize_block
   %0 = d2m.empty() {virtualGridForwardMapping = #rank6_vgm_forward, virtualGridInverseMapping = #rank6_vgm_inverse} : tensor<1x1x1x1x128x4096xf32, #rank_incompatible_vgm_src>
   %view = d2m.view_layout %0 remapping = #rank8_view : tensor<1x1x1x1x128x4096xf32, #rank_incompatible_vgm_src> -> tensor<1x1x1x1x1x128x32x128xf32, #rank_incompatible_vgm_view>
@@ -377,4 +379,56 @@ func.func @untilize_input_only_vgm_fallback() -> tensor<32x32xbf16> {
   %1 = d2m.empty() : tensor<32x32xbf16>
   %2 = d2m.to_layout %0, %1 : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layer_tile_with_vgm_dst> into tensor<32x32xbf16> -> tensor<32x32xbf16>
   return %2 : tensor<32x32xbf16>
+}
+
+#host_to_dram_with_vgm_dst = #ttcore.metal_layout<logical_shape = 64x64, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, dram, sharded>
+
+func.func @host_to_dram_with_vgm(%arg0: tensor<64x64xbf16>) -> tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst> {
+  // CHECK-LABEL: @host_to_dram_with_vgm
+  // CHECK: %[[DRAM:.*]] = d2m.empty() {virtualGridForwardMapping = #map{{[0-9]+}}, virtualGridInverseMapping = #map{{[0-9]+}}} : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>
+  // CHECK: %[[MID:.*]] = d2m.empty() {virtualGridForwardMapping = #map{{[0-9]+}}, virtualGridInverseMapping = #map{{[0-9]+}}} : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>
+  // CHECK: %[[TODEV:.*]] = d2m.to_device %arg0, %[[MID]] layout = #layout{{[0-9]+}} : tensor<64x64xbf16> into tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>
+  // CHECK: %[[COPY:.*]] = d2m.generic
+  // CHECK-SAME: grid = #ttcore.grid<2x2, virt_to_physical_map = {{.*}}, physical_to_virt_map = {{.*}}>
+  // CHECK-NEXT: ins(%[[TODEV]] : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>)
+  // CHECK-NEXT: outs(%[[DRAM]] : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>)
+  // CHECK-NOT: d2m.generic
+  // CHECK: return %[[COPY]]
+  %0 = d2m.empty() {virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>, virtualGridInverseMapping = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>} : tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst>
+  %1 = d2m.to_layout %arg0, %0 : tensor<64x64xbf16> into tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst> -> tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst>
+  return %1 : tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst>
+}
+
+func.func @dram_to_dram_vgm_change(%arg0: tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst>) -> tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst> {
+  // CHECK-LABEL: @dram_to_dram_vgm_change
+  // CHECK: %[[DRAM:.*]] = d2m.empty() {virtualGridForwardMapping = #map{{[0-9]+}}, virtualGridInverseMapping = #map{{[0-9]+}}} : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>
+  // CHECK: %[[L1:.*]] = d2m.empty() : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>
+  // CHECK: %[[TO_L1:.*]] = d2m.generic
+  // CHECK-NEXT: ins(%arg0 : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>)
+  // CHECK-NEXT: outs(%[[L1]] : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>)
+  // CHECK: %[[TO_DRAM:.*]] = d2m.generic
+  // CHECK-SAME: grid = #ttcore.grid<2x2, virt_to_physical_map = {{.*}}, physical_to_virt_map = {{.*}}>
+  // CHECK-NEXT: ins(%[[TO_L1]] : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>)
+  // CHECK-NEXT: outs(%[[DRAM]] : tensor<2x2x32x32xbf16, #layout{{[0-9]+}}>)
+  // CHECK: return %[[TO_DRAM]]
+  %0 = d2m.empty() {virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0 + 2, d1 + 3, d2, d3)>, virtualGridInverseMapping = affine_map<(d0, d1) -> (0, d0 - 2, d1 - 3)>} : tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst>
+  %1 = d2m.to_layout %arg0, %0 : tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst> into tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst> -> tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst>
+  return %1 : tensor<2x2x32x32xbf16, #host_to_dram_with_vgm_dst>
+}
+
+#l1_rank8_vgm_src = #ttcore.metal_layout<logical_shape = 1x8x512x128, dim_alignments = 1x1x256x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#dram_rank4_collapsed_dst = #ttcore.metal_layout<logical_shape = 1x8x512x128, dim_alignments = 256x1x32x32, collapsed_intervals = dense<[[0, 3], [3, 4]]> : tensor<2x2xi64>, dram, sharded>
+
+func.func @l1_vgm_to_collapsed_dram_uses_grid_rank(%arg0: tensor<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #l1_rank8_vgm_src>) -> tensor<8x4x16x1x!ttcore.tile<32x32, bf16>, #dram_rank4_collapsed_dst> {
+  // CHECK-LABEL: @l1_vgm_to_collapsed_dram_uses_grid_rank
+  // CHECK: d2m.generic
+  // CHECK-SAME: grid = #ttcore.grid<1x1x16x4, virt_to_physical_map = {{.*}}, physical_to_virt_map = {{.*}}>
+  // CHECK: d2m.block_index(3)
+  // CHECK: d2m.remote_load {{.*}}[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}]
+  // CHECK: d2m.remote_store {{.*}}[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}]
+  %0 = d2m.empty() {virtualGridForwardMapping = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (((d3 + d2 * 4) floordiv 8) mod 8, (d3 + d2 * 4) mod 8, d4, d5, d6, d7)>, virtualGridInverseMapping = affine_map<(d0, d1) -> (0, 0, 0, (d1 floordiv 4 + d0 * 2) mod 16, d1 mod 4)>} : tensor<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #l1_rank8_vgm_src>
+  %1 = d2m.to_layout %arg0, %0 : tensor<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #l1_rank8_vgm_src> into tensor<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #l1_rank8_vgm_src> -> tensor<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #l1_rank8_vgm_src>
+  %2 = d2m.empty() : tensor<8x4x16x1x!ttcore.tile<32x32, bf16>, #dram_rank4_collapsed_dst>
+  %3 = d2m.to_layout %1, %2 : tensor<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #l1_rank8_vgm_src> into tensor<8x4x16x1x!ttcore.tile<32x32, bf16>, #dram_rank4_collapsed_dst> -> tensor<8x4x16x1x!ttcore.tile<32x32, bf16>, #dram_rank4_collapsed_dst>
+  return %3 : tensor<8x4x16x1x!ttcore.tile<32x32, bf16>, #dram_rank4_collapsed_dst>
 }

--- a/test/unittests/LowerToLayout/TestPlan.cpp
+++ b/test/unittests/LowerToLayout/TestPlan.cpp
@@ -338,6 +338,30 @@ TEST_F(CanonicalizeTest, HostToDeviceVirtualGridUsesNativeLayout) {
   EXPECT_FALSE(static_cast<bool>(step->output.vgmInverse));
 }
 
+TEST_F(CanonicalizeTest, HostToDRAMPreservesTargetVgmOnDRAMStep) {
+  auto collapsed = ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
+      &context, /*rank=*/2);
+  Type elemType = Float32Type::get(&context);
+  RankedTensorType systemType = RankedTensorType::get({64, 64}, elemType);
+  RankedTensorType targetType =
+      makeTensorType(context, {64, 64}, {32, 32}, collapsed, {2, 2},
+                     ttcore::MemorySpace::DeviceDRAM,
+                     ttcore::TensorMemoryLayout::Sharded, elemType);
+
+  AffineExpr d0 = getAffineDimExpr(0, &context);
+  AffineExpr d1 = getAffineDimExpr(1, &context);
+  AffineMap vgm = AffineMap::get(2, 0, {d0, d1}, &context);
+
+  Plan plan =
+      canonicalize(PlanState{systemType}, PlanState{targetType, {}, vgm, vgm},
+                   {8, 8}, &context);
+  ASSERT_EQ(plan.size(), 2u);
+  ASSERT_TRUE(std::holds_alternative<HostToDeviceStep>(plan[0]));
+  ASSERT_TRUE(std::holds_alternative<L1ToDRAMStep>(plan[1]));
+  EXPECT_EQ(std::get<L1ToDRAMStep>(plan[1]).output.vgmForward, vgm);
+  EXPECT_EQ(std::get<L1ToDRAMStep>(plan[1]).output.vgmInverse, vgm);
+}
+
 TEST_F(CanonicalizeTest, RemapOnlyChangeProducesExplicitRemapStep) {
   auto collapsed = ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
       &context, /*rank=*/2);


### PR DESCRIPTION
### Problem description
More ops that go dram to dram are running into vgm errors

### What's changed
- Use common virtual grid helper instead of having multiple passes rederive it
- Ignore DRAM outputs for L1 execution-grid VGM verification
- Added lit tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
