### PR TITLE
Fix scatter to embedding_backward lowering which results in low pcc.

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -6615,14 +6615,18 @@ public:
     // Create embedding_backward op into a temporary value.
     auto embeddingBackwardOp = rewriter.create<ttir::EmbeddingBackwardOp>(
         srcOp.getLoc(), outputType, scatterIndices, operand, update);
+    Value result = embeddingBackwardOp.getResult();
 
-    // Add the original operand to the embedding_backward result.
-    auto addResultType = outputType;
-    auto addOp = rewriter.create<ttir::AddOp>(
-        srcOp.getLoc(), addResultType,
-        ValueRange{embeddingBackwardOp.getResult(), operand});
+    // Add the original operand to the embedding_backward result only if operand
+    // is non-zero.
+    if (!matchPattern(operand, m_Zero()) &&
+        !matchPattern(operand, m_AnyZeroFloat())) {
+      auto addOp = rewriter.create<ttir::AddOp>(
+          srcOp.getLoc(), outputType, embeddingBackwardOp.getResult(), operand);
+      result = addOp.getResult();
+    }
 
-    rewriter.replaceOp(srcOp, addOp.getResult());
+    rewriter.replaceOp(srcOp, result);
 
     return success();
   }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -6612,8 +6612,17 @@ public:
                                                     scatterIndices, newShape);
     }
 
-    rewriter.replaceOpWithNewOp<ttir::EmbeddingBackwardOp>(
-        srcOp, outputType, scatterIndices, operand, update);
+    // Create embedding_backward op into a temporary value.
+    auto embeddingBackwardOp = rewriter.create<ttir::EmbeddingBackwardOp>(
+        srcOp.getLoc(), outputType, scatterIndices, operand, update);
+
+    // Add the original operand to the embedding_backward result.
+    auto addResultType = outputType;
+    auto addOp = rewriter.create<ttir::AddOp>(
+        srcOp.getLoc(), addResultType,
+        ValueRange{embeddingBackwardOp.getResult(), operand});
+
+    rewriter.replaceOp(srcOp, addOp.getResult());
 
     return success();
   }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -471,6 +471,18 @@ public:
     // Get data type, tensor layout, buffer type and memory config.
     ttcore::DataTypeAttr dTypeAttr = ttcore::DataTypeAttr::get(
         rewriter.getContext(), layoutAttr.getDataType());
+
+    auto currentIndicesType =
+        mlir::cast<RankedTensorType>(inputIndices.getType());
+    if (currentIndicesType.getRank() == 2) {
+      llvm::SmallVector<int64_t, 4> fourDShape{
+          currentIndicesType.getDimSize(0), 1, 1,
+          currentIndicesType.getDimSize(1)};
+      inputIndices = mlir::tt::ttir_to_ttnn::utils::generateReshape(
+          mlir::cast<TypedValue<RankedTensorType>>(inputIndices), fourDShape,
+          rewriter, ttmlir::utils::appendLocationSuffix(loc, "_4d_indices"));
+    }
+
     rewriter.replaceOpWithNewOp<ttnn::EmbeddingBackwardOp>(
         op, this->getTypeConverter()->convertType(op.getType()), inputIndices,
         adaptor.getWeight(), reshapedGrad, dTypeAttr);

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -387,12 +387,7 @@ public:
       indicesType = mlir::cast<RankedTensorType>(inputIndices.getType());
     }
 
-    // tt-metal reshapes indices from (batch, seq_len) to (batch, 1, 1, seq_len)
-    // and asserts batch * seq_len == number of gradient vectors which are
-    // further embedded into the weight tensor. For 1D indices (N,) it takes
-    // first_dim == last_dim == N, producing (N, 1, 1, N) and the assert fails
-    // (N*N != N). Unsqueeze to 2D: (N,) -> (1, N) so tt-metal sees
-    // (1, 1, 1, N).
+    // Unsqueeze 1D tensor to 2D tensor: (N,) -> (1, N).
     if (indicesType.getRank() == 1) {
       llvm::SmallVector<int64_t, 2> unsqueezedShape{1,
                                                     indicesType.getDimSize(0)};
@@ -472,6 +467,8 @@ public:
     ttcore::DataTypeAttr dTypeAttr = ttcore::DataTypeAttr::get(
         rewriter.getContext(), layoutAttr.getDataType());
 
+    // tt-metal requires 4D indices tensor:
+    // [batch_size, seq_len] --> [batch_size, 1, 1, seq_len].
     auto currentIndicesType =
         mlir::cast<RankedTensorType>(inputIndices.getType());
     if (currentIndicesType.getRank() == 2) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1986,6 +1986,14 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttnn::ReshapeOp op) {
     return emitOpError("Input's last dim must be divisible by TILE_WIDTH");
   }
 
+  if (inputType.getRank() != 4) {
+    return emitOpError("Input index tensor must be a 4D tensor");
+  }
+  if (inputType.getDimSize(1) != 1 || inputType.getDimSize(2) != 1) {
+    return emitOpError("Input index tensor dims 1 and 2 must be 1, "
+                       "got shape (B, ?, ?, N) where ? must be 1");
+  }
+
   // weightType must have rank of 2: (dictionary_size, embedding_size).
   if (weightType.getRank() != 2) {
     return emitOpError("Input must be a 2D tensor");
@@ -2004,13 +2012,10 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttnn::ReshapeOp op) {
     return emitOpError("Input gradient must be in the form (1, 1, R, C)");
   }
 
-  int64_t inputTypeVolume = 1;
-  for (int64_t dim : inputType.getShape()) {
-    inputTypeVolume *= dim;
-  }
-  if (inputGradType.getDimSize(2) != inputTypeVolume) {
-    return emitOpError("Input gradient first dimension must match the volume "
-                       "of the input tensor");
+  int64_t expectedRows = inputType.getDimSize(0) * inputType.getShape().back();
+  if (inputGradType.getDimSize(2) != expectedRows) {
+    return emitOpError(
+        "Input gradient dim 2 must equal index_shape[0] * index_shape[-1]");
   }
   if (inputGradType.getDimSize(3) != weightType.getDimSize(1)) {
     return emitOpError("Input gradient second dimension must match the second "

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op_to_embedding_bw.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op_to_embedding_bw.mlir
@@ -7,6 +7,8 @@ module {
     %c0 = stablehlo.constant dense<0.0> : tensor<2x128xf32>
     // CHECK: "ttir.embedding_backward"
     // CHECK: (tensor<1x10x1xsi32>, tensor<2x128xf32>, tensor<1x10x128xf32>) -> tensor<2x128xf32>
+    // CHECK: "ttir.add"
+    // CHECK: (tensor<2x128xf32>, tensor<2x128xf32>) -> tensor<2x128xf32>
     %result = "stablehlo.scatter"(%weight, %indices, %gradient) ({
     ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
       %sum = stablehlo.add %arg0, %arg1 : tensor<f32>
@@ -29,11 +31,35 @@ module {
   // CHECK: (tensor<256x1xi64>) -> tensor<1x256x1xi64>
   // CHECK: "ttir.embedding_backward"
   // CHECK: (tensor<1x256x1xi64>, tensor<50257x768xf32>, tensor<256x768xf32>) -> tensor<50257x768xf32>
+  // CHECK: "ttir.add"
+  // CHECK: (tensor<50257x768xf32>, tensor<50257x768xf32>) -> tensor<50257x768xf32>
   %result = "stablehlo.scatter"(%arg0, %arg1, %arg2) <{scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>}> ({
       ^bb0(%argL: tensor<f32>, %argR: tensor<f32>):
         %sum = stablehlo.add %argL, %argR : tensor<f32>
         stablehlo.return %sum : tensor<f32>
       }) : (tensor<50257x768xf32>, tensor<256x1xi64>, tensor<256x768xf32>) -> tensor<50257x768xf32>
     return %result : tensor<50257x768xf32>
+  }
+
+  func.func @test_embedding_backward_zero_float_operand(%indices: tensor<1x10x1xsi32>, %gradient: tensor<1x10x128xf32>) -> tensor<2x128xf32> {
+    %c0 = stablehlo.constant dense<0.0> : tensor<2x128xf32>
+    // CHECK: "ttir.embedding_backward"
+    // CHECK: (tensor<1x10x1xsi32>, tensor<2x128xf32>, tensor<1x10x128xf32>) -> tensor<2x128xf32>
+    // CHECK-NOT: "ttir.add"
+    %result = "stablehlo.scatter"(%c0, %indices, %gradient) ({
+    ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+      %sum = stablehlo.add %arg0, %arg1 : tensor<f32>
+      stablehlo.return %sum : tensor<f32>
+    }) {
+      scatter_dimension_numbers = #stablehlo.scatter<
+        update_window_dims = [2],
+        inserted_window_dims = [0],
+        scatter_dims_to_operand_dims = [0],
+        index_vector_dim = 2
+      >,
+      indices_are_sorted = false,
+      unique_indices = false
+    } : (tensor<2x128xf32>, tensor<1x10x1xsi32>, tensor<1x10x128xf32>) -> tensor<2x128xf32>
+    return %result : tensor<2x128xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
@@ -31,7 +31,7 @@ module attributes {} {
     // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<1x1x32x128xbf16
     // Check that the data type of the output operand is transformed in bf16.
-    %4 = "ttnn.embedding_bw"(%0, %1, %3) <{dtype = #ttcore.supportedDataTypes<f32>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x1x1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<512x128xf32, #ttnn_layout4>
+    %4 = "ttnn.embedding_bw"(%0, %1, %3) <{dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<1x1x1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<512x128xf32, #ttnn_layout4>
     // CHECK-NEXT: %[[EMBEDDING_BW_OP:.*]] = "ttnn.embedding_bw"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]], %[[TO_LAYOUT_IN_GRADIENT]])
     // Check that the output operand is transformed back into the f32 data type.
     // CHECK-NEXT: "ttnn.to_layout"(%[[EMBEDDING_BW_OP]])

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
@@ -2,24 +2,24 @@
 // RUN: FileCheck %s --input-file=%t
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
-#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x32xf32, #system_memory>>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #system_memory>>
 #ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<512x128xf32, #system_memory>>
 #ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x128xf32, #system_memory>>
-#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #ttnn_layout4 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<16x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {} {
-  func.func @backward(%arg0: tensor<1x32xf32, #ttnn_layout>, %arg1: tensor<512x128xf32, #ttnn_layout1>, %arg2: tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<512x128xf32, #ttnn_layout1> {
-    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>}> : (tensor<1x32xf32, #ttnn_layout>) -> tensor<1x32xf32, #ttnn_layout3>
-    %1 = "ttnn.to_layout"(%arg1) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>}> : (tensor<512x128xf32, #ttnn_layout1>) -> tensor<512x128xf32, #ttnn_layout4>
-    %2 = "ttnn.to_layout"(%arg2) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>}> : (tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<1x32x128xf32, #ttnn_layout5>
+  func.func @backward(%arg0: tensor<1x1x1x32xf32, #ttnn_layout>, %arg1: tensor<512x128xf32, #ttnn_layout1>, %arg2: tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<512x128xf32, #ttnn_layout1> {
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x1x1x32xf32, #ttnn_layout>) -> tensor<1x1x1x32xf32, #ttnn_layout3>
+    %1 = "ttnn.to_layout"(%arg1) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<512x128xf32, #ttnn_layout1>) -> tensor<512x128xf32, #ttnn_layout4>
+    %2 = "ttnn.to_layout"(%arg2) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<1x32x128xf32, #ttnn_layout5>
     // CHECK: "ttnn.reshape"
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]}> : (tensor<1x32x128xf32, #ttnn_layout5>) -> tensor<1x1x32x128xf32, #ttnn_layout5>
     // Check that the input operand is transformed into the row major layout.
     // CHECK-NEXT: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<u32>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
-    // CHECK-SAME: -> tensor<1x32xui32
+    // CHECK-SAME: -> tensor<1x1x1x32xui32
     // Check that the data type of the weight operand is transformed in bf16.
     // CHECK-NEXT: %[[TO_LAYOUT_WEIGHTS:.*]] = "ttnn.to_layout"
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
@@ -31,7 +31,7 @@ module attributes {} {
     // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<1x1x32x128xbf16
     // Check that the data type of the output operand is transformed in bf16.
-    %4 = "ttnn.embedding_bw"(%0, %1, %3) <{dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<512x128xf32, #ttnn_layout4>
+    %4 = "ttnn.embedding_bw"(%0, %1, %3) <{dtype = #ttcore.supportedDataTypes<f32>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x1x1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<512x128xf32, #ttnn_layout4>
     // CHECK-NEXT: %[[EMBEDDING_BW_OP:.*]] = "ttnn.embedding_bw"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]], %[[TO_LAYOUT_IN_GRADIENT]])
     // Check that the output operand is transformed back into the f32 data type.
     // CHECK-NEXT: "ttnn.to_layout"(%[[EMBEDDING_BW_OP]])

--- a/test/ttmlir/Dialect/TTNN/embedding/embedding_backward_1d_indices.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/embedding_backward_1d_indices.mlir
@@ -1,13 +1,17 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
 module attributes {} {
-  // 1D indices (N,) must be unsqueezed to (1, N) before ttnn.embedding_bw,
-  // otherwise tt-metal reshapes them to (N, 1, 1, N) and the internal
-  // assertion N*N == N fails.
+  // 1D indices (N,) must be unsqueezed to (1, 1, 1, N) before ttnn.embedding_bw,
+  // tt-metal requires a 4D index tensor with dims 1 and 2 equal to 1.
   func.func @backward_1d_indices(%arg0: tensor<32xsi32>, %arg1: tensor<512x128xbf16>, %arg2: tensor<32x128xbf16>) -> tensor<512x128xbf16> {
     // CHECK: "ttnn.reshape"
-    // CHECK-SAME: <{shape = [1 : i32, 32 : i32]}>
+    // CHECK-SAME: <{shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]}>
+    // CHECK-SAME: tensor<32x128xbf16
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: <{shape = [1 : i32, 1 : i32, 1 : i32, 32 : i32]}>
     // CHECK-SAME: tensor<32xsi32
+    // CHECK: "ttnn.typecast"
+    // CHECK-SAME: #ttcore.supportedDataTypes<u32>
     // CHECK: "ttnn.embedding_bw"
     %1 = "ttir.embedding_backward"(%arg0, %arg1, %arg2) : (tensor<32xsi32>, tensor<512x128xbf16>, tensor<32x128xbf16>) -> tensor<512x128xbf16>
     return %1 : tensor<512x128xbf16>


### PR DESCRIPTION
### Ticket
#8475 

### Problem description
The following scatter add is resulting in bad pcc:
```
    %12 = "stablehlo.scatter"(%1, %9, %11) <{scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>}> ({
    ^bb0(%arg3: tensor<bf16> loc("scatter.32"), %arg4: tensor<bf16> loc("scatter.32")):
      %13 = stablehlo.add %arg3, %arg4 : tensor<bf16> loc(#loc17)
      stablehlo.return %13 : tensor<bf16> loc(#loc)
    }) : (tensor<40x32xbf16>, tensor<20x1xi32>, tensor<20x32xbf16>) -> tensor<40x32xbf16> loc(#loc16)
    return %12 : tensor<40x32xbf16> loc(#loc)
```

This is due to a misunderstanding of how embedding_backward is supposed to work. Embedding backward assumes gradients are initialized to zeros, whereas the lowering did not assume this. Therefore, the scatter operand value is missing from the output. 

### What's changed
Instead of converting scatter to solely embedding_backward, it is now converted to embedding_backward + add. The operand is added to the result of embedding backward. 

Certain semantics about embedding backward op were outdated and updated. The following restrictions are now being checked based on: https://github.com/tenstorrent/tt-metal/blob/main/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp 

- index tensor needs to be 4d and 
```
TT_FATAL(
    index_tensor_shape[1] == 1 && index_tensor_shape[2] == 1,
    "Only dim 0 && 3 for the index tensor can be non 1");
```
- `grad_tensor_shape[2] == index_tensor_shape[0] * index_tensor_shape[-1]`
-  Grad tensor must be 4D [1, 1, R, C]

### Checklist
- [x] mlir uplift qualifications: https://github.com/tenstorrent/tt-xla/actions/runs/26191714947
