### PR TITLE
Revert "[TTIR] Narrow RankNormalization scoping to skip only const_eval helpers (#8414)"

### DIFF
--- a/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
@@ -58,10 +58,9 @@ static bool needsRankExpansion(Type type) {
   return false;
 }
 
-/// Collects functions that participate in rank normalization:
-///   - external functions whose signature needs rank expansion;
-///   - all other non-external functions, except const_eval helpers (which are
-///     intentionally TTNN-only with rank<2 signatures).
+/// Collects functions that participate in rank normalization. A function
+/// participates if it is external and its signature needs rank expansion, or
+/// if its body contains at least one TTIR-dialect op.
 static DenseSet<func::FuncOp> collectParticipatingFuncs(ModuleOp module) {
   DenseSet<func::FuncOp> result;
   module.walk([&](func::FuncOp funcOp) {
@@ -73,10 +72,17 @@ static DenseSet<func::FuncOp> collectParticipatingFuncs(ModuleOp module) {
       return;
     }
 
-    if (ttmlir::utils::isConstEvalFunc(funcOp)) {
-      return;
+    bool hasTTIROp = false;
+    funcOp.walk([&](Operation *inner) {
+      if (isa<ttir::TTIRDialect>(inner->getDialect())) {
+        hasTTIROp = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (hasTTIROp) {
+      result.insert(funcOp);
     }
-    result.insert(funcOp);
   });
   return result;
 }

--- a/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization_scoping.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization_scoping.mlir
@@ -75,18 +75,6 @@ func.func private @cpu_hoisted_decl(tensor<32xf32>) -> tensor<32xf32>
     attributes {tt.function_type = "ForwardCPUDeclaration"}
 
 // =============================================================================
-// Non-const_eval function with no TTIR ops in its body but rank-1 tensors in
-// its signature must participate so the signature is promoted to rank-2.
-// =============================================================================
-
-// CHECK-LABEL: func.func @forward_rank1_no_ttir_op
-// CHECK-SAME: (%arg0: tensor<1x32xf32>) -> tensor<1x32xf32>
-// CHECK: return %{{.*}} : tensor<1x32xf32>
-func.func @forward_rank1_no_ttir_op(%arg0: tensor<32xf32>) -> tensor<32xf32> {
-  return %arg0 : tensor<32xf32>
-}
-
-// =============================================================================
 // Function with rank-2 TTIR ops which should be left untouched.
 // =============================================================================
 


### PR DESCRIPTION
Reverts #8414.

The original change was made under a mistaken assumption about the
behavior it was addressing, and on re-checking it is not needed.
Revert to restore the pre-#8414 behavior (body-walk proxy from #8248).

Made with [Cursor](https://cursor.com)