### PR TITLE
[Optimizer:Matmul] Matmul program config fixes

### DIFF
--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -278,9 +278,21 @@ generateMatmulProgramConfig(Operation *op, TTNNLayoutAttr outputLayout) {
   }
 
   if (outputMemLayout == TensorMemoryLayout::BlockSharded) {
-    return generateMatmul2DProgramConfig(ctx, Mt, Nt, Kt, outputLayout,
-                                         fusedActivation, maxSubblockSize,
-                                         fuseBatch);
+    // 2D mcast requires both grid dims > 1. On a degenerate grid (one dim == 1)
+    // fall back to 1D mcast: tt-metal treats BlockSharded + 1D-grid as an
+    // intentional alias for WidthSharded/HeightSharded (see
+    // ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+    // ~L197), and the 1D mcast direction must follow which grid dim is
+    // degenerate, not outputMemLayout (otherwise mcast_in0 picks the wrong
+    // direction).
+    auto [gridX, gridY] = utils::getPhysicalGridDimensions(outputLayout);
+    if (gridX > 1 && gridY > 1) {
+      return generateMatmul2DProgramConfig(ctx, Mt, Nt, Kt, outputLayout,
+                                           fusedActivation, maxSubblockSize,
+                                           fuseBatch);
+    }
+    outputMemLayout = (gridY == 1) ? TensorMemoryLayout::WidthSharded
+                                   : TensorMemoryLayout::HeightSharded;
   }
 
   return generateMatmul1DProgramConfig(ctx, Mt, Nt, Kt, outputLayout,

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -33,6 +33,22 @@ static bool isL1Interleaved(const OpConfig &config) {
          memLayout.getValue() == TensorMemoryLayout::Interleaved;
 }
 
+static bool isSharded(const OpConfig &config) {
+  if (!config.outputLayout) {
+    return false;
+  }
+  auto memLayout = config.outputLayout.getMemLayout();
+  return memLayout && isShardedMemoryLayout(memLayout.getValue());
+}
+
+static bool hasMatmulProgramConfig(const OpConfig &config) {
+  if (const auto *attrs = std::get_if<MatmulAttrs>(&config.opSpecificAttrs)) {
+    return attrs->matmulProgramConfig.has_value() &&
+           attrs->matmulProgramConfig.value();
+  }
+  return false;
+}
+
 OutputHints MatmulRuleBook::getOutputHints(
     Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
   // Use partial configs: deduplicate by (bufferType, memLayout),
@@ -59,6 +75,18 @@ OutputHints MatmulRuleBook::getOutputHints(
   std::vector<OpConfig> filtered;
   for (const auto &cfg : partialConfigs) {
     if (isL1Interleaved(cfg)) {
+      continue;
+    }
+    // Skip sharded outputs when no MatmulProgramConfig is available.
+    //
+    // Without a program config, tt-metal's runtime auto-picker
+    // (create_simple_matmul_program_config) is non-idempotent due to allocator
+    // dependency. At compile time, validation invokes the autopicker which may
+    // emit a captured output spec on grid G1 (e.g. 5x6), which we adopt into
+    // the IR. At runtime, the matmul is re-invoked with that adopted G1 spec,
+    // the autopicker re-runs against G1 and can pick a different mcast path and
+    // per_core_M/N pair, producing a new grid G2.
+    if (isSharded(cfg) && !hasMatmulProgramConfig(cfg)) {
       continue;
     }
     filtered.push_back(cfg);

--- a/test/ttmlir/Dialect/TTNN/optimizer/d2m_optimizer_linear_chain.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/d2m_optimizer_linear_chain.mlir
@@ -17,17 +17,17 @@ module {
       %arg4: tensor<64x64xbf16, #layout>) -> tensor<64x64xbf16, #layout> {
     %0 = "ttnn.matmul"(%arg0, %arg1) : (tensor<64x64xbf16, #layout>, tensor<64x64xbf16, #layout>) -> tensor<64x64xbf16, #layout>
     // CHECK: %[[MATMUL_0_OUT:.*]] = "ttnn.matmul"
-    // CHECK-SAME: memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>
+    // CHECK-SAME: memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <height_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>
     %1 = "ttnn.matmul"(%0, %arg2) : (tensor<64x64xbf16, #layout>, tensor<64x64xbf16, #layout>) -> tensor<64x64xbf16, #layout>
     // CHECK: %[[MATMUL_1_OUT:.*]] = "ttnn.matmul"
-    // CHECK-SAME: memref<1x1x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>
+    // CHECK-SAME: memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <height_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>
     %2 = "ttnn.add"(%1, %arg3) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<64x64xbf16, #layout>, tensor<64x64xbf16, #layout>) -> tensor<64x64xbf16, #layout>
     %3 = "ttnn.multiply"(%2, %arg0) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<64x64xbf16, #layout>, tensor<64x64xbf16, #layout>) -> tensor<64x64xbf16, #layout>
     // CHECK: %[[EMPTY:.*]] = "ttnn.empty"
     // CHECK-SAME: memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>
     // CHECK: %[[D2M_SUBGRAPH_OUT:.*]] = ttnn.d2m_subgraph @d2m_subgraph_0
     // CHECK: ins(%[[MATMUL_1_OUT]], %arg3, %arg0 :
-    // CHECK-SAME: tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<1x1x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>,
+    // CHECK-SAME: tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <height_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>,
     // CHECK-SAME: tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<2x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <interleaved>>>,
     // CHECK-SAME: tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<2x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <interleaved>>>)
     // CHECK: outs(%[[EMPTY]] : tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>)
@@ -41,12 +41,12 @@ module {
   }
 
   // CHECK: func.func private @d2m_subgraph_0
-  // CHECK-SAME: (%arg0: tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<1x1x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>,
+  // CHECK-SAME: (%arg0: tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <height_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>,
   // CHECK-SAME: %arg1: tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<2x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <interleaved>>>,
   // CHECK-SAME: %arg2: tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<2x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <interleaved>>>)
   // CHECK-SAME: -> tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>> {
   // CHECK: %[[ADD_OUT:.*]] = "ttnn.add"
-  // CHECK-SAME: (tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}#ttnn.buffer_type<l1>>, <block_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>,
+  // CHECK-SAME: (tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}#ttnn.buffer_type<l1>>, <height_sharded>{{(, core_ranges = <\[[^]]*\]>)?}}>>,
   // CHECK-SAME: tensor<64x64xbf16, #ttnn.ttnn_layout<{{.*}}#ttnn.buffer_type<l1>>, <interleaved>>>)
   // CHECK: %[[MULTIPLY_OUT:.*]] = "ttnn.multiply"
   // CHECK-SAME: (%[[ADD_OUT]]

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_sharding.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_sharding.mlir
@@ -4,11 +4,11 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn mnist_sharding_ttnn.mlir
 
 // CHECK: %[[LINEAR1:.*]] = "ttnn.linear"
-// CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<block_sharded>{{(, core_ranges = (#ttnn\.core_range_set)?<\[[^]]*\]>)?}}>>
+// CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>{{(, core_ranges = (#ttnn\.core_range_set)?<\[[^]]*\]>)?}}>>
 // CHECK: %[[RELU:.*]] = "ttnn.relu"(%[[LINEAR1]]
-// CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<block_sharded>{{(, core_ranges = (#ttnn\.core_range_set)?<\[[^]]*\]>)?}}>>
-// CHECK: %[[LINEAR2:.*]] = "ttnn.linear"(%[[RELU]]
-// CHECK-SAME: -> tensor<1x10xf32, #ttnn.ttnn_layout<{{.*}}<block_sharded>{{(, core_ranges = (#ttnn\.core_range_set)?<\[[^]]*\]>)?}}>>
+// CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>{{(, core_ranges = (#ttnn\.core_range_set)?<\[[^]]*\]>)?}}>>
+// CHECK: %[[LINEAR2:.*]] = "ttnn.linear"
+// CHECK-SAME: -> tensor<1x10xf32, #ttnn.ttnn_layout<{{.*}}<height_sharded>{{(, core_ranges = (#ttnn\.core_range_set)?<\[[^]]*\]>)?}}>>
 
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {


### PR DESCRIPTION
### Changes

1. MatmulProgramConfig: guard 2D mcast on grid > 1x1.

2. MatmulRules: filter sharded output hints when no MatmulProgramConfig would be emitted (batched matmuls).


