### PR TITLE
[chisel] program-level golden accumulation

### DIFF
--- a/test/python/chisel/test_builder_chisel_integration.py
+++ b/test/python/chisel/test_builder_chisel_integration.py
@@ -33,7 +33,10 @@ def test_chisel_records_one_layer_nn(request, device, tmp_path):
             y = builder.linear(x, w, bias=b, transpose_b=True)
             return builder.multiply(y, y)
 
-    with chisel.session(results_path=str(tmp_path / "chisel_result.jsonl")) as report:
+    with chisel.session(
+        results_path=str(tmp_path / "chisel_result.jsonl"),
+        checks_config=chisel.ChiselChecksConfig(isolation=True, accumulation=True),
+    ) as report:
         compile_and_execute_ttnn(
             module,
             test_base=request.node.name,
@@ -54,19 +57,35 @@ def test_chisel_records_one_layer_nn(request, device, tmp_path):
     )
 
     PCC_THRESHOLD = 0.99
-    pcc_records = [r for r in records if r.check == "numerics"]
-    assert pcc_records, "no numerics (PCC) records produced"
 
-    for op in expected:
-        op_pcc = [r for r in pcc_records if r.op == op]
-        assert op_pcc, f"no PCC record for {op}"
-        for r in op_pcc:
-            assert (
-                r.status == chisel.RecordStatus.OK
-            ), f"{op}: PCC check status={r.status} payload={r.payload}"
-            assert (
-                r.payload.pcc >= PCC_THRESHOLD
-            ), f"{op}: PCC {r.payload.pcc} below threshold {PCC_THRESHOLD}"
+    def assert_pcc(mode: chisel.NumericsMode) -> None:
+        label = str(mode)
+        pcc_records = [
+            r for r in records if r.check == "numerics" and r.payload.mode == mode
+        ]
+        assert pcc_records, f"no {label} (PCC) records produced"
+        for op in expected:
+            op_pcc = [r for r in pcc_records if r.op == op]
+            assert op_pcc, f"no {label} PCC record for {op}"
+            for r in op_pcc:
+                assert (
+                    r.status == chisel.RecordStatus.OK
+                ), f"{op}: {label} PCC status={r.status} payload={r.payload}"
+                assert r.payload.pcc >= PCC_THRESHOLD, (
+                    f"{op}: {label} PCC {r.payload.pcc} below threshold {PCC_THRESHOLD}"
+                )
+
+    assert_pcc(chisel.NumericsMode.ISOLATED)
+    assert_pcc(chisel.NumericsMode.ACCUMULATED)
+
+    # One promotion per function arg (x, w, b); extras mean a golden is missing.
+    EXPECTED_PROMOTIONS = 3
+    promotions = [r for r in records if r.check == "golden_promoted"]
+    assert len(promotions) == EXPECTED_PROMOTIONS, (
+        f"expected {EXPECTED_PROMOTIONS} golden_promoted records "
+        f"(one per function arg), got {len(promotions)}: "
+        f"{[(r.op, r.ssa) for r in promotions]}"
+    )
 
 
 def test_chisel_dumps_debug_artifacts_on_pcc_fail(request, device, tmp_path):

--- a/test/python/chisel/test_builder_chisel_integration.py
+++ b/test/python/chisel/test_builder_chisel_integration.py
@@ -71,9 +71,9 @@ def test_chisel_records_one_layer_nn(request, device, tmp_path):
                 assert (
                     r.status == chisel.RecordStatus.OK
                 ), f"{op}: {label} PCC status={r.status} payload={r.payload}"
-                assert r.payload.pcc >= PCC_THRESHOLD, (
-                    f"{op}: {label} PCC {r.payload.pcc} below threshold {PCC_THRESHOLD}"
-                )
+                assert (
+                    r.payload.pcc >= PCC_THRESHOLD
+                ), f"{op}: {label} PCC {r.payload.pcc} below threshold {PCC_THRESHOLD}"
 
     assert_pcc(chisel.NumericsMode.ISOLATED)
     assert_pcc(chisel.NumericsMode.ACCUMULATED)

--- a/test/python/chisel/test_report.py
+++ b/test/python/chisel/test_report.py
@@ -11,6 +11,7 @@ from chisel.report import (
     DtypeMismatchPayload,
     ErrorPayload,
     NoGoldenPayload,
+    NumericsMode,
     NumericsPayload,
     ShapeMismatchPayload,
     SkippedNumericsPayload,
@@ -27,7 +28,12 @@ def _records_for_each_status():
             program_name="prog0",
             program_index=0,
             payload=NumericsPayload(
-                status=RecordStatus.OK, pcc=0.999, atol=1e-8, rtol=1e-5, device_id=0
+                status=RecordStatus.OK,
+                mode=NumericsMode.ISOLATED,
+                pcc=0.999,
+                atol=1e-8,
+                rtol=1e-5,
+                device_id=0,
             ),
         ),
         ChiselRecord(
@@ -47,6 +53,7 @@ def _records_for_each_status():
             op_asm="some asm",
             payload=NumericsPayload(
                 status=RecordStatus.NUMERICS_FAIL,
+                mode=NumericsMode.ACCUMULATED,
                 pcc=0.42,
                 atol=1.0,
                 rtol=1.0,
@@ -54,7 +61,11 @@ def _records_for_each_status():
             ),
         ),
         ChiselRecord(op="ttnn.linear", check="numerics", payload=ErrorPayload()),
-        ChiselRecord(op="ttnn.add", check="numerics", payload=SkippedNumericsPayload()),
+        ChiselRecord(
+            op="ttnn.add",
+            check="numerics",
+            payload=SkippedNumericsPayload(mode=NumericsMode.ISOLATED),
+        ),
         ChiselRecord(
             op="ttnn.unknown",
             check="numerics",

--- a/tools/chisel/CMakeLists.txt
+++ b/tools/chisel/CMakeLists.txt
@@ -10,6 +10,7 @@ declare_mlir_python_sources(ChiselSources
     ops.py
     executor.py
     exceptions.py
+    op_handlers.py
     op_configs.py
     recorder.py
     report.py

--- a/tools/chisel/chisel/__init__.py
+++ b/tools/chisel/chisel/__init__.py
@@ -5,7 +5,7 @@
 from .bind import bind, configure, get_report, register_op_config, session, unbind
 from .context import ChiselContext
 from .op_configs import ChiselOpConfig
-from .report import ChiselRecord, ChiselReport, RecordStatus
+from .report import ChiselRecord, ChiselReport, NumericsMode, RecordStatus
 from .validators import ChiselChecksConfig, PCCConfig
 
 __all__ = [
@@ -20,6 +20,7 @@ __all__ = [
     "ChiselRecord",
     "ChiselReport",
     "ChiselChecksConfig",
+    "NumericsMode",
     "PCCConfig",
     "RecordStatus",
 ]

--- a/tools/chisel/chisel/callbacks.py
+++ b/tools/chisel/chisel/callbacks.py
@@ -22,10 +22,20 @@ from golden import GoldenMapTensor
 
 from .context import ChiselContext, get_instance
 from .exceptions import IrRuntimeMismatch
-from .executor import build_role_keyed_inputs, execute_golden
+from .executor import (
+    build_role_keyed_inputs,
+    execute_golden,
+    execute_golden_from_pool,
+)
 from .op_configs import ChiselOpConfig
 from .ops import SSAName, get_op_inputs, get_op_outputs
-from .report import ChiselRecord, NoGoldenPayload, SkippedNumericsPayload
+from .report import (
+    ChiselRecord,
+    GoldenPromotedPayload,
+    NoGoldenPayload,
+    NumericsMode,
+    SkippedNumericsPayload,
+)
 from .safety import chisel_safe
 from .utils import get_op_asm, retrieve_tensor
 from .validators import check_numerics, check_shape_dtype
@@ -80,20 +90,16 @@ def _validate_and_retrieve_tensor(
 
 def _run_isolation_golden(
     op: OpView,
-    mlir_outputs: List[Value],
     asm_state,
     ssa_inputs: Dict[SSAName, GoldenMapTensor],
 ) -> List[GoldenMapTensor]:
     role_inputs = build_role_keyed_inputs(op, ssa_inputs, asm_state)
-    iso_outs = execute_golden(op, role_inputs)
-    for mlir_output, iso_out in zip(mlir_outputs, iso_outs, strict=True):
-        check_shape_dtype(op, "mlir_vs_golden", mlir_output, iso_out)
-    return iso_outs
+    return execute_golden(op, role_inputs)
 
 
 @chisel_safe
 def _default_pre_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
-    """Stash a host copy of every device input so POST can drive the golden."""
+    """Stash host copies of device inputs and seed function args into the pool."""
     op = ctx.op
     if config.no_golden:
         ctx.write_record(
@@ -107,21 +113,61 @@ def _default_pre_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
 
     _assert_op_matches_runtime(ctx)
     asm_state = ctx.asm_state
+    pool = ctx.golden_tensor_pool
 
     mlir_op_inputs = get_op_inputs(op)
     for mlir_input, rt_tensor_ref in zip(mlir_op_inputs, ctx.input_refs, strict=True):
         # TODO(ndrakulic): Right now we are pulling input device tensors to host potentially multiple times
         tensor = _validate_and_retrieve_tensor(ctx, mlir_input, rt_tensor_ref)
-        ctx.stashed_inputs[mlir_input.get_name(asm_state)] = tensor
+        ssa = mlir_input.get_name(asm_state)
+        ctx.stashed_inputs[ssa] = tensor
+        # Seed only SSAs not yet produced by a prior op's golden (i.e. function args).
+        if ssa in pool:
+            continue
+
+        pool[ssa] = tensor
+        ctx.write_record(
+            ChiselRecord(
+                op=op.name,
+                check="golden_promoted",
+                ssa=ssa,
+                payload=GoldenPromotedPayload(),
+            )
+        )
+
+
+def _emit_pcc(
+    ctx: ChiselContext,
+    op,
+    ssa: SSAName,
+    mlir_output: Value,
+    golden_out: GoldenMapTensor,
+    device_tensor: GoldenMapTensor,
+    *,
+    mode: NumericsMode,
+    skip_pcc: bool,
+) -> None:
+    """Shape/dtype + PCC for one (golden, device) pair under `mode`."""
+    check_shape_dtype(op, "mlir_vs_golden", mlir_output, golden_out)
+    if skip_pcc:
+        ctx.write_record(
+            ChiselRecord(
+                op=op.name,
+                check="numerics",
+                ssa=ssa,
+                payload=SkippedNumericsPayload(mode=mode),
+            )
+        )
+        return
+    check_numerics(ctx, op, ssa, golden_out, device_tensor, mode=mode)
 
 
 @chisel_safe
 def _default_post_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
-    """Run the golden, validate shapes/dtypes, and PCC-check each output."""
+    """Run isolation + accumulation goldens; shape/dtype + PCC each output."""
     if config.no_golden:
         return
 
-    skip_isolated_pcc = config.skip_isolated_pcc
     op = ctx.op
     asm_state = ctx.asm_state
 
@@ -129,25 +175,45 @@ def _default_post_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
     if not mlir_op_outputs:
         return
 
-    iso_outs = _run_isolation_golden(op, mlir_op_outputs, asm_state, ctx.stashed_inputs)
+    if ctx.checks_config.isolation:
+        iso_outs = _run_isolation_golden(op, asm_state, ctx.stashed_inputs)
+    else:
+        iso_outs = [None] * len(mlir_op_outputs)
 
-    for mlir_output, output_ref, iso_out in zip(
-        mlir_op_outputs, ctx.output_refs, iso_outs, strict=True
+    if ctx.checks_config.accumulation:
+        accum_outs = execute_golden_from_pool(op, ctx.golden_tensor_pool, asm_state)
+    else:
+        accum_outs = [None] * len(mlir_op_outputs)
+
+    for mlir_output, output_ref, iso_out, accum_out in zip(
+        mlir_op_outputs, ctx.output_refs, iso_outs, accum_outs, strict=True
     ):
         device_tensor = _validate_and_retrieve_tensor(ctx, mlir_output, output_ref)
         ssa = mlir_output.get_name(asm_state)
-        if skip_isolated_pcc:
-            ctx.write_record(
-                ChiselRecord(
-                    op=op.name,
-                    check="numerics",
-                    ssa=ssa,
-                    payload=SkippedNumericsPayload(),
-                )
-            )
-            continue
 
-        check_numerics(ctx, op, ssa, iso_out, device_tensor)
+        if iso_out is not None:
+            _emit_pcc(
+                ctx,
+                op,
+                ssa,
+                mlir_output,
+                iso_out,
+                device_tensor,
+                mode=NumericsMode.ISOLATED,
+                skip_pcc=config.skip_pcc,
+            )
+
+        if accum_out is not None:
+            _emit_pcc(
+                ctx,
+                op,
+                ssa,
+                mlir_output,
+                accum_out,
+                device_tensor,
+                mode=NumericsMode.ACCUMULATED,
+                skip_pcc=config.skip_pcc,
+            )
 
 
 def run_op_callback(
@@ -157,16 +223,18 @@ def run_op_callback(
     *,
     phase: CallbackPhase,
 ) -> None:
-    """Dispatch the PRE or POST handler for the current op."""
+    """Dispatch the per-op pre/post handler (config override falls back to default)."""
     ctx = get_instance()
     with _op_callback(ctx, rt_binary, rt_program_context, rt_op_context, phase=phase):
         config = ctx.get_op_config(ctx.op)
         if phase is CallbackPhase.PRE:
-            pre_succeeded = _default_pre_op(ctx, config)
+            pre_fn = config.pre_op or _default_pre_op
+            pre_succeeded = pre_fn(ctx, config)
             ctx.pre_failed = not pre_succeeded
         else:
             # PRE recorded a failure - skip POST to avoid cascading into a
             # chisel_bug from incomplete state.
             if ctx.pre_failed:
                 return
-            _default_post_op(ctx, config)
+            post_fn = config.post_op or _default_post_op
+            post_fn(ctx, config)

--- a/tools/chisel/chisel/callbacks.py
+++ b/tools/chisel/chisel/callbacks.py
@@ -16,16 +16,15 @@ from typing import Dict, Iterator, List
 from _ttmlir_runtime import runtime as tt_runtime
 from _ttmlir_runtime.binary import Binary
 from _ttmlir_runtime.runtime import CallbackContext, OpContext, TensorRef
-from ttmlir.ir import OpView, Value
+from ttmlir.ir import Value
 
 from golden import GoldenMapTensor
 
 from .context import ChiselContext, get_instance
 from .exceptions import IrRuntimeMismatch
 from .executor import (
-    build_role_keyed_inputs,
-    execute_golden,
     execute_golden_from_pool,
+    execute_golden_with_ssa_inputs,
 )
 from .op_configs import ChiselOpConfig
 from .ops import SSAName, get_op_inputs, get_op_outputs
@@ -86,15 +85,6 @@ def _validate_and_retrieve_tensor(
     tensor = retrieve_tensor(ctx.rt_program_context, rt_tensor_ref)
     check_shape_dtype(op, "mlir_vs_runtime_tensor", mlir_value, tensor)
     return tensor
-
-
-def _run_isolation_golden(
-    op: OpView,
-    asm_state,
-    ssa_inputs: Dict[SSAName, GoldenMapTensor],
-) -> List[GoldenMapTensor]:
-    role_inputs = build_role_keyed_inputs(op, ssa_inputs, asm_state)
-    return execute_golden(op, role_inputs)
 
 
 @chisel_safe
@@ -176,7 +166,7 @@ def _default_post_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
         return
 
     if ctx.checks_config.isolation:
-        iso_outs = _run_isolation_golden(op, asm_state, ctx.stashed_inputs)
+        iso_outs = execute_golden_with_ssa_inputs(op, ctx.stashed_inputs, asm_state)
     else:
         iso_outs = [None] * len(mlir_op_outputs)
 

--- a/tools/chisel/chisel/callbacks.py
+++ b/tools/chisel/chisel/callbacks.py
@@ -220,7 +220,7 @@ def run_op_callback(
         if phase is CallbackPhase.PRE:
             pre_fn = config.pre_op or _default_pre_op
             pre_succeeded = pre_fn(ctx, config)
-            ctx.pre_failed = not pre_succeeded
+            ctx.pre_failed = pre_succeeded is False
         else:
             # PRE recorded a failure - skip POST to avoid cascading into a
             # chisel_bug from incomplete state.

--- a/tools/chisel/chisel/context.py
+++ b/tools/chisel/chisel/context.py
@@ -116,6 +116,14 @@ class ChiselContext:
         return value
 
     @property
+    def golden_tensor_pool(self) -> Dict[SSAName, GoldenMapTensor]:
+        """Program-scoped SSA -> golden tensor map; persists across ops."""
+        program = self._current_callback_program
+        if program is None:
+            raise UnexpectedStateError("golden_tensor_pool")
+        return program._golden_tensor_pool
+
+    @property
     def rt_program_context(self) -> Optional[CallbackContext]:
         program = self._current_callback_program
         return program._rt_program_context if program is not None else None
@@ -270,6 +278,8 @@ class ProgramState:
         self._current_output_refs: Optional[List[TensorRef]] = None
         self._stashed_inputs: Optional[Dict[SSAName, GoldenMapTensor]] = None
         self._pre_failed: bool = False
+        # Persists across ops within a program; not reset per op.
+        self._golden_tensor_pool: Dict[SSAName, GoldenMapTensor] = {}
 
     def begin_op(self) -> None:
         self._current_op = next(self._op_iter).opview

--- a/tools/chisel/chisel/executor.py
+++ b/tools/chisel/chisel/executor.py
@@ -103,14 +103,23 @@ def execute_golden(
     return tensors
 
 
+def execute_golden_with_ssa_inputs(
+    op: Operation,
+    ssa_inputs: Dict[SSAName, GoldenMapTensor],
+    asm_state,
+) -> List[GoldenMapTensor]:
+    """Re-key SSA-keyed inputs by role and run the registered golden for `op`."""
+    role_inputs = build_role_keyed_inputs(op, ssa_inputs, asm_state)
+    return execute_golden(op, role_inputs)
+
+
 def execute_golden_from_pool(
     op: Operation, pool: Dict[SSAName, GoldenMapTensor], asm_state
 ) -> List[GoldenMapTensor]:
     """Read inputs from `pool`, run golden, store outputs back into `pool`."""
     names = (inp.get_name(asm_state) for inp in get_op_inputs(op))
     ssa_inputs: Dict[SSAName, GoldenMapTensor] = {name: pool[name] for name in names}
-    role_inputs = build_role_keyed_inputs(op, ssa_inputs, asm_state)
-    result = execute_golden(op, role_inputs)
+    result = execute_golden_with_ssa_inputs(op, ssa_inputs, asm_state)
     for out_val, tensor in zip(get_op_outputs(op), result):
         pool[out_val.get_name(asm_state)] = tensor
     return result

--- a/tools/chisel/chisel/executor.py
+++ b/tools/chisel/chisel/executor.py
@@ -20,6 +20,7 @@ from .ops import (
     RoleName,
     SSAName,
     get_flat_inplace_vals,
+    get_op_inputs,
     get_op_outputs,
     is_tensor_value,
 )
@@ -100,3 +101,16 @@ def execute_golden(
         f"then one tensor per provided in-place operand"
     )
     return tensors
+
+
+def execute_golden_from_pool(
+    op: Operation, pool: Dict[SSAName, GoldenMapTensor], asm_state
+) -> List[GoldenMapTensor]:
+    """Read inputs from `pool`, run golden, store outputs back into `pool`."""
+    names = (inp.get_name(asm_state) for inp in get_op_inputs(op))
+    ssa_inputs: Dict[SSAName, GoldenMapTensor] = {name: pool[name] for name in names}
+    role_inputs = build_role_keyed_inputs(op, ssa_inputs, asm_state)
+    result = execute_golden(op, role_inputs)
+    for out_val, tensor in zip(get_op_outputs(op), result):
+        pool[out_val.get_name(asm_state)] = tensor
+    return result

--- a/tools/chisel/chisel/executor.py
+++ b/tools/chisel/chisel/executor.py
@@ -120,6 +120,6 @@ def execute_golden_from_pool(
     names = (inp.get_name(asm_state) for inp in get_op_inputs(op))
     ssa_inputs: Dict[SSAName, GoldenMapTensor] = {name: pool[name] for name in names}
     result = execute_golden_with_ssa_inputs(op, ssa_inputs, asm_state)
-    for out_val, tensor in zip(get_op_outputs(op), result):
+    for out_val, tensor in zip(get_op_outputs(op), result, strict=True):
         pool[out_val.get_name(asm_state)] = tensor
     return result

--- a/tools/chisel/chisel/op_configs.py
+++ b/tools/chisel/chisel/op_configs.py
@@ -13,7 +13,7 @@ from .op_handlers import _deallocate_pre_op, _noop_post_op
 logger = logging.getLogger("chisel")
 
 
-PreOrPostFn = Callable[["ChiselContext", "ChiselOpConfig"], None]
+PreOrPostFn = Callable[["ChiselContext", "ChiselOpConfig"], bool]
 
 
 @dataclass

--- a/tools/chisel/chisel/op_configs.py
+++ b/tools/chisel/chisel/op_configs.py
@@ -22,7 +22,7 @@ class ChiselOpConfig:
 
     no_golden: skip golden calculation; emit a NoGoldenPayload.
     skip_pcc: run golden, check shape/dtype, but skip PCC checks.
-    pre_op / post_op: override default handlers; must be @chisel_safe.
+    pre_op / post_op: overrides for default handlers; must be @chisel_safe.
     """
 
     no_golden: bool = False

--- a/tools/chisel/chisel/op_configs.py
+++ b/tools/chisel/chisel/op_configs.py
@@ -3,38 +3,50 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from dataclasses import dataclass
-from typing import Dict, Type
+from typing import Callable, Dict, Optional, Type
 
 from ttmlir.dialects import func, ttcore, ttnn
 from ttmlir.ir import OpView
 
+from .op_handlers import _deallocate_pre_op, _noop_post_op
+
 logger = logging.getLogger("chisel")
+
+
+PreOrPostFn = Callable[["ChiselContext", "ChiselOpConfig"], None]
 
 
 @dataclass
 class ChiselOpConfig:
-    # no_golden: do not run the isolation golden; emit a NoGoldenPayload
-    # record per op so the report shows the op was visited but skipped.
-    # skip_isolated_pcc: run the isolation golden (shape/dtype still checked)
-    # but skip the PCC comparison.
+    """Per-op chisel behavior overrides.
+
+    no_golden: skip golden calculation; emit a NoGoldenPayload.
+    skip_pcc: run golden, check shape/dtype, but skip PCC checks.
+    pre_op / post_op: override default handlers; must be @chisel_safe.
+    """
+
     no_golden: bool = False
-    skip_isolated_pcc: bool = False
+    skip_pcc: bool = False
+    pre_op: Optional[PreOrPostFn] = None
+    post_op: Optional[PreOrPostFn] = None
 
 
 def default_configs() -> Dict[Type[OpView], ChiselOpConfig]:
-    # Returns a fresh dict each call so callers cannot mutate the defaults.
-    # In-place ops (UpdateCacheOp, FillCacheOp, etc.) are flagged no_golden
-    # because chisel does not yet validate in-place tensor mutations.
+    """Fresh dict of default per-op configs."""
     return {
         # ttnn.empty produces uninitialized memory - PCC comparison is meaningless.
-        ttnn.EmptyOp: ChiselOpConfig(skip_isolated_pcc=True),
+        ttnn.EmptyOp: ChiselOpConfig(skip_pcc=True),
         # ttnn.generic: IR output count = 0 but FB output count = 1.
         ttnn.GenericOp: ChiselOpConfig(no_golden=True),
         # Non-executable ops (device handles, I/O, control flow): no golden to run.
         func.CallOp: ChiselOpConfig(no_golden=True),
         ttnn.GetDeviceOp: ChiselOpConfig(no_golden=True),
         ttnn.LoadTensorOp: ChiselOpConfig(no_golden=True),
-        ttnn.DeallocateOp: ChiselOpConfig(no_golden=True),
+        # Custom pre_op evicts inputs from the golden pool
+        ttnn.DeallocateOp: ChiselOpConfig(
+            pre_op=_deallocate_pre_op,
+            post_op=_noop_post_op,
+        ),
         ttcore.LoadCachedOp: ChiselOpConfig(no_golden=True),
         # Trace / control-flow / I/O ops.
         ttnn.AllocOp: ChiselOpConfig(no_golden=True),

--- a/tools/chisel/chisel/op_handlers.py
+++ b/tools/chisel/chisel/op_handlers.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .ops import get_op_inputs
+from .report import ChiselRecord, GoldenEvictedPayload
+from .safety import chisel_safe
+
+
+@chisel_safe
+def _deallocate_pre_op(ctx, config) -> None:
+    """Evict each input SSA from the golden pool; emit one record per eviction."""
+    pool = ctx.golden_tensor_pool
+    asm_state = ctx.asm_state
+    op = ctx.op
+    for inp in get_op_inputs(op):
+        ssa = inp.get_name(asm_state)
+        if pool.pop(ssa, None) is None:
+            continue
+
+        ctx.write_record(
+            ChiselRecord(
+                op=op.name,
+                check="golden_evicted",
+                ssa=ssa,
+                payload=GoldenEvictedPayload(),
+            )
+        )
+
+
+@chisel_safe
+def _noop_post_op(ctx, config) -> None:
+    pass

--- a/tools/chisel/chisel/report.py
+++ b/tools/chisel/chisel/report.py
@@ -27,25 +27,48 @@ class RecordStatus(str, Enum):
     NO_GOLDEN = "no_golden"
     IR_RUNTIME_MISMATCH = "ir_runtime_mismatch"
     CHISEL_BUG = "chisel_bug"
+    GOLDEN_PROMOTED = "golden_promoted"
+    GOLDEN_EVICTED = "golden_evicted"
 
 
 PASS_STATUS = frozenset(
-    {RecordStatus.OK, RecordStatus.SKIPPED_NUMERICS, RecordStatus.NO_GOLDEN}
+    {
+        RecordStatus.OK,
+        RecordStatus.SKIPPED_NUMERICS,
+        RecordStatus.NO_GOLDEN,
+        RecordStatus.GOLDEN_PROMOTED,
+        RecordStatus.GOLDEN_EVICTED,
+    }
 )
 
 
+class NumericsMode(str, Enum):
+    """How a numerics record's golden was produced.
+
+    ISOLATED: per-op golden from device inputs.
+    ACCUMULATED: program-scoped chain from prior goldens' outputs.
+    """
+
+    ISOLATED = "isolated"
+    ACCUMULATED = "accumulated"
+
+
 class _Payload(BaseModel):
-    # Each payload declares only the fields valid for its RecordStatus; extra="forbid"
-    # so wrong-field-for-status mistakes raise at construction, not at the
-    # downstream consumer.
+    """Base for status-discriminated payloads.
+
+    Each payload declares only the fields valid for its RecordStatus;
+    extra="forbid" so wrong-field-for-status mistakes raise at construction,
+    not at the downstream consumer.
+    """
+
     model_config = ConfigDict(extra="forbid")
 
 
 class NumericsPayload(_Payload):
-    # OK and NUMERICS_FAIL share the same schema - only the status
-    # discriminator differs, set by validators.check_numerics based on the
-    # configured pcc/atol/rtol gates.
+    """Shared by OK and NUMERICS_FAIL; status set by check_numerics."""
+
     status: Literal[RecordStatus.OK, RecordStatus.NUMERICS_FAIL]
+    mode: NumericsMode
     pcc: float
     atol: float
     rtol: float
@@ -70,10 +93,27 @@ class ErrorPayload(_Payload):
 
 class SkippedNumericsPayload(_Payload):
     status: Literal[RecordStatus.SKIPPED_NUMERICS] = RecordStatus.SKIPPED_NUMERICS
+    mode: NumericsMode
 
 
 class NoGoldenPayload(_Payload):
     status: Literal[RecordStatus.NO_GOLDEN] = RecordStatus.NO_GOLDEN
+
+
+class GoldenPromotedPayload(_Payload):
+    """Audit-only: emitted when a device tensor is seeded into the golden pool.
+
+    Ideally only function args are promoted; intermediate-SSA promotions
+    mean a producer op is missing a golden.
+    """
+
+    status: Literal[RecordStatus.GOLDEN_PROMOTED] = RecordStatus.GOLDEN_PROMOTED
+
+
+class GoldenEvictedPayload(_Payload):
+    """Audit-only: one record per SSA removed from the golden pool."""
+
+    status: Literal[RecordStatus.GOLDEN_EVICTED] = RecordStatus.GOLDEN_EVICTED
 
 
 class IrRuntimeMismatchPayload(_Payload):
@@ -96,6 +136,8 @@ Payload = Annotated[
         NoGoldenPayload,
         IrRuntimeMismatchPayload,
         ChiselBugPayload,
+        GoldenPromotedPayload,
+        GoldenEvictedPayload,
     ],
     Field(discriminator="status"),
 ]

--- a/tools/chisel/chisel/validators.py
+++ b/tools/chisel/chisel/validators.py
@@ -12,7 +12,7 @@ from golden.mapping import mlir_datatype_to_torch_dtype, mlir_type_to_torch_dtyp
 from golden.metrics import get_atol_rtol_pcc
 
 from .exceptions import ChiselFailure, DtypeMismatch, ShapeMismatch
-from .report import ChiselRecord, NumericsPayload, RecordStatus
+from .report import ChiselRecord, NumericsMode, NumericsPayload, RecordStatus
 
 logger = logging.getLogger("chisel")
 
@@ -46,6 +46,12 @@ class ChiselChecksConfig:
     max_atol: Optional[float] = None
     max_rtol: Optional[float] = None
 
+    # Per-op golden modes:
+    #   isolation:   re-run the golden each op from device inputs.
+    #   accumulation: chain goldens through a program-scoped pool.
+    isolation: bool = False
+    accumulation: bool = True
+
 
 def _extract_shape_dtype(source) -> tuple[list, torch.dtype]:
     # Accepts a GoldenMapTensor, an MLIR IR Value, a flatbuffer TensorRef, or
@@ -78,13 +84,14 @@ def check_shape_dtype(op, check: str, expected, actual) -> None:
 
 
 def check_numerics(
-    ctx, op, ssa: str, golden: GoldenMapTensor, device: GoldenMapTensor
+    ctx,
+    op,
+    ssa: str,
+    golden: GoldenMapTensor,
+    device: GoldenMapTensor,
+    mode: NumericsMode = NumericsMode.ISOLATED,
 ) -> None:
-    """Per-shard PCC check.
-
-    Writes one record per shard; multi-shard tensors are compared shard-by-shard
-    rather than collapsed to a single comparison.
-    """
+    """Per-shard PCC check; emits one record per shard, tagged by `mode`."""
     check = "numerics"
     check_shape_dtype(op, check, golden, device)
 
@@ -118,7 +125,12 @@ def check_numerics(
                 check=check,
                 ssa=ssa,
                 payload=NumericsPayload(
-                    status=status, pcc=pcc, atol=atol, rtol=rtol, device_id=device_id
+                    status=status,
+                    mode=mode,
+                    pcc=pcc,
+                    atol=atol,
+                    rtol=rtol,
+                    device_id=device_id,
                 ),
             )
         )


### PR DESCRIPTION
### Ticket
Closes #7842 

### Summary

Adds accumulated-mode golden checking to chisel: every PCC comparison now runs against a golden derived from a chain of prior op goldens (program-scoped), rather than only against an isolation golden recomputed from device inputs each op. Accumulated mode catches errors that isolation hides — e.g., a wrong layout or quantization upstream that the next op's isolation golden re-derives from "corrected" device inputs.

Isolation and accumulation modes are independently togglable via `ChiselChecksConfig(isolation=..., accumulation=...)`; by default chisel emits accumulation only. Pass `chisel.session(checks_config=ChiselChecksConfig(isolation=True))` to also run isolation.

### What's new

- **`NumericsMode`** (`isolated` | `accumulated`) tags every `NumericsPayload` / `SkippedNumericsPayload`, so downstream consumers can tell which golden a record was scored against.
- **Golden pool** lives on `ProgramState` as `_golden_tensor_pool: Dict[SSAName, GoldenMapTensor]`. It persists across ops within a program; reset per program.
- **Promotion**: in `_default_pre_op`, any input SSA not yet in the pool is seeded with the current device tensor. Emits a `golden_promoted` record (status `GOLDEN_PROMOTED`). Ideally only function args ever get promoted - intermediates promotions are an audit signal that some producer is `no_golden` or there is some other problem with ops before.
- **Eviction**: `ttnn.DeallocateOp` now has a custom `pre_op` (`_deallocate_pre_op`) that pops each input SSA from the pool and emits a `golden_evicted` record (`GOLDEN_EVICTED`).
- **Per-op handler overrides**: `ChiselOpConfig` gains `pre_op` / `post_op` callables. `run_op_callback` calls the override if set, else the default handler.
- **Renames** for clarity:
  - `ChiselOpConfig.skip_isolated_pcc` → `skip_pcc` (now skips PCC for both modes — shape/dtype still checked).

### Defaults

- `ChiselChecksConfig(isolation=False, accumulation=True)`. Accumulation is the cheaper and stricter signal for end-to-end runs; isolation is opt-in for debugging.

