### PR TITLE
[D2M] Conv: stacking views through `composite_view`

### DIFF
--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1502,18 +1502,13 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
     }
   }
 
-  // VGM propagation (Utils.cpp) walks the first input's view chain, so
-  // mixing view and non-view inputs would yield inconsistent results, and
-  // divergent VGM maps across inputs would silently mis-address per-core data.
+  // VGM propagation (Utils.cpp) walks the first input's chain, so mixing
+  // view and non-view inputs would yield inconsistent results.
   auto isViewInput = [](Value v) {
     return mlir::isa_and_nonnull<d2m::ViewOpInterface>(v.getDefiningOp());
   };
   auto inputs = this->getInputs();
   const bool firstIsView = isViewInput(inputs.front());
-  const auto firstFwd =
-      firstIsView
-          ? mlir::tt::d2m::utils::getVirtualGridForwardMapping(inputs.front())
-          : std::nullopt;
   for (auto [i, input] : llvm::enumerate(llvm::drop_begin(inputs))) {
     if (isViewInput(input) != firstIsView) {
       return emitOpError() << "inputs must be uniformly views "
@@ -1521,12 +1516,42 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
                               "input "
                            << (i + 1) << " disagrees with input 0";
     }
-    if (firstIsView &&
-        mlir::tt::d2m::utils::getVirtualGridForwardMapping(input) != firstFwd) {
-      return emitOpError() << "all view inputs must share the same "
-                              "virtualGridForwardMapping; input "
-                           << (i + 1) << " has a divergent map from input 0";
+  }
+
+  // VGM uniformity: any input that exposes a virtual-grid map (via a view
+  // chain or directly on a d2m.empty / to_layout) must agree with the rest.
+  // Propagation through composite_view picks inputs.front() blindly, so
+  // divergence here would silently mis-address per-core data.
+  auto checkUniformVgm = [&](auto mappingGetter,
+                             StringRef mapName) -> LogicalResult {
+    std::optional<AffineMap> sharedMap;
+    int64_t sharedSourceIdx = -1;
+    for (auto [i, input] : llvm::enumerate(inputs)) {
+      auto inputMap = mappingGetter(input);
+      if (!inputMap) {
+        continue;
+      }
+      if (!sharedMap) {
+        sharedMap = inputMap;
+        sharedSourceIdx = static_cast<int64_t>(i);
+        continue;
+      }
+      if (*inputMap != *sharedMap) {
+        return emitOpError()
+               << "all composite_view inputs that carry a " << mapName
+               << " must share the same map; input " << i
+               << " disagrees with input " << sharedSourceIdx;
+      }
     }
+    return success();
+  };
+  if (failed(checkUniformVgm(mlir::tt::d2m::utils::getVirtualGridForwardMapping,
+                             "virtualGridForwardMapping"))) {
+    return failure();
+  }
+  if (failed(checkUniformVgm(mlir::tt::d2m::utils::getVirtualGridInverseMapping,
+                             "virtualGridInverseMapping"))) {
+    return failure();
   }
 
   return mlir::success();

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1502,8 +1502,7 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
     }
   }
 
-  // VGM propagation (Utils.cpp) walks the first input's chain, so mixing
-  // view and non-view inputs would yield inconsistent results.
+  // composite_view inputs must be uniformly views or uniformly non-views
   auto isViewInput = [](Value v) {
     return mlir::isa_and_nonnull<d2m::ViewOpInterface>(v.getDefiningOp());
   };
@@ -1516,42 +1515,6 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
                               "input "
                            << (i + 1) << " disagrees with input 0";
     }
-  }
-
-  // VGM uniformity: any input that exposes a virtual-grid map (via a view
-  // chain or directly on a d2m.empty / to_layout) must agree with the rest.
-  // Propagation through composite_view picks inputs.front() blindly, so
-  // divergence here would silently mis-address per-core data.
-  auto checkUniformVgm = [&](auto mappingGetter,
-                             StringRef mapName) -> LogicalResult {
-    std::optional<AffineMap> sharedMap;
-    int64_t sharedSourceIdx = -1;
-    for (auto [i, input] : llvm::enumerate(inputs)) {
-      auto inputMap = mappingGetter(input);
-      if (!inputMap) {
-        continue;
-      }
-      if (!sharedMap) {
-        sharedMap = inputMap;
-        sharedSourceIdx = static_cast<int64_t>(i);
-        continue;
-      }
-      if (*inputMap != *sharedMap) {
-        return emitOpError()
-               << "all composite_view inputs that carry a " << mapName
-               << " must share the same map; input " << i
-               << " disagrees with input " << sharedSourceIdx;
-      }
-    }
-    return success();
-  };
-  if (failed(checkUniformVgm(mlir::tt::d2m::utils::getVirtualGridForwardMapping,
-                             "virtualGridForwardMapping"))) {
-    return failure();
-  }
-  if (failed(checkUniformVgm(mlir::tt::d2m::utils::getVirtualGridInverseMapping,
-                             "virtualGridInverseMapping"))) {
-    return failure();
   }
 
   return mlir::success();

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1453,6 +1453,90 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
     }
   }
 
+  // RM width-concat: each input becomes one NoC L1 DMA, so its byte size
+  // must satisfy NoC L1 alignment (>= 16 and a multiple of 16).
+  constexpr int64_t kNocL1AlignBytes = 16;
+  const bool isWidthConcat = (compositeDim == rank - 1);
+  if (isWidthConcat) {
+    Type elemType;
+    if (isTensorType) {
+      elemType = mlir::cast<RankedTensorType>(outType).getElementType();
+    } else {
+      elemType = mlir::cast<MemRefType>(outType).getElementType();
+    }
+    if (!mlir::isa<ttcore::TileType>(elemType) && elemType.isIntOrFloat()) {
+      const int64_t elemBytes = elemType.getIntOrFloatBitWidth() / 8;
+
+      SmallVector<int64_t> sizes;
+      if (isTensorType) {
+        for (auto input : this->getInputs()) {
+          auto inLayout = mlir::cast<ttcore::MetalLayoutAttr>(
+              mlir::cast<RankedTensorType>(input.getType()).getEncoding());
+          sizes.push_back(inLayout.getLogicalShape()[compositeDim]);
+        }
+      } else if (this->getLogicalSizes().has_value()) {
+        auto attr = this->getLogicalSizes().value();
+        sizes.assign(attr.begin(), attr.end());
+      }
+
+      for (int64_t n : sizes) {
+        const int64_t chunkBytes = n * elemBytes;
+        if (chunkBytes < kNocL1AlignBytes ||
+            chunkBytes % kNocL1AlignBytes != 0) {
+          return emitOpError()
+                 << "row-major width-concat requires each input's per-DMA "
+                    "byte count (logicalSizes[i] * sizeof(elem)) to be >= "
+                 << kNocL1AlignBytes
+                 << " and a multiple of it (NoC L1 alignment); got " << n
+                 << " elems * " << elemBytes << " bytes = " << chunkBytes
+                 << " bytes";
+        }
+      }
+    }
+  }
+
+  // VGM propagation (Utils.cpp) walks the first input's view chain, so
+  // mixing view and non-view inputs would yield inconsistent results.
+  bool firstIsView = false;
+  {
+    bool isFirst = true;
+    for (Value input : this->getInputs()) {
+      mlir::Operation *defOp = input.getDefiningOp();
+      const bool isView =
+          defOp != nullptr && mlir::isa<d2m::ViewOpInterface>(defOp);
+      if (isFirst) {
+        firstIsView = isView;
+        isFirst = false;
+        continue;
+      }
+      if (isView != firstIsView) {
+        return emitOpError(
+            "inputs must be uniformly views (ViewOpInterface) or uniformly "
+            "non-views; mixing is not supported");
+      }
+    }
+  }
+
+  // VGM propagation returns the first input's map; divergent maps across
+  // inputs would silently mis-address per-core data.
+  if (firstIsView) {
+    std::optional<mlir::AffineMap> sharedFwd;
+    bool isFirst = true;
+    for (Value input : this->getInputs()) {
+      auto fwd = mlir::tt::d2m::utils::getVirtualGridForwardMapping(input);
+      if (isFirst) {
+        sharedFwd = fwd;
+        isFirst = false;
+        continue;
+      }
+      if (fwd != sharedFwd) {
+        return emitOpError(
+            "all view inputs must share the same virtualGridForwardMapping "
+            "(divergent VGM maps across composite inputs not supported)");
+      }
+    }
+  }
+
   return mlir::success();
 }
 

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1454,8 +1454,8 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
   }
 
   // RM width-concat: each input becomes one NoC L1 DMA, so its byte size
-  // must satisfy NoC L1 alignment (>= 16 and a multiple of 16).
-  constexpr int64_t kNocL1AlignBytes = 16;
+  // must satisfy NoC L1 alignment from the system descriptor (skipped when no
+  // system desc / device is registered, e.g. early standalone parses).
   const bool isWidthConcat = (compositeDim == rank - 1);
   if (isWidthConcat) {
     Type elemType;
@@ -1464,8 +1464,16 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
     } else {
       elemType = mlir::cast<MemRefType>(outType).getElementType();
     }
-    if (!mlir::isa<ttcore::TileType>(elemType) && elemType.isIntOrFloat()) {
+    auto moduleOp = (*this)->getParentOfType<ModuleOp>();
+    const bool hasSystemDesc =
+        moduleOp && moduleOp->hasAttr(ttcore::SystemDescAttr::name) &&
+        ttcore::lookupDeviceOp(*this) != nullptr;
+    if (hasSystemDesc && !mlir::isa<ttcore::TileType>(elemType) &&
+        elemType.isIntOrFloat()) {
       const int64_t elemBytes = elemType.getIntOrFloatBitWidth() / 8;
+      const int64_t nocL1AlignBytes =
+          mlir::tt::d2m::utils::getNocAddressAlignmentBytes(
+              *this, ttcore::MemorySpace::DeviceL1);
 
       SmallVector<int64_t> sizes;
       if (isTensorType) {
@@ -1481,12 +1489,11 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
 
       for (int64_t n : sizes) {
         const int64_t chunkBytes = n * elemBytes;
-        if (chunkBytes < kNocL1AlignBytes ||
-            chunkBytes % kNocL1AlignBytes != 0) {
+        if (chunkBytes < nocL1AlignBytes || chunkBytes % nocL1AlignBytes != 0) {
           return emitOpError()
                  << "row-major width-concat requires each input's per-DMA "
                     "byte count (logicalSizes[i] * sizeof(elem)) to be >= "
-                 << kNocL1AlignBytes
+                 << nocL1AlignBytes
                  << " and a multiple of it (NoC L1 alignment); got " << n
                  << " elems * " << elemBytes << " bytes = " << chunkBytes
                  << " bytes";
@@ -1496,44 +1503,29 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
   }
 
   // VGM propagation (Utils.cpp) walks the first input's view chain, so
-  // mixing view and non-view inputs would yield inconsistent results.
-  bool firstIsView = false;
-  {
-    bool isFirst = true;
-    for (Value input : this->getInputs()) {
-      mlir::Operation *defOp = input.getDefiningOp();
-      const bool isView =
-          defOp != nullptr && mlir::isa<d2m::ViewOpInterface>(defOp);
-      if (isFirst) {
-        firstIsView = isView;
-        isFirst = false;
-        continue;
-      }
-      if (isView != firstIsView) {
-        return emitOpError(
-            "inputs must be uniformly views (ViewOpInterface) or uniformly "
-            "non-views; mixing is not supported");
-      }
+  // mixing view and non-view inputs would yield inconsistent results, and
+  // divergent VGM maps across inputs would silently mis-address per-core data.
+  auto isViewInput = [](Value v) {
+    return mlir::isa_and_nonnull<d2m::ViewOpInterface>(v.getDefiningOp());
+  };
+  auto inputs = this->getInputs();
+  const bool firstIsView = isViewInput(inputs.front());
+  const auto firstFwd =
+      firstIsView
+          ? mlir::tt::d2m::utils::getVirtualGridForwardMapping(inputs.front())
+          : std::nullopt;
+  for (auto [i, input] : llvm::enumerate(llvm::drop_begin(inputs))) {
+    if (isViewInput(input) != firstIsView) {
+      return emitOpError() << "inputs must be uniformly views "
+                              "(ViewOpInterface) or uniformly non-views; "
+                              "input "
+                           << (i + 1) << " disagrees with input 0";
     }
-  }
-
-  // VGM propagation returns the first input's map; divergent maps across
-  // inputs would silently mis-address per-core data.
-  if (firstIsView) {
-    std::optional<mlir::AffineMap> sharedFwd;
-    bool isFirst = true;
-    for (Value input : this->getInputs()) {
-      auto fwd = mlir::tt::d2m::utils::getVirtualGridForwardMapping(input);
-      if (isFirst) {
-        sharedFwd = fwd;
-        isFirst = false;
-        continue;
-      }
-      if (fwd != sharedFwd) {
-        return emitOpError(
-            "all view inputs must share the same virtualGridForwardMapping "
-            "(divergent VGM maps across composite inputs not supported)");
-      }
+    if (firstIsView &&
+        mlir::tt::d2m::utils::getVirtualGridForwardMapping(input) != firstFwd) {
+      return emitOpError() << "all view inputs must share the same "
+                              "virtualGridForwardMapping; input "
+                           << (i + 1) << " has a divergent map from input 0";
     }
   }
 

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
@@ -605,6 +605,18 @@ public:
     }
     PlanState src = extractPlanState(op.getInput());
     PlanState tgt = extractPlanState(op.getOutput());
+    // Derive VGM when target grid requires it but the user-authored empty did
+    // not carry one; downstream composite_view chains rely on VGM presence.
+    if (!tgt.vgmForward && tgt.hasLayout()) {
+      auto gridShape = llvm::to_vector(tgt.getGridShape());
+      if (ttmlir::d2m::utils::grids::requiresVirtualGrid(gridShape,
+                                                         targetGridShape)) {
+        auto [fwd, inv] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
+            rewriter.getContext(), gridShape, targetGridShape);
+        tgt.vgmForward = fwd;
+        tgt.vgmInverse = inv;
+      }
+    }
     Plan plan = minimize(
         canonicalize(src, tgt, targetGridShape, rewriter.getContext()));
     if (plan.empty()) {

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
@@ -605,18 +605,6 @@ public:
     }
     PlanState src = extractPlanState(op.getInput());
     PlanState tgt = extractPlanState(op.getOutput());
-    // Derive VGM when target grid requires it but the user-authored empty did
-    // not carry one; downstream composite_view chains rely on VGM presence.
-    if (!tgt.vgmForward && tgt.hasLayout()) {
-      auto gridShape = llvm::to_vector(tgt.getGridShape());
-      if (ttmlir::d2m::utils::grids::requiresVirtualGrid(gridShape,
-                                                         targetGridShape)) {
-        auto [fwd, inv] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
-            rewriter.getContext(), gridShape, targetGridShape);
-        tgt.vgmForward = fwd;
-        tgt.vgmInverse = inv;
-      }
-    }
     Plan plan = minimize(
         canonicalize(src, tgt, targetGridShape, rewriter.getContext()));
     if (plan.empty()) {

--- a/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
+++ b/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
+#include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -59,12 +60,52 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
       builder.getContext(), layout.getLogicalShape(), layout.getDimAlignments(),
       layout.getCollapsedIntervals(), layout.getMemorySpace(),
       layout.getMemoryLayout());
-  auto emptyOp = builder.create<d2m::EmptyOp>(
-      loc, tensorType.getShape(), tensorType.getElementType(), newLayout);
+  // Derive VGM fresh from destination grid; upstream VGM rank may not match.
+  ttcore::GridAttr destGrid = getGridFromType(tensorType);
+  TT_assert(destGrid != nullptr);
+  AffineMapAttr fwdAttr;
+  AffineMapAttr invAttr;
+  if (auto deviceOp = ttcore::lookupDevice(builder.getInsertionBlock()
+                                               ->getParent()
+                                               ->getParentOfType<ModuleOp>())) {
+    auto targetGrid = llvm::to_vector(deviceOp.getWorkerGrid().getShape());
+    auto gridShape = llvm::to_vector(destGrid.getShape());
+    if (ttmlir::d2m::utils::grids::requiresVirtualGrid(gridShape, targetGrid)) {
+      auto [fwd, inv] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
+          builder.getContext(), gridShape, targetGrid);
+      fwdAttr = AffineMapAttr::get(fwd);
+      invAttr = AffineMapAttr::get(inv);
+    }
+  }
 
-  // Extract the grid from the tensor's layout to determine core distribution.
-  ttcore::GridAttr grid = getGridFromType(tensorType);
-  TT_assert(grid != nullptr);
+  auto emptyOp =
+      fwdAttr ? builder.create<d2m::EmptyOp>(loc, tensorType, invAttr, fwdAttr)
+              : builder.create<d2m::EmptyOp>(loc, tensorType.getShape(),
+                                             tensorType.getElementType(),
+                                             newLayout);
+
+  // GridAttr's forward map is grid-rank (not memref-rank), so build it
+  // directly rather than reusing the EmptyOp's memref-level VGM.
+  ttcore::GridAttr grid;
+  if (fwdAttr) {
+    auto targetGrid =
+        llvm::to_vector(ttcore::lookupDevice(builder.getInsertionBlock()
+                                                 ->getParent()
+                                                 ->getParentOfType<ModuleOp>())
+                            .getWorkerGrid()
+                            .getShape());
+    auto gridShape = llvm::to_vector(destGrid.getShape());
+    auto fwdGrid = ttmlir::d2m::utils::grids::create1DtoNDMap(
+                       builder.getContext(), targetGrid)
+                       .compose(ttmlir::d2m::utils::grids::createCollapseMap(
+                           builder.getContext(), gridShape));
+    fwdGrid =
+        fwdGrid.insertResult(getAffineConstantExpr(0, builder.getContext()), 0);
+    grid = ttcore::GridAttr::get(builder.getContext(), gridShape, fwdGrid,
+                                 invAttr.getValue());
+  } else {
+    grid = destGrid;
+  }
 
   // Build identity affine maps for parallel iteration over all grid dimensions.
   size_t rank = grid.getShape().size();

--- a/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
+++ b/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
@@ -16,6 +16,9 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "d2m-materialize-view-returns"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MMATERIALIZEVIEWRETURNS
@@ -34,6 +37,7 @@ std::optional<std::pair<Value, AffineMap>> findUpstreamVgmSource(Value v) {
   if (!defOp) {
     return std::nullopt;
   }
+  unsigned idx = mlir::cast<OpResult>(v).getResultNumber();
   if (auto emptyOp = mlir::dyn_cast<EmptyOp>(defOp)) {
     if (auto fwd = emptyOp.getVirtualGridForwardMappingAttr()) {
       return std::make_pair(v, fwd.getValue());
@@ -47,20 +51,10 @@ std::optional<std::pair<Value, AffineMap>> findUpstreamVgmSource(Value v) {
     return findUpstreamVgmSource(toDeviceOp.getOutput());
   }
   if (auto genericOp = mlir::dyn_cast<GenericOp>(defOp)) {
-    for (auto [idx, result] : llvm::enumerate(genericOp.getResults())) {
-      if (result == v) {
-        return findUpstreamVgmSource(genericOp.getOutputs()[idx]);
-      }
-    }
-    return std::nullopt;
+    return findUpstreamVgmSource(genericOp.getOutputs()[idx]);
   }
   if (auto spatialOp = mlir::dyn_cast<SpatialOp>(defOp)) {
-    for (auto [idx, result] : llvm::enumerate(spatialOp.getResults())) {
-      if (result == v) {
-        return findUpstreamVgmSource(spatialOp.getOutputs()[idx]);
-      }
-    }
-    return std::nullopt;
+    return findUpstreamVgmSource(spatialOp.getOutputs()[idx]);
   }
   if (auto viewOp = mlir::dyn_cast<ViewOpInterface>(defOp)) {
     if (viewOp.isComposite()) {
@@ -129,7 +123,9 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
       builder.getContext(), layout.getLogicalShape(), layout.getDimAlignments(),
       layout.getCollapsedIntervals(), layout.getMemorySpace(),
       layout.getMemoryLayout());
-  // Pin phys grid to upstream's so writes stay local; else clean-factor.
+  // Reuse upstream's phys grid when volumes match (output writes land on same
+  // cores as upstream input). Otherwise pick a phys grid that exactly
+  // factorizes the virt vol.
   ttcore::GridAttr destGrid = getGridFromType(tensorType);
   TT_assert(destGrid != nullptr);
   AffineMapAttr fwdAttr;
@@ -149,10 +145,17 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
                             std::multiplies<>());
         if (inheritedVolume == targetVolume) {
           physGrid = *inherited;
+        } else {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "materializeView: upstream physGrid vol "
+                     << inheritedVolume << " != virt grid vol " << targetVolume
+                     << "; falling back to volume-exact factorization\n");
         }
       }
       if (physGrid.empty()) {
-        // Clean-factor avoids mod-wrap on uneven worker grids (e.g. BH 10x11).
+        // Exact factorization (physH * physW == virt vol) avoids mod-wrap when
+        // the worker grid doesn't divide vol evenly (e.g. BH worker 10x11,
+        // virt vol 64 -> phys 8x8 instead of mod 11 over 10x11).
         physGrid =
             llvm::to_vector(ttmlir::d2m::utils::grids::getPhysicalGridExtent(
                 gridShape, targetGrid));

--- a/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
+++ b/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
@@ -71,8 +71,12 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
     auto targetGrid = llvm::to_vector(deviceOp.getWorkerGrid().getShape());
     auto gridShape = llvm::to_vector(destGrid.getShape());
     if (ttmlir::d2m::utils::grids::requiresVirtualGrid(gridShape, targetGrid)) {
+      // Use clean-factor physGrid; raw worker grid would mod-wrap unevenly
+      // (e.g. mod 11 on BH 10x11 for a 64-vol virt grid).
+      auto physGrid = ttmlir::d2m::utils::grids::getPhysicalGridExtent(
+          gridShape, targetGrid);
       auto [fwd, inv] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
-          builder.getContext(), gridShape, targetGrid);
+          builder.getContext(), gridShape, physGrid);
       fwdAttr = AffineMapAttr::get(fwd);
       invAttr = AffineMapAttr::get(inv);
     }
@@ -85,7 +89,8 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
                                              newLayout);
 
   // GridAttr's forward map is grid-rank (not memref-rank), so build it
-  // directly rather than reusing the EmptyOp's memref-level VGM.
+  // directly rather than reusing the EmptyOp's memref-level VGM. Project onto
+  // clean-factor physGrid.
   ttcore::GridAttr grid;
   if (fwdAttr) {
     auto targetGrid =
@@ -95,8 +100,10 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
                             .getWorkerGrid()
                             .getShape());
     auto gridShape = llvm::to_vector(destGrid.getShape());
+    auto physGrid =
+        ttmlir::d2m::utils::grids::getPhysicalGridExtent(gridShape, targetGrid);
     auto fwdGrid = ttmlir::d2m::utils::grids::create1DtoNDMap(
-                       builder.getContext(), targetGrid)
+                       builder.getContext(), physGrid)
                        .compose(ttmlir::d2m::utils::grids::createCollapseMap(
                            builder.getContext(), gridShape));
     fwdGrid =

--- a/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
+++ b/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
@@ -24,6 +25,74 @@ namespace {
 
 bool isViewOp(Operation *op) {
   return mlir::isa_and_nonnull<d2m::ViewOpInterface>(op);
+}
+
+// Walks the view chain to the op that owns the VGM. Returns the value plus
+// its forward map so the caller can read its tensor shape.
+std::optional<std::pair<Value, AffineMap>> findUpstreamVgmSource(Value v) {
+  Operation *defOp = v.getDefiningOp();
+  if (!defOp) {
+    return std::nullopt;
+  }
+  if (auto emptyOp = mlir::dyn_cast<EmptyOp>(defOp)) {
+    if (auto fwd = emptyOp.getVirtualGridForwardMappingAttr()) {
+      return std::make_pair(v, fwd.getValue());
+    }
+    return std::nullopt;
+  }
+  if (auto toLayoutOp = mlir::dyn_cast<ToLayoutOp>(defOp)) {
+    return findUpstreamVgmSource(toLayoutOp.getOutput());
+  }
+  if (auto toDeviceOp = mlir::dyn_cast<ToDeviceOp>(defOp)) {
+    return findUpstreamVgmSource(toDeviceOp.getOutput());
+  }
+  if (auto genericOp = mlir::dyn_cast<GenericOp>(defOp)) {
+    for (auto [idx, result] : llvm::enumerate(genericOp.getResults())) {
+      if (result == v) {
+        return findUpstreamVgmSource(genericOp.getOutputs()[idx]);
+      }
+    }
+    return std::nullopt;
+  }
+  if (auto spatialOp = mlir::dyn_cast<SpatialOp>(defOp)) {
+    for (auto [idx, result] : llvm::enumerate(spatialOp.getResults())) {
+      if (result == v) {
+        return findUpstreamVgmSource(spatialOp.getOutputs()[idx]);
+      }
+    }
+    return std::nullopt;
+  }
+  if (auto viewOp = mlir::dyn_cast<ViewOpInterface>(defOp)) {
+    if (viewOp.isComposite()) {
+      auto inputs = viewOp.getCompositeInputs();
+      if (inputs.empty()) {
+        return std::nullopt;
+      }
+      return findUpstreamVgmSource(inputs.front());
+    }
+    return findUpstreamVgmSource(viewOp.getInput());
+  }
+  return std::nullopt;
+}
+
+// 2D phys grid extent inherited from upstream VGM, or nullopt.
+std::optional<SmallVector<int64_t>> inheritPhysGridExtent(Value v) {
+  auto info = findUpstreamVgmSource(v);
+  if (!info) {
+    return std::nullopt;
+  }
+  auto [srcVal, fwdMap] = *info;
+  auto srcType = mlir::dyn_cast<RankedTensorType>(srcVal.getType());
+  if (!srcType || fwdMap.getNumResults() < 2 ||
+      fwdMap.getNumDims() != static_cast<unsigned>(srcType.getRank())) {
+    return std::nullopt;
+  }
+  auto physMap = ttmlir::utils::affineMapTakeFrontResults(fwdMap, 2);
+  auto evaluated = ttmlir::utils::evalShape(physMap, srcType.getShape());
+  if (evaluated.size() < 2) {
+    return std::nullopt;
+  }
+  return SmallVector<int64_t>(evaluated.begin(), evaluated.begin() + 2);
 }
 
 // Extract the grid attribute from a tensor's metal layout encoding.
@@ -60,21 +129,34 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
       builder.getContext(), layout.getLogicalShape(), layout.getDimAlignments(),
       layout.getCollapsedIntervals(), layout.getMemorySpace(),
       layout.getMemoryLayout());
-  // Derive VGM fresh from destination grid; upstream VGM rank may not match.
+  // Pin phys grid to upstream's so writes stay local; else clean-factor.
   ttcore::GridAttr destGrid = getGridFromType(tensorType);
   TT_assert(destGrid != nullptr);
   AffineMapAttr fwdAttr;
   AffineMapAttr invAttr;
+  SmallVector<int64_t> gridShape = llvm::to_vector(destGrid.getShape());
+  SmallVector<int64_t> physGrid;
   if (auto deviceOp = ttcore::lookupDevice(builder.getInsertionBlock()
                                                ->getParent()
                                                ->getParentOfType<ModuleOp>())) {
     auto targetGrid = llvm::to_vector(deviceOp.getWorkerGrid().getShape());
-    auto gridShape = llvm::to_vector(destGrid.getShape());
     if (ttmlir::d2m::utils::grids::requiresVirtualGrid(gridShape, targetGrid)) {
-      // Use clean-factor physGrid; raw worker grid would mod-wrap unevenly
-      // (e.g. mod 11 on BH 10x11 for a 64-vol virt grid).
-      auto physGrid = ttmlir::d2m::utils::grids::getPhysicalGridExtent(
-          gridShape, targetGrid);
+      int64_t targetVolume = std::accumulate(gridShape.begin(), gridShape.end(),
+                                             int64_t{1}, std::multiplies<>());
+      if (auto inherited = inheritPhysGridExtent(viewResult)) {
+        int64_t inheritedVolume =
+            std::accumulate(inherited->begin(), inherited->end(), int64_t{1},
+                            std::multiplies<>());
+        if (inheritedVolume == targetVolume) {
+          physGrid = *inherited;
+        }
+      }
+      if (physGrid.empty()) {
+        // Clean-factor avoids mod-wrap on uneven worker grids (e.g. BH 10x11).
+        physGrid =
+            llvm::to_vector(ttmlir::d2m::utils::grids::getPhysicalGridExtent(
+                gridShape, targetGrid));
+      }
       auto [fwd, inv] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
           builder.getContext(), gridShape, physGrid);
       fwdAttr = AffineMapAttr::get(fwd);
@@ -88,20 +170,10 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
                                              tensorType.getElementType(),
                                              newLayout);
 
-  // GridAttr's forward map is grid-rank (not memref-rank), so build it
-  // directly rather than reusing the EmptyOp's memref-level VGM. Project onto
-  // clean-factor physGrid.
+  // GridAttr fwd is grid-rank (not memref-rank); build directly, share
+  // physGrid.
   ttcore::GridAttr grid;
   if (fwdAttr) {
-    auto targetGrid =
-        llvm::to_vector(ttcore::lookupDevice(builder.getInsertionBlock()
-                                                 ->getParent()
-                                                 ->getParentOfType<ModuleOp>())
-                            .getWorkerGrid()
-                            .getShape());
-    auto gridShape = llvm::to_vector(destGrid.getShape());
-    auto physGrid =
-        ttmlir::d2m::utils::grids::getPhysicalGridExtent(gridShape, targetGrid);
     auto fwdGrid = ttmlir::d2m::utils::grids::create1DtoNDMap(
                        builder.getContext(), physGrid)
                        .compose(ttmlir::d2m::utils::grids::createCollapseMap(

--- a/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
+++ b/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
@@ -16,9 +16,6 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "llvm/Support/Debug.h"
-
-#define DEBUG_TYPE "d2m-materialize-view-returns"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MMATERIALIZEVIEWRETURNS
@@ -145,11 +142,6 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
                             std::multiplies<>());
         if (inheritedVolume == targetVolume) {
           physGrid = *inherited;
-        } else {
-          LLVM_DEBUG(llvm::dbgs()
-                     << "materializeView: upstream physGrid vol "
-                     << inheritedVolume << " != virt grid vol " << targetVolume
-                     << "; falling back to volume-exact factorization\n");
         }
       }
       if (physGrid.empty()) {

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -440,12 +440,26 @@ std::optional<AffineMap> getVirtualGridInverseMapping(Value val) {
     // Trace through view/stream ops via ViewOpInterface.
     if (auto viewOp = mlir::dyn_cast<ViewOpInterface>(defOp)) {
       if (viewOp.isComposite()) {
-        // Composite inputs are required to share VGM (enforced by verifier).
+        // Propagate only when every composite input agrees on the inverse
+        // VGM (or none carry one).
         auto inputs = viewOp.getCompositeInputs();
         if (inputs.empty()) {
           return std::nullopt;
         }
-        return getVirtualGridInverseMapping(inputs.front());
+        std::optional<AffineMap> shared;
+        bool sharedSet = false;
+        for (Value input : inputs) {
+          auto inputMap = getVirtualGridInverseMapping(input);
+          if (!sharedSet) {
+            shared = inputMap;
+            sharedSet = true;
+            continue;
+          }
+          if (inputMap != shared) {
+            return std::nullopt;
+          }
+        }
+        return shared;
       }
       return getVirtualGridInverseMapping(viewOp.getInput());
     }
@@ -509,12 +523,25 @@ std::optional<AffineMap> getVirtualGridForwardMapping(Value val) {
     // Trace through view/stream ops via ViewOpInterface.
     if (auto viewOp = mlir::dyn_cast<ViewOpInterface>(defOp)) {
       if (viewOp.isComposite()) {
-        // Composite inputs are required to share VGM (enforced by verifier).
+        // Only propagate when every input agrees, otherwise return nullopt.
         auto inputs = viewOp.getCompositeInputs();
         if (inputs.empty()) {
           return std::nullopt;
         }
-        return getVirtualGridForwardMapping(inputs.front());
+        std::optional<AffineMap> shared;
+        bool sharedSet = false;
+        for (Value input : inputs) {
+          auto inputMap = getVirtualGridForwardMapping(input);
+          if (!sharedSet) {
+            shared = inputMap;
+            sharedSet = true;
+            continue;
+          }
+          if (inputMap != shared) {
+            return std::nullopt;
+          }
+        }
+        return shared;
       }
       return getVirtualGridForwardMapping(viewOp.getInput());
     }

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -440,7 +440,12 @@ std::optional<AffineMap> getVirtualGridInverseMapping(Value val) {
     // Trace through view/stream ops via ViewOpInterface.
     if (auto viewOp = mlir::dyn_cast<ViewOpInterface>(defOp)) {
       if (viewOp.isComposite()) {
-        return std::nullopt;
+        // Composite inputs are required to share VGM (enforced by verifier).
+        auto inputs = viewOp.getCompositeInputs();
+        if (inputs.empty()) {
+          return std::nullopt;
+        }
+        return getVirtualGridInverseMapping(inputs.front());
       }
       return getVirtualGridInverseMapping(viewOp.getInput());
     }
@@ -504,7 +509,12 @@ std::optional<AffineMap> getVirtualGridForwardMapping(Value val) {
     // Trace through view/stream ops via ViewOpInterface.
     if (auto viewOp = mlir::dyn_cast<ViewOpInterface>(defOp)) {
       if (viewOp.isComposite()) {
-        return std::nullopt;
+        // Composite inputs are required to share VGM (enforced by verifier).
+        auto inputs = viewOp.getCompositeInputs();
+        if (inputs.empty()) {
+          return std::nullopt;
+        }
+        return getVirtualGridForwardMapping(inputs.front());
       }
       return getVirtualGridForwardMapping(viewOp.getInput());
     }

--- a/test/python/golden/d2m/test_view_chain_snippets.py
+++ b/test/python/golden/d2m/test_view_chain_snippets.py
@@ -52,7 +52,6 @@ def _compile_and_run_snippet(mlir_text, golden_input_output, request, device):
         input_output_goldens={0: golden_input_output},
         device=device,
         save_artifacts=True,
-        artifact_dir="builder-artifacts",
         check_pcc=True,
         check_atol=True,
         check_rtol=True,

--- a/test/python/golden/d2m/test_view_chain_snippets.py
+++ b/test/python/golden/d2m/test_view_chain_snippets.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from collections import OrderedDict
+
+import pytest
+import torch
+
+from ttmlir.ir import Context, Location, Module
+from ttmlir.passes import ttmetal_to_flatbuffer_bin
+
+from builder.base.builder_apis import create_custom_ttir_pipeline_fn
+from builder.base.builder_utils import run_ttir_pipeline
+from builder.base.builder_runtime import execute_fb
+from golden import GoldenMapTensor
+
+pytestmark = pytest.mark.frontend("ttir")
+
+_D2M_POST_GRID_WITH_VIEW_PIPELINE = (
+    "d2m-lower-to-layout,d2m-materialize-view-returns,canonicalize,"
+    "ttir-bufferization-pipeline,d2m-insert-scratch-buffers,"
+    "d2m-generic-apply-interchange,d2m-generate-outer-loops,d2m-allocate,"
+    "d2m-lower-multicast-loads,d2m-generic-lower-to-explicit-form,canonicalize,"
+    "d2m-be-pipeline,d2m-to-ttkernel-pipeline,d2m-to-ttmetal-pipeline"
+)
+
+_SNIPPETS_DIR = os.path.join(os.path.dirname(__file__), "view_chain_snippets")
+
+
+def _load_snippet(name):
+    with open(os.path.join(_SNIPPETS_DIR, name), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _compile_and_run_snippet(mlir_text, golden_input_output, request, device):
+    ctx = Context()
+    with ctx, Location.unknown(ctx):
+        module = Module.parse(mlir_text)
+
+    module = run_ttir_pipeline(
+        module,
+        create_custom_ttir_pipeline_fn(_D2M_POST_GRID_WITH_VIEW_PIPELINE),
+        pipeline_options=[],
+        save_artifacts=True,
+        system_desc_path=request.config.getoption("--sys-desc"),
+        mesh_dict=OrderedDict([("x", 1), ("y", 1)]),
+    )
+    #
+    # _prev = torch._tensor_str.PRINT_OPTS
+    # torch.set_printoptions(
+    #     threshold=10_000_000, linewidth=400, precision=1, sci_mode=False
+    # )
+    # try:
+    #     for name, g in golden_input_output.items():
+    #         tensor = next(iter(g.shard_map.values()))
+    #         print(f"\n[{name}] shape={tuple(tensor.shape)} dtype={tensor.dtype}")
+    #         if name.startswith("output_"):
+    #             print(tensor)
+    #         else:
+    #             print(f"  first row: {tensor[0].tolist()}")
+    #             print(f"  last row : {tensor[-1].tolist()}")
+    # finally:
+    #     torch.set_printoptions(
+    #         precision=_prev.precision,
+    #         threshold=_prev.threshold,
+    #         edgeitems=_prev.edgeitems,
+    #         linewidth=_prev.linewidth,
+    #         sci_mode=_prev.sci_mode,
+    #     )
+
+    _golden_report, output_tensors = execute_fb(
+        ttmetal_to_flatbuffer_bin(module),
+        input_output_goldens={0: golden_input_output},
+        device=device,
+        save_artifacts=True,
+        artifact_dir="builder-artifacts",
+        check_pcc=True,
+        check_atol=True,
+        check_rtol=True,
+    )
+    # torch.set_printoptions(
+    #     threshold=10_000_000, linewidth=400, precision=1, sci_mode=False
+    # )
+    # for prog_key, program in output_tensors.items():
+    #     for key, shards in program.items():
+    #         if not key.startswith("device_output_"):
+    #             continue
+    #         for shard_id, tensor in shards.items():
+    #             print(
+    #                 f"\n[{prog_key}/{key} shard={shard_id}] shape={tuple(tensor.shape)}"
+    #             )
+    #             print(tensor)
+
+
+def _im2col_nhwc_flat(t: torch.Tensor, K: int = 2) -> torch.Tensor:
+    # Mirrors snippet: per (ki, kj) take slice t[:, ki:ki+H_out, kj:kj+W_out, :],
+    # flatten to (N*H_out*W_out, C), then concat K*K on C dim → (N*H_out*W_out,
+    # K*K*C). Block order (ki, kj) row-major; channel order preserved within.
+    N, H, W, C = t.shape
+    H_out, W_out = H - K + 1, W - K + 1
+    cols = []
+    for ki in range(K):
+        for kj in range(K):
+            patch = t[:, ki : ki + H_out, kj : kj + W_out, :]
+            cols.append(patch.reshape(N * H_out * W_out, C))
+    return torch.cat(cols, dim=1)
+
+
+_DTYPE_MAP = {"f32": torch.float32, "bf16": torch.bfloat16}
+
+
+def _substitute_dtype(mlir_text: str, dtype: str) -> str:
+    # All element-type occurrences in our snippets are `xf32` (in shape decls)
+    # or `f32` as a bare type (inside !ttcore.tile<...> attrs etc). Our RM
+    # snippets only use the `xf32` form, so a single str.replace is sufficient.
+    # Comments containing "f32" are stripped at parse time, so they are safe.
+    return mlir_text.replace("xf32", f"x{dtype}")
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("dtype", ["f32", "bf16"])
+def test_composite_im2col_rm(target, dtype, request, device):
+    # Single-core im2col, K=2, parametrized on element type.
+    N, H, W, C = 1, 9, 9, 32
+    K = 2
+    H_out = W_out = H - K + 1  # 8
+    in_shape = (N, H, W, C)
+    out_shape = (N * H_out * W_out, K * K * C)  # (64, 128)
+
+    torch_dtype = _DTYPE_MAP[dtype]
+    arg0 = torch.arange(N * H * W * C, dtype=torch_dtype).reshape(in_shape)
+    expected = _im2col_nhwc_flat(arg0, K=K)
+    assert expected.shape == out_shape
+
+    goldens = {
+        "input_0": GoldenMapTensor({0: arg0}, (1, 1)),
+        "output_0": GoldenMapTensor({0: expected}, (1, 1)),
+    }
+
+    _compile_and_run_snippet(
+        _substitute_dtype(_load_snippet("composite_im2col_rm.mlir"), dtype),
+        goldens,
+        request,
+        device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("dtype", ["f32", "bf16"])
+def test_composite_im2col_rm_grid8x8(target, dtype, request, device):
+    # im2col K=2 block-sharded on grid<8x8>, parametrized on element type.
+    N, H, W, C = 1, 17, 17, 64
+    K = 2
+    H_out = H - K + 1  # 16
+    W_out = W - K + 1  # 16
+    out_shape = (N * H_out * W_out, K * K * C)  # (256, 256)
+
+    torch_dtype = _DTYPE_MAP[dtype]
+    arg0 = torch.arange(N * H * W * C, dtype=torch_dtype).reshape(N, H, W, C)
+    expected = _im2col_nhwc_flat(arg0, K=K)
+    assert expected.shape == out_shape
+
+    goldens = {
+        "input_0": GoldenMapTensor({0: arg0}, (1, 1)),
+        "output_0": GoldenMapTensor({0: expected}, (1, 1)),
+    }
+
+    _compile_and_run_snippet(
+        _substitute_dtype(_load_snippet("composite_im2col_rm_grid8x8.mlir"), dtype),
+        goldens,
+        request,
+        device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("dtype", ["f32", "bf16"])
+def test_composite_im2col_rm_grid64x1(target, dtype, request, device):
+    # N=1, H=W=66, C=32,
+    # K=3 stride=1 no pad → H_out=W_out=64. NHW_flat=4096, KKC=9*32=288.
+    # Per-core L1: input 24 KB + output 72 KB ≈ 96 KB.
+    N, H, W, C = 1, 66, 66, 32
+    K = 3
+    H_out = H - K + 1  # 64
+    W_out = W - K + 1  # 64
+    out_shape = (N * H_out * W_out, K * K * C)  # (4096, 288)
+
+    torch_dtype = _DTYPE_MAP[dtype]
+    arg0 = torch.arange(N * H * W * C, dtype=torch_dtype).reshape(N, H, W, C)
+    expected = _im2col_nhwc_flat(arg0, K=K)
+    assert expected.shape == out_shape
+
+    goldens = {
+        "input_0": GoldenMapTensor({0: arg0}, (1, 1)),
+        "output_0": GoldenMapTensor({0: expected}, (1, 1)),
+    }
+
+    _compile_and_run_snippet(
+        _substitute_dtype(_load_snippet("composite_im2col_rm_grid64x1.mlir"), dtype),
+        goldens,
+        request,
+        device,
+    )

--- a/test/python/golden/d2m/test_view_chain_snippets.py
+++ b/test/python/golden/d2m/test_view_chain_snippets.py
@@ -47,29 +47,6 @@ def _compile_and_run_snippet(mlir_text, golden_input_output, request, device):
         system_desc_path=request.config.getoption("--sys-desc"),
         mesh_dict=OrderedDict([("x", 1), ("y", 1)]),
     )
-    #
-    # _prev = torch._tensor_str.PRINT_OPTS
-    # torch.set_printoptions(
-    #     threshold=10_000_000, linewidth=400, precision=1, sci_mode=False
-    # )
-    # try:
-    #     for name, g in golden_input_output.items():
-    #         tensor = next(iter(g.shard_map.values()))
-    #         print(f"\n[{name}] shape={tuple(tensor.shape)} dtype={tensor.dtype}")
-    #         if name.startswith("output_"):
-    #             print(tensor)
-    #         else:
-    #             print(f"  first row: {tensor[0].tolist()}")
-    #             print(f"  last row : {tensor[-1].tolist()}")
-    # finally:
-    #     torch.set_printoptions(
-    #         precision=_prev.precision,
-    #         threshold=_prev.threshold,
-    #         edgeitems=_prev.edgeitems,
-    #         linewidth=_prev.linewidth,
-    #         sci_mode=_prev.sci_mode,
-    #     )
-
     _golden_report, output_tensors = execute_fb(
         ttmetal_to_flatbuffer_bin(module),
         input_output_goldens={0: golden_input_output},
@@ -80,18 +57,6 @@ def _compile_and_run_snippet(mlir_text, golden_input_output, request, device):
         check_atol=True,
         check_rtol=True,
     )
-    # torch.set_printoptions(
-    #     threshold=10_000_000, linewidth=400, precision=1, sci_mode=False
-    # )
-    # for prog_key, program in output_tensors.items():
-    #     for key, shards in program.items():
-    #         if not key.startswith("device_output_"):
-    #             continue
-    #         for shard_id, tensor in shards.items():
-    #             print(
-    #                 f"\n[{prog_key}/{key} shard={shard_id}] shape={tuple(tensor.shape)}"
-    #             )
-    #             print(tensor)
 
 
 def _im2col_nhwc_flat(t: torch.Tensor, K: int = 2) -> torch.Tensor:

--- a/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm.mlir
+++ b/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm.mlir
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// 2D im2col, single NHWC input, f32. Input <1x9x9x32>, output <64x128>,
+// grid <1x1>, K=2. Single-core, row-major.
+// 4 spatial-shift views (K*K=4) -> 4 flatten views -> composite stack on
+// logical dim 1 (C) -> <64, 128> where 128 = K*K*C.
+
+#l_in   = #ttcore.metal_layout<logical_shape = 1x9x9x32, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_view = #ttcore.metal_layout<logical_shape = 1x8x8x32, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_flat = #ttcore.metal_layout<logical_shape = 64x32,    dim_alignments = 32x32,      collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_out  = #ttcore.metal_layout<logical_shape = 64x128,   dim_alignments = 32x32,      collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+
+// Step 1: 8D -> 8D spatial-shift. Identity on grid (d0..d3), N (d4), C (d7).
+#sh_00 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5,     d6,     d7)>
+#sh_01 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5,     d6 + 1, d7)>
+#sh_10 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5 + 1, d6,     d7)>
+#sh_11 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5 + 1, d6 + 1, d7)>
+
+// Step 2: 4D -> 8D flatten. NHW reshape; identity on C.
+#flatten = affine_map<(d0, d1, d2, d3) -> (0, 0, 0, 0, 0, d2 floordiv 8, d2 mod 8, d3)>
+
+func.func @composite_im2col_nhwc(%arg0: tensor<1x9x9x32xf32>) -> tensor<64x128xf32> {
+  %d_init = d2m.empty() : tensor<1x1x1x1x1x32x32x32xf32, #l_in>
+  %dev = d2m.to_layout %arg0, %d_init : tensor<1x9x9x32xf32> into tensor<1x1x1x1x1x32x32x32xf32, #l_in>
+    -> tensor<1x1x1x1x1x32x32x32xf32, #l_in>
+
+  %s00 = d2m.view_layout %dev remapping = #sh_00 : tensor<1x1x1x1x1x32x32x32xf32, #l_in> -> tensor<1x1x1x1x1x32x32x32xf32, #l_view>
+  %s01 = d2m.view_layout %dev remapping = #sh_01 : tensor<1x1x1x1x1x32x32x32xf32, #l_in> -> tensor<1x1x1x1x1x32x32x32xf32, #l_view>
+  %s10 = d2m.view_layout %dev remapping = #sh_10 : tensor<1x1x1x1x1x32x32x32xf32, #l_in> -> tensor<1x1x1x1x1x32x32x32xf32, #l_view>
+  %s11 = d2m.view_layout %dev remapping = #sh_11 : tensor<1x1x1x1x1x32x32x32xf32, #l_in> -> tensor<1x1x1x1x1x32x32x32xf32, #l_view>
+
+  %f00 = d2m.view_layout %s00 remapping = #flatten : tensor<1x1x1x1x1x32x32x32xf32, #l_view> -> tensor<1x1x64x32xf32, #l_flat>
+  %f01 = d2m.view_layout %s01 remapping = #flatten : tensor<1x1x1x1x1x32x32x32xf32, #l_view> -> tensor<1x1x64x32xf32, #l_flat>
+  %f10 = d2m.view_layout %s10 remapping = #flatten : tensor<1x1x1x1x1x32x32x32xf32, #l_view> -> tensor<1x1x64x32xf32, #l_flat>
+  %f11 = d2m.view_layout %s11 remapping = #flatten : tensor<1x1x1x1x1x32x32x32xf32, #l_view> -> tensor<1x1x64x32xf32, #l_flat>
+
+  %cv = "d2m.composite_view"(%f00, %f01, %f10, %f11)
+        <{dim = 1 : si32}> :
+        (tensor<1x1x64x32xf32, #l_flat>, tensor<1x1x64x32xf32, #l_flat>,
+         tensor<1x1x64x32xf32, #l_flat>, tensor<1x1x64x32xf32, #l_flat>)
+     -> tensor<1x1x64x128xf32, #l_out>
+
+  %h_empty = d2m.empty() : tensor<64x128xf32>
+  %result = d2m.to_layout %cv, %h_empty : tensor<1x1x64x128xf32, #l_out> into tensor<64x128xf32>
+    -> tensor<64x128xf32>
+  return %result : tensor<64x128xf32>
+}

--- a/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm.mlir
+++ b/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm.mlir
@@ -7,10 +7,10 @@
 // 4 spatial-shift views (K*K=4) -> 4 flatten views -> composite stack on
 // logical dim 1 (C) -> <64, 128> where 128 = K*K*C.
 
-#l_in   = #ttcore.metal_layout<logical_shape = 1x9x9x32, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#l_view = #ttcore.metal_layout<logical_shape = 1x8x8x32, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#l_flat = #ttcore.metal_layout<logical_shape = 64x32,    dim_alignments = 32x32,      collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#l_out  = #ttcore.metal_layout<logical_shape = 64x128,   dim_alignments = 32x32,      collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_in   = #ttcore.metal_layout<logical_shape = 1x9x9x32, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#l_view = #ttcore.metal_layout<logical_shape = 1x8x8x32, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#l_flat = #ttcore.metal_layout<logical_shape = 64x32,    dim_alignments = 32x32,      collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#l_out  = #ttcore.metal_layout<logical_shape = 64x128,   dim_alignments = 32x32,      collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
 
 // Step 1: 8D -> 8D spatial-shift. Identity on grid (d0..d3), N (d4), C (d7).
 #sh_00 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5,     d6,     d7)>

--- a/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid64x1.mlir
+++ b/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid64x1.mlir
@@ -7,10 +7,10 @@
 // 9 spatial-shift views (K*K=9) -> 9 flatten views (4D grid<64x1>) ->
 // composite stack on logical dim 1 (KKC) -> <4096, 288> where 288 = K*K*C.
 
-#l_in    = #ttcore.metal_layout<logical_shape = 1x66x66x32, dim_alignments = 1x64x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#l_view  = #ttcore.metal_layout<logical_shape = 1x64x64x32, dim_alignments = 1x64x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#l_flat  = #ttcore.metal_layout<logical_shape = 4096x32,    dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#l_out   = #ttcore.metal_layout<logical_shape = 4096x288,   dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_in    = #ttcore.metal_layout<logical_shape = 1x66x66x32, dim_alignments = 1x64x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#l_view  = #ttcore.metal_layout<logical_shape = 1x64x64x32, dim_alignments = 1x64x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#l_flat  = #ttcore.metal_layout<logical_shape = 4096x32,    dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#l_out   = #ttcore.metal_layout<logical_shape = 4096x288,   dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
 
 // Step 1: 8D -> 8D spatial-shift. Input shard_H = 2, shard_W = 96 (W not
 // sharded, W_g=1). H shift wraps across grid_h via floordiv 2 / mod 2.

--- a/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid64x1.mlir
+++ b/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid64x1.mlir
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// 2D im2col, single NHWC input, rowmajor input <1x66x66x32>, output <4096x288>,
+// input grid <1x64x1x1>, output grid <64x1>, K=3.
+// 9 spatial-shift views (K*K=9) -> 9 flatten views (4D grid<64x1>) ->
+// composite stack on logical dim 1 (KKC) -> <4096, 288> where 288 = K*K*C.
+
+#l_in    = #ttcore.metal_layout<logical_shape = 1x66x66x32, dim_alignments = 1x64x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_view  = #ttcore.metal_layout<logical_shape = 1x64x64x32, dim_alignments = 1x64x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_flat  = #ttcore.metal_layout<logical_shape = 4096x32,    dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_out   = #ttcore.metal_layout<logical_shape = 4096x288,   dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+
+// Step 1: 8D -> 8D spatial-shift. Input shard_H = 2, shard_W = 96 (W not
+// sharded, W_g=1). H shift wraps across grid_h via floordiv 2 / mod 2.
+#sh_00 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 2 + d5    ) floordiv 2, d2, d3, d4, (d1 * 2 + d5    ) mod 2, d6    , d7)>
+#sh_01 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 2 + d5    ) floordiv 2, d2, d3, d4, (d1 * 2 + d5    ) mod 2, d6 + 1, d7)>
+#sh_02 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 2 + d5    ) floordiv 2, d2, d3, d4, (d1 * 2 + d5    ) mod 2, d6 + 2, d7)>
+#sh_10 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 2 + d5 + 1) floordiv 2, d2, d3, d4, (d1 * 2 + d5 + 1) mod 2, d6    , d7)>
+#sh_11 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 2 + d5 + 1) floordiv 2, d2, d3, d4, (d1 * 2 + d5 + 1) mod 2, d6 + 1, d7)>
+#sh_12 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 2 + d5 + 1) floordiv 2, d2, d3, d4, (d1 * 2 + d5 + 1) mod 2, d6 + 2, d7)>
+#sh_20 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 2 + d5 + 2) floordiv 2, d2, d3, d4, (d1 * 2 + d5 + 2) mod 2, d6    , d7)>
+#sh_21 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 2 + d5 + 2) floordiv 2, d2, d3, d4, (d1 * 2 + d5 + 2) mod 2, d6 + 1, d7)>
+#sh_22 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 2 + d5 + 2) floordiv 2, d2, d3, d4, (d1 * 2 + d5 + 2) mod 2, d6 + 2, d7)>
+
+// Step 2: 4D grid<64x1> -> 8D grid<1x64x1x1>.
+#flatten_g64x1 = affine_map<(d0, d1, d2, d3) -> (0, ((d0 * 64 + d2) floordiv 64) floordiv 2, 0, 0, 0, ((d0 * 64 + d2) floordiv 64) mod 2, (d0 * 64 + d2) mod 64, d3)>
+
+func.func @composite_im2col_nhwc_grid64x1(%arg0: tensor<1x66x66x32xf32>) -> tensor<4096x288xf32> {
+  %d_init = d2m.empty() : tensor<1x64x1x1x1x2x96x32xf32, #l_in>
+  %dev = d2m.to_layout %arg0, %d_init : tensor<1x66x66x32xf32> into tensor<1x64x1x1x1x2x96x32xf32, #l_in>
+    -> tensor<1x64x1x1x1x2x96x32xf32, #l_in>
+
+  %s00 = d2m.view_layout %dev remapping = #sh_00 : tensor<1x64x1x1x1x2x96x32xf32, #l_in> -> tensor<1x64x1x1x1x2x96x32xf32, #l_view>
+  %s01 = d2m.view_layout %dev remapping = #sh_01 : tensor<1x64x1x1x1x2x96x32xf32, #l_in> -> tensor<1x64x1x1x1x2x96x32xf32, #l_view>
+  %s02 = d2m.view_layout %dev remapping = #sh_02 : tensor<1x64x1x1x1x2x96x32xf32, #l_in> -> tensor<1x64x1x1x1x2x96x32xf32, #l_view>
+  %s10 = d2m.view_layout %dev remapping = #sh_10 : tensor<1x64x1x1x1x2x96x32xf32, #l_in> -> tensor<1x64x1x1x1x2x96x32xf32, #l_view>
+  %s11 = d2m.view_layout %dev remapping = #sh_11 : tensor<1x64x1x1x1x2x96x32xf32, #l_in> -> tensor<1x64x1x1x1x2x96x32xf32, #l_view>
+  %s12 = d2m.view_layout %dev remapping = #sh_12 : tensor<1x64x1x1x1x2x96x32xf32, #l_in> -> tensor<1x64x1x1x1x2x96x32xf32, #l_view>
+  %s20 = d2m.view_layout %dev remapping = #sh_20 : tensor<1x64x1x1x1x2x96x32xf32, #l_in> -> tensor<1x64x1x1x1x2x96x32xf32, #l_view>
+  %s21 = d2m.view_layout %dev remapping = #sh_21 : tensor<1x64x1x1x1x2x96x32xf32, #l_in> -> tensor<1x64x1x1x1x2x96x32xf32, #l_view>
+  %s22 = d2m.view_layout %dev remapping = #sh_22 : tensor<1x64x1x1x1x2x96x32xf32, #l_in> -> tensor<1x64x1x1x1x2x96x32xf32, #l_view>
+
+  %f00 = d2m.view_layout %s00 remapping = #flatten_g64x1 : tensor<1x64x1x1x1x2x96x32xf32, #l_view> -> tensor<64x1x64x32xf32, #l_flat>
+  %f01 = d2m.view_layout %s01 remapping = #flatten_g64x1 : tensor<1x64x1x1x1x2x96x32xf32, #l_view> -> tensor<64x1x64x32xf32, #l_flat>
+  %f02 = d2m.view_layout %s02 remapping = #flatten_g64x1 : tensor<1x64x1x1x1x2x96x32xf32, #l_view> -> tensor<64x1x64x32xf32, #l_flat>
+  %f10 = d2m.view_layout %s10 remapping = #flatten_g64x1 : tensor<1x64x1x1x1x2x96x32xf32, #l_view> -> tensor<64x1x64x32xf32, #l_flat>
+  %f11 = d2m.view_layout %s11 remapping = #flatten_g64x1 : tensor<1x64x1x1x1x2x96x32xf32, #l_view> -> tensor<64x1x64x32xf32, #l_flat>
+  %f12 = d2m.view_layout %s12 remapping = #flatten_g64x1 : tensor<1x64x1x1x1x2x96x32xf32, #l_view> -> tensor<64x1x64x32xf32, #l_flat>
+  %f20 = d2m.view_layout %s20 remapping = #flatten_g64x1 : tensor<1x64x1x1x1x2x96x32xf32, #l_view> -> tensor<64x1x64x32xf32, #l_flat>
+  %f21 = d2m.view_layout %s21 remapping = #flatten_g64x1 : tensor<1x64x1x1x1x2x96x32xf32, #l_view> -> tensor<64x1x64x32xf32, #l_flat>
+  %f22 = d2m.view_layout %s22 remapping = #flatten_g64x1 : tensor<1x64x1x1x1x2x96x32xf32, #l_view> -> tensor<64x1x64x32xf32, #l_flat>
+
+  %cv = "d2m.composite_view"(%f00, %f01, %f02, %f10, %f11, %f12, %f20, %f21, %f22)
+        <{dim = 1 : si32}> :
+        (tensor<64x1x64x32xf32, #l_flat>, tensor<64x1x64x32xf32, #l_flat>, tensor<64x1x64x32xf32, #l_flat>,
+         tensor<64x1x64x32xf32, #l_flat>, tensor<64x1x64x32xf32, #l_flat>, tensor<64x1x64x32xf32, #l_flat>,
+         tensor<64x1x64x32xf32, #l_flat>, tensor<64x1x64x32xf32, #l_flat>, tensor<64x1x64x32xf32, #l_flat>)
+     -> tensor<64x1x64x288xf32, #l_out>
+
+  %h_empty = d2m.empty() : tensor<4096x288xf32>
+  %result = d2m.to_layout %cv, %h_empty : tensor<64x1x64x288xf32, #l_out> into tensor<4096x288xf32>
+    -> tensor<4096x288xf32>
+  return %result : tensor<4096x288xf32>
+}

--- a/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid64x1.mlir
+++ b/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid64x1.mlir
@@ -27,8 +27,14 @@
 // Step 2: 4D grid<64x1> -> 8D grid<1x64x1x1>.
 #flatten_g64x1 = affine_map<(d0, d1, d2, d3) -> (0, ((d0 * 64 + d2) floordiv 64) floordiv 2, 0, 0, 0, ((d0 * 64 + d2) floordiv 64) mod 2, (d0 * 64 + d2) mod 64, d3)>
 
+#vgm_fwd = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ((d0 * 64 + d1 + d2 + d3) floordiv 8 mod 8, (d0 * 64 + d1 + d2 + d3) mod 8, d4, d5, d6, d7)>
+#vgm_inv = affine_map<(d0, d1) -> (0, 0, (d0 * 8 + d1) mod 64, 0, 0)>
+
 func.func @composite_im2col_nhwc_grid64x1(%arg0: tensor<1x66x66x32xf32>) -> tensor<4096x288xf32> {
-  %d_init = d2m.empty() : tensor<1x64x1x1x1x2x96x32xf32, #l_in>
+  %d_init = d2m.empty() {
+    virtualGridForwardMapping = #vgm_fwd,
+    virtualGridInverseMapping = #vgm_inv
+  } : tensor<1x64x1x1x1x2x96x32xf32, #l_in>
   %dev = d2m.to_layout %arg0, %d_init : tensor<1x66x66x32xf32> into tensor<1x64x1x1x1x2x96x32xf32, #l_in>
     -> tensor<1x64x1x1x1x2x96x32xf32, #l_in>
 

--- a/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid8x8.mlir
+++ b/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid8x8.mlir
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// 2D im2col, single NHWC input, f32. Input <1x17x17x64>, output <256x256>,
+// input grid <1x8x8x1>, output grid <8x8>, K=2. Row-major.
+// 4 spatial-shift views (K*K=4) -> 4 flatten views (4D grid<8x8>) ->
+// composite stack on logical dim 1 (KKC) -> <256, 256> where 256 = K*K*C.
+
+#l_in    = #ttcore.metal_layout<logical_shape = 1x17x17x64, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_view  = #ttcore.metal_layout<logical_shape = 1x16x16x64, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_flat  = #ttcore.metal_layout<logical_shape = 256x64,     dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_out   = #ttcore.metal_layout<logical_shape = 256x256,    dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+
+// Step 1: 8D -> 8D spatial-shift. Input shard_H = shard_W = 4. H, W shifts
+// wrap across grid via floordiv 4 / mod 4.
+#sh_00 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 4 + d5)     floordiv 4, (d2 * 4 + d6)     floordiv 4, d3, d4, (d1 * 4 + d5)     mod 4, (d2 * 4 + d6)     mod 4, d7)>
+#sh_01 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 4 + d5)     floordiv 4, (d2 * 4 + d6 + 1) floordiv 4, d3, d4, (d1 * 4 + d5)     mod 4, (d2 * 4 + d6 + 1) mod 4, d7)>
+#sh_10 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 4 + d5 + 1) floordiv 4, (d2 * 4 + d6)     floordiv 4, d3, d4, (d1 * 4 + d5 + 1) mod 4, (d2 * 4 + d6)     mod 4, d7)>
+#sh_11 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, (d1 * 4 + d5 + 1) floordiv 4, (d2 * 4 + d6 + 1) floordiv 4, d3, d4, (d1 * 4 + d5 + 1) mod 4, (d2 * 4 + d6 + 1) mod 4, d7)>
+
+// Step 2: 4D grid<8x8> -> 8D grid<1x8x8x1>.
+#flatten_g8x8 = affine_map<(d0, d1, d2, d3) -> (0, ((d0 * 32 + d2) floordiv 16) floordiv 4, ((d0 * 32 + d2) mod 16) floordiv 4, 0, 0, ((d0 * 32 + d2) floordiv 16) mod 4, ((d0 * 32 + d2) mod 16) mod 4, d1 * 8 + d3)>
+
+func.func @composite_im2col_nhwc_grid8x8(%arg0: tensor<1x17x17x64xf32>) -> tensor<256x256xf32> {
+  %d_init = d2m.empty() : tensor<1x8x8x1x1x4x4x64xf32, #l_in>
+  %dev = d2m.to_layout %arg0, %d_init : tensor<1x17x17x64xf32> into tensor<1x8x8x1x1x4x4x64xf32, #l_in>
+    -> tensor<1x8x8x1x1x4x4x64xf32, #l_in>
+
+  %s00 = d2m.view_layout %dev remapping = #sh_00 : tensor<1x8x8x1x1x4x4x64xf32, #l_in> -> tensor<1x8x8x1x1x4x4x64xf32, #l_view>
+  %s01 = d2m.view_layout %dev remapping = #sh_01 : tensor<1x8x8x1x1x4x4x64xf32, #l_in> -> tensor<1x8x8x1x1x4x4x64xf32, #l_view>
+  %s10 = d2m.view_layout %dev remapping = #sh_10 : tensor<1x8x8x1x1x4x4x64xf32, #l_in> -> tensor<1x8x8x1x1x4x4x64xf32, #l_view>
+  %s11 = d2m.view_layout %dev remapping = #sh_11 : tensor<1x8x8x1x1x4x4x64xf32, #l_in> -> tensor<1x8x8x1x1x4x4x64xf32, #l_view>
+
+  %f00 = d2m.view_layout %s00 remapping = #flatten_g8x8 : tensor<1x8x8x1x1x4x4x64xf32, #l_view> -> tensor<8x8x32x8xf32, #l_flat>
+  %f01 = d2m.view_layout %s01 remapping = #flatten_g8x8 : tensor<1x8x8x1x1x4x4x64xf32, #l_view> -> tensor<8x8x32x8xf32, #l_flat>
+  %f10 = d2m.view_layout %s10 remapping = #flatten_g8x8 : tensor<1x8x8x1x1x4x4x64xf32, #l_view> -> tensor<8x8x32x8xf32, #l_flat>
+  %f11 = d2m.view_layout %s11 remapping = #flatten_g8x8 : tensor<1x8x8x1x1x4x4x64xf32, #l_view> -> tensor<8x8x32x8xf32, #l_flat>
+
+  %cv = "d2m.composite_view"(%f00, %f01, %f10, %f11)
+        <{dim = 1 : si32}> :
+        (tensor<8x8x32x8xf32, #l_flat>, tensor<8x8x32x8xf32, #l_flat>,
+         tensor<8x8x32x8xf32, #l_flat>, tensor<8x8x32x8xf32, #l_flat>)
+     -> tensor<8x8x32x32xf32, #l_out>
+
+  %h_empty = d2m.empty() : tensor<256x256xf32>
+  %result = d2m.to_layout %cv, %h_empty : tensor<8x8x32x32xf32, #l_out> into tensor<256x256xf32>
+    -> tensor<256x256xf32>
+  return %result : tensor<256x256xf32>
+}

--- a/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid8x8.mlir
+++ b/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid8x8.mlir
@@ -22,8 +22,15 @@
 // Step 2: 4D grid<8x8> -> 8D grid<1x8x8x1>.
 #flatten_g8x8 = affine_map<(d0, d1, d2, d3) -> (0, ((d0 * 32 + d2) floordiv 16) floordiv 4, ((d0 * 32 + d2) mod 16) floordiv 4, 0, 0, ((d0 * 32 + d2) floordiv 16) mod 4, ((d0 * 32 + d2) mod 16) mod 4, d1 * 8 + d3)>
 
+// VGM for virt grid [1, 8, 8, 1] placed on physical grid 8x8 (volume=64).
+#vgm_fwd = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ((d0 * 64 + d1 * 8 + d2 + d3) floordiv 8 mod 8, (d0 * 64 + d1 * 8 + d2 + d3) mod 8, d4, d5, d6, d7)>
+#vgm_inv = affine_map<(d0, d1) -> (0, 0, (d0 * 8 + d1) floordiv 8 mod 8, (d0 * 8 + d1) mod 8, 0)>
+
 func.func @composite_im2col_nhwc_grid8x8(%arg0: tensor<1x17x17x64xf32>) -> tensor<256x256xf32> {
-  %d_init = d2m.empty() : tensor<1x8x8x1x1x4x4x64xf32, #l_in>
+  %d_init = d2m.empty() {
+    virtualGridForwardMapping = #vgm_fwd,
+    virtualGridInverseMapping = #vgm_inv
+  } : tensor<1x8x8x1x1x4x4x64xf32, #l_in>
   %dev = d2m.to_layout %arg0, %d_init : tensor<1x17x17x64xf32> into tensor<1x8x8x1x1x4x4x64xf32, #l_in>
     -> tensor<1x8x8x1x1x4x4x64xf32, #l_in>
 

--- a/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid8x8.mlir
+++ b/test/python/golden/d2m/view_chain_snippets/composite_im2col_rm_grid8x8.mlir
@@ -7,10 +7,10 @@
 // 4 spatial-shift views (K*K=4) -> 4 flatten views (4D grid<8x8>) ->
 // composite stack on logical dim 1 (KKC) -> <256, 256> where 256 = K*K*C.
 
-#l_in    = #ttcore.metal_layout<logical_shape = 1x17x17x64, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#l_view  = #ttcore.metal_layout<logical_shape = 1x16x16x64, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#l_flat  = #ttcore.metal_layout<logical_shape = 256x64,     dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#l_out   = #ttcore.metal_layout<logical_shape = 256x256,    dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#l_in    = #ttcore.metal_layout<logical_shape = 1x17x17x64, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#l_view  = #ttcore.metal_layout<logical_shape = 1x16x16x64, dim_alignments = 1x32x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#l_flat  = #ttcore.metal_layout<logical_shape = 256x64,     dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#l_out   = #ttcore.metal_layout<logical_shape = 256x256,    dim_alignments = 1x32,       collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
 
 // Step 1: 8D -> 8D spatial-shift. Input shard_H = shard_W = 4. H, W shifts
 // wrap across grid via floordiv 4 / mod 4.

--- a/test/ttmlir/Dialect/D2M/Transforms/expand_dma_read_composite_view.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/expand_dma_read_composite_view.mlir
@@ -1,4 +1,5 @@
 // RUN: ttmlir-opt --ttcore-register-device --d2m-expand-dma-read-composite-view %s | FileCheck %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-expand-dma-read-composite-view %s | FileCheck %s --check-prefix=COUNT
 
 #l1 = #ttcore.memory_space<l1>
 module attributes {} {
@@ -138,5 +139,256 @@ module attributes {} {
     memref.dealloc %alloc_0 : memref<2x7x1x1x32x32xf32, #ttcore.shard<4096x128x4, 1>, #l1>
     memref.dealloc %alloc_1 : memref<2x7x1x1x32x32xf32, #ttcore.shard<4096x128x4, 1>, #l1>
     return %alloc_2 : memref<2x16x1x1x32x32xf32, #ttcore.shard<4096x128x4, 1>, #l1>
+  }
+
+  // Tiled chained-views variant of @test_composite_view_large_grid_padded:
+  // each input fed by a 2-step view_layout chain.
+  // CHECK-LABEL: func.func @test_composite_view_chained_views_tiled
+  func.func @test_composite_view_chained_views_tiled() -> memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1> {
+    %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1>
+    %alloc_1 = memref.alloc() {address = 132384 : i64, alignment = 16 : i64} : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1>
+    %pre_0 = d2m.view_layout %alloc_0 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1> -> memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %pre_1 = d2m.view_layout %alloc_1 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1> -> memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %view_0 = d2m.view_layout %pre_0 remapping = affine_map<(d0, d1, d2, d3) -> (0, 0, 0, d1 mod 7)> : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<1x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %view_1 = d2m.view_layout %pre_1 remapping = affine_map<(d0, d1, d2, d3) -> (0, 0, 0, d1 mod 7)> : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<1x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    // CHECK-NOT: d2m.composite_view
+    %0 = "d2m.composite_view"(%view_0, %view_1) <{dim = 1 : si32}> : (memref<1x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>) -> memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %alloc_2 = memref.alloc() {address = 161056 : i64, alignment = 16 : i64} : memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x8>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%0 : memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>)
+        outs(%alloc_2 : memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+    ^datamovement0:
+      %1 = d2m.get_cb(1) : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      // CHECK: d2m.reserve
+      %2 = d2m.reserve %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x2x!ttcore.tile<32x32, f32>, #l1>
+      // CHECK: scf.if
+      // CHECK: d2m.dma_read
+      // CHECK: d2m.dma_wait
+      // CHECK: else
+      // CHECK: d2m.dma_read
+      // CHECK: d2m.dma_wait
+      %tx = d2m.dma_read %0[%core0, %core1], %2, <0> : (memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+      d2m.dma_wait %tx : !d2m.mem_tx<read>
+      // CHECK: d2m.push
+      d2m.push %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    memref.dealloc %alloc_0 : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1>
+    memref.dealloc %alloc_1 : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1>
+    return %alloc_2 : memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+  }
+
+  // Row-major chained-views variant with mixed chain depths (1, 2) per input.
+  // CHECK-LABEL: func.func @test_composite_view_chained_views_row_major
+  func.func @test_composite_view_chained_views_row_major() -> memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1> {
+    %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    %alloc_1 = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    %pre_1 = d2m.view_layout %alloc_1 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1> -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1>
+    %view_0 = d2m.view_layout %alloc_0 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1> -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1>
+    %view_1 = d2m.view_layout %pre_1 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<4x1x32x32xf32, #ttcore.view<4>, #l1> -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1>
+    // CHECK-NOT: d2m.composite_view
+    %0 = "d2m.composite_view"(%view_0, %view_1) <{dim = 1 : si32, logicalSizes = array<i64: 16, 16>}> : (memref<4x1x32x32xf32, #ttcore.view<4>, #l1>, memref<4x1x32x32xf32, #ttcore.view<4>, #l1>) -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1>
+    %alloc_2 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<4x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%0 : memref<4x1x32x32xf32, #ttcore.view<4>, #l1>)
+        outs(%alloc_2 : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>)
+     {
+      %1 = d2m.get_cb(1) resolution_stage =  compile : <memref<32x32xf32, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      // CHECK: d2m.reserve
+      %2 = d2m.reserve %1 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+      // CHECK: scf.for
+      // CHECK: scf.for
+      // CHECK: scf.if
+      // CHECK: d2m.dma_read
+      // CHECK: d2m.dma_wait
+      // CHECK: else
+      // CHECK: d2m.dma_read
+      // CHECK: d2m.dma_wait
+      %tx = d2m.dma_read %0[%core0, %core1], %2, <0> : (memref<4x1x32x32xf32, #ttcore.view<4>, #l1>, memref<32x32xf32, #l1>) -> !d2m.mem_tx<read>
+      d2m.dma_wait %tx : !d2m.mem_tx<read>
+      // CHECK: d2m.push
+      d2m.push %1 : <memref<32x32xf32, #l1>>
+    }
+    memref.dealloc %alloc_1 : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    memref.dealloc %alloc_0 : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    return %alloc_2 : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+  }
+
+  // Row-major width-concat coalescing factor = 16B / elemBytes; varied via
+  // element type across the three funcs below.
+
+  // f32 -> factor 4.
+  // CHECK-LABEL: func.func @test_composite_view_row_major_f32_coalesce
+  func.func @test_composite_view_row_major_f32_coalesce() -> memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1> {
+    %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    %alloc_1 = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    // CHECK-NOT: d2m.composite_view
+    %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32, logicalSizes = array<i64: 16, 16>}> : (memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1>
+    %alloc_2 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<4x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%0 : memref<4x1x32x32xf32, #ttcore.view<4>, #l1>)
+        outs(%alloc_2 : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>)
+     {
+      %1 = d2m.get_cb(1) resolution_stage =  compile : <memref<32x32xf32, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %2 = d2m.reserve %1 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+      // CHECK: [[F32_STEP:%.+]] = arith.constant 4 : index
+      // CHECK: scf.for
+      // CHECK: scf.for {{.*}} step [[F32_STEP]]
+      // CHECK: d2m.dma_read {{.*}}, <4> : (memref<4x1x32x32xf32
+      // CHECK: d2m.dma_read {{.*}}, <4> : (memref<4x1x32x32xf32
+      %tx = d2m.dma_read %0[%core0, %core1], %2, <0> : (memref<4x1x32x32xf32, #ttcore.view<4>, #l1>, memref<32x32xf32, #l1>) -> !d2m.mem_tx<read>
+      d2m.dma_wait %tx : !d2m.mem_tx<read>
+      d2m.push %1 : <memref<32x32xf32, #l1>>
+    }
+    memref.dealloc %alloc_1 : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    memref.dealloc %alloc_0 : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+    return %alloc_2 : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+  }
+
+  // bf16 -> factor 8.
+  // CHECK-LABEL: func.func @test_composite_view_row_major_bf16_coalesce
+  func.func @test_composite_view_row_major_bf16_coalesce() -> memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1> {
+    %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>
+    %alloc_1 = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>
+    // CHECK-NOT: d2m.composite_view
+    %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32, logicalSizes = array<i64: 16, 16>}> : (memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>, memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>) -> memref<4x1x32x32xbf16, #ttcore.view<4>, #l1>
+    %alloc_2 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<4x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%0 : memref<4x1x32x32xbf16, #ttcore.view<4>, #l1>)
+        outs(%alloc_2 : memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>)
+     {
+      %1 = d2m.get_cb(1) resolution_stage =  compile : <memref<32x32xbf16, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %2 = d2m.reserve %1 : <memref<32x32xbf16, #l1>> -> memref<32x32xbf16, #l1>
+      // CHECK: [[BF16_STEP:%.+]] = arith.constant 8 : index
+      // CHECK: scf.for
+      // CHECK: scf.for {{.*}} step [[BF16_STEP]]
+      // CHECK: d2m.dma_read {{.*}}, <8> : (memref<4x1x32x32xbf16
+      // CHECK: d2m.dma_read {{.*}}, <8> : (memref<4x1x32x32xbf16
+      %tx = d2m.dma_read %0[%core0, %core1], %2, <0> : (memref<4x1x32x32xbf16, #ttcore.view<4>, #l1>, memref<32x32xbf16, #l1>) -> !d2m.mem_tx<read>
+      d2m.dma_wait %tx : !d2m.mem_tx<read>
+      d2m.push %1 : <memref<32x32xbf16, #l1>>
+    }
+    memref.dealloc %alloc_1 : memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>
+    memref.dealloc %alloc_0 : memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>
+    return %alloc_2 : memref<4x1x32x32xbf16, #ttcore.shard<64x2, 1>, #l1>
+  }
+
+  // i8 -> factor 16.
+  // CHECK-LABEL: func.func @test_composite_view_row_major_u8_coalesce
+  func.func @test_composite_view_row_major_u8_coalesce() -> memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1> {
+    %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1>
+    %alloc_1 = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1>
+    // CHECK-NOT: d2m.composite_view
+    %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32, logicalSizes = array<i64: 16, 16>}> : (memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1>, memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1>) -> memref<4x1x32x32xi8, #ttcore.view<4>, #l1>
+    %alloc_2 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<4x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%0 : memref<4x1x32x32xi8, #ttcore.view<4>, #l1>)
+        outs(%alloc_2 : memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1>)
+     {
+      %1 = d2m.get_cb(1) resolution_stage =  compile : <memref<32x32xi8, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %2 = d2m.reserve %1 : <memref<32x32xi8, #l1>> -> memref<32x32xi8, #l1>
+      // CHECK: [[U8_STEP:%.+]] = arith.constant 16 : index
+      // CHECK: scf.for
+      // CHECK: scf.for {{.*}} step [[U8_STEP]]
+      // CHECK: d2m.dma_read {{.*}}, <16> : (memref<4x1x32x32xi8
+      // CHECK: d2m.dma_read {{.*}}, <16> : (memref<4x1x32x32xi8
+      %tx = d2m.dma_read %0[%core0, %core1], %2, <0> : (memref<4x1x32x32xi8, #ttcore.view<4>, #l1>, memref<32x32xi8, #l1>) -> !d2m.mem_tx<read>
+      d2m.dma_wait %tx : !d2m.mem_tx<read>
+      d2m.push %1 : <memref<32x32xi8, #l1>>
+    }
+    memref.dealloc %alloc_1 : memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1>
+    memref.dealloc %alloc_0 : memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1>
+    return %alloc_2 : memref<4x1x32x32xi8, #ttcore.shard<32x1, 1>, #l1>
+  }
+
+  // 49 single-tile views of one 7x7 source memref fanout into composite_view
+  // checks 48 nested scf.if + 49 dma_read.
+  // CHECK-LABEL: func.func @test_composite_view_49_inputs
+  func.func @test_composite_view_49_inputs() -> memref<1x49x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> {
+    %src = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+
+    %v_0 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (0, 0, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_1 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (0, 1, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_2 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (0, 2, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_3 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (0, 3, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_4 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (0, 4, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_5 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (0, 5, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_6 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (0, 6, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_7 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (1, 0, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_8 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (1, 1, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_9 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (1, 2, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_10 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (1, 3, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_11 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (1, 4, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_12 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (1, 5, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_13 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (1, 6, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_14 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (2, 0, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_15 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (2, 1, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_16 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (2, 2, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_17 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (2, 3, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_18 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (2, 4, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_19 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (2, 5, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_20 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (2, 6, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_21 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (3, 0, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_22 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (3, 1, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_23 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (3, 2, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_24 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (3, 3, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_25 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (3, 4, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_26 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (3, 5, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_27 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (3, 6, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_28 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (4, 0, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_29 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (4, 1, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_30 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (4, 2, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_31 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (4, 3, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_32 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (4, 4, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_33 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (4, 5, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_34 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (4, 6, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_35 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (5, 0, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_36 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (5, 1, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_37 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (5, 2, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_38 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (5, 3, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_39 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (5, 4, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_40 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (5, 5, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_41 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (5, 6, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_42 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (6, 0, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_43 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (6, 1, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_44 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (6, 2, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_45 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (6, 3, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_46 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (6, 4, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_47 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (6, 5, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %v_48 = d2m.view_layout %src remapping = affine_map<(d0, d1, d2, d3) -> (6, 6, d2, d3)> : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+
+    // CHECK-NOT: d2m.composite_view
+    %0 = "d2m.composite_view"(%v_0, %v_1, %v_2, %v_3, %v_4, %v_5, %v_6, %v_7, %v_8, %v_9, %v_10, %v_11, %v_12, %v_13, %v_14, %v_15, %v_16, %v_17, %v_18, %v_19, %v_20, %v_21, %v_22, %v_23, %v_24, %v_25, %v_26, %v_27, %v_28, %v_29, %v_30, %v_31, %v_32, %v_33, %v_34, %v_35, %v_36, %v_37, %v_38, %v_39, %v_40, %v_41, %v_42, %v_43, %v_44, %v_45, %v_46, %v_47, %v_48) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>) -> memref<1x49x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %alloc_out = memref.alloc() {address = 505120 : i64, alignment = 16 : i64} : memref<1x49x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x49>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%0 : memref<1x49x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>)
+        outs(%alloc_out : memref<1x49x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^datamovement0:
+      %1 = d2m.get_cb(1) : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      // CHECK: d2m.reserve
+      %2 = d2m.reserve %1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      // CHECK-COUNT-48: scf.if
+      // CHECK-NOT: scf.if
+      // COUNT-LABEL: func.func @test_composite_view_49_inputs
+      // COUNT-COUNT-49: d2m.dma_read
+      // COUNT-NOT: d2m.dma_read
+      %tx = d2m.dma_read %0[%core0, %core1], %2, <0> : (memref<1x49x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+      d2m.dma_wait %tx : !d2m.mem_tx<read>
+      // CHECK: d2m.push
+      d2m.push %1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    memref.dealloc %src : memref<7x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    return %alloc_out : memref<1x49x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
   }
 }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_composite_view.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_composite_view.mlir
@@ -38,3 +38,89 @@ func.func @test_composite_view() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #tt
   // CHECK: return %[[ALLOC_OUT]]
   return %alloc_2 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
 }
+
+// Two-deep view_layout chain per composite input (tiled): exactly two base
+// allocations + the output, no chain-intermediate allocs.
+// CHECK-LABEL: func.func @test_composite_view_chain_tiled
+func.func @test_composite_view_chain_tiled() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>> {
+  // CHECK: %[[ALLOC_LHS:.+]] = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc_0 = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+  // CHECK: %[[ALLOC_RHS:.+]] = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc_1 = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+
+  // CHECK-NOT: memref.alloc{{[^()]*}}#ttcore.view
+  %v0a = d2m.view_layout %alloc_0 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+  %v1a = d2m.view_layout %alloc_1 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+  %v0b = d2m.view_layout %v0a remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+  %v1b = d2m.view_layout %v1a remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+
+  %0 = "d2m.composite_view"(%v0b, %v1b) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+
+  // CHECK: %[[ALLOC_OUT:.+]] = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc_2 = memref.alloc() : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+
+  d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x2>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<unified>]}
+      ins(%0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>)
+      outs(%alloc_2 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>)
+   {
+    %block_factor0 = d2m.get_block_factor(0) : index
+    %block_factor1 = d2m.get_block_factor(1) : index
+    affine.for %arg2 = 0 to %block_factor0 {
+      affine.for %arg3 = 0 to %block_factor1 {
+        %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x1x!ttcore.tile<32x32, f32>>
+        %block_offset0 = d2m.block_offset(0) : index
+        %1 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg2)[%block_offset0]
+        %block_offset1 = d2m.block_offset(1) : index
+        %2 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg3)[%block_offset1]
+        %3 = d2m.remote_load %alloc_3 %0[%1, %2] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
+        %4 = d2m.remote_store %alloc_2[%1, %2] %alloc_3 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>> -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+      } {d2m.blocking_loop = 1 : i64}
+    } {d2m.blocking_loop = 0 : i64}
+  }
+
+  // CHECK: return %[[ALLOC_OUT]]
+  return %alloc_2 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+}
+
+// Mixed chain depths (1 and 3) across composite inputs.
+// CHECK-LABEL: func.func @test_composite_view_chain_mixed_depths
+func.func @test_composite_view_chain_mixed_depths() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>> {
+  // CHECK: %[[ALLOC_LHS:.+]] = memref.alloc() {address = {{[0-9]+}} : i64
+  %alloc_0 = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+  // CHECK: %[[ALLOC_RHS:.+]] = memref.alloc() {address = {{[0-9]+}} : i64
+  %alloc_1 = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+
+  // CHECK-NOT: memref.alloc{{[^()]*}}#ttcore.view
+  %v0 = d2m.view_layout %alloc_0 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+
+  %v1a = d2m.view_layout %alloc_1 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+  %v1b = d2m.view_layout %v1a remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+  %v1c = d2m.view_layout %v1b remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+
+  %0 = "d2m.composite_view"(%v0, %v1c) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+
+  // CHECK: %[[ALLOC_OUT:.+]] = memref.alloc() {address = {{[0-9]+}} : i64
+  %alloc_2 = memref.alloc() : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+
+  d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x2>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<unified>]}
+      ins(%0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>)
+      outs(%alloc_2 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>)
+   {
+    %block_factor0 = d2m.get_block_factor(0) : index
+    %block_factor1 = d2m.get_block_factor(1) : index
+    affine.for %arg2 = 0 to %block_factor0 {
+      affine.for %arg3 = 0 to %block_factor1 {
+        %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x1x!ttcore.tile<32x32, f32>>
+        %block_offset0 = d2m.block_offset(0) : index
+        %1 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg2)[%block_offset0]
+        %block_offset1 = d2m.block_offset(1) : index
+        %2 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg3)[%block_offset1]
+        %3 = d2m.remote_load %alloc_3 %0[%1, %2] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
+        %4 = d2m.remote_store %alloc_2[%1, %2] %alloc_3 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>> -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+      } {d2m.blocking_loop = 1 : i64}
+    } {d2m.blocking_loop = 0 : i64}
+  }
+
+  // CHECK: return %[[ALLOC_OUT]]
+  return %alloc_2 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+}

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_composite_view.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_composite_view.mlir
@@ -72,8 +72,8 @@ func.func @test_composite_view_chain_tiled() -> memref<1x2x1x1x!ttcore.tile<32x3
         %1 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg2)[%block_offset0]
         %block_offset1 = d2m.block_offset(1) : index
         %2 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg3)[%block_offset1]
-        %3 = d2m.remote_load %alloc_3 %0[%1, %2] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
-        %4 = d2m.remote_store %alloc_2[%1, %2] %alloc_3 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>> -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+        d2m.remote_load %alloc_3 %0[%1, %2] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+        d2m.remote_store %alloc_2[%1, %2] %alloc_3 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>>
       } {d2m.blocking_loop = 1 : i64}
     } {d2m.blocking_loop = 0 : i64}
   }
@@ -115,8 +115,8 @@ func.func @test_composite_view_chain_mixed_depths() -> memref<1x2x1x1x!ttcore.ti
         %1 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg2)[%block_offset0]
         %block_offset1 = d2m.block_offset(1) : index
         %2 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg3)[%block_offset1]
-        %3 = d2m.remote_load %alloc_3 %0[%1, %2] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
-        %4 = d2m.remote_store %alloc_2[%1, %2] %alloc_3 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>> -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+        d2m.remote_load %alloc_3 %0[%1, %2] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+        d2m.remote_store %alloc_2[%1, %2] %alloc_3 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>>
       } {d2m.blocking_loop = 1 : i64}
     } {d2m.blocking_loop = 0 : i64}
   }

--- a/test/ttmlir/Dialect/D2M/bufferization/bufferization.mlir
+++ b/test/ttmlir/Dialect/D2M/bufferization/bufferization.mlir
@@ -109,3 +109,63 @@ func.func @test_composite_view_logical_sizes() -> tensor<1x1x32x32xf32, #ttcore.
   } : tensor<1x1x32x32xf32, #ttcore.metal_layout<logical_shape = 32x28, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>>
   return %5 : tensor<1x1x32x32xf32, #ttcore.metal_layout<logical_shape = 32x28, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>>
 }
+
+#linput_chain = #ttcore.metal_layout<logical_shape = 32x4, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#linput_chain2 = #ttcore.metal_layout<logical_shape = 32x8, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#linput_chain3 = #ttcore.metal_layout<logical_shape = 32x16, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#lout_chain = #ttcore.metal_layout<logical_shape = 32x28, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#map_chain_id = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+
+// CompositeViewOp::bufferize on chained view_layout inputs preserves the
+// chain and derives per-input logicalSizes from the outermost view's layout.
+// CHECK-LABEL: func.func @test_composite_view_chain_logical_sizes
+func.func @test_composite_view_chain_logical_sizes() -> tensor<1x1x32x32xf32, #lout_chain> {
+  // CHECK: memref.alloc
+  // CHECK: memref.alloc
+  // CHECK: memref.alloc
+  %0 = d2m.empty() : tensor<1x1x32x32xf32, #linput_chain>
+  %1 = d2m.empty() : tensor<1x1x32x32xf32, #linput_chain2>
+  %2 = d2m.empty() : tensor<1x1x32x32xf32, #linput_chain3>
+
+  // CHECK: d2m.view_layout
+  %v0 = d2m.view_layout %0 remapping = #map_chain_id : tensor<1x1x32x32xf32, #linput_chain> -> tensor<1x1x32x32xf32, #linput_chain>
+
+  // CHECK: d2m.view_layout
+  %v1a = d2m.view_layout %1 remapping = #map_chain_id : tensor<1x1x32x32xf32, #linput_chain2> -> tensor<1x1x32x32xf32, #linput_chain2>
+  // CHECK: d2m.view_layout
+  %v1b = d2m.view_layout %v1a remapping = #map_chain_id : tensor<1x1x32x32xf32, #linput_chain2> -> tensor<1x1x32x32xf32, #linput_chain2>
+
+  // CHECK: d2m.view_layout
+  %v2a = d2m.view_layout %2 remapping = #map_chain_id : tensor<1x1x32x32xf32, #linput_chain3> -> tensor<1x1x32x32xf32, #linput_chain3>
+  // CHECK: d2m.view_layout
+  %v2b = d2m.view_layout %v2a remapping = #map_chain_id : tensor<1x1x32x32xf32, #linput_chain3> -> tensor<1x1x32x32xf32, #linput_chain3>
+  // CHECK: d2m.view_layout
+  %v2c = d2m.view_layout %v2b remapping = #map_chain_id : tensor<1x1x32x32xf32, #linput_chain3> -> tensor<1x1x32x32xf32, #linput_chain3>
+
+  // CHECK: "d2m.composite_view"({{.+}}) <{dim = 1 : si32, logicalSizes = array<i64: 4, 8, 16>}> : (memref{{.+}}, memref{{.+}}, memref{{.+}}) -> memref
+  %3 = "d2m.composite_view"(%v0, %v1b, %v2c) <{dim = 1 : si32, logicalSizes = array<i64: 4, 8, 16>}> :
+      (tensor<1x1x32x32xf32, #linput_chain>,
+       tensor<1x1x32x32xf32, #linput_chain2>,
+       tensor<1x1x32x32xf32, #linput_chain3>) ->
+       tensor<1x1x32x32xf32, #lout_chain>
+  %4 = d2m.empty() : tensor<1x1x32x32xf32, #lout_chain>
+
+  // CHECK: d2m.generic
+  %5 = d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<unified>]}
+      ins(%3 : tensor<1x1x32x32xf32, #lout_chain>)
+      outs(%4 : tensor<1x1x32x32xf32, #lout_chain>)
+   {
+    %6 = tensor.empty() : tensor<32x32xf32>
+    %block0 = d2m.block_index(0) : index
+    %block1 = d2m.block_index(1) : index
+    %7 = d2m.remote_load %6 %3[%block0, %block1] :
+        tensor<32x32xf32>, tensor<1x1x32x32xf32, #lout_chain> ->
+        tensor<32x32xf32>
+    %8 = d2m.remote_store %4[%block0, %block1] %7 :
+        tensor<1x1x32x32xf32, #lout_chain>,
+        tensor<32x32xf32> ->
+        tensor<1x1x32x32xf32, #lout_chain>
+    d2m.yield %8 : (tensor<1x1x32x32xf32, #lout_chain>)
+  } : tensor<1x1x32x32xf32, #lout_chain>
+  return %5 : tensor<1x1x32x32xf32, #lout_chain>
+}

--- a/test/ttmlir/Dialect/D2M/bufferization/bufferization.mlir
+++ b/test/ttmlir/Dialect/D2M/bufferization/bufferization.mlir
@@ -110,10 +110,10 @@ func.func @test_composite_view_logical_sizes() -> tensor<1x1x32x32xf32, #ttcore.
   return %5 : tensor<1x1x32x32xf32, #ttcore.metal_layout<logical_shape = 32x28, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>>
 }
 
-#linput_chain = #ttcore.metal_layout<logical_shape = 32x4, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#linput_chain2 = #ttcore.metal_layout<logical_shape = 32x8, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#linput_chain3 = #ttcore.metal_layout<logical_shape = 32x16, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#lout_chain = #ttcore.metal_layout<logical_shape = 32x28, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#linput_chain = #ttcore.metal_layout<logical_shape = 32x4, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#linput_chain2 = #ttcore.metal_layout<logical_shape = 32x8, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#linput_chain3 = #ttcore.metal_layout<logical_shape = 32x16, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#lout_chain = #ttcore.metal_layout<logical_shape = 32x28, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
 #map_chain_id = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 
 // CompositeViewOp::bufferize on chained view_layout inputs preserves the

--- a/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
+++ b/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
@@ -1,0 +1,161 @@
+// RUN: ttmlir-opt --ttcore-register-device --verify-diagnostics --split-input-file %s
+
+#l1 = #ttcore.memory_space<l1>
+
+// Rule 1 = only one input.
+func.func @composite_view_one_input() -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+  // expected-error @+1 {{must have at least two inputs.}}
+  %0 = "d2m.composite_view"(%alloc_0) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+  return %0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+}
+
+// -----
+
+// Rule 2 = dim out of range (negative).
+#l1_r2neg = #ttcore.memory_space<l1>
+func.func @composite_view_dim_negative() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_r2neg> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_r2neg>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_r2neg>
+  // expected-error @+1 {{dim out of range.}}
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = -1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_r2neg>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_r2neg>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_r2neg>
+  return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_r2neg>
+}
+
+// -----
+
+// Rule 2 = dim out of range (>= rank).
+#l1_r2pos = #ttcore.memory_space<l1>
+func.func @composite_view_dim_too_large() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_r2pos> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_r2pos>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_r2pos>
+  // expected-error @+1 {{dim out of range.}}
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 2 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_r2pos>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_r2pos>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_r2pos>
+  return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_r2pos>
+}
+
+// -----
+
+// Rule 3 = inputs/output rank mismatch.
+#l1_rank = #ttcore.memory_space<l1>
+func.func @composite_view_rank_mismatch() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_rank> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096x4096, 1>, #l1_rank>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_rank>
+  // expected-error @+1 {{incompatible inputs & output ranks.}}
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32}> : (memref<1x1x1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096x4096, 1>, #l1_rank>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_rank>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_rank>
+  return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_rank>
+}
+
+// -----
+
+// Rule 4 = non-composite dim mismatch between inputs and output.
+#l1_noncomp = #ttcore.memory_space<l1>
+func.func @composite_view_noncomposite_dim_mismatch() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_noncomp> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<2x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_noncomp>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<2x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_noncomp>
+  // expected-error @+1 {{incompatible non-composite dim.}}
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32}> : (memref<2x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_noncomp>, memref<2x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_noncomp>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_noncomp>
+  return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_noncomp>
+}
+
+// -----
+
+// Rule 5 = composite dim sum across inputs != output (tensor-typed).
+#linput_cd = #ttcore.metal_layout<logical_shape = 32x4, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#lout_cd = #ttcore.metal_layout<logical_shape = 32x16, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+func.func @composite_view_composite_dim_mismatch() -> tensor<1x1x32x32xf32, #lout_cd> {
+  %0 = d2m.empty() : tensor<1x1x32x32xf32, #linput_cd>
+  %1 = d2m.empty() : tensor<1x1x32x32xf32, #linput_cd>
+  // expected-error @+1 {{incompatible composite dim.}}
+  %2 = "d2m.composite_view"(%0, %1) <{dim = 1 : si32}> : (tensor<1x1x32x32xf32, #linput_cd>, tensor<1x1x32x32xf32, #linput_cd>) -> tensor<1x1x32x32xf32, #lout_cd>
+  return %2 : tensor<1x1x32x32xf32, #lout_cd>
+}
+
+// -----
+
+// Rule 6 = logicalSizes attr set on tiled output.
+#l1_unneeded = #ttcore.memory_space<l1>
+func.func @composite_view_unneeded_logical_sizes() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_unneeded> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_unneeded>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_unneeded>
+  // expected-error @+1 {{unneeded logicalSizes attr.}}
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32, logicalSizes = array<i64: 32, 32>}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_unneeded>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_unneeded>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_unneeded>
+  return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_unneeded>
+}
+
+// -----
+
+// Rule 7 = logicalSizes missing on row-major output.
+#l1_missing = #ttcore.memory_space<l1>
+func.func @composite_view_missing_logical_sizes() -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1_missing> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_missing>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_missing>
+  // expected-error @+1 {{missing logicalSizes attr.}}
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32}> : (memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_missing>, memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_missing>) -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1_missing>
+  return %0 : memref<4x1x32x32xf32, #ttcore.view<4>, #l1_missing>
+}
+
+// -----
+
+// Rule 8 = logicalSizes length != number of inputs.
+#l1_wronglen = #ttcore.memory_space<l1>
+func.func @composite_view_wrong_logical_sizes_length() -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1_wronglen> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_wronglen>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_wronglen>
+  // expected-error @+1 {{wrong logicalSizes length.}}
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32, logicalSizes = array<i64: 16, 16, 16>}> : (memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_wronglen>, memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_wronglen>) -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1_wronglen>
+  return %0 : memref<4x1x32x32xf32, #ttcore.view<4>, #l1_wronglen>
+}
+
+// -----
+
+// Rule 9 = sum of logicalSizes exceeds output capacity.
+#l1_oversum = #ttcore.memory_space<l1>
+func.func @composite_view_logical_sizes_exceed_capacity() -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1_oversum> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_oversum>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_oversum>
+  // expected-error @+1 {{sum of logicalSizes exceeds output capacity.}}
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32, logicalSizes = array<i64: 40, 40>}> : (memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_oversum>, memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1_oversum>) -> memref<4x1x32x32xf32, #ttcore.view<4>, #l1_oversum>
+  return %0 : memref<4x1x32x32xf32, #ttcore.view<4>, #l1_oversum>
+}
+
+// -----
+
+// Rule 10 = row-major width-concat per-DMA byte count not 16B-aligned.
+#l1_align = #ttcore.memory_space<l1>
+func.func @composite_view_row_major_width_alignment() -> memref<4x1x32x6xf32, #ttcore.view<4>, #l1_align> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<4x1x32x3xf32, #ttcore.shard<12x4, 1>, #l1_align>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<4x1x32x3xf32, #ttcore.shard<12x4, 1>, #l1_align>
+  // expected-error @+1 {{row-major width-concat requires each input's per-DMA byte count}}
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32, logicalSizes = array<i64: 3, 3>}> : (memref<4x1x32x3xf32, #ttcore.shard<12x4, 1>, #l1_align>, memref<4x1x32x3xf32, #ttcore.shard<12x4, 1>, #l1_align>) -> memref<4x1x32x6xf32, #ttcore.view<4>, #l1_align>
+  return %0 : memref<4x1x32x6xf32, #ttcore.view<4>, #l1_align>
+}
+
+// -----
+
+// Rule 11 = inputs mix view and non-view operands.
+#l1_mix = #ttcore.memory_space<l1>
+#map_mix = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+func.func @composite_view_mixed_view_and_nonview() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_mix>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_mix>
+  %view_0 = d2m.view_layout %alloc_0 remapping = #map_mix : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_mix> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>
+  // expected-error @+1 {{inputs must be uniformly views (ViewOpInterface) or uniformly non-views; mixing is not supported}}
+  %0 = "d2m.composite_view"(%view_0, %alloc_1) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_mix>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>
+  return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>
+}
+
+// -----
+
+// Rule 12 = view inputs have divergent virtualGridForwardMapping.
+#l1_vgm = #ttcore.memory_space<l1>
+#map_vgm = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+func.func @composite_view_vgm_mismatch() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm> {
+  %alloc_0 = memref.alloc() {alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm>
+  %alloc_1 = memref.alloc() {alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d1, d0, d2, d3)>} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm>
+  %view_0 = d2m.view_layout %alloc_0 remapping = #map_vgm : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
+  %view_1 = d2m.view_layout %alloc_1 remapping = #map_vgm : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
+  // expected-error @+1 {{all view inputs must share the same virtualGridForwardMapping}}
+  %0 = "d2m.composite_view"(%view_0, %view_1) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
+  return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
+}

--- a/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
+++ b/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
@@ -155,7 +155,7 @@ func.func @composite_view_vgm_mismatch() -> memref<1x2x1x1x!ttcore.tile<32x32, f
   %alloc_1 = memref.alloc() {alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d1, d0, d2, d3)>} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm>
   %view_0 = d2m.view_layout %alloc_0 remapping = #map_vgm : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
   %view_1 = d2m.view_layout %alloc_1 remapping = #map_vgm : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
-  // expected-error @+1 {{all view inputs must share the same virtualGridForwardMapping}}
+  // expected-error @+1 {{all composite_view inputs that carry a virtualGridForwardMapping must share the same map}}
   %0 = "d2m.composite_view"(%view_0, %view_1) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
   return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
 }

--- a/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
+++ b/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
@@ -61,8 +61,8 @@ func.func @composite_view_noncomposite_dim_mismatch() -> memref<1x2x1x1x!ttcore.
 // -----
 
 // Rule 5 = composite dim sum across inputs != output (tensor-typed).
-#linput_cd = #ttcore.metal_layout<logical_shape = 32x4, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
-#lout_cd = #ttcore.metal_layout<logical_shape = 32x16, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#linput_cd = #ttcore.metal_layout<logical_shape = 32x4, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
+#lout_cd = #ttcore.metal_layout<logical_shape = 32x16, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, l1, sharded>
 func.func @composite_view_composite_dim_mismatch() -> tensor<1x1x32x32xf32, #lout_cd> {
   %0 = d2m.empty() : tensor<1x1x32x32xf32, #linput_cd>
   %1 = d2m.empty() : tensor<1x1x32x32xf32, #linput_cd>

--- a/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
+++ b/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
@@ -144,18 +144,3 @@ func.func @composite_view_mixed_view_and_nonview() -> memref<1x2x1x1x!ttcore.til
   %0 = "d2m.composite_view"(%view_0, %alloc_1) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_mix>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>
   return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>
 }
-
-// -----
-
-// Rule 12 = view inputs have divergent virtualGridForwardMapping.
-#l1_vgm = #ttcore.memory_space<l1>
-#map_vgm = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-func.func @composite_view_vgm_mismatch() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm> {
-  %alloc_0 = memref.alloc() {alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm>
-  %alloc_1 = memref.alloc() {alignment = 16 : i64, d2m.virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> (d1, d0, d2, d3)>} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm>
-  %view_0 = d2m.view_layout %alloc_0 remapping = #map_vgm : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
-  %view_1 = d2m.view_layout %alloc_1 remapping = #map_vgm : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_vgm> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
-  // expected-error @+1 {{all composite_view inputs that carry a virtualGridForwardMapping must share the same map}}
-  %0 = "d2m.composite_view"(%view_0, %view_1) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
-  return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_vgm>
-}

--- a/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
+++ b/test/ttmlir/Dialect/D2M/composite_view_invalid.mlir
@@ -140,7 +140,7 @@ func.func @composite_view_mixed_view_and_nonview() -> memref<1x2x1x1x!ttcore.til
   %alloc_0 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_mix>
   %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_mix>
   %view_0 = d2m.view_layout %alloc_0 remapping = #map_mix : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_mix> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>
-  // expected-error @+1 {{inputs must be uniformly views (ViewOpInterface) or uniformly non-views; mixing is not supported}}
+  // expected-error @+1 {{inputs must be uniformly views (ViewOpInterface) or uniformly non-views; input 1 disagrees with input 0}}
   %0 = "d2m.composite_view"(%view_0, %alloc_1) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_mix>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>
   return %0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_mix>
 }

--- a/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
+++ b/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
@@ -261,7 +261,7 @@ func.func @chained_view(%arg0: tensor<2x4x32x32xf32, #layout_base_view>) -> tens
 func.func @test_virtual_dram_bounce_aligned(%arg0: tensor<4x32x32xf32>) -> tensor<4x1x1x1x32x32xf32, #layout_virtual_dram_aligned> {
   // CHECK-LABEL: @test_virtual_dram_bounce_aligned
   // CHECK-NOT: tensor<1x1x128x32xf32
-  // CHECK: %[[DST:.*]] = d2m.empty() : tensor<4x1x1x1x32x32xf32, #layout[[VIRTUAL_LAYOUT_ALIGNED:[0-9]*]]
+  // CHECK: %[[DST:.*]] = d2m.empty(){{.*}} : tensor<4x1x1x1x32x32xf32, #layout[[VIRTUAL_LAYOUT_ALIGNED:[0-9]*]]
   // CHECK: d2m.to_device %arg0, %[[DST]] layout = #layout[[VIRTUAL_LAYOUT_ALIGNED]]
   %0 = d2m.empty() : tensor<4x1x1x1x32x32xf32, #layout_virtual_dram_aligned>
   %1 = d2m.to_layout %arg0, %0 : tensor<4x32x32xf32> into tensor<4x1x1x1x32x32xf32, #layout_virtual_dram_aligned> -> tensor<4x1x1x1x32x32xf32, #layout_virtual_dram_aligned>
@@ -273,7 +273,7 @@ func.func @test_virtual_dram_bounce_aligned(%arg0: tensor<4x32x32xf32>) -> tenso
 func.func @test_virtual_dram_bounce_unaligned(%arg0: tensor<4x128x32xf32>) -> tensor<4x4x1x1x32x32xf32, #layout_virtual_dram_unaligned> {
   // CHECK-LABEL: @test_virtual_dram_bounce_unaligned
   // CHECK-NOT: tensor<1x1x512x32xf32
-  // CHECK: %[[DST:.*]] = d2m.empty() : tensor<4x4x1x1x32x32xf32, #layout[[VIRTUAL_LAYOUT_UNALIGNED:[0-9]*]]
+  // CHECK: %[[DST:.*]] = d2m.empty(){{.*}} : tensor<4x4x1x1x32x32xf32, #layout[[VIRTUAL_LAYOUT_UNALIGNED:[0-9]*]]
   // CHECK: d2m.to_device %arg0, %[[DST]] layout = #layout[[VIRTUAL_LAYOUT_UNALIGNED]]
   %0 = d2m.empty() : tensor<4x4x1x1x32x32xf32, #layout_virtual_dram_unaligned>
   %1 = d2m.to_layout %arg0, %0 : tensor<4x128x32xf32> into tensor<4x4x1x1x32x32xf32, #layout_virtual_dram_unaligned> -> tensor<4x4x1x1x32x32xf32, #layout_virtual_dram_unaligned>

--- a/test/ttmlir/Dialect/D2M/materialize_view_returns.mlir
+++ b/test/ttmlir/Dialect/D2M/materialize_view_returns.mlir
@@ -184,8 +184,8 @@ func.func @view_before_device_to_device_unchanged(%arg0: tensor<1x1x8x24x!ttcore
   return %to_device : tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout8x8>
 }
 
-#linput_chain = #ttcore.metal_layout<logical_shape = 64x96, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
-#lout_chain = #ttcore.metal_layout<logical_shape = 64x192, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#linput_chain = #ttcore.metal_layout<logical_shape = 64x96, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+#lout_chain = #ttcore.metal_layout<logical_shape = 64x192, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
 #map_chain = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 
 // Chain of view_layouts feeding composite_view consumed by a generic: no

--- a/test/ttmlir/Dialect/D2M/materialize_view_returns.mlir
+++ b/test/ttmlir/Dialect/D2M/materialize_view_returns.mlir
@@ -121,9 +121,9 @@ func.func @higher_rank_view_return(%arg0: tensor<1x4x4x2x3x6x!ttcore.tile<32x32,
   %view = d2m.view_layout %arg0 remapping = #map6 : tensor<1x4x4x2x3x6x!ttcore.tile<32x32, f32>, #layout_6d_1x4x4> -> tensor<1x8x2x1x6x6x!ttcore.tile<32x32, f32>, #layout_6d_1x8x2>
 
   // Materialization uses load+store pair
-  // CHECK: d2m.empty() : tensor<1x8x2x1x6x6x!ttcore.tile<32x32, f32>
+  // CHECK: d2m.empty(){{.*}} : tensor<1x8x2x1x6x6x!ttcore.tile<32x32, f32>
   // CHECK: %[[MATERIALIZED:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<1x8x2>
+  // CHECK-SAME: grid = #ttcore.grid<1x8x2
   // CHECK-SAME: threads = [#d2m.thread<unified>]
   // CHECK: ins(%[[VIEW]]
   // CHECK: d2m.remote_load
@@ -182,4 +182,89 @@ func.func @view_before_device_to_device_unchanged(%arg0: tensor<1x1x8x24x!ttcore
   // CHECK-NOT: d2m.generic
   // CHECK: return %{{.*}}
   return %to_device : tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout8x8>
+}
+
+#linput_chain = #ttcore.metal_layout<logical_shape = 64x96, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#lout_chain = #ttcore.metal_layout<logical_shape = 64x192, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#map_chain = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+
+// Chain of view_layouts feeding composite_view consumed by a generic: no
+// materialization should fire on the chain intermediates.
+// CHECK-LABEL: @chain_feeds_composite_consumed_by_generic
+func.func @chain_feeds_composite_consumed_by_generic(%arg0: tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>, %arg1: tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>) -> tensor<1x1x2x6x!ttcore.tile<32x32, f32>, #lout_chain> {
+  // CHECK: %[[V0A:.*]] = d2m.view_layout %arg0
+  %v0a = d2m.view_layout %arg0 remapping = #map_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+  // CHECK: %[[V0B:.*]] = d2m.view_layout %[[V0A]]
+  %v0b = d2m.view_layout %v0a remapping = #map_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+  // CHECK: %[[V1A:.*]] = d2m.view_layout %arg1
+  %v1a = d2m.view_layout %arg1 remapping = #map_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+  // CHECK: %[[V1B:.*]] = d2m.view_layout %[[V1A]]
+  %v1b = d2m.view_layout %v1a remapping = #map_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+  // CHECK: %[[CV:.*]] = "d2m.composite_view"(%[[V0B]], %[[V1B]])
+  %cv = "d2m.composite_view"(%v0b, %v1b) <{dim = 1 : si32}> : (tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>, tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>) -> tensor<1x1x2x6x!ttcore.tile<32x32, f32>, #lout_chain>
+  %empty = d2m.empty() : tensor<1x1x2x6x!ttcore.tile<32x32, f32>, #lout_chain>
+
+  // CHECK-NOT: d2m.remote_load
+  // CHECK-NOT: d2m.remote_store
+  // CHECK: %[[RES:.*]] = d2m.generic
+  // CHECK: ins(%[[CV]]
+  %result = d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>,
+                         indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+                         iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>],
+                         threads = [#d2m.thread<datamovement>]}
+      ins(%cv : tensor<1x1x2x6x!ttcore.tile<32x32, f32>, #lout_chain>)
+      outs(%empty : tensor<1x1x2x6x!ttcore.tile<32x32, f32>, #lout_chain>) {
+    ^bb0:
+      %in_cb = d2m.get_cb(0) : !d2m.cb<tensor<2x6x!ttcore.tile<32x32, f32>>>
+      %out_cb = d2m.get_cb(1) : !d2m.cb<tensor<2x6x!ttcore.tile<32x32, f32>>>
+      %in = d2m.wait %in_cb : !d2m.cb<tensor<2x6x!ttcore.tile<32x32, f32>>> -> tensor<2x6x!ttcore.tile<32x32, f32>>
+      %out = d2m.reserve %out_cb : !d2m.cb<tensor<2x6x!ttcore.tile<32x32, f32>>> -> tensor<2x6x!ttcore.tile<32x32, f32>>
+      d2m.yield %out : (tensor<2x6x!ttcore.tile<32x32, f32>>)
+  } : tensor<1x1x2x6x!ttcore.tile<32x32, f32>, #lout_chain>
+
+  // CHECK-NOT: d2m.generic
+  // CHECK: return %[[RES]]
+  return %result : tensor<1x1x2x6x!ttcore.tile<32x32, f32>, #lout_chain>
+}
+
+// 3-deep view_layout chain returned directly: only the outermost view
+// materializes via a single d2m.generic.
+// CHECK-LABEL: @chain_returned_directly
+func.func @chain_returned_directly(%arg0: tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>) -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> {
+  // CHECK: %[[V1:.*]] = d2m.view_layout %arg0
+  %v1 = d2m.view_layout %arg0 remapping = #map_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+  // CHECK: %[[V2:.*]] = d2m.view_layout %[[V1]]
+  %v2 = d2m.view_layout %v1 remapping = #map_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+  // CHECK: %[[V3:.*]] = d2m.view_layout %[[V2]]
+  %v3 = d2m.view_layout %v2 remapping = #map_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+
+  // CHECK: d2m.empty() : tensor<1x1x2x3x!ttcore.tile<32x32, f32>
+  // CHECK: %[[RES:.*]] = d2m.generic
+  // CHECK-SAME: threads = [#d2m.thread<unified>]
+  // CHECK: ins(%[[V3]]
+  // CHECK: d2m.remote_load
+  // CHECK: d2m.remote_store
+  // CHECK: d2m.yield
+  // CHECK: return %[[RES]]
+  return %v3 : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+}
+
+// view_layout chain feeding to_host: only the outermost view materializes.
+// CHECK-LABEL: @chain_before_to_host
+func.func @chain_before_to_host(%arg0: tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>) -> tensor<64x96xf32> {
+  // CHECK: %[[V1:.*]] = d2m.view_layout %arg0
+  %v1 = d2m.view_layout %arg0 remapping = #map_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+  // CHECK: %[[V2:.*]] = d2m.view_layout %[[V1]]
+  %v2 = d2m.view_layout %v1 remapping = #map_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> -> tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain>
+  %host_empty = d2m.empty() : tensor<64x96xf32>
+
+  // CHECK: d2m.empty() : tensor<1x1x2x3x!ttcore.tile<32x32, f32>
+  // CHECK: %[[MATERIALIZED:.*]] = d2m.generic
+  // CHECK: ins(%[[V2]]
+  // CHECK: d2m.remote_load
+  // CHECK: d2m.remote_store
+  // CHECK: d2m.to_host %[[MATERIALIZED]]
+  %to_host = d2m.to_host %v2, %host_empty layout = #linput_chain : tensor<1x1x2x3x!ttcore.tile<32x32, f32>, #linput_chain> into tensor<64x96xf32> -> tensor<64x96xf32>
+
+  return %to_host : tensor<64x96xf32>
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8242

### Problem description
We want to be able to stack views through `d2m.composite_view`. The functionality is basically there, just needs more thorough testing.

Most of this PR is just lit tests.

### What's changed
- in `getVirtualGrid{Forward,Inverse}Mapping` propogate VGM through `composite_view`
- more verifier checks for `composite_view`
  - rm width-concat check `logical size * sizeof(elem)` always aligned w/ noc & >= noc quantum
  - inputs to `composite_view` either all views or no views at all
  - all view inputs must share same VGM
- `MaterializeViewReturns` will now derive VGM for inserted `d2m.empty` by
  - reusing upstream chain's phys grid when volume matches to derive same VGM as input
  - otherwisepick a physical grid that factorizes the virtual grid, where its dimensions must multiply to the virtual core count to guarantee a clean 1:1 mapping with no wraparound

### Checklist
- [x] New/Existing tests provide coverage for changes
  - negative tests
  - stacking views through composite view tests for allocate, bufferization, ExpandDMAComposite, materialize
  - e2e im2col w/ stacked views w/ golden check