### PR TITLE
[CMAKE] Guard _ttmlir_runtime install on TTMLIR_PYTHON_PACKAGES_DIR

### DIFF
--- a/runtime/python/CMakeLists.txt
+++ b/runtime/python/CMakeLists.txt
@@ -97,10 +97,12 @@ if (TTMLIR_ENABLE_RUNTIME)
   target_sources(_ttmlir_runtime PRIVATE $<TARGET_OBJECTS:_mlir_runtime_utils>)
   set_property(TARGET _mlir_runtime_utils PROPERTY CXX_STANDARD 20)
 
-  install(FILES $<TARGET_FILE:_ttmlir_runtime>
-    DESTINATION ${TTMLIR_PYTHON_PACKAGES_DIR}
-    COMPONENT SharedLib
-  )
+  if (TTMLIR_PYTHON_PACKAGES_DIR)
+    install(FILES $<TARGET_FILE:_ttmlir_runtime>
+      DESTINATION ${TTMLIR_PYTHON_PACKAGES_DIR}
+      COMPONENT SharedLib
+    )
+  endif()
 endif()
 
 if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
## Summary

- Commit `50fc26674` added an `install()` call for `_ttmlir_runtime` inside `if(TTMLIR_ENABLE_RUNTIME)` in `runtime/python/CMakeLists.txt`, but `TTMLIR_PYTHON_PACKAGES_DIR` is only set when both `MLIR_ENABLE_BINDINGS_PYTHON` and `TTMLIR_ENABLE_BINDINGS_PYTHON` are `ON`.
- tt-forge-onnx building with `-DTTMLIR_ENABLE_BINDINGS_PYTHON=OFF`  get an empty `DESTINATION`, causing CMake configure to fail with `install FILES given no DESTINATION!`.
- Wrapped the `install()` call in `if(TTMLIR_PYTHON_PACKAGES_DIR)` so it is skipped when Python bindings are disabled and the variable is not set.
