### PR TITLE
d2m: add opt-in M/N auto reblocking for matmul

### DIFF
--- a/include/ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h
@@ -18,7 +18,7 @@ namespace mlir::tt::d2m {
 /// explicit-datamovement form), this analysis computes reblocked block
 /// factors according to the configured buffer size policy.
 struct BlockFactorAnalysis {
-  enum class BufferSizePolicy { Auto, Bounded, Min, Max };
+  enum class BufferSizePolicy { Auto, AutoMN, Bounded, Min, Max };
 
   struct Options {
     BufferSizePolicy policy = BufferSizePolicy::Auto;

--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -176,7 +176,8 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
   Option<std::string> testBufferSizePolicy{
       *this, "test-buffer-size-policy",
       llvm::cl::desc(
-          "Set policy for sizing stream buffers ('auto', 'min', 'max')."),
+          "Set policy for sizing stream buffers ('auto', 'auto-mn', 'min', "
+          "'max')."),
       llvm::cl::init("auto")};
 
   // Option to ingest a mix of ttnn and ttir ops and lower through D2m to TTNN

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -675,7 +675,7 @@ def D2MAllocate: Pass<"d2m-allocate", "::mlir::ModuleOp"> {
     Option<"testBufferSizePolicy",
           "test-buffer-size-policy",
           "std::string", /*default=*/"\"auto\"",
-          "Set policy for sizing stream buffers ('auto', 'bounded', 'min', 'max').">,
+          "Set policy for sizing stream buffers ('auto', 'auto-mn', 'bounded', 'min', 'max').">,
   ];
 }
 

--- a/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
@@ -59,12 +59,67 @@ static llvm::BitVector getDimMask(std::size_t rank,
   return mask;
 }
 
+static SmallVector<std::size_t>
+getReductionDims(ArrayRef<ttcore::IteratorType> iteratorTypes) {
+  SmallVector<std::size_t> reductionDims;
+  for (auto [dim, iteratorType] : llvm::enumerate(iteratorTypes)) {
+    if (iteratorType == ttcore::IteratorType::Reduction) {
+      reductionDims.push_back(dim);
+    }
+  }
+  return reductionDims;
+}
+
+static SmallVector<std::size_t>
+getAllParallelCandidateDims(GenericOp genericOp,
+                            ArrayRef<int64_t> shardFactors) {
+  SmallVector<std::size_t> candidateDims;
+  const llvm::BitVector participationMask = getParticipatingDimMask(genericOp);
+  for (std::size_t dim = 0; dim < shardFactors.size(); ++dim) {
+    if (participationMask[dim] && shardFactors[dim] > 1) {
+      candidateDims.push_back(dim);
+    }
+  }
+  return candidateDims;
+}
+
+static bool isSingleReductionPanelDim(GenericOp genericOp, std::size_t dim) {
+  unsigned numOperandsUsingDim = 0;
+  AffineExpr dimExpr =
+      getAffineDimExpr(static_cast<unsigned>(dim), genericOp.getContext());
+  for (AffineMap indexingMap : genericOp.getIndexingMapsValue()) {
+    if (llvm::is_contained(indexingMap.getResults(), dimExpr)) {
+      ++numOperandsUsingDim;
+    }
+  }
+
+  // Do not reblock the batch dimension.
+  return numOperandsUsingDim > 0 &&
+         numOperandsUsingDim < genericOp.getInputsAndOutputs().size();
+}
+
+static SmallVector<std::size_t> getSingleReductionCandidateDims(
+    GenericOp genericOp, ArrayRef<std::size_t> reductionDims,
+    ArrayRef<int64_t> shardFactors, bool allowMNReblocking) {
+  if (!allowMNReblocking) {
+    return llvm::to_vector(reductionDims);
+  }
+
+  SmallVector<std::size_t> candidateDims;
+  for (std::size_t dim = 0; dim < shardFactors.size(); ++dim) {
+    if (shardFactors[dim] > 1 && isSingleReductionPanelDim(genericOp, dim)) {
+      candidateDims.push_back(dim);
+    }
+  }
+  return candidateDims;
+}
+
 /// Classify a generic op's iteration shape for auto-policy search.
 /// @return the search config or nullopt if auto-blocking is not applicable.
 static std::optional<AutoSearchConfig>
 classifyAutoSearch(GenericOp genericOp,
                    ArrayRef<ttcore::IteratorType> iteratorTypes,
-                   ArrayRef<int64_t> shardFactors) {
+                   ArrayRef<int64_t> shardFactors, bool allowMNReblocking) {
   if (genericOp.isDMAOnlyForm() || genericOp.isExplicitDatamovementForm() ||
       genericOp.getOutputs().size() != 1) {
     return std::nullopt;
@@ -88,35 +143,27 @@ classifyAutoSearch(GenericOp genericOp,
     }
   }
 
-  SmallVector<std::size_t> reductionDims;
-  for (auto [dim, iteratorType] : llvm::enumerate(iteratorTypes)) {
-    if (iteratorType == ttcore::IteratorType::Reduction) {
-      reductionDims.push_back(dim);
+  SmallVector<std::size_t> reductionDims = getReductionDims(iteratorTypes);
+  if (reductionDims.empty()) {
+    SmallVector<std::size_t> candidateDims =
+        getAllParallelCandidateDims(genericOp, shardFactors);
+    if (candidateDims.empty()) {
+      return std::nullopt;
     }
+    return AutoSearchConfig{AutoShapeClass::AllParallelEltwise,
+                            std::move(candidateDims)};
   }
 
-  if (reductionDims.size() == 1) {
-    return AutoSearchConfig{AutoShapeClass::SingleReduction,
-                            std::move(reductionDims)};
-  }
-  if (!reductionDims.empty()) {
+  if (reductionDims.size() != 1) {
     return std::nullopt;
   }
-  // At this point, the generic op is an all-parallel operation.
 
-  // Candidate dim filter: all participating dims with a shard factor > 1.
-  SmallVector<std::size_t> candidateDims;
-  const llvm::BitVector participationMask = getParticipatingDimMask(genericOp);
-  for (std::size_t dim = 0; dim < shardFactors.size(); ++dim) {
-    if (participationMask[dim] && shardFactors[dim] > 1) {
-      candidateDims.push_back(dim);
-    }
-  }
+  SmallVector<std::size_t> candidateDims = getSingleReductionCandidateDims(
+      genericOp, reductionDims, shardFactors, allowMNReblocking);
   if (candidateDims.empty()) {
     return std::nullopt;
   }
-
-  return AutoSearchConfig{AutoShapeClass::AllParallelEltwise,
+  return AutoSearchConfig{AutoShapeClass::SingleReduction,
                           std::move(candidateDims)};
 }
 
@@ -363,7 +410,9 @@ static SmallVector<int64_t> applyMinPolicy(GenericOp genericOp,
 
 // The auto policy currently has three cases:
 // 1. Single reduction: aggressively reduce the block factor of the reduction
-// dim.
+// dim.  M/N widening for matmul is available only through the non-default
+// auto-mn policy until issues #8346/#8369 model loop-carried output
+// accumulation explicitly.
 // 2. All parallel eltwise: aggressively reduce the block factor of all
 // participating dims.
 // 3. Unsupported: in all other cases, return the original block factors.
@@ -373,14 +422,15 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
                 ArrayRef<int64_t> gridExtents, ArrayRef<int64_t> shardExtents,
                 ArrayRef<int64_t> shardFactors, ttcore::DeviceAttr device,
                 ttcore::MemorySpaceAttr l1Attr, uint32_t numBuffers,
-                bool useBoundedEltwiseSearch) {
+                bool useBoundedEltwiseSearch, bool allowMNReblocking) {
   const SmallVector<int64_t> originalBlockFactors =
       genericOp.getBlockFactorsValue();
 
   //===------------------------------------------------------------------===//
   // Classify the generic op's iteration shape.
   //===------------------------------------------------------------------===//
-  auto config = classifyAutoSearch(genericOp, iteratorTypes, shardFactors);
+  auto config = classifyAutoSearch(genericOp, iteratorTypes, shardFactors,
+                                   allowMNReblocking);
   if (!config) {
     return originalBlockFactors;
   }
@@ -516,11 +566,15 @@ static SmallVector<int64_t> chooseReblockedFactors(
   case BlockFactorAnalysis::BufferSizePolicy::Auto:
     return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
                            shardExtents, shardFactors, device, l1Attr,
-                           numBuffers, /*useBoundedEltwiseSearch=*/false);
+                           numBuffers, /*useBoundedEltwiseSearch=*/false, /*allowMNReblocking=*/false);
   case BlockFactorAnalysis::BufferSizePolicy::Bounded:
     return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
                            shardExtents, shardFactors, device, l1Attr,
-                           numBuffers, /*useBoundedEltwiseSearch=*/true);
+                           numBuffers, /*useBoundedEltwiseSearch=*/true, /*allowMNReblocking=*/false);
+  case BlockFactorAnalysis::BufferSizePolicy::AutoMN:
+    return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
+                           shardExtents, shardFactors, device, l1Attr,
+                           numBuffers, /*useBoundedEltwiseSearch=*/false, /*allowMNReblocking=*/true);
   }
 
   llvm_unreachable("unknown buffer size policy");

--- a/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
@@ -566,15 +566,18 @@ static SmallVector<int64_t> chooseReblockedFactors(
   case BlockFactorAnalysis::BufferSizePolicy::Auto:
     return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
                            shardExtents, shardFactors, device, l1Attr,
-                           numBuffers, /*useBoundedEltwiseSearch=*/false, /*allowMNReblocking=*/false);
+                           numBuffers, /*useBoundedEltwiseSearch=*/false,
+                           /*allowMNReblocking=*/false);
   case BlockFactorAnalysis::BufferSizePolicy::Bounded:
     return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
                            shardExtents, shardFactors, device, l1Attr,
-                           numBuffers, /*useBoundedEltwiseSearch=*/true, /*allowMNReblocking=*/false);
+                           numBuffers, /*useBoundedEltwiseSearch=*/true,
+                           /*allowMNReblocking=*/false);
   case BlockFactorAnalysis::BufferSizePolicy::AutoMN:
     return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
                            shardExtents, shardFactors, device, l1Attr,
-                           numBuffers, /*useBoundedEltwiseSearch=*/false, /*allowMNReblocking=*/true);
+                           numBuffers, /*useBoundedEltwiseSearch=*/false,
+                           /*allowMNReblocking=*/true);
   }
 
   llvm_unreachable("unknown buffer size policy");

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -291,6 +291,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     return llvm::StringSwitch<std::optional<BufferSizePolicy>>(policy)
         .Case("auto", BufferSizePolicy::Auto)
         .Case("bounded", BufferSizePolicy::Bounded)
+        .Case("auto-mn", BufferSizePolicy::AutoMN)
         .Case("min", BufferSizePolicy::Min)
         .Case("max", BufferSizePolicy::Max)
         .Default(std::nullopt);
@@ -308,7 +309,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     if (!parsedBufferSizePolicy.has_value()) {
       moduleOp.emitOpError()
           << "invalid test-buffer-size-policy '" << testBufferSizePolicy
-          << "' (expected one of: auto, bounded, min, max)";
+          << "' (expected one of: auto, bounded, auto-mn, min, max)";
       return signalPassFailure();
     }
     bufferSizePolicy = *parsedBufferSizePolicy;

--- a/lib/Dialect/D2M/Transforms/GenerateOuterLoops.cpp
+++ b/lib/Dialect/D2M/Transforms/GenerateOuterLoops.cpp
@@ -160,6 +160,14 @@ public:
     for (auto [i, loop] : llvm::enumerate(loops)) {
       loop->setAttr("d2m.blocking_loop",
                     rewriter.getI64IntegerAttr(static_cast<int64_t>(i)));
+      if (generic.getIteratorTypes().size() > i) {
+        auto iteratorType =
+            mlir::cast<ttcore::IteratorTypeAttr>(generic.getIteratorTypes()[i])
+                .getValue();
+        if (iteratorType == ttcore::IteratorType::Reduction) {
+          loop->setAttr("d2m.reduction_loop", rewriter.getUnitAttr());
+        }
+      }
     }
 
     // First rewrite block_index(dim) -> block_offset(dim) + iter_index(dim).

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -628,15 +628,7 @@ static void applyViewLayoutUpdate(const OperandGridInfo &info, bool ttnnMode,
       mlir::cast<ttcore::MetalLayoutAttr>(newResultType.getEncoding());
   if (!llvm::equal(oldLayout.getDimAlignments(),
                    newLayout.getDimAlignments())) {
-    llvm::SmallVector<int64_t> tileShape;
-    if (auto tileType =
-            mlir::dyn_cast<ttcore::TileType>(oldResultType.getElementType())) {
-      tileShape = llvm::to_vector(tileType.getShape());
-    }
-    TT_assert(ttmlir::utils::volume(oldLayout.getGridShape(oldResultType)) ==
-              1);
-    oldShape = newLayout.getDeviceShape(oldLayout.getGridShape(oldResultType),
-                                        tileShape);
+    oldShape = llvm::to_vector(oldResultType.getShape());
   }
 
   mlir::AffineMap newRemapping = viewOp.getRemapping();

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -628,7 +628,13 @@ static void applyViewLayoutUpdate(const OperandGridInfo &info, bool ttnnMode,
       mlir::cast<ttcore::MetalLayoutAttr>(newResultType.getEncoding());
   if (!llvm::equal(oldLayout.getDimAlignments(),
                    newLayout.getDimAlignments())) {
-    oldShape = llvm::to_vector(oldResultType.getShape());
+    llvm::SmallVector<int64_t> tileShape;
+    if (auto tileType =
+            mlir::dyn_cast<ttcore::TileType>(oldResultType.getElementType())) {
+      tileShape = llvm::to_vector(tileType.getShape());
+    }
+    oldShape = newLayout.getDeviceShape(oldLayout.getGridShape(oldResultType),
+                                        tileShape);
   }
 
   mlir::AffineMap newRemapping = viewOp.getRemapping();

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
@@ -273,11 +273,56 @@ static bool accessDependsOnIV(const DstAccess &access, Value iv) {
   return accessDependsOnIV(access.op, access.kind, iv);
 }
 
+static Operation *getLoopOpForIV(Value iv) {
+  auto blockArg = mlir::dyn_cast<BlockArgument>(iv);
+  if (!blockArg) {
+    return nullptr;
+  }
+  return blockArg.getOwner()->getParentOp();
+}
+
+static std::optional<bool> isReductionBlockingLoop(Operation *loopOp) {
+  auto blockingLoopAttr =
+      loopOp->getAttrOfType<IntegerAttr>("d2m.blocking_loop");
+  if (!blockingLoopAttr) {
+    return std::nullopt;
+  }
+
+  if (loopOp->hasAttr("d2m.reduction_loop")) {
+    return true;
+  }
+
+  auto genericOp = loopOp->getParentOfType<GenericOp>();
+  if (!genericOp) {
+    return false;
+  }
+
+  int64_t dim = blockingLoopAttr.getInt();
+  auto iteratorTypes = genericOp.getIteratorTypes();
+  if (iteratorTypes.empty() || dim < 0 ||
+      static_cast<size_t>(dim) >= iteratorTypes.size()) {
+    return false;
+  }
+
+  auto iteratorType =
+      mlir::cast<ttcore::IteratorTypeAttr>(iteratorTypes[dim]).getValue();
+  return iteratorType == ttcore::IteratorType::Reduction;
+}
+
 static SmallVector<Value> getGuardLoopIVs(Operation *loadOrStore,
                                           DstAccessKind kind,
                                           Operation *contextOp) {
   SmallVector<Value> guardIVs;
   for (Value loopIV : collectAncestorLoopIVs(contextOp)) {
+    Operation *loopOp = getLoopOpForIV(loopIV);
+
+    if (loopOp) {
+      std::optional<bool> isReduction = isReductionBlockingLoop(loopOp);
+      if (isReduction.has_value() && !*isReduction) {
+        continue;
+      }
+    }
+
     if (!accessDependsOnIV(loadOrStore, kind, loopIV)) {
       guardIVs.push_back(loopIV);
     }
@@ -392,20 +437,24 @@ Value findClosestReductionLoopIVForL1Acc(Operation *acquireDstOp,
   // (it reverses the upward walk).
   SmallVector<Value> ancestorIVs = collectAncestorLoopIVs(acquireDstOp);
   for (Value iv : llvm::reverse(ancestorIVs)) {
-    if (anyOutputStoreDependsOnIV(copyInfos, iv)) {
-      // This loop indexes the output -- it is parallel, not a reduction.
-      continue;
-    }
-    // Found the closest reduction loop. Only enable L1-acc if the loop
-    // actually iterates more than once (otherwise the per-iteration
-    // accumulation guard would never fire and we'd just emit dead code).
-    Operation *loopOp = nullptr;
-    if (auto blockArg = mlir::dyn_cast<BlockArgument>(iv)) {
-      loopOp = blockArg.getOwner()->getParentOp();
-    }
+    Operation *loopOp = getLoopOpForIV(iv);
     if (!loopOp) {
       continue;
     }
+
+    std::optional<bool> isReduction = isReductionBlockingLoop(loopOp);
+    if (isReduction.has_value() && !*isReduction) {
+      continue;
+    }
+    if (!isReduction.has_value() && anyOutputStoreDependsOnIV(copyInfos, iv)) {
+      // Non-blocking fallback: if this loop indexes the output, it is parallel,
+      // not a reduction.
+      continue;
+    }
+
+    // Found the closest reduction loop. Only enable L1-acc if the loop
+    // actually iterates more than once (otherwise the per-iteration
+    // accumulation guard would never fire and we'd just emit dead code).
     std::optional<int64_t> tripCount = tryGetConstantTripCount(loopOp);
     if (tripCount.has_value() && *tripCount <= 1) {
       continue;
@@ -1464,6 +1513,11 @@ buildIndices(PatternRewriter &rewriter, Location loc,
 
 void insertPackerL1AccGuard(PatternRewriter &rewriter, Location loc,
                             AcquireDstOp acquireDst, Value loopIV) {
+  Operation *loopOp = getLoopOpForIV(loopIV);
+  if (!loopOp) {
+    return;
+  }
+
   rewriter.setInsertionPointAfter(acquireDst);
   Value firstIterationValue = getFirstIterationValue(rewriter, loc, loopIV);
   Value isFirstIteration = rewriter.create<arith::CmpIOp>(
@@ -1475,6 +1529,13 @@ void insertPackerL1AccGuard(PatternRewriter &rewriter, Location loc,
   Value flag = rewriter.create<arith::SelectOp>(loc, isFirstIteration,
                                                 disableFlag, enableFlag);
   rewriter.create<SetL1AccumulateOp>(loc, flag);
+
+  // Packer L1-acc is sticky. Scope it to the reduction loop so enclosing
+  // parallel M/N reblock iterations start from a clean packer state.
+  rewriter.setInsertionPointAfter(loopOp);
+  Value resetFlag = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(0));
+  rewriter.create<SetL1AccumulateOp>(loc, resetFlag);
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/Dialect/D2M/Transforms/LowerToExplicitForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToExplicitForm.cpp
@@ -46,6 +46,9 @@ static void lowerBlockingAffineLoopsToSCF(IRRewriter &rewriter,
   // Preserve the d2m.blocking_loop marker attribute (carries block factor
   // index).
   scfForOp->setAttr("d2m.blocking_loop", forOp->getAttr("d2m.blocking_loop"));
+  if (forOp->hasAttr("d2m.reduction_loop")) {
+    scfForOp->setAttr("d2m.reduction_loop", rewriter.getUnitAttr());
+  }
 
   Block *affineBody = forOp.getBody();
   Block *scfBody = scfForOp.getBody();

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -673,10 +673,7 @@ getMemoryMapImpl(ttcore::DeviceAttr device, MemRefType memrefType,
   if (auto shardLayout =
           mlir::dyn_cast<ttcore::ShardLayoutAttr>(memrefType.getLayout())) {
 
-    unsigned shardRank = shardLayout.getRank();
-    unsigned gridRank = memrefType.getRank() - shardRank;
-
-    auto gridShape = memrefType.getShape().take_front(gridRank);
+    auto gridShape = shardLayout.getGridShape(memrefType);
     auto deviceGridShape = device.getWorkerGrid().getShape();
 
     // Use stored forward map if available; otherwise fall back to

--- a/test/python/golden/d2m/test_generic_matmul_reblock.py
+++ b/test/python/golden/d2m/test_generic_matmul_reblock.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from conftest import get_request_kwargs
+
+from builder.base.builder_apis import compile_and_execute_ttir
+from d2m.test_matmul import create_matmul_constrained_inputs
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_matmul_auto_mn_policy(
+    target,
+    request,
+    device,
+):
+    options = [
+        "test-buffer-size-policy=auto-mn",
+        "num-stream-buffers=1",
+        "use-tile-matmul=false",
+    ]
+    compile_and_execute_ttir(
+        create_matmul_constrained_inputs((512, 32), (32, 2048), torch.bfloat16),
+        target=target,
+        device=device,
+        custom_pipeline=f"ttir-to-ttmetal-pipeline{{{' '.join(options)}}}",
+        **get_request_kwargs(request),
+    )


### PR DESCRIPTION
- adds in policy, `test-buffer-size-policy=auto-mn` which enables matmul reblocking to consider the M/N panel dimensions.
- Refactors `BlockFactorAnalysis` auto-policy classification so shape class and candidate-dim selection are explicit:
  - all-parallel ops: participating dims
  - single-reduction default auto: reduction dim only
  - single-reduction `auto-mn`: M/N/K panel dims, excluding batch-like dims
  - multi-reduction ops: unsupported
- Adds/keeps infrastructure needed for explicit M/N reblocking:
  - non-unit-grid view layout handling
  - shard memory-map grid shape fix
  - reduction-loop metadata preservation for `InsertDst` (`d2m.reduction_loop` label)
- Adds focused `auto-mn` matmul tests.

Depends on #8369 for enabling as default. At that point we can get rid of the `d2m.reduction_loop` label which is currently needed because InsertDst needs to identify the loop over which L1 accumulation is valid. Enabling M/N/K reblocking for all matmuls exposed correctness failures in the current `InsertDst`/packer accumulation model specifically for loop-carried matmul reductions split across K panels.