### PR TITLE
Fix #8495 - incorrect arg names in TTNN->EmitPy conversion for ttnn.moe_expert_token_remap

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -4094,8 +4094,10 @@ public:
         emitter.emit(srcOp.getTopkTensor()),
         emitter.emit(srcOp.getExpertMapping()),
         emitter.emit(srcOp.getExpertMetadata()),
-        emitter.emit(srcOp.getReductionSize()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
+        /*optional_output_tensor=*/emitter.emit(std::nullopt),
+        /*optional_reduced_tensor=*/emitter.emit(std::nullopt),
+        emitter.emit(srcOp.getReductionSize()),
     };
 
     // Multi-result: returns std::vector<ttnn::Tensor> with 2 elements.

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -3745,8 +3745,8 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getTopkTensor(), "topk_tensor"),
-        emitter.emit(srcOp.getExpertMapping(), "expert_mapping"),
-        emitter.emit(srcOp.getExpertMetadata(), "expert_metadata"),
+        emitter.emit(srcOp.getExpertMapping(), "expert_mapping_tensor"),
+        emitter.emit(srcOp.getExpertMetadata(), "expert_metadata_tensor"),
         emitter.emit(srcOp.getReductionSize(), "reduction_size"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };

--- a/test/python/golden/ttnn_ops/ccl/test_ttnn_moe_expert_token_remap.py
+++ b/test/python/golden/ttnn_ops/ccl/test_ttnn_moe_expert_token_remap.py
@@ -9,7 +9,6 @@ from conftest import get_request_kwargs
 from builder.base.builder_utils import Operand, Shape
 from builder.ttnn.ttnn_builder import TTNNBuilder
 from builder.base.builder_apis import compile_and_execute_ttnn
-from test_utils import shape_str
 
 pytestmark = pytest.mark.frontend("ttnn")
 

--- a/test/python/golden/ttnn_ops/ccl/test_ttnn_moe_expert_token_remap.py
+++ b/test/python/golden/ttnn_ops/ccl/test_ttnn_moe_expert_token_remap.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from typing import List, Optional
+from conftest import get_request_kwargs
+from builder.base.builder_utils import Operand, Shape
+from builder.ttnn.ttnn_builder import TTNNBuilder
+from builder.base.builder_apis import compile_and_execute_ttnn
+from test_utils import shape_str
+
+pytestmark = pytest.mark.frontend("ttnn")
+
+
+@pytest.mark.parametrize(
+    "topk_shape,expert_mapping_shape,expert_metadata_shape,reduction_size,"
+    "mapping_shape,reduced_shape",
+    [
+        (
+            (1, 1, 32, 8),  # topk_tensor: [1, BD, S, E]
+            (1, 1, 8, 1),  # expert_mapping: [1, 1, E, num_devices=1]
+            (1, 1, 32, 4),  # expert_metadata: [1, BD, S, K]
+            32,  # reduction_size
+            (1, 1, 32, 8),  # mapping output: [1, BD, S, E/num_devices]
+            (1, 1, 1, 8),  # reduced output: [1, 1, ceil(BD*S/R), E/num_devices]
+        ),
+    ],
+    ids=["1x32x8_r32"],
+)
+@pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
+def test_moe_expert_token_remap(
+    topk_shape: Shape,
+    expert_mapping_shape: Shape,
+    expert_metadata_shape: Shape,
+    reduction_size: int,
+    mapping_shape: Shape,
+    reduced_shape: Shape,
+    target: str,
+    request,
+    device,
+):
+    def module(builder: TTNNBuilder):
+        @builder.func(
+            [topk_shape, expert_mapping_shape, expert_metadata_shape],
+            [torch.bfloat16, torch.int64, torch.int64],
+        )
+        def moe_expert_token_remap(
+            topk_tensor: Operand,
+            expert_mapping: Operand,
+            expert_metadata: Operand,
+            builder: TTNNBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.moe_expert_token_remap(
+                topk_tensor,
+                expert_mapping,
+                expert_metadata,
+                reduction_size=reduction_size,
+                mapping_shape=mapping_shape,
+                mapping_type=torch.bfloat16,
+                reduced_shape=reduced_shape,
+                reduced_type=torch.bfloat16,
+                unit_attrs=unit_attrs,
+            )
+
+    # Golden for moe_expert_token_remap is a stub (returns zeros) since the op
+    # performs device-level expert routing that can't be replicated on host.
+    # Skip PCC check; this test validates compilation and execution.
+    compile_and_execute_ttnn(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target=target,
+        check_pcc=False,
+    )

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -10641,13 +10641,15 @@ class TTNNBuilder(Builder):
             for attr_name in unit_attrs:
                 op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
 
-        golden_mapping = GoldenMapTensor(
-            {0: torch.zeros(mapping_shape, dtype=mapping_type)},
-            mesh_shape=self._mesh_shape,
-        )
-        golden_reduced = GoldenMapTensor(
-            {0: torch.zeros(reduced_shape, dtype=reduced_type)},
-            mesh_shape=self._mesh_shape,
+        topk_golden = self._get_golden_tensor(topk_tensor)
+        expert_mapping_golden = self._get_golden_tensor(expert_mapping)
+        expert_metadata_golden = self._get_golden_tensor(expert_metadata)
+        op_golden_function = get_golden_function(ttnn.MoeExpertTokenRemapOp)
+        golden_mapping, golden_reduced = op_golden_function(
+            topk_golden,
+            expert_mapping_golden,
+            expert_metadata_golden,
+            reduction_size,
         )
         self._set_golden_tensor(op.mapping, golden_mapping)
         self._set_golden_tensor(op.reduced, golden_reduced)

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -10583,6 +10583,203 @@ class TTNNBuilder(Builder):
 
         return reduce_scatter_module, reduce_scatter_builder
 
+    ############### ttnn.MoeExpertTokenRemapOp ###############
+
+    @tag(ttnn.MoeExpertTokenRemapOp)
+    def moe_expert_token_remap(
+        self,
+        topk_tensor: Operand,
+        expert_mapping: Operand,
+        expert_metadata: Operand,
+        reduction_size: int = 32,
+        mapping_shape: Optional[Shape] = None,
+        mapping_type: Optional[torch.dtype] = None,
+        reduced_shape: Optional[Shape] = None,
+        reduced_type: Optional[torch.dtype] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> Tuple[OpResult, OpResult]:
+        assert (
+            mapping_shape is not None
+        ), "mapping_shape must be provided for moe_expert_token_remap"
+        assert (
+            mapping_type is not None
+        ), "mapping_type must be provided for moe_expert_token_remap"
+        assert (
+            reduced_shape is not None
+        ), "reduced_shape must be provided for moe_expert_token_remap"
+        assert (
+            reduced_type is not None
+        ), "reduced_type must be provided for moe_expert_token_remap"
+
+        mlir_mapping_type = self._get_type_from_torch_dtype(mapping_type)
+        mlir_reduced_type = self._get_type_from_torch_dtype(reduced_type)
+
+        mapping_result = self._create_ranked_tensor_type(
+            mapping_shape, mlir_mapping_type
+        )
+        reduced_result = self._create_ranked_tensor_type(
+            reduced_shape, mlir_reduced_type
+        )
+
+        reduction_size_attr = IntegerAttr.get(
+            IntegerType.get_signless(64), reduction_size
+        )
+
+        loc = self._get_location()
+
+        op = ttnn.MoeExpertTokenRemapOp(
+            mapping_result,
+            reduced_result,
+            topk_tensor,
+            expert_mapping,
+            expert_metadata,
+            reduction_size_attr,
+            loc=loc,
+        )
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        golden_mapping = GoldenMapTensor(
+            {0: torch.zeros(mapping_shape, dtype=mapping_type)},
+            mesh_shape=self._mesh_shape,
+        )
+        golden_reduced = GoldenMapTensor(
+            {0: torch.zeros(reduced_shape, dtype=reduced_type)},
+            mesh_shape=self._mesh_shape,
+        )
+        self._set_golden_tensor(op.mapping, golden_mapping)
+        self._set_golden_tensor(op.reduced, golden_reduced)
+
+        return op.mapping, op.reduced
+
+    @parse(ttnn.MoeExpertTokenRemapOp)
+    def moe_expert_token_remap_parser(
+        self,
+        old_op: ttnn.MoeExpertTokenRemapOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttnn_op = self.get_opview_from_parser(TTNNBuilder.moe_expert_token_remap_parser)
+
+        topk_tensor = global_dict[old_op.topk_tensor]
+        expert_mapping = global_dict[old_op.expert_mapping]
+        expert_metadata = global_dict[old_op.expert_metadata]
+        reduction_size_attr = old_op.reduction_size
+
+        mapping_result = old_op.mapping.type
+        reduced_result = old_op.reduced.type
+
+        new_op = ttnn_op(
+            mapping_result,
+            reduced_result,
+            topk_tensor,
+            expert_mapping,
+            expert_metadata,
+            reduction_size_attr,
+            loc=old_op.location,
+        )
+
+        topk_golden = self._get_golden_tensor(topk_tensor)
+        expert_mapping_golden = self._get_golden_tensor(expert_mapping)
+        expert_metadata_golden = self._get_golden_tensor(expert_metadata)
+        op_golden_function = get_golden_function(ttnn_op)
+        golden_mapping, golden_reduced = op_golden_function(
+            topk_golden,
+            expert_mapping_golden,
+            expert_metadata_golden,
+            unpack_mlir_attr(reduction_size_attr),
+        )
+        self._set_golden_tensor(new_op.mapping, golden_mapping)
+        self._set_golden_tensor(new_op.reduced, golden_reduced)
+
+        return new_op, {
+            old_op.mapping: new_op.mapping,
+            old_op.reduced: new_op.reduced,
+        }
+
+    @split(ttnn.MoeExpertTokenRemapOp)
+    def moe_expert_token_remap_split(
+        self,
+        old_op: ttnn.MoeExpertTokenRemapOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.moe_expert_token_remap_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            moe_module = Module.create()
+            moe_builder = TTNNBuilder(
+                old_ctx, old_loc, mesh_name=self._mesh_name, mesh_dict=self._mesh_dict
+            )
+            op_input_types = [
+                old_op.topk_tensor.type,
+                old_op.expert_mapping.type,
+                old_op.expert_metadata.type,
+            ]
+
+            with InsertionPoint(moe_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="moe_expert_token_remap_module")
+                def decorated_func(*inputs):
+                    topk_tensor = inputs[0]
+                    expert_mapping = inputs[1]
+                    expert_metadata = inputs[2]
+
+                    mapping_result = old_op.mapping.type
+                    reduced_result = old_op.reduced.type
+                    reduction_size_attr = old_op.reduction_size
+
+                    new_op = ttnn_op(
+                        mapping_result,
+                        reduced_result,
+                        topk_tensor,
+                        expert_mapping,
+                        expert_metadata,
+                        reduction_size_attr,
+                        loc=old_op.location,
+                    )
+
+                    old_mapping_golden = self._get_golden_tensor(old_op.mapping)
+                    old_reduced_golden = self._get_golden_tensor(old_op.reduced)
+                    moe_builder._set_golden_tensor(new_op.mapping, old_mapping_golden)
+                    moe_builder._set_golden_tensor(new_op.reduced, old_reduced_golden)
+
+                    topk_golden = self._get_golden_tensor(old_op.topk_tensor)
+                    expert_mapping_golden = self._get_golden_tensor(
+                        old_op.expert_mapping
+                    )
+                    expert_metadata_golden = self._get_golden_tensor(
+                        old_op.expert_metadata
+                    )
+                    moe_builder._set_golden_tensor(topk_tensor, topk_golden)
+                    moe_builder._set_golden_tensor(
+                        expert_mapping, expert_mapping_golden
+                    )
+                    moe_builder._set_golden_tensor(
+                        expert_metadata, expert_metadata_golden
+                    )
+                    moe_builder._annotate_presharded_arg(topk_tensor)
+                    moe_builder._annotate_presharded_arg(expert_mapping)
+                    moe_builder._annotate_presharded_arg(expert_metadata)
+                    ordered_inputs.extend(
+                        [topk_tensor, expert_mapping, expert_metadata]
+                    )
+                    ordered_outputs.extend([new_op.mapping, new_op.reduced])
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                moe_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return moe_module, moe_builder
+
     # ----- Parse ttnn module ----
 
     @staticmethod

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -1704,15 +1704,19 @@ def ttir_moe_expert_token_remap_golden(
     E_local = E // num_devices
     BD = topk_tensor.shape[1]
     S = topk_tensor.shape[2]
+    mesh_shape = topk_tensor.mesh_shape
+    num_shards = mesh_shape[0] * mesh_shape[1]
+    mapping_tensor = torch.zeros(1, BD, S, E_local, dtype=topk_tensor.dtype)
     mapping = GoldenMapTensor(
-        {0: torch.zeros(1, BD, S, E_local, dtype=topk_tensor.dtype)},
-        mesh_shape=topk_tensor.mesh_shape,
+        {i: mapping_tensor.clone() for i in range(num_shards)},
+        mesh_shape=mesh_shape,
     )
     M = reduction_size
     reduced_seq = (BD * S + M - 1) // M
+    reduced_tensor = torch.zeros(1, 1, reduced_seq, E_local, dtype=topk_tensor.dtype)
     reduced = GoldenMapTensor(
-        {0: torch.zeros(1, 1, reduced_seq, E_local, dtype=topk_tensor.dtype)},
-        mesh_shape=topk_tensor.mesh_shape,
+        {i: reduced_tensor.clone() for i in range(num_shards)},
+        mesh_shape=mesh_shape,
     )
     return mapping, reduced
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -7977,6 +7977,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.SamplingOp: ttnn_sampling_golden,
     ttnn.AllReduceAsyncOp: ttnn_all_reduce_async_golden,
     ttnn.ReduceScatterOp: ttnn_reduce_scatter_golden,
+    ttnn.MoeExpertTokenRemapOp: ttir_moe_expert_token_remap_golden,
     # ----- DEBUG OPS -----
     debug.AnnotateOp: debug_annotate_golden,
     debug.RegionStartOp: debug_region_start_golden,

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -1698,14 +1698,22 @@ def ttir_moe_expert_token_remap_golden(
     reduction_size=32,
 ) -> GoldenMapTensor:
     """Golden for remap. Returns (mapping, reduced) with matching shapes."""
-    # mapping: same shape as topk but last dim = E_local
-    E_local = expert_mapping.shape[3]  # [1, 1, E, D] -> D = E_local
+    # topk_tensor: [1, BD, S, E], expert_mapping: [1, 1, E, num_devices]
+    E = topk_tensor.shape[3]
+    num_devices = expert_mapping.shape[3]
+    E_local = E // num_devices
     BD = topk_tensor.shape[1]
     S = topk_tensor.shape[2]
-    mapping = torch.zeros(1, BD, S, E_local, dtype=topk_tensor.dtype)
+    mapping = GoldenMapTensor(
+        {0: torch.zeros(1, BD, S, E_local, dtype=topk_tensor.dtype)},
+        mesh_shape=topk_tensor.mesh_shape,
+    )
     M = reduction_size
     reduced_seq = (BD * S + M - 1) // M
-    reduced = torch.zeros(1, 1, reduced_seq, E_local, dtype=topk_tensor.dtype)
+    reduced = GoldenMapTensor(
+        {0: torch.zeros(1, 1, reduced_seq, E_local, dtype=topk_tensor.dtype)},
+        mesh_shape=topk_tensor.mesh_shape,
+    )
     return mapping, reduced
 
 

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -17,6 +17,7 @@
 #include "operations/creation/creation.hpp"
 #include "operations/data_movement/concat/concat.hpp"
 #include "operations/data_movement/gather/gather.hpp"
+#include "operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.hpp"
 #include "operations/data_movement/pad/pad.hpp"
 #include "operations/data_movement/permute/permute.hpp"
 #include "operations/data_movement/repeat/repeat.hpp"


### PR DESCRIPTION
### Ticket
#8495

### Problem description
Arg keywords misnamed:
```py
    expert_mapping=...
    expert_metadata=...
```

### What's changed
Fixed arg keywords:
```py
    expert_mapping_tensor=...
    expert_metadata_tensor=...
```

Added builder tests for ttnn/emitpy/emitc, confirmed the issue repros, added the fix.

No golden as this is a CCL op so PCC check is skipped - compilation and execution are still tested.

### Checklist
- [x] New/Existing tests provide coverage for changes
