### PR TITLE
[StableHLOToTTIR] Fix replicate-pad gather lowering for singleton dim and back-pad slice

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -5673,10 +5673,11 @@ public:
 
     auto slicedIndices = indices.getValue();
     for (auto index : slicedIndices.getValues<llvm::APInt>()) {
+      // When maxIndex == 0, 0 and maxIndex collapse to the same value; count
+      // such indices only as starts to avoid double-counting them as ends.
       if (index == 0) {
         starts++;
-      }
-      if (index == maxIndex) {
+      } else if (index == maxIndex) {
         ends++;
       }
       if (!((index - lastIndex == 1) || (index == lastIndex && index == 0) ||
@@ -5693,13 +5694,17 @@ public:
 
     // Body [0, 1, ..., maxIndex] must be present, i.e. at least one 0 and one
     // maxIndex. Rejects constant-uniform indices like [1, 1, ..., 1].
-    if (starts == 0 || ends == 0) {
+    // When maxIndex == 0 the body is just [0]; only starts is meaningful, and
+    // all surplus indices become front padding.
+    if (starts == 0 || (maxIndex != 0 && ends == 0)) {
       return rewriter.notifyMatchFailure(
           srcOp, "Indices do not contain the body [0, 1, ..., maxIndex]");
     }
 
     starts--;
-    ends--;
+    if (maxIndex != 0) {
+      ends--;
+    }
 
     SmallVector<Value> slicesToConcat;
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
@@ -114,3 +114,26 @@ module @test_gather_uniform_max_indices {
     return %2 : tensor<193x768xf32>
   }
 }
+
+// When the indexed dim has size 1 (maxIndex == 0), 0 and maxIndex collapse;
+// all surplus indices become front padding without double-counting them as
+// back padding.
+// CHECK-LABEL: func.func @repeat_front_singleton_indexed_dim
+module @test_gather_repeat_front_singleton_indexed_dim {
+  func.func @repeat_front_singleton_indexed_dim(%arg0: tensor<1x16x1x40x64xbf16>) -> (tensor<1x16x3x40x64xbf16>) {
+    // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 16 : i32, 1 : i32, 40 : i32, 64 : i32]
+    // CHECK-SAME: (tensor<1x16x1x40x64xbf16>) -> tensor<1x16x1x40x64xbf16>
+    // CHECK: "ttir.repeat"
+    // CHECK-SAME: repeat_dimensions = array<i64: 1, 1, 2, 1, 1>
+    // CHECK-SAME: (tensor<1x16x1x40x64xbf16>) -> tensor<1x16x2x40x64xbf16>
+    // CHECK: "ttir.concat"
+    // CHECK-SAME: dim = 2
+    // CHECK-SAME: (tensor<1x16x2x40x64xbf16>, tensor<1x16x1x40x64xbf16>) -> tensor<1x16x3x40x64xbf16>
+    // CHECK-NOT: stablehlo.gather
+    %1 = "stablehlo.constant"() <{value = dense<[[0], [0], [0]]> : tensor<3x1xi64>}> : () -> tensor<3x1xi64>
+    %2 = "stablehlo.gather"(%arg0, %1) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 1, 3, 4], collapsed_slice_dims = [2], start_index_map = [2], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 16, 1, 40, 64>}> : (tensor<1x16x1x40x64xbf16>, tensor<3x1xi64>) -> tensor<1x16x3x40x64xbf16>
+    return %2 : tensor<1x16x3x40x64xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
[#4792](https://github.com/tenstorrent/tt-xla/issues/4792)

### Problem description

- StableHLOGatherToSliceRepeatConcatPattern lowers replicate-padding gathers (e.g. F.pad(..., mode="replicate")) into ttir.slice_static + ttir.repeat + ttir.concat. HunyuanVideo's VAE decoder feeds a 5D tensor 1x16x1x40x64xbf16 into a HunyuanVideoCausalConv3d with replicate pad (1, 1, 1, 1, 2, 0), exposing a bug in this pattern when the indexed dim has size sliceSize (maxIndex == 0):

- eEvery index 0 is also maxIndex, so the matcher's two independent if branches double-counted these indices into both starts and ends. For dim 2 (size 1, indices [[0],[0],[0]]) this produced a concat with 2 + 1 + 2 = 5 inputs versus the gather's output dim of 3, failing with:

`loc("gather.58"): error: 'ttir.concat' op Output tensor dimension 2 does not match the sum of input tensor dimensions: 3 vs. 5.`

- Back-pad slice took the front frame: createSlices had no sliceStart parameter and hardcoded buildSliceArrays(0, sliceSize, ...), so the back-pad call sliced [0 : sliceSize] — the first frame — instead of [N - sliceSize : N]. Both front-pad and back-pad ended up replicating the first frame. This latent bug was masked by (1); once (1) was fixed and the test reached runtime, it surfaced as a pcc=0.9666122866537071. Required: pcc=0.99.

### What's changed

- In StableHLOGatherToSliceRepeatConcatPattern, singleton indexed dim: use else if between the starts/ends increments so each index increments at most one counter. Relax the body-presence guard (starts == 0 || ends == 0) to require only starts >= 1 when maxIndex == 0, and skip ends-- in that case. All surplus indices become front padding (safe because the first and last frame coincide when the indexed dim has size sliceSize).

- Added repeat_front_singleton_indexed_dim to gather_to_slice_repeat_concat.mlir covering the singleton-indexed-dim case (input 1x16x1x40x64, indices [[0],[0],[0]], expected concat of front_repeat(1x16x2x40x64) + input(1x16x1x40x64) → 1x16x3x40x64).

### Checklist

- [x] Verify the changes through local testing in N150

### Logs

[ttir_concat_before_fix.log](https://github.com/user-attachments/files/28054960/ttir_concat_before_fix.log)
[ttir_concat_after_fix.log](https://github.com/user-attachments/files/28054959/ttir_concat_after_fix.log)


