### PR TITLE
OpTPathParity tests

### DIFF
--- a/cmake/modules/BuildFlatbuffers.cmake
+++ b/cmake/modules/BuildFlatbuffers.cmake
@@ -44,6 +44,7 @@ foreach(FILE ${sources})
     ARGS --keep-prefix
     ARGS --gen-name-strings
     ARGS --gen-object-api
+    ARGS --gen-compare
     ARGS -o "${CMAKE_CURRENT_BINARY_DIR}/${FILE_DIR}/" "${FILE}"
     COMMENT "Generating flatbuffer file: ${FBS_GEN_FILE}"
     DEPENDS ${FILE} ${deps} ${sources}

--- a/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
+++ b/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPMODEL_TTNN_NATIVEFROMMLIR_H
+#define TTMLIR_OPMODEL_TTNN_NATIVEFROMMLIR_H
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Target/TTNN/Target.h"
+
+#include "mlir/IR/Attributes.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+namespace mlir::tt::ttnn::op_model {
+
+namespace detail {
+std::optional<::tt::target::ttnn::MemoryConfigT>
+getNullableMemoryConfigT(TTNNLayoutAttr layout);
+
+std::unique_ptr<::tt::target::ttnn::TensorRefT>
+getOutputTensorRefT(TTNNLayoutAttr layout);
+
+std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>>
+reorderPool2dPadding(llvm::ArrayRef<int32_t> padding);
+} // namespace detail
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseUnaryOpT
+buildEltwiseUnaryOpTFromMLIR(TTNNLayoutAttr outputLayout,
+                             std::optional<llvm::APFloat> slope = std::nullopt);
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseUnaryCompositeOpT
+buildEltwiseUnaryCompositeOpTFromMLIR(TTNNLayoutAttr outputLayout);
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseBinaryOpT
+buildEltwiseBinaryOpTFromMLIR(TTNNLayoutAttr outputLayout,
+                              ttcore::DataTypeAttr opDtypeAttr = nullptr);
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseBinaryCompositeOpT
+buildEltwiseBinaryCompositeOpTFromMLIR(TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+buildEltwiseBinaryCompositeScalarOpTFromMLIR(mlir::Attribute exponent,
+                                             TTNNLayoutAttr outputLayout);
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseTernaryWhereOpT
+buildEltwiseTernaryOpTFromMLIR(TTNNLayoutAttr outputLayout);
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseQuantizationOpT
+buildEltwiseQuantizationOpTFromMLIR(std::optional<int32_t> axis,
+                                    std::optional<ttcore::DataType> outputDtype,
+                                    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::LinearOpT buildLinearOpTFromMLIR(
+    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::MatmulOpT buildMatmulOpTFromMLIR(
+    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::Conv2dOpT buildConv2dOpTFromMLIR(
+    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+    uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::EltwiseUnaryCompositeOpT
+buildEltwiseUnaryCompositeClampScalarOpTFromMLIR(mlir::Attribute min,
+                                                 mlir::Attribute max,
+                                                 TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::EltwiseUnaryCompositeOpT
+buildEltwiseUnaryCompositeClampTensorOpTFromMLIR(TTNNLayoutAttr outputLayout);
+
+} // namespace mlir::tt::ttnn::op_model
+#endif // TTMLIR_ENABLE_OPMODEL
+
+#endif // TTMLIR_OPMODEL_TTNN_NATIVEFROMMLIR_H

--- a/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
+++ b/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
@@ -7,6 +7,7 @@
 
 #include "mlir/IR/Operation.h"
 #include "mlir/Support/LogicalResult.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
 
 namespace mlir::tt::ttnn {
@@ -42,6 +43,52 @@ LogicalResult translateTTNNToFlatbuffer(
         */
         &goldenMap = {},
     const std::vector<std::pair<std::string, std::string>> &moduleCache = {});
+
+::flatbuffers::Offset<::tt::target::ttnn::MatmulOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, MatmulOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::LinearOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, LinearOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::Conv2dOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, Conv2dOp op);
+
+::flatbuffers::Offset<::tt::target::DeviceRef>
+createDeviceRef(::mlir::tt::FlatbufferObjectCache &cache, ::mlir::Value device);
+
+template <typename EltwiseUnaryOp>
+::flatbuffers::Offset<::tt::target::ttnn::EltwiseUnaryOp>
+createEltwiseUnaryOp(::mlir::tt::FlatbufferObjectCache &cache,
+                     EltwiseUnaryOp op);
+
+template <typename EltwiseUnaryCompositeOp>
+::flatbuffers::Offset<::tt::target::ttnn::EltwiseUnaryCompositeOp>
+createEltwiseUnaryCompositeOp(::mlir::tt::FlatbufferObjectCache &cache,
+                              EltwiseUnaryCompositeOp op);
+
+template <typename EltwiseBinaryOp>
+::flatbuffers::Offset<::tt::target::ttnn::EltwiseBinaryOp>
+createEltwiseBinaryOp(::mlir::tt::FlatbufferObjectCache &cache,
+                      EltwiseBinaryOp op);
+
+template <typename EltwiseBinaryCompositeOp>
+::flatbuffers::Offset<::tt::target::ttnn::EltwiseBinaryCompositeOp>
+createEltwiseBinaryCompositeOp(::mlir::tt::FlatbufferObjectCache &cache,
+                               EltwiseBinaryCompositeOp op);
+
+template <typename EltwiseBinaryCompositeScalarOp>
+::flatbuffers::Offset<::tt::target::ttnn::EltwiseBinaryCompositeScalarOp>
+createEltwiseBinaryCompositeScalarOp(::mlir::tt::FlatbufferObjectCache &cache,
+                                     EltwiseBinaryCompositeScalarOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::EltwiseTernaryWhereOp>
+createEltwiseTernaryWhereOp(::mlir::tt::FlatbufferObjectCache &cache,
+                            WhereOp op);
+
+template <typename EltwiseQuantizationOp>
+::flatbuffers::Offset<::tt::target::ttnn::EltwiseQuantizationOp>
+createEltwiseQuantizationOp(::mlir::tt::FlatbufferObjectCache &cache,
+                            EltwiseQuantizationOp op);
 } // namespace mlir::tt::ttnn
 
-#endif
+#endif // TTMLIR_TARGET_TTNN_TTNNTOFLATBUFFER_H

--- a/lib/OpModel/TTNN/CMakeLists.txt
+++ b/lib/OpModel/TTNN/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     TTNNOutputTensorInference.cpp
     Conversion.cpp
     SingletonDeviceContext.cpp
+    NativeFromMLIR.cpp
 )
 add_library(${LIB_NAME} STATIC ${SOURCES})
 

--- a/lib/OpModel/TTNN/NativeFromMLIR.cpp
+++ b/lib/OpModel/TTNN/NativeFromMLIR.cpp
@@ -1,0 +1,483 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpModel/TTNN/NativeFromMLIR.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/OpModel/TTNN/Conversion.h"
+#include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/Attributes.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <variant>
+#include <vector>
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+
+namespace mlir::tt::ttnn::op_model {
+
+namespace detail {
+std::optional<::tt::target::ttnn::MemoryConfigT>
+getNullableMemoryConfigT(TTNNLayoutAttr layout) {
+  if (!layout) {
+    return std::nullopt;
+  }
+  return conversion::getMemoryConfigT(layout);
+}
+
+std::unique_ptr<::tt::target::ttnn::TensorRefT>
+getOutputTensorRefT(TTNNLayoutAttr layout) {
+  auto memoryConfigNative = getNullableMemoryConfigT(layout);
+  if (!memoryConfigNative.has_value()) {
+    return nullptr;
+  }
+
+  auto tensorRefNative = std::make_unique<::tt::target::ttnn::TensorRefT>();
+  tensorRefNative->desc = std::make_unique<::tt::target::ttnn::TensorDescT>();
+  tensorRefNative->desc->layout =
+      std::make_unique<::tt::target::ttnn::LayoutDescT>();
+  tensorRefNative->desc->layout->memory_desc =
+      std::make_unique<::tt::target::ttnn::MemoryDescT>();
+  tensorRefNative->desc->layout->memory_desc->memory_config =
+      std::make_unique<::tt::target::ttnn::MemoryConfigT>(
+          memoryConfigNative.value());
+
+  tensorRefNative->desc->layout->memory_desc->data_type =
+      toNative(layout.getDataType());
+
+  return tensorRefNative;
+}
+
+/**
+ * @brief Reorder pool2d padding from IR convention to tt-metal convention.
+ *
+ * IR stores padding as [H_low, W_low, H_high, W_high] (top, left, bottom,
+ * right) but tt-metal expects [top, bottom, left, right] (H_low, H_high,
+ * W_low, W_high). The runtime does this reordering when executing from
+ * flatbuffers, but the op_model constraint query path must do it too.
+ */
+std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>>
+reorderPool2dPadding(llvm::ArrayRef<int32_t> padding) {
+  if (padding.size() == 2) {
+    return conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding);
+  }
+  return std::array<uint32_t, 4>{
+      static_cast<uint32_t>(padding[0]), // top
+      static_cast<uint32_t>(padding[2]), // bottom
+      static_cast<uint32_t>(padding[1]), // left
+      static_cast<uint32_t>(padding[3]), // right
+  };
+}
+} // namespace detail
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseUnaryOpT
+buildEltwiseUnaryOpTFromMLIR(TTNNLayoutAttr outputLayout,
+                             std::optional<llvm::APFloat> slope) {
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOp;
+
+  if (std::is_same_v<OpTy, TanhOp>) {
+    eltwiseUnaryOp.type = ::tt::target::ttnn::EltwiseUnaryOpType::Tanh;
+  } else if (std::is_same_v<OpTy, SigmoidOp>) {
+    eltwiseUnaryOp.type = ::tt::target::ttnn::EltwiseUnaryOpType::Sigmoid;
+  } else if (std::is_same_v<OpTy, LeakyReluOp>) {
+    eltwiseUnaryOp.type = ::tt::target::ttnn::EltwiseUnaryOpType::LeakyRelu;
+    assert(slope.has_value() && "LeakyReluOp requires a slope value");
+    ::tt::target::ttnn::EltwiseOpWithFloatParamsT
+        eltwiseOpWithFloatParamsNative;
+    eltwiseOpWithFloatParamsNative.parameter = slope.value().convertToFloat();
+    eltwiseUnaryOp.params.Set(eltwiseOpWithFloatParamsNative);
+  }
+
+  eltwiseUnaryOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseUnaryOp;
+}
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseUnaryCompositeOpT
+buildEltwiseUnaryCompositeOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOp;
+
+  eltwiseUnaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseUnaryCompositeOp;
+}
+
+#define INSTANTIATE_BUILD_ELTWISE_UNARY(OP)                                    \
+  template ::tt::target::ttnn::EltwiseUnaryOpT                                 \
+      buildEltwiseUnaryOpTFromMLIR<OP>(TTNNLayoutAttr,                         \
+                                       std::optional<llvm::APFloat>);
+
+#define INSTANTIATE_BUILD_ELTWISE_UNARY_COMPOSITE(OP)                          \
+  template ::tt::target::ttnn::EltwiseUnaryCompositeOpT                        \
+      buildEltwiseUnaryCompositeOpTFromMLIR<OP>(TTNNLayoutAttr);
+
+INSTANTIATE_BUILD_ELTWISE_UNARY(ReluOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(Relu6Op);
+INSTANTIATE_BUILD_ELTWISE_UNARY(HardsigmoidOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(SqrtOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(SinOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(AbsOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(CosOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(LogOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(CeilOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(SignOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(FloorOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(IsFiniteOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(LogicalNotOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(NegOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(TanOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(AtanOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(AsinOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(AsinhOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(AcosOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(ReciprocalOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY_COMPOSITE(CbrtOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(BitwiseNotOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(SiluOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(MishOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY_COMPOSITE(Log1pOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(Expm1Op);
+INSTANTIATE_BUILD_ELTWISE_UNARY(RsqrtOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(ErfOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(ErfcOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(ExpOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(GeluOp);
+
+INSTANTIATE_BUILD_ELTWISE_UNARY(TanhOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(SigmoidOp);
+INSTANTIATE_BUILD_ELTWISE_UNARY(LeakyReluOp);
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseBinaryOpT
+buildEltwiseBinaryOpTFromMLIR(TTNNLayoutAttr outputLayout,
+                              ttcore::DataTypeAttr opDtypeAttr) {
+  ::tt::target::ttnn::EltwiseBinaryOpT eltwiseBinaryOp;
+
+  eltwiseBinaryOp.out = detail::getOutputTensorRefT(outputLayout);
+  if (eltwiseBinaryOp.out) {
+    eltwiseBinaryOp.output_dtype =
+        eltwiseBinaryOp.out->desc->layout->memory_desc->data_type;
+  }
+  if (opDtypeAttr) {
+    eltwiseBinaryOp.output_dtype = toNative(opDtypeAttr.getValue());
+    if (eltwiseBinaryOp.out && eltwiseBinaryOp.output_dtype.has_value()) {
+      eltwiseBinaryOp.out->desc->layout->memory_desc->data_type =
+          eltwiseBinaryOp.output_dtype.value();
+    }
+  }
+
+  return eltwiseBinaryOp;
+}
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseBinaryCompositeOpT
+buildEltwiseBinaryCompositeOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseBinaryCompositeOpT eltwiseBinaryCompositeOp;
+
+  eltwiseBinaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseBinaryCompositeOp;
+}
+
+#define INSTANTIATE_BUILD_ELTWISE_BINARY(OP)                                   \
+  template ::tt::target::ttnn::EltwiseBinaryOpT                                \
+      buildEltwiseBinaryOpTFromMLIR<OP>(TTNNLayoutAttr, ttcore::DataTypeAttr);
+
+#define INSTANTIATE_BUILD_ELTWISE_BINARY_COMPOSITE(OP)                         \
+  template ::tt::target::ttnn::EltwiseBinaryCompositeOpT                       \
+      buildEltwiseBinaryCompositeOpTFromMLIR<OP>(TTNNLayoutAttr);
+
+INSTANTIATE_BUILD_ELTWISE_BINARY(AddOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(MultiplyOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(LogicalRightShiftOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(SubtractOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(MaximumOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(MinimumOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(DivideOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(EqualOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(NotEqualOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(GreaterEqualOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(GreaterThanOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(LessEqualOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(LessThanOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(LogicalAndOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(LogicalOrOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(LogicalXorOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(PowTensorOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY(RemainderOp);
+
+INSTANTIATE_BUILD_ELTWISE_BINARY_COMPOSITE(BitwiseAndOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY_COMPOSITE(BitwiseOrOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY_COMPOSITE(BitwiseXorOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY_COMPOSITE(LogicalLeftShiftOp);
+INSTANTIATE_BUILD_ELTWISE_BINARY_COMPOSITE(Atan2Op);
+
+::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+buildEltwiseBinaryCompositeScalarOpTFromMLIR(mlir::Attribute exponent,
+                                             TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+      eltwiseBinaryCompositeScalarOp;
+  eltwiseBinaryCompositeScalarOp.type =
+      ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpType::PowScalar;
+
+  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(exponent)) {
+    ::tt::target::ttnn::FloatingPointTypeT fp;
+    fp.value = floatAttr.getValue().convertToFloat();
+    eltwiseBinaryCompositeScalarOp.rhs.Set(fp);
+  } else if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(exponent)) {
+    ::tt::target::ttnn::IntegralTypeT i32;
+    i32.value = static_cast<int32_t>(intAttr.getInt());
+    eltwiseBinaryCompositeScalarOp.rhs.Set(i32);
+  } else {
+    llvm::report_fatal_error("Invalid exponent");
+  }
+
+  eltwiseBinaryCompositeScalarOp.out =
+      detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseBinaryCompositeScalarOp;
+}
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseTernaryWhereOpT
+buildEltwiseTernaryOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseTernaryWhereOpT eltwiseTernaryWhereOp;
+
+  eltwiseTernaryWhereOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseTernaryWhereOp;
+}
+
+#define INSTANTIATE_BUILD_ELTWISE_TERNARY(OP)                                  \
+  template ::tt::target::ttnn::EltwiseTernaryWhereOpT                          \
+      buildEltwiseTernaryOpTFromMLIR<OP>(TTNNLayoutAttr);
+
+INSTANTIATE_BUILD_ELTWISE_TERNARY(WhereOp);
+
+template <typename OpTy>
+::tt::target::ttnn::EltwiseQuantizationOpT
+buildEltwiseQuantizationOpTFromMLIR(std::optional<int32_t> axis,
+                                    std::optional<ttcore::DataType> outputDtype,
+                                    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseQuantizationOpT eltwiseQuantizationOp;
+
+  if constexpr (std::is_same_v<OpTy, QuantizeOp>) {
+    eltwiseQuantizationOp.type =
+        ::tt::target::ttnn::EltwiseQuantizationOpType::Quantize;
+  } else if constexpr (std::is_same_v<OpTy, DequantizeOp>) {
+    eltwiseQuantizationOp.type =
+        ::tt::target::ttnn::EltwiseQuantizationOpType::Dequantize;
+  } else if constexpr (std::is_same_v<OpTy, RequantizeOp>) {
+    eltwiseQuantizationOp.type =
+        ::tt::target::ttnn::EltwiseQuantizationOpType::Requantize;
+  } else {
+    static_assert(ttmlir::utils::always_false(), "Unsupported OpTy");
+  }
+
+  eltwiseQuantizationOp.axis =
+      axis.has_value() ? ::flatbuffers::Optional<int32_t>(axis.value())
+                       : ::flatbuffers::nullopt;
+
+  eltwiseQuantizationOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseQuantizationOp;
+}
+
+#define INSTANTIATE_BUILD_ELTWISE_QUANTIZATION(OP)                             \
+  template ::tt::target::ttnn::EltwiseQuantizationOpT                          \
+      buildEltwiseQuantizationOpTFromMLIR<OP>(std::optional<int32_t>,          \
+                                              std::optional<ttcore::DataType>, \
+                                              TTNNLayoutAttr);
+
+INSTANTIATE_BUILD_ELTWISE_QUANTIZATION(QuantizeOp);
+INSTANTIATE_BUILD_ELTWISE_QUANTIZATION(DequantizeOp);
+INSTANTIATE_BUILD_ELTWISE_QUANTIZATION(RequantizeOp);
+
+::tt::target::ttnn::LinearOpT buildLinearOpTFromMLIR(
+    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+
+  ::tt::target::ttnn::LinearOpT linearOp;
+
+  linearOp.transpose_a = transposeA;
+  linearOp.transpose_b = transposeB;
+
+  if (activation) {
+    linearOp.activation = activation->str();
+  }
+
+  if (programConfigAttr.has_value()) {
+    mlir::TypeSwitch<mlir::Attribute>(*programConfigAttr)
+        .Case<MatmulMultiCoreReuseProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCastProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+            [&](auto config) {
+              linearOp.matmul_program_config.Set(toNative(config));
+            });
+  }
+  linearOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+
+  linearOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return linearOp;
+}
+
+::tt::target::ttnn::MatmulOpT buildMatmulOpTFromMLIR(
+    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+
+  ::tt::target::ttnn::MatmulOpT matmulOp;
+
+  matmulOp.transpose_a = transposeA;
+  matmulOp.transpose_b = transposeB;
+
+  if (activation) {
+    matmulOp.activation = activation->str();
+  }
+
+  if (programConfigAttr.has_value()) {
+    mlir::TypeSwitch<mlir::Attribute>(*programConfigAttr)
+        .Case<MatmulMultiCoreReuseProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCastProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+            [&](auto config) {
+              matmulOp.matmul_program_config.Set(toNative(config));
+            });
+  }
+  matmulOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+
+  matmulOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return matmulOp;
+}
+
+::tt::target::ttnn::Conv2dOpT buildConv2dOpTFromMLIR(
+    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+    uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::Conv2dOpT conv2dOp;
+  conv2dOp.in_channels = in_channels;
+  conv2dOp.out_channels = out_channels;
+  conv2dOp.batch_size = batch_size;
+  conv2dOp.input_height = input_height;
+  conv2dOp.input_width = input_width;
+  conv2dOp.kernel_size =
+      std::vector<int32_t>(kernel_size.begin(), kernel_size.end());
+  conv2dOp.stride = std::vector<int32_t>(stride.begin(), stride.end());
+  auto reorderedPadding = detail::reorderPool2dPadding(padding);
+  std::visit(
+      [&conv2dOp](const auto &arr) {
+        conv2dOp.padding.assign(arr.begin(), arr.end());
+      },
+      reorderedPadding);
+  conv2dOp.dilation = std::vector<int32_t>(dilation.begin(), dilation.end());
+  conv2dOp.groups = groups;
+  conv2dOp.out = detail::getOutputTensorRefT(outputLayout);
+  conv2dOp.conv2d_config =
+      (conv2dConfig.has_value() && *conv2dConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dConfigT>(
+                toNative(*conv2dConfig))
+          : nullptr;
+  conv2dOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  conv2dOp.conv2d_slice_config =
+      (conv2dSliceConfig.has_value() && *conv2dSliceConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dSliceConfigT>(
+                toNative(*conv2dSliceConfig))
+          : nullptr;
+
+  return conv2dOp;
+}
+
+::tt::target::ttnn::EltwiseUnaryCompositeOpT
+buildEltwiseUnaryCompositeClampScalarOpTFromMLIR(mlir::Attribute min,
+                                                 mlir::Attribute max,
+                                                 TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOp;
+  eltwiseUnaryCompositeOp.type =
+      ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampScalar;
+
+  ::tt::target::ttnn::ClampScalarOpParamsT params;
+
+  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(min)) {
+    ::tt::target::ttnn::FloatingPointTypeT fp;
+    fp.value = floatAttr.getValue().convertToFloat();
+    params.min.Set(fp);
+  } else if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(min)) {
+    ::tt::target::ttnn::IntegralTypeT i32;
+    i32.value = static_cast<int32_t>(intAttr.getInt());
+    params.min.Set(i32);
+  } else {
+    llvm_unreachable("Invalid clamp min attribute");
+  }
+
+  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(max)) {
+    ::tt::target::ttnn::FloatingPointTypeT fp;
+    fp.value = floatAttr.getValue().convertToFloat();
+    params.max.Set(fp);
+  } else if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(max)) {
+    ::tt::target::ttnn::IntegralTypeT i32;
+    i32.value = static_cast<int32_t>(intAttr.getInt());
+    params.max.Set(i32);
+  } else {
+    llvm_unreachable("Invalid clamp max attribute");
+  }
+
+  eltwiseUnaryCompositeOp.params.Set(params);
+
+  eltwiseUnaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseUnaryCompositeOp;
+}
+
+::tt::target::ttnn::EltwiseUnaryCompositeOpT
+buildEltwiseUnaryCompositeClampTensorOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOp;
+  eltwiseUnaryCompositeOp.type =
+      ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampTensor;
+
+  eltwiseUnaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseUnaryCompositeOp;
+}
+
+} // namespace mlir::tt::ttnn::op_model
+
+#endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -21,6 +21,7 @@
 #include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
 #include "ttmlir/OpInvoke/TTNN/utils/utils.h"
 #include "ttmlir/OpModel/TTNN/Conversion.h"
+#include "ttmlir/OpModel/TTNN/NativeFromMLIR.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
 #include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
 #include "ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp"
@@ -232,58 +233,6 @@ getNullableMemoryConfig(TTNNLayoutAttr layout) {
     return std::nullopt;
   }
   return conversion::getMemoryConfig(layout);
-}
-
-std::optional<::tt::target::ttnn::MemoryConfigT>
-getNullableMemoryConfigT(TTNNLayoutAttr layout) {
-  if (!layout) {
-    return std::nullopt;
-  }
-  return conversion::getMemoryConfigT(layout);
-}
-
-std::unique_ptr<::tt::target::ttnn::TensorRefT>
-getOutputTensorRefT(TTNNLayoutAttr layout) {
-  auto memoryConfigNative = getNullableMemoryConfigT(layout);
-  if (!memoryConfigNative.has_value()) {
-    return nullptr;
-  }
-
-  auto tensorRefNative = std::make_unique<::tt::target::ttnn::TensorRefT>();
-  tensorRefNative->desc = std::make_unique<::tt::target::ttnn::TensorDescT>();
-  tensorRefNative->desc->layout =
-      std::make_unique<::tt::target::ttnn::LayoutDescT>();
-  tensorRefNative->desc->layout->memory_desc =
-      std::make_unique<::tt::target::ttnn::MemoryDescT>();
-  tensorRefNative->desc->layout->memory_desc->memory_config =
-      std::make_unique<::tt::target::ttnn::MemoryConfigT>(
-          memoryConfigNative.value());
-
-  tensorRefNative->desc->layout->memory_desc->data_type =
-      toNative(layout.getDataType());
-
-  return tensorRefNative;
-}
-
-/**
- * @brief Reorder pool2d padding from IR convention to tt-metal convention.
- *
- * IR stores padding as [H_low, W_low, H_high, W_high] (top, left, bottom,
- * right) but tt-metal expects [top, bottom, left, right] (H_low, H_high,
- * W_low, W_high). The runtime does this reordering when executing from
- * flatbuffers, but the op_model constraint query path must do it too.
- */
-std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>>
-reorderPool2dPadding(llvm::ArrayRef<int32_t> padding) {
-  if (padding.size() == 2) {
-    return conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding);
-  }
-  return std::array<uint32_t, 4>{
-      static_cast<uint32_t>(padding[0]), // top
-      static_cast<uint32_t>(padding[2]), // bottom
-      static_cast<uint32_t>(padding[1]), // left
-      static_cast<uint32_t>(padding[3]), // right
-  };
 }
 
 /**
@@ -997,31 +946,6 @@ OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints(
 //===----------------------------------------------------------------------===//
 // Unary Eltwise Ops
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-template <typename OpTy>
-static ::tt::target::ttnn::EltwiseUnaryOpT buildEltwiseUnaryOpTFromMLIR(
-    TTNNLayoutAttr outputLayout,
-    std::optional<llvm::APFloat> slope = std::nullopt) {
-  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOp;
-
-  if (std::is_same_v<OpTy, TanhOp>) {
-    eltwiseUnaryOp.type = ::tt::target::ttnn::EltwiseUnaryOpType::Tanh;
-  } else if (std::is_same_v<OpTy, SigmoidOp>) {
-    eltwiseUnaryOp.type = ::tt::target::ttnn::EltwiseUnaryOpType::Sigmoid;
-  } else if (std::is_same_v<OpTy, LeakyReluOp>) {
-    eltwiseUnaryOp.type = ::tt::target::ttnn::EltwiseUnaryOpType::LeakyRelu;
-    assert(slope.has_value() && "LeakyReluOp requires a slope value");
-    ::tt::target::ttnn::EltwiseOpWithFloatParamsT
-        eltwiseOpWithFloatParamsNative;
-    eltwiseOpWithFloatParamsNative.parameter = slope.value().convertToFloat();
-    eltwiseUnaryOp.params.Set(eltwiseOpWithFloatParamsNative);
-  }
-
-  eltwiseUnaryOp.out = detail::getOutputTensorRefT(outputLayout);
-
-  return eltwiseUnaryOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints>
@@ -1175,17 +1099,6 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Unary Composite Eltwise Ops
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-template <typename OpTy>
-static ::tt::target::ttnn::EltwiseUnaryCompositeOpT
-buildEltwiseUnaryCompositeOpTFromMLIR(TTNNLayoutAttr outputLayout) {
-  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOp;
-
-  eltwiseUnaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
-
-  return eltwiseUnaryCompositeOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints>
@@ -1614,29 +1527,6 @@ llvm::Expected<size_t> OpModel<LeakyReluOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Binary Eltwise Ops
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-template <typename OpTy>
-static ::tt::target::ttnn::EltwiseBinaryOpT
-buildEltwiseBinaryOpTFromMLIR(TTNNLayoutAttr outputLayout,
-                              ttcore::DataTypeAttr opDtypeAttr = nullptr) {
-  ::tt::target::ttnn::EltwiseBinaryOpT eltwiseBinaryOp;
-
-  eltwiseBinaryOp.out = detail::getOutputTensorRefT(outputLayout);
-  if (eltwiseBinaryOp.out) {
-    eltwiseBinaryOp.output_dtype =
-        eltwiseBinaryOp.out->desc->layout->memory_desc->data_type;
-  }
-  if (opDtypeAttr) {
-    eltwiseBinaryOp.output_dtype = toNative(opDtypeAttr.getValue());
-    if (eltwiseBinaryOp.out && eltwiseBinaryOp.output_dtype.has_value()) {
-      eltwiseBinaryOp.out->desc->layout->memory_desc->data_type =
-          eltwiseBinaryOp.output_dtype.value();
-    }
-  }
-
-  return eltwiseBinaryOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
@@ -1718,18 +1608,6 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
 }
-
-#ifdef TTMLIR_ENABLE_OPMODEL
-template <typename OpTy>
-static ::tt::target::ttnn::EltwiseBinaryCompositeOpT
-buildEltwiseBinaryCompositeOpTFromMLIR(TTNNLayoutAttr outputLayout) {
-  ::tt::target::ttnn::EltwiseBinaryCompositeOpT eltwiseBinaryCompositeOp;
-
-  eltwiseBinaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
-
-  return eltwiseBinaryCompositeOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
@@ -1911,33 +1789,6 @@ llvm::Expected<size_t> OpModel<GeluBackwardOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // PowScalar
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-static ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
-buildEltwiseBinaryCompositeScalarOpTFromMLIR(mlir::Attribute exponent,
-                                             TTNNLayoutAttr outputLayout) {
-  ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
-      eltwiseBinaryCompositeScalarOp;
-  eltwiseBinaryCompositeScalarOp.type =
-      ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpType::PowScalar;
-
-  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(exponent)) {
-    ::tt::target::ttnn::FloatingPointTypeT fp;
-    fp.value = floatAttr.getValue().convertToFloat();
-    eltwiseBinaryCompositeScalarOp.rhs.Set(fp);
-  } else if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(exponent)) {
-    ::tt::target::ttnn::IntegralTypeT i32;
-    i32.value = static_cast<int32_t>(intAttr.getInt());
-    eltwiseBinaryCompositeScalarOp.rhs.Set(i32);
-  } else {
-    llvm::report_fatal_error("Invalid exponent");
-  }
-
-  eltwiseBinaryCompositeScalarOp.out =
-      detail::getOutputTensorRefT(outputLayout);
-
-  return eltwiseBinaryCompositeScalarOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2016,17 +1867,6 @@ llvm::Expected<size_t> OpModel<PowScalarOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-template <typename OpTy>
-static ::tt::target::ttnn::EltwiseTernaryWhereOpT
-buildEltwiseTernaryOpTFromMLIR(TTNNLayoutAttr outputLayout) {
-  ::tt::target::ttnn::EltwiseTernaryWhereOpT eltwiseTernaryWhereOp;
-
-  eltwiseTernaryWhereOp.out = detail::getOutputTensorRefT(outputLayout);
-
-  return eltwiseTernaryWhereOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
@@ -4549,36 +4389,6 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
 //===----------------------------------------------------------------------===//
 // Quantization Ops
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-template <typename OpTy>
-static ::tt::target::ttnn::EltwiseQuantizationOpT
-buildEltwiseQuantizationOpTFromMLIR(std::optional<int32_t> axis,
-                                    std::optional<ttcore::DataType> outputDtype,
-                                    TTNNLayoutAttr outputLayout) {
-  ::tt::target::ttnn::EltwiseQuantizationOpT eltwiseQuantizationOp;
-
-  if constexpr (std::is_same_v<OpTy, QuantizeOp>) {
-    eltwiseQuantizationOp.type =
-        ::tt::target::ttnn::EltwiseQuantizationOpType::Quantize;
-  } else if constexpr (std::is_same_v<OpTy, DequantizeOp>) {
-    eltwiseQuantizationOp.type =
-        ::tt::target::ttnn::EltwiseQuantizationOpType::Dequantize;
-  } else if constexpr (std::is_same_v<OpTy, RequantizeOp>) {
-    eltwiseQuantizationOp.type =
-        ::tt::target::ttnn::EltwiseQuantizationOpType::Requantize;
-  } else {
-    static_assert(ttmlir::utils::always_false(), "Unsupported OpTy");
-  }
-
-  eltwiseQuantizationOp.axis =
-      axis.has_value() ? ::flatbuffers::Optional<int32_t>(axis.value())
-                       : ::flatbuffers::nullopt;
-
-  eltwiseQuantizationOp.out = detail::getOutputTensorRefT(outputLayout);
-
-  return eltwiseQuantizationOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> QuantizationOpModel<OpTy>::getOpConstraints(
@@ -4806,43 +4616,6 @@ llvm::Expected<size_t> OpModel<RequantizeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // LinearOp
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-static ::tt::target::ttnn::LinearOpT buildLinearOpTFromMLIR(
-    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
-    std::optional<mlir::Attribute> programConfigAttr,
-    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
-    TTNNLayoutAttr outputLayout) {
-
-  ::tt::target::ttnn::LinearOpT linearOp;
-
-  linearOp.transpose_a = transposeA;
-  linearOp.transpose_b = transposeB;
-
-  if (activation) {
-    linearOp.activation = activation->str();
-  }
-
-  if (programConfigAttr.has_value()) {
-    mlir::TypeSwitch<mlir::Attribute>(*programConfigAttr)
-        .Case<MatmulMultiCoreReuseProgramConfigAttr,
-              MatmulMultiCoreReuseMultiCastProgramConfigAttr,
-              MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
-              MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
-            [&](auto config) {
-              linearOp.matmul_program_config.Set(toNative(config));
-            });
-  }
-  linearOp.compute_config =
-      (computeKernelConfig.has_value() && *computeKernelConfig)
-          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
-                toNative(*computeKernelConfig))
-          : nullptr;
-
-  linearOp.out = detail::getOutputTensorRefT(outputLayout);
-
-  return linearOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -4952,43 +4725,6 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-static ::tt::target::ttnn::MatmulOpT buildMatmulOpTFromMLIR(
-    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
-    std::optional<mlir::Attribute> programConfigAttr,
-    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
-    TTNNLayoutAttr outputLayout) {
-
-  ::tt::target::ttnn::MatmulOpT matmulOp;
-
-  matmulOp.transpose_a = transposeA;
-  matmulOp.transpose_b = transposeB;
-
-  if (activation) {
-    matmulOp.activation = activation->str();
-  }
-
-  if (programConfigAttr.has_value()) {
-    mlir::TypeSwitch<mlir::Attribute>(*programConfigAttr)
-        .Case<MatmulMultiCoreReuseProgramConfigAttr,
-              MatmulMultiCoreReuseMultiCastProgramConfigAttr,
-              MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
-              MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
-            [&](auto config) {
-              matmulOp.matmul_program_config.Set(toNative(config));
-            });
-  }
-  matmulOp.compute_config =
-      (computeKernelConfig.has_value() && *computeKernelConfig)
-          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
-                toNative(*computeKernelConfig))
-          : nullptr;
-
-  matmulOp.out = detail::getOutputTensorRefT(outputLayout);
-
-  return matmulOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -5424,57 +5160,6 @@ llvm::Expected<size_t> OpModel<PagedFillCacheOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Conv2dOp
 //===----------------------------------------------------------------------===//
-
-#ifdef TTMLIR_ENABLE_OPMODEL
-static ::tt::target::ttnn::Conv2dOpT buildConv2dOpTFromMLIR(
-    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
-    uint32_t input_height, uint32_t input_width,
-    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
-    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-    TTNNLayoutAttr outputLayout) {
-  ::tt::target::ttnn::Conv2dOpT conv2dOp;
-  conv2dOp.in_channels = in_channels;
-  conv2dOp.out_channels = out_channels;
-  conv2dOp.batch_size = batch_size;
-  conv2dOp.input_height = input_height;
-  conv2dOp.input_width = input_width;
-  conv2dOp.kernel_size =
-      std::vector<int32_t>(kernel_size.begin(), kernel_size.end());
-  conv2dOp.stride = std::vector<int32_t>(stride.begin(), stride.end());
-  auto reorderedPadding = detail::reorderPool2dPadding(padding);
-  std::visit(
-      [&conv2dOp](const auto &arr) {
-        conv2dOp.padding.assign(arr.begin(), arr.end());
-      },
-      reorderedPadding);
-  conv2dOp.dilation = std::vector<int32_t>(dilation.begin(), dilation.end());
-  conv2dOp.groups = groups;
-  conv2dOp.out = detail::getOutputTensorRefT(outputLayout);
-  if (conv2dOp.out) {
-    conv2dOp.output_dtype = conv2dOp.out->desc->layout->memory_desc->data_type;
-  }
-  conv2dOp.conv2d_config =
-      (conv2dConfig.has_value() && *conv2dConfig)
-          ? std::make_unique<::tt::target::ttnn::Conv2dConfigT>(
-                toNative(*conv2dConfig))
-          : nullptr;
-  conv2dOp.compute_config =
-      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
-          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
-                toNative(*deviceComputeKernelConfig))
-          : nullptr;
-  conv2dOp.conv2d_slice_config =
-      (conv2dSliceConfig.has_value() && *conv2dSliceConfig)
-          ? std::make_unique<::tt::target::ttnn::Conv2dSliceConfigT>(
-                toNative(*conv2dSliceConfig))
-          : nullptr;
-
-  return conv2dOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -7401,48 +7086,6 @@ llvm::Expected<size_t> OpModel<GroupNormOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ClampScalar
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-static ::tt::target::ttnn::EltwiseUnaryCompositeOpT
-buildEltwiseUnaryCompositeClampScalarOpTFromMLIR(mlir::Attribute min,
-                                                 mlir::Attribute max,
-                                                 TTNNLayoutAttr outputLayout) {
-  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOp;
-  eltwiseUnaryCompositeOp.type =
-      ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampScalar;
-
-  ::tt::target::ttnn::ClampScalarOpParamsT params;
-
-  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(min)) {
-    ::tt::target::ttnn::FloatingPointTypeT fp;
-    fp.value = floatAttr.getValue().convertToFloat();
-    params.min.Set(fp);
-  } else if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(min)) {
-    ::tt::target::ttnn::IntegralTypeT i32;
-    i32.value = static_cast<int32_t>(intAttr.getInt());
-    params.min.Set(i32);
-  } else {
-    llvm_unreachable("Invalid clamp min attribute");
-  }
-
-  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(max)) {
-    ::tt::target::ttnn::FloatingPointTypeT fp;
-    fp.value = floatAttr.getValue().convertToFloat();
-    params.max.Set(fp);
-  } else if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(max)) {
-    ::tt::target::ttnn::IntegralTypeT i32;
-    i32.value = static_cast<int32_t>(intAttr.getInt());
-    params.max.Set(i32);
-  } else {
-    llvm_unreachable("Invalid clamp max attribute");
-  }
-
-  eltwiseUnaryCompositeOp.params.Set(params);
-
-  eltwiseUnaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
-
-  return eltwiseUnaryCompositeOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -7517,18 +7160,6 @@ llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ClampTensor
 //===----------------------------------------------------------------------===//
-#ifdef TTMLIR_ENABLE_OPMODEL
-static ::tt::target::ttnn::EltwiseUnaryCompositeOpT
-buildEltwiseUnaryCompositeClampTensorOpTFromMLIR(TTNNLayoutAttr outputLayout) {
-  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOp;
-  eltwiseUnaryCompositeOp.type =
-      ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampTensor;
-
-  eltwiseUnaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
-
-  return eltwiseUnaryCompositeOp;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,

--- a/test/unittests/MLIRAttrToFBNative/CMakeLists.txt
+++ b/test/unittests/MLIRAttrToFBNative/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_mlir_unittest(ToNativeConsistencyTests
     ToNativeConsistency.cpp
+    OpTPathParity.cpp
     PARTIAL_SOURCES_INTENDED
 )
 
@@ -24,4 +25,7 @@ target_link_libraries(ToNativeConsistencyTests
     gtest_main
     MLIRTTCoreDialect
     MLIRTTNNDialect
+    MLIRTTTransforms
+    TTNNTargetFlatbuffer
+    TTNNOpModelLib
 )

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
@@ -1,0 +1,1376 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "OpTPathParity.h"
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttmlir/OpModel/TTNN/NativeFromMLIR.h"
+#include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
+#include "ttmlir/Target/TTNN/TTNNToFlatbuffer.h"
+
+void compareOutputTensorRefT(
+    const std::unique_ptr<::tt::target::ttnn::TensorRefT> &opNativeOpModelOut,
+    const std::unique_ptr<::tt::target::ttnn::TensorRefT> &opNativeFBOut) {
+  if (!opNativeOpModelOut && !opNativeFBOut) {
+    return;
+  }
+  ASSERT_TRUE(opNativeOpModelOut && opNativeFBOut);
+  EXPECT_EQ(ttnn_op_invoke::operations::utils::getTensorRefMemoryConfig(
+                *opNativeOpModelOut),
+            ttnn_op_invoke::operations::utils::getTensorRefMemoryConfig(
+                *opNativeFBOut));
+  EXPECT_EQ(ttnn_op_invoke::operations::utils::getDataType(*opNativeOpModelOut),
+            ttnn_op_invoke::operations::utils::getDataType(*opNativeFBOut));
+}
+
+//===----------------------------------------------------------------------===//
+// MatmulOpTPathParity
+//===----------------------------------------------------------------------===//
+constexpr std::array<int64_t, 2> shapeArray = {32, 32};
+const llvm::ArrayRef<int64_t> defaultShape = shapeArray;
+
+const mlir::tt::ttcore::DataTypeAttr bf16DtypeAttr =
+    mlir::tt::ttcore::DataTypeAttr::get(getContext(),
+                                        mlir::tt::ttcore::DataType::BFloat16);
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::MatmulOpT &opNativeOpModel,
+                       ::tt::target::ttnn::MatmulOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::MatmulOpT &op) {
+    op.a.reset();
+    op.b.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::MatmulOp buildTestMatmulOp(
+    bool transposeA = false, bool transposeB = false,
+    mlir::StringAttr activation = {}, mlir::Attribute programConfigAttr = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeKernelConfig = {}) {
+  auto &e = env();
+
+  auto typeA = tiledL1BF16Type(defaultShape);
+  auto typeB = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  auto loc = e.builder.getUnknownLoc();
+  mlir::Value a = e.builder
+                      .create<mlir::tt::ttnn::OnesOp>(
+                          loc, mlir::TypeRange{typeA}, mlir::ValueRange{})
+                      .getResult();
+  mlir::Value b = e.builder
+                      .create<mlir::tt::ttnn::OnesOp>(
+                          loc, mlir::TypeRange{typeB}, mlir::ValueRange{})
+                      .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::MatmulOp>(
+      loc, outputType, a, b, transposeA, transposeB, programConfigAttr,
+      activation, computeKernelConfig);
+}
+
+} // namespace
+
+using MatmulOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::MatmulOp>;
+
+TEST_P(MatmulOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::MatmulOp matmulOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::MatmulOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildMatmulOpTFromMLIR(
+          matmulOp.getTransposeA(), matmulOp.getTransposeB(),
+          matmulOp.getActivation(), matmulOp.getMatmulProgramConfig(),
+          matmulOp.getComputeConfig(), resolveOutputLayout(matmulOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, matmulOp.getA(), matmulOp.getB());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, matmulOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::MatmulOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::MatmulOp> matmulOpList = {
+    buildTestMatmulOp(),
+    buildTestMatmulOp(/*transposeA=*/true),
+    buildTestMatmulOp(/*transposeA=*/false, /*transposeB=*/true),
+    buildTestMatmulOp(
+        /*transposeA=*/false, /*transposeB=*/false,
+        /*activation=*/mlir::StringAttr::get(getContext(), "relu")),
+    buildTestMatmulOp(
+        /*transposeA=*/false, /*transposeB=*/false, /*activation=*/{},
+        /*programConfigAttr=*/
+        mlir::tt::ttnn::MatmulMultiCoreReuseProgramConfigAttr::get(
+            getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(getContext(), 8, 8), 2, 4, 4, 8,
+            8)),
+    buildTestMatmulOp(
+        /*transposeA=*/false, /*transposeB=*/false, /*activation=*/{},
+        /*programConfigAttr=*/
+        mlir::tt::ttnn::MatmulMultiCoreReuseMultiCastProgramConfigAttr::get(
+            getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(getContext(), 8, 8), 2, 4, 4, 8,
+            8, 8, 8, false, mlir::tt::ttnn::UnaryWithParamAttr(), false)),
+    buildTestMatmulOp(
+        /*transposeA=*/false, /*transposeB=*/false, /*activation=*/{},
+        /*programConfigAttr=*/
+        mlir::tt::ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigAttr::get(
+            getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(getContext(), 4, 4), 1, 2, 2, 4,
+            4, 4, 4, true, mlir::tt::ttnn::UnaryWithParamAttr(), false, true,
+            mlir::tt::ttnn::CoreRangeSetAttr::get(
+                getContext(), llvm::ArrayRef<mlir::tt::ttnn::CoreRangeAttr>()),
+            0, false)),
+    buildTestMatmulOp(
+        /*transposeA=*/false, /*transposeB=*/false, /*activation=*/{},
+        /*programConfigAttr=*/
+        mlir::tt::ttnn::
+            MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr::get(
+                getContext(), 4, 8, 8, mlir::tt::ttnn::UnaryWithParamAttr())),
+    buildTestMatmulOp(/*transposeA=*/false, /*transposeB=*/false,
+                      /*activation=*/{}, /*programConfigAttr=*/{},
+                      /*computeKernelConfig=*/
+                      mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
+                          getContext(), mlir::tt::ttnn::MathFidelity::HiFi2,
+                          mlir::BoolAttr::get(getContext(), false),
+                          mlir::BoolAttr::get(getContext(), true),
+                          mlir::BoolAttr::get(getContext(), true),
+                          mlir::BoolAttr::get(getContext(), false))),
+    buildTestMatmulOp(
+        /*transposeA=*/true, /*transposeB=*/true,
+        /*activation=*/mlir::StringAttr::get(getContext(), "relu"),
+        /*programConfigAttr=*/
+        mlir::tt::ttnn::MatmulMultiCoreReuseProgramConfigAttr::get(
+            getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(getContext(), 8, 8), 2, 4, 4, 8,
+            8),
+        /*computeKernelConfig=*/
+        mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
+            getContext(), mlir::tt::ttnn::MathFidelity::HiFi4,
+            mlir::BoolAttr::get(getContext(), true),
+            mlir::BoolAttr::get(getContext(), false),
+            mlir::BoolAttr::get(getContext(), true),
+            mlir::BoolAttr::get(getContext(), true))),
+};
+
+INSTANTIATE_TEST_SUITE_P(MatmulOpTPathParityTest, MatmulOpTPathParityTest,
+                         ::testing::ValuesIn(matmulOpList));
+
+//===----------------------------------------------------------------------===//
+// Conv2dOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::Conv2dOpT &opNativeOpModel,
+                       ::tt::target::ttnn::Conv2dOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::Conv2dOpT &op) {
+    op.input.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.device.reset();
+    op.out.reset();
+    op.output_dtype.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::Conv2dOp buildTestConv2dOp(
+    bool withBias = false, mlir::tt::ttcore::DataTypeAttr outputDtype = {},
+    mlir::tt::ttnn::Conv2dConfigAttr conv2dConfig = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeKernelConfig = {},
+    mlir::tt::ttnn::Conv2dSliceConfigAttr conv2dSliceConfig = {},
+    uint32_t inChannels = 3, uint32_t outChannels = 64, uint32_t batchSize = 1,
+    uint32_t inputHeight = 224, uint32_t inputWidth = 224,
+    llvm::ArrayRef<int32_t> kernelSize = {7, 7},
+    llvm::ArrayRef<int32_t> stride = {2, 2},
+    llvm::ArrayRef<int32_t> padding = {3, 3},
+    llvm::ArrayRef<int32_t> dilation = {1, 1}, uint32_t groups = 1) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto weightType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value weight =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{weightType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value bias = nullptr;
+  if (withBias) {
+    auto biasType = tiledL1BF16Type(defaultShape);
+    bias = e.builder
+               .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{biasType},
+                                               mlir::ValueRange{})
+               .getResult();
+  }
+
+  mlir::Value device =
+      e.builder
+          .create<mlir::tt::ttnn::GetDeviceOp>(
+              loc, e.builder.getType<mlir::tt::ttnn::DeviceType>(),
+              mlir::tt::ttnn::MeshShapeAttr::get(&e.context, 1, 1),
+              mlir::tt::ttnn::MeshOffsetAttr::get(&e.context, 0, 0))
+          .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::Conv2dOp>(
+      loc, outputType, input, weight, bias, device, inChannels, outChannels,
+      batchSize, inputHeight, inputWidth, kernelSize, stride, padding, dilation,
+      groups, conv2dConfig, computeKernelConfig, conv2dSliceConfig);
+}
+
+} // namespace
+
+using Conv2dOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::Conv2dOp>;
+
+TEST_P(Conv2dOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::Conv2dOp conv2dOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::Conv2dOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildConv2dOpTFromMLIR(
+          conv2dOp.getInChannels(), conv2dOp.getOutChannels(),
+          conv2dOp.getBatchSize(), conv2dOp.getInputHeight(),
+          conv2dOp.getInputWidth(), conv2dOp.getKernelSize(),
+          conv2dOp.getStride(), conv2dOp.getPadding(), conv2dOp.getDilation(),
+          conv2dOp.getGroups(), conv2dOp.getConv2dConfig(),
+          conv2dOp.getComputeConfig(), conv2dOp.getConv2dSliceConfig(),
+          resolveOutputLayout(conv2dOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, conv2dOp.getInput(),
+                               conv2dOp.getWeight());
+  if (conv2dOp.getBias()) {
+    prepopulateOperandTensorRefs(cache, conv2dOp.getBias());
+  }
+  cache.getOrCreate(conv2dOp.getDevice(), mlir::tt::ttnn::createDeviceRef);
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, conv2dOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::Conv2dOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::Conv2dOp> conv2dOpList = {
+    buildTestConv2dOp(),
+    buildTestConv2dOp(/*withBias=*/true),
+    buildTestConv2dOp(/*withBias=*/false,
+                      /*outputDtype=*/bf16DtypeAttr),
+    buildTestConv2dOp(
+        /*withBias=*/false, /*outputDtype=*/{},
+        /*conv2dConfig=*/
+        mlir::tt::ttnn::Conv2dConfigAttr::get(
+            getContext(),
+            /*weights_dtype=*/mlir::tt::ttcore::DataType::BFloat16,
+            /*activation=*/mlir::tt::ttnn::UnaryWithParamAttr(),
+            /*deallocate_activation=*/mlir::BoolAttr::get(getContext(), false),
+            /*reallocate_halo_output=*/mlir::BoolAttr::get(getContext(), true),
+            /*act_block_h_override=*/0, /*act_block_w_div=*/1,
+            /*reshard_if_not_optimal=*/mlir::BoolAttr::get(getContext(), false),
+            /*override_sharding_config=*/
+            mlir::BoolAttr::get(getContext(), false),
+            /*shard_layout=*/std::nullopt,
+            /*core_grid=*/mlir::tt::ttnn::CoreRangeSetAttr(),
+            /*transpose_shards=*/mlir::BoolAttr::get(getContext(), false),
+            /*output_layout=*/mlir::tt::ttnn::Layout::Tile,
+            /*enable_act_double_buffer=*/
+            mlir::BoolAttr::get(getContext(), true),
+            /*enable_weights_double_buffer=*/
+            mlir::BoolAttr::get(getContext(), true),
+            /*enable_kernel_stride_folding=*/
+            mlir::BoolAttr::get(getContext(), false),
+            /*config_tensors_in_dram=*/mlir::BoolAttr())),
+    buildTestConv2dOp(
+        /*withBias=*/false, /*outputDtype=*/{}, /*conv2dConfig=*/{},
+        /*computeKernelConfig=*/
+        mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
+            getContext(), mlir::tt::ttnn::MathFidelity::HiFi2,
+            mlir::BoolAttr::get(getContext(), false),
+            mlir::BoolAttr::get(getContext(), true),
+            mlir::BoolAttr::get(getContext(), true),
+            mlir::BoolAttr::get(getContext(), false))),
+    buildTestConv2dOp(
+        /*withBias=*/false, /*outputDtype=*/{}, /*conv2dConfig=*/{},
+        /*computeKernelConfig=*/{},
+        /*conv2dSliceConfig=*/
+        mlir::tt::ttnn::Conv2dSliceConfigAttr::get(
+            getContext(), mlir::tt::ttnn::Conv2dSliceType::DramHeight, 4)),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/64u),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/3u,
+                      /*outChannels=*/128u),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/3u,
+                      /*outChannels=*/64u, /*batchSize=*/8u),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/3u,
+                      /*outChannels=*/64u, /*batchSize=*/1u,
+                      /*inputHeight=*/56u),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/3u,
+                      /*outChannels=*/64u, /*batchSize=*/1u,
+                      /*inputHeight=*/224u, /*inputWidth=*/56u),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/3u,
+                      /*outChannels=*/64u, /*batchSize=*/1u,
+                      /*inputHeight=*/224u, /*inputWidth=*/224u,
+                      /*kernelSize=*/{3, 3}),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/3u,
+                      /*outChannels=*/64u, /*batchSize=*/1u,
+                      /*inputHeight=*/224u, /*inputWidth=*/224u,
+                      /*kernelSize=*/{7, 7}, /*stride=*/{1, 1}),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/3u,
+                      /*outChannels=*/64u, /*batchSize=*/1u,
+                      /*inputHeight=*/224u, /*inputWidth=*/224u,
+                      /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
+                      /*padding=*/{1, 1}),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/3u,
+                      /*outChannels=*/64u, /*batchSize=*/1u,
+                      /*inputHeight=*/224u, /*inputWidth=*/224u,
+                      /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
+                      /*padding=*/{3, 3}, /*dilation=*/{2, 2}),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/{}, /*inChannels=*/3u,
+                      /*outChannels=*/64u, /*batchSize=*/1u,
+                      /*inputHeight=*/224u, /*inputWidth=*/224u,
+                      /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
+                      /*padding=*/{3, 3}, /*dilation=*/{1, 1},
+                      /*groups=*/3u),
+    buildTestConv2dOp(
+        /*withBias=*/true,
+        /*outputDtype=*/bf16DtypeAttr,
+        /*conv2dConfig=*/
+        mlir::tt::ttnn::Conv2dConfigAttr::get(
+            getContext(),
+            /*weights_dtype=*/mlir::tt::ttcore::DataType::BFloat16,
+            /*activation=*/mlir::tt::ttnn::UnaryWithParamAttr(),
+            /*deallocate_activation=*/mlir::BoolAttr::get(getContext(), true),
+            /*reallocate_halo_output=*/mlir::BoolAttr::get(getContext(), false),
+            /*act_block_h_override=*/32, /*act_block_w_div=*/1,
+            /*reshard_if_not_optimal=*/mlir::BoolAttr::get(getContext(), false),
+            /*override_sharding_config=*/
+            mlir::BoolAttr::get(getContext(), false),
+            /*shard_layout=*/std::nullopt,
+            /*core_grid=*/mlir::tt::ttnn::CoreRangeSetAttr(),
+            /*transpose_shards=*/mlir::BoolAttr::get(getContext(), false),
+            /*output_layout=*/mlir::tt::ttnn::Layout::Tile,
+            /*enable_act_double_buffer=*/
+            mlir::BoolAttr::get(getContext(), true),
+            /*enable_weights_double_buffer=*/
+            mlir::BoolAttr::get(getContext(), false),
+            /*enable_kernel_stride_folding=*/
+            mlir::BoolAttr::get(getContext(), false),
+            /*config_tensors_in_dram=*/mlir::BoolAttr()),
+        /*computeKernelConfig=*/
+        mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
+            getContext(), mlir::tt::ttnn::MathFidelity::HiFi3,
+            mlir::BoolAttr::get(getContext(), false),
+            mlir::BoolAttr::get(getContext(), false),
+            mlir::BoolAttr::get(getContext(), true),
+            mlir::BoolAttr::get(getContext(), true)),
+        /*conv2dSliceConfig=*/
+        mlir::tt::ttnn::Conv2dSliceConfigAttr::get(
+            getContext(), mlir::tt::ttnn::Conv2dSliceType::DramHeight, 2),
+        /*inChannels=*/16u, /*outChannels=*/32u, /*batchSize=*/2u,
+        /*inputHeight=*/112u, /*inputWidth=*/112u,
+        /*kernelSize=*/{3, 3}, /*stride=*/{1, 1}, /*padding=*/{1, 1},
+        /*dilation=*/{1, 1}, /*groups=*/1u),
+};
+
+INSTANTIATE_TEST_SUITE_P(Conv2dOpTPathParityTest, Conv2dOpTPathParityTest,
+                         ::testing::ValuesIn(conv2dOpList));
+
+//===----------------------------------------------------------------------===//
+// LinearOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::LinearOpT &opNativeOpModel,
+                       ::tt::target::ttnn::LinearOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::LinearOpT &op) {
+    op.a.reset();
+    op.b.reset();
+    op.bias.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::LinearOp buildTestLinearOp(
+    bool withBias = false, bool transposeA = false, bool transposeB = false,
+    mlir::StringAttr activation = {}, mlir::Attribute programConfigAttr = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeKernelConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto typeA = tiledL1BF16Type(defaultShape);
+  auto typeB = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  mlir::Value a = e.builder
+                      .create<mlir::tt::ttnn::OnesOp>(
+                          loc, mlir::TypeRange{typeA}, mlir::ValueRange{})
+                      .getResult();
+  mlir::Value b = e.builder
+                      .create<mlir::tt::ttnn::OnesOp>(
+                          loc, mlir::TypeRange{typeB}, mlir::ValueRange{})
+                      .getResult();
+  mlir::Value bias = nullptr;
+  if (withBias) {
+    auto biasType = tiledL1BF16Type(defaultShape);
+    bias = e.builder
+               .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{biasType},
+                                               mlir::ValueRange{})
+               .getResult();
+  }
+
+  return e.builder.create<mlir::tt::ttnn::LinearOp>(
+      loc, outputType, a, b, bias, transposeA, transposeB, programConfigAttr,
+      activation, computeKernelConfig);
+}
+
+} // namespace
+
+using LinearOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::LinearOp>;
+
+TEST_P(LinearOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::LinearOp linearOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::LinearOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildLinearOpTFromMLIR(
+          linearOp.getTransposeA(), linearOp.getTransposeB(),
+          linearOp.getActivation(), linearOp.getMatmulProgramConfig(),
+          linearOp.getComputeConfig(), resolveOutputLayout(linearOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, linearOp.getA(), linearOp.getB());
+  if (linearOp.getBias()) {
+    prepopulateOperandTensorRefs(cache, linearOp.getBias());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, linearOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::LinearOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::LinearOp> linearOpList = {
+    buildTestLinearOp(),
+    buildTestLinearOp(/*withBias=*/true),
+    buildTestLinearOp(/*withBias=*/false, /*transposeA=*/true),
+    buildTestLinearOp(/*withBias=*/false, /*transposeA=*/false,
+                      /*transposeB=*/true),
+    buildTestLinearOp(/*withBias=*/false, /*transposeA=*/false,
+                      /*transposeB=*/false,
+                      mlir::StringAttr::get(getContext(), "relu")),
+    buildTestLinearOp(
+        /*withBias=*/false, /*transposeA=*/false, /*transposeB=*/false,
+        /*activation=*/{},
+        mlir::tt::ttnn::MatmulMultiCoreReuseProgramConfigAttr::get(
+            getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(getContext(), 8, 8), 2, 4, 4, 8,
+            8)),
+    buildTestLinearOp(/*withBias=*/false, /*transposeA=*/false,
+                      /*transposeB=*/false,
+                      /*activation=*/{}, /*programConfigAttr=*/{},
+                      mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
+                          getContext(), mlir::tt::ttnn::MathFidelity::HiFi2,
+                          mlir::BoolAttr::get(getContext(), false),
+                          mlir::BoolAttr::get(getContext(), true),
+                          mlir::BoolAttr::get(getContext(), true),
+                          mlir::BoolAttr::get(getContext(), false))),
+    buildTestLinearOp(
+        /*withBias=*/true, /*transposeA=*/true, /*transposeB=*/true,
+        mlir::StringAttr::get(getContext(), "relu"),
+        mlir::tt::ttnn::MatmulMultiCoreReuseProgramConfigAttr::get(
+            getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(getContext(), 8, 8), 2, 4, 4, 8,
+            8),
+        mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
+            getContext(), mlir::tt::ttnn::MathFidelity::HiFi2,
+            mlir::BoolAttr::get(getContext(), false),
+            mlir::BoolAttr::get(getContext(), true),
+            mlir::BoolAttr::get(getContext(), true),
+            mlir::BoolAttr::get(getContext(), false))),
+};
+
+INSTANTIATE_TEST_SUITE_P(LinearOpTPathParityTest, LinearOpTPathParityTest,
+                         ::testing::ValuesIn(linearOpList));
+
+//===----------------------------------------------------------------------===//
+// EltwiseUnaryOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::EltwiseUnaryOpT &opNativeOpModel,
+                       ::tt::target::ttnn::EltwiseUnaryOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::EltwiseUnaryOpT &op) {
+    op.in.reset();
+    op.memory_config.reset();
+    op.out.reset();
+    if (op.type != ::tt::target::ttnn::EltwiseUnaryOpType::LeakyRelu &&
+        op.type != ::tt::target::ttnn::EltwiseUnaryOpType::Tanh &&
+        op.type != ::tt::target::ttnn::EltwiseUnaryOpType::Sigmoid) {
+      op.type = tt::target::ttnn::EltwiseUnaryOpType::Abs;
+    }
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+template <typename OpTy>
+OpTy buildTestEltwiseUnaryOp(float slope = 0.01f) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::LeakyReluOp>) {
+    return e.builder.create<OpTy>(loc, outputType, input,
+                                  e.builder.getF32FloatAttr(slope));
+  } else {
+    return e.builder.create<OpTy>(loc, outputType, input);
+  }
+}
+
+} // namespace
+
+template <typename OpTy>
+static void runEltwiseUnaryParityCheck(OpTy op) {
+  ::tt::target::ttnn::EltwiseUnaryOpT opNativeOpModel;
+  if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::LeakyReluOp>) {
+    opNativeOpModel =
+        mlir::tt::ttnn::op_model::buildEltwiseUnaryOpTFromMLIR<OpTy>(
+            resolveOutputLayout(op), op.getParameter());
+  } else {
+    opNativeOpModel =
+        mlir::tt::ttnn::op_model::buildEltwiseUnaryOpTFromMLIR<OpTy>(
+            resolveOutputLayout(op));
+  }
+
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, op.getInput());
+  auto fbOffset = mlir::tt::ttnn::createEltwiseUnaryOp(cache, op);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::EltwiseUnaryOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+#define ELTWISE_UNARY_PARITY_SUITE(OpTy)                                       \
+  using OpTy##TPathParityTest =                                                \
+      ::testing::TestWithParam<mlir::tt::ttnn::OpTy>;                          \
+  TEST_P(OpTy##TPathParityTest, BuildEqualsFlatbufferRoundTrip) {              \
+    runEltwiseUnaryParityCheck<mlir::tt::ttnn::OpTy>(GetParam());              \
+  }                                                                            \
+  const std::initializer_list<mlir::tt::ttnn::OpTy> OpTy##List = {             \
+      buildTestEltwiseUnaryOp<mlir::tt::ttnn::OpTy>(),                         \
+  };                                                                           \
+  INSTANTIATE_TEST_SUITE_P(OpTy##TPathParityTest, OpTy##TPathParityTest,       \
+                           ::testing::ValuesIn(OpTy##List))
+
+ELTWISE_UNARY_PARITY_SUITE(ReluOp);
+ELTWISE_UNARY_PARITY_SUITE(Relu6Op);
+ELTWISE_UNARY_PARITY_SUITE(HardsigmoidOp);
+ELTWISE_UNARY_PARITY_SUITE(SqrtOp);
+ELTWISE_UNARY_PARITY_SUITE(SinOp);
+ELTWISE_UNARY_PARITY_SUITE(AbsOp);
+ELTWISE_UNARY_PARITY_SUITE(CosOp);
+ELTWISE_UNARY_PARITY_SUITE(LogOp);
+ELTWISE_UNARY_PARITY_SUITE(CeilOp);
+ELTWISE_UNARY_PARITY_SUITE(SignOp);
+ELTWISE_UNARY_PARITY_SUITE(FloorOp);
+ELTWISE_UNARY_PARITY_SUITE(IsFiniteOp);
+ELTWISE_UNARY_PARITY_SUITE(LogicalNotOp);
+ELTWISE_UNARY_PARITY_SUITE(NegOp);
+ELTWISE_UNARY_PARITY_SUITE(TanOp);
+ELTWISE_UNARY_PARITY_SUITE(AtanOp);
+ELTWISE_UNARY_PARITY_SUITE(AsinOp);
+ELTWISE_UNARY_PARITY_SUITE(AsinhOp);
+ELTWISE_UNARY_PARITY_SUITE(AcosOp);
+ELTWISE_UNARY_PARITY_SUITE(ReciprocalOp);
+ELTWISE_UNARY_PARITY_SUITE(BitwiseNotOp);
+ELTWISE_UNARY_PARITY_SUITE(SiluOp);
+ELTWISE_UNARY_PARITY_SUITE(MishOp);
+ELTWISE_UNARY_PARITY_SUITE(Expm1Op);
+ELTWISE_UNARY_PARITY_SUITE(RsqrtOp);
+ELTWISE_UNARY_PARITY_SUITE(ErfOp);
+ELTWISE_UNARY_PARITY_SUITE(ErfcOp);
+ELTWISE_UNARY_PARITY_SUITE(ExpOp);
+ELTWISE_UNARY_PARITY_SUITE(GeluOp);
+ELTWISE_UNARY_PARITY_SUITE(TanhOp);
+ELTWISE_UNARY_PARITY_SUITE(SigmoidOp);
+
+#undef ELTWISE_UNARY_PARITY_SUITE
+
+using LeakyReluOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::LeakyReluOp>;
+
+TEST_P(LeakyReluOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runEltwiseUnaryParityCheck<mlir::tt::ttnn::LeakyReluOp>(GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::LeakyReluOp> leakyReluOpList = {
+    buildTestEltwiseUnaryOp<mlir::tt::ttnn::LeakyReluOp>(),
+    buildTestEltwiseUnaryOp<mlir::tt::ttnn::LeakyReluOp>(/*slope=*/0.2f),
+};
+
+INSTANTIATE_TEST_SUITE_P(LeakyReluOpTPathParityTest, LeakyReluOpTPathParityTest,
+                         ::testing::ValuesIn(leakyReluOpList));
+
+//===----------------------------------------------------------------------===//
+// EltwiseUnaryCompositeOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::EltwiseUnaryCompositeOpT &opNativeOpModel,
+    ::tt::target::ttnn::EltwiseUnaryCompositeOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::EltwiseUnaryCompositeOpT &op) {
+    op.in.reset();
+    op.memory_config.reset();
+    op.out.reset();
+    if (op.type ==
+        ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampTensor) {
+      op.params.Reset();
+    }
+
+    if (op.type !=
+            ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampScalar &&
+        op.type !=
+            ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampTensor) {
+      op.type = ::tt::target::ttnn::EltwiseUnaryCompositeOpType::Cbrt;
+    }
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+template <typename OpTy>
+OpTy buildTestEltwiseUnaryCompositeOp() {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  return e.builder.create<OpTy>(loc, outputType, input);
+}
+
+mlir::tt::ttnn::ClampScalarOp buildTestClampScalarOp(mlir::Attribute min,
+                                                     mlir::Attribute max) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  return e.builder.create<mlir::tt::ttnn::ClampScalarOp>(loc, outputType, input,
+                                                         min, max);
+}
+
+mlir::tt::ttnn::ClampTensorOp buildTestClampTensorOp() {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto minType = tiledL1BF16Type(defaultShape);
+  auto maxType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value min = e.builder
+                        .create<mlir::tt::ttnn::OnesOp>(
+                            loc, mlir::TypeRange{minType}, mlir::ValueRange{})
+                        .getResult();
+  mlir::Value max = e.builder
+                        .create<mlir::tt::ttnn::OnesOp>(
+                            loc, mlir::TypeRange{maxType}, mlir::ValueRange{})
+                        .getResult();
+  return e.builder.create<mlir::tt::ttnn::ClampTensorOp>(loc, outputType, input,
+                                                         min, max);
+}
+
+template <typename OpTy>
+void runEltwiseUnaryCompositeParityCheck(OpTy op) {
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT opNativeOpModel;
+  if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::ClampScalarOp>) {
+    opNativeOpModel = mlir::tt::ttnn::op_model::
+        buildEltwiseUnaryCompositeClampScalarOpTFromMLIR(
+            op.getMin(), op.getMax(), resolveOutputLayout(op));
+  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::ClampTensorOp>) {
+    opNativeOpModel = mlir::tt::ttnn::op_model::
+        buildEltwiseUnaryCompositeClampTensorOpTFromMLIR(
+            resolveOutputLayout(op));
+  } else {
+    opNativeOpModel =
+        mlir::tt::ttnn::op_model::buildEltwiseUnaryCompositeOpTFromMLIR<OpTy>(
+            resolveOutputLayout(op));
+  }
+
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, op.getInput());
+  if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::ClampTensorOp>) {
+    prepopulateOperandTensorRefs(cache, op.getMin(), op.getMax());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createEltwiseUnaryCompositeOp(cache, op);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+} // namespace
+
+using CbrtOpTPathParityTest = ::testing::TestWithParam<mlir::tt::ttnn::CbrtOp>;
+
+TEST_P(CbrtOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runEltwiseUnaryCompositeParityCheck<mlir::tt::ttnn::CbrtOp>(GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::CbrtOp> cbrtOpList = {
+    buildTestEltwiseUnaryCompositeOp<mlir::tt::ttnn::CbrtOp>(),
+};
+
+INSTANTIATE_TEST_SUITE_P(CbrtOpTPathParityTest, CbrtOpTPathParityTest,
+                         ::testing::ValuesIn(cbrtOpList));
+
+using Log1pOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::Log1pOp>;
+
+TEST_P(Log1pOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runEltwiseUnaryCompositeParityCheck<mlir::tt::ttnn::Log1pOp>(GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::Log1pOp> log1pOpList = {
+    buildTestEltwiseUnaryCompositeOp<mlir::tt::ttnn::Log1pOp>(),
+};
+
+INSTANTIATE_TEST_SUITE_P(Log1pOpTPathParityTest, Log1pOpTPathParityTest,
+                         ::testing::ValuesIn(log1pOpList));
+
+using ClampScalarOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ClampScalarOp>;
+
+TEST_P(ClampScalarOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runEltwiseUnaryCompositeParityCheck<mlir::tt::ttnn::ClampScalarOp>(
+      GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::ClampScalarOp> clampScalarOpList = {
+    buildTestClampScalarOp(
+        /*min=*/mlir::Builder(getContext()).getF32FloatAttr(0.0f),
+        /*max=*/mlir::Builder(getContext()).getF32FloatAttr(1.0f)),
+    buildTestClampScalarOp(
+        /*min=*/mlir::Builder(getContext()).getF32FloatAttr(-1.5f),
+        /*max=*/mlir::Builder(getContext()).getF32FloatAttr(1.0f)),
+    buildTestClampScalarOp(
+        /*min=*/mlir::Builder(getContext()).getF32FloatAttr(0.0f),
+        /*max=*/mlir::Builder(getContext()).getF32FloatAttr(5.5f)),
+    buildTestClampScalarOp(
+        /*min=*/mlir::Builder(getContext()).getI32IntegerAttr(-3),
+        /*max=*/mlir::Builder(getContext()).getI32IntegerAttr(7)),
+};
+
+INSTANTIATE_TEST_SUITE_P(ClampScalarOpTPathParityTest,
+                         ClampScalarOpTPathParityTest,
+                         ::testing::ValuesIn(clampScalarOpList));
+
+using ClampTensorOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ClampTensorOp>;
+
+TEST_P(ClampTensorOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runEltwiseUnaryCompositeParityCheck<mlir::tt::ttnn::ClampTensorOp>(
+      GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::ClampTensorOp> clampTensorOpList = {
+    buildTestClampTensorOp(),
+};
+
+INSTANTIATE_TEST_SUITE_P(ClampTensorOpTPathParityTest,
+                         ClampTensorOpTPathParityTest,
+                         ::testing::ValuesIn(clampTensorOpList));
+
+//===----------------------------------------------------------------------===//
+// EltwiseBinaryOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::EltwiseBinaryOpT &opNativeOpModel,
+                       ::tt::target::ttnn::EltwiseBinaryOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::EltwiseBinaryOpT &op) {
+    op.lhs.reset();
+    op.rhs.reset();
+    op.memory_config.reset();
+    op.output_dtype.reset();
+    op.out.reset();
+    op.type = ::tt::target::ttnn::EltwiseBinaryOpType::Add;
+  };
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+template <typename OpTy>
+OpTy buildTestEltwiseBinaryOp(mlir::tt::ttcore::DataTypeAttr dtype = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto lhsType = tiledL1BF16Type(defaultShape);
+  auto rhsType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value lhs = e.builder
+                        .create<mlir::tt::ttnn::OnesOp>(
+                            loc, mlir::TypeRange{lhsType}, mlir::ValueRange{})
+                        .getResult();
+  mlir::Value rhs = e.builder
+                        .create<mlir::tt::ttnn::OnesOp>(
+                            loc, mlir::TypeRange{rhsType}, mlir::ValueRange{})
+                        .getResult();
+  return e.builder.create<OpTy>(loc, outputType, lhs, rhs);
+}
+
+template <typename OpTy>
+void runEltwiseBinaryParityCheck(OpTy op) {
+  ::tt::target::ttnn::EltwiseBinaryOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildEltwiseBinaryOpTFromMLIR<OpTy>(
+          resolveOutputLayout(op), op.getDtypeAttr());
+
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, op.getLhs(), op.getRhs());
+  auto fbOffset = mlir::tt::ttnn::createEltwiseBinaryOp(cache, op);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::EltwiseBinaryOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+} // namespace
+
+#define ELTWISE_BINARY_PARITY_SUITE(OpTy)                                      \
+  using OpTy##TPathParityTest =                                                \
+      ::testing::TestWithParam<mlir::tt::ttnn::OpTy>;                          \
+  TEST_P(OpTy##TPathParityTest, BuildEqualsFlatbufferRoundTrip) {              \
+    runEltwiseBinaryParityCheck<mlir::tt::ttnn::OpTy>(GetParam());             \
+  }                                                                            \
+  const std::initializer_list<mlir::tt::ttnn::OpTy> OpTy##List = {             \
+      buildTestEltwiseBinaryOp<mlir::tt::ttnn::OpTy>(),                        \
+      buildTestEltwiseBinaryOp<mlir::tt::ttnn::OpTy>(bf16DtypeAttr),           \
+  };                                                                           \
+  INSTANTIATE_TEST_SUITE_P(OpTy##TPathParityTest, OpTy##TPathParityTest,       \
+                           ::testing::ValuesIn(OpTy##List))
+
+ELTWISE_BINARY_PARITY_SUITE(AddOp);
+ELTWISE_BINARY_PARITY_SUITE(MultiplyOp);
+ELTWISE_BINARY_PARITY_SUITE(LogicalRightShiftOp);
+ELTWISE_BINARY_PARITY_SUITE(SubtractOp);
+ELTWISE_BINARY_PARITY_SUITE(DivideOp);
+ELTWISE_BINARY_PARITY_SUITE(EqualOp);
+ELTWISE_BINARY_PARITY_SUITE(NotEqualOp);
+ELTWISE_BINARY_PARITY_SUITE(GreaterEqualOp);
+ELTWISE_BINARY_PARITY_SUITE(GreaterThanOp);
+ELTWISE_BINARY_PARITY_SUITE(LessEqualOp);
+ELTWISE_BINARY_PARITY_SUITE(LessThanOp);
+ELTWISE_BINARY_PARITY_SUITE(LogicalAndOp);
+ELTWISE_BINARY_PARITY_SUITE(LogicalOrOp);
+ELTWISE_BINARY_PARITY_SUITE(LogicalXorOp);
+
+#undef ELTWISE_BINARY_PARITY_SUITE
+
+//===----------------------------------------------------------------------===//
+// EltwiseBinaryCompositeOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::EltwiseBinaryCompositeOpT &opNativeOpModel,
+    ::tt::target::ttnn::EltwiseBinaryCompositeOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::EltwiseBinaryCompositeOpT &op) {
+    op.lhs.reset();
+    op.rhs.reset();
+    op.memory_config.reset();
+    op.out.reset();
+    op.type = ::tt::target::ttnn::EltwiseBinaryCompositeOpType::Maximum;
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+void resetUnusedFields(
+    ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT &opNativeOpModel,
+    ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT &op) {
+    op.lhs.reset();
+    op.memory_config.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+template <typename OpTy>
+OpTy buildTestEltwiseBinaryCompositeOp() {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto lhsType = tiledL1BF16Type(defaultShape);
+  auto rhsType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value lhs = e.builder
+                        .create<mlir::tt::ttnn::OnesOp>(
+                            loc, mlir::TypeRange{lhsType}, mlir::ValueRange{})
+                        .getResult();
+  mlir::Value rhs = e.builder
+                        .create<mlir::tt::ttnn::OnesOp>(
+                            loc, mlir::TypeRange{rhsType}, mlir::ValueRange{})
+                        .getResult();
+  return e.builder.create<OpTy>(loc, outputType, lhs, rhs);
+}
+
+mlir::tt::ttnn::PowScalarOp buildTestPowScalarOp(mlir::Attribute exponent) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto lhsType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value lhs = e.builder
+                        .create<mlir::tt::ttnn::OnesOp>(
+                            loc, mlir::TypeRange{lhsType}, mlir::ValueRange{})
+                        .getResult();
+  return e.builder.create<mlir::tt::ttnn::PowScalarOp>(loc, outputType, lhs,
+                                                       exponent);
+}
+
+template <typename OpTy>
+void runEltwiseBinaryCompositeParityCheck(OpTy op) {
+  ::tt::target::ttnn::EltwiseBinaryCompositeOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildEltwiseBinaryCompositeOpTFromMLIR<OpTy>(
+          resolveOutputLayout(op));
+
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, op.getLhs(), op.getRhs());
+  auto fbOffset = mlir::tt::ttnn::createEltwiseBinaryCompositeOp(cache, op);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::EltwiseBinaryCompositeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+void runPowScalarParityCheck(mlir::tt::ttnn::PowScalarOp op) {
+  ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildEltwiseBinaryCompositeScalarOpTFromMLIR(
+          op.getRhs(), resolveOutputLayout(op));
+
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, op.getLhs());
+  auto fbOffset =
+      mlir::tt::ttnn::createEltwiseBinaryCompositeScalarOp(cache, op);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+} // namespace
+
+#define ELTWISE_BINARY_COMPOSITE_PARITY_SUITE(OpTy)                            \
+  using OpTy##TPathParityTest =                                                \
+      ::testing::TestWithParam<mlir::tt::ttnn::OpTy>;                          \
+  TEST_P(OpTy##TPathParityTest, BuildEqualsFlatbufferRoundTrip) {              \
+    runEltwiseBinaryCompositeParityCheck<mlir::tt::ttnn::OpTy>(GetParam());    \
+  }                                                                            \
+  const std::initializer_list<mlir::tt::ttnn::OpTy> OpTy##List = {             \
+      buildTestEltwiseBinaryCompositeOp<mlir::tt::ttnn::OpTy>(),               \
+  };                                                                           \
+  INSTANTIATE_TEST_SUITE_P(OpTy##TPathParityTest, OpTy##TPathParityTest,       \
+                           ::testing::ValuesIn(OpTy##List))
+
+ELTWISE_BINARY_COMPOSITE_PARITY_SUITE(BitwiseAndOp);
+ELTWISE_BINARY_COMPOSITE_PARITY_SUITE(BitwiseOrOp);
+ELTWISE_BINARY_COMPOSITE_PARITY_SUITE(BitwiseXorOp);
+ELTWISE_BINARY_COMPOSITE_PARITY_SUITE(LogicalLeftShiftOp);
+ELTWISE_BINARY_COMPOSITE_PARITY_SUITE(Atan2Op);
+
+#undef ELTWISE_BINARY_COMPOSITE_PARITY_SUITE
+
+using PowScalarOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::PowScalarOp>;
+
+TEST_P(PowScalarOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runPowScalarParityCheck(GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::PowScalarOp> powScalarOpList = {
+    buildTestPowScalarOp(env().builder.getF32FloatAttr(2.0f)),
+    buildTestPowScalarOp(env().builder.getI32IntegerAttr(3)),
+};
+
+INSTANTIATE_TEST_SUITE_P(PowScalarOpTPathParityTest, PowScalarOpTPathParityTest,
+                         ::testing::ValuesIn(powScalarOpList));
+
+//===----------------------------------------------------------------------===//
+// EltwiseTernaryOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::EltwiseTernaryWhereOpT &opNativeOpModel,
+    ::tt::target::ttnn::EltwiseTernaryWhereOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::EltwiseTernaryWhereOpT &op) {
+    op.first.reset();
+    op.second.reset();
+    op.third.reset();
+    op.memory_config.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::WhereOp buildTestWhereOp() {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto firstType = tiledL1BF16Type(defaultShape);
+  auto secondType = tiledL1BF16Type(defaultShape);
+  auto thirdType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value first =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{firstType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value second =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{secondType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value third =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{thirdType},
+                                          mlir::ValueRange{})
+          .getResult();
+  return e.builder.create<mlir::tt::ttnn::WhereOp>(loc, outputType, first,
+                                                   second, third);
+}
+
+void runEltwiseTernaryParityCheck(mlir::tt::ttnn::WhereOp op) {
+  ::tt::target::ttnn::EltwiseTernaryWhereOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildEltwiseTernaryOpTFromMLIR<
+          mlir::tt::ttnn::WhereOp>(resolveOutputLayout(op));
+
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, op.getFirst(), op.getSecond(),
+                               op.getThird());
+  auto fbOffset = mlir::tt::ttnn::createEltwiseTernaryWhereOp(cache, op);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::EltwiseTernaryWhereOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+} // namespace
+
+using WhereOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::WhereOp>;
+
+TEST_P(WhereOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runEltwiseTernaryParityCheck(GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::WhereOp> whereOpList = {
+    buildTestWhereOp(),
+};
+
+INSTANTIATE_TEST_SUITE_P(WhereOpTPathParityTest, WhereOpTPathParityTest,
+                         ::testing::ValuesIn(whereOpList));
+
+//===----------------------------------------------------------------------===//
+// EltwiseQuantizationOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::EltwiseQuantizationOpT &opNativeOpModel,
+    ::tt::target::ttnn::EltwiseQuantizationOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::EltwiseQuantizationOpT &op) {
+    op.in.reset();
+    op.memory_config.reset();
+    op.output_dtype.reset();
+    op.params.Reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+template <typename OpTy>
+OpTy buildTestQuantDequantOp(mlir::IntegerAttr axis = {},
+                             mlir::tt::ttcore::DataTypeAttr outputDtype = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto scaleType = tiledL1BF16Type(defaultShape);
+  auto zeroPointType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value scale =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{scaleType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value zeroPoint =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{zeroPointType},
+                                          mlir::ValueRange{})
+          .getResult();
+  return e.builder.create<OpTy>(loc, outputType, input, scale, zeroPoint, axis,
+                                outputDtype);
+}
+
+mlir::tt::ttnn::RequantizeOp
+buildTestRequantizeOp(mlir::IntegerAttr axis = {},
+                      mlir::tt::ttcore::DataTypeAttr outputDtype = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto inScaleType = tiledL1BF16Type(defaultShape);
+  auto inZeroPointType = tiledL1BF16Type(defaultShape);
+  auto outScaleType = tiledL1BF16Type(defaultShape);
+  auto outZeroPointType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value inScale =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inScaleType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value inZeroPoint =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inZeroPointType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value outScale =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{outScaleType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value outZeroPoint =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(
+              loc, mlir::TypeRange{outZeroPointType}, mlir::ValueRange{})
+          .getResult();
+  return e.builder.create<mlir::tt::ttnn::RequantizeOp>(
+      loc, outputType, input, inScale, inZeroPoint, outScale, outZeroPoint,
+      axis, outputDtype);
+}
+
+template <typename OpTy>
+void runEltwiseQuantizationParityCheck(OpTy op) {
+  ::tt::target::ttnn::EltwiseQuantizationOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildEltwiseQuantizationOpTFromMLIR<OpTy>(
+          op.getAxis(), op.getOutputDtype(), resolveOutputLayout(op));
+
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::RequantizeOp>) {
+    prepopulateOperandTensorRefs(cache, op.getInput(), op.getInScale(),
+                                 op.getInZeroPoint(), op.getOutScale(),
+                                 op.getOutZeroPoint());
+  } else {
+    prepopulateOperandTensorRefs(cache, op.getInput(), op.getScale(),
+                                 op.getZeroPoint());
+  }
+  auto fbOffset = mlir::tt::ttnn::createEltwiseQuantizationOp(cache, op);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::EltwiseQuantizationOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+} // namespace
+
+using QuantizeOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::QuantizeOp>;
+
+TEST_P(QuantizeOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runEltwiseQuantizationParityCheck<mlir::tt::ttnn::QuantizeOp>(GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::QuantizeOp> quantizeOpList = {
+    buildTestQuantDequantOp<mlir::tt::ttnn::QuantizeOp>(),
+    buildTestQuantDequantOp<mlir::tt::ttnn::QuantizeOp>(
+        mlir::Builder(getContext()).getI32IntegerAttr(0)),
+    buildTestQuantDequantOp<mlir::tt::ttnn::QuantizeOp>(
+        mlir::Builder(getContext()).getI32IntegerAttr(1)),
+    buildTestQuantDequantOp<mlir::tt::ttnn::QuantizeOp>(
+        /*axis=*/{}, bf16DtypeAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(QuantizeOpTPathParityTest, QuantizeOpTPathParityTest,
+                         ::testing::ValuesIn(quantizeOpList));
+
+using DequantizeOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::DequantizeOp>;
+
+TEST_P(DequantizeOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runEltwiseQuantizationParityCheck<mlir::tt::ttnn::DequantizeOp>(GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::DequantizeOp> dequantizeOpList = {
+    buildTestQuantDequantOp<mlir::tt::ttnn::DequantizeOp>(),
+    buildTestQuantDequantOp<mlir::tt::ttnn::DequantizeOp>(
+        mlir::Builder(getContext()).getI32IntegerAttr(0)),
+    buildTestQuantDequantOp<mlir::tt::ttnn::DequantizeOp>(
+        mlir::Builder(getContext()).getI32IntegerAttr(1)),
+    buildTestQuantDequantOp<mlir::tt::ttnn::DequantizeOp>(
+        /*axis=*/{}, bf16DtypeAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(DequantizeOpTPathParityTest,
+                         DequantizeOpTPathParityTest,
+                         ::testing::ValuesIn(dequantizeOpList));
+
+using RequantizeOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::RequantizeOp>;
+
+TEST_P(RequantizeOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runEltwiseQuantizationParityCheck<mlir::tt::ttnn::RequantizeOp>(GetParam());
+}
+
+const std::initializer_list<mlir::tt::ttnn::RequantizeOp> requantizeOpList = {
+    buildTestRequantizeOp(),
+    buildTestRequantizeOp(mlir::Builder(getContext()).getI32IntegerAttr(0)),
+    buildTestRequantizeOp(mlir::Builder(getContext()).getI32IntegerAttr(1)),
+    buildTestRequantizeOp(/*axis=*/{}, bf16DtypeAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(RequantizeOpTPathParityTest,
+                         RequantizeOpTPathParityTest,
+                         ::testing::ValuesIn(requantizeOpList));
+
+#endif // TTMLIR_ENABLE_OPMODEL

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.h
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.h
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TEST_UNITTESTS_MLIRATTRTOFBNATIVE_OPTPATHPARITY_H
+#define TTMLIR_TEST_UNITTESTS_MLIRATTRTOFBNATIVE_OPTPATHPARITY_H
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTCore/Transforms/Transforms.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
+#include "ttmlir/Target/Utils/FuncOpToProgram.h"
+#include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+
+#include "flatbuffers/flatbuffer_builder.h"
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <optional>
+
+namespace mlir::tt::ttnn {
+::flatbuffers::Offset<::tt::target::ttnn::TensorRef>
+tensorValueToFlatbuffer(::mlir::tt::FlatbufferObjectCache &cache,
+                        ::mlir::Value value,
+                        ::mlir::tt::ttcore::ShardStatus shardStatus,
+                        std::optional<::mlir::RankedTensorType> localShape);
+} // namespace mlir::tt::ttnn
+
+struct Env {
+  mlir::MLIRContext context;
+  mlir::OwningOpRef<mlir::ModuleOp> module;
+  mlir::OpBuilder builder;
+
+  Env() : builder(&context) {
+    context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
+    context.loadDialect<mlir::tt::ttnn::TTNNDialect>();
+    module = mlir::ModuleOp::create(builder.getUnknownLoc());
+    builder.setInsertionPointToStart(&module->getBodyRegion().front());
+    mlir::tt::ttcore::registerDevice(module.get());
+  }
+};
+
+inline Env &env() {
+  static Env e;
+  return e;
+}
+
+inline mlir::MLIRContext *getContext() { return &env().context; }
+
+inline mlir::tt::ttnn::TTNNLayoutAttr
+createTiledL1InterleavedLayout(llvm::ArrayRef<int64_t> shape) {
+  auto &e = env();
+  auto device = mlir::tt::ttcore::lookupDevice(e.module.get());
+  auto tileType = mlir::tt::ttcore::TileType::get(e.builder.getBF16Type());
+  llvm::SmallVector<int64_t> gridShape = {1, 1, 32, 32};
+  return mlir::tt::ttnn::TTNNLayoutAttr::Builder(&e.context, shape, tileType)
+      .setBufferType(mlir::tt::ttnn::BufferType::L1)
+      .setMemoryLayout(mlir::tt::ttnn::TensorMemoryLayout::Interleaved)
+      .setGridShape(gridShape)
+      .buildWithCanonicalCorePlacement(device);
+}
+
+inline mlir::RankedTensorType tiledL1BF16Type(llvm::ArrayRef<int64_t> shape) {
+  return mlir::RankedTensorType::get(shape, env().builder.getBF16Type(),
+                                     createTiledL1InterleavedLayout(shape));
+}
+
+template <typename OpT>
+inline mlir::tt::ttnn::TTNNLayoutAttr resolveOutputLayout(OpT op) {
+  return mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+      mlir::cast<mlir::RankedTensorType>(op.getResult().getType())
+          .getEncoding());
+}
+
+template <typename... Values>
+inline void prepopulateOperandTensorRefs(mlir::tt::FlatbufferObjectCache &cache,
+                                         Values... operands) {
+  (cache.getOrCreateNoSharding(
+       mlir::tt::ttnn::getOperandThroughDPSOps(operands),
+       mlir::tt::ttnn::tensorValueToFlatbuffer,
+       /*localShape=*/std::nullopt),
+   ...);
+}
+
+#endif // TTMLIR_TEST_UNITTESTS_MLIRATTRTOFBNATIVE_OPTPATHPARITY_H

--- a/test/unittests/MLIRAttrToFBNative/ToNativeConsistency.cpp
+++ b/test/unittests/MLIRAttrToFBNative/ToNativeConsistency.cpp
@@ -37,11 +37,8 @@ protected:
     NativeT unpacked;
     table->UnPackTo(&unpacked);
 
-    compareFields(native, unpacked);
+    EXPECT_EQ(native, unpacked);
   }
-
-  virtual void compareFields(const NativeT &native,
-                             const NativeT &unpacked) = 0;
 };
 
 template <typename Attr, typename NativeT>
@@ -50,94 +47,13 @@ mlir::MLIRContext ToNativeConsistencyTest<Attr, NativeT>::context;
 template <typename Attr, typename NativeT>
 bool ToNativeConsistencyTest<Attr, NativeT>::initialized = false;
 
-namespace {
-
-using ::tt::target::ttnn::CoreCoord;
-using ::tt::target::ttnn::CoreRangeSetT;
-using ::tt::target::ttnn::NDShardSpecT;
-using ::tt::target::ttnn::ShardSpecT;
-using ::tt::target::ttnn::UnaryWithParamT;
-
-void compareCoreCoordPtr(const std::unique_ptr<CoreCoord> &native,
-                         const std::unique_ptr<CoreCoord> &unpacked) {
-  ASSERT_EQ(native == nullptr, unpacked == nullptr);
-  if (native) {
-    EXPECT_EQ(native->x(), unpacked->x());
-    EXPECT_EQ(native->y(), unpacked->y());
-  }
-}
-
-void compareCoreRangeSet(const CoreRangeSetT &native,
-                         const CoreRangeSetT &unpacked) {
-  ASSERT_EQ(native.core_ranges.size(), unpacked.core_ranges.size());
-  for (size_t i = 0; i < native.core_ranges.size(); ++i) {
-    EXPECT_EQ(native.core_ranges[i].start_coord().x(),
-              unpacked.core_ranges[i].start_coord().x());
-    EXPECT_EQ(native.core_ranges[i].start_coord().y(),
-              unpacked.core_ranges[i].start_coord().y());
-    EXPECT_EQ(native.core_ranges[i].end_coord().x(),
-              unpacked.core_ranges[i].end_coord().x());
-    EXPECT_EQ(native.core_ranges[i].end_coord().y(),
-              unpacked.core_ranges[i].end_coord().y());
-  }
-}
-
-void compareCoreRangeSetPtr(const std::unique_ptr<CoreRangeSetT> &native,
-                            const std::unique_ptr<CoreRangeSetT> &unpacked) {
-  ASSERT_EQ(native == nullptr, unpacked == nullptr);
-  if (native) {
-    compareCoreRangeSet(*native, *unpacked);
-  }
-}
-
-void compareUnaryWithParamPtr(
-    const std::unique_ptr<UnaryWithParamT> &native,
-    const std::unique_ptr<UnaryWithParamT> &unpacked) {
-  ASSERT_EQ(native == nullptr, unpacked == nullptr);
-  if (native) {
-    EXPECT_EQ(native->op_type, unpacked->op_type);
-    EXPECT_EQ(native->params, unpacked->params);
-  }
-}
-
-void compareShardSpecPtr(const std::unique_ptr<ShardSpecT> &native,
-                         const std::unique_ptr<ShardSpecT> &unpacked) {
-  ASSERT_EQ(native == nullptr, unpacked == nullptr);
-  if (native) {
-    compareCoreRangeSetPtr(native->core_range_set, unpacked->core_range_set);
-    EXPECT_EQ(native->shape, unpacked->shape);
-    EXPECT_EQ(native->orientation, unpacked->orientation);
-  }
-}
-
-void compareNDShardSpecPtr(const std::unique_ptr<NDShardSpecT> &native,
-                           const std::unique_ptr<NDShardSpecT> &unpacked) {
-  ASSERT_EQ(native == nullptr, unpacked == nullptr);
-  if (native) {
-    compareCoreRangeSetPtr(native->core_range_set, unpacked->core_range_set);
-    EXPECT_EQ(native->shape, unpacked->shape);
-    EXPECT_EQ(native->orientation, unpacked->orientation);
-    EXPECT_EQ(native->distribution_strategy, unpacked->distribution_strategy);
-  }
-}
-
-} // namespace
-
 //===----------------------------------------------------------------------===//
 // UnaryWithParam
 //===----------------------------------------------------------------------===//
 
 class UnaryWithParamTest
     : public ToNativeConsistencyTest<mlir::tt::ttnn::UnaryWithParamAttr,
-                                     ::tt::target::ttnn::UnaryWithParamT> {
-protected:
-  void
-  compareFields(const ::tt::target::ttnn::UnaryWithParamT &native,
-                const ::tt::target::ttnn::UnaryWithParamT &unpacked) override {
-    EXPECT_EQ(native.op_type, unpacked.op_type);
-    EXPECT_EQ(native.params, unpacked.params);
-  }
-};
+                                     ::tt::target::ttnn::UnaryWithParamT> {};
 
 TEST_P(UnaryWithParamTest, UnaryWithParam) { RunTest(GetParam()); }
 
@@ -172,14 +88,7 @@ INSTANTIATE_TEST_SUITE_P(UnaryWithParamTest, UnaryWithParamTest,
 
 class CoreRangeSetTest
     : public ToNativeConsistencyTest<mlir::tt::ttnn::CoreRangeSetAttr,
-                                     ::tt::target::ttnn::CoreRangeSetT> {
-protected:
-  void
-  compareFields(const ::tt::target::ttnn::CoreRangeSetT &native,
-                const ::tt::target::ttnn::CoreRangeSetT &unpacked) override {
-    compareCoreRangeSet(native, unpacked);
-  }
-};
+                                     ::tt::target::ttnn::CoreRangeSetT> {};
 
 TEST_P(CoreRangeSetTest, CoreRangeSet) { RunTest(GetParam()); }
 
@@ -223,18 +132,7 @@ INSTANTIATE_TEST_SUITE_P(CoreRangeSetTest, CoreRangeSetTest,
 class DeviceComputeKernelConfigTest
     : public ToNativeConsistencyTest<
           mlir::tt::ttnn::DeviceComputeKernelConfigAttr,
-          ::tt::target::ttnn::DeviceComputeKernelConfigT> {
-protected:
-  void compareFields(
-      const ::tt::target::ttnn::DeviceComputeKernelConfigT &native,
-      const ::tt::target::ttnn::DeviceComputeKernelConfigT &unpacked) override {
-    EXPECT_EQ(native.math_fidelity, unpacked.math_fidelity);
-    EXPECT_EQ(native.math_approx_mode, unpacked.math_approx_mode);
-    EXPECT_EQ(native.fp32_dest_acc_en, unpacked.fp32_dest_acc_en);
-    EXPECT_EQ(native.packer_l1_acc, unpacked.packer_l1_acc);
-    EXPECT_EQ(native.dst_full_sync_en, unpacked.dst_full_sync_en);
-  }
-};
+          ::tt::target::ttnn::DeviceComputeKernelConfigT> {};
 
 TEST_P(DeviceComputeKernelConfigTest, DeviceComputeKernelConfig) {
   RunTest(GetParam());
@@ -276,51 +174,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 class Conv2dConfigTest
     : public ToNativeConsistencyTest<mlir::tt::ttnn::Conv2dConfigAttr,
-                                     ::tt::target::ttnn::Conv2dConfigT> {
-protected:
-  void
-  compareFields(const ::tt::target::ttnn::Conv2dConfigT &native,
-                const ::tt::target::ttnn::Conv2dConfigT &unpacked) override {
-    EXPECT_EQ(native.weights_dtype, unpacked.weights_dtype);
-    EXPECT_EQ(native.deallocate_activation, unpacked.deallocate_activation);
-    EXPECT_EQ(native.reallocate_halo_output, unpacked.reallocate_halo_output);
-    EXPECT_EQ(native.act_block_h_override, unpacked.act_block_h_override);
-    EXPECT_EQ(native.act_block_w_div, unpacked.act_block_w_div);
-    EXPECT_EQ(native.reshard_if_not_optimal, unpacked.reshard_if_not_optimal);
-    EXPECT_EQ(native.override_sharding_config,
-              unpacked.override_sharding_config);
-    EXPECT_EQ(native.shard_layout, unpacked.shard_layout);
-    EXPECT_EQ(native.transpose_shards, unpacked.transpose_shards);
-    EXPECT_EQ(native.output_layout, unpacked.output_layout);
-    EXPECT_EQ(native.enable_act_double_buffer,
-              unpacked.enable_act_double_buffer);
-    EXPECT_EQ(native.enable_weights_double_buffer,
-              unpacked.enable_weights_double_buffer);
-    EXPECT_EQ(native.enable_kernel_stride_folding,
-              unpacked.enable_kernel_stride_folding);
-    EXPECT_EQ(native.config_tensors_in_dram, unpacked.config_tensors_in_dram);
-
-    ASSERT_EQ(native.activation == nullptr, unpacked.activation == nullptr);
-    if (native.activation) {
-      EXPECT_EQ(native.activation->op_type, unpacked.activation->op_type);
-      EXPECT_EQ(native.activation->params, unpacked.activation->params);
-    }
-
-    ASSERT_EQ(native.core_grid == nullptr, unpacked.core_grid == nullptr);
-    if (native.core_grid) {
-      ASSERT_EQ(native.core_grid->core_ranges.size(),
-                unpacked.core_grid->core_ranges.size());
-      for (size_t i = 0; i < native.core_grid->core_ranges.size(); ++i) {
-        const auto &nr = native.core_grid->core_ranges[i];
-        const auto &rr = unpacked.core_grid->core_ranges[i];
-        EXPECT_EQ(nr.start_coord().x(), rr.start_coord().x());
-        EXPECT_EQ(nr.start_coord().y(), rr.start_coord().y());
-        EXPECT_EQ(nr.end_coord().x(), rr.end_coord().x());
-        EXPECT_EQ(nr.end_coord().y(), rr.end_coord().y());
-      }
-    }
-  }
-};
+                                     ::tt::target::ttnn::Conv2dConfigT> {};
 
 TEST_P(Conv2dConfigTest, Conv2dConfig) { RunTest(GetParam()); }
 
@@ -430,15 +284,7 @@ INSTANTIATE_TEST_SUITE_P(Conv2dConfigTest, Conv2dConfigTest,
 
 class Conv2dSliceConfigTest
     : public ToNativeConsistencyTest<mlir::tt::ttnn::Conv2dSliceConfigAttr,
-                                     ::tt::target::ttnn::Conv2dSliceConfigT> {
-protected:
-  void compareFields(
-      const ::tt::target::ttnn::Conv2dSliceConfigT &native,
-      const ::tt::target::ttnn::Conv2dSliceConfigT &unpacked) override {
-    EXPECT_EQ(native.slice_type, unpacked.slice_type);
-    EXPECT_EQ(native.num_slices, unpacked.num_slices);
-  }
-};
+                                     ::tt::target::ttnn::Conv2dSliceConfigT> {};
 
 TEST_P(Conv2dSliceConfigTest, Conv2dSliceConfig) { RunTest(GetParam()); }
 
@@ -463,19 +309,7 @@ INSTANTIATE_TEST_SUITE_P(Conv2dSliceConfigTest, Conv2dSliceConfigTest,
 
 class Conv3dConfigTest
     : public ToNativeConsistencyTest<mlir::tt::ttnn::Conv3dConfigAttr,
-                                     ::tt::target::ttnn::Conv3dConfigT> {
-protected:
-  void
-  compareFields(const ::tt::target::ttnn::Conv3dConfigT &native,
-                const ::tt::target::ttnn::Conv3dConfigT &unpacked) override {
-    EXPECT_EQ(native.weights_dtype, unpacked.weights_dtype);
-    EXPECT_EQ(native.t_out_block, unpacked.t_out_block);
-    EXPECT_EQ(native.w_out_block, unpacked.w_out_block);
-    EXPECT_EQ(native.h_out_block, unpacked.h_out_block);
-    EXPECT_EQ(native.c_out_block, unpacked.c_out_block);
-    EXPECT_EQ(native.c_in_block, unpacked.c_in_block);
-  }
-};
+                                     ::tt::target::ttnn::Conv3dConfigT> {};
 
 TEST_P(Conv3dConfigTest, Conv3dConfig) { RunTest(GetParam()); }
 
@@ -502,15 +336,7 @@ INSTANTIATE_TEST_SUITE_P(Conv3dConfigTest, Conv3dConfigTest,
 
 class ShardSpecTest
     : public ToNativeConsistencyTest<mlir::tt::ttnn::ShardSpecAttr,
-                                     ::tt::target::ttnn::ShardSpecT> {
-protected:
-  void compareFields(const ::tt::target::ttnn::ShardSpecT &native,
-                     const ::tt::target::ttnn::ShardSpecT &unpacked) override {
-    compareCoreRangeSetPtr(native.core_range_set, unpacked.core_range_set);
-    EXPECT_EQ(native.shape, unpacked.shape);
-    EXPECT_EQ(native.orientation, unpacked.orientation);
-  }
-};
+                                     ::tt::target::ttnn::ShardSpecT> {};
 
 TEST_P(ShardSpecTest, ShardSpec) { RunTest(GetParam()); }
 
@@ -563,17 +389,7 @@ INSTANTIATE_TEST_SUITE_P(ShardSpecTest, ShardSpecTest,
 
 class NDShardSpecTest
     : public ToNativeConsistencyTest<mlir::tt::ttnn::NDShardSpecAttr,
-                                     ::tt::target::ttnn::NDShardSpecT> {
-protected:
-  void
-  compareFields(const ::tt::target::ttnn::NDShardSpecT &native,
-                const ::tt::target::ttnn::NDShardSpecT &unpacked) override {
-    compareCoreRangeSetPtr(native.core_range_set, unpacked.core_range_set);
-    EXPECT_EQ(native.shape, unpacked.shape);
-    EXPECT_EQ(native.orientation, unpacked.orientation);
-    EXPECT_EQ(native.distribution_strategy, unpacked.distribution_strategy);
-  }
-};
+                                     ::tt::target::ttnn::NDShardSpecT> {};
 
 TEST_P(NDShardSpecTest, NDShardSpec) { RunTest(GetParam()); }
 
@@ -627,17 +443,7 @@ INSTANTIATE_TEST_SUITE_P(NDShardSpecTest, NDShardSpecTest,
 
 class MemoryConfigTest
     : public ToNativeConsistencyTest<mlir::tt::ttnn::MemoryConfigAttr,
-                                     ::tt::target::ttnn::MemoryConfigT> {
-protected:
-  void
-  compareFields(const ::tt::target::ttnn::MemoryConfigT &native,
-                const ::tt::target::ttnn::MemoryConfigT &unpacked) override {
-    EXPECT_EQ(native.tensor_memory_layout, unpacked.tensor_memory_layout);
-    EXPECT_EQ(native.buffer_type, unpacked.buffer_type);
-    compareShardSpecPtr(native.shard_spec, unpacked.shard_spec);
-    compareNDShardSpecPtr(native.nd_shard_spec, unpacked.nd_shard_spec);
-  }
-};
+                                     ::tt::target::ttnn::MemoryConfigT> {};
 
 TEST_P(MemoryConfigTest, MemoryConfig) { RunTest(GetParam()); }
 
@@ -695,21 +501,7 @@ INSTANTIATE_TEST_SUITE_P(MemoryConfigTest, MemoryConfigTest,
 class MatmulMultiCoreReuseProgramConfigTest
     : public ToNativeConsistencyTest<
           mlir::tt::ttnn::MatmulMultiCoreReuseProgramConfigAttr,
-          ::tt::target::ttnn::MatmulMultiCoreReuseProgramConfigT> {
-protected:
-  void compareFields(
-      const ::tt::target::ttnn::MatmulMultiCoreReuseProgramConfigT &native,
-      const ::tt::target::ttnn::MatmulMultiCoreReuseProgramConfigT &unpacked)
-      override {
-    compareCoreCoordPtr(native.compute_with_storage_grid_size,
-                        unpacked.compute_with_storage_grid_size);
-    EXPECT_EQ(native.in0_block_w, unpacked.in0_block_w);
-    EXPECT_EQ(native.out_subblock_h, unpacked.out_subblock_h);
-    EXPECT_EQ(native.out_subblock_w, unpacked.out_subblock_w);
-    EXPECT_EQ(native.per_core_m, unpacked.per_core_m);
-    EXPECT_EQ(native.per_core_n, unpacked.per_core_n);
-  }
-};
+          ::tt::target::ttnn::MatmulMultiCoreReuseProgramConfigT> {};
 
 TEST_P(MatmulMultiCoreReuseProgramConfigTest,
        MatmulMultiCoreReuseProgramConfig) {
@@ -741,28 +533,7 @@ INSTANTIATE_TEST_SUITE_P(MatmulMultiCoreReuseProgramConfigTest,
 class MatmulMultiCoreReuseMultiCastProgramConfigTest
     : public ToNativeConsistencyTest<
           mlir::tt::ttnn::MatmulMultiCoreReuseMultiCastProgramConfigAttr,
-          ::tt::target::ttnn::MatmulMultiCoreReuseMultiCastProgramConfigT> {
-protected:
-  void compareFields(
-      const ::tt::target::ttnn::MatmulMultiCoreReuseMultiCastProgramConfigT
-          &native,
-      const ::tt::target::ttnn::MatmulMultiCoreReuseMultiCastProgramConfigT
-          &unpacked) override {
-    compareCoreCoordPtr(native.compute_with_storage_grid_size,
-                        unpacked.compute_with_storage_grid_size);
-    EXPECT_EQ(native.in0_block_w, unpacked.in0_block_w);
-    EXPECT_EQ(native.out_subblock_h, unpacked.out_subblock_h);
-    EXPECT_EQ(native.out_subblock_w, unpacked.out_subblock_w);
-    EXPECT_EQ(native.out_block_h, unpacked.out_block_h);
-    EXPECT_EQ(native.out_block_w, unpacked.out_block_w);
-    EXPECT_EQ(native.per_core_m, unpacked.per_core_m);
-    EXPECT_EQ(native.per_core_n, unpacked.per_core_n);
-    EXPECT_EQ(native.transpose_mcast, unpacked.transpose_mcast);
-    compareUnaryWithParamPtr(native.fused_activation,
-                             unpacked.fused_activation);
-    EXPECT_EQ(native.fuse_batch, unpacked.fuse_batch);
-  }
-};
+          ::tt::target::ttnn::MatmulMultiCoreReuseMultiCastProgramConfigT> {};
 
 TEST_P(MatmulMultiCoreReuseMultiCastProgramConfigTest,
        MatmulMultiCoreReuseMultiCastProgramConfig) {
@@ -803,32 +574,7 @@ INSTANTIATE_TEST_SUITE_P(
 class MatmulMultiCoreReuseMultiCast1DProgramConfigTest
     : public ToNativeConsistencyTest<
           mlir::tt::ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
-          ::tt::target::ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigT> {
-protected:
-  void compareFields(
-      const ::tt::target::ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigT
-          &native,
-      const ::tt::target::ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigT
-          &unpacked) override {
-    compareCoreCoordPtr(native.compute_with_storage_grid_size,
-                        unpacked.compute_with_storage_grid_size);
-    EXPECT_EQ(native.in0_block_w, unpacked.in0_block_w);
-    EXPECT_EQ(native.out_subblock_h, unpacked.out_subblock_h);
-    EXPECT_EQ(native.out_subblock_w, unpacked.out_subblock_w);
-    EXPECT_EQ(native.out_block_h, unpacked.out_block_h);
-    EXPECT_EQ(native.out_block_w, unpacked.out_block_w);
-    EXPECT_EQ(native.per_core_m, unpacked.per_core_m);
-    EXPECT_EQ(native.per_core_n, unpacked.per_core_n);
-    EXPECT_EQ(native.fuse_batch, unpacked.fuse_batch);
-    compareUnaryWithParamPtr(native.fused_activation,
-                             unpacked.fused_activation);
-    EXPECT_EQ(native.mcast_in0, unpacked.mcast_in0);
-    EXPECT_EQ(native.gather_in0, unpacked.gather_in0);
-    compareCoreRangeSetPtr(native.hop_cores, unpacked.hop_cores);
-    EXPECT_EQ(native.num_global_cb_receivers, unpacked.num_global_cb_receivers);
-    EXPECT_EQ(native.untilize_out, unpacked.untilize_out);
-  }
-};
+          ::tt::target::ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigT> {};
 
 TEST_P(MatmulMultiCoreReuseMultiCast1DProgramConfigTest,
        MatmulMultiCoreReuseMultiCast1DProgramConfig) {
@@ -890,21 +636,7 @@ class MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigTest
           mlir::tt::ttnn::
               MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr,
           ::tt::target::ttnn::
-              MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigT> {
-protected:
-  void compareFields(
-      const ::tt::target::ttnn::
-          MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigT &native,
-      const ::tt::target::ttnn::
-          MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigT &unpacked)
-      override {
-    EXPECT_EQ(native.in0_block_w, unpacked.in0_block_w);
-    EXPECT_EQ(native.per_core_m, unpacked.per_core_m);
-    EXPECT_EQ(native.per_core_n, unpacked.per_core_n);
-    compareUnaryWithParamPtr(native.fused_activation,
-                             unpacked.fused_activation);
-  }
-};
+              MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigT> {};
 
 TEST_P(MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigTest,
        MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig) {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The way `TTNNOpInvokeLib` is currently implemented, it's easy to introduce bugs when building the NativeTable type.

### What's changed
Added regression tests that check the NativeTable type built with `buildOpTFromMLIR`(OpModel) matches the one built with `createOp + UnPackTo` (runtime). This way, if the two paths ever go out of sync, the tests will catch it.

### Checklist
- [ ] New/Existing tests provide coverage for changes
