### PR TITLE
[StableHLO] Fix sharded reshape compilation failure

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -555,6 +555,20 @@ def InsertExplicitReshardsPass : Pass<"insert-explicit-reshards", "::mlir::Modul
   ];
 }
 
+def InsertReshardsForUnpropagatedOpsPass : Pass<"insert-reshards-for-unpropagated-ops", "::mlir::ModuleOp">
+{
+  let summary = "Insert sdy.reshard to replicate operands of ops Shardy left unsharded.";
+  let description = [{
+    For ops whose results have no sdy.sharding after propagation, reshard
+    any sharded operand to fully replicated. Closes a gap that breaks
+    UpdateGlobalToLocalShapes.
+  }];
+
+  let dependentDialects = [
+    "::mlir::sdy::SdyDialect"
+  ];
+}
+
 def ShardyCCLCanonicalizationPass : Pass<"shardy-ccl-canonicalization", "::mlir::ModuleOp">
 {
   let summary = "Canonicalize Shardy CCL operations.";

--- a/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
@@ -116,6 +116,11 @@ mlir::sdy::TensorShardingAttr
 getDefaultTensorSdyShardingAttr(MLIRContext *context, llvm::StringRef meshName,
                                 mlir::Type type);
 
+// Get a fully replicated sdy.sharding annotation with closed dims, so Shardy
+// propagation cannot re-shard the tensor.
+mlir::sdy::TensorShardingAttr getClosedReplicatedTensorSdyShardingAttr(
+    MLIRContext *context, llvm::StringRef meshName, int64_t rank);
+
 // Get the argument sharding attributes.
 llvm::SmallVector<mlir::sdy::TensorShardingAttr>
 getInShardingAttrs(MLIRContext *context, func::FuncOp &funcOp,
@@ -127,10 +132,12 @@ llvm::SmallVector<mlir::sdy::TensorShardingAttr>
 getOutShardingAttrs(MLIRContext *context, func::FuncOp &funcOp,
                     mlir::sdy::MeshOp &globalMeshOp);
 
-// Get the sharding attribute for an operand.
+// Get the sharding attribute for an operand. Pass `createIfMissing=false` for
+// a read-only lookup; the default mutates unannotated func args.
 mlir::sdy::TensorShardingAttr
 getOperandShardingAttr(const mlir::OpOperand &operand,
-                       mlir::sdy::MeshOp globalMeshOp);
+                       mlir::sdy::MeshOp globalMeshOp,
+                       bool createIfMissing = true);
 
 // Calculate the updated shape based on the tensor sharding annotation.
 FailureOr<int64_t>
@@ -184,8 +191,10 @@ private:
   mlir::sdy::TensorShardingAttr sdySharding;
 };
 
-// Return true if every dimension has no axes -> replicated.
-bool isFullyReplicatedTensor(mlir::sdy::TensorShardingAttr tsh);
+// Return true if every dimension is replicated. With `meshOp`, axes resolving
+// to unit-sized mesh dims are also treated as replicated.
+bool isFullyReplicatedTensor(mlir::sdy::TensorShardingAttr tsh,
+                             mlir::sdy::MeshOp meshOp = {});
 
 // Return true if the module has any sdy tensor sharding annotations that are
 // not fully replicated.

--- a/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
+++ b/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
@@ -99,6 +99,12 @@ void createStableHLOPipeline(OpPassManager &pm,
   // reshard ops between the replicated constant and its sharded consumers.
   pm.addPass(createReplicateNonSplittableConstantsPass());
 
+  // Close propagation gaps left by Shardy's conservative mode: when an op
+  // has no propagated result sharding but its operands are sharded, insert
+  // sdy.reshard ops to fully replicate those operands so per-shard shapes
+  // match in UpdateGlobalToLocalShapes. See tt-xla#3643.
+  pm.addPass(createInsertReshardsForUnpropagatedOpsPass());
+
   // Insert explicit reshards conditionally.
   pm.addPass(createInsertExplicitReshardsPass());
 

--- a/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
+++ b/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_dialect_library(MLIRStableHLOTransforms
   DecoupleConstFanout.cpp
   FlattenOrConvertComposites.cpp
   FuseDistributedCustomCalls.cpp
+  InsertReshardsForUnpropagatedOps.cpp
   PartiallyConvertSdyToStableHLO.cpp
   RegisterCustomShardingRule.cpp
   ReoutlineComposite.cpp

--- a/lib/Dialect/StableHLO/Transforms/InsertReshardsForUnpropagatedOps.cpp
+++ b/lib/Dialect/StableHLO/Transforms/InsertReshardsForUnpropagatedOps.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
+#include "ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h"
+
+#include "shardy/dialect/sdy/ir/dialect.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mlir::tt::stablehlo {
+#define GEN_PASS_DEF_INSERTRESHARDSFORUNPROPAGATEDOPSPASS
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
+
+static bool anyResultHasSharding(mlir::Operation *op) {
+  auto spv = op->getAttrOfType<mlir::sdy::TensorShardingPerValueAttr>(
+      mlir::sdy::TensorShardingAttr::name);
+  return spv && !spv.getShardings().empty();
+}
+
+static void replicateOperandViaReshard(mlir::OpBuilder &builder,
+                                       mlir::Operation *op,
+                                       mlir::OpOperand &operand,
+                                       mlir::StringAttr meshName) {
+  auto tensorType =
+      mlir::dyn_cast<mlir::RankedTensorType>(operand.get().getType());
+  if (!tensorType) {
+    return;
+  }
+
+  mlir::sdy::TensorShardingAttr replicated =
+      shardy_utils::getClosedReplicatedTensorSdyShardingAttr(
+          builder.getContext(), meshName, tensorType.getRank());
+
+  builder.setInsertionPoint(op);
+  auto reshard = builder.create<mlir::sdy::ReshardOp>(
+      op->getLoc(), operand.get(), replicated);
+  operand.set(reshard.getResult());
+}
+
+// For ops whose results were left unsharded by Shardy propagation, reshard
+// any sharded operand to fully replicated. The reshard later lowers to an
+// all_gather, so the consumer sees replicated operands and per-shard shapes
+// match in UpdateGlobalToLocalShapes. See tt-xla#3643.
+class InsertReshardsForUnpropagatedOpsPass
+    : public impl::InsertReshardsForUnpropagatedOpsPassBase<
+          InsertReshardsForUnpropagatedOpsPass> {
+public:
+  using impl::InsertReshardsForUnpropagatedOpsPassBase<
+      InsertReshardsForUnpropagatedOpsPass>::
+      InsertReshardsForUnpropagatedOpsPassBase;
+
+  void runOnOperation() final {
+    mlir::ModuleOp rootModule = getOperation();
+    MLIRContext *context = rootModule.getContext();
+
+    if (shardy_utils::isGraphSolved(rootModule)) {
+      return;
+    }
+
+    llvm::SmallVector<mlir::sdy::MeshOp> meshOps =
+        shardy_utils::getMeshOps(rootModule);
+    if (meshOps.empty()) {
+      return;
+    }
+    if (meshOps.size() > 1) {
+      rootModule.emitError("Pass currently only supports a single shardy mesh "
+                           "op in the module");
+      signalPassFailure();
+      return;
+    }
+    mlir::sdy::MeshOp globalMeshOp = meshOps[0];
+    mlir::StringAttr meshName = globalMeshOp.getSymNameAttr();
+
+    mlir::OpBuilder builder(context);
+
+    rootModule.walk([&](mlir::Operation *op) {
+      // Restricted to stablehlo.reshape — the only op known to hit this
+      // propagation gap. Other ops have custom sharding rules registered.
+      if (!mlir::isa<mlir::stablehlo::ReshapeOp>(op)) {
+        return;
+      }
+      if (op->getParentOfType<mlir::sdy::ManualComputationOp>()) {
+        return;
+      }
+      if (anyResultHasSharding(op)) {
+        return;
+      }
+
+      for (mlir::OpOperand &operand : op->getOpOperands()) {
+        if (!mlir::isa<mlir::RankedTensorType>(operand.get().getType())) {
+          continue;
+        }
+        mlir::sdy::TensorShardingAttr operandSharding =
+            shardy_utils::getOperandShardingAttr(operand, globalMeshOp,
+                                                 /*createIfMissing=*/false);
+        if (!operandSharding || shardy_utils::isFullyReplicatedTensor(
+                                    operandSharding, globalMeshOp)) {
+          continue;
+        }
+        replicateOperandViaReshard(builder, op, operand, meshName);
+      }
+    });
+  }
+};
+
+} // namespace mlir::tt::stablehlo

--- a/lib/Dialect/StableHLO/Transforms/ReplicateNonSplittableConstants.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ReplicateNonSplittableConstants.cpp
@@ -108,16 +108,9 @@ public:
 
       // Non-splat, non-periodic constant: change sharding to fully replicated
       // so InsertExplicitReshards will insert the necessary reshard ops.
-      llvm::SmallVector<mlir::sdy::DimensionShardingAttr>
-          replicatedDimShardings;
-      for (int64_t dim = 0; dim < oldType.getRank(); ++dim) {
-        replicatedDimShardings.push_back(
-            mlir::sdy::DimensionShardingAttr::get(context, /*axes=*/{},
-                                                  /*isClosed=*/true));
-      }
-      auto replicatedSharding = mlir::sdy::TensorShardingAttr::get(
-          context, globalMeshOp.getSymName(), replicatedDimShardings,
-          /*replicatedAxes=*/{}, /*unknownAxes=*/{});
+      auto replicatedSharding =
+          shardy_utils::getClosedReplicatedTensorSdyShardingAttr(
+              context, globalMeshOp.getSymName(), oldType.getRank());
 
       constantOp->setAttr(mlir::sdy::TensorShardingAttr::name,
                           mlir::sdy::TensorShardingPerValueAttr::get(

--- a/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
+++ b/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
@@ -328,6 +328,19 @@ getDefaultTensorSdyShardingAttr(MLIRContext *context, llvm::StringRef meshName,
                                             {});
 }
 
+mlir::sdy::TensorShardingAttr getClosedReplicatedTensorSdyShardingAttr(
+    MLIRContext *context, llvm::StringRef meshName, int64_t rank) {
+  llvm::SmallVector<mlir::sdy::DimensionShardingAttr> dimShardings;
+  dimShardings.reserve(rank);
+  for (int64_t d = 0; d < rank; ++d) {
+    dimShardings.push_back(mlir::sdy::DimensionShardingAttr::get(
+        context, /*axes=*/{}, /*isClosed=*/true));
+  }
+  return mlir::sdy::TensorShardingAttr::get(context, meshName, dimShardings,
+                                            /*replicatedAxes=*/{},
+                                            /*unknownAxes=*/{});
+}
+
 // Get the argument sharding attributes.
 // If createIfMissing is true, create default sharding attributes (replicated
 // on) for any arguments that do not have sdy.sharding annotations.
@@ -426,7 +439,7 @@ getOutShardingAttrs(MLIRContext *context, func::FuncOp &funcOp,
 // Falls back to full replicate if none found.
 mlir::sdy::TensorShardingAttr
 getOperandShardingAttr(const mlir::OpOperand &operand,
-                       mlir::sdy::MeshOp globalMeshOp) {
+                       mlir::sdy::MeshOp globalMeshOp, bool createIfMissing) {
   mlir::Value val = operand.get();
 
   mlir::sdy::TensorShardingAttr result =
@@ -437,7 +450,8 @@ getOperandShardingAttr(const mlir::OpOperand &operand,
     unsigned argNo = barg.getArgNumber();
     mlir::Operation *parentOp = barg.getOwner()->getParentOp();
     if (auto func = llvm::dyn_cast_or_null<mlir::func::FuncOp>(parentOp)) {
-      auto inAttrs = getInShardingAttrs(func.getContext(), func, globalMeshOp);
+      auto inAttrs = getInShardingAttrs(func.getContext(), func, globalMeshOp,
+                                        createIfMissing);
       if (argNo < inAttrs.size()) {
         result = inAttrs[argNo];
       }
@@ -693,10 +707,27 @@ ShardyMeshSharding::generate(sdy::MeshAttr meshAttr,
                             shardStatus,    meshAttr,  sdySharding};
 }
 
-bool isFullyReplicatedTensor(mlir::sdy::TensorShardingAttr tsh) {
+bool isFullyReplicatedTensor(mlir::sdy::TensorShardingAttr tsh,
+                             mlir::sdy::MeshOp meshOp) {
   for (auto dim : tsh.getDimShardings()) {
-    if (!dim.getAxes().empty()) {
+    if (dim.getAxes().empty()) {
+      continue;
+    }
+    if (!meshOp) {
       return false;
+    }
+    mlir::sdy::MeshAttr meshAttr = meshOp.getMesh();
+    for (mlir::sdy::AxisRefAttr axisRef : dim.getAxes()) {
+      int64_t axisSize = 1;
+      for (mlir::sdy::MeshAxisAttr meshAxis : meshAttr.getAxes()) {
+        if (meshAxis.getName() == axisRef.getName()) {
+          axisSize = meshAxis.getSize();
+          break;
+        }
+      }
+      if (axisSize > 1) {
+        return false;
+      }
     }
   }
   return true;

--- a/test/ttmlir/Dialect/StableHLO/shardy/insert_reshards_for_unpropagated_ops.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/insert_reshards_for_unpropagated_ops.mlir
@@ -1,0 +1,15 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline="mesh-shape=1,4" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module @reshape_split_sharded {
+  sdy.mesh @mesh = <["batch"=1, "model"=4]>
+  func.func public @main(%arg0: tensor<3x30720xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"model"}]>}) -> tensor<3x6x5120xbf16> {
+    %0 = stablehlo.reshape %arg0 : (tensor<3x30720xbf16>) -> tensor<3x6x5120xbf16>
+    return %0 : tensor<3x6x5120xbf16>
+  }
+}
+
+// CHECK-LABEL: @main
+// CHECK: stablehlo.all_gather
+// CHECK: stablehlo.reshape


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/3643
- closes https://github.com/tenstorrent/tt-xla/issues/4767

### Problem description

- Shardy's `UserPriorityPropagation` (run with `conservativePropagation=true`) cannot place an output sharding when a `stablehlo.reshape` splits a sharded flat dim into `(N, D)` where `N` is indivisible by the shard count. 
- The reshape result is left unannotated; `UpdateGlobalToLocalShapes` then resizes the operand to per-shard but keeps the result global, so the StableHLO verifier rejects it (e.g. `92160 vs 23040` for `(3, 30720) -> (3, 6, 5120)` on 4 chips).

### What's changed

- New `insert-reshards-for-unpropagated-ops` pass, slotted after `ReplicateNonSplittableConstants` and before `InsertExplicitReshards`. For every `stablehlo.reshape` whose result Shardy left without an `sdy.sharding`, it inserts `sdy.reshard <@mesh, [{}, ...]>` for each genuinely sharded operand.
- The reshard lowers to `all_gather` via `ReshardToCollectives`, so the consumer sees replicated operands and per-shard shapes match.
- Consolidated helpers into `ShardyUtils` (`getClosedReplicatedTensorSdyShardingAttr`, mesh-aware overload of `isFullyReplicatedTensor`, `createIfMissing` parameter on `getOperandShardingAttr`) and deduped the closed-replicated builder shared with `ReplicateNonSplittableConstants`.


### Checklist

- [x] Verify the changes through local testing in N150

### Logs

- [jun1_reshape_shard_before_fix.log](https://github.com/user-attachments/files/28470406/jun1_reshape_shard_before_fix.log)
- [jun1_reshape_shard_after_fix.log](https://github.com/user-attachments/files/28470405/jun1_reshape_shard_after_fix.log)
- [jun1_krea_transformer_before_fix.log](https://github.com/user-attachments/files/28470404/jun1_krea_transformer_before_fix.log)
- [jun1_krea_transformer_after_fix.log](https://github.com/user-attachments/files/28470398/jun1_krea_transformer_after_fix.log)







 