### PR TITLE
[d2m] embedding dram support

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1587,7 +1587,7 @@ def D2M_IndexedRowCopyOp : D2M_GenericRegionDatamovementOp<"indexed_row_copy",
     let arguments = (ins
       DeviceL1MemRef:$indices,
       DeviceMemRef:$src,
-      DeviceL1MemRef:$dst,
+      DeviceMemRef:$dst,
       DeviceL1MemRef:$indexScratch,
       DeviceL1MemRef:$rowScratch,
       I64Attr:$numRows,

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1586,7 +1586,7 @@ def D2M_IndexedRowCopyOp : D2M_GenericRegionDatamovementOp<"indexed_row_copy",
 
     let arguments = (ins
       DeviceL1MemRef:$indices,
-      DeviceL1MemRef:$src,
+      DeviceMemRef:$src,
       DeviceL1MemRef:$dst,
       DeviceL1MemRef:$indexScratch,
       DeviceL1MemRef:$rowScratch,

--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -5,6 +5,8 @@
 #ifndef TTMLIR_DIALECT_D2M_UTILS_UTILS_H
 #define TTMLIR_DIALECT_D2M_UTILS_UTILS_H
 
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -164,6 +166,17 @@ collapseToPhysicalGrid2D(ArrayRef<int64_t> gridShape,
 
 AffineMap canonicalStridedMap(MLIRContext *context, ArrayRef<int64_t> shape,
                               Type elementType, AffineMap map);
+
+// Return the NoC address alignment (also the minimum NoC transfer size) for a
+// memory space.
+int32_t getNocAddressAlignmentBytes(Operation *op,
+                                    ttcore::MemorySpace memorySpace);
+
+// Return the NoC alignment (also the minimum NoC transfer size) measured in
+// number of tensor/memref elements.
+int32_t
+getNocElementAlignment(Operation *op, ttcore::MemorySpace memorySpace,
+                       const std::variant<RankedTensorType, MemRefType> &type);
 
 // Return the L1 NoC alignment (also the minimum L1 NoC transfer size) measured
 // in number of tensor/memref elements.

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2113,21 +2113,33 @@ static Value getCollapsedOutputRow(OpBuilder &rewriter, Location loc,
   return row;
 }
 
-static Value buildMappedL1NocAddr(OpBuilder &rewriter, Location loc, Value base,
-                                  AffineMap memoryMap,
-                                  ValueRange logicalIndices,
-                                  ttcore::ChipDescAttr chipDesc) {
+static Value buildMappedNocAddr(OpBuilder &rewriter, Location loc, Value base,
+                                AffineMap memoryMap, ValueRange logicalIndices,
+                                ttcore::ChipDescAttr chipDesc,
+                                ttcore::MemorySpace memorySpace) {
   SmallVector<Value> mappedIndices =
       d2m::utils::applyMap(rewriter, loc, memoryMap, logicalIndices, true);
   return buildNocAddress(rewriter, loc, base, mappedIndices, chipDesc,
-                         ttcore::MemorySpace::DeviceL1);
+                         memorySpace);
 }
 
-static Value loadI32FromL1PacketThroughScratch(OpBuilder &rewriter,
-                                               Location loc, Value scratchCb,
-                                               Value srcNocAddr, Value laneI32,
-                                               Value transferSizeBytes,
-                                               Value onePage) {
+static int64_t getNocReadAlignmentBytes(ttcore::ChipDescAttr chipDesc,
+                                        ttcore::MemorySpace memorySpace) {
+  switch (memorySpace) {
+  case ttcore::MemorySpace::DeviceL1:
+    return chipDesc.getNocL1AddressAlignBytes();
+  case ttcore::MemorySpace::DeviceDRAM:
+    return chipDesc.getNocDRAMAddressAlignBytes();
+  default:
+    llvm_unreachable("Unsupported indexed row copy memory space");
+  }
+}
+
+static Value loadI32FromNocPacketThroughScratch(OpBuilder &rewriter,
+                                                Location loc, Value scratchCb,
+                                                Value srcNocAddr, Value laneI32,
+                                                Value transferSizeBytes,
+                                                Value onePage) {
   rewriter.create<ttkernel::CBReserveBackOp>(loc, scratchCb, onePage);
   Value writePtr = rewriter.create<ttkernel::GetWritePtrOp>(loc, scratchCb);
   rewriter.create<ttkernel::NocAsyncReadOp>(loc, srcNocAddr, writePtr,
@@ -2144,10 +2156,10 @@ static Value loadI32FromL1PacketThroughScratch(OpBuilder &rewriter,
   return value;
 }
 
-static void copyL1ToL1ThroughScratch(OpBuilder &rewriter, Location loc,
-                                     Value scratchCb, Value srcNocAddr,
-                                     Value dstNocAddr, Value transferSizeBytes,
-                                     Value onePage) {
+static void copyNocToNocThroughScratch(OpBuilder &rewriter, Location loc,
+                                       Value scratchCb, Value srcNocAddr,
+                                       Value dstNocAddr,
+                                       Value transferSizeBytes, Value onePage) {
   rewriter.create<ttkernel::CBReserveBackOp>(loc, scratchCb, onePage);
   Value writePtr = rewriter.create<ttkernel::GetWritePtrOp>(loc, scratchCb);
   rewriter.create<ttkernel::NocAsyncReadOp>(loc, srcNocAddr, writePtr,
@@ -2392,12 +2404,17 @@ public:
     auto srcType = mlir::cast<MemRefType>(op.getSrc().getType());
     auto dstType = mlir::cast<MemRefType>(op.getDst().getType());
 
+    ttcore::MemorySpace srcMemorySpace = ttcore::getMemorySpace(srcType);
     if (ttcore::getMemorySpace(indicesType) != ttcore::MemorySpace::DeviceL1 ||
-        ttcore::getMemorySpace(srcType) != ttcore::MemorySpace::DeviceL1 ||
         ttcore::getMemorySpace(dstType) != ttcore::MemorySpace::DeviceL1) {
       return rewriter.notifyMatchFailure(
-          op, "indexed row copy currently supports L1 indices, source, and "
+          op, "indexed row copy currently supports L1 indices and "
               "destination");
+    }
+    if (srcMemorySpace != ttcore::MemorySpace::DeviceL1 &&
+        srcMemorySpace != ttcore::MemorySpace::DeviceDRAM) {
+      return rewriter.notifyMatchFailure(
+          op, "indexed row copy currently supports L1 or DRAM source");
     }
     if (!hasCollapsed2DShard(indicesType) || !hasCollapsed2DShard(srcType) ||
         !hasCollapsed2DShard(dstType)) {
@@ -2427,20 +2444,31 @@ public:
     AffineMap dstMemoryMap =
         d2m::utils::getMemoryMap(device, op.getDst(), true);
 
-    constexpr int64_t kIndexTransferSizeBytes = 16;
-    constexpr int64_t kMaxRowTransferSizeBytes = 16;
+    int64_t indexElementSizeBytes =
+        ttcore::getElementSizeBytes(indicesType.getElementType());
+    int64_t indexTransferSizeBytes =
+        getNocReadAlignmentBytes(chipDesc, ttcore::MemorySpace::DeviceL1);
+    TT_assert(indexTransferSizeBytes > 0);
+    TT_assert(indexTransferSizeBytes % indexElementSizeBytes == 0);
+    int64_t indexElementsPerTransfer =
+        indexTransferSizeBytes / indexElementSizeBytes;
+
     int64_t rowElementSizeBytes =
         ttcore::getElementSizeBytes(srcType.getElementType());
-    int64_t rowElementsPerTransfer =
-        kMaxRowTransferSizeBytes / rowElementSizeBytes;
+    int64_t rowTransferSizeBytes =
+        getNocReadAlignmentBytes(chipDesc, srcMemorySpace);
+    TT_assert(rowTransferSizeBytes > 0);
+    TT_assert(rowTransferSizeBytes % rowElementSizeBytes == 0);
+    int64_t rowElementsPerTransfer = rowTransferSizeBytes / rowElementSizeBytes;
 
     Value onePage = i32(rewriter, loc, 1);
-    Value indexTransferSizeBytes = i32(rewriter, loc, kIndexTransferSizeBytes);
-    Value rowElementSizeBytesValue = i32(rewriter, loc, rowElementSizeBytes);
-    Value maxRowElementsPerTransfer =
+    Value indexTransferSizeBytesValue =
+        i32(rewriter, loc, indexTransferSizeBytes);
+    Value rowTransferSizeBytesValue = i32(rewriter, loc, rowTransferSizeBytes);
+    Value rowElementsPerTransferValue =
         index(rewriter, loc, rowElementsPerTransfer);
-    Value fourIndex = index(rewriter, loc, 4);
-    Value rowStep = index(rewriter, loc, rowElementsPerTransfer);
+    Value indexElementsPerTransferValue =
+        index(rewriter, loc, indexElementsPerTransfer);
     Value oneIndex = index(rewriter, loc, 1);
     Value myY = rewriter.create<ttkernel::MyLogicalYOp>(loc);
     Value myX = rewriter.create<ttkernel::MyLogicalXOp>(loc);
@@ -2480,10 +2508,10 @@ public:
             rewriter.create<arith::MulIOp>(loc, indexRow, columnExtent);
         indexColumn = rewriter.create<arith::SubIOp>(loc, i, rowBase);
       }
-      Value indexColumnGroup =
-          rewriter.create<arith::DivSIOp>(loc, indexColumn, fourIndex);
-      Value indexGroupColumn =
-          rewriter.create<arith::MulIOp>(loc, indexColumnGroup, fourIndex);
+      Value indexColumnGroup = rewriter.create<arith::DivSIOp>(
+          loc, indexColumn, indexElementsPerTransferValue);
+      Value indexGroupColumn = rewriter.create<arith::MulIOp>(
+          loc, indexColumnGroup, indexElementsPerTransferValue);
       Value indexLane =
           rewriter.create<arith::SubIOp>(loc, indexColumn, indexGroupColumn);
       Value indexLaneI32 = rewriter.create<arith::IndexCastOp>(
@@ -2491,48 +2519,37 @@ public:
 
       SmallVector<Value> indexLogicalIndices = getCollapsed2DElementIndices(
           rewriter, loc, indicesType, indexRow, indexGroupColumn);
-      Value indexNocAddr =
-          buildMappedL1NocAddr(rewriter, loc, adaptor.getIndices(),
-                               indicesMemoryMap, indexLogicalIndices, chipDesc);
-      Value indexValue = loadI32FromL1PacketThroughScratch(
+      Value indexNocAddr = buildMappedNocAddr(
+          rewriter, loc, adaptor.getIndices(), indicesMemoryMap,
+          indexLogicalIndices, chipDesc, ttcore::MemorySpace::DeviceL1);
+      Value indexValue = loadI32FromNocPacketThroughScratch(
           rewriter, loc, adaptor.getIndexScratch(), indexNocAddr, indexLaneI32,
-          indexTransferSizeBytes, onePage);
+          indexTransferSizeBytesValue, onePage);
 
       Value srcRowIndex = rewriter.create<arith::IndexCastOp>(
           loc, rewriter.getIndexType(), indexValue);
       Value outputRow = getCollapsedOutputRow(
           rewriter, loc, indicesShape, i, getCollapsed2DPhysicalRows(dstType));
-      auto columnLoop =
-          rewriter.create<scf::ForOp>(loc, startColumn, endColumn, rowStep);
+      auto columnLoop = rewriter.create<scf::ForOp>(
+          loc, startColumn, endColumn, rowElementsPerTransferValue);
       {
         OpBuilder::InsertionGuard columnGuard(rewriter);
         rewriter.setInsertionPointToStart(columnLoop.getBody());
         Value j = columnLoop.getInductionVar();
-        Value remainingElements =
-            rewriter.create<arith::SubIOp>(loc, endColumn, j);
-        Value hasTailTransfer = rewriter.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::slt, remainingElements,
-            maxRowElementsPerTransfer);
-        Value rowElementsThisTransfer = rewriter.create<arith::SelectOp>(
-            loc, hasTailTransfer, remainingElements, maxRowElementsPerTransfer);
-        Value rowElementsThisTransferI32 = rewriter.create<arith::IndexCastOp>(
-            loc, rewriter.getI32Type(), rowElementsThisTransfer);
-        Value rowTransferSizeBytes = rewriter.create<arith::MulIOp>(
-            loc, rowElementsThisTransferI32, rowElementSizeBytesValue);
 
         SmallVector<Value> srcLogicalIndices = getCollapsed2DElementIndices(
             rewriter, loc, srcType, srcRowIndex, j);
         Value srcNocAddr =
-            buildMappedL1NocAddr(rewriter, loc, adaptor.getSrc(), srcMemoryMap,
-                                 srcLogicalIndices, chipDesc);
+            buildMappedNocAddr(rewriter, loc, adaptor.getSrc(), srcMemoryMap,
+                               srcLogicalIndices, chipDesc, srcMemorySpace);
         SmallVector<Value> outputLogicalIndices =
             getCollapsed2DElementIndices(rewriter, loc, dstType, outputRow, j);
-        Value outputNocAddr =
-            buildMappedL1NocAddr(rewriter, loc, adaptor.getDst(), dstMemoryMap,
-                                 outputLogicalIndices, chipDesc);
-        copyL1ToL1ThroughScratch(rewriter, loc, adaptor.getRowScratch(),
-                                 srcNocAddr, outputNocAddr,
-                                 rowTransferSizeBytes, onePage);
+        Value outputNocAddr = buildMappedNocAddr(
+            rewriter, loc, adaptor.getDst(), dstMemoryMap, outputLogicalIndices,
+            chipDesc, ttcore::MemorySpace::DeviceL1);
+        copyNocToNocThroughScratch(rewriter, loc, adaptor.getRowScratch(),
+                                   srcNocAddr, outputNocAddr,
+                                   rowTransferSizeBytesValue, onePage);
       }
     }
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -28,6 +28,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <type_traits>
 #include <utility>
@@ -2067,6 +2068,12 @@ static int64_t getCollapsed2DPhysicalRows(MemRefType memrefType) {
   return shape[0] * shape[2];
 }
 
+static int64_t getCollapsed2DShardWidth(MemRefType memrefType) {
+  assert(hasCollapsed2DShard(memrefType) &&
+         "expected 2D sharded memref with explicit grid and shard dims");
+  return memrefType.getShape()[3];
+}
+
 static SmallVector<Value> getCollapsed2DElementIndices(OpBuilder &rewriter,
                                                        Location loc,
                                                        MemRefType memrefType,
@@ -2121,18 +2128,6 @@ static Value buildMappedNocAddr(OpBuilder &rewriter, Location loc, Value base,
       d2m::utils::applyMap(rewriter, loc, memoryMap, logicalIndices, true);
   return buildNocAddress(rewriter, loc, base, mappedIndices, chipDesc,
                          memorySpace);
-}
-
-static int64_t getNocReadAlignmentBytes(ttcore::ChipDescAttr chipDesc,
-                                        ttcore::MemorySpace memorySpace) {
-  switch (memorySpace) {
-  case ttcore::MemorySpace::DeviceL1:
-    return chipDesc.getNocL1AddressAlignBytes();
-  case ttcore::MemorySpace::DeviceDRAM:
-    return chipDesc.getNocDRAMAddressAlignBytes();
-  default:
-    llvm_unreachable("Unsupported indexed row copy memory space");
-  }
 }
 
 static Value loadI32FromNocPacketThroughScratch(OpBuilder &rewriter,
@@ -2404,17 +2399,18 @@ public:
     auto srcType = mlir::cast<MemRefType>(op.getSrc().getType());
     auto dstType = mlir::cast<MemRefType>(op.getDst().getType());
 
+    ttcore::MemorySpace indicesMemorySpace =
+        ttcore::getMemorySpace(indicesType);
     ttcore::MemorySpace srcMemorySpace = ttcore::getMemorySpace(srcType);
-    if (ttcore::getMemorySpace(indicesType) != ttcore::MemorySpace::DeviceL1 ||
-        ttcore::getMemorySpace(dstType) != ttcore::MemorySpace::DeviceL1) {
+    ttcore::MemorySpace dstMemorySpace = ttcore::getMemorySpace(dstType);
+    if (indicesMemorySpace != ttcore::MemorySpace::DeviceL1 ||
+        (srcMemorySpace != ttcore::MemorySpace::DeviceL1 &&
+         srcMemorySpace != ttcore::MemorySpace::DeviceDRAM) ||
+        (dstMemorySpace != ttcore::MemorySpace::DeviceL1 &&
+         dstMemorySpace != ttcore::MemorySpace::DeviceDRAM)) {
       return rewriter.notifyMatchFailure(
-          op, "indexed row copy currently supports L1 indices and "
-              "destination");
-    }
-    if (srcMemorySpace != ttcore::MemorySpace::DeviceL1 &&
-        srcMemorySpace != ttcore::MemorySpace::DeviceDRAM) {
-      return rewriter.notifyMatchFailure(
-          op, "indexed row copy currently supports L1 or DRAM source");
+          op, "indexed row copy currently supports L1 indices, L1/DRAM "
+              "source, and L1/DRAM destination");
     }
     if (!hasCollapsed2DShard(indicesType) || !hasCollapsed2DShard(srcType) ||
         !hasCollapsed2DShard(dstType)) {
@@ -2446,8 +2442,8 @@ public:
 
     int64_t indexElementSizeBytes =
         ttcore::getElementSizeBytes(indicesType.getElementType());
-    int64_t indexTransferSizeBytes =
-        getNocReadAlignmentBytes(chipDesc, ttcore::MemorySpace::DeviceL1);
+    int64_t indexTransferSizeBytes = d2m::utils::getNocAddressAlignmentBytes(
+        op, ttcore::MemorySpace::DeviceL1);
     TT_assert(indexTransferSizeBytes > 0);
     TT_assert(indexTransferSizeBytes % indexElementSizeBytes == 0);
     int64_t indexElementsPerTransfer =
@@ -2455,11 +2451,26 @@ public:
 
     int64_t rowElementSizeBytes =
         ttcore::getElementSizeBytes(srcType.getElementType());
+    int64_t srcTransferAlignmentBytes =
+        d2m::utils::getNocAddressAlignmentBytes(op, srcMemorySpace);
+    int64_t dstTransferAlignmentBytes =
+        d2m::utils::getNocAddressAlignmentBytes(op, dstMemorySpace);
     int64_t rowTransferSizeBytes =
-        getNocReadAlignmentBytes(chipDesc, srcMemorySpace);
+        std::max(srcTransferAlignmentBytes, dstTransferAlignmentBytes);
     TT_assert(rowTransferSizeBytes > 0);
     TT_assert(rowTransferSizeBytes % rowElementSizeBytes == 0);
     int64_t rowElementsPerTransfer = rowTransferSizeBytes / rowElementSizeBytes;
+    if (getCollapsed2DShardWidth(indicesType) % indexElementsPerTransfer != 0) {
+      return rewriter.notifyMatchFailure(
+          op, "indexed row copy requires index shard width to be NoC transfer "
+              "aligned");
+    }
+    if (getCollapsed2DShardWidth(srcType) % rowElementsPerTransfer != 0 ||
+        getCollapsed2DShardWidth(dstType) % rowElementsPerTransfer != 0) {
+      return rewriter.notifyMatchFailure(
+          op, "indexed row copy requires source and destination shard widths "
+              "to be NoC transfer aligned");
+    }
 
     Value onePage = i32(rewriter, loc, 1);
     Value indexTransferSizeBytesValue =
@@ -2544,9 +2555,9 @@ public:
                                srcLogicalIndices, chipDesc, srcMemorySpace);
         SmallVector<Value> outputLogicalIndices =
             getCollapsed2DElementIndices(rewriter, loc, dstType, outputRow, j);
-        Value outputNocAddr = buildMappedNocAddr(
-            rewriter, loc, adaptor.getDst(), dstMemoryMap, outputLogicalIndices,
-            chipDesc, ttcore::MemorySpace::DeviceL1);
+        Value outputNocAddr =
+            buildMappedNocAddr(rewriter, loc, adaptor.getDst(), dstMemoryMap,
+                               outputLogicalIndices, chipDesc, dstMemorySpace);
         copyNocToNocThroughScratch(rewriter, loc, adaptor.getRowScratch(),
                                    srcNocAddr, outputNocAddr,
                                    rowTransferSizeBytesValue, onePage);

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -360,6 +360,8 @@ protected:
     }
 
     auto tensorType = mlir::cast<mlir::RankedTensorType>(value.getType());
+    // Relayouts of already-layouted values can still need the original logical
+    // tensor shape, e.g. embedding indices staged from DRAM back to L1.
     if (!logicalType) {
       logicalType = tensorType;
     }
@@ -3269,19 +3271,20 @@ public:
     }
 
     Location loc = op.getLoc();
-    SmallVector<Value> boundaryInputs{
-        createOptimalLayoutOp(op.getInput(), memorySpaces[0],
-                              /*tiled=*/false, /*noCollapse=*/false, rewriter),
+    Value weightInput =
         createOptimalLayoutOp(op.getWeight(), memorySpaces[0],
-                              /*tiled=*/false, /*noCollapse=*/false, rewriter)};
+                              /*tiled=*/false, /*noCollapse=*/false, rewriter);
+    Value indicesBoundaryInput =
+        createOptimalLayoutOp(op.getInput(), memorySpaces[0],
+                              /*tiled=*/false, /*noCollapse=*/false, rewriter);
     Value indicesInput =
         memorySpaces[0] == ttcore::MemorySpace::DeviceL1
-            ? boundaryInputs[0]
+            ? indicesBoundaryInput
             : createOptimalLayoutOp(
-                  boundaryInputs[0], ttcore::MemorySpace::DeviceL1,
+                  indicesBoundaryInput, ttcore::MemorySpace::DeviceL1,
                   /*tiled=*/false, /*noCollapse=*/false, rewriter,
                   ttcore::OOBVal::Undef, indicesType);
-    SmallVector<Value> inputs{indicesInput, boundaryInputs[1]};
+    SmallVector<Value> inputs{indicesInput, weightInput};
     SmallVector<Value> origOutputs =
         createDpsOutputs(loc, rewriter, {resultType});
     SmallVector<Value> outputs{

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3236,12 +3236,6 @@ public:
   LogicalResult
   matchAndRewrite(ttir::EmbeddingOp op, ttir::EmbeddingOp::Adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (memorySpaces[0] != ttcore::MemorySpace::DeviceL1 ||
-        memorySpaces[1] != ttcore::MemorySpace::DeviceL1) {
-      return rewriter.notifyMatchFailure(
-          op, "D2M embedding currently supports L1 inputs and outputs only");
-    }
-
     auto indicesType = mlir::cast<RankedTensorType>(op.getInput().getType());
     auto weightType = mlir::cast<RankedTensorType>(op.getWeight().getType());
     auto resultType = mlir::cast<RankedTensorType>(op.getResult().getType());
@@ -3270,16 +3264,60 @@ public:
     }
 
     Location loc = op.getLoc();
-    SmallVector<Value> inputs{
+    auto createUntiledLayoutOp = [&](Value value, RankedTensorType logicalType,
+                                     ttcore::MemorySpace memSpace) -> Value {
+      ArrayRef<int64_t> logicalShape = logicalType.getShape();
+      ttcore::MetalLayoutAttr layout;
+      if (!collapseTensors) {
+        auto emptyIntervalType = RankedTensorType::get(
+            {0, 2}, IntegerType::get(rewriter.getContext(), 64));
+        DenseIntElementsAttr emptyCollapseIntervals =
+            DenseIntElementsAttr::get(emptyIntervalType, ArrayRef<int64_t>{});
+        layout = ttcore::MetalLayoutAttr::get(
+            rewriter.getContext(), logicalShape, memSpace,
+            ttcore::TensorMemoryLayout::Sharded, emptyCollapseIntervals);
+      } else {
+        layout = ttcore::MetalLayoutAttr::get(
+            rewriter.getContext(), logicalShape, memSpace,
+            ttcore::TensorMemoryLayout::Sharded);
+      }
+
+      llvm::SmallVector<int64_t> tileShape;
+      llvm::SmallVector<int64_t> unshardedShape =
+          layout.getPhysicalShape(tileShape);
+      llvm::SmallVector<int64_t> simpleGrid(unshardedShape.size(), 1);
+      llvm::SmallVector<int64_t> shardedShape =
+          layout.getDeviceShape(simpleGrid, tileShape);
+      auto emptyOp = rewriter.create<d2m::EmptyOp>(
+          value.getLoc(), shardedShape, logicalType.getElementType(), layout);
+      if (logicalShape.size() > 2) {
+        auto [forwardMap, inverseMap] =
+            ttmlir::d2m::utils::grids::createCoreVirtMaps(rewriter.getContext(),
+                                                          simpleGrid, {1, 1});
+        emptyOp.setVirtualGridInverseMappingAttr(
+            AffineMapAttr::get(inverseMap));
+        emptyOp.setVirtualGridForwardMappingAttr(
+            AffineMapAttr::get(forwardMap));
+      }
+      return rewriter.create<d2m::ToLayoutOp>(value.getLoc(), value, emptyOp)
+          .getResult(0);
+    };
+
+    SmallVector<Value> boundaryInputs{
         createOptimalLayoutOp(op.getInput(), memorySpaces[0],
                               /*tiled=*/false, /*noCollapse=*/false, rewriter),
         createOptimalLayoutOp(op.getWeight(), memorySpaces[0],
                               /*tiled=*/false, /*noCollapse=*/false, rewriter)};
-
+    Value indicesInput =
+        memorySpaces[0] == ttcore::MemorySpace::DeviceL1
+            ? boundaryInputs[0]
+            : createUntiledLayoutOp(boundaryInputs[0], indicesType,
+                                    ttcore::MemorySpace::DeviceL1);
+    SmallVector<Value> inputs{indicesInput, boundaryInputs[1]};
     SmallVector<Value> origOutputs =
         createDpsOutputs(loc, rewriter, {resultType});
     SmallVector<Value> outputs{
-        createOptimalLayoutOp(origOutputs[0], memorySpaces[1],
+        createOptimalLayoutOp(origOutputs[0], ttcore::MemorySpace::DeviceL1,
                               /*tiled=*/false, /*noCollapse=*/false, rewriter)};
 
     const std::size_t physicalRank =
@@ -3321,8 +3359,19 @@ public:
     rewriter.finalizeOpModification(generic);
     rewriter.restoreInsertionPoint(insertPoint);
 
-    rewriter.replaceOp(op, unLayoutResult(rewriter, generic->getResult(0),
-                                          op->getResult(0).getType()));
+    Value result = generic->getResult(0);
+    if (memorySpaces[1] != ttcore::MemorySpace::DeviceL1) {
+      Value boundaryOutput = createOptimalLayoutOp(
+          origOutputs[0], memorySpaces[1],
+          /*tiled=*/false, /*noCollapse=*/false, rewriter);
+      result = rewriter
+                   .create<d2m::ToLayoutOp>(loc, generic->getResult(0),
+                                            boundaryOutput)
+                   .getResult(0);
+    }
+
+    rewriter.replaceOp(
+        op, unLayoutResult(rewriter, result, op->getResult(0).getType()));
     return success();
   }
 };

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -298,7 +298,8 @@ protected:
   Value createOptimalLayoutOp(Value value, ttcore::MemorySpace memSpace,
                               bool tiled, bool noCollapse,
                               mlir::ConversionPatternRewriter &rewriter,
-                              ttcore::OOBVal oobVal) const {
+                              ttcore::OOBVal oobVal,
+                              RankedTensorType logicalType = {}) const {
     bool isTTNN = isTTNNTensor(value.getType());
     if (isTTNN) {
       assert(ttnnMode && "Unexpected TTNN tensor as op operand");
@@ -359,9 +360,12 @@ protected:
     }
 
     auto tensorType = mlir::cast<mlir::RankedTensorType>(value.getType());
-    ArrayRef<int64_t> logicalShape = tensorType.getShape();
+    if (!logicalType) {
+      logicalType = tensorType;
+    }
+    ArrayRef<int64_t> logicalShape = logicalType.getShape();
 
-    Type elementType = tensorType.getElementType();
+    Type elementType = logicalType.getElementType();
     llvm::SmallVector<int64_t> tileShape;
     if (tiled) {
       constexpr std::array<int64_t, 2> defaultShape =
@@ -392,11 +396,12 @@ protected:
     llvm::SmallVector<int64_t> unshardedShape =
         layout.getPhysicalShape(tileShape);
 
-    // Use a placeholder, 1-filled grid for this pass.
-    llvm::SmallVector<int64_t> simpleGrid(unshardedShape.size(), 1);
+    // Use a placeholder, 1-filled tensor grid for this pass. The length is the
+    // physical tensor rank, not a device-grid height.
+    llvm::SmallVector<int64_t> placeholderTensorGrid(unshardedShape.size(), 1);
 
     llvm::SmallVector<int64_t> shardedShape =
-        layout.getDeviceShape(simpleGrid, tileShape);
+        layout.getDeviceShape(placeholderTensorGrid, tileShape);
 
     auto emptyOp = rewriter.create<d2m::EmptyOp>(value.getLoc(), shardedShape,
                                                  elementType, layout);
@@ -406,8 +411,8 @@ protected:
     // optimizes the grid.
     if (logicalShape.size() > 2) {
       auto [forwardMap, inverseMap] =
-          ttmlir::d2m::utils::grids::createCoreVirtMaps(rewriter.getContext(),
-                                                        simpleGrid, {1, 1});
+          ttmlir::d2m::utils::grids::createCoreVirtMaps(
+              rewriter.getContext(), placeholderTensorGrid, {1, 1});
       emptyOp.setVirtualGridInverseMappingAttr(AffineMapAttr::get(inverseMap));
       emptyOp.setVirtualGridForwardMappingAttr(AffineMapAttr::get(forwardMap));
     }
@@ -3264,45 +3269,6 @@ public:
     }
 
     Location loc = op.getLoc();
-    auto createUntiledLayoutOp = [&](Value value, RankedTensorType logicalType,
-                                     ttcore::MemorySpace memSpace) -> Value {
-      ArrayRef<int64_t> logicalShape = logicalType.getShape();
-      ttcore::MetalLayoutAttr layout;
-      if (!collapseTensors) {
-        auto emptyIntervalType = RankedTensorType::get(
-            {0, 2}, IntegerType::get(rewriter.getContext(), 64));
-        DenseIntElementsAttr emptyCollapseIntervals =
-            DenseIntElementsAttr::get(emptyIntervalType, ArrayRef<int64_t>{});
-        layout = ttcore::MetalLayoutAttr::get(
-            rewriter.getContext(), logicalShape, memSpace,
-            ttcore::TensorMemoryLayout::Sharded, emptyCollapseIntervals);
-      } else {
-        layout = ttcore::MetalLayoutAttr::get(
-            rewriter.getContext(), logicalShape, memSpace,
-            ttcore::TensorMemoryLayout::Sharded);
-      }
-
-      llvm::SmallVector<int64_t> tileShape;
-      llvm::SmallVector<int64_t> unshardedShape =
-          layout.getPhysicalShape(tileShape);
-      llvm::SmallVector<int64_t> simpleGrid(unshardedShape.size(), 1);
-      llvm::SmallVector<int64_t> shardedShape =
-          layout.getDeviceShape(simpleGrid, tileShape);
-      auto emptyOp = rewriter.create<d2m::EmptyOp>(
-          value.getLoc(), shardedShape, logicalType.getElementType(), layout);
-      if (logicalShape.size() > 2) {
-        auto [forwardMap, inverseMap] =
-            ttmlir::d2m::utils::grids::createCoreVirtMaps(rewriter.getContext(),
-                                                          simpleGrid, {1, 1});
-        emptyOp.setVirtualGridInverseMappingAttr(
-            AffineMapAttr::get(inverseMap));
-        emptyOp.setVirtualGridForwardMappingAttr(
-            AffineMapAttr::get(forwardMap));
-      }
-      return rewriter.create<d2m::ToLayoutOp>(value.getLoc(), value, emptyOp)
-          .getResult(0);
-    };
-
     SmallVector<Value> boundaryInputs{
         createOptimalLayoutOp(op.getInput(), memorySpaces[0],
                               /*tiled=*/false, /*noCollapse=*/false, rewriter),
@@ -3311,13 +3277,15 @@ public:
     Value indicesInput =
         memorySpaces[0] == ttcore::MemorySpace::DeviceL1
             ? boundaryInputs[0]
-            : createUntiledLayoutOp(boundaryInputs[0], indicesType,
-                                    ttcore::MemorySpace::DeviceL1);
+            : createOptimalLayoutOp(
+                  boundaryInputs[0], ttcore::MemorySpace::DeviceL1,
+                  /*tiled=*/false, /*noCollapse=*/false, rewriter,
+                  ttcore::OOBVal::Undef, indicesType);
     SmallVector<Value> inputs{indicesInput, boundaryInputs[1]};
     SmallVector<Value> origOutputs =
         createDpsOutputs(loc, rewriter, {resultType});
     SmallVector<Value> outputs{
-        createOptimalLayoutOp(origOutputs[0], ttcore::MemorySpace::DeviceL1,
+        createOptimalLayoutOp(origOutputs[0], memorySpaces[1],
                               /*tiled=*/false, /*noCollapse=*/false, rewriter)};
 
     const std::size_t physicalRank =
@@ -3359,19 +3327,8 @@ public:
     rewriter.finalizeOpModification(generic);
     rewriter.restoreInsertionPoint(insertPoint);
 
-    Value result = generic->getResult(0);
-    if (memorySpaces[1] != ttcore::MemorySpace::DeviceL1) {
-      Value boundaryOutput = createOptimalLayoutOp(
-          origOutputs[0], memorySpaces[1],
-          /*tiled=*/false, /*noCollapse=*/false, rewriter);
-      result = rewriter
-                   .create<d2m::ToLayoutOp>(loc, generic->getResult(0),
-                                            boundaryOutput)
-                   .getResult(0);
-    }
-
-    rewriter.replaceOp(
-        op, unLayoutResult(rewriter, result, op->getResult(0).getType()));
+    rewriter.replaceOp(op, unLayoutResult(rewriter, generic->getResult(0),
+                                          op->getResult(0).getType()));
     return success();
   }
 };

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
@@ -260,6 +260,8 @@ modifyDeviceType(MLIRContext *ctx, RankedTensorType baseType,
   }
 
   ArrayRef<int64_t> tileShape;
+  // `elementType` is the target element type. Tiled-to-untiled changes pass a
+  // scalar `newElementType`, so this branch is only for tiled targets.
   if (auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType)) {
     if (newTileShape) {
       tileShape = *newTileShape;

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
@@ -260,9 +260,14 @@ modifyDeviceType(MLIRContext *ctx, RankedTensorType baseType,
   }
 
   ArrayRef<int64_t> tileShape;
-  if (mlir::isa<ttcore::TileType>(elementType)) {
-    tileShape =
-        newTileShape.value_or(ttcore::getTensorTileShapeOrEmpty(baseType));
+  if (auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType)) {
+    if (newTileShape) {
+      tileShape = *newTileShape;
+    } else if (ttcore::isTiled(baseType)) {
+      tileShape = ttcore::getTensorTileShape(baseType);
+    } else {
+      tileShape = tileType.getShape();
+    }
   }
   return RankedTensorType::get(layout.getDeviceShape(tensorGrid, tileShape),
                                elementType, layout);

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -560,6 +560,8 @@ getGridMapsFromVirtualGridMapping(Value val, ArrayRef<int64_t> gridShape) {
   SmallVector<int64_t> physicalGridShape =
       ttmlir::utils::evalShape(gridFwdMap, gridShape);
   ArrayRef<int64_t> physicalWorkerGridShape(physicalGridShape);
+  // The transformed map must cover the same worker count after collapsing the
+  // virtual grid back to physical device/core coordinates.
   if (ttmlir::utils::volume<int64_t>(physicalWorkerGridShape.drop_front()) !=
       ttmlir::utils::volume<int64_t>(gridShape)) {
     return std::nullopt;

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -560,9 +560,8 @@ getGridMapsFromVirtualGridMapping(Value val, ArrayRef<int64_t> gridShape) {
   SmallVector<int64_t> physicalGridShape =
       ttmlir::utils::evalShape(gridFwdMap, gridShape);
   ArrayRef<int64_t> physicalWorkerGridShape(physicalGridShape);
-  if (physicalGridShape.size() != 3 ||
-      ttmlir::utils::volume<int64_t>(physicalWorkerGridShape.drop_front()) !=
-          ttmlir::utils::volume<int64_t>(gridShape)) {
+  if (ttmlir::utils::volume<int64_t>(physicalWorkerGridShape.drop_front()) !=
+      ttmlir::utils::volume<int64_t>(gridShape)) {
     return std::nullopt;
   }
 
@@ -947,11 +946,24 @@ collapseToPhysicalGrid2D(ArrayRef<int64_t> gridShape,
   return result;
 }
 
-int32_t getNocElementAlignmentL1(
-    Operation *op, const std::variant<RankedTensorType, MemRefType> &type) {
-  const int32_t nocAlignmentL1 =
-      ttcore::getOpChipDescAttr(op).getNocL1AddressAlignBytes();
+int32_t getNocAddressAlignmentBytes(Operation *op,
+                                    ttcore::MemorySpace memorySpace) {
+  ttcore::ChipDescAttr chipDesc = ttcore::getOpChipDescAttr(op);
+  switch (memorySpace) {
+  case ttcore::MemorySpace::DeviceL1:
+    return chipDesc.getNocL1AddressAlignBytes();
+  case ttcore::MemorySpace::DeviceDRAM:
+    return chipDesc.getNocDRAMAddressAlignBytes();
+  default:
+    llvm_unreachable("Unsupported NoC memory space");
+  }
+}
 
+int32_t
+getNocElementAlignment(Operation *op, ttcore::MemorySpace memorySpace,
+                       const std::variant<RankedTensorType, MemRefType> &type) {
+  const int32_t nocAlignmentBytes =
+      getNocAddressAlignmentBytes(op, memorySpace);
   const int32_t elemBitWidth = std::visit(
       [&](auto &&ty) -> int32_t {
         return static_cast<int32_t>(ty.getElementTypeBitWidth());
@@ -959,8 +971,13 @@ int32_t getNocElementAlignmentL1(
       type);
   const int32_t elemBytes = std::max(1, elemBitWidth / 8);
 
-  TT_assert(((nocAlignmentL1 != 0) && (nocAlignmentL1 % elemBytes == 0)));
-  return nocAlignmentL1 / elemBytes;
+  TT_assert(((nocAlignmentBytes != 0) && (nocAlignmentBytes % elemBytes == 0)));
+  return nocAlignmentBytes / elemBytes;
+}
+
+int32_t getNocElementAlignmentL1(
+    Operation *op, const std::variant<RankedTensorType, MemRefType> &type) {
+  return getNocElementAlignment(op, ttcore::MemorySpace::DeviceL1, type);
 }
 
 } // namespace mlir::tt::d2m::utils

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -556,6 +556,16 @@ getGridMapsFromVirtualGridMapping(Value val, ArrayRef<int64_t> gridShape) {
   if (gridFwdMap.getNumDims() != rank || gridFwdMap.getNumResults() != 3) {
     return std::nullopt;
   }
+
+  SmallVector<int64_t> physicalGridShape =
+      ttmlir::utils::evalShape(gridFwdMap, gridShape);
+  ArrayRef<int64_t> physicalWorkerGridShape(physicalGridShape);
+  if (physicalGridShape.size() != 3 ||
+      ttmlir::utils::volume<int64_t>(physicalWorkerGridShape.drop_front()) !=
+          ttmlir::utils::volume<int64_t>(gridShape)) {
+    return std::nullopt;
+  }
+
   return std::make_pair(gridFwdMap, *invMap);
 }
 

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -360,6 +360,13 @@ DRAM_EMBEDDING_CASES = [
     ),
     pytest.param(
         (1, 32),
+        (1024, 40),
+        torch.uint32,
+        torch.bfloat16,
+        id="ui32_indices_bf16_table_1x32_1024x40",
+    ),
+    pytest.param(
+        (1, 32),
         (1024, 32),
         torch.uint32,
         torch.int32,

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
+import math
 import pytest
 import torch
 from typing import List, Optional
@@ -347,3 +348,68 @@ def test_dram_reduction(
         atol=_reduction_atol(reduce_type, shape, dim_arg, dtype),
         pcc=0.99,
     )
+
+
+DRAM_EMBEDDING_CASES = [
+    pytest.param(
+        (1, 32),
+        (1024, 32),
+        torch.uint32,
+        torch.bfloat16,
+        id="ui32_indices_bf16_table_1x32_1024x32",
+    ),
+    pytest.param(
+        (1, 32),
+        (1024, 32),
+        torch.uint32,
+        torch.int32,
+        marks=pytest.mark.skip_config(["sim"]),
+        id="ui32_indices_i32_table_1x32_1024x32",
+    ),
+    pytest.param(
+        (1, 32),
+        (8192, 64),
+        torch.uint32,
+        torch.float32,
+        id="ui32_indices_f32_table_1x32_8192x64",
+    ),
+    pytest.param(
+        (1, 128),
+        (40960, 128),
+        torch.uint32,
+        torch.bfloat16,
+        id="ui32_indices_bf16_table_1x128_40960x128",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "indices_shape,weight_shape,indices_dtype,weight_dtype", DRAM_EMBEDDING_CASES
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_embedding(
+    indices_shape: Shape,
+    weight_shape: Shape,
+    indices_dtype: torch.dtype,
+    weight_dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    num_indices = math.prod(indices_shape)
+
+    def module(builder: TTIRBuilder):
+        @builder.func([indices_shape, weight_shape], [indices_dtype, weight_dtype])
+        def embedding(
+            indices: Operand,
+            weight: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            valid_indices = (
+                torch.arange(num_indices, dtype=torch.int64).reshape(indices_shape) * 7
+            ) % weight_shape[0]
+            builder.set_goldens(inputs={indices: valid_indices.to(indices_dtype)})
+            return builder.embedding(indices, weight, unit_attrs=unit_attrs)
+
+    compile_and_execute_dram_test(module, request, device, target)

--- a/test/ttmlir/Conversion/D2MToTTKernel/embedding.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/embedding.mlir
@@ -1,6 +1,7 @@
 // RUN: ttmlir-opt --ttcore-register-device --convert-d2m-to-ttkernel %s | FileCheck %s
 
 #l1 = #ttcore.memory_space<l1>
+#dram = #ttcore.memory_space<dram>
 
 module {
   func.func private @embedding_bf16_table_ui32_indices() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
@@ -13,15 +14,32 @@ module {
     // CHECK: !ttkernel.cb<1024, ui32>
     // CHECK: !ttkernel.cb<1024, bf16>
     // CHECK: %[[INDEX_BYTES:.*]] = arith.constant 16 : i32
-    // CHECK: %[[BF16_BYTES:.*]] = arith.constant 2 : i32
+    // CHECK: %[[ROW_BYTES:.*]] = arith.constant 16 : i32
     // CHECK: ttkernel.noc_async_read({{.*}}, {{.*}}, %[[INDEX_BYTES]])
     // CHECK: ttkernel.load_from_l1({{.*}}, {{.*}}) : (!ttkernel.l1_addr_ptr, i32) -> i32
-    // CHECK: %[[ROW_ELEMS:.*]] = arith.select {{.*}} : index
-    // CHECK: %[[ROW_ELEMS_I32:.*]] = arith.index_cast %[[ROW_ELEMS]] : index to i32
-    // CHECK: %[[ROW_BYTES:.*]] = arith.muli %[[ROW_ELEMS_I32]], %[[BF16_BYTES]] : i32
     // CHECK: ttkernel.noc_async_read({{.*}}, {{.*}}, %[[ROW_BYTES]])
     // CHECK: ttkernel.noc_async_write({{.*}}, {{.*}}, %[[ROW_BYTES]])
     d2m.indexed_row_copy %indices, %weight, %output scratch %index_scratch, %row_scratch<6, 5> {indicesShape = array<i64: 2, 3>} : memref<1x1x32x32xui32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>, memref<2x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>, memref<1x1024xui32, #ttcore.cb_layout<4096x4, 1>, #l1>, memref<1x1024xbf16, #ttcore.cb_layout<2048x2, 1>, #l1>
+    return
+  }
+
+  func.func private @embedding_dram_bf16_table_ui32_indices() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
+    %indices = d2m.get_arg(0) resolution_stage = compile : memref<1x1x32x32xui32, #ttcore.shard<128x4, 1>, #l1>
+    %weight = d2m.get_arg(1) resolution_stage = compile : memref<1x1x32x32xbf16, #ttcore.shard<64x2, 1>, #dram>
+    %output = d2m.get_arg(2) resolution_stage = compile : memref<2x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>
+    %index_scratch = d2m.get_arg(3) resolution_stage = compile : memref<1x1024xui32, #ttcore.cb_layout<4096x4, 1>, #l1>
+    %row_scratch = d2m.get_arg(4) resolution_stage = compile : memref<1x1024xbf16, #ttcore.cb_layout<2048x2, 1>, #l1>
+    // CHECK-LABEL: func.func private @embedding_dram_bf16_table_ui32_indices
+    // CHECK: !ttkernel.cb<1024, ui32>
+    // CHECK: !ttkernel.cb<1024, bf16>
+    // CHECK: %[[INDEX_BYTES:.*]] = arith.constant 16 : i32
+    // CHECK: %[[ROW_BYTES:.*]] = arith.constant 32 : i32
+    // CHECK: ttkernel.noc_async_read({{.*}}, {{.*}}, %[[INDEX_BYTES]])
+    // CHECK: ttkernel.load_from_l1({{.*}}, {{.*}}) : (!ttkernel.l1_addr_ptr, i32) -> i32
+    // CHECK: ttkernel.get_noc_addr_from_bank_id
+    // CHECK: ttkernel.noc_async_read({{.*}}, {{.*}}, %[[ROW_BYTES]])
+    // CHECK: ttkernel.noc_async_write({{.*}}, {{.*}}, %[[ROW_BYTES]])
+    d2m.indexed_row_copy %indices, %weight, %output scratch %index_scratch, %row_scratch<6, 5> {indicesShape = array<i64: 2, 3>} : memref<1x1x32x32xui32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x32x32xbf16, #ttcore.shard<64x2, 1>, #dram>, memref<2x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>, memref<1x1024xui32, #ttcore.cb_layout<4096x4, 1>, #l1>, memref<1x1024xbf16, #ttcore.cb_layout<2048x2, 1>, #l1>
     return
   }
 
@@ -35,12 +53,9 @@ module {
     // CHECK: !ttkernel.cb<1024, ui32>
     // CHECK: !ttkernel.cb<1024, i32>
     // CHECK: %[[INDEX_BYTES:.*]] = arith.constant 16 : i32
-    // CHECK: %[[I32_BYTES:.*]] = arith.constant 4 : i32
+    // CHECK: %[[ROW_BYTES:.*]] = arith.constant 16 : i32
     // CHECK: ttkernel.noc_async_read({{.*}}, {{.*}}, %[[INDEX_BYTES]])
     // CHECK: ttkernel.load_from_l1({{.*}}, {{.*}}) : (!ttkernel.l1_addr_ptr, i32) -> i32
-    // CHECK: %[[ROW_ELEMS:.*]] = arith.select {{.*}} : index
-    // CHECK: %[[ROW_ELEMS_I32:.*]] = arith.index_cast %[[ROW_ELEMS]] : index to i32
-    // CHECK: %[[ROW_BYTES:.*]] = arith.muli %[[ROW_ELEMS_I32]], %[[I32_BYTES]] : i32
     // CHECK: ttkernel.noc_async_read({{.*}}, {{.*}}, %[[ROW_BYTES]])
     // CHECK: ttkernel.noc_async_write({{.*}}, {{.*}}, %[[ROW_BYTES]])
     d2m.indexed_row_copy %indices, %weight, %output scratch %index_scratch, %row_scratch<3, 1> {indicesShape = array<i64: 3, 1>} : memref<1x1x32x32xui32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x32x32xi32, #ttcore.shard<128x4, 1>, #l1>, memref<3x1x32x32xi32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1024xui32, #ttcore.cb_layout<4096x4, 1>, #l1>, memref<1x1024xi32, #ttcore.cb_layout<4096x4, 1>, #l1>

--- a/test/ttmlir/Conversion/D2MToTTKernel/embedding.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/embedding.mlir
@@ -43,6 +43,24 @@ module {
     return
   }
 
+  func.func private @embedding_dram_bf16_output_ui32_indices() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
+    %indices = d2m.get_arg(0) resolution_stage = compile : memref<1x1x32x32xui32, #ttcore.shard<128x4, 1>, #l1>
+    %weight = d2m.get_arg(1) resolution_stage = compile : memref<1x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>
+    %output = d2m.get_arg(2) resolution_stage = compile : memref<2x1x32x32xbf16, #ttcore.shard<64x2, 1>, #dram>
+    %index_scratch = d2m.get_arg(3) resolution_stage = compile : memref<1x1024xui32, #ttcore.cb_layout<4096x4, 1>, #l1>
+    %row_scratch = d2m.get_arg(4) resolution_stage = compile : memref<1x1024xbf16, #ttcore.cb_layout<2048x2, 1>, #l1>
+    // CHECK-LABEL: func.func private @embedding_dram_bf16_output_ui32_indices
+    // CHECK: %[[INDEX_BYTES:.*]] = arith.constant 16 : i32
+    // CHECK: %[[ROW_BYTES:.*]] = arith.constant 32 : i32
+    // CHECK: ttkernel.noc_async_read({{.*}}, {{.*}}, %[[INDEX_BYTES]])
+    // CHECK: ttkernel.load_from_l1({{.*}}, {{.*}}) : (!ttkernel.l1_addr_ptr, i32) -> i32
+    // CHECK: ttkernel.get_noc_addr_from_bank_id
+    // CHECK: ttkernel.noc_async_read({{.*}}, {{.*}}, %[[ROW_BYTES]])
+    // CHECK: ttkernel.noc_async_write({{.*}}, {{.*}}, %[[ROW_BYTES]])
+    d2m.indexed_row_copy %indices, %weight, %output scratch %index_scratch, %row_scratch<6, 5> {indicesShape = array<i64: 2, 3>} : memref<1x1x32x32xui32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>, memref<2x1x32x32xbf16, #ttcore.shard<64x2, 1>, #dram>, memref<1x1024xui32, #ttcore.cb_layout<4096x4, 1>, #l1>, memref<1x1024xbf16, #ttcore.cb_layout<2048x2, 1>, #l1>
+    return
+  }
+
   func.func private @embedding_i32_table_ui32_indices() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
     %indices = d2m.get_arg(0) resolution_stage = compile : memref<1x1x32x32xui32, #ttcore.shard<128x4, 1>, #l1>
     %weight = d2m.get_arg(1) resolution_stage = compile : memref<1x1x32x32xi32, #ttcore.shard<128x4, 1>, #l1>

--- a/test/ttmlir/Conversion/TTIRToD2M/embedding_types.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/embedding_types.mlir
@@ -1,10 +1,28 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --canonicalize %s | FileCheck %s
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --canonicalize %s | FileCheck %s --check-prefixes=CHECK,L1
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m="default-input-memspace=dram default-output-memspace=dram" --canonicalize %s | FileCheck %s --check-prefixes=CHECK,DRAM
+
+// L1-DAG: #[[L1_INDICES_BF16:.*]] = #ttcore.metal_layout<logical_shape = 2x3{{.*}}l1, sharded>
+// L1-DAG: #[[L1_WEIGHT_BF16:.*]] = #ttcore.metal_layout<logical_shape = 16x8{{.*}}l1, sharded>
+// L1-DAG: #[[L1_OUTPUT_BF16:.*]] = #ttcore.metal_layout<logical_shape = 2x3x8{{.*}}l1, sharded>
+// L1-DAG: #[[L1_INDICES_I32:.*]] = #ttcore.metal_layout<logical_shape = 3x1{{.*}}l1, sharded>
+// L1-DAG: #[[L1_WEIGHT_I32:.*]] = #ttcore.metal_layout<logical_shape = 16x1{{.*}}l1, sharded>
+// L1-DAG: #[[L1_OUTPUT_I32:.*]] = #ttcore.metal_layout<logical_shape = 3x1x1{{.*}}l1, sharded>
+// DRAM-DAG: #[[DRAM_WEIGHT_BF16:.*]] = #ttcore.metal_layout<logical_shape = 16x8{{.*}}dram, sharded>
+// DRAM-DAG: #[[DRAM_L1_INDICES_BF16:.*]] = #ttcore.metal_layout<logical_shape = 2x3{{.*}}l1, sharded>
+// DRAM-DAG: #[[DRAM_L1_OUTPUT_BF16:.*]] = #ttcore.metal_layout<logical_shape = 2x3x8{{.*}}l1, sharded>
+// DRAM-DAG: #[[DRAM_WEIGHT_I32:.*]] = #ttcore.metal_layout<logical_shape = 16x1{{.*}}dram, sharded>
+// DRAM-DAG: #[[DRAM_L1_INDICES_I32:.*]] = #ttcore.metal_layout<logical_shape = 3x1{{.*}}l1, sharded>
+// DRAM-DAG: #[[DRAM_L1_OUTPUT_I32:.*]] = #ttcore.metal_layout<logical_shape = 3x1x1{{.*}}l1, sharded>
 
 module {
   // CHECK-LABEL: func.func @embedding_bf16_table_ui32_indices
   func.func @embedding_bf16_table_ui32_indices(
       %indices: tensor<2x3xui32>,
       %weight: tensor<16x8xbf16>) -> tensor<2x3x8xbf16> {
+    // L1: d2m.to_layout %arg0, %{{.*}} : tensor<2x3xui32> into tensor<{{.*}}xui32, #[[L1_INDICES_BF16]]>
+    // L1: d2m.to_layout %arg1, %{{.*}} : tensor<16x8xbf16> into tensor<{{.*}}xbf16, #[[L1_WEIGHT_BF16]]>
+    // DRAM: d2m.to_layout %arg1, %{{.*}} : tensor<16x8xbf16> into tensor<{{.*}}xbf16, #[[DRAM_WEIGHT_BF16]]>
+    // DRAM: d2m.to_layout %arg0, %{{.*}} : tensor<2x3xui32> into tensor<{{.*}}xui32, #[[DRAM_L1_INDICES_BF16]]>
     // CHECK: d2m.generic
     // CHECK-SAME: indexing_maps = [
     // CHECK-SAME: iterator_types = [#parallel, #parallel]
@@ -12,8 +30,12 @@ module {
     // CHECK: d2m.embedding
     // CHECK-SAME: <6, 8>
     // CHECK-SAME: {indicesShape = array<i64: 2, 3>}
-    // CHECK-SAME: tensor<{{.*}}xui32
-    // CHECK-SAME: tensor<{{.*}}xbf16
+    // L1-SAME: tensor<{{[^,]*}}xui32, #[[L1_INDICES_BF16]]
+    // L1-SAME: tensor<{{[^,]*}}xbf16, #[[L1_WEIGHT_BF16]]
+    // L1-SAME: tensor<{{[^,]*}}xbf16, #[[L1_OUTPUT_BF16]]
+    // DRAM-SAME: tensor<{{[^,]*}}xui32, #[[DRAM_L1_INDICES_BF16]]
+    // DRAM-SAME: tensor<{{[^,]*}}xbf16, #[[DRAM_WEIGHT_BF16]]
+    // DRAM-SAME: tensor<{{[^,]*}}xbf16, #[[DRAM_L1_OUTPUT_BF16]]
     %0 = "ttir.embedding"(%indices, %weight) : (tensor<2x3xui32>, tensor<16x8xbf16>) -> tensor<2x3x8xbf16>
     return %0 : tensor<2x3x8xbf16>
   }
@@ -22,6 +44,10 @@ module {
   func.func @embedding_i32_table_ui32_indices(
       %indices: tensor<3x1xui32>,
       %weight: tensor<16x1xi32>) -> tensor<3x1x1xi32> {
+    // L1: d2m.to_layout %arg0, %{{.*}} : tensor<3x1xui32> into tensor<{{.*}}xui32, #[[L1_INDICES_I32]]>
+    // L1: d2m.to_layout %arg1, %{{.*}} : tensor<16x1xi32> into tensor<{{.*}}xi32, #[[L1_WEIGHT_I32]]>
+    // DRAM: d2m.to_layout %arg1, %{{.*}} : tensor<16x1xi32> into tensor<{{.*}}xi32, #[[DRAM_WEIGHT_I32]]>
+    // DRAM: d2m.to_layout %arg0, %{{.*}} : tensor<3x1xui32> into tensor<{{.*}}xui32, #[[DRAM_L1_INDICES_I32]]>
     // CHECK: d2m.generic
     // CHECK-SAME: indexing_maps = [
     // CHECK-SAME: iterator_types = [#parallel, #parallel]
@@ -29,8 +55,12 @@ module {
     // CHECK: d2m.embedding
     // CHECK-SAME: <3, 1>
     // CHECK-SAME: {indicesShape = array<i64: 3, 1>}
-    // CHECK-SAME: tensor<{{.*}}xui32
-    // CHECK-SAME: tensor<{{.*}}xi32
+    // L1-SAME: tensor<{{[^,]*}}xui32, #[[L1_INDICES_I32]]
+    // L1-SAME: tensor<{{[^,]*}}xi32, #[[L1_WEIGHT_I32]]
+    // L1-SAME: tensor<{{[^,]*}}xi32, #[[L1_OUTPUT_I32]]
+    // DRAM-SAME: tensor<{{[^,]*}}xui32, #[[DRAM_L1_INDICES_I32]]
+    // DRAM-SAME: tensor<{{[^,]*}}xi32, #[[DRAM_WEIGHT_I32]]
+    // DRAM-SAME: tensor<{{[^,]*}}xi32, #[[DRAM_L1_OUTPUT_I32]]
     %0 = "ttir.embedding"(%indices, %weight) : (tensor<3x1xui32>, tensor<16x1xi32>) -> tensor<3x1x1xi32>
     return %0 : tensor<3x1x1xi32>
   }

--- a/test/ttmlir/Conversion/TTIRToD2M/embedding_types.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/embedding_types.mlir
@@ -19,10 +19,10 @@ module {
   func.func @embedding_bf16_table_ui32_indices(
       %indices: tensor<2x3xui32>,
       %weight: tensor<16x8xbf16>) -> tensor<2x3x8xbf16> {
-    // L1: d2m.to_layout %arg0, %{{.*}} : tensor<2x3xui32> into tensor<{{.*}}xui32, #[[L1_INDICES_BF16]]>
-    // L1: d2m.to_layout %arg1, %{{.*}} : tensor<16x8xbf16> into tensor<{{.*}}xbf16, #[[L1_WEIGHT_BF16]]>
-    // DRAM: d2m.to_layout %arg1, %{{.*}} : tensor<16x8xbf16> into tensor<{{.*}}xbf16, #[[DRAM_WEIGHT_BF16]]>
-    // DRAM: d2m.to_layout %arg0, %{{.*}} : tensor<2x3xui32> into tensor<{{.*}}xui32, #[[DRAM_L1_INDICES_BF16]]>
+    // L1-DAG: d2m.to_layout %arg0, %{{.*}} : tensor<2x3xui32> into tensor<{{.*}}xui32, #[[L1_INDICES_BF16]]>
+    // L1-DAG: d2m.to_layout %arg1, %{{.*}} : tensor<16x8xbf16> into tensor<{{.*}}xbf16, #[[L1_WEIGHT_BF16]]>
+    // DRAM-DAG: d2m.to_layout %arg1, %{{.*}} : tensor<16x8xbf16> into tensor<{{.*}}xbf16, #[[DRAM_WEIGHT_BF16]]>
+    // DRAM-DAG: d2m.to_layout %arg0, %{{.*}} : tensor<2x3xui32> into tensor<{{.*}}xui32, #[[DRAM_L1_INDICES_BF16]]>
     // CHECK: d2m.generic
     // CHECK-SAME: indexing_maps = [
     // CHECK-SAME: iterator_types = [#parallel, #parallel]
@@ -44,10 +44,10 @@ module {
   func.func @embedding_i32_table_ui32_indices(
       %indices: tensor<3x1xui32>,
       %weight: tensor<16x1xi32>) -> tensor<3x1x1xi32> {
-    // L1: d2m.to_layout %arg0, %{{.*}} : tensor<3x1xui32> into tensor<{{.*}}xui32, #[[L1_INDICES_I32]]>
-    // L1: d2m.to_layout %arg1, %{{.*}} : tensor<16x1xi32> into tensor<{{.*}}xi32, #[[L1_WEIGHT_I32]]>
-    // DRAM: d2m.to_layout %arg1, %{{.*}} : tensor<16x1xi32> into tensor<{{.*}}xi32, #[[DRAM_WEIGHT_I32]]>
-    // DRAM: d2m.to_layout %arg0, %{{.*}} : tensor<3x1xui32> into tensor<{{.*}}xui32, #[[DRAM_L1_INDICES_I32]]>
+    // L1-DAG: d2m.to_layout %arg0, %{{.*}} : tensor<3x1xui32> into tensor<{{.*}}xui32, #[[L1_INDICES_I32]]>
+    // L1-DAG: d2m.to_layout %arg1, %{{.*}} : tensor<16x1xi32> into tensor<{{.*}}xi32, #[[L1_WEIGHT_I32]]>
+    // DRAM-DAG: d2m.to_layout %arg1, %{{.*}} : tensor<16x1xi32> into tensor<{{.*}}xi32, #[[DRAM_WEIGHT_I32]]>
+    // DRAM-DAG: d2m.to_layout %arg0, %{{.*}} : tensor<3x1xui32> into tensor<{{.*}}xui32, #[[DRAM_L1_INDICES_I32]]>
     // CHECK: d2m.generic
     // CHECK-SAME: indexing_maps = [
     // CHECK-SAME: iterator_types = [#parallel, #parallel]

--- a/test/ttmlir/Conversion/TTIRToD2M/embedding_types.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/embedding_types.mlir
@@ -9,10 +9,10 @@
 // L1-DAG: #[[L1_OUTPUT_I32:.*]] = #ttcore.metal_layout<logical_shape = 3x1x1{{.*}}l1, sharded>
 // DRAM-DAG: #[[DRAM_WEIGHT_BF16:.*]] = #ttcore.metal_layout<logical_shape = 16x8{{.*}}dram, sharded>
 // DRAM-DAG: #[[DRAM_L1_INDICES_BF16:.*]] = #ttcore.metal_layout<logical_shape = 2x3{{.*}}l1, sharded>
-// DRAM-DAG: #[[DRAM_L1_OUTPUT_BF16:.*]] = #ttcore.metal_layout<logical_shape = 2x3x8{{.*}}l1, sharded>
+// DRAM-DAG: #[[DRAM_OUTPUT_BF16:.*]] = #ttcore.metal_layout<logical_shape = 2x3x8{{.*}}dram, sharded>
 // DRAM-DAG: #[[DRAM_WEIGHT_I32:.*]] = #ttcore.metal_layout<logical_shape = 16x1{{.*}}dram, sharded>
 // DRAM-DAG: #[[DRAM_L1_INDICES_I32:.*]] = #ttcore.metal_layout<logical_shape = 3x1{{.*}}l1, sharded>
-// DRAM-DAG: #[[DRAM_L1_OUTPUT_I32:.*]] = #ttcore.metal_layout<logical_shape = 3x1x1{{.*}}l1, sharded>
+// DRAM-DAG: #[[DRAM_OUTPUT_I32:.*]] = #ttcore.metal_layout<logical_shape = 3x1x1{{.*}}dram, sharded>
 
 module {
   // CHECK-LABEL: func.func @embedding_bf16_table_ui32_indices
@@ -35,7 +35,7 @@ module {
     // L1-SAME: tensor<{{[^,]*}}xbf16, #[[L1_OUTPUT_BF16]]
     // DRAM-SAME: tensor<{{[^,]*}}xui32, #[[DRAM_L1_INDICES_BF16]]
     // DRAM-SAME: tensor<{{[^,]*}}xbf16, #[[DRAM_WEIGHT_BF16]]
-    // DRAM-SAME: tensor<{{[^,]*}}xbf16, #[[DRAM_L1_OUTPUT_BF16]]
+    // DRAM-SAME: tensor<{{[^,]*}}xbf16, #[[DRAM_OUTPUT_BF16]]
     %0 = "ttir.embedding"(%indices, %weight) : (tensor<2x3xui32>, tensor<16x8xbf16>) -> tensor<2x3x8xbf16>
     return %0 : tensor<2x3x8xbf16>
   }
@@ -60,7 +60,7 @@ module {
     // L1-SAME: tensor<{{[^,]*}}xi32, #[[L1_OUTPUT_I32]]
     // DRAM-SAME: tensor<{{[^,]*}}xui32, #[[DRAM_L1_INDICES_I32]]
     // DRAM-SAME: tensor<{{[^,]*}}xi32, #[[DRAM_WEIGHT_I32]]
-    // DRAM-SAME: tensor<{{[^,]*}}xi32, #[[DRAM_L1_OUTPUT_I32]]
+    // DRAM-SAME: tensor<{{[^,]*}}xi32, #[[DRAM_OUTPUT_I32]]
     %0 = "ttir.embedding"(%indices, %weight) : (tensor<3x1xui32>, tensor<16x1xi32>) -> tensor<3x1x1xi32>
     return %0 : tensor<3x1x1xi32>
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_to_layout_dram_tiled_untilize.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_to_layout_dram_tiled_untilize.mlir
@@ -1,0 +1,21 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-lower-to-layout --d2m-materialize-view-returns %s | FileCheck %s
+
+#layout_l1 = #ttcore.metal_layout<logical_shape = 1x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+#layout_dram = #ttcore.metal_layout<logical_shape = 1x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, dram, sharded>
+
+func.func @untilize_dram_tiled_to_l1_scalar(%arg0: tensor<1x4x1x1x!ttcore.tile<32x32, u32>, #layout_dram>) -> tensor<1x4x32x32xui32, #layout_l1> {
+  // CHECK-LABEL: @untilize_dram_tiled_to_l1_scalar
+  // CHECK: %[[SCALAR:.*]] = d2m.empty() : tensor<1x4x32x32xui32, #[[L1_LAYOUT:.*]]>
+  // CHECK: %[[L1_TILED:.*]] = d2m.empty() : tensor<1x4x1x1x!ttcore.tile<32x32, u32>, #[[L1_LAYOUT]]>
+  // CHECK-NOT: tensor<1x4x32x32x!ttcore.tile<32x32, u32>
+  // CHECK: %[[DRAM_TO_L1:.*]] = d2m.generic
+  // CHECK: ins(%arg0 : tensor<1x4x1x1x!ttcore.tile<32x32, u32>
+  // CHECK: outs(%[[L1_TILED]] : tensor<1x4x1x1x!ttcore.tile<32x32, u32>, #[[L1_LAYOUT]]>)
+  // CHECK: d2m.generic
+  // CHECK: ins(%[[DRAM_TO_L1]] : tensor<1x4x1x1x!ttcore.tile<32x32, u32>, #[[L1_LAYOUT]]>)
+  // CHECK: outs(%[[SCALAR]] : tensor<1x4x32x32xui32, #[[L1_LAYOUT]]>)
+  // CHECK: d2m.tile_untilize_block
+  %0 = d2m.empty() : tensor<1x4x32x32xui32, #layout_l1>
+  %1 = d2m.to_layout %arg0, %0 : tensor<1x4x1x1x!ttcore.tile<32x32, u32>, #layout_dram> into tensor<1x4x32x32xui32, #layout_l1> -> tensor<1x4x32x32xui32, #layout_l1>
+  return %1 : tensor<1x4x32x32xui32, #layout_l1>
+}

--- a/test/ttmlir/Dialect/D2M/bufferization/embedding.mlir
+++ b/test/ttmlir/Dialect/D2M/bufferization/embedding.mlir
@@ -5,6 +5,7 @@
 #output_layout = #ttcore.metal_layout<logical_shape = 2x4x16, dim_alignments = 1x32x32, collapsed_intervals = dense<[[0, 2], [2, 3]]> : tensor<2x2xi64>, l1, sharded>
 #indices_ui32_layout = #ttcore.metal_layout<logical_shape = 2x3, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
 #weight_bf16_layout = #ttcore.metal_layout<logical_shape = 16x8, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+#weight_bf16_dram_layout = #ttcore.metal_layout<logical_shape = 16x8, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, dram, sharded>
 #output_bf16_layout = #ttcore.metal_layout<logical_shape = 2x3x8, dim_alignments = 1x32x32, collapsed_intervals = dense<[[0, 2], [2, 3]]> : tensor<2x2xi64>, l1, sharded>
 #indices_i32_layout = #ttcore.metal_layout<logical_shape = 3x1, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
 #weight_i32_layout = #ttcore.metal_layout<logical_shape = 16x1, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
@@ -46,6 +47,23 @@ func.func @embedding_bf16_table_ui32_indices(
     // CHECK: memref.alloc() {{.*}} : memref<1x1024xbf16
     // CHECK: d2m.indexed_row_copy {{.*}} scratch {{.*}}<6, 8>
     %embed = d2m.embedding %indices, %weight, %output<6, 8> {indicesShape = array<i64: 2, 3>} : tensor<1x1x2x3xui32, #indices_ui32_layout>, tensor<1x1x16x8xbf16, #weight_bf16_layout>, tensor<1x1x6x8xbf16, #output_bf16_layout> -> tensor<1x1x6x8xbf16, #output_bf16_layout>
+    d2m.yield %embed : (tensor<1x1x6x8xbf16, #output_bf16_layout>)
+  } : tensor<1x1x6x8xbf16, #output_bf16_layout>
+  return %result : tensor<1x1x6x8xbf16, #output_bf16_layout>
+}
+
+// CHECK-LABEL: func.func @embedding_dram_table_bf16_indices_l1_output_l1
+func.func @embedding_dram_table_bf16_indices_l1_output_l1(
+    %indices: tensor<1x1x2x3xui32, #indices_ui32_layout>,
+    %weight: tensor<1x1x16x8xbf16, #weight_bf16_dram_layout>) -> tensor<1x1x6x8xbf16, #output_bf16_layout> {
+  %output = d2m.empty() : tensor<1x1x6x8xbf16, #output_bf16_layout>
+  %result = d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+      ins(%indices, %weight : tensor<1x1x2x3xui32, #indices_ui32_layout>, tensor<1x1x16x8xbf16, #weight_bf16_dram_layout>)
+      outs(%output : tensor<1x1x6x8xbf16, #output_bf16_layout>)
+   {
+    // CHECK: d2m.indexed_row_copy {{.*}}<6, 8>
+    // CHECK-SAME: : memref<{{.*}}xui32, #ttcore.shard<{{.*}}>, #l1>, memref<{{.*}}xbf16, #ttcore.shard<{{.*}}>, #dram>, memref<{{.*}}xbf16, #ttcore.shard<{{.*}}>, #l1>
+    %embed = d2m.embedding %indices, %weight, %output<6, 8> {indicesShape = array<i64: 2, 3>} : tensor<1x1x2x3xui32, #indices_ui32_layout>, tensor<1x1x16x8xbf16, #weight_bf16_dram_layout>, tensor<1x1x6x8xbf16, #output_bf16_layout> -> tensor<1x1x6x8xbf16, #output_bf16_layout>
     d2m.yield %embed : (tensor<1x1x6x8xbf16, #output_bf16_layout>)
   } : tensor<1x1x6x8xbf16, #output_bf16_layout>
   return %result : tensor<1x1x6x8xbf16, #output_bf16_layout>

--- a/test/ttmlir/Dialect/D2M/generic/embedding.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/embedding.mlir
@@ -29,6 +29,7 @@ module {
 // -----
 
 #l1 = #ttcore.memory_space<l1>
+#dram = #ttcore.memory_space<dram>
 
 module {
   // CHECK-LABEL: func.func @memref_indexed_row_copy_explicit
@@ -41,6 +42,19 @@ module {
     // CHECK: d2m.indexed_row_copy {{.*}} scratch {{.*}}<8, 16>
     // CHECK-SAME: {indicesShape = array<i64: 2, 4>}
     d2m.indexed_row_copy %indices, %weight, %output scratch %index_scratch, %row_scratch<8, 16> {indicesShape = array<i64: 2, 4>} : memref<1x1x2x4xi32, #l1>, memref<1x1x8x16xf32, #l1>, memref<1x1x8x16xf32, #l1>, memref<1x1024xi32, #l1>, memref<1x1024xf32, #l1>
+    return
+  }
+
+  // CHECK-LABEL: func.func @memref_indexed_row_copy_dram_source_explicit
+  func.func @memref_indexed_row_copy_dram_source_explicit(
+      %indices: memref<1x1x2x4xi32, #l1>,
+      %weight: memref<1x1x8x16xf32, #dram>,
+      %output: memref<1x1x8x16xf32, #l1>,
+      %index_scratch: memref<1x1024xi32, #l1>,
+      %row_scratch: memref<1x1024xf32, #l1>) {
+    // CHECK: d2m.indexed_row_copy {{.*}} scratch {{.*}}<8, 16>
+    // CHECK-SAME: : memref<{{.*}}, #l1>, memref<{{.*}}, #dram>, memref<{{.*}}, #l1>
+    d2m.indexed_row_copy %indices, %weight, %output scratch %index_scratch, %row_scratch<8, 16> {indicesShape = array<i64: 2, 4>} : memref<1x1x2x4xi32, #l1>, memref<1x1x8x16xf32, #dram>, memref<1x1x8x16xf32, #l1>, memref<1x1024xi32, #l1>, memref<1x1024xf32, #l1>
     return
   }
 }


### PR DESCRIPTION
### Problem description
Need to support dram as input and output memspace for embedding op

### What's changed
- `TTIRToD2M` embedding now supports DRAM defaults for input/output memspace
- Keeps indices in L1 for the actual d2m.embedding
- `d2m.indexed_row_copy` now accepts a DRAM source and dest memref for embedding table
- `D2MToTTKernel` generates correct noc address based on source memref and accounts for noc alignment reqs
- Fix tiled to untiled layout shape handing in lower to layout
-  Added builder and lit tests
### Checklist
- [ ] New/Existing tests provide coverage for changes
