### PR TITLE
Uplift third_party/tt-metal to 75ad1dc18e69d5cb54fe223e34954ab9ed69f787 2026-05-27

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=2c0072ef33f24c4f51f6a2b4b11a1aa376c0939b
+ARG TT_METAL_DEPENDENCIES_COMMIT=75ad1dc18e69d5cb54fe223e34954ab9ed69f787
 
 # Install dependencies
 RUN <<EOT

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=ab59a2ea9e894b73011e918aed1c78622d02a647
+ARG TT_METAL_DEPENDENCIES_COMMIT=2c0072ef33f24c4f51f6a2b4b11a1aa376c0939b
 
 # Install dependencies
 RUN <<EOT

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=75ad1dc18e69d5cb54fe223e34954ab9ed69f787
+ARG TT_METAL_DEPENDENCIES_COMMIT=e4f47ae9b424a0bfe59cc4942f433255f54d3186
 
 # Install dependencies
 RUN <<EOT

--- a/.github/workflows/call-test-ttsim.yml
+++ b/.github/workflows/call-test-ttsim.yml
@@ -16,7 +16,7 @@ on:
         description: "TTSim release tag"
         required: false
         type: string
-        default: "v1.6.1"
+        default: "v1.6.4"
       timeout:
         description: "Timeout in minutes for the TTSim test job"
         required: false

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "c5ebc6351098dfb68ce913eedcc20ee5abd1509f")
+set(TT_METAL_VERSION "2c0072ef33f24c4f51f6a2b4b11a1aa376c0939b")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "75ad1dc18e69d5cb54fe223e34954ab9ed69f787")
+set(TT_METAL_VERSION "e4f47ae9b424a0bfe59cc4942f433255f54d3186")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "2c0072ef33f24c4f51f6a2b4b11a1aa376c0939b")
+set(TT_METAL_VERSION "75ad1dc18e69d5cb54fe223e34954ab9ed69f787")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 75ad1dc18e69d5cb54fe223e34954ab9ed69f787

Uplift to tt-metal [branch](https://github.com/tenstorrent/tt-metal/tree/jzx/75ad1dc_may22_revert_9cb25bb) that reverts [9cb25bb](https://github.com/tenstorrent/tt-metal/commit/9cb25bbbbe6c9cd3c91dbe30d47457b2e6d35ebe)

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/26607674889
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):