### PR TITLE
[ttkernel] Add ttkernel support for noc_semaphore_set_remote

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3564,6 +3564,23 @@ def TTKernel_NocSemaphoreSetOp : TTKernel_Op<"noc_semaphore_set"> {
     }];
 }
 
+def TTKernel_RemoteSramWriteU32Op : TTKernel_Op<"remote_sram_write_u32"> {
+    let summary = "RemoteSramWriteU32";
+    let description = [{
+      Initiates a 4-byte remote SRAM write of the u32 value stored at a local
+      SRAM address on the Tensix core executing this function call. The source
+      SRAM word is usually used as a semaphore or mailbox value.
+    }];
+
+    let arguments = (ins AnyTypeOf<[TTKernel_L1Addr, TTKernel_LocalSemaphore]>:$src_sram_addr,
+                         TTKernel_NocAddr:$dst_remote_addr,
+                         Optional<I8>:$noc_id);
+
+    let assemblyFormat = [{
+      `(` $src_sram_addr `,` $dst_remote_addr (`,` $noc_id^)? `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
 def TTKernel_SemaphoreWaitOp : TTKernel_Op<"experimental::semaphore_wait"> {
     let summary = "SemaphoreWait";
     let description = [{

--- a/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
@@ -62,6 +62,7 @@ inline const llvm::StringMap<HeaderRequirement> &getCalleeToHeadersMap() {
         {"noc_async_write_tile",                           {"", "api/dataflow/dataflow_api.h"}},
         {"noc_semaphore_inc",                              {"", "api/dataflow/dataflow_api.h"}},
         {"noc_semaphore_set",                              {"", "api/dataflow/dataflow_api.h"}},
+        {"noc_semaphore_set_remote",                       {"", "api/dataflow/dataflow_api.h"}},
         {"noc_semaphore_set_multicast",                    {"", "api/dataflow/dataflow_api.h"}},
         {"noc_semaphore_set_multicast_loopback_src",       {"", "api/dataflow/dataflow_api.h"}},
         {"reset_noc_trid_barrier_counter",                 {"", "api/dataflow/dataflow_api.h"}},

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1879,6 +1879,9 @@ public:
     patterns.add<TTKernelToEmitCCBResultMethodRewriter<ttkernel::GetReadPtrOp>>(
         typeConverter, funcOp.getContext(), "get_read_ptr");
 
+    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::RemoteSramWriteU32Op>>(
+        typeConverter, funcOp.getContext(), "noc_semaphore_set_remote");
+
     patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(
         typeConverter, funcOp.getContext(), "get_noc_addr");
     patterns

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2006,6 +2006,37 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @remote_sram_write_u32_sram_addr
+    func.func @remote_sram_write_u32_sram_addr() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = buffer_address, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[SRC_ADDR:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %src_addr = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !ttkernel.l1_addr
+      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      %noc_x = arith.constant 1 : index
+      %noc_y = arith.constant 1 : index
+      %temp = arith.constant 262400 : i32
+      %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: emitc.call_opaque "noc_semaphore_set_remote"(%[[SRC_ADDR]], %[[DST_NOC_ADDR]])
+      "ttkernel.remote_sram_write_u32"(%src_addr, %dst_noc_addr) : (!ttkernel.l1_addr, !ttkernel.noc_addr) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @remote_sram_write_u32_local_semaphore_with_noc_id
+    func.func @remote_sram_write_u32_local_semaphore_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_semaphore"
+      %sem_idx = arith.constant 2 : i32
+      %src_addr = "ttkernel.get_semaphore"(%sem_idx) : (i32) -> (!ttkernel.local_semaphore)
+      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      %noc_x = arith.constant 1 : index
+      %noc_y = arith.constant 1 : index
+      %temp = arith.constant 262400 : i32
+      %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
+      %noc_id = arith.constant 1 : i8
+      // CHECK: emitc.call_opaque "noc_semaphore_set_remote"(%[[SRC_ADDR]], %[[DST_NOC_ADDR]], %[[NOC_ID]])
+      "ttkernel.remote_sram_write_u32"(%src_addr, %dst_noc_addr, %noc_id) : (!ttkernel.local_semaphore, !ttkernel.noc_addr, i8) -> ()
+      return
+    }
+
     // CHECK-LABEL: func @semaphore_wait
     func.func @semaphore_wait() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast

--- a/test/ttmlir/Dialect/TTKernel/ops.mlir
+++ b/test/ttmlir/Dialect/TTKernel/ops.mlir
@@ -188,3 +188,40 @@ func.func @test_noc_trid_with_implicit_noc(%trid: i32) {
       : (i32, i32, i32, i32) -> ()
   return
 }
+
+// CHECK-LABEL: func.func @test_remote_sram_write_u32_sram_addr
+// CHECK-SAME: (%[[SRC:.*]]: !ttkernel.l1_addr, %[[DST:.*]]: !ttkernel.noc_addr)
+func.func @test_remote_sram_write_u32_sram_addr(%src: !ttkernel.l1_addr, %dst: !ttkernel.noc_addr) {
+  // CHECK: ttkernel.remote_sram_write_u32(%[[SRC]], %[[DST]]) : (!ttkernel.l1_addr, !ttkernel.noc_addr) -> ()
+  ttkernel.remote_sram_write_u32(%src, %dst) : (!ttkernel.l1_addr, !ttkernel.noc_addr) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @test_remote_sram_write_u32_local_semaphore
+// CHECK-SAME: (%[[SRC:.*]]: !ttkernel.local_semaphore, %[[DST:.*]]: !ttkernel.noc_addr, %[[NOC:.*]]: i8)
+func.func @test_remote_sram_write_u32_local_semaphore(%src: !ttkernel.local_semaphore, %dst: !ttkernel.noc_addr, %noc: i8) {
+  // CHECK: ttkernel.remote_sram_write_u32(%[[SRC]], %[[DST]], %[[NOC]]) : (!ttkernel.local_semaphore, !ttkernel.noc_addr, i8) -> ()
+  ttkernel.remote_sram_write_u32(%src, %dst, %noc) : (!ttkernel.local_semaphore, !ttkernel.noc_addr, i8) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @test_remote_mailbox_protocol_ops
+func.func @test_remote_mailbox_protocol_ops(%mailbox: !ttkernel.l1_addr) {
+  %zero = arith.constant 0 : i32
+  %one = arith.constant 1 : index
+  %value = arith.constant 64 : i32
+  // CHECK: %[[SEM:.*]] = ttkernel.get_semaphore
+  %sem = ttkernel.get_semaphore(%zero) : (i32) -> !ttkernel.local_semaphore
+  // CHECK: %[[PTR:.*]] = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>
+  %sem_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%sem) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
+  // CHECK: ttkernel.store_to_l1
+  ttkernel.store_to_l1(%value, %sem_ptr, %zero) : (i32, !ttkernel.l1_addr_ptr, i32) -> ()
+  // CHECK: ttkernel.load_from_l1
+  %loaded = ttkernel.load_from_l1(%sem_ptr, %zero) : (!ttkernel.l1_addr_ptr, i32) -> i32
+  // CHECK: %[[DST:.*]] = ttkernel.get_noc_addr
+  %dst = ttkernel.get_noc_addr(%one, %one, %mailbox) : (index, index, !ttkernel.l1_addr) -> !ttkernel.noc_addr
+  // CHECK: ttkernel.remote_sram_write_u32(%[[SEM]], %[[DST]])
+  ttkernel.remote_sram_write_u32(%sem, %dst) : (!ttkernel.local_semaphore, !ttkernel.noc_addr) -> ()
+  %sink = arith.addi %loaded, %zero : i32
+  return
+}

--- a/test/ttmlir/Dialect/TTKernel/remote_sram_write_u32_invalid.mlir
+++ b/test/ttmlir/Dialect/TTKernel/remote_sram_write_u32_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --split-input-file --verify-diagnostics %s
+
+// Test: $src_sram_addr must be !ttkernel.l1_addr or !ttkernel.local_semaphore.
+func.func @test_remote_sram_write_u32_wrong_src_type(%dst: !ttkernel.noc_addr) {
+  // expected-note @+1 {{prior use here}}
+  %bad_src = arith.constant 0 : i32
+  // expected-error @+1 {{use of value '%bad_src' expects different type than prior uses: '!ttkernel.l1_addr' vs 'i32'}}
+  ttkernel.remote_sram_write_u32(%bad_src, %dst) : (!ttkernel.l1_addr, !ttkernel.noc_addr) -> ()
+  return
+}

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -52,6 +52,10 @@ func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<n
     %4 = ttkernel.get_noc_addr(%c0_idx, %c0_idx, %c262208_i32) : (index, index, i32) -> !ttkernel.noc_addr
     // CHECK: noc_async_read([[NOCADDR1]], [[B0]], [[C0]])
     ttkernel.noc_async_read(%4, %c262432_i32, %c32_i32) : (!ttkernel.noc_addr, i32, i32) -> ()
+    // CHECK: int32_t [[SEM:.*]] = get_semaphore
+    %sem = ttkernel.get_semaphore(%c0_idx) : (index) -> !ttkernel.local_semaphore
+    // CHECK: noc_semaphore_set_remote([[SEM]], [[NOCADDR1]])
+    ttkernel.remote_sram_write_u32(%sem, %4) : (!ttkernel.local_semaphore, !ttkernel.noc_addr) -> ()
     // CHECK: noc_async_read_barrier
     ttkernel.noc_async_read_barrier() : () -> ()
     // CHECK: return


### PR DESCRIPTION
### Ticket
N/A

### Problem description
TTKernel did not model tt-metal `noc_semaphore_set_remote`, needed to copy a u32 SRAM mailbox value from the executing core to a remote SRAM address.

### What's changed
Added `ttkernel.remote_sram_write_u32`, a semantic TTKernel op for remote u32 SRAM writes. The op accepts `!ttkernel.l1_addr` or `!ttkernel.local_semaphore` sources, a `!ttkernel.noc_addr` destination, and an optional `i8` NOC id. EmitC lowering currently emits `noc_semaphore_set_remote(...)`.

Added parser/printer, invalid operand type, EmitC lowering, and TTKernel C++ translation coverage.

### Checklist
- [x] New/Existing tests provide coverage for changes