### PR TITLE
[TTNN] Enable multi-chip const-eval CPU-hoisting

### DIFF
--- a/include/ttmlir/Dialect/EmitPy/IR/EmitPyOps.td
+++ b/include/ttmlir/Dialect/EmitPy/IR/EmitPyOps.td
@@ -594,6 +594,55 @@ def EmitPy_ExpressionOp : EmitPy_Op<"expression", [
   let hasCustomAssemblyFormat = 1;
 }
 
+def EmitPy_NestedFuncReturnOp : EmitPy_Op<"nested_func_return",
+    [Pure, ReturnLike, Terminator, ParentOneOf<["NestedFuncOp"]>]> {
+  let summary = "Return operation for emitpy.nested_func";
+  let description = [{
+    Terminates an `emitpy.nested_func` body, emitting a Python `return`.
+    Optionally returns one or more values.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+  let assemblyFormat = "($operands^ `:` type($operands))? attr-dict";
+
+  // Zero-argument builder so SingleBlockImplicitTerminator can insert an
+  // empty `return`.
+  let builders = [OpBuilder<(ins), [{ /* no operands */ }]>];
+}
+
+def EmitPy_NestedFuncOp : EmitPy_Op<"nested_func", [
+    AutomaticAllocationScope, IsolatedFromAbove, SingleBlock,
+    SingleBlockImplicitTerminator<"NestedFuncReturnOp">]> {
+  let summary = "Nested (local) Python function definition";
+  let description = [{
+    The `emitpy.nested_func` operation represents a nested Python `def` emitted
+    inside another function body. Its single-block region's arguments are the
+    function parameters, and `emitpy.nested_func_return` terminates it. Unlike
+    `func.func` it is not a module-level symbol, so it can live inside another
+    function's body.
+
+    Example:
+
+    ```mlir
+    emitpy.nested_func "impl" (%a: !emitpy.opaque<"torch.Tensor">) {
+      %0 = emitpy.call_opaque "ttir_cpu.relu"(%a) : (!emitpy.opaque<"torch.Tensor">) -> !emitpy.opaque<"torch.Tensor">
+      emitpy.nested_func_return %0 : !emitpy.opaque<"torch.Tensor">
+    }
+    ```
+
+    emits:
+    ```python
+    def impl(a):
+      return ttir_cpu.relu(a)
+    ```
+  }];
+
+  let arguments = (ins StrAttr:$sym_name);
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = "$sym_name $body attr-dict";
+}
+
 def EmitPy_FileOp
     : EmitPy_Op<"file", [IsolatedFromAbove, NoRegionArguments, SymbolTable,
                         NoTerminator]> {

--- a/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
+++ b/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
@@ -5,23 +5,17 @@
 // ConvertTTIRCPUToEmitPy pass
 // ===========================
 //
-// Lowers TTIR ops inside CPU-hoisted functions to EmitPy CallOpaqueOp calls
-// targeting `ttir_cpu.<op>` — pure-torch implementations that run on the host.
+// Lowers each CPU-hoisted function to a ttnn-typed wrapper around a nested
+// pure-torch body, so the body can run shard-by-shard for multi-chip meshes:
 //
-// The generated code operates at two type levels:
+//   def <name>(ttnn.Tensor...):                  # wrapper, keeps the symbol
+//     def <name>_impl(torch.Tensor...): ...      # nested ttir_cpu.* body
+//     return utils.execute_cpu_hoisted_function([...], <name>_impl)
 //
-//   Function boundary (signature, args, returns): ttnn.Tensor
-//     Callers live in the TTNN world and pass/receive ttnn tensors.
-//
-//   Function body (internal ops): torch.Tensor
-//     The ttir_cpu.* implementations are pure torch, so ops use torch tensors.
-//
-// The bridge is explicit:
-//   - FuncOpBoundaryPattern  rewrites signatures to ttnn.Tensor and inserts
-//     ttnn.to_torch at function entry.
-//   - ReturnOpBoundaryPattern inserts ttnn.from_torch before each return.
-//   - All other patterns use the type converter (MLIR tensor -> torch.Tensor)
-//     to produce internal CallOpaqueOp results.
+// In two steps: dialect conversion lowers the function in place to torch.Tensor
+// (stock signature/return conversion plus per-op ttir -> ttir_cpu patterns),
+// then wrapAndNest builds the ttnn wrapper and nests the body as an
+// emitpy.nested_func.
 //
 
 #include "ttmlir/Conversion/TTIRToEmitPy/TTIRToEmitPy.h"
@@ -29,6 +23,7 @@
 #include "ttmlir/Dialect/EmitPy/IR/EmitPyOps.h"
 #include "ttmlir/Dialect/EmitPy/IR/EmitPyTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/FunctionTypes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
@@ -49,13 +44,10 @@ namespace {
 // Type converter
 // ============================================================================
 
-// Converts MLIR tensor types to emitpy::OpaqueType("torch.Tensor").
-// This is the type used by internal ops (CallOpaqueOp results) — it reflects
-// the fact that ttir_cpu.* functions operate on torch tensors at runtime.
-//
-// Function boundaries use ttnn.Tensor instead; that conversion is handled
-// separately by FuncOpBoundaryPattern / ReturnOpBoundaryPattern, which
-// bypass the type converter.
+// Converts MLIR tensor types to emitpy::OpaqueType("torch.Tensor"). The whole
+// CPU-hoisted function is lowered to this torch.Tensor world (signature,
+// internal ttir_cpu ops, and return); the ttnn.Tensor boundary is introduced
+// later by wrapAndNest, which wraps the torch body in a ttnn-typed function.
 class EmitPyTypeConverter : public TypeConverter {
 public:
   EmitPyTypeConverter(MLIRContext *ctx) {
@@ -231,81 +223,6 @@ private:
   SmallVector<Value> operands;
   SmallVector<Attribute> args;
   SmallVector<Attribute> kwargNames;
-};
-
-// ============================================================================
-// Function boundary patterns
-// ============================================================================
-
-// Rewrites the function signature to ttnn.Tensor and inserts ttnn.to_torch
-// for each argument so internal ops receive torch tensors.
-class FuncOpBoundaryPattern : public OpConversionPattern<func::FuncOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(func::FuncOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto *ctx = rewriter.getContext();
-    auto ttnnType = emitpy::OpaqueType::get(ctx, "ttnn.Tensor");
-    auto torchType = emitpy::OpaqueType::get(ctx, "torch.Tensor");
-
-    // Build the new signature: all tensor args/results become ttnn.Tensor.
-    auto oldType = op.getFunctionType();
-    SmallVector<Type> newArgTypes(oldType.getNumInputs(), ttnnType);
-    SmallVector<Type> newResultTypes(oldType.getNumResults(), ttnnType);
-    auto newType = FunctionType::get(ctx, newArgTypes, newResultTypes);
-
-    // Create a new function with the ttnn.Tensor signature and move the body.
-    auto newOp =
-        rewriter.create<func::FuncOp>(op.getLoc(), op.getName(), newType);
-    newOp->setAttrs(op->getAttrs());
-    newOp.setFunctionType(newType);
-
-    // Inline the old body into the new function, converting block arg types.
-    Block &oldEntry = op.getBody().front();
-    Block &newEntry = newOp.getBody().emplaceBlock();
-
-    // Add ttnn.Tensor block args and insert to_torch for each.
-    rewriter.setInsertionPointToStart(&newEntry);
-    SmallVector<Value> torchArgs;
-    for (unsigned i = 0; i < oldEntry.getNumArguments(); ++i) {
-      auto newArg = newEntry.addArgument(ttnnType, op.getLoc());
-      auto toTorch = rewriter.create<emitpy::CallOpaqueOp>(
-          op.getLoc(), torchType, "ttnn.to_torch", ValueRange{newArg}, nullptr,
-          nullptr);
-      torchArgs.push_back(toTorch.getResult(0));
-    }
-
-    // Merge the old block, replacing old block args with torch values.
-    rewriter.mergeBlocks(&oldEntry, &newEntry, torchArgs);
-    rewriter.eraseOp(op);
-    return success();
-  }
-};
-
-// Inserts ttnn.from_torch before each return, converting torch.Tensor
-// results back to ttnn.Tensor for the caller.
-class ReturnOpBoundaryPattern : public OpConversionPattern<func::ReturnOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(func::ReturnOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto ttnnType =
-        emitpy::OpaqueType::get(rewriter.getContext(), "ttnn.Tensor");
-
-    SmallVector<Value> newOperands;
-    for (Value operand : adaptor.getOperands()) {
-      auto fromTorch = rewriter.create<emitpy::CallOpaqueOp>(
-          op.getLoc(), ttnnType, "ttnn.from_torch", ValueRange{operand},
-          nullptr, nullptr);
-      newOperands.push_back(fromTorch.getResult(0));
-    }
-    rewriter.replaceOpWithNewOp<func::ReturnOp>(op, newOperands);
-    return success();
-  }
 };
 
 // ============================================================================
@@ -1102,6 +1019,92 @@ public:
   }
 };
 
+// Wraps each in-place-lowered (now torch-typed) CPU-hoisted function in a
+// ttnn-typed wrapper that defers to utils.execute_cpu_hoisted_function, with
+// the torch body emitted as a nested `<name>_impl` def. Given
+//
+//   func @cpu_hoisted_X(torch...) -> torch... { ...ttir_cpu... }   //
+//   forward_cpu
+//
+// it produces
+//
+//   def cpu_hoisted_X(a, b):                      # ttnn wrapper
+//     def cpu_hoisted_X_impl(a, b): ...ttir_cpu...
+//     return utils.execute_cpu_hoisted_function([a, b], cpu_hoisted_X_impl)
+//
+// Keeping the body nested means the impl is not a module-level symbol (no
+// symbol-DCE concern, nothing for module linking to relocate separately).
+static void wrapAndNest(ModuleOp module) {
+  MLIRContext *ctx = module.getContext();
+  auto ttnnType = emitpy::OpaqueType::get(ctx, "ttnn.Tensor");
+
+  SmallVector<func::FuncOp> impls;
+  for (auto func : module.getOps<func::FuncOp>()) {
+    if (ttmlir::utils::isForwardCPUFunc(func)) {
+      impls.push_back(func);
+    }
+  }
+
+  for (func::FuncOp impl : impls) {
+    auto origName = impl.getSymName().str();
+    auto implName = origName + "_impl";
+    unsigned numInputs = impl.getNumArguments();
+    unsigned numResults = impl.getFunctionType().getNumResults();
+
+    OpBuilder builder(impl);
+
+    // The body lives in a nested function named <name>_impl; the wrapper keeps
+    // the original symbol and a ttnn.Tensor signature so callers are unchanged.
+    impl.setSymName(implName);
+    auto wrapType =
+        FunctionType::get(ctx, SmallVector<Type>(numInputs, ttnnType),
+                          SmallVector<Type>(numResults, ttnnType));
+    auto wrapOp =
+        builder.create<func::FuncOp>(impl.getLoc(), origName, wrapType);
+    wrapOp->setAttrs(impl->getAttrs());
+    wrapOp.setSymName(origName);
+    wrapOp.setFunctionType(wrapType);
+
+    Block &wrapEntry = wrapOp.getBody().emplaceBlock();
+    SmallVector<Value> wrapArgs;
+    for (unsigned i = 0; i < numInputs; ++i) {
+      wrapArgs.push_back(wrapEntry.addArgument(ttnnType, impl.getLoc()));
+    }
+    builder.setInsertionPointToStart(&wrapEntry);
+
+    // Nested torch body: move the impl's body in and swap its terminator for an
+    // emitpy.nested_func_return.
+    auto funcOp = builder.create<emitpy::NestedFuncOp>(impl.getLoc(), implName);
+    funcOp.getBody().takeBody(impl.getBody());
+    auto returnOp =
+        cast<func::ReturnOp>(funcOp.getBody().front().getTerminator());
+    {
+      OpBuilder retBuilder(returnOp);
+      retBuilder.create<emitpy::NestedFuncReturnOp>(returnOp.getLoc(),
+                                                    returnOp.getOperands());
+      returnOp.erase();
+    }
+
+    // result = utils.execute_cpu_hoisted_function([arg0, ...], <name>_impl)
+    builder.setInsertionPointToEnd(&wrapEntry);
+    auto listOp = builder.create<emitpy::CallOpaqueOp>(
+        impl.getLoc(), emitpy::OpaqueType::get(ctx, "[ttnn.Tensor]"),
+        "util_create_list", wrapArgs, nullptr, nullptr);
+    SmallVector<Value> callOperands{listOp.getResult(0)};
+    SmallVector<Attribute> callArgs{IntegerAttr::get(IndexType::get(ctx), 0),
+                                    emitpy::OpaqueAttr::get(ctx, implName)};
+    SmallVector<Attribute> callKwargs{StringAttr::get(ctx, ""),
+                                      StringAttr::get(ctx, "")};
+    auto callOp = builder.create<emitpy::CallOpaqueOp>(
+        impl.getLoc(), SmallVector<Type>(numResults, ttnnType),
+        "utils.execute_cpu_hoisted_function", callOperands,
+        ArrayAttr::get(ctx, callArgs), ArrayAttr::get(ctx, callKwargs));
+    builder.create<func::ReturnOp>(impl.getLoc(), callOp.getResults());
+
+    impl.erase();
+  }
+}
+
 // ============================================================================
 // Pass definition
 // ============================================================================
@@ -1130,15 +1133,15 @@ struct ConvertTTIRCPUToEmitPyPass
     EmitPyTypeConverter typeConverter(&getContext());
     RewritePatternSet patterns(&getContext());
 
-    // Function boundary: signature becomes ttnn.Tensor, with to_torch /
-    // from_torch bridging to the torch.Tensor world used by internal ops.
-    patterns.add<FuncOpBoundaryPattern, ReturnOpBoundaryPattern>(typeConverter,
-                                                                 &getContext());
-    target.addDynamicallyLegalOp<func::FuncOp>([](func::FuncOp op) {
-      return llvm::all_of(op.getArgumentTypes(),
-                          llvm::IsaPred<emitpy::OpaqueType>) &&
-             llvm::all_of(op.getResultTypes(),
-                          llvm::IsaPred<emitpy::OpaqueType>);
+    // Lower the CPU-hoisted function in place to the torch.Tensor world used by
+    // the internal ttir_cpu ops, using stock signature/return type conversion.
+    // The ttnn-typed wrapper and the nested impl are built afterwards by
+    // wrapAndNest.
+    populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+        patterns, typeConverter);
+    populateReturnOpTypeConversionPattern(patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+      return typeConverter.isSignatureLegal(op.getFunctionType());
     });
     target.addDynamicallyLegalOp<func::ReturnOp>([](func::ReturnOp op) {
       return llvm::all_of(op.getOperandTypes(),
@@ -1228,6 +1231,8 @@ struct ConvertTTIRCPUToEmitPyPass
       signalPassFailure();
       return;
     }
+
+    wrapAndNest(getOperation());
   }
 };
 

--- a/lib/Dialect/TTIR/Transforms/HoistCPUOps/CPUHoistConstEval.cpp
+++ b/lib/Dialect/TTIR/Transforms/HoistCPUOps/CPUHoistConstEval.cpp
@@ -28,12 +28,11 @@
 // After this pass, the device module function becomes:
 //
 //   func @const_eval(%x: bf16, %y: bf16) {
-//     // --- segment 0: bf16 → f32, compute on CPU, f32 → bf16 ---
-//     %x_f32 = to_layout(%x)  : bf16 -> f32         // typecast + from_device
-//     transfer %y_f32 = to_layout(%y)  : bf16 -> f32 %b_f32 = call
-//     @cpu_hoisted_0(%x_f32, %y_f32)  // executes on host %b     =
-//     to_layout(%b_f32) : f32 -> bf16       // typecast + to_device transfer
-//     transfer
+//     // --- segment 0: bf16 -> f32, compute on CPU, f32 -> bf16 ---
+//     %x_f32 = to_layout(%x) : bf16 -> f32      // typecast + from_device
+//     %y_f32 = to_layout(%y) : bf16 -> f32      // typecast + from_device
+//     %b_f32 = call @cpu_hoisted_0(%x_f32, %y_f32)  // executes on host
+//     %b     = to_layout(%b_f32) : f32 -> bf16  // typecast + to_device
 //
 //     // --- barrier: stays on device ---
 //     %g = all_gather(%b)
@@ -89,9 +88,7 @@ static bool isTransparentOp(mlir::Operation *op) {
 // Check if an op is a barrier for CPU hoisting - CCL and MeshShard ops must
 // remain on device and split the subgraph into segments.
 static bool isBarrierOp(mlir::Operation *op) {
-  return mlir::isa<MeshShardOp, AllGatherOp, AllReduceOp, ReduceScatterOp,
-                   CollectivePermuteOp, AllToAllOp, CollectiveBroadcastOp,
-                   MeshPartitionOp>(op);
+  return mlir::isa<CCL>(op) || mlir::isa<MeshShardOp, MeshPartitionOp>(op);
 }
 
 // Walk backward from a value through transparent ops in a single traversal.
@@ -184,11 +181,16 @@ analyzeConstEval(func::FuncOp funcOp) {
   // Build a CPUHoistedOpsDescriptor descriptor for each segment.
   llvm::SmallVector<CPUHoistedOpsDescriptor> descriptors;
   for (const auto &segment : segments) {
-    // Verify all ops can be lowered to Linalg.
-    bool canLower = llvm::all_of(
-        segment, [&](mlir::Operation *op) { return canLowerTTIRToLinalg(op); });
+    // Verify all ops can be lowered to Linalg. If any op fails, skip
+    // CPU-hoisting this segment.
+    auto *unlowerableOp = llvm::find_if(segment, [&](mlir::Operation *op) {
+      return !canLowerTTIRToLinalg(op);
+    });
 
-    if (!canLower) {
+    if (unlowerableOp != segment.end()) {
+      (*unlowerableOp)
+          ->emitWarning("Skipping CPU hoisting of const-eval "
+                        "subgraph: op cannot be lowered to Linalg");
       continue;
     }
 

--- a/lib/Dialect/TTIR/Transforms/HoistCPUOps/CPUHoistConstEval.cpp
+++ b/lib/Dialect/TTIR/Transforms/HoistCPUOps/CPUHoistConstEval.cpp
@@ -1,6 +1,65 @@
 // SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+//
+// CPU-hoist const-eval pass.
+//
+// Hoists compute ops from const-eval functions to the CPU module, splitting
+// the subgraph into segments around CCL barriers. Each segment becomes a
+// separate CPU-hoisted function call, while CCL ops remain on device.
+//
+// Motivation:
+// - CPU-hoisted ops operate on 32-bit integers/floats, which should result in
+//   more precise calculations compared to device execution.
+// - Peak DRAM/L1 usage should be reduced, since intermediate tensors are stored
+//   in host memory. This is especially beneficial for tensors which would take
+//   up significantly more L1 if tilized (e.g. tensor<1024x1024x1x1).
+//
+// Example — a const-eval function with one all_gather (types are bf16):
+//
+//   func @const_eval(%x: bf16, %y: bf16) {
+//     %a = add(%x, %y)           // segment 0
+//     %b = multiply(%a, %x)      // segment 0
+//     %g = all_gather(%b)         // barrier (stays on device)
+//     %c = subtract(%g, %g)      // segment 1
+//     return %c
+//   }
+//
+// After this pass, the device module function becomes:
+//
+//   func @const_eval(%x: bf16, %y: bf16) {
+//     // --- segment 0: bf16 → f32, compute on CPU, f32 → bf16 ---
+//     %x_f32 = to_layout(%x)  : bf16 -> f32         // typecast + from_device
+//     transfer %y_f32 = to_layout(%y)  : bf16 -> f32 %b_f32 = call
+//     @cpu_hoisted_0(%x_f32, %y_f32)  // executes on host %b     =
+//     to_layout(%b_f32) : f32 -> bf16       // typecast + to_device transfer
+//     transfer
+//
+//     // --- barrier: stays on device ---
+//     %g = all_gather(%b)
+//
+//     // --- segment 1: bf16 → f32, compute on CPU, f32 → bf16 ---
+//     %g_f32 = to_layout(%g)  : bf16 -> f32
+//     %c_f32 = call @cpu_hoisted_1(%g_f32, %g_f32)
+//     %c     = to_layout(%c_f32) : f32 -> bf16
+//     return %c
+//   }
+//
+// And the CPU module gets the hoisted function definitions:
+//
+//   cpu_module {
+//     func @cpu_hoisted_0(%x: f32, %y: f32) -> f32 {
+//       %a = add(%x, %y)
+//       %b = multiply(%a, %x)
+//       return %b
+//     }
+//     func @cpu_hoisted_1(%g0: f32, %g1: f32) -> f32 {
+//       %c = subtract(%g0, %g1)
+//       return %c
+//     }
+//   }
+//
+//===----------------------------------------------------------------------===//
 
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
@@ -13,6 +72,7 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallString.h"
 
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_CPUHOISTCONSTEVALTRANSFORM
@@ -24,6 +84,14 @@ namespace {
 // just format/type.
 static bool isTransparentOp(mlir::Operation *op) {
   return mlir::isa<ReshapeOp, TypecastOp>(op);
+}
+
+// Check if an op is a barrier for CPU hoisting - CCL and MeshShard ops must
+// remain on device and split the subgraph into segments.
+static bool isBarrierOp(mlir::Operation *op) {
+  return mlir::isa<MeshShardOp, AllGatherOp, AllReduceOp, ReduceScatterOp,
+                   CollectivePermuteOp, AllToAllOp, CollectiveBroadcastOp,
+                   MeshPartitionOp>(op);
 }
 
 // Walk backward from a value through transparent ops in a single traversal.
@@ -51,40 +119,17 @@ static llvm::SmallVector<mlir::Operation *> traceCreationOpChain(Value v) {
 }
 
 // Analyze a const-eval function for ops to perform CPU-hoisting on.
-//
-// Motivation for CPU-hoisting const-eval ops:
-// - CPU-hoisted ops operate on 32-bit integers/floats, which should result in
-//   more precise calculations compared to device execution.
-// - Peak DRAM/L1 usage should be reduced, since intermediate tensors are stored
-//   in host memory. This is especially beneficial for tensors which would take
-//   up significantly more L1 if tilized (e.g. tensor<1024x1024x1x1).
+// See file-level comment for motivation and an illustrative example.
 static llvm::SmallVector<CPUHoistedOpsDescriptor>
 analyzeConstEval(func::FuncOp funcOp) {
   if (!ttmlir::utils::isConstEvalFunc(funcOp)) {
     return {};
   }
 
-  // Skip CPU-hoisting for multi-device graphs.
-  // TODO(dmilinkovic) - issue #6709.
-  auto deviceAttr = ttcore::lookupDevice(funcOp);
-  if (deviceAttr && ttmlir::utils::volume(deviceAttr.getMeshShape()) > 1) {
-    return {};
-  }
-
-  CPUHoistedOpsDescriptor descriptor({}, {}, llvm::StringRef("const_eval"));
-
-  // Check if it is possible to CPU-hoist this const-eval function.
-  auto walkResult = funcOp.walk([&](mlir::Operation *nestedOp) {
-    // If there is already a CPU-hoisted call inside the const-eval
-    // subgraph, skip CPU hoisting altogether to avoid nested hoisting.
-    if (nestedOp->hasAttr(ttir::CPUHoistedCallAttr::name)) {
-      return WalkResult::interrupt();
-    }
-
-    return WalkResult::advance();
-  });
-
-  if (walkResult.wasInterrupted()) {
+  // Skip if there is already a CPU-hoisted call.
+  if (llvm::any_of(funcOp.getOps(), [](Operation &op) {
+        return op.hasAttr(ttir::CPUHoistedCallAttr::name);
+      })) {
     return {};
   }
 
@@ -101,14 +146,16 @@ analyzeConstEval(func::FuncOp funcOp) {
   //    improve PCC nor peak DRAM/L1 usage.
   for (Value retVal : returnOp.getOperands()) {
     auto chain = traceCreationOpChain(retVal);
-    if (chain.empty()) {
-      descriptor.outputValues.push_back(retVal);
-    } else {
+    if (!chain.empty()) {
       opsToSkip.insert(chain.begin(), chain.end());
     }
   }
 
-  // Collect all ops that are not skipped.
+  // Partition ops into segments separated by barrier ops.
+  // Each segment contains consecutive non-barrier, non-skip ops.
+  llvm::SmallVector<OpsVectorType> segments;
+  OpsVectorType currentSegment;
+
   funcOp.walk([&](mlir::Operation *nestedOp) {
     if (llvm::isa<func::FuncOp, func::ReturnOp>(nestedOp)) {
       return;
@@ -118,24 +165,54 @@ analyzeConstEval(func::FuncOp funcOp) {
       return;
     }
 
-    descriptor.operations.push_back(nestedOp);
+    // Start a new segment at barrier ops.
+    if (isBarrierOp(nestedOp)) {
+      if (!currentSegment.empty()) {
+        segments.push_back(std::move(currentSegment));
+        currentSegment = {};
+      }
+      return;
+    }
+
+    currentSegment.push_back(nestedOp);
   });
 
-  if (descriptor.operations.empty()) {
-    return {};
+  if (!currentSegment.empty()) {
+    segments.push_back(std::move(currentSegment));
   }
 
-  // Verify all ops in the descriptor can be lowered to Linalg.
-  // If any op fails, skip CPU-hoisting altogether.
-  for (auto *op : descriptor.operations) {
-    if (!canLowerTTIRToLinalg(op)) {
-      op->emitWarning("Skipping CPU hoisting of const-eval "
-                      "subgraph: op cannot be lowered to Linalg");
-      return {};
+  // Build a CPUHoistedOpsDescriptor descriptor for each segment.
+  llvm::SmallVector<CPUHoistedOpsDescriptor> descriptors;
+  for (const auto &segment : segments) {
+    // Verify all ops can be lowered to Linalg.
+    bool canLower = llvm::all_of(
+        segment, [&](mlir::Operation *op) { return canLowerTTIRToLinalg(op); });
+
+    if (!canLower) {
+      continue;
     }
+
+    // Output values of this CPU-hoisted segment are op results used by ops
+    // outside the segment.
+    ValuesVectorType outputValues;
+    for (auto *op : segment) {
+      for (auto result : op->getResults()) {
+        bool usedOutsideSegment =
+            llvm::any_of(result.getUsers(), [&](Operation *user) {
+              return !llvm::is_contained(segment, user);
+            });
+
+        if (usedOutsideSegment) {
+          outputValues.push_back(result);
+        }
+      }
+    }
+
+    descriptors.emplace_back(segment, outputValues,
+                             llvm::SmallString<64>("const_eval"));
   }
 
-  return {descriptor};
+  return descriptors;
 }
 
 // Transform pass to hoist const-eval subgraphs as a whole.

--- a/lib/Target/Python/TranslateToPython.cpp
+++ b/lib/Target/Python/TranslateToPython.cpp
@@ -749,6 +749,45 @@ static LogicalResult printOperation(PythonEmitter &emitter, ClassOp classOp) {
 }
 
 static LogicalResult printOperation(PythonEmitter &emitter,
+                                    NestedFuncOp funcOp) {
+  PythonEmitter::Scope scope(emitter);
+  raw_indented_ostream &os = emitter.ostream();
+  emitter.reserveName(funcOp.getSymName().str());
+
+  os << "def " << funcOp.getSymName() << "(";
+  Block &body = funcOp.getBody().front();
+  if (failed(interleaveCommaWithError(body.getArguments(), os,
+                                      [&](BlockArgument arg) {
+                                        return emitter.emitOperand(arg, "arg");
+                                      }))) {
+    return failure();
+  }
+  os << "): \n";
+
+  os.indent();
+  for (Operation &op : body.getOperations()) {
+    if (failed(emitter.emitOperation(op))) {
+      return failure();
+    }
+  }
+  os.unindent();
+  return success();
+}
+
+static LogicalResult printOperation(PythonEmitter &emitter,
+                                    NestedFuncReturnOp returnOp) {
+  raw_indented_ostream &os = emitter.ostream();
+  os << "return";
+  if (returnOp.getNumOperands() > 0) {
+    os << " ";
+    if (failed(emitter.emitOperands(*returnOp.getOperation()))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+static LogicalResult printOperation(PythonEmitter &emitter,
                                     ConstantOp constantOp) {
   Attribute value = constantOp.getValue();
 
@@ -1006,7 +1045,8 @@ LogicalResult PythonEmitter::emitOperation(Operation &op) {
           .Case<CallOpaqueOp, ImportOp, AssignOp, GetAttrOp, SetAttrOp,
                 ConstantOp, SubscriptOp, ClassOp, GlobalOp, AssignGlobalOp,
                 GlobalStatementOp, CreateDictOp, ExpressionOp, YieldOp, IfOp,
-                FileOp>([&](auto op) { return printOperation(*this, op); })
+                NestedFuncOp, NestedFuncReturnOp, FileOp>(
+              [&](auto op) { return printOperation(*this, op); })
           .Case<LiteralOp>([&](auto op) {
             registerDeferredValue(op.getResult(), op.getValue());
             return success();

--- a/lib/Target/Python/TranslateToPython.cpp
+++ b/lib/Target/Python/TranslateToPython.cpp
@@ -750,9 +750,9 @@ static LogicalResult printOperation(PythonEmitter &emitter, ClassOp classOp) {
 
 static LogicalResult printOperation(PythonEmitter &emitter,
                                     NestedFuncOp funcOp) {
+  emitter.reserveName(funcOp.getSymName().str());
   PythonEmitter::Scope scope(emitter);
   raw_indented_ostream &os = emitter.ostream();
-  emitter.reserveName(funcOp.getSymName().str());
 
   os << "def " << funcOp.getSymName() << "(";
   Block &body = funcOp.getBody().front();

--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -92,6 +92,11 @@ def _get_device_for_target(
             return _current_device
         elif _current_device_target == "emitpy":
             ttnn.close_mesh_device(_current_device)
+            # Clear the DeviceGetter singleton too; otherwise it keeps the old
+            # mesh shape and rejects the next emitpy test that requests a
+            # different one.
+            utils.DeviceGetter._instance = None
+            utils.DeviceGetter._mesh_shape = None
         else:  # Cache miss, need to teardown
             print(
                 f"Found new target {target} with mesh shape {mesh_shape} and fabric config {fabric_config}, closing device for {_current_device_target} with {_current_device_mesh_shape} and {_current_fabric_config}"

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -204,6 +204,77 @@ def test_hoisted_div(shape: Shape, dtype: torch.dtype, target: str, request, dev
     )
 
 
+@pytest.mark.parametrize("shape", [(64, 128)], ids=shape_str)
+@pytest.mark.parametrize("shard_dims", [(0, 1)])
+@pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=shape_str)
+@pytest.mark.parametrize("target", ["ttnn", "emitpy" | SkipIf("sim")])
+def test_cpu_hoisted_multichip(
+    shape: Shape,
+    shard_dims: Tuple[int, int],
+    mesh_shape: Tuple[int, int],
+    target: str,
+    request,
+    device,
+):
+    # Sharded inputs run each CPU-hoisted op shard-by-shard; the reduce_scatter
+    # CCL between them stays on device and keeps the data distributed, so both
+    # hoisted ops see distinct shards.
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, shape], [torch.float32, torch.float32])
+        def hoisted_multichip(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            shard_shape = make_shard_shape(len(shape), shard_dims, mesh_shape)
+            s0 = builder.mesh_shard(
+                in0,
+                shard_direction=MeshShardDirection.FullToShard.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape,
+                shard_dims=list(shard_dims),
+            )
+            s1 = builder.mesh_shard(
+                in1,
+                shard_direction=MeshShardDirection.FullToShard.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape,
+                shard_dims=list(shard_dims),
+            )
+            # CPU-hoisted, runs on each device's distinct shard.
+            a = builder.add(s0, s1, unit_attrs=["ttir.should_hoist"])
+
+            # CCL barrier: stays on device. Scatters the reduced result along
+            # the sharded dim, so each device keeps a distinct slice.
+            rs = builder.reduce_scatter(
+                a,
+                reduce_type=ReduceType.Sum.value,
+                scatter_dim=1,
+                cluster_axis=1,
+            )
+
+            # CPU-hoisted again, still on distinct per-device shards.
+            m = builder.multiply(rs, rs, unit_attrs=["ttir.should_hoist"])
+
+            return builder.mesh_shard(
+                m,
+                shard_direction=MeshShardDirection.ShardToFull.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape,
+                shard_dims=list(shard_dims),
+            )
+
+    compile_and_execute_ttir(
+        module,
+        mesh_name="mesh",
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        target=target,
+        device=device,
+        **get_request_kwargs(request),
+    )
+
+
 @pytest.mark.parametrize("shape", [(1, 1, 32) | SkipIf("sim")], ids=shape_str)
 @pytest.mark.parametrize("broadcast_dimensions", [[1, 16, 1]])
 def test_broadcast(shape: List[int], broadcast_dimensions: List[int], request, device):

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -207,7 +207,7 @@ def test_hoisted_div(shape: Shape, dtype: torch.dtype, target: str, request, dev
 @pytest.mark.parametrize("shape", [(64, 128)], ids=shape_str)
 @pytest.mark.parametrize("shard_dims", [(0, 1)])
 @pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=shape_str)
-@pytest.mark.parametrize("target", ["ttnn", "emitpy" | SkipIf("sim")])
+@pytest.mark.parametrize("target", ["ttnn" | SkipIf("sim"), "emitpy" | SkipIf("sim")])
 def test_cpu_hoisted_multichip(
     shape: Shape,
     shard_dims: Tuple[int, int],

--- a/test/ttmlir/Dialect/TTIR/Transforms/HoistCPUOps/const_eval_hoist_multichip.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/HoistCPUOps/const_eval_hoist_multichip.mlir
@@ -1,0 +1,416 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttcore-register-device --ttcore-wrap-device-module --cpu-hoist-const-eval --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// CHECK: ttcore.device_module {
+// CHECK: builtin.module
+
+// =============================================================================
+// Basic barrier segmentation
+// =============================================================================
+
+// --- Single all_gather barrier ---
+// Compute chain before and after the CCL, each becoming a hoisted call.
+
+// CHECK-LABEL: func.func private @single_all_gather_barrier
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @single_all_gather_barrier(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%add, %arg0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %sub = "ttir.subtract"(%gathered, %gathered) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  %mul2 = "ttir.multiply"(%sub, %gathered) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  return %mul2 : tensor<64x32xbf16>
+}
+
+// --- Only ops before CCL ---
+
+// CHECK-LABEL: func.func private @ops_before_ccl_only
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK-NOT: call @cpu_hoisted
+// CHECK: return
+func.func private @ops_before_ccl_only(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%add, %add) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  return %gathered : tensor<64x32xbf16>
+}
+
+// --- Only ops after CCL ---
+
+// CHECK-LABEL: func.func private @ops_after_ccl_only
+// CHECK-NOT: call @cpu_hoisted
+// CHECK: ttir.all_gather
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @ops_after_ccl_only(
+    %arg0: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %gathered = "ttir.all_gather"(%arg0) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %mul = "ttir.multiply"(%gathered, %gathered) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  %sub = "ttir.subtract"(%mul, %gathered) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  return %sub : tensor<64x32xbf16>
+}
+
+// --- CCL-only - nothing to hoist ---
+
+// CHECK-LABEL: func.func private @ccl_only_no_hoist
+// CHECK-NOT: call @cpu_hoisted
+// CHECK: ttir.all_gather
+// CHECK: return
+func.func private @ccl_only_no_hoist(
+    %arg0: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %gathered = "ttir.all_gather"(%arg0) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  return %gathered : tensor<64x32xbf16>
+}
+
+// =============================================================================
+// Multiple barriers and consecutive CCLs
+// =============================================================================
+
+// --- Multiple barriers with multi-op segments ---
+
+// CHECK-LABEL: func.func private @multiple_barriers_multi_op
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK-NOT: ttir.add
+// CHECK-NOT: ttir.multiply
+// CHECK: ttir.all_gather
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK-NOT: ttir.subtract
+// CHECK: ttir.all_reduce
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @multiple_barriers_multi_op(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%add, %arg0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %sub = "ttir.subtract"(%gathered, %gathered) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  %reduced = "ttir.all_reduce"(%sub) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  %mul2 = "ttir.multiply"(%reduced, %reduced) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  %add2 = "ttir.add"(%mul2, %reduced) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  return %add2 : tensor<64x32xbf16>
+}
+
+// --- Consecutive CCL barriers with no ops between ---
+// Two back-to-back CCLs produce no middle segment.
+
+// CHECK-LABEL: func.func private @consecutive_ccl_barriers
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK: ttir.all_reduce
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @consecutive_ccl_barriers(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%add, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %reduced = "ttir.all_reduce"(%gathered) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  %sub = "ttir.subtract"(%reduced, %reduced) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  return %sub : tensor<64x32xbf16>
+}
+
+// =============================================================================
+// Different CCL barrier types
+// =============================================================================
+
+// --- All-reduce barrier ---
+
+// CHECK-LABEL: func.func private @all_reduce_barrier
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_reduce
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @all_reduce_barrier(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<32x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%add, %add) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %reduced = "ttir.all_reduce"(%mul) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %sub = "ttir.subtract"(%reduced, %reduced) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  return %sub : tensor<32x32xbf16>
+}
+
+// --- Reduce-scatter barrier ---
+
+// CHECK-LABEL: func.func private @reduce_scatter_barrier
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.reduce_scatter
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @reduce_scatter_barrier(
+    %arg0: tensor<64x32xbf16>, %arg1: tensor<64x32xbf16>
+) -> tensor<32x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  %rs = "ttir.reduce_scatter"(%add) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 0 : si32}> : (tensor<64x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%rs, %rs) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  return %mul : tensor<32x32xbf16>
+}
+
+// --- MeshShard alongside a real barrier ---
+// Both the MeshShard and the all_gather act as barriers,
+// producing three segments around them.
+
+// CHECK-LABEL: func.func private @mesh_shard_with_barrier
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @mesh_shard_with_barrier(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %shard = "ttir.mesh_shard"(%add) <{shard_dims = array<i64: -1>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 1>, shard_type = #ttcore.shard_type<devices>}> : (tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%shard, %shard) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %sub = "ttir.subtract"(%gathered, %gathered) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  return %sub : tensor<64x32xbf16>
+}
+
+// =============================================================================
+// Inter-segment dependencies
+// =============================================================================
+
+// --- Segment 2 uses a function arg also used by segment 1 ---
+// %arg1 feeds both the first segment and the second segment (via the
+// function argument, not through the CCL). Both segments should be
+// hoisted correctly with %arg1 as an input to both.
+
+// CHECK-LABEL: func.func private @shared_func_arg_across_segments
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @shared_func_arg_across_segments(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%add) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  // %arg1 is 32x32, gathered is 64x32 — use reshape to match shapes.
+  %reshaped = "ttir.reshape"(%arg1) <{shape = [1 : i32, 1024 : i32]}> : (tensor<32x32xbf16>) -> tensor<1x1024xbf16>
+  %reshaped_back = "ttir.reshape"(%reshaped) <{shape = [32 : i32, 32 : i32]}> : (tensor<1x1024xbf16>) -> tensor<32x32xbf16>
+  %arg1_gathered = "ttir.all_gather"(%reshaped_back) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %mul = "ttir.multiply"(%gathered, %arg1_gathered) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  return %mul : tensor<64x32xbf16>
+}
+
+// --- Multiple outputs from a segment feed the CCL and post-CCL ---
+// Segment 1 produces two values: one feeds the CCL, the other is also
+// consumed by segment 2 after the CCL via a function arg passthrough.
+
+// CHECK-LABEL: func.func private @segment_multi_output
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK-NOT: ttir.add
+// CHECK-NOT: ttir.subtract
+// CHECK: ttir.all_gather
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @segment_multi_output(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %sub = "ttir.subtract"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered_add = "ttir.all_gather"(%add) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %gathered_sub = "ttir.all_gather"(%sub) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %mul = "ttir.multiply"(%gathered_add, %gathered_sub) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  return %mul : tensor<64x32xbf16>
+}
+
+// =============================================================================
+// Skippable ops interacting with barriers
+// =============================================================================
+
+// --- Creation op consumed within a segment ---
+// A zeros op used as an operand in the segment should be hoisted
+// together with the segment (not skipped, since it's not at return).
+
+// CHECK-LABEL: func.func private @creation_op_inside_segment
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK-NOT: ttir.zeros
+// CHECK-NOT: ttir.multiply
+// CHECK: ttir.all_gather
+// CHECK: return
+func.func private @creation_op_inside_segment(
+    %arg0: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %zeros = "ttir.zeros"() <{shape = array<i32: 32, 32>}> : () -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%arg0, %zeros) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  return %gathered : tensor<64x32xbf16>
+}
+
+// --- Creation op at return with CCL in between ---
+// The creation op chain at return is skipped. The segment before the
+// CCL is hoisted. The CCL result is returned alongside the creation.
+
+// CHECK-LABEL: func.func private @creation_at_return_with_ccl
+// CHECK: ttir.zeros
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK-NOT: call @cpu_hoisted
+// CHECK: return
+func.func private @creation_at_return_with_ccl(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> (tensor<64x32xbf16>, tensor<64x32xbf16>) attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%add, %add) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %zeros = "ttir.zeros"() <{shape = array<i32: 64, 32>}> : () -> tensor<64x32xbf16>
+  return %gathered, %zeros : tensor<64x32xbf16>, tensor<64x32xbf16>
+}
+
+// --- Creation op with transparent chain at return, plus CCL ---
+// A zeros → reshape chain at return is skipped. The compute segment
+// before the CCL is hoisted. Canonicalize folds the chain into a
+// single zeros with the reshaped shape.
+
+// CHECK-LABEL: func.func private @creation_chain_at_return_with_ccl
+// CHECK: ttir.zeros
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK-NOT: call @cpu_hoisted
+// CHECK: return
+func.func private @creation_chain_at_return_with_ccl(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> (tensor<64x32xbf16>, tensor<1x1024xbf16>) attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%add) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %zeros = "ttir.zeros"() <{shape = array<i32: 32, 32>}> : () -> tensor<32x32xbf16>
+  %reshaped = "ttir.reshape"(%zeros) <{shape = [1 : i32, 1024 : i32]}> : (tensor<32x32xbf16>) -> tensor<1x1024xbf16>
+  return %gathered, %reshaped : tensor<64x32xbf16>, tensor<1x1024xbf16>
+}
+
+// =============================================================================
+// Complex dependency patterns
+// =============================================================================
+
+// --- Diamond dependency through CCL ---
+// Segment 1 produces a value that fans out to two CCLs, then segment 2
+// combines both CCL results.
+
+// CHECK-LABEL: func.func private @diamond_through_ccl
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK: ttir.all_reduce
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @diamond_through_ccl(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%add, %add) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  // Same value fans out to two different CCLs.
+  %gathered = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %reduced = "ttir.all_reduce"(%mul) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  // Combine results from both CCL paths.
+  %reduced_gathered = "ttir.all_gather"(%reduced) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %result = "ttir.add"(%gathered, %reduced_gathered) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  return %result : tensor<64x32xbf16>
+}
+
+// --- Long chain with interleaved CCLs ---
+// A realistic pattern: compute → CCL → compute → CCL → compute → CCL → compute.
+
+// CHECK-LABEL: func.func private @long_interleaved_chain
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_reduce
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @long_interleaved_chain(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<128x32xbf16> attributes {tt.function_type = "const_eval"} {
+  // Segment 1
+  %s1_add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %s1_mul = "ttir.multiply"(%s1_add, %s1_add) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  // CCL 1
+  %ccl1 = "ttir.all_gather"(%s1_mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  // Segment 2
+  %s2_sub = "ttir.subtract"(%ccl1, %ccl1) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  %s2_add = "ttir.add"(%s2_sub, %ccl1) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  // CCL 2
+  %ccl2 = "ttir.all_reduce"(%s2_add) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  // Segment 3
+  %s3_mul = "ttir.multiply"(%ccl2, %ccl2) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  // CCL 3
+  %ccl3 = "ttir.all_gather"(%s3_mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<64x32xbf16>) -> tensor<128x32xbf16>
+  // Segment 4
+  %s4_sub = "ttir.subtract"(%ccl3, %ccl3) : (tensor<128x32xbf16>, tensor<128x32xbf16>) -> tensor<128x32xbf16>
+  %s4_add = "ttir.add"(%s4_sub, %ccl3) : (tensor<128x32xbf16>, tensor<128x32xbf16>) -> tensor<128x32xbf16>
+  return %s4_add : tensor<128x32xbf16>
+}
+
+// --- Segment produces multiple outputs consumed by different barriers ---
+// Two values from segment 1 each feed a separate CCL, and the post-CCL
+// segment consumes both CCL results.
+
+// CHECK-LABEL: func.func private @multi_output_to_different_ccls
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK-NOT: ttir.add
+// CHECK-NOT: ttir.subtract
+// CHECK: ttir.all_gather
+// CHECK: ttir.all_reduce
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: return
+func.func private @multi_output_to_different_ccls(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  // Segment 1: produces %add and %sub.
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %sub = "ttir.subtract"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  // %add → all_gather, %sub → all_reduce
+  %gathered = "ttir.all_gather"(%add) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %reduced = "ttir.all_reduce"(%sub) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  // Segment 2: consumes both CCL results.
+  %reduced_gathered = "ttir.all_gather"(%reduced) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %mul = "ttir.multiply"(%gathered, %reduced_gathered) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+  return %mul : tensor<64x32xbf16>
+}
+
+// =============================================================================
+// Partial hoisting
+// =============================================================================
+
+// --- Non-lowerable op in one segment doesn't block others ---
+// Only the segment with the non-lowerable rms_norm is skipped.
+
+// CHECK-LABEL: func.func private @non_lowerable_in_one_segment
+// CHECK: call @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttir.all_gather
+// CHECK: ttir.rms_norm
+// CHECK-NOT: call @cpu_hoisted
+// CHECK: return
+func.func private @non_lowerable_in_one_segment(
+    %arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>, %arg2: tensor<32xbf16>
+) -> tensor<64x32xbf16> attributes {tt.function_type = "const_eval"} {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %mul = "ttir.multiply"(%add, %add) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %gathered = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xbf16>) -> tensor<64x32xbf16>
+  %rms = "ttir.rms_norm"(%gathered, %arg2) <{normalized_shape = array<i64: 32>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<64x32xbf16>, tensor<32xbf16>) -> tensor<64x32xbf16>
+  return %rms : tensor<64x32xbf16>
+}
+
+// Verify hoisted function declarations and definitions.
+// CHECK: func.func private @cpu_hoisted_const_eval_{{.*}}
+// CHECK: ttcore.cpu_module {
+// CHECK: builtin.module {
+// CHECK: func.func @cpu_hoisted_const_eval_{{.*}}

--- a/test/ttmlir/EmitPy/cpu_hoisted_const_eval.mlir
+++ b/test/ttmlir/EmitPy/cpu_hoisted_const_eval.mlir
@@ -83,10 +83,16 @@ func.func @forward_all_const(%arg0: tensor<32x16xf32> {ttcore.argument_type = #t
 
 // CHECK-LABEL : # File: "consteval"
 
-// CHECK-LABEL: def cpu_hoisted_const_eval_{{.*}}
+// Each hoisted segment is a ttnn-typed wrapper that defers to the
+// shard-by-shard helper, with the pure-torch body (ttir_cpu.*) emitted as a
+// nested `_impl` def passed to the helper.
+// CHECK-LABEL: def cpu_hoisted_const_eval_{{.*}}(
+// The impl is a nested def (indented) inside the wrapper.
+// CHECK: {{^  }}def cpu_hoisted_const_eval_{{.*}}_impl(
 // CHECK: ttir_cpu.
+// CHECK: utils.execute_cpu_hoisted_function({{.*}}, cpu_hoisted_const_eval_{{.*}}_impl)
 // CHECK-LABEL: def forward_const_eval_0(
-// CHECK: cpu_hoisted_const_eval_{{.*}}
+// CHECK: cpu_hoisted_const_eval_{{.*}}(
 // CHECK-LABEL: def consteval_forward(
 // CHECK-LABEL: def cpu_hoisted_const_eval_{{.*}}
 // CHECK: ttir_cpu.

--- a/test/ttmlir/EmitPy/cpu_hoisted_const_eval_multichip.mlir
+++ b/test/ttmlir/EmitPy/cpu_hoisted_const_eval_multichip.mlir
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline="mesh-shape=1,2 enable-cpu-hoisted-const-eval=true" -o %t.mlir %s
+// RUN: ttmlir-translate --mlir-to-python -o %t.py %t.mlir
+// RUN: FileCheck %s --input-file=%t.py
+
+// Multi-chip const-eval CPU hoisting. The const-eval subgraph is segmented
+// around the all_gather barrier into two CPU-hoisted segments. Each segment is
+// emitted as a torch-typed `_impl` body plus a ttnn-typed wrapper that defers
+// to utils.execute_cpu_hoisted_function, which runs the body shard-by-shard
+// over the mesh. The all_gather stays on device between the two calls.
+
+// CHECK: # File: "consteval"
+
+// Two segment bodies (add/multiply before the CCL, subtract/multiply after).
+// CHECK-DAG: def cpu_hoisted_const_eval_{{.*}}_impl(
+// CHECK-DAG: ttir_cpu.add(
+// CHECK-DAG: ttir_cpu.subtract(
+
+// Each hoisted segment defers to the shard-by-shard helper, passing its body.
+// CHECK-DAG: utils.execute_cpu_hoisted_function({{.*}}, cpu_hoisted_const_eval_{{.*}}_impl)
+// CHECK-DAG: utils.execute_cpu_hoisted_function({{.*}}, cpu_hoisted_const_eval_{{.*}}_impl)
+
+// The device-side const-eval function calls the first segment, performs the
+// all_gather on device, brings the result to host, then calls the second
+// segment.
+// CHECK-LABEL: def forward_const_eval_0(
+// CHECK: cpu_hoisted_const_eval_{{.*}}(
+// CHECK: ttnn.all_gather
+// CHECK: ttnn.from_device
+// CHECK: cpu_hoisted_const_eval_{{.*}}(
+// CHECK: return
+func.func @forward(
+    %arg0: tensor<32x32xf32> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+    %arg1: tensor<32x32xf32> {ttcore.argument_type = #ttcore.argument_type<parameter>}
+) -> tensor<64x32xf32> {
+  %add = "ttir.add"(%arg0, %arg1) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  %mul = "ttir.multiply"(%add, %arg0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  %g = "ttir.all_gather"(%mul) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32}> : (tensor<32x32xf32>) -> tensor<64x32xf32>
+  %sub = "ttir.subtract"(%g, %g) : (tensor<64x32xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+  %mul2 = "ttir.multiply"(%sub, %g) : (tensor<64x32xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+  return %mul2 : tensor<64x32xf32>
+}

--- a/tools/tt-alchemist/templates/python/local/utils.py
+++ b/tools/tt-alchemist/templates/python/local/utils.py
@@ -89,6 +89,67 @@ def load_tensor(file_path: str, layout, dtype, device, memory_config) -> ttnn.Te
     return loaded_tensor
 
 
+# Heavy-lifting helper for CPU-hoisted functions. Mirrors the runtime logic in
+# runtime/lib/ttnn/operations/cpu/cpu.cpp (runSingleChip / runMultiChip):
+# CPU-hoisted segments are barrier-free local compute, so each device's shard is
+# computed independently on the host and the per-shard results are reassembled
+# into a multi-device tensor.
+def execute_cpu_hoisted_function(inputs, function):
+    """Run a pure-torch CPU-hoisted body shard-by-shard over a mesh.
+
+    inputs:   list of ttnn.Tensor operands (device-resident, possibly sharded).
+    function: pure-torch callable mapping torch tensors -> torch tensor(s).
+    Returns a single ttnn.Tensor, or a tuple of them for multi-output bodies.
+    """
+
+    def _wrap_outputs(result):
+        return result if isinstance(result, (list, tuple)) else (result,)
+
+    # The mesh device comes from the program context (the DeviceGetter
+    # singleton), not from the inputs: CPU-hoisted inputs have already been
+    # brought to host by the device program, so their .device() is None. This
+    # mirrors how the runtime obtains the mesh device from the ProgramContext.
+    mesh_device = DeviceGetter._instance
+
+    # No mesh context: run the body once on the host and return host tensor(s).
+    if mesh_device is None:
+        torch_inputs = [ttnn.to_torch(tensor) for tensor in inputs]
+        outputs = _wrap_outputs(function(*torch_inputs))
+        host_outputs = [ttnn.from_torch(out) for out in outputs]
+        return host_outputs[0] if len(host_outputs) == 1 else tuple(host_outputs)
+
+    mesh_shape = mesh_device.shape
+    num_shards = mesh_device.get_num_devices()
+
+    # Split each input into per-device torch shards. get_device_tensors returns
+    # one shard per device for a sharded tensor, or a single shard for an
+    # unsharded (replicated) tensor, which is then reused across devices.
+    input_shards = []
+    for tensor in inputs:
+        if tensor.device() is not None:
+            tensor = ttnn.from_device(tensor)
+        shards = ttnn.get_device_tensors(tensor)
+        input_shards.append([ttnn.to_torch(shard) for shard in shards])
+
+    # Run the body once per device shard.
+    output_shards = []
+    for shard_idx in range(num_shards):
+        args = [
+            shards[shard_idx] if len(shards) > 1 else shards[0]
+            for shards in input_shards
+        ]
+        output_shards.append(_wrap_outputs(function(*args)))
+
+    # Reassemble each output across shards into a multi-device host tensor.
+    num_outputs = len(output_shards[0])
+    results = []
+    for out_idx in range(num_outputs):
+        torch_shards = [output_shards[s][out_idx] for s in range(num_shards)]
+        ttnn_shards = [ttnn.from_torch(shard) for shard in torch_shards]
+        results.append(ttnn.from_host_shards(ttnn_shards, mesh_shape))
+    return results[0] if num_outputs == 1 else tuple(results)
+
+
 # Helpers for distributed RMS norm EmitPy support.
 # These mirror the runtime logic in
 # runtime/lib/ttnn/operations/normalization/distributed_rms_norm.cpp


### PR DESCRIPTION
### Ticket
Closes #6709

### Problem description
CPU-hoisting of const-eval subgraphs was single-device only: `CPUHoistConstEval`
bailed out on multi-device graphs, and the EmitPy backend ran each hoisted
function once on a single tensor. On a mesh this is both incorrect (CCLs can't
sit inside a hoisted host function) and unsupported.

### What's changed

**General (TTIR)**
- `CPUHoistConstEval` now segments const-eval functions around CCL / mesh-shard
  barriers instead of bailing out on multi-device graphs. Each barrier-free run
  of compute becomes its own hoisted call; CCLs stay on device between segments.
- A non-lowerable op now only skips its own segment instead of the whole
  function.

**EmitPy backend**
- Hoisted segments run shard-by-shard. Each hoisted function emits a ttnn-typed
  wrapper that defers to a new `utils.execute_cpu_hoisted_function` helper, which
  brings inputs to host, splits them per device (`get_device_tensors`), runs the
  pure-torch body once per shard, and reassembles via `from_host_shards`
  (mirroring the runtime `runMultiChip`).
- The pure-torch body is emitted as a nested `def` via two new ops
  (`emitpy.nested_func` / `emitpy.nested_func_return`), so it stays local to the
  wrapper.
- `ConvertTTIRCPUToEmitPy` lowers the hoisted func in place with stock
  func/return type conversion, then a single post-pass (`wrapAndNest`) builds the
  wrapper and nests the body — removing the bespoke boundary patterns.
- Fixed a latent conftest bug where switching EmitPy mesh shapes across tests
  didn't reset the `DeviceGetter` singleton.

A CPU-hoisted function now emits as a ttnn-typed wrapper around a nested
pure-torch body that runs shard-by-shard:

```python
def cpu_hoisted_const_eval_64873cce(arg_0, arg_1):
    def cpu_hoisted_const_eval_64873cce_impl(arg, arg_0_1):
        ttir_cpu_subtract_0 = ttir_cpu.subtract(arg, arg_0_1)
        return ttir_cpu_subtract_0

    util_create_list_0 = [arg_0, arg_1]
    utils_execute_cpu_hoisted_function_0 = utils.execute_cpu_hoisted_function(
        util_create_list_0, cpu_hoisted_const_eval_64873cce_impl
    )
    return utils_execute_cpu_hoisted_function_0
```

### Checklist
- [x] New/Existing tests provide coverage for changes
  - General (TTIR lit): `const_eval_hoist_multichip.mlir` (barrier segmentation)
  - EmitPy lit: `cpu_hoisted_const_eval_multichip.mlir` + nested-`def` checks
  - EmitPy builder (n300): `test_cpu_hoisted_multichip` runs both hoisted
    segments shard-by-shard on a 1x2 mesh on distinct shards, PCC verified

<!-- xla-validate -->
---
### tt-xla Validation

Two passes: **(1)** full run on uplift base `464a5f34`; **(2)** filtered re-run of the failures on rebased base `5e7218a6` (= [#8798](https://github.com/tenstorrent/tt-mlir/pull/8798) + this PR).

**Pass 1 — base `464a5f34`**

| Suite | Result |
|-------|--------|
| [full-mlir-uplift-qualification](https://github.com/tenstorrent/tt-xla/actions/runs/27706700570) | :white_check_mark: passed (43/43) |
| [model-test-passing](https://github.com/tenstorrent/tt-xla/actions/runs/27706704752) | :x: failed |
| [model-test-emitpy](https://github.com/tenstorrent/tt-xla/actions/runs/27706702928) | :x: failed |
| [perf-benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/27706803989) (n300-llmbox) | :x: failed |

**Failures → root cause → re-run outcome** — all pre-existing, none introduced by this PR:

| Failing tests | Root cause | Re-run on `5e7218a6` |
|---------------|------------|----------------------|
| TP-PCC: llama 70B/8B + qwen 72B (decode/prefill); benchmark `llama_3_1_70b_tp` | RMS-norm distributed-decomp bug — [#5256](https://github.com/tenstorrent/tt-xla/issues/5256), fixed by [#8798](https://github.com/tenstorrent/tt-mlir/pull/8798) | :white_check_mark: **pass** ([model-test](https://github.com/tenstorrent/tt-xla/actions/runs/27751545414), [bench](https://github.com/tenstorrent/tt-xla/actions/runs/27751547449)) |
| gemma3-27b multimodal TP | DRAM OOM — [#4007](https://github.com/tenstorrent/tt-xla/issues/4007) | :x: still fails (out of #8798 scope) |
| olmo3-32b TP | runtime `Error code: 13` | :x: still fails (out of #8798 scope) |
| benchmark `qwen_2_5_coder_32b_instruct_tp` | `slice` tile-alignment — [#5207](https://github.com/tenstorrent/tt-xla/issues/5207) | not re-run (out of scope) |
| single-device: maskformer, transfuser, phi4 | `Error code: 13` — [#4584](https://github.com/tenstorrent/tt-xla/issues/4584), [#4338](https://github.com/tenstorrent/tt-xla/issues/4338) | not re-run (single-device, unrelated) |
| model-test-emitpy (all jobs) | 149-min job timeout (EmitPy compile path; infra/duration) | not re-run |

**Conclusion:** `full-mlir-uplift-qualification` is clean (43/43). The TP-PCC cluster — the only failures #8798 targets — is confirmed fixed on the rebased base (all decode/prefill TP jobs + benchmark pass). Every other failure is a pre-existing, unrelated issue. **No regressions attributable to PR #8474.**
<!-- /xla-validate -->










