### PR TITLE
fix(StableHLOToTTIR): use last element for gather back-pad in SliceRepeatConcat

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -5630,13 +5630,18 @@ public:
 
     SmallVector<Value> slicesToConcat;
 
-    slicesToConcat = createSlices(starts, indexedDim, sliceSize, inputShape,
-                                  inputType, rewriter, srcOp, input);
+    // Front pad: replicate the first slice along indexedDim.
+    slicesToConcat = createSlices(starts, indexedDim, sliceSize,
+                                  /*sliceStart=*/0, inputShape, inputType,
+                                  rewriter, srcOp, input);
 
     slicesToConcat.push_back(input);
 
-    slicesToConcat.append(createSlices(ends, indexedDim, sliceSize, inputShape,
-                                       inputType, rewriter, srcOp, input));
+    // Back pad: replicate the *last* slice along indexedDim.
+    slicesToConcat.append(
+        createSlices(ends, indexedDim, sliceSize,
+                     /*sliceStart=*/inputShape[indexedDim] - sliceSize,
+                     inputShape, inputType, rewriter, srcOp, input));
 
     auto outputType = mlir::cast<RankedTensorType>(
         getTypeConverter()->convertType(srcOp.getResult().getType()));
@@ -5671,15 +5676,16 @@ private:
 
   SmallVector<Value>
   createSlices(int32_t numberOfRepeats, int32_t indexedDim, int32_t sliceSize,
-               ArrayRef<int64_t> inputShape, RankedTensorType inputType,
-               ConversionPatternRewriter &rewriter,
+               int32_t sliceStart, ArrayRef<int64_t> inputShape,
+               RankedTensorType inputType, ConversionPatternRewriter &rewriter,
                mlir::stablehlo::GatherOp srcOp, Value input) const {
     SmallVector<Value> slices;
     if (numberOfRepeats > 0) {
+      int32_t sliceEnd = sliceStart + sliceSize;
       auto [begins, endsArr, step] =
-          buildSliceArrays(0, sliceSize, indexedDim, inputShape);
+          buildSliceArrays(sliceStart, sliceEnd, indexedDim, inputShape);
       auto sliceShape =
-          computeSliceResultShape(0, sliceSize, indexedDim, inputShape);
+          computeSliceResultShape(sliceStart, sliceEnd, indexedDim, inputShape);
       auto sliceType = RankedTensorType::get(
           sliceShape, inputType.getElementType(), inputType.getEncoding());
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
@@ -5,7 +5,10 @@
 // CHECK-LABEL: func.func @repeat_front
 module @test_gather_repeat_front {
   func.func @repeat_front(%arg0: tensor<1x768x4x60x106xbf16>) -> (tensor<1x768x6x60x106xbf16>) {
+    // Front pad must slice the *first* element along the indexed dim ([0,1)).
     // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 768 : i32, 1 : i32, 60 : i32, 106 : i32]
     // CHECK-SAME: (tensor<1x768x4x60x106xbf16>) -> tensor<1x768x1x60x106xbf16>
     // CHECK: "ttir.repeat"
     // CHECK-SAME: repeat_dimensions = array<i64: 1, 1, 2, 1, 1>
@@ -23,7 +26,10 @@ module @test_gather_repeat_front {
 // CHECK-LABEL: func.func @repeat_back
 module @test_gather_repeat_back {
   func.func @repeat_back(%arg0: tensor<1x768x4x60x106xbf16>) -> (tensor<1x768x6x60x106xbf16>) {
+    // Back pad must slice the *last* element along the indexed dim ([3,4)).
     // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 3 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 768 : i32, 4 : i32, 60 : i32, 106 : i32]
     // CHECK-SAME: (tensor<1x768x4x60x106xbf16>) -> tensor<1x768x1x60x106xbf16>
     // CHECK: "ttir.repeat"
     // CHECK-SAME: repeat_dimensions = array<i64: 1, 1, 2, 1, 1>
@@ -41,7 +47,17 @@ module @test_gather_repeat_back {
 // CHECK-LABEL: func.func @repeat_both
 module @test_gather_slice_no_repeat_both {
   func.func @repeat_both(%arg0: tensor<1x768x4x60x106xbf16>) -> (tensor<1x768x6x60x106xbf16>) {
+    // Front pad: slice [0,1) along indexed dim.
     // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 768 : i32, 1 : i32, 60 : i32, 106 : i32]
+    // CHECK-SAME: (tensor<1x768x4x60x106xbf16>) -> tensor<1x768x1x60x106xbf16>
+    // CHECK: "ttir.repeat"
+    // CHECK-SAME: repeat_dimensions = array<i64: 1, 1, 1, 1, 1>
+    // Back pad: slice [3,4) along indexed dim.
+    // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 3 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 768 : i32, 4 : i32, 60 : i32, 106 : i32]
     // CHECK-SAME: (tensor<1x768x4x60x106xbf16>) -> tensor<1x768x1x60x106xbf16>
     // CHECK: "ttir.repeat"
     // CHECK-SAME: repeat_dimensions = array<i64: 1, 1, 1, 1, 1>
@@ -59,7 +75,18 @@ module @test_gather_slice_no_repeat_both {
 // CHECK-LABEL: func.func @repeat_both_multiple
 module @test_gather_repeat_both_multiple {
   func.func @repeat_both_multiple(%arg0: tensor<1x768x4x60x106xbf16>) -> (tensor<1x768x8x60x106xbf16>) {
+    // Front pad: slice [0,1) along indexed dim, repeated 2x.
     // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 768 : i32, 1 : i32, 60 : i32, 106 : i32]
+    // CHECK-SAME: (tensor<1x768x4x60x106xbf16>) -> tensor<1x768x1x60x106xbf16>
+    // CHECK: "ttir.repeat"
+    // CHECK-SAME: repeat_dimensions = array<i64: 1, 1, 2, 1, 1>
+    // CHECK-SAME: (tensor<1x768x1x60x106xbf16>) -> tensor<1x768x2x60x106xbf16>
+    // Back pad: slice [3,4) along indexed dim, repeated 2x.
+    // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 3 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 768 : i32, 4 : i32, 60 : i32, 106 : i32]
     // CHECK-SAME: (tensor<1x768x4x60x106xbf16>) -> tensor<1x768x1x60x106xbf16>
     // CHECK: "ttir.repeat"
     // CHECK-SAME: repeat_dimensions = array<i64: 1, 1, 2, 1, 1>


### PR DESCRIPTION
### Ticket
Fixes [#4644](https://github.com/tenstorrent/tt-xla/issues/4644)

### Problem description
The StableHLOGatherToSliceRepeatConcatPattern lowering decomposes replicate-padding-shaped stablehlo.gather ops into [front_pad, input, back_pad] concat, where each pad is built by slicing the edge element along the indexed dim and repeating it. The helper createSlices was hardcoded to always slice [0, sliceSize) along the indexed dim, so the back-pad replicated the first element instead of the last. Front-only pads happened to work; any gather with non-zero trailing pad produced wrong values at the trailing edge. This caused the HunyuanVideo VAE decoder sanity test to fail with PCC=0.904 (required 0.99), since F.pad(..., mode="replicate") with right>0 padding on H/W lowers through this pattern.

### What's changed
In StableHLOGatherToSliceRepeatConcatPattern::createSlices, added a sliceStart parameter and pass inputShape[indexedDim] - sliceSize at the back-pad call site so the slice picks the actual last element; front-pad call passes sliceStart=0 unchanged. Front-only and back-only patterns are unaffected when they were already exercising only the correct edge — the fix is structural rather than special-cased, so the pattern now produces semantically correct replicate-padding regardless of which dim is padded or how large the pad is.

Tightened test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir to CHECK the begins/ends of every ttir.slice_static across all four cases (repeat_front, repeat_back, repeat_both, repeat_both_multiple). The previous shape-only checks were satisfied by both the buggy [0,1) slice and the correct [N-1,N) slice, which is why the regression went unnoticed.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs

[pad_op_before_fix.log](https://github.com/user-attachments/files/28006224/pad_op_before_fix.log)
[pad_op_after_fix.log](https://github.com/user-attachments/files/28006231/pad_op_after_fix.log)