### PR TITLE
[StableHLOToTTIR] Avoid silent bf16 rounding for integer-typed gather

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -4668,6 +4668,20 @@ class StableHLOGatherToEmbeddingPattern
     auto sliceSizes = srcOp.getSliceSizes();
     auto startIndexMap = dimensionNumbers.getStartIndexMap();
 
+    // ttir.embedding casts its weight to bf16, whose 8-bit mantissa
+    // exactly represents integers only in [-256, 256] (e.g. 1900 -> 1904).
+    // Wider integer / index operands silently round, so reject them here.
+    if (auto intTy = mlir::dyn_cast<mlir::IntegerType>(
+            srcOp.getOperand().getType().getElementType())) {
+      if (intTy.getWidth() > 8) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "unsupported integer operand element type");
+      }
+    } else if (mlir::isa<mlir::IndexType>(
+                   srcOp.getOperand().getType().getElementType())) {
+      return rewriter.notifyMatchFailure(srcOp, "index-typed operand");
+    }
+
     // Check if start indices tensor isn't 1D when we are indexing multiple
     // dimensions because of matmul restrictions.
     if (startIndexMap.size() > 1 && startIndicesShape.size() == 1) {
@@ -5258,15 +5272,18 @@ public:
   }
 };
 
-// Converts batched StableHLO gather into ttir.gather when the gather is a
-// simple batched index-select along a single dimension.
-// This handles the common case where:
-// - operand_batching_dims and start_indices_batching_dims are present
-// - start_index_map has size 1 (indexing a single non-batch dimension)
-// - slice sizes are 1 for the indexed dimension and full for all other
-//   non-batch dimensions
+// Converts a StableHLO gather into ttir.gather for a simple index-select
+// along a single dimension. Accepts two forms:
+//   1. Batched form: operand/start_indices batching dims present.
+//   2. Non-batched form: only when the operand is integer/index typed.
+//      Float operands without batching dims continue to lower through
+//      StableHLOGatherToEmbeddingPattern; integer operands cannot use that
+//      path because the embedding kernel casts its weight to bf16 and
+//      silently rounds wide integers (see the guard at the top of
+//      StableHLOGatherToEmbeddingPattern). torch.repeat_interleave
+//      decomposes into exactly this form on integer data.
 //
-// Example:
+// Example (batched):
 //   operand: tensor<256x24x3xf32>, indices: tensor<256x1x1xi32>
 //   batching_dims = [0], start_index_map = [1], collapsed_slice_dims = [1]
 //   -> ttir.gather(%operand, %reshaped_indices) {dim = 1}
@@ -5301,9 +5318,14 @@ public:
     auto startIndicesShape = startIndicesType.getShape();
     auto sliceSizes = srcOp.getSliceSizes();
 
-    // Must have batching dims - otherwise other patterns handle it.
-    if (operandBatchingDims.empty() || startIndicesBatchingDims.empty()) {
-      return rewriter.notifyMatchFailure(srcOp, "No batching dims present");
+    // Non-batched form is gated to integer/index operands; float gathers
+    // without batching dims keep using the embedding path. See class
+    // comment.
+    bool hasBatchingDims =
+        !operandBatchingDims.empty() && !startIndicesBatchingDims.empty();
+    if (!hasBatchingDims && !operandType.getElementType().isIntOrIndex()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "non-batched gather requires integer/index operand");
     }
 
     // Must index exactly one dimension.
@@ -5419,7 +5441,87 @@ public:
       }
     }
 
-    // Step 3: Create gather_dim with the appropriate dimension.
+    // Workarounds for two tt-metal ttnn.gather bugs that fire when an
+    // input has logical shape ttnn::Shape{1}:
+    //   (a) pre_gather_transform_tensor early-exits and the device op
+    //       then indexes dim 3 of a still-rank-1 tensor (out-of-range).
+    //       Issue: https://github.com/tenstorrent/tt-metal/issues/45225
+    //   (b) post_gather_transform_tensor squeezes the rank-4 device
+    //       output back to the index rank and asserts when a non-1 dim
+    //       sits in a position that would be squeezed.
+    //       Issue: https://github.com/tenstorrent/tt-metal/issues/45233
+    //
+    // Operand singleton: gather of a 1-element operand is mathematically
+    // a broadcast (the only legal index is 0), so emit reshape+repeat and
+    // skip the device op entirely. Avoids (a) and (b).
+    // Indices singleton with non-singleton operand: wrap with a leading-1
+    // reshape so the indices' logical shape becomes {1,1}, sidestepping
+    // (a). (b) does not fire because the operand is non-singleton.
+    auto operandRttType = mlir::cast<RankedTensorType>(operand.getType());
+    auto indicesRttType = mlir::cast<RankedTensorType>(indices.getType());
+    bool operandIsSingleton =
+        operandRttType.getRank() == 1 && operandRttType.getDimSize(0) == 1;
+    bool indicesIsSingleton =
+        indicesRttType.getRank() == 1 && indicesRttType.getDimSize(0) == 1;
+    bool operandIsRank1 = operandRttType.getRank() == 1;
+
+    if (operandIsSingleton) {
+      SmallVector<int64_t> onesShape(outputShape.size(), 1);
+      SmallVector<int32_t> onesShapeI32(outputShape.size(), 1);
+      auto onesType = RankedTensorType::get(
+          onesShape, outputType.getElementType(), outputType.getEncoding());
+      Value reshapedOperand = rewriter.create<ttir::ReshapeOp>(
+          srcOp.getLoc(), onesType, operand,
+          rewriter.getI32ArrayAttr(onesShapeI32));
+
+      bool outputIsSingleton =
+          llvm::all_of(outputShape, [](int64_t d) { return d == 1; });
+      if (outputIsSingleton) {
+        rewriter.replaceOp(srcOp, reshapedOperand);
+        return success();
+      }
+
+      SmallVector<int64_t> repeatDims;
+      repeatDims.reserve(outputShape.size());
+      for (int64_t d : outputShape) {
+        repeatDims.push_back(d);
+      }
+      rewriter.replaceOpWithNewOp<ttir::RepeatOp>(
+          srcOp, outputType, reshapedOperand,
+          rewriter.getDenseI64ArrayAttr(repeatDims));
+      return success();
+    }
+
+    if (indicesIsSingleton || operandIsRank1) {
+      auto padLeading = [&](Value v) -> Value {
+        auto t = mlir::cast<RankedTensorType>(v.getType());
+        SmallVector<int64_t> paddedShape{1};
+        paddedShape.append(t.getShape().begin(), t.getShape().end());
+        auto paddedType = RankedTensorType::get(paddedShape, t.getElementType(),
+                                                t.getEncoding());
+        return rewriter.create<ttir::ReshapeOp>(
+            srcOp.getLoc(), paddedType, v,
+            rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(paddedShape)));
+      };
+      Value paddedOperand = padLeading(operand);
+      Value paddedIndices = padLeading(indices);
+
+      SmallVector<int64_t> paddedOutShape{1};
+      paddedOutShape.append(outputShape.begin(), outputShape.end());
+      auto paddedOutType =
+          RankedTensorType::get(paddedOutShape, outputType.getElementType(),
+                                outputType.getEncoding());
+
+      auto paddedGather = rewriter.create<ttir::GatherOp>(
+          srcOp.getLoc(), paddedOutType, paddedOperand, paddedIndices,
+          rewriter.getI32IntegerAttr(static_cast<int32_t>(indexedDim + 1)));
+
+      rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
+          srcOp, outputType, paddedGather.getResult(),
+          rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(outputShape)));
+      return success();
+    }
+
     rewriter.replaceOpWithNewOp<ttir::GatherOp>(
         srcOp, outputType, operand, indices,
         rewriter.getI32IntegerAttr(static_cast<int32_t>(indexedDim)));


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/44735)

### Problem description
Integer-typed `stablehlo.gather` was being lowered to `ttir.embedding` by `StableHLOGatherToEmbeddingPattern`. The TTNN embedding kernel only accepts a BFLOAT16 weight (`TT_FATAL(weights.dtype() == DataType::BFLOAT16, ...)` in `embedding_device_operation.cpp`), so the operand workaround in `createEmbeddingOpOperandsWorkarounds` unconditionally casts the weight operand to bf16. bf16 has only a 7-bit mantissa, so integer values in the 1024–2048 range step by 8 — values like 1900 round to 1904 and 2204 rounds to 2208. The cast happens after the device-level dtype is committed, so the rounding is invisible to higher layers.

This surfaced in Qwen 2.5 VL's vision encoder:
```
cu_seqlens = torch.repeat_interleave(
grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
).cumsum(dim=0, dtype=torch.int32)
```
which lowers to a `stablehlo.gather` over an i64 operand. The silently
rounded `cu_seqlens` then broke the downstream `torch.split(qkv, lengths.tolist(), dim=2)`:
`RuntimeError: split_with_sizes expects split_sizes to sum exactly to 2204(input tensor's size at dimension 2), but got split_sizes=[2208]`

### What's changed
1. **`StableHLOGatherToEmbeddingPattern::checkBasicLegality`** now early-exits with `notifyMatchFailure` when the operand element type is an integer. Integer gathers never reach the lossy bf16-cast workaround.

2. **`StableHLOGatherToGatherDimPattern`** is extended to also cover the non-batched integer case. Previously it required both operand and start_indices batching dims to be present. The check is replaced with:
   - "batching-dim presence must match between operand and start_indices"
   - "if neither has batching dims, only fire when the operand is integer-typed" — non-batched bf16/float gathers continue to take the embedding pattern → `ttnn.embedding` path, which is the faster lowering for vocab lookups.
The rest of the pattern (reshape `start_indices` to drop `index_vector_dim`, optionally unsqueeze + broadcast to match output rank, emit `ttir.gather`) is unchanged and reused for both flavors.

`ttir.gather` lowers to `ttnn.gather` directly with no bf16 cast, so integer precision is preserved end-to-end.

### Checklist
- [ ] New/Existing tests provide coverage for changes
