### PR TITLE
[TTNN] Fix rank-0 scalar tensor crash in MemoryLayoutPropagation

### DIFF
--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -796,7 +796,8 @@ void MemoryLayoutPropagation::addReshardCandidates(
     auto outputLayout =
         mlir::dyn_cast_or_null<TTNNLayoutAttr>(outputType.getEncoding());
     if (outputLayout &&
-        mlir::isa<ttcore::TileType>(outputLayout.getElementType())) {
+        mlir::isa<ttcore::TileType>(outputLayout.getElementType()) &&
+        outputType.getRank() > 0) {
       auto shape = outputType.getShape();
       int64_t cols = (shape.back() + TILE_WIDTH - 1) / TILE_WIDTH;
       int64_t rows =

--- a/test/ttmlir/Dialect/TTNN/optimizer/scalar_tensor.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/scalar_tensor.mlir
@@ -1,0 +1,13 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module attributes {} {
+  // CHECK-LABEL: func.func @scalar_add
+  func.func @scalar_add(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    %1 = "ttir.add"(%0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    %2 = "ttir.add"(%1, %arg0) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    %3 = "ttir.add"(%2, %1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    return %3 : tensor<f32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
@@ -10,7 +10,6 @@ module attributes {} {
   // CHECK-LABEL: func.func @scalar_add
   func.func @scalar_add(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
     %0 = "ttir.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-    // CHECK: "ttnn.add"
     return %0 : tensor<f32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
@@ -7,6 +7,7 @@ module attributes {} {
     // CHECK: "ttnn.multiply"
     return %1 : tensor<64x128xf32>
   }
+  // CHECK-LABEL: func.func @scalar_add
   func.func @scalar_add(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
     %0 = "ttir.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     // CHECK: "ttnn.add"

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
@@ -7,9 +7,4 @@ module attributes {} {
     // CHECK: "ttnn.multiply"
     return %1 : tensor<64x128xf32>
   }
-  // CHECK-LABEL: func.func @scalar_add
-  func.func @scalar_add(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-    %0 = "ttir.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
-  }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
@@ -7,4 +7,9 @@ module attributes {} {
     // CHECK: "ttnn.multiply"
     return %1 : tensor<64x128xf32>
   }
+  func.func @scalar_add(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    // CHECK: "ttnn.add"
+    return %0 : tensor<f32>
+  }
 }


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-mlir/issues/8322

### Problem description

Compile crashes when trying to translate ttir to ttnn on ops on rank-0 tensors. For example:

```
func.func @scalar_add(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
  %0 = "ttir.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
  return %0 : tensor<f32>
}
```

### What's changed

Adds a guard in TTNN memory layout propagation so the tiled-output maxGridVolume heuristic is only applied to rank>0 results. Also adds an opt-level-1 optimizer pipeline regression test for scalar ttir.add.

### Checklist
- [x] New/Existing tests provide coverage for changes


### Testing

**Without fix (`optimization_level=2`):**
```
$ git checkout main -- lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp && cmake --build build --target ttmlir-opt 2>&1 | tail -3 && llvm-lit -av test/ttmlir/Dialect/TTNN/optimizer/scalar_tensor.mlir
```

```
ttmlir-opt: /opt/ttmlir-toolchain/include/llvm/ADT/ArrayRef.h:157: const T &llvm::ArrayRef<long>::back() const [T = long]: Assertion `!empty()' failed.
...
Failed: 1 (100.00%)
```

**With fix:**
```
$ git checkout fix/8322-rank-0-scalar-crash -- lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp && cmake --build build --target ttmlir-opt 2>&1 | tail -3 && llvm-lit -av test/ttmlir/Dialect/TTNN/optimizer/scalar_tensor.mlir
```
```
Passed: 1 (100.00%)
```
