### PR TITLE
TTNN/Utils/PassOverrides: add missing parse and toString support for enable_kernel_stride_folding and config_tensors_in_dram

### DIFF
--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -239,6 +239,28 @@ bool Conv2dConfigOverrideParser::parse(
           return true;
         }
         params.enableWeightsDoubleBuffer = enableWeightsDoubleBuffer;
+      } else if (paramName == "enable_kernel_stride_folding") {
+        bool enableKernelStrideFolding;
+        if (parseBool(paramValue, enableKernelStrideFolding)) {
+          opt.error("Invalid enable_kernel_stride_folding: " + paramValue);
+          return true;
+        }
+        if (params.enableKernelStrideFolding.has_value()) {
+          opt.error("Duplicate enable_kernel_stride_folding: " + paramValue);
+          return true;
+        }
+        params.enableKernelStrideFolding = enableKernelStrideFolding;
+      } else if (paramName == "config_tensors_in_dram") {
+        bool configTensorsInDram;
+        if (parseBool(paramValue, configTensorsInDram)) {
+          opt.error("Invalid config_tensors_in_dram: " + paramValue);
+          return true;
+        }
+        if (params.configTensorsInDram.has_value()) {
+          opt.error("Duplicate config_tensors_in_dram: " + paramValue);
+          return true;
+        }
+        params.configTensorsInDram = configTensorsInDram;
       } else {
         opt.error("Invalid override parameter: " + paramName);
         return true;
@@ -307,6 +329,15 @@ std::string Conv2dConfigOverrideParser::toString(
       rso << "enable_weights_double_buffer#"
           << (params.enableWeightsDoubleBuffer.value() ? "true" : "false")
           << ":";
+    }
+    if (params.enableKernelStrideFolding.has_value()) {
+      rso << "enable_kernel_stride_folding#"
+          << (params.enableKernelStrideFolding.value() ? "true" : "false")
+          << ":";
+    }
+    if (params.configTensorsInDram.has_value()) {
+      rso << "config_tensors_in_dram#"
+          << (params.configTensorsInDram.value() ? "true" : "false") << ":";
     }
     rso.flush();
     // Remove the last ':' if there are parameters


### PR DESCRIPTION
### Ticket
N/A — discovered during codebase audit

### Problem description
`Conv2dConfigParams` defines two fields — `enableKernelStrideFolding` and
`configTensorsInDram` — that are serialized in the struct's `operator<<`,
but were never wired up in `Conv2dConfigOverrideParser::parse` or
`Conv2dConfigOverrideParser::toString` in `PassOverrides.cpp`.

This means:
- Passing `enable_kernel_stride_folding#true` or `config_tensors_in_dram#true`
  as a command-line conv2d config override would hit the catch-all
  `opt.error("Invalid override parameter: ...")` and fail at compile time,
  making these two parameters completely unusable as overrides.
- Any in-memory `Conv2dConfigOverrideParams` with either field set would
  silently drop them during `toString` serialization, breaking round-trip
  fidelity.

### What's changed
- Added `else if (paramName == "enable_kernel_stride_folding")` and
  `else if (paramName == "config_tensors_in_dram")` branches in
  `Conv2dConfigOverrideParser::parse`, following the identical pattern
  (same `bool` type, same `parseBool` helper, same duplicate-check idiom)
  used for all other boolean fields in that function.
- Added corresponding `if (params.enableKernelStrideFolding.has_value())`
  and `if (params.configTensorsInDram.has_value())` blocks in
  `Conv2dConfigOverrideParser::toString`, consistent with existing
  serialization style.

No existing behavior is changed; only previously unhandled code paths
are now correctly handled.

### Checklist
- [ ] New/Existing tests provide coverage for changes