### PR TITLE
[L1SpillManagement] Remove ttnn.output_l1_usage IR attribute and address review comments

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -147,8 +147,8 @@ private:
   llvm::DenseMap<uint64_t, AliasGroup> aliasGroups;
 };
 
-/// L1SpillManagement enforces L1 budget constraints using Belady's optimal
-/// page replacement algorithm with validation-based budget enforcement.
+/// L1SpillManagement enforces L1 budget constraints using farthest-last-use
+/// eviction with validation-based budget enforcement.
 /// Each op is re-validated during the sweep using validateOperation() with
 /// the sum of live tensor L1 sizes as additionalL1Usage. When validation
 /// fails (OOM), tensors are evicted until it succeeds.
@@ -159,7 +159,6 @@ private:
 /// After processing, it modifies the IR:
 /// - Inserts ToMemoryConfigOp after spilled ops (L1 -> DRAM)
 /// - Reconnects uses to read from spilled tensor
-/// - Removes "ttnn.output_l1_usage" attributes (cleanup)
 template <typename MemoryTracker = SumL1MemoryTracker>
 class L1SpillManagement {
 public:
@@ -167,8 +166,8 @@ public:
                     uint64_t l1BudgetPerCore,
                     std::unique_ptr<L1SpillObserver> observer = nullptr);
 
-  /// Run Belady's algorithm with validation-based eviction and apply spills
-  /// directly to the IR.
+  /// Run farthest-last-use eviction with validation-based enforcement and apply
+  /// spills directly to the IR.
   void run();
 
   /// Access the observer (always non-null; NullObject when tracing disabled).
@@ -188,7 +187,7 @@ private:
   /// Pluggable memory state tracker.
   MemoryTracker memoryTracker;
 
-  /// Belady eviction ordering: max-heap by lastUsePosition, keyed by Value.
+  /// Farthest-last-use ordering: max-heap by lastUsePosition, keyed by Value.
   using LiveEntry = std::pair<int64_t, Value>;
   struct LiveEntryCompare {
     bool operator()(const LiveEntry &a, const LiveEntry &b) const {
@@ -261,9 +260,6 @@ private:
   /// right before that op (e.g., a CCL op) instead of after the defining op.
   void spillToDram(Value result, Operation *insertBefore = nullptr);
 
-  /// Remove all "ttnn.output_l1_usage" attributes from ops in the function.
-  void cleanupL1UsageAttrs();
-
   /// Bundled schedule data built once at the start of run().
   struct ScheduleData {
     llvm::SmallVector<Operation *> schedule;
@@ -286,30 +282,29 @@ private:
   bool wouldCBsOverlapTensors(Operation *op, int64_t pos, uint64_t cbPeakUsage,
                               uint64_t speculativeOutputAddr);
 
-  /// Output cannot fit contiguously in the free list. Evict using Belady's
-  /// algorithm until the output fits, then re-validate. Returns L1 bytes to
-  /// add to live set (0 if demoted to DRAM).
+  /// Output cannot fit contiguously in the free list. Evict farthest-last-use
+  /// tensors until the output fits, then re-validate. Returns L1 bytes to add
+  /// to live set (0 if demoted to DRAM).
   uint64_t handleNoFit(Operation *op, int64_t pos, const ScheduleData &data,
-                       uint64_t opL1Usage, uint64_t outputL1Size);
+                       uint64_t outputL1Size);
 
   /// CB fragmentation recovery: evict tensors in the CB danger zone,
   /// re-validate, or demote output to DRAM. Returns L1 bytes to add to live
   /// set (0 if demoted).
   uint64_t handleFragmentation(Operation *op, int64_t pos,
-                               const ScheduleData &data, uint64_t opL1Usage,
-                               uint64_t cbPeakUsage, uint64_t outputL1Size);
+                               const ScheduleData &data, uint64_t cbPeakUsage,
+                               uint64_t outputL1Size);
 
   /// Run contiguous-fit and CB-fragmentation checks on a validated op's
   /// output. Returns the (possibly updated) L1 size to add to the live set,
   /// or 0 if the output was demoted to DRAM.
   uint64_t ensureFitsL1(Operation *op, int64_t pos, const ScheduleData &data,
-                        uint64_t opL1Usage, uint64_t cbPeakUsage,
-                        uint64_t l1Size);
+                        uint64_t cbPeakUsage, uint64_t l1Size);
 
-  /// OOM recovery: demote to L1-interleaved, evict farthest-use, or spill self.
+  /// OOM recovery: evict farthest-last-use tensors or demote self to DRAM.
   void handleOOM(Operation *op, int64_t pos,
                  llvm::ArrayRef<OpResult> tensorResults,
-                 const ScheduleData &data, uint64_t opL1Usage,
+                 const ScheduleData &data,
                  std::function<void(uint64_t)> addResultsToLiveSet);
 
   /// Evict all live L1 tensors. Used when encountering ops without OpModel
@@ -319,14 +314,14 @@ private:
   void evictAllFromL1(int64_t pos, const ScheduleData &data,
                       Operation *triggerOp = nullptr);
 
-  /// Evict live tensors using Belady's algorithm until no tensor's simulated
+  /// Evict live tensors (farthest-last-use first) until no tensor's simulated
   /// address falls below the cushioned CB threshold. Replaces the former
   /// evictTensorsBelow, which was incorrect after address rebuild (addresses
   /// shift, making the threshold check stale).
   void evictForCBOverlap(uint64_t cushionedCBUsage, int64_t pos,
                          const ScheduleData &data);
 
-  /// Evict tensors using Belady's algorithm until shouldStop() returns true
+  /// Evict tensors (farthest-last-use first) until shouldStop() returns true
   /// or the live set is empty. Returns true if shouldStop was satisfied.
   /// After each eviction, rebuilds address simulation and inserts reshards
   /// for already-processed consumers.

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillObserver.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillObserver.h
@@ -42,7 +42,7 @@ public:
   virtual void onDemotion(Operation *op, int64_t pos, bool success,
                           uint64_t newL1Usage) {}
 
-  /// Belady eviction: victim tensor spilled to DRAM.
+  /// Farthest-last-use eviction: victim tensor spilled to DRAM.
   virtual void onEviction(Operation *victim, int64_t pos, uint64_t freedBytes) {
   }
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -219,14 +219,14 @@ struct TTIRToTTNNCommonPipelineOptions
                                   "Use mock quasar system desc.")),
       llvm::cl::init(ttcore::Arch::WormholeB0)};
 
-  // Option to override maximum number of sharded layouts to be generated
-  // in legal layout analysis.
-  //
+  // Maximum number of sharded layouts per op in legal layout analysis.
+  // Needs to be at least maxReshardCandidatesPerType * numShardingTypes (=12
+  // with defaults of 4 and 3) so all reshard types get adequate coverage.
   Option<int64_t> maxLegalLayouts{
       *this, OptionNames::maxLegalLayouts,
       llvm::cl::desc("Override maximum number of sharded layouts for legal "
                      "layout analysis."),
-      llvm::cl::init(8)};
+      llvm::cl::init(64)};
 
   ListOption<int64_t> meshShape{
       *this, OptionNames::meshShape,

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -739,10 +739,10 @@ def TTNNMemoryManagement : Pass<"ttnn-memory-management", "::mlir::ModuleOp"> {
 }
 
 def TTNNGreedyL1SpillManagement : Pass<"ttnn-greedy-l1-spill-management", "::mlir::ModuleOp"> {
-  let summary = "Belady's algorithm for L1 budget enforcement.";
+  let summary = "Farthest-last-use eviction for L1 budget enforcement.";
   let description = [{
-    This pass uses Belady's optimal page replacement algorithm to enforce L1
-    memory budgets by spilling tensors to DRAM when necessary.
+    This pass enforces L1 memory budgets by spilling tensors to DRAM using a
+    farthest-last-use eviction strategy.
   }];
   let options = [
     Option<"enableDecisionTrace", "enable-decision-trace", "bool", "false",

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -364,12 +364,10 @@ void L1SpillManagement<MemoryTracker>::applyOutputConfig(
     }
 
     size_t ri = opResult.getResultNumber();
-    TTNNLayoutAttr resultLayout = (ri < result.actualOutputLayouts.size())
-                                      ? result.actualOutputLayouts[ri]
-                                      : chosenLayout;
-    if (!resultLayout) {
-      continue;
-    }
+    assert(ri < result.actualOutputLayouts.size() &&
+           "validation result has fewer output layouts than tensor results");
+    TTNNLayoutAttr resultLayout = result.actualOutputLayouts[ri];
+    assert(resultLayout && "result layout is null for tensor result");
 
     llvm::ArrayRef<int64_t> tensorShape = tensorType.getShape();
 
@@ -396,15 +394,6 @@ void L1SpillManagement<MemoryTracker>::applyOutputConfig(
     ttcore::DataTypeAttr newDataTypeAttr =
         ttcore::DataTypeAttr::get(op->getContext(), chosenLayout.getDataType());
     dtypeOp.setDtypeAttr(newDataTypeAttr);
-  }
-
-  // Update L1 usage attribute.
-  if (chosenLayout.hasL1BufferType() && result.outputL1Usage > 0) {
-    OpBuilder builder(op->getContext());
-    op->setAttr("ttnn.output_l1_usage",
-                builder.getI64IntegerAttr(result.outputL1Usage));
-  } else {
-    op->removeAttr("ttnn.output_l1_usage");
   }
 }
 
@@ -582,11 +571,11 @@ void L1SpillManagement<MemoryTracker>::processDeadTensors(
 
 template <typename MemoryTracker>
 uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(
-    Operation *op, int64_t pos, const ScheduleData &data, uint64_t opL1Usage,
-    uint64_t cbPeakUsage, uint64_t l1Size) {
+    Operation *op, int64_t pos, const ScheduleData &data, uint64_t cbPeakUsage,
+    uint64_t l1Size) {
   auto speculativeAddr = memoryTracker.wouldAllocateAt(l1Size);
   if (!speculativeAddr) {
-    l1Size = handleNoFit(op, pos, data, opL1Usage, l1Size);
+    l1Size = handleNoFit(op, pos, data, l1Size);
     speculativeAddr = memoryTracker.wouldAllocateAt(l1Size);
   }
   // Always run the overlap check when the op declares a non-zero CB peak;
@@ -597,7 +586,7 @@ uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(
       speculativeAddr.value_or(std::numeric_limits<uint64_t>::max());
   if (cbPeakUsage > 0 &&
       wouldCBsOverlapTensors(op, pos, cbPeakUsage, addrForCheck)) {
-    l1Size = handleFragmentation(op, pos, data, opL1Usage, cbPeakUsage, l1Size);
+    l1Size = handleFragmentation(op, pos, data, cbPeakUsage, l1Size);
   }
   return l1Size;
 }
@@ -609,31 +598,37 @@ uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(
 template <typename MemoryTracker>
 void L1SpillManagement<MemoryTracker>::handleOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
-    const ScheduleData &data, uint64_t opL1Usage,
+    const ScheduleData &data,
     std::function<void(uint64_t)> addResultsToLiveSet) {
   observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "    OOM: validation failed, trying demotion/eviction");
 
-  auto inputLayouts = utils::extractInputLayouts(op);
-  auto config = extractOpConfigFromIR(op);
-
-  // Evict from live set (Belady: farthest last-use first).
+  // Evict from live set (farthest last-use first) until validation succeeds.
   // Uses evictUntil which inserts reshards for already-processed consumers
   // instead of cascade revalidation, preserving downstream sharded layouts.
-  auto result = memoryTracker.validate(op, inputLayouts, config);
-  if (!result.isSuccess()) {
-    evictUntil(pos, data, [&]() {
-      inputLayouts = utils::extractInputLayouts(op);
-      result = memoryTracker.validate(op, inputLayouts, config);
-      return result.isSuccess();
-    });
-  }
+  // handleOOM is only called when validation already failed — skip the initial
+  // redundant validate and go straight to eviction.
+  auto inputLayouts = utils::extractInputLayouts(op);
+  auto config = extractOpConfigFromIR(op);
+  auto result =
+      op_constraint_validation::ValidationResult::outOfMemoryError("");
+  evictUntil(pos, data, [&]() {
+    inputLayouts = utils::extractInputLayouts(op);
+    result = memoryTracker.validate(op, inputLayouts, config);
+    return result.isSuccess();
+  });
 
   if (result.isSuccess()) {
-    uint64_t l1Size =
-        result.outputL1Usage > 0 ? result.outputL1Usage : opL1Usage;
-    l1Size = ensureFitsL1(op, pos, data, opL1Usage, result.cbPeakUsage, l1Size);
+    uint64_t l1Size = result.outputL1Usage;
+    if (l1Size > 0) {
+      l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
+    } else {
+      // DRAM-output op: validate's byte-budget check accounts for CB usage in
+      // total but not for CB-vs-tensor address overlap. Evict low-address
+      // tensors that would collide with the op's CB region.
+      evictForDramCBGrowth(op, pos, data);
+    }
     if (l1Size > 0) {
       addResultsToLiveSet(l1Size);
       observer_->onLiveAdded(op, pos, l1Size, pos,
@@ -645,13 +640,13 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
                    liveValues.size());
     }
   } else {
-    // Stage 3: Op exceeds budget alone -- spill all results to DRAM.
+    // Stage 3: Op exceeds L1 budget even with no other live tensors — the op
+    // itself is too large for the configured cap. Demote its output to DRAM.
+    // No evictForDramCBGrowth needed: evictUntil already drained the live set.
     observer_->onSelfSpill(op, pos);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "    SPILL SELF: op exceeds budget alone");
-    for (auto r : tensorResults) {
-      spillToDram(r);
-    }
+                 "    DEMOTE SELF: op exceeds budget alone");
+    demoteToDram(op);
   }
 }
 
@@ -783,6 +778,10 @@ void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
 
       if (needsReshard) {
         for (unsigned i : spilledOperandIdx) {
+          TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                       "    RESHARD: inserting L1 reshard before {0} "
+                       "(operand {1} changed L1→DRAM after eviction of {2})",
+                       consumer->getName(), i, ttmlir::opToString(victimOp));
           insertReshardForConsumer(consumer, i, originalL1Layout);
         }
       }
@@ -811,7 +810,6 @@ template <typename MemoryTracker>
 uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
                                                        int64_t pos,
                                                        const ScheduleData &data,
-                                                       uint64_t opL1Usage,
                                                        uint64_t outputL1Size) {
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "    NO_FIT: output {0} bytes can't fit contiguously, evicting",
@@ -834,8 +832,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
   auto freshResult = memoryTracker.validate(op, freshInputLayouts, freshConfig);
   if (freshResult.isSuccess()) {
     applyOutputConfig(op, freshResult);
-    uint64_t freshL1 =
-        freshResult.outputL1Usage > 0 ? freshResult.outputL1Usage : opL1Usage;
+    uint64_t freshL1 = freshResult.outputL1Usage;
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "    NO_FIT resolved: L1 now {0}/{1}",
                  memoryTracker.getOccupiedL1(), l1BudgetPerCore);
@@ -856,13 +853,13 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
 
 template <typename MemoryTracker>
 uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
-    Operation *op, int64_t pos, const ScheduleData &data, uint64_t opL1Usage,
-    uint64_t cbPeakUsage, uint64_t outputL1Size) {
+    Operation *op, int64_t pos, const ScheduleData &data, uint64_t cbPeakUsage,
+    uint64_t outputL1Size) {
   // Add the same safety cushion as wouldCBsOverlapTensors to account for
   // unmodeled runtime fragmentation from transient internal op allocations.
   uint64_t cushionedCBUsage = cbPeakUsage + cbFragCushion;
 
-  // Evict tensors using Belady's algorithm until CB overlap resolves.
+  // Evict tensors (farthest last-use first) until CB overlap resolves.
   evictUntil(pos, data, [&]() {
     auto specAddr = memoryTracker.wouldAllocateAt(outputL1Size);
     if (!specAddr) {
@@ -902,8 +899,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
   auto config = extractOpConfigFromIR(op);
   auto freshResult = memoryTracker.validate(op, inputLayouts, config);
   if (freshResult.isSuccess()) {
-    uint64_t freshL1 =
-        freshResult.outputL1Usage > 0 ? freshResult.outputL1Usage : opL1Usage;
+    uint64_t freshL1 = freshResult.outputL1Usage;
     applyOutputConfig(op, freshResult);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "    FRAG_RESOLVED: L1 now {0}/{1}",
@@ -1020,7 +1016,7 @@ void L1SpillManagement<MemoryTracker>::run() {
 
   [[maybe_unused]] int64_t spillCount = 0;
 
-  // Belady's algorithm sweep with validation-based eviction.
+  // Farthest-last-use eviction sweep with validation-based enforcement.
   for (int64_t pos = 0; pos < static_cast<int64_t>(data.schedule.size());
        ++pos) {
     Operation *op = data.schedule[pos];
@@ -1037,13 +1033,13 @@ void L1SpillManagement<MemoryTracker>::run() {
     }
 
     // ToLayoutOp with L1 output: workaround-inserted and always immediately
-    // consumed by the target op. MemoryLayoutPropagation skips these, so
-    // output_l1_usage is never set and pre-decomposition OpModel is inaccurate.
-    // Use Belady to evict other live tensors if needed to create room, but do
-    // not add the output to liveValues — it is not a long-lived L1 tenant and
-    // will be gone (or dead) before any subsequent eviction decision matters.
-    // Being absent from liveValues also means evictAllFromL1 (e.g. triggered by
-    // DistributedRMSNormOp's isNotImplemented) cannot spill it.
+    // consumed by the target op. MemoryLayoutPropagation skips these, and
+    // pre-decomposition OpModel is inaccurate.
+    // Use farthest-last-use eviction for live tensors if needed to create room,
+    // but do not add the output to liveValues — it is not a long-lived L1
+    // tenant and will be gone (or dead) before any subsequent eviction decision
+    // matters. Being absent from liveValues also means evictAllFromL1 (e.g.
+    // triggered by DistributedRMSNormOp's isNotImplemented) cannot spill it.
     if (isa<ToLayoutOp>(op)) {
       auto resultType =
           mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
@@ -1060,21 +1056,25 @@ void L1SpillManagement<MemoryTracker>::run() {
                      memoryTracker.getOccupiedL1(), l1BudgetPerCore);
         // CBPeakUsage fixed to 0 as we have no validation result for ToLayoutOp
         // itself which is yet to be decomposed.
-        ensureFitsL1(op, pos, data, derivedL1, /*cbPeakUsage=*/0, derivedL1);
+        ensureFitsL1(op, pos, data, /*cbPeakUsage=*/0, derivedL1);
         continue;
       }
       // DRAM ToLayoutOp: fall through to standard processing.
     }
 
-    // Ops with L1 output annotation get full processing.
-    // DRAM-output ops (no annotation) still need CB overlap checking against
-    // live L1 tensors -- skip only if there are no live L1 tensors that could
-    // clash. Ops that can't be checked return NotImplemented from validation,
-    // which triggers a full spill regardless of live set size.
-    auto l1Attr = op->getAttrOfType<IntegerAttr>("ttnn.output_l1_usage");
-    uint64_t opL1Usage = l1Attr ? l1Attr.getValue().getZExtValue() : 0;
+    // Determine if the op outputs to L1 by inspecting its result types
+    // directly. DRAM-output ops still need CB overlap checking against live L1
+    // tensors -- skip only if there are no live L1 tensors that could clash.
+    // Ops that can't be checked return NotImplemented from validation, which
+    // triggers a full spill regardless of live set size.
+    bool hasL1Output = llvm::any_of(op->getResults(), [](OpResult r) {
+      auto tt = mlir::dyn_cast<RankedTensorType>(r.getType());
+      auto lo = tt ? mlir::dyn_cast_or_null<TTNNLayoutAttr>(tt.getEncoding())
+                   : nullptr;
+      return lo && lo.hasL1BufferType();
+    });
 
-    if (!l1Attr) {
+    if (!hasL1Output) {
       if (liveValues.empty()) {
         continue;
       }
@@ -1091,9 +1091,9 @@ void L1SpillManagement<MemoryTracker>::run() {
 
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "  [pos={0}] PROCESS: {1}\n"
-                 "    output L1: {2} bytes, tensor results: {3}\n"
+                 "    hasL1Output: {2}, tensor results: {3}\n"
                  "    occupied L1 before: {4}/{5} ({6} tensors)",
-                 pos, ttmlir::opToString(op), opL1Usage, numTensorResults,
+                 pos, ttmlir::opToString(op), hasL1Output, numTensorResults,
                  memoryTracker.getOccupiedL1(), l1BudgetPerCore,
                  liveValues.size());
 
@@ -1153,16 +1153,14 @@ void L1SpillManagement<MemoryTracker>::run() {
     }
 
     if (result.isSuccess()) {
-      uint64_t l1Size =
-          result.outputL1Usage > 0 ? result.outputL1Usage : opL1Usage;
+      uint64_t l1Size = result.outputL1Usage;
 
       TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                    "    VALIDATION SUCCESS: op {0}, "
                    "cbPeakUsage={1}, outputL1={2} bytes",
                    ttmlir::opToString(op), result.cbPeakUsage, l1Size);
 
-      l1Size =
-          ensureFitsL1(op, pos, data, opL1Usage, result.cbPeakUsage, l1Size);
+      l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
       if (l1Size == 0) {
         continue;
       }
@@ -1177,23 +1175,22 @@ void L1SpillManagement<MemoryTracker>::run() {
       continue;
     }
 
-    // Backend constraint error: ops like SDPA have hard input-layout
-    // constraints (e.g. mask must be DRAM) that the L1 spill management
-    // sweep can violate when upstream evictions change input buffer types.
-    // Gracefully spill to DRAM rather than crashing.
+    // Non-OOM backend constraint error: the op rejects its current
+    // input/output layout combination. Eviction can't help (the failure
+    // isn't from L1 pressure), so skip the OOM path and demote the output
+    // to DRAM as a graceful fallback rather than crash on a hard
+    // constraint.
     if (result.isMetalBackendError()) {
       TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                    "    BACKEND_ERROR at pos {0} for {1}: {2}. "
-                   "Spilling to DRAM.",
+                   "Demoting to DRAM.",
                    pos, ttmlir::opToString(op), result.errorMessage);
-      for (auto r : tensorResults) {
-        spillToDram(r);
-      }
+      demoteToDram(op);
       ++spillCount;
       continue;
     }
 
-    handleOOM(op, pos, tensorResults, data, opL1Usage, addResultsToLiveSet);
+    handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
   }
 
   // Print final memory view summary.
@@ -1205,9 +1202,6 @@ void L1SpillManagement<MemoryTracker>::run() {
                "  Final live L1: {1}/{2} ({3} tensors)",
                spillCount, memoryTracker.getOccupiedL1(), l1BudgetPerCore,
                liveValues.size());
-
-  // Step 4: Cleanup L1 usage attributes.
-  cleanupL1UsageAttrs();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1277,9 +1271,6 @@ void L1SpillManagement<MemoryTracker>::demoteToDram(Operation *op) {
         utils::RankedTensorTypeFactory::create(tensorType, dramLayout);
     opResult.setType(newType);
   }
-
-  // Remove L1 usage annotation since the output is now DRAM.
-  op->removeAttr("ttnn.output_l1_usage");
 
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer, "Demoted to DRAM: {0}",
                ttmlir::opToString(op));
@@ -1460,19 +1451,6 @@ void L1SpillManagement<MemoryTracker>::insertReshardForConsumer(
                "Inserted reshard op: {0} before {1}",
                ttmlir::opToString(reshardOp.getOperation()),
                ttmlir::opToString(consumer));
-}
-
-//===----------------------------------------------------------------------===//
-// cleanupL1UsageAttrs
-//===----------------------------------------------------------------------===//
-
-template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::cleanupL1UsageAttrs() {
-  func->walk([](Operation *op) {
-    if (op->hasAttr("ttnn.output_l1_usage")) {
-      op->removeAttr("ttnn.output_l1_usage");
-    }
-  });
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1369,15 +1369,6 @@ void MemoryLayoutPropagation::applyOpConfig(Operation *op,
     d2m_optimizer_utils::applyChosenLayoutToD2MSubgraphOp(
         dispatchOp, chosenLayout, deviceAttr.getWorkerGrid());
 
-    // Attach L1 usage annotation for spill management.
-    if (chosenLayout.hasL1BufferType() &&
-        candidate.validationResult.isSuccess() &&
-        candidate.validationResult.outputL1Usage > 0) {
-      OpBuilder builder(op->getContext());
-      op->setAttr(
-          "ttnn.output_l1_usage",
-          builder.getI64IntegerAttr(candidate.validationResult.outputL1Usage));
-    }
     return;
   }
 
@@ -1425,22 +1416,6 @@ void MemoryLayoutPropagation::applyOpConfig(Operation *op,
   }
 
   applyOpSpecificAttrs(op, candidate);
-
-  // Attach L1 usage annotation for spill management.
-  if (chosenLayout.hasL1BufferType() &&
-      candidate.validationResult.isSuccess() &&
-      candidate.validationResult.outputL1Usage > 0) {
-    OpBuilder builder(op->getContext());
-    op->setAttr(
-        "ttnn.output_l1_usage",
-        builder.getI64IntegerAttr(candidate.validationResult.outputL1Usage));
-    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "L1 annotation: {0} @{1} -> outputL1Usage={2} bytes, "
-                 "bufType={3}, memLayout={4}",
-                 op->getName(), op->getLoc(),
-                 candidate.validationResult.outputL1Usage,
-                 chosenLayout.getBufferType(), chosenLayout.getMemLayout());
-  }
 }
 
 void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
@@ -1491,15 +1466,6 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
       builder.create<ToMemoryConfigOp>(loc, newTensorType, operand);
 
   consumerOp->setOperand(operandIndex, memoryReconfigOp->getResult(0));
-
-  // Annotate L1 output usage so L1SpillManagement can track this op.
-  if (outputLayout.hasL1BufferType()) {
-    uint64_t l1Usage = utils::getPerCoreL1Usage(
-        outputLayout, deviceAttr.getWorkerGrid().getGridVolume());
-    OpBuilder attrBuilder(memoryReconfigOp->getContext());
-    memoryReconfigOp->setAttr("ttnn.output_l1_usage",
-                              attrBuilder.getI64IntegerAttr(l1Usage));
-  }
 
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                "Inserted memory reconfig op: {0}", memoryReconfigOp);

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -137,7 +137,6 @@ void createTTNNPipelineAnalysisPasses(
       TTNNGreedyMemoryLayoutPropagationPipelineOptions propagationOptions;
       propagationOptions.maxLegalLayouts = options.maxLegalLayouts;
       propagationOptions.rowMajorEnabled = options.rowMajorEnabled;
-      propagationOptions.beamWidth = 8;
       propagationOptions.enableL1ShardingLayouts =
           options.memoryLayoutAnalysisEnabled;
       propagationOptions.overrideOutputLayout = options.overrideOutputLayout;

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_dram_demotion.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_dram_demotion.mlir
@@ -2,8 +2,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-greedy-optimizer=true tensor-l1-usage-cap=0.01" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 //
-// Test: L1 spill management under tight L1 budget (1% cap).
-// Verify ops are demoted to DRAM and the pass produces valid TTNN IR.
+// Test: With an extremely low L1 usage cap (1%), the spill pass should
+// enforce L1 budget by demoting outputs to DRAM. Verify the pass runs
+// without crashing and produces valid TTNN IR with DRAM layouts.
 
 // Verify outputs use DRAM buffer type under 1% cap.
 // CHECK: #dram = #ttnn.buffer_type<dram>
@@ -17,7 +18,8 @@ module attributes {} {
     %1 = "ttir.multiply"(%arg0, %arg2) : (tensor<512x512xbf16>, tensor<512x512xbf16>) -> tensor<512x512xbf16>
     // CHECK: "ttnn.add"{{.*}} -> tensor<512x512xbf16, #ttnn_layout>
     %2 = "ttir.add"(%0, %1) : (tensor<512x512xbf16>, tensor<512x512xbf16>) -> tensor<512x512xbf16>
-    // CHECK-NOT: ttnn.output_l1_usage
-    return %2 : tensor<512x512xbf16>
+    // CHECK: "ttnn.relu"{{.*}} -> tensor<512x512xbf16, #ttnn_layout>
+    %3 = "ttir.relu"(%2) : (tensor<512x512xbf16>) -> tensor<512x512xbf16>
+    return %3 : tensor<512x512xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_dram_demotion_fork.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_dram_demotion_fork.mlir
@@ -2,9 +2,8 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-greedy-optimizer=true tensor-l1-usage-cap=0.01" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 //
-// Test: With an extremely low L1 usage cap (1%), Belady's algorithm should
-// enforce L1 budget by demoting outputs to DRAM. Verify the pass runs
-// without crashing and produces valid TTNN IR with DRAM layouts.
+// Test: L1 spill management under tight L1 budget (1% cap).
+// Verify ops are demoted to DRAM and the pass produces valid TTNN IR.
 
 // Verify outputs use DRAM buffer type under 1% cap.
 // CHECK: #dram = #ttnn.buffer_type<dram>
@@ -18,10 +17,6 @@ module attributes {} {
     %1 = "ttir.multiply"(%arg0, %arg2) : (tensor<512x512xbf16>, tensor<512x512xbf16>) -> tensor<512x512xbf16>
     // CHECK: "ttnn.add"{{.*}} -> tensor<512x512xbf16, #ttnn_layout>
     %2 = "ttir.add"(%0, %1) : (tensor<512x512xbf16>, tensor<512x512xbf16>) -> tensor<512x512xbf16>
-    // CHECK: "ttnn.relu"{{.*}} -> tensor<512x512xbf16, #ttnn_layout>
-    %3 = "ttir.relu"(%2) : (tensor<512x512xbf16>) -> tensor<512x512xbf16>
-    // Verify no L1 usage attributes remain (cleaned up).
-    // CHECK-NOT: ttnn.output_l1_usage
-    return %3 : tensor<512x512xbf16>
+    return %2 : tensor<512x512xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_spill_reshape_view_alias.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_spill_reshape_view_alias.mlir
@@ -29,20 +29,20 @@ module attributes {ttnn.tensor_l1_usage_cap = 1.400000e-01 : f32} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
     // P0: forked producer in L1. ~64 KiB per core.
-    %P0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_dram_2d>, tensor<4096x512xbf16, #ttnn_layout_dram_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+    %P0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<4096x512xbf16, #ttnn_layout_dram_2d>, tensor<4096x512xbf16, #ttnn_layout_dram_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
 
     // V: zero-copy view of P0 (last dim unchanged, leading-1 reshape, tile-aligned).
-    %V = "ttnn.reshape"(%P0) <{shape = [1 : i32, 4096 : i32, 512 : i32]}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>
+    %V = "ttnn.reshape"(%P0) <{shape = [1 : i32, 4096 : i32, 512 : i32]}> : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>
 
     // T validates with both P0 and V live.
     // alias-aware: additionalL1 ≈ 64 KiB.
     // double-count: additionalL1 ≈ 128 KiB → spill (or eviction of P0 or V).
-    %T = "ttnn.add"(%arg2, %arg3) <{dtype = #ttcore.supportedDataTypes<bf16>}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_dram_2d>, tensor<4096x512xbf16, #ttnn_layout_dram_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+    %T = "ttnn.add"(%arg2, %arg3) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<4096x512xbf16, #ttnn_layout_dram_2d>, tensor<4096x512xbf16, #ttnn_layout_dram_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
 
     // Single-input consumers keep P0 and T alive past T's validation
     // without inflating each consumer's overallPeakL1Usage to >budget.
-    %R1 = "ttnn.relu"(%P0) {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
-    %R2 = "ttnn.relu"(%T) {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+    %R1 = "ttnn.relu"(%P0) : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+    %R2 = "ttnn.relu"(%T) : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
 
     return %R1, %V : tensor<4096x512xbf16, #ttnn_layout_l1_2d>, tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>
   }
@@ -50,6 +50,4 @@ module attributes {ttnn.tensor_l1_usage_cap = 1.400000e-01 : f32} {
   // CHECK-LABEL: func.func @forked_view_no_spill
   // No DRAM demotions: alias-aware accounting keeps everything in L1.
   // CHECK-NOT: "ttnn.to_memory_config"{{.*}}#dram
-  // L1-usage attributes are stripped by the spill pass at completion.
-  // CHECK-NOT: ttnn.output_l1_usage
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_spill_reshape_view_multi_alias.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_spill_reshape_view_multi_alias.mlir
@@ -25,15 +25,15 @@ module attributes {ttnn.tensor_l1_usage_cap = 1.400000e-01 : f32} {
       -> (tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>, tensor<1x1x4096x512xbf16, #ttnn_layout_l1_4d>) {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
-    %P0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_dram_2d>, tensor<4096x512xbf16, #ttnn_layout_dram_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+    %P0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<4096x512xbf16, #ttnn_layout_dram_2d>, tensor<4096x512xbf16, #ttnn_layout_dram_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
 
     // First view: 2D → 3D, leading-1 inserted (last+second-to-last unchanged).
-    %V1 = "ttnn.reshape"(%P0) <{shape = [1 : i32, 4096 : i32, 512 : i32]}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>
+    %V1 = "ttnn.reshape"(%P0) <{shape = [1 : i32, 4096 : i32, 512 : i32]}> : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>
 
     // Second view of the SAME producer: 2D → 4D, two leading 1s.
     // Under move-based aliasing, this `allocateAddressAt(V2, P0)` asserts
     // because P0 was removed from tensorAddresses by V1's reshape.
-    %V2 = "ttnn.reshape"(%P0) <{shape = [1 : i32, 1 : i32, 4096 : i32, 512 : i32]}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<1x1x4096x512xbf16, #ttnn_layout_l1_4d>
+    %V2 = "ttnn.reshape"(%P0) <{shape = [1 : i32, 1 : i32, 4096 : i32, 512 : i32]}> : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<1x1x4096x512xbf16, #ttnn_layout_l1_4d>
 
     return %V1, %V2 : tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>, tensor<1x1x4096x512xbf16, #ttnn_layout_l1_4d>
   }
@@ -41,5 +41,4 @@ module attributes {ttnn.tensor_l1_usage_cap = 1.400000e-01 : f32} {
   // CHECK-LABEL: func.func @forked_two_views_no_spill
   // Both reshape views remain in L1 alongside P0.
   // CHECK-NOT: "ttnn.to_memory_config"{{.*}}#dram
-  // CHECK-NOT: ttnn.output_l1_usage
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy/no_spill_headroom.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy/no_spill_headroom.mlir
@@ -14,8 +14,6 @@ module attributes {} {
     %1 = "ttir.relu"(%0) : (tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // Verify no spill ops were inserted with comfortable headroom.
     // CHECK-NOT: "ttnn.to_memory_config"
-    // Verify no ttnn.output_l1_usage attributes remain (cleaned up by spill pass).
-    // CHECK-NOT: ttnn.output_l1_usage
     return %1 : tensor<64x128xbf16>
   }
 }


### PR DESCRIPTION
## Summary

- Drop the temporary `ttnn.output_l1_usage` IR attribute. L1/DRAM distinction in `L1SpillManagement` is now derived directly from the result type's `TTNNLayoutAttr` via `hasL1BufferType()`. The cached L1-size fallback was a no-op (attribute was only set when `result.outputL1Usage > 0`, which `validate()` already returns).
- Raise outer `maxLegalLayouts` default 8 → 64 to match the inner pass default. This ensures the reshard candidate generator gets enough material to populate all three sharding-type buckets (block / height / width) up to the `maxReshardCandidatesPerType=4` cap (=12 total).
- Address remaining review comments on #7686: drop "Belady" naming in favor of "farthest-last-use eviction", rename test files (`belady_spill` → `l1_dram_demotion`, `beam_spill_with_reshards` → `l1_dram_demotion_fork`), simplify 5 helper signatures (`ensureFitsL1`, `handleNoFit`, `handleFragmentation`, `handleOOM` lose `attrOutputL1Usage` param), remove redundant initial `validate()` in `handleOOM`, assert instead of silent-continue on null/OOB result layouts, add debug log on L1 reshard insertion, and use `demoteToDram` (not `spillToDram`) in stage-3 OOM since `evictUntil` already drained the live set.
