### PR TITLE
[d2m] gather_core op support

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1392,32 +1392,56 @@ def D2M_DMAReadOp : D2M_GenericRegionDatamovementOp<"dma_read",
            memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
       ```
 
+      Cross-core local-L1 read form (srcCore is non-empty): %src is a local
+      L1 memref whose L1 offset is uniform across the grid (e.g. a scratch
+      allocation), and `srcCore` selects the source core whose copy of %src
+      to read. The current core issues a NoC read against the source core's
+      L1; the source core is not required to equal the current core.
+
+      ```mlir
+      %tx = d2m.dma_read %src[%offset] core[%srcY, %srcX], %dst[%offset], <8>
+        : (memref<2x4x!ttcore.tile<32x32, f32>, #l1>,
+           memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
+      ```
+
       This operation only supports unicast (multicast are write-only).
 
       Constraints:
       - dst MUST be a LOCAL memref!
       - src and dst must have the same element type.
+      - `srcCore` is mutually exclusive with a device-laid-out src.
     }];
 
     let arguments = (ins AnyRankedTensorOrMemRef:$src, Variadic<Index>:$srcIndices,
                          AnyRankedTensorOrMemRef:$dst, Variadic<Index>:$dstIndices,
-                         I64Attr:$numElems);
+                         I64Attr:$numElems,
+                         Variadic<Index>:$srcCore);
     let results = (outs D2M_MemTx:$result);
 
     let builders = [
       // Shard-level form (grid indices on src, no indices on dst, numElems = 0)
       OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, ValueRange(), $_builder.getI64IntegerAttr(0));
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, ValueRange(), $_builder.getI64IntegerAttr(0), /*srcCore=*/ValueRange());
       }]>,
       // Fully indexed form
       OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "IntegerAttr": $numElems),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, dstIndices, numElems);
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, dstIndices, numElems, /*srcCore=*/ValueRange());
+      }]>,
+      // Cross-core local-L1 read, fully indexed (srcCore selects source core)
+      OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "IntegerAttr": $numElems, "ValueRange": $srcCore),
+      [{
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, dstIndices, numElems, srcCore);
+      }]>,
+      // Cross-core local-L1 read, shard-level (no indices on dst, numElems = 0)
+      OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $srcCore),
+      [{
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, ValueRange(), $_builder.getI64IntegerAttr(0), srcCore);
       }]>,
     ];
 
-    let assemblyFormat    = [{ $src `[` $srcIndices `]` `,` $dst (`[` $dstIndices^ `]`)? `,` `<` $numElems `>` attr-dict `:` `(` type($src) `,` type($dst) `)` `->` qualified(type($result))}];
+    let assemblyFormat    = [{ $src `[` $srcIndices `]` (`core` `[` $srcCore^ `]`)? `,` $dst (`[` $dstIndices^ `]`)? `,` `<` $numElems `>` attr-dict `:` `(` type($src) `,` type($dst) `)` `->` qualified(type($result))}];
 
     let hasVerifier = 1;
 
@@ -1428,6 +1452,9 @@ def D2M_DMAReadOp : D2M_GenericRegionDatamovementOp<"dma_read",
       MemRefType getDstMemRefType() { return cast<MemRefType>(getDst().getType()); }
       bool isShardLevel() { return getNumElems() == 0; }
       bool isFullyIndexed() { return getNumElems() > 0; }
+      /// True if this op selects an explicit remote source core (cross-core
+      /// local-L1 read form). Mutually exclusive with a device-laid-out src.
+      bool hasSrcCore() { return !getSrcCore().empty(); }
       size_t getSizeBytes() {
         assert(isFullyIndexed() && "getSizeBytes() requires fully indexed form");
         auto elementSizeBytes =
@@ -2273,6 +2300,138 @@ def D2M_RemoteStoreOp : D2M_GenericRegionDatamovementOp<"remote_store",
 
       bool isConsumer(mlir::OpOperand &operand) {
         return llvm::any_of(getLocalBufferMutable(), [&](mlir::OpOperand &op) { return &op == &operand; });
+      }
+    }];
+}
+
+def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
+  [ AttrSizedOperandSegments
+  , MemoryEffects<[MemRead, MemWrite]>
+  , DestinationStyleOpInterface
+  , DeclareOpInterfaceMethods<BufferizableOpInterface, [
+      "bufferizesToMemoryRead",
+      "bufferizesToMemoryWrite",
+      "bufferize",
+      "getAliasingValues",
+      "getBufferType",
+      "hasTensorSemantics"
+    ]>
+  , D2M_SynchronizableOpInterface
+  ]> {
+    let summary = "D2M collective gather across cores.";
+    let description = [{
+      Collective gather of per-core local L1 buffers into a designated
+      collector core. All cores in the rectangular group
+      `[groupStartIndex, groupStartIndex + groupShape)` execute this op. The
+      collector at `collectorIndex` reads each source core's local `%src`
+      into its local `%dst`. Non-collector cores publish their `%src` (via
+      prior writes) and then synchronize; they do not touch `%dst`.
+
+      The op relies on the invariant that `%src` has the *same L1 offset*
+      on every core in the group (i.e. it is a scratch-style allocation, or
+      the underlying memref of a CB-backed buffer). The verifier does not
+      currently prove this structurally; the lowering passes assume it.
+
+      Tensor form (pre-bufferization): the result aliases `%dst` in DPS
+      style.
+
+      ```mlir
+      %result = d2m.gather_core %src into %dst
+        group [%groupY, %groupX] shape [%groupSizeY, %groupSizeX]
+        collector [%collectorY, %collectorX]
+        : tensor<2x4x!ttcore.tile<32x32, f32>>,
+          tensor<2x4x!ttcore.tile<32x32, f32>>
+        -> tensor<2x4x!ttcore.tile<32x32, f32>>
+      ```
+
+      Memref form (post-bufferization): no result.
+
+      ```mlir
+      d2m.gather_core %src into %dst
+        group [%groupY, %groupX] shape [%groupSizeY, %groupSizeX]
+        collector [%collectorY, %collectorX]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #l1>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      ```
+
+      V1 constraints:
+      - `groupStartIndex`, `groupShape`, and `collectorIndex` each have
+        exactly 2 entries (single-device, 2D core grid).
+      - Source and destination element types must match.
+      - Source and destination shapes must match.
+      - Neither operand has a device layout.
+      - In memref form, both operands are in `#l1` memory space.
+      - Synchronization between sources and the collector is implemented
+        by two local semaphores allocated by a dedicated preallocation
+        pass; the lowering in `D2MLowerLoadStoreOpsToDMA` materializes
+        the `semaphore_inc/set/wait` machinery.
+    }];
+
+    let arguments = (ins
+      Arg<AnyRankedTensorOrMemRef, "per-core local L1 source",
+        [MemRead]>:$src,
+      Arg<AnyRankedTensorOrMemRef, "local L1 destination on the collector",
+        [MemWrite]>:$dst,
+      Variadic<Index>:$groupStartIndex,
+      Variadic<Index>:$groupShape,
+      Variadic<Index>:$collectorIndex);
+
+    let results = (outs Optional<AnyRankedTensorOrMemRef>:$result);
+
+    let builders = [
+      // Memref form (no result; DPS in-place).
+      //
+      // The tensor form is reachable via the auto-generated builder that
+      // takes an `Optional<Type>` for the result; calling it with a non-null
+      // Type produces the tensor form, calling it with `Type{}` produces
+      // the memref form. The explicit builder below is just convenience
+      // for the common memref-form case.
+      OpBuilder<(ins "Value":$src, "Value":$dst,
+                     "ValueRange":$groupStartIndex, "ValueRange":$groupShape,
+                     "ValueRange":$collectorIndex),
+      [{
+        build($_builder, $_state, /*result=*/Type{}, src, dst,
+              groupStartIndex, groupShape, collectorIndex);
+      }]>
+    ];
+
+    let assemblyFormat = [{
+      $src `into` $dst
+      `group` `[` $groupStartIndex `]`
+      `shape` `[` $groupShape `]`
+      `collector` `[` $collectorIndex `]`
+      attr-dict `:` type($src) `,` type($dst)
+      (`->` type($result)^)?
+    }];
+
+    let hasVerifier = 1;
+
+    let extraClassDeclaration = [{
+      // Required by DestinationStyleOpInterface.
+      // The dst operand is the DPS init (destination) for the gather.
+      MutableOperandRange getDpsInitsMutable() {
+        return getDstMutable();
+      }
+
+      /// Returns true if the result is present (tensor form).
+      bool hasResultForm() { return static_cast<bool>(getResult()); }
+
+      /// Returns the shaped type (memref or tensor) of the src operand.
+      ShapedType getSrcShapedType() {
+        return cast<ShapedType>(getSrc().getType());
+      }
+
+      /// Returns the shaped type (memref or tensor) of the dst operand.
+      ShapedType getDstShapedType() {
+        return cast<ShapedType>(getDst().getType());
+      }
+
+      bool isProducer(mlir::OpOperand &operand) {
+        return operand.get() == getDst();
+      }
+
+      bool isConsumer(mlir::OpOperand &operand) {
+        return operand.get() == getSrc();
       }
     }];
 }

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -2332,9 +2332,15 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
       the underlying memref of a CB-backed buffer). The verifier does not
       currently prove this structurally; the lowering passes assume it.
 
-      Tensor form (pre-bufferization): the result aliases `%dst` in DPS
-      style.
+      Each side (src and dst) independently chooses between an implicit
+      memref/tensor operand and an explicit CB operand. This produces four
+      possible surface forms; the lowering handles each combination on
+      its own merits. The mixed forms model the realistic shape where one
+      buffer is a per-core scratch alloc (uniform L1 address invariant)
+      and the other crosses the DM-compute thread boundary as a
+      generic-operand CB.
 
+      Tensor form (pre-bufferization), DPS-style — both sides implicit:
       ```mlir
       %result = d2m.gather_core %src into %dst
         group [%groupY, %groupX] shape [%groupSizeY, %groupSizeX]
@@ -2344,8 +2350,7 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
         -> tensor<2x4x!ttcore.tile<32x32, f32>>
       ```
 
-      Memref form (post-bufferization): no result.
-
+      Implicit memref form (post-bufferization, pre-`SplitUnifiedThread`):
       ```mlir
       d2m.gather_core %src into %dst
         group [%groupY, %groupX] shape [%groupSizeY, %groupSizeX]
@@ -2354,24 +2359,47 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
           memref<2x4x!ttcore.tile<32x32, f32>, #l1>
       ```
 
+      Explicit CB form (post-`SplitUnifiedThread`): one or both of
+      `%srcCb` / `%dstCb` are `!d2m.cb<memref<...>>` values produced by
+      `d2m.get_cb`. The lowering emits `wait`/`pop` on `%srcCb` on every
+      core in the group (when present) and `reserve`/`push` on `%dstCb`
+      only on the collector (option (c) of the dst-asymmetry plan:
+      `%dstCb` is allocated on every core but only the collector
+      executes the relevant CB ops).
+      ```mlir
+      d2m.gather_core from %srcCb into %dstCb
+        group [%groupY, %groupX] shape [%groupSizeY, %groupSizeX]
+        collector [%collectorY, %collectorX]
+        : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>,
+          !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      ```
+
       V1 constraints:
+      - Exactly one of (`$src`, `$srcCb`) and one of (`$dst`, `$dstCb`)
+        is present; the two sides are independent.
+      - Tensor form is only valid with both sides in implicit form
+        (CBs and tensors do not mix).
       - `groupStartIndex`, `groupShape`, and `collectorIndex` each have
         exactly 2 entries (single-device, 2D core grid).
       - Source and destination element types must match.
-      - Source and destination shapes must match.
-      - Neither operand has a device layout.
-      - In memref form, both operands are in `#l1` memory space.
+      - Source and destination shapes must match (CB underlying shape in
+        CB form).
+      - In implicit form, neither operand has a device layout.
+      - No memory-space check on memref form (`remote_load`-style):
+        the L1 invariant is enforced structurally by the allocator.
       - Synchronization between sources and the collector is implemented
-        by two local semaphores allocated by a dedicated preallocation
-        pass; the lowering in `D2MLowerLoadStoreOpsToDMA` materializes
-        the `semaphore_inc/set/wait` machinery.
+        by two local semaphores allocated by `D2MPreallocateMcastSemaphores`
+        (extended to recognize `gather_core`); the lowering in
+        `D2MLowerLoadStoreOpsToDMA` materializes the
+        `semaphore_inc/set/wait` machinery and (in CB form) the
+        `wait/pop` / `reserve/push` CB ops.
     }];
 
     let arguments = (ins
-      Arg<AnyRankedTensorOrMemRef, "per-core local L1 source",
-        [MemRead]>:$src,
-      Arg<AnyRankedTensorOrMemRef, "local L1 destination on the collector",
-        [MemWrite]>:$dst,
+      Optional<AnyRankedTensorOrMemRef>:$src,
+      Optional<AnyRankedTensorOrMemRef>:$dst,
+      Optional<D2M_CB>:$srcCb,
+      Optional<D2M_CB>:$dstCb,
       Variadic<Index>:$groupStartIndex,
       Variadic<Index>:$groupShape,
       Variadic<Index>:$collectorIndex);
@@ -2379,59 +2407,95 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
     let results = (outs Optional<AnyRankedTensorOrMemRef>:$result);
 
     let builders = [
-      // Memref form (no result; DPS in-place).
+      // Implicit form (memref or tensor) builder. The tensor form is
+      // reachable via the auto-generated builder that takes an
+      // `Optional<Type>` for the result.
       //
-      // The tensor form is reachable via the auto-generated builder that
-      // takes an `Optional<Type>` for the result; calling it with a non-null
-      // Type produces the tensor form, calling it with `Type{}` produces
-      // the memref form. The explicit builder below is just convenience
-      // for the common memref-form case.
+      // The explicit-CB form has the same signature shape as this builder
+      // (two `Value`s + three `ValueRange`s); to avoid an "Unexpected
+      // overlap" tablegen collision, callers building in CB form should use
+      // the auto-generated builder by passing nulls for the implicit
+      // src/dst operands (e.g. via SplitUnifiedThread).
       OpBuilder<(ins "Value":$src, "Value":$dst,
                      "ValueRange":$groupStartIndex, "ValueRange":$groupShape,
                      "ValueRange":$collectorIndex),
       [{
         build($_builder, $_state, /*result=*/Type{}, src, dst,
+              /*srcCb=*/Value{}, /*dstCb=*/Value{},
               groupStartIndex, groupShape, collectorIndex);
       }]>
     ];
 
-    let assemblyFormat = [{
-      $src `into` $dst
-      `group` `[` $groupStartIndex `]`
-      `shape` `[` $groupShape `]`
-      `collector` `[` $collectorIndex `]`
-      attr-dict `:` type($src) `,` type($dst)
-      (`->` type($result)^)?
-    }];
+    let hasCustomAssemblyFormat = 1;
 
     let hasVerifier = 1;
 
     let extraClassDeclaration = [{
-      // Required by DestinationStyleOpInterface.
-      // The dst operand is the DPS init (destination) for the gather.
+      // Required by DestinationStyleOpInterface. The dst operand is the
+      // DPS init in implicit form; in explicit CB form there is no DPS
+      // init (CB form is post-bufferization and not a tensor op).
       MutableOperandRange getDpsInitsMutable() {
         return getDstMutable();
+      }
+
+      /// Returns true if the op is in explicit CB form.
+      bool isExplicitCBForm() {
+        return static_cast<bool>(getSrcCb()) || static_cast<bool>(getDstCb());
+      }
+
+      /// Returns true if the op is in implicit form (memref or tensor).
+      bool isImplicitForm() {
+        return static_cast<bool>(getSrc()) || static_cast<bool>(getDst());
       }
 
       /// Returns true if the result is present (tensor form).
       bool hasResultForm() { return static_cast<bool>(getResult()); }
 
-      /// Returns the shaped type (memref or tensor) of the src operand.
+      /// Returns the shaped type (memref or tensor, or CB underlying) of
+      /// the src operand. Asserts that exactly one of src/srcCb is set.
       ShapedType getSrcShapedType() {
-        return cast<ShapedType>(getSrc().getType());
+        if (getSrc())
+          return cast<ShapedType>(getSrc().getType());
+        if (getSrcCb())
+          return cast<CBType>(getSrcCb().getType()).getUnderlyingAs<ShapedType>();
+        llvm_unreachable("GatherCoreOp has neither src nor srcCb");
       }
 
-      /// Returns the shaped type (memref or tensor) of the dst operand.
+      /// Returns the shaped type (memref or tensor, or CB underlying) of
+      /// the dst operand. Asserts that exactly one of dst/dstCb is set.
       ShapedType getDstShapedType() {
-        return cast<ShapedType>(getDst().getType());
+        if (getDst())
+          return cast<ShapedType>(getDst().getType());
+        if (getDstCb())
+          return cast<CBType>(getDstCb().getType()).getUnderlyingAs<ShapedType>();
+        llvm_unreachable("GatherCoreOp has neither dst nor dstCb");
       }
 
+      /// Returns the source CB type, or null if not in explicit CB form.
+      CBType getSrcCbType() {
+        Value cb = getSrcCb();
+        if (!cb) return CBType();
+        return cast<CBType>(cb.getType());
+      }
+
+      /// Returns the destination CB type, or null if not in explicit CB form.
+      CBType getDstCbType() {
+        Value cb = getDstCb();
+        if (!cb) return CBType();
+        return cast<CBType>(cb.getType());
+      }
+
+      // SynchronizableOpInterface: both the implicit and the CB operand on
+      // each side play the producer/consumer role, so the CB-usage analysis
+      // sees the right values pre- and post-`SplitUnifiedThread`.
       bool isProducer(mlir::OpOperand &operand) {
-        return operand.get() == getDst();
+        return (getDst() && operand.get() == getDst()) ||
+               (getDstCb() && operand.get() == getDstCb());
       }
 
       bool isConsumer(mlir::OpOperand &operand) {
-        return operand.get() == getSrc();
+        return (getSrc() && operand.get() == getSrc()) ||
+               (getSrcCb() && operand.get() == getSrcCb());
       }
     }];
 }

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1392,11 +1392,9 @@ def D2M_DMAReadOp : D2M_GenericRegionDatamovementOp<"dma_read",
            memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
       ```
 
-      Cross-core local-L1 read form (srcCore is non-empty): %src is a local
-      L1 memref whose L1 offset is uniform across the grid (e.g. a scratch
-      allocation), and `srcCore` selects the source core whose copy of %src
-      to read. The current core issues a NoC read against the source core's
-      L1; the source core is not required to equal the current core.
+      Cross-core local-L1 read form: when `srcCore` is non-empty, `%src` is
+      a local memref with a uniform L1 offset across the grid, and `srcCore`
+      selects the source core to read from (no `my_logical_*` is implied).
 
       ```mlir
       %tx = d2m.dma_read %src[%offset] core[%srcY, %srcX], %dst[%offset], <8>
@@ -1409,7 +1407,7 @@ def D2M_DMAReadOp : D2M_GenericRegionDatamovementOp<"dma_read",
       Constraints:
       - dst MUST be a LOCAL memref!
       - src and dst must have the same element type.
-      - `srcCore` is mutually exclusive with a device-laid-out src.
+      - `srcCore`, if present, is mutually exclusive with a device-laid-out src.
     }];
 
     let arguments = (ins AnyRankedTensorOrMemRef:$src, Variadic<Index>:$srcIndices,
@@ -1429,12 +1427,12 @@ def D2M_DMAReadOp : D2M_GenericRegionDatamovementOp<"dma_read",
       [{
         build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, dstIndices, numElems, /*srcCore=*/ValueRange());
       }]>,
-      // Cross-core local-L1 read, fully indexed (srcCore selects source core)
+      // Cross-core local-L1 read, fully indexed form.
       OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "IntegerAttr": $numElems, "ValueRange": $srcCore),
       [{
         build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, dstIndices, numElems, srcCore);
       }]>,
-      // Cross-core local-L1 read, shard-level (no indices on dst, numElems = 0)
+      // Cross-core local-L1 read, shard-level form.
       OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $srcCore),
       [{
         build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, ValueRange(), $_builder.getI64IntegerAttr(0), srcCore);
@@ -1452,8 +1450,7 @@ def D2M_DMAReadOp : D2M_GenericRegionDatamovementOp<"dma_read",
       MemRefType getDstMemRefType() { return cast<MemRefType>(getDst().getType()); }
       bool isShardLevel() { return getNumElems() == 0; }
       bool isFullyIndexed() { return getNumElems() > 0; }
-      /// True if this op selects an explicit remote source core (cross-core
-      /// local-L1 read form). Mutually exclusive with a device-laid-out src.
+      // True for the cross-core local-L1 read form.
       bool hasSrcCore() { return !getSrcCore().empty(); }
       size_t getSizeBytes() {
         assert(isFullyIndexed() && "getSizeBytes() requires fully indexed form");
@@ -2327,20 +2324,16 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
       into its local `%dst`. Non-collector cores publish their `%src` (via
       prior writes) and then synchronize; they do not touch `%dst`.
 
-      The op relies on the invariant that `%src` has the *same L1 offset*
-      on every core in the group (i.e. it is a scratch-style allocation, or
-      the underlying memref of a CB-backed buffer). The verifier does not
-      currently prove this structurally; the lowering passes assume it.
+      The op relies on the invariant that `%src` has the same L1 offset
+      on every core in the group. The lowering passes assume this.
 
       Each side (src and dst) independently chooses between an implicit
-      memref/tensor operand and an explicit CB operand. This produces four
-      possible surface forms; the lowering handles each combination on
-      its own merits. The mixed forms model the realistic shape where one
-      buffer is a per-core scratch alloc (uniform L1 address invariant)
-      and the other crosses the DM-compute thread boundary as a
-      generic-operand CB.
+      memref/tensor operand and an explicit CB operand, for four possible
+      surface forms. Mixed forms support cases where one buffer is a
+      scratch alloc and the other crosses the DM/compute thread boundary
+      as a CB.
 
-      Tensor form (pre-bufferization), DPS-style — both sides implicit:
+      Tensor form (pre-bufferization, DPS — both sides implicit):
       ```mlir
       %result = d2m.gather_core %src into %dst
         group [%groupY, %groupX] shape [%groupSizeY, %groupSizeX]
@@ -2360,12 +2353,9 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
       ```
 
       Explicit CB form (post-`SplitUnifiedThread`): one or both of
-      `%srcCb` / `%dstCb` are `!d2m.cb<memref<...>>` values produced by
-      `d2m.get_cb`. The lowering emits `wait`/`pop` on `%srcCb` on every
-      core in the group (when present) and `reserve`/`push` on `%dstCb`
-      only on the collector (option (c) of the dst-asymmetry plan:
-      `%dstCb` is allocated on every core but only the collector
-      executes the relevant CB ops).
+      `%srcCb` / `%dstCb` are `!d2m.cb<memref<...>>` values. `%dstCb` is
+      allocated on every group core but only the collector executes its
+      CB ops.
       ```mlir
       d2m.gather_core from %srcCb into %dstCb
         group [%groupY, %groupX] shape [%groupSizeY, %groupSizeX]
@@ -2374,25 +2364,19 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
           !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       ```
 
-      V1 constraints:
+      Constraints (V1):
       - Exactly one of (`$src`, `$srcCb`) and one of (`$dst`, `$dstCb`)
         is present; the two sides are independent.
-      - Tensor form is only valid with both sides in implicit form
-        (CBs and tensors do not mix).
+      - Tensor form is only valid with both sides implicit (CBs and
+        tensors do not mix).
       - `groupStartIndex`, `groupShape`, and `collectorIndex` each have
-        exactly 2 entries (single-device, 2D core grid).
-      - Source and destination element types must match.
-      - Source and destination shapes must match (CB underlying shape in
-        CB form).
+        exactly 2 entries (2D core grid).
+      - Source and destination element types and shapes must match.
       - In implicit form, neither operand has a device layout.
-      - No memory-space check on memref form (`remote_load`-style):
-        the L1 invariant is enforced structurally by the allocator.
-      - Synchronization between sources and the collector is implemented
-        by two local semaphores allocated by `D2MPreallocateMcastSemaphores`
-        (extended to recognize `gather_core`); the lowering in
-        `D2MLowerLoadStoreOpsToDMA` materializes the
-        `semaphore_inc/set/wait` machinery and (in CB form) the
-        `wait/pop` / `reserve/push` CB ops.
+
+      Synchronization uses two local semaphores preallocated by
+      `D2MPreallocateMcastSemaphores`; the protocol body is materialized
+      by `D2MLowerLoadStoreOpsToDMA`.
     }];
 
     let arguments = (ins
@@ -2407,15 +2391,8 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
     let results = (outs Optional<AnyRankedTensorOrMemRef>:$result);
 
     let builders = [
-      // Implicit form (memref or tensor) builder. The tensor form is
-      // reachable via the auto-generated builder that takes an
-      // `Optional<Type>` for the result.
-      //
-      // The explicit-CB form has the same signature shape as this builder
-      // (two `Value`s + three `ValueRange`s); to avoid an "Unexpected
-      // overlap" tablegen collision, callers building in CB form should use
-      // the auto-generated builder by passing nulls for the implicit
-      // src/dst operands (e.g. via SplitUnifiedThread).
+      // Implicit memref form. Tensor and CB forms use the auto-generated
+      // builders by passing nullptrs for the other side's operand.
       OpBuilder<(ins "Value":$src, "Value":$dst,
                      "ValueRange":$groupStartIndex, "ValueRange":$groupShape,
                      "ValueRange":$collectorIndex),
@@ -2431,28 +2408,21 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
     let hasVerifier = 1;
 
     let extraClassDeclaration = [{
-      // Required by DestinationStyleOpInterface. The dst operand is the
-      // DPS init in implicit form; in explicit CB form there is no DPS
-      // init (CB form is post-bufferization and not a tensor op).
+      // DestinationStyleOpInterface: dst is the DPS init in implicit form;
+      // empty otherwise.
       MutableOperandRange getDpsInitsMutable() {
         return getDstMutable();
       }
 
-      /// Returns true if the op is in explicit CB form.
       bool isExplicitCBForm() {
         return static_cast<bool>(getSrcCb()) || static_cast<bool>(getDstCb());
       }
-
-      /// Returns true if the op is in implicit form (memref or tensor).
       bool isImplicitForm() {
         return static_cast<bool>(getSrc()) || static_cast<bool>(getDst());
       }
-
-      /// Returns true if the result is present (tensor form).
       bool hasResultForm() { return static_cast<bool>(getResult()); }
 
-      /// Returns the shaped type (memref or tensor, or CB underlying) of
-      /// the src operand. Asserts that exactly one of src/srcCb is set.
+      // Underlying shaped type of each side, regardless of form.
       ShapedType getSrcShapedType() {
         if (getSrc())
           return cast<ShapedType>(getSrc().getType());
@@ -2460,9 +2430,6 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
           return cast<CBType>(getSrcCb().getType()).getUnderlyingAs<ShapedType>();
         llvm_unreachable("GatherCoreOp has neither src nor srcCb");
       }
-
-      /// Returns the shaped type (memref or tensor, or CB underlying) of
-      /// the dst operand. Asserts that exactly one of dst/dstCb is set.
       ShapedType getDstShapedType() {
         if (getDst())
           return cast<ShapedType>(getDst().getType());
@@ -2471,28 +2438,23 @@ def D2M_GatherCoreOp : D2M_GenericRegionDatamovementOp<"gather_core",
         llvm_unreachable("GatherCoreOp has neither dst nor dstCb");
       }
 
-      /// Returns the source CB type, or null if not in explicit CB form.
+      // CB type accessors; null if the corresponding side is implicit.
       CBType getSrcCbType() {
         Value cb = getSrcCb();
-        if (!cb) return CBType();
-        return cast<CBType>(cb.getType());
+        return cb ? cast<CBType>(cb.getType()) : CBType();
       }
-
-      /// Returns the destination CB type, or null if not in explicit CB form.
       CBType getDstCbType() {
         Value cb = getDstCb();
-        if (!cb) return CBType();
-        return cast<CBType>(cb.getType());
+        return cb ? cast<CBType>(cb.getType()) : CBType();
       }
 
-      // SynchronizableOpInterface: both the implicit and the CB operand on
-      // each side play the producer/consumer role, so the CB-usage analysis
-      // sees the right values pre- and post-`SplitUnifiedThread`.
+      // SynchronizableOpInterface: cover both implicit and CB operand on
+      // each side so the CB-usage analysis sees the right value pre- and
+      // post-SplitUnifiedThread.
       bool isProducer(mlir::OpOperand &operand) {
         return (getDst() && operand.get() == getDst()) ||
                (getDstCb() && operand.get() == getDstCb());
       }
-
       bool isConsumer(mlir::OpOperand &operand) {
         return (getSrc() && operand.get() == getSrc()) ||
                (getSrcCb() && operand.get() == getSrcCb());

--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -17,6 +17,7 @@
 
 namespace mlir::tt::ttcore {
 class DeviceAttr;
+class GridAttr;
 } // namespace mlir::tt::ttcore
 
 namespace mlir::tt::d2m::utils {
@@ -188,6 +189,16 @@ getNocElementAlignment(Operation *op, ttcore::MemorySpace memorySpace,
 // in number of tensor/memref elements.
 int32_t getNocElementAlignmentL1(
     Operation *op, const std::variant<RankedTensorType, MemRefType> &type);
+
+// Maps virtual core indices to physical core indices using the grid's
+// virtToPhysicalMap. If the map is empty/identity, returns the input
+// values unchanged. Used by passes that emit cross-core ops (gather_core,
+// remote_load mcast, etc.) where the lowered runtime arguments are
+// physical NoC coordinates but the surface IR carries virtual ones.
+SmallVector<Value> mapVirtualToPhysicalCoreIndex(OpBuilder &builder,
+                                                 Location loc,
+                                                 ttcore::GridAttr grid,
+                                                 ValueRange virtualCoreIndex);
 
 } // namespace mlir::tt::d2m::utils
 

--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -190,11 +190,10 @@ getNocElementAlignment(Operation *op, ttcore::MemorySpace memorySpace,
 int32_t getNocElementAlignmentL1(
     Operation *op, const std::variant<RankedTensorType, MemRefType> &type);
 
-// Maps virtual core indices to physical core indices using the grid's
-// virtToPhysicalMap. If the map is empty/identity, returns the input
-// values unchanged. Used by passes that emit cross-core ops (gather_core,
-// remote_load mcast, etc.) where the lowered runtime arguments are
-// physical NoC coordinates but the surface IR carries virtual ones.
+// Apply the grid's virt-to-physical map to a virtual core index. Returns
+// the input unchanged if the map is empty/identity. Used by passes that
+// emit cross-core ops (multicast remote_load, gather_core, etc.) whose
+// runtime arguments are physical NoC coordinates.
 SmallVector<Value> mapVirtualToPhysicalCoreIndex(OpBuilder &builder,
                                                  Location loc,
                                                  ttcore::GridAttr grid,

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2386,10 +2386,8 @@ public:
     if (op.isSrcLocal()) {
       Value srcL1Addr = buildL1Address<ttkernel::GetReadPtrOp>(
           rewriter, loc, adaptor.getSrc(), op.getSrcIndices());
-      // Cross-core local-L1 read: use the explicit source-core coords. Plain
-      // local read (current core): use myY/myX. In both cases the source
-      // memref's L1 offset is uniform across cores, so the only difference is
-      // which logical worker we ask the NoC to read from.
+      // Source logical coords: srcCore (cross-core form) or my_logical_y/x
+      // (plain local read).
       Value srcLogicalY, srcLogicalX;
       if (op.hasSrcCore()) {
         srcLogicalY = op.getSrcCore()[0];

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2386,10 +2386,20 @@ public:
     if (op.isSrcLocal()) {
       Value srcL1Addr = buildL1Address<ttkernel::GetReadPtrOp>(
           rewriter, loc, adaptor.getSrc(), op.getSrcIndices());
-      auto myY = rewriter.create<ttkernel::MyLogicalYOp>(loc);
-      auto myX = rewriter.create<ttkernel::MyLogicalXOp>(loc);
+      // Cross-core local-L1 read: use the explicit source-core coords. Plain
+      // local read (current core): use myY/myX. In both cases the source
+      // memref's L1 offset is uniform across cores, so the only difference is
+      // which logical worker we ask the NoC to read from.
+      Value srcLogicalY, srcLogicalX;
+      if (op.hasSrcCore()) {
+        srcLogicalY = op.getSrcCore()[0];
+        srcLogicalX = op.getSrcCore()[1];
+      } else {
+        srcLogicalY = rewriter.create<ttkernel::MyLogicalYOp>(loc);
+        srcLogicalX = rewriter.create<ttkernel::MyLogicalXOp>(loc);
+      }
       auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
-          rewriter, loc, chipDesc, ValueRange{myY, myX});
+          rewriter, loc, chipDesc, ValueRange{srcLogicalY, srcLogicalX});
       NocEndpoint srcEndpoint{
           ttcore::MemorySpace::DeviceL1, {virtX, virtY}, nullptr, srcL1Addr};
       createNocAsyncRead(rewriter, loc, srcEndpoint, dstL1Addr, size);

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -139,9 +139,8 @@ static mlir::ConstantIntRanges getIndexRange(uint64_t umin, uint64_t umax) {
   if (srcType.getElementType() != dstType.getElementType()) {
     return emitOpError("Operands to DMARead must have the same element type");
   }
-  // Cross-core local-L1 read form: srcCore is mutually exclusive with a
-  // device-laid-out src (it only makes sense when %src is a local memref
-  // whose L1 offset is uniform across the grid).
+  // Cross-core local-L1 read form: srcCore requires a non-device-laid-out
+  // src and is a 2D core coordinate.
   if (hasSrcCore()) {
     if (isSrcRemote()) {
       return emitOpError(
@@ -1653,28 +1652,12 @@ bool RemoteStoreOp::hasTensorSemantics() {
 }
 
 //===----------------------------------------------------------------------===//
-// GatherCoreOp Verifier
-//===----------------------------------------------------------------------===//
-
-//===----------------------------------------------------------------------===//
-// GatherCoreOp Custom Parser / Printer
+// GatherCoreOp Parser / Printer / Verifier
 //===----------------------------------------------------------------------===//
 //
-// Four surface forms (each side independent, mirroring LocalCopy's CB story
-// but allowing per-side asymmetry):
-//   Pure implicit (both memref/tensor):
-//     d2m.gather_core %src into %dst ... : T, T  (-> T)?
-//   src-CB only:
-//     d2m.gather_core from %srcCb into %dst ... : !d2m.cb<...>, T
-//   dst-CB only:
-//     d2m.gather_core %src into %dstCb ... : T, !d2m.cb<...>
-//   Both CB:
-//     d2m.gather_core from %srcCb into %dstCb ... : !d2m.cb<...>, !d2m.cb<...>
-//
-// The `from` keyword toggles src vs srcCb on the input side; the type of
-// the dst-side operand toggles dst vs dstCb. Tensor form is only valid in
-// the pure implicit shape (CBs and tensors don't mix; enforced by the
-// verifier).
+// Surface form per side: an optional leading `from` toggles src vs srcCb;
+// the dst-side type toggles dst vs dstCb (`into` is mandatory). Tensor
+// form is only valid with both sides implicit (enforced by verify()).
 
 ParseResult GatherCoreOp::parse(OpAsmParser &parser, OperationState &result) {
   bool srcIsCb = succeeded(parser.parseOptionalKeyword("from"));
@@ -1722,15 +1705,11 @@ ParseResult GatherCoreOp::parse(OpAsmParser &parser, OperationState &result) {
     result.addTypes(resultType);
   }
 
-  // The dst side's form is decided by the type: CBType -> dstCb, otherwise
-  // implicit (memref or tensor). The src side's form is decided by the
-  // `from` keyword presence (the type must then agree, and the verifier
-  // catches mismatches).
+  // Dst form is determined by its type; src form by the `from` keyword.
   bool dstIsCb = mlir::isa<CBType>(secondType);
 
-  // Resolve operands into the canonical segment order:
-  //   [src, dst, srcCb, dstCb,
-  //    groupStartIndex, groupShape, collectorIndex]
+  // Resolve operands in canonical segment order:
+  // [src, dst, srcCb, dstCb, groupStartIndex, groupShape, collectorIndex].
   int32_t srcSeg = 0, dstSeg = 0, srcCbSeg = 0, dstCbSeg = 0;
   if (!srcIsCb) {
     if (parser.resolveOperand(firstOp, firstType, result.operands)) {
@@ -1779,7 +1758,6 @@ ParseResult GatherCoreOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void GatherCoreOp::print(OpAsmPrinter &p) {
-  // Src side: `from %srcCb` or just `%src`.
   if (Value srcCb = getSrcCb()) {
     p << " from ";
     p.printOperand(srcCb);
@@ -1787,13 +1765,8 @@ void GatherCoreOp::print(OpAsmPrinter &p) {
     p << " ";
     p.printOperand(getSrc());
   }
-  // Dst side: always preceded by `into`.
   p << " into ";
-  if (Value dstCb = getDstCb()) {
-    p.printOperand(dstCb);
-  } else {
-    p.printOperand(getDst());
-  }
+  p.printOperand(getDstCb() ? getDstCb() : getDst());
 
   auto printIdxList = [&](StringRef keyword, OperandRange indices) {
     p << " " << keyword << "[";
@@ -1807,19 +1780,10 @@ void GatherCoreOp::print(OpAsmPrinter &p) {
   llvm::StringRef elidedAttrs[] = {"operandSegmentSizes"};
   p.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
 
-  // Types: one for src side, one for dst side.
   p << " : ";
-  if (Value srcCb = getSrcCb()) {
-    p.printType(srcCb.getType());
-  } else {
-    p.printType(getSrc().getType());
-  }
+  p.printType(getSrcCb() ? getSrcCb().getType() : getSrc().getType());
   p << ", ";
-  if (Value dstCb = getDstCb()) {
-    p.printType(dstCb.getType());
-  } else {
-    p.printType(getDst().getType());
-  }
+  p.printType(getDstCb() ? getDstCb().getType() : getDst().getType());
   if (Value result = getResult()) {
     p << " -> ";
     p.printType(result.getType());
@@ -1831,65 +1795,42 @@ void GatherCoreOp::print(OpAsmPrinter &p) {
   Value dst = getDst();
   Value srcCb = getSrcCb();
   Value dstCb = getDstCb();
-
-  // Form check: exactly one of (src, srcCb) must be present and exactly one
-  // of (dst, dstCb) must be present, but the two sides are *independent*.
-  // Allowed combos:
-  //   (src,  dst)    -- pure implicit memref/tensor form
-  //   (srcCb,dst)    -- src is CB-backed, dst is a plain memref
-  //   (src,  dstCb)  -- dst is CB-backed, src is a plain memref
-  //   (srcCb,dstCb)  -- both CB-backed (post-`SplitUnifiedThread`)
-  // The mixed forms model the realistic reduction-app shape where one
-  // buffer is a scratch alloc (uniform L1 address invariant) and the other
-  // crosses the DM-compute thread boundary as a generic-operand CB.
   bool hasSrc = static_cast<bool>(src);
   bool hasSrcCb = static_cast<bool>(srcCb);
   bool hasDst = static_cast<bool>(dst);
   bool hasDstCb = static_cast<bool>(dstCb);
+
+  // Each side is an XOR: exactly one of (implicit, CB) per side.
   if (hasSrc == hasSrcCb) {
-    return emitOpError(
-        "exactly one of src and srcCb must be present (implicit XOR "
-        "explicit-CB form)");
+    return emitOpError("exactly one of src and srcCb must be present");
   }
   if (hasDst == hasDstCb) {
-    return emitOpError(
-        "exactly one of dst and dstCb must be present (implicit XOR "
-        "explicit-CB form)");
+    return emitOpError("exactly one of dst and dstCb must be present");
   }
 
-  // Tensor form is only meaningful for the pure implicit form (both sides
-  // implicit and both tensors). CBs and tensors do not mix.
+  // Tensor form requires both sides implicit and tensor-typed.
   bool srcIsTensor = hasSrc && mlir::isa<RankedTensorType>(src.getType());
   bool dstIsTensor = hasDst && mlir::isa<RankedTensorType>(dst.getType());
   if (srcIsTensor != dstIsTensor) {
     return emitOpError("src and dst must both be tensors or both be memrefs");
   }
   if ((srcIsTensor || dstIsTensor) && (hasSrcCb || hasDstCb)) {
-    return emitOpError(
-        "tensor form is only valid with both sides in implicit form (CBs "
-        "and tensors do not mix)");
+    return emitOpError("tensor form requires both sides to be implicit");
   }
 
-  // Result presence is tied to the type domain (DPS in tensor form, in-place
-  // otherwise).
+  // DPS: tensor form has a result aliasing dst; memref/CB form has none.
   bool hasResult = static_cast<bool>(getResult());
   if (srcIsTensor && !hasResult) {
-    return emitOpError(
-        "tensor form must have a result (DPS); use the memref form for "
-        "in-place semantics");
+    return emitOpError("tensor form must have a result");
   }
   if (!srcIsTensor && hasResult) {
-    return emitOpError(
-        "non-tensor form must not have a result; the dst operand is the "
-        "destination (DPS)");
+    return emitOpError("non-tensor form must not have a result");
   }
   if (hasResult && getResult().getType() != dst.getType()) {
     return emitOpError("result type must match dst type");
   }
 
-  // No device layout on the implicit-side operands. CBs are inherently
-  // L1-local and don't carry device layouts, so they are exempt from this
-  // check.
+  // Implicit operands must not carry a device layout. (CBs are L1-local.)
   if (hasSrc && ttcore::hasDeviceLayout(src)) {
     return emitOpError("src must not have a device layout");
   }
@@ -1897,8 +1838,6 @@ void GatherCoreOp::print(OpAsmPrinter &p) {
     return emitOpError("dst must not have a device layout");
   }
 
-  // Shape / element-type checks operate on the underlying shaped type
-  // regardless of form.
   ShapedType srcShaped = getSrcShapedType();
   ShapedType dstShaped = getDstShapedType();
   if (srcShaped.getElementType() != dstShaped.getElementType()) {
@@ -1908,14 +1847,7 @@ void GatherCoreOp::print(OpAsmPrinter &p) {
     return emitOpError("src and dst shapes must match");
   }
 
-  // No memory-space check on the memref form: bufferization-produced memrefs
-  // start out with no memory space and pick one up later in the pipeline,
-  // and the L1 invariant for the lowering is enforced structurally by the
-  // allocator (uniform L1 placement for sharded L1 allocs / CB-backed
-  // buffers). This mirrors `remote_load`, which similarly does not gate on
-  // memory space.
-
-  // V1 is single-device, 2D grid: group and collector are 2-vectors.
+  // V1: 2D core grid, single device.
   if (getGroupStartIndex().size() != 2) {
     return emitOpError("groupStartIndex must have exactly 2 indices");
   }
@@ -1948,9 +1880,8 @@ bool GatherCoreOp::bufferizesToMemoryWrite(
 mlir::bufferization::AliasingValueList
 GatherCoreOp::getAliasingValues(mlir::OpOperand &operand,
                                 const mlir::bufferization::AnalysisState &) {
+  // DPS aliasing only matters in tensor form (result <-> dst).
   mlir::bufferization::AliasingValueList aliasList;
-  // In tensor form the result aliases dst (DPS). In memref/CB form there is
-  // no result and nothing aliases.
   Value result = getResult();
   Value dst = getDst();
   if (result && dst && operand.get() == dst) {
@@ -1978,12 +1909,12 @@ mlir::LogicalResult GatherCoreOp::bufferize(
     mlir::RewriterBase &rewriter,
     const mlir::bufferization::BufferizationOptions &options,
     mlir::bufferization::BufferizationState &state) {
+  // Only the tensor form needs bufferization; memref/CB forms are
+  // already lowered.
   Value result = getResult();
   Value src = getSrc();
   Value dst = getDst();
   if (!result || !src || !dst) {
-    // Already in memref or explicit-CB form (no result, or no implicit
-    // operands); nothing to bufferize.
     return mlir::failure();
   }
 
@@ -1998,13 +1929,9 @@ mlir::LogicalResult GatherCoreOp::bufferize(
     return dstBuffer;
   }
 
-  // Use the explicit implicit-memref-form convenience builder.
   rewriter.create<GatherCoreOp>(getLoc(), *srcBuffer, *dstBuffer,
                                 getGroupStartIndex(), getGroupShape(),
                                 getCollectorIndex());
-
-  // Wrap the dst buffer in a ToTensorOp so downstream tensor-form consumers
-  // can still resolve to the underlying memref via getBuffer().
   auto toTensor = rewriter.create<bufferization::ToTensorOp>(
       getLoc(), result.getType(), *dstBuffer);
   rewriter.replaceAllUsesWith(result, toTensor.getResult());

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -1656,19 +1656,222 @@ bool RemoteStoreOp::hasTensorSemantics() {
 // GatherCoreOp Verifier
 //===----------------------------------------------------------------------===//
 
-::mlir::LogicalResult GatherCoreOp::verify() {
-  Type srcType = getSrc().getType();
-  Type dstType = getDst().getType();
-  bool srcIsTensor = mlir::isa<RankedTensorType>(srcType);
-  bool dstIsTensor = mlir::isa<RankedTensorType>(dstType);
+//===----------------------------------------------------------------------===//
+// GatherCoreOp Custom Parser / Printer
+//===----------------------------------------------------------------------===//
+//
+// Four surface forms (each side independent, mirroring LocalCopy's CB story
+// but allowing per-side asymmetry):
+//   Pure implicit (both memref/tensor):
+//     d2m.gather_core %src into %dst ... : T, T  (-> T)?
+//   src-CB only:
+//     d2m.gather_core from %srcCb into %dst ... : !d2m.cb<...>, T
+//   dst-CB only:
+//     d2m.gather_core %src into %dstCb ... : T, !d2m.cb<...>
+//   Both CB:
+//     d2m.gather_core from %srcCb into %dstCb ... : !d2m.cb<...>, !d2m.cb<...>
+//
+// The `from` keyword toggles src vs srcCb on the input side; the type of
+// the dst-side operand toggles dst vs dstCb. Tensor form is only valid in
+// the pure implicit shape (CBs and tensors don't mix; enforced by the
+// verifier).
 
-  // Both operands must be in the same type domain.
+ParseResult GatherCoreOp::parse(OpAsmParser &parser, OperationState &result) {
+  bool srcIsCb = succeeded(parser.parseOptionalKeyword("from"));
+
+  OpAsmParser::UnresolvedOperand firstOp, secondOp;
+  if (parser.parseOperand(firstOp) || parser.parseKeyword("into") ||
+      parser.parseOperand(secondOp)) {
+    return failure();
+  }
+
+  auto parseIndexList =
+      [&](StringRef keyword,
+          SmallVector<OpAsmParser::UnresolvedOperand> &indices) -> ParseResult {
+    if (parser.parseKeyword(keyword) || parser.parseLSquare() ||
+        parser.parseOperandList(indices) || parser.parseRSquare()) {
+      return failure();
+    }
+    return success();
+  };
+
+  SmallVector<OpAsmParser::UnresolvedOperand> groupStartIndex;
+  SmallVector<OpAsmParser::UnresolvedOperand> groupShape;
+  SmallVector<OpAsmParser::UnresolvedOperand> collectorIndex;
+  if (parseIndexList("group", groupStartIndex) ||
+      parseIndexList("shape", groupShape) ||
+      parseIndexList("collector", collectorIndex)) {
+    return failure();
+  }
+
+  if (parser.parseOptionalAttrDict(result.attributes)) {
+    return failure();
+  }
+
+  Type firstType, secondType;
+  if (parser.parseColon() || parser.parseType(firstType) ||
+      parser.parseComma() || parser.parseType(secondType)) {
+    return failure();
+  }
+
+  Type resultType;
+  if (succeeded(parser.parseOptionalArrow())) {
+    if (parser.parseType(resultType)) {
+      return failure();
+    }
+    result.addTypes(resultType);
+  }
+
+  // The dst side's form is decided by the type: CBType -> dstCb, otherwise
+  // implicit (memref or tensor). The src side's form is decided by the
+  // `from` keyword presence (the type must then agree, and the verifier
+  // catches mismatches).
+  bool dstIsCb = mlir::isa<CBType>(secondType);
+
+  // Resolve operands into the canonical segment order:
+  //   [src, dst, srcCb, dstCb,
+  //    groupStartIndex, groupShape, collectorIndex]
+  int32_t srcSeg = 0, dstSeg = 0, srcCbSeg = 0, dstCbSeg = 0;
+  if (!srcIsCb) {
+    if (parser.resolveOperand(firstOp, firstType, result.operands)) {
+      return failure();
+    }
+    srcSeg = 1;
+  }
+  if (!dstIsCb) {
+    if (parser.resolveOperand(secondOp, secondType, result.operands)) {
+      return failure();
+    }
+    dstSeg = 1;
+  }
+  if (srcIsCb) {
+    if (parser.resolveOperand(firstOp, firstType, result.operands)) {
+      return failure();
+    }
+    srcCbSeg = 1;
+  }
+  if (dstIsCb) {
+    if (parser.resolveOperand(secondOp, secondType, result.operands)) {
+      return failure();
+    }
+    dstCbSeg = 1;
+  }
+
+  auto indexType = parser.getBuilder().getIndexType();
+  if (parser.resolveOperands(groupStartIndex, indexType, result.operands) ||
+      parser.resolveOperands(groupShape, indexType, result.operands) ||
+      parser.resolveOperands(collectorIndex, indexType, result.operands)) {
+    return failure();
+  }
+
+  SmallVector<int32_t> segmentSizes = {
+      srcSeg,
+      dstSeg,
+      srcCbSeg,
+      dstCbSeg,
+      static_cast<int32_t>(groupStartIndex.size()),
+      static_cast<int32_t>(groupShape.size()),
+      static_cast<int32_t>(collectorIndex.size()),
+  };
+  result.addAttribute("operandSegmentSizes",
+                      parser.getBuilder().getDenseI32ArrayAttr(segmentSizes));
+  return success();
+}
+
+void GatherCoreOp::print(OpAsmPrinter &p) {
+  // Src side: `from %srcCb` or just `%src`.
+  if (Value srcCb = getSrcCb()) {
+    p << " from ";
+    p.printOperand(srcCb);
+  } else {
+    p << " ";
+    p.printOperand(getSrc());
+  }
+  // Dst side: always preceded by `into`.
+  p << " into ";
+  if (Value dstCb = getDstCb()) {
+    p.printOperand(dstCb);
+  } else {
+    p.printOperand(getDst());
+  }
+
+  auto printIdxList = [&](StringRef keyword, OperandRange indices) {
+    p << " " << keyword << "[";
+    p.printOperands(indices);
+    p << "]";
+  };
+  printIdxList("group", getGroupStartIndex());
+  printIdxList("shape", getGroupShape());
+  printIdxList("collector", getCollectorIndex());
+
+  llvm::StringRef elidedAttrs[] = {"operandSegmentSizes"};
+  p.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
+
+  // Types: one for src side, one for dst side.
+  p << " : ";
+  if (Value srcCb = getSrcCb()) {
+    p.printType(srcCb.getType());
+  } else {
+    p.printType(getSrc().getType());
+  }
+  p << ", ";
+  if (Value dstCb = getDstCb()) {
+    p.printType(dstCb.getType());
+  } else {
+    p.printType(getDst().getType());
+  }
+  if (Value result = getResult()) {
+    p << " -> ";
+    p.printType(result.getType());
+  }
+}
+
+::mlir::LogicalResult GatherCoreOp::verify() {
+  Value src = getSrc();
+  Value dst = getDst();
+  Value srcCb = getSrcCb();
+  Value dstCb = getDstCb();
+
+  // Form check: exactly one of (src, srcCb) must be present and exactly one
+  // of (dst, dstCb) must be present, but the two sides are *independent*.
+  // Allowed combos:
+  //   (src,  dst)    -- pure implicit memref/tensor form
+  //   (srcCb,dst)    -- src is CB-backed, dst is a plain memref
+  //   (src,  dstCb)  -- dst is CB-backed, src is a plain memref
+  //   (srcCb,dstCb)  -- both CB-backed (post-`SplitUnifiedThread`)
+  // The mixed forms model the realistic reduction-app shape where one
+  // buffer is a scratch alloc (uniform L1 address invariant) and the other
+  // crosses the DM-compute thread boundary as a generic-operand CB.
+  bool hasSrc = static_cast<bool>(src);
+  bool hasSrcCb = static_cast<bool>(srcCb);
+  bool hasDst = static_cast<bool>(dst);
+  bool hasDstCb = static_cast<bool>(dstCb);
+  if (hasSrc == hasSrcCb) {
+    return emitOpError(
+        "exactly one of src and srcCb must be present (implicit XOR "
+        "explicit-CB form)");
+  }
+  if (hasDst == hasDstCb) {
+    return emitOpError(
+        "exactly one of dst and dstCb must be present (implicit XOR "
+        "explicit-CB form)");
+  }
+
+  // Tensor form is only meaningful for the pure implicit form (both sides
+  // implicit and both tensors). CBs and tensors do not mix.
+  bool srcIsTensor = hasSrc && mlir::isa<RankedTensorType>(src.getType());
+  bool dstIsTensor = hasDst && mlir::isa<RankedTensorType>(dst.getType());
   if (srcIsTensor != dstIsTensor) {
     return emitOpError("src and dst must both be tensors or both be memrefs");
   }
+  if ((srcIsTensor || dstIsTensor) && (hasSrcCb || hasDstCb)) {
+    return emitOpError(
+        "tensor form is only valid with both sides in implicit form (CBs "
+        "and tensors do not mix)");
+  }
 
   // Result presence is tied to the type domain (DPS in tensor form, in-place
-  // in memref form).
+  // otherwise).
   bool hasResult = static_cast<bool>(getResult());
   if (srcIsTensor && !hasResult) {
     return emitOpError(
@@ -1677,25 +1880,27 @@ bool RemoteStoreOp::hasTensorSemantics() {
   }
   if (!srcIsTensor && hasResult) {
     return emitOpError(
-        "memref form must not have a result; the dst memref is the "
+        "non-tensor form must not have a result; the dst operand is the "
         "destination (DPS)");
   }
-  if (hasResult && getResult().getType() != dstType) {
+  if (hasResult && getResult().getType() != dst.getType()) {
     return emitOpError("result type must match dst type");
   }
 
-  // Neither operand has a device layout. Gather operates on per-core local
-  // L1 buffers; a device layout would imply a grid-indexed remote operand,
-  // which is the remote_load path, not this one.
-  if (ttcore::hasDeviceLayout(getSrc())) {
+  // No device layout on the implicit-side operands. CBs are inherently
+  // L1-local and don't carry device layouts, so they are exempt from this
+  // check.
+  if (hasSrc && ttcore::hasDeviceLayout(src)) {
     return emitOpError("src must not have a device layout");
   }
-  if (ttcore::hasDeviceLayout(getDst())) {
+  if (hasDst && ttcore::hasDeviceLayout(dst)) {
     return emitOpError("dst must not have a device layout");
   }
 
-  auto srcShaped = mlir::cast<ShapedType>(srcType);
-  auto dstShaped = mlir::cast<ShapedType>(dstType);
+  // Shape / element-type checks operate on the underlying shaped type
+  // regardless of form.
+  ShapedType srcShaped = getSrcShapedType();
+  ShapedType dstShaped = getDstShapedType();
   if (srcShaped.getElementType() != dstShaped.getElementType()) {
     return emitOpError("src and dst element types must match");
   }
@@ -1703,23 +1908,12 @@ bool RemoteStoreOp::hasTensorSemantics() {
     return emitOpError("src and dst shapes must match");
   }
 
-  // Memory-space check applies only to the memref form.
-  if (!srcIsTensor) {
-    auto checkL1 = [&](MemRefType memrefType, StringRef name) -> LogicalResult {
-      auto memSpace = mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
-          memrefType.getMemorySpace());
-      if (!memSpace || memSpace.getValue() != ttcore::MemorySpace::DeviceL1) {
-        return emitOpError() << name << " must be in L1 memory space";
-      }
-      return success();
-    };
-    if (failed(checkL1(mlir::cast<MemRefType>(srcType), "src"))) {
-      return failure();
-    }
-    if (failed(checkL1(mlir::cast<MemRefType>(dstType), "dst"))) {
-      return failure();
-    }
-  }
+  // No memory-space check on the memref form: bufferization-produced memrefs
+  // start out with no memory space and pick one up later in the pipeline,
+  // and the L1 invariant for the lowering is enforced structurally by the
+  // allocator (uniform L1 placement for sharded L1 allocs / CB-backed
+  // buffers). This mirrors `remote_load`, which similarly does not gate on
+  // memory space.
 
   // V1 is single-device, 2D grid: group and collector are 2-vectors.
   if (getGroupStartIndex().size() != 2) {
@@ -1741,22 +1935,25 @@ bool RemoteStoreOp::hasTensorSemantics() {
 
 bool GatherCoreOp::bufferizesToMemoryRead(
     mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
-  return operand.get() == getSrc();
+  Value src = getSrc();
+  return src && operand.get() == src;
 }
 
 bool GatherCoreOp::bufferizesToMemoryWrite(
     mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
-  return operand.get() == getDst();
+  Value dst = getDst();
+  return dst && operand.get() == dst;
 }
 
 mlir::bufferization::AliasingValueList
 GatherCoreOp::getAliasingValues(mlir::OpOperand &operand,
                                 const mlir::bufferization::AnalysisState &) {
   mlir::bufferization::AliasingValueList aliasList;
-  // In tensor form the result aliases dst (DPS). In memref form there is no
-  // result and nothing aliases.
+  // In tensor form the result aliases dst (DPS). In memref/CB form there is
+  // no result and nothing aliases.
   Value result = getResult();
-  if (result && operand.get() == getDst()) {
+  Value dst = getDst();
+  if (result && dst && operand.get() == dst) {
     aliasList.addAlias(
         {result, mlir::bufferization::BufferRelation::Equivalent});
   }
@@ -1768,7 +1965,9 @@ GatherCoreOp::getBufferType(mlir::Value value,
                             const mlir::bufferization::BufferizationOptions &,
                             const mlir::bufferization::BufferizationState &,
                             ::llvm::SmallVector<mlir::Value> &) {
-  if (value == getSrc() || value == getDst()) {
+  Value src = getSrc();
+  Value dst = getDst();
+  if ((src && value == src) || (dst && value == dst)) {
     return ttcore::getBufferType(value.getType(), /*isView=*/false);
   }
   return mlir::failure();
@@ -1780,23 +1979,26 @@ mlir::LogicalResult GatherCoreOp::bufferize(
     const mlir::bufferization::BufferizationOptions &options,
     mlir::bufferization::BufferizationState &state) {
   Value result = getResult();
-  if (!result) {
-    // Already in memref form (no result); nothing to bufferize.
+  Value src = getSrc();
+  Value dst = getDst();
+  if (!result || !src || !dst) {
+    // Already in memref or explicit-CB form (no result, or no implicit
+    // operands); nothing to bufferize.
     return mlir::failure();
   }
 
   mlir::FailureOr<Value> srcBuffer =
-      mlir::bufferization::getBuffer(rewriter, getSrc(), options, state);
+      mlir::bufferization::getBuffer(rewriter, src, options, state);
   if (failed(srcBuffer)) {
     return srcBuffer;
   }
   mlir::FailureOr<Value> dstBuffer =
-      mlir::bufferization::getBuffer(rewriter, getDst(), options, state);
+      mlir::bufferization::getBuffer(rewriter, dst, options, state);
   if (failed(dstBuffer)) {
     return dstBuffer;
   }
 
-  // Use the explicit memref-form convenience builder.
+  // Use the explicit implicit-memref-form convenience builder.
   rewriter.create<GatherCoreOp>(getLoc(), *srcBuffer, *dstBuffer,
                                 getGroupStartIndex(), getGroupShape(),
                                 getCollectorIndex());
@@ -1812,8 +2014,10 @@ mlir::LogicalResult GatherCoreOp::bufferize(
 // NOLINTEND(clang-analyzer-core.StackAddressEscape)
 
 bool GatherCoreOp::hasTensorSemantics() {
-  bool srcIsTensor = mlir::isa<RankedTensorType>(getSrc().getType());
-  bool dstIsTensor = mlir::isa<RankedTensorType>(getDst().getType());
+  Value src = getSrc();
+  Value dst = getDst();
+  bool srcIsTensor = src && mlir::isa<RankedTensorType>(src.getType());
+  bool dstIsTensor = dst && mlir::isa<RankedTensorType>(dst.getType());
   Value result = getResult();
   bool resultIsTensor = result && mlir::isa<RankedTensorType>(result.getType());
   return srcIsTensor || dstIsTensor || resultIsTensor;

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -139,6 +139,18 @@ static mlir::ConstantIntRanges getIndexRange(uint64_t umin, uint64_t umax) {
   if (srcType.getElementType() != dstType.getElementType()) {
     return emitOpError("Operands to DMARead must have the same element type");
   }
+  // Cross-core local-L1 read form: srcCore is mutually exclusive with a
+  // device-laid-out src (it only makes sense when %src is a local memref
+  // whose L1 offset is uniform across the grid).
+  if (hasSrcCore()) {
+    if (isSrcRemote()) {
+      return emitOpError(
+          "srcCore is mutually exclusive with a device-laid-out src");
+    }
+    if (getSrcCore().size() != 2) {
+      return emitOpError("srcCore must have exactly 2 indices");
+    }
+  }
   int64_t numDstIndices = getDstIndices().size();
   int64_t numSrcIndices = getSrcIndices().size();
   if (isShardLevel()) {
@@ -1638,6 +1650,173 @@ bool RemoteStoreOp::hasTensorSemantics() {
   Value result = getResult();
   bool resultIsTensor = result && mlir::isa<RankedTensorType>(result.getType());
   return memrefIsTensor || localBufferIsTensor || resultIsTensor;
+}
+
+//===----------------------------------------------------------------------===//
+// GatherCoreOp Verifier
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult GatherCoreOp::verify() {
+  Type srcType = getSrc().getType();
+  Type dstType = getDst().getType();
+  bool srcIsTensor = mlir::isa<RankedTensorType>(srcType);
+  bool dstIsTensor = mlir::isa<RankedTensorType>(dstType);
+
+  // Both operands must be in the same type domain.
+  if (srcIsTensor != dstIsTensor) {
+    return emitOpError("src and dst must both be tensors or both be memrefs");
+  }
+
+  // Result presence is tied to the type domain (DPS in tensor form, in-place
+  // in memref form).
+  bool hasResult = static_cast<bool>(getResult());
+  if (srcIsTensor && !hasResult) {
+    return emitOpError(
+        "tensor form must have a result (DPS); use the memref form for "
+        "in-place semantics");
+  }
+  if (!srcIsTensor && hasResult) {
+    return emitOpError(
+        "memref form must not have a result; the dst memref is the "
+        "destination (DPS)");
+  }
+  if (hasResult && getResult().getType() != dstType) {
+    return emitOpError("result type must match dst type");
+  }
+
+  // Neither operand has a device layout. Gather operates on per-core local
+  // L1 buffers; a device layout would imply a grid-indexed remote operand,
+  // which is the remote_load path, not this one.
+  if (ttcore::hasDeviceLayout(getSrc())) {
+    return emitOpError("src must not have a device layout");
+  }
+  if (ttcore::hasDeviceLayout(getDst())) {
+    return emitOpError("dst must not have a device layout");
+  }
+
+  auto srcShaped = mlir::cast<ShapedType>(srcType);
+  auto dstShaped = mlir::cast<ShapedType>(dstType);
+  if (srcShaped.getElementType() != dstShaped.getElementType()) {
+    return emitOpError("src and dst element types must match");
+  }
+  if (srcShaped.getShape() != dstShaped.getShape()) {
+    return emitOpError("src and dst shapes must match");
+  }
+
+  // Memory-space check applies only to the memref form.
+  if (!srcIsTensor) {
+    auto checkL1 = [&](MemRefType memrefType, StringRef name) -> LogicalResult {
+      auto memSpace = mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
+          memrefType.getMemorySpace());
+      if (!memSpace || memSpace.getValue() != ttcore::MemorySpace::DeviceL1) {
+        return emitOpError() << name << " must be in L1 memory space";
+      }
+      return success();
+    };
+    if (failed(checkL1(mlir::cast<MemRefType>(srcType), "src"))) {
+      return failure();
+    }
+    if (failed(checkL1(mlir::cast<MemRefType>(dstType), "dst"))) {
+      return failure();
+    }
+  }
+
+  // V1 is single-device, 2D grid: group and collector are 2-vectors.
+  if (getGroupStartIndex().size() != 2) {
+    return emitOpError("groupStartIndex must have exactly 2 indices");
+  }
+  if (getGroupShape().size() != 2) {
+    return emitOpError("groupShape must have exactly 2 indices");
+  }
+  if (getCollectorIndex().size() != 2) {
+    return emitOpError("collectorIndex must have exactly 2 indices");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// GatherCoreOp Bufferization Interface Implementation
+//===----------------------------------------------------------------------===//
+
+bool GatherCoreOp::bufferizesToMemoryRead(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  return operand.get() == getSrc();
+}
+
+bool GatherCoreOp::bufferizesToMemoryWrite(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  return operand.get() == getDst();
+}
+
+mlir::bufferization::AliasingValueList
+GatherCoreOp::getAliasingValues(mlir::OpOperand &operand,
+                                const mlir::bufferization::AnalysisState &) {
+  mlir::bufferization::AliasingValueList aliasList;
+  // In tensor form the result aliases dst (DPS). In memref form there is no
+  // result and nothing aliases.
+  Value result = getResult();
+  if (result && operand.get() == getDst()) {
+    aliasList.addAlias(
+        {result, mlir::bufferization::BufferRelation::Equivalent});
+  }
+  return aliasList;
+}
+
+mlir::FailureOr<mlir::bufferization::BufferLikeType>
+GatherCoreOp::getBufferType(mlir::Value value,
+                            const mlir::bufferization::BufferizationOptions &,
+                            const mlir::bufferization::BufferizationState &,
+                            ::llvm::SmallVector<mlir::Value> &) {
+  if (value == getSrc() || value == getDst()) {
+    return ttcore::getBufferType(value.getType(), /*isView=*/false);
+  }
+  return mlir::failure();
+}
+
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+mlir::LogicalResult GatherCoreOp::bufferize(
+    mlir::RewriterBase &rewriter,
+    const mlir::bufferization::BufferizationOptions &options,
+    mlir::bufferization::BufferizationState &state) {
+  Value result = getResult();
+  if (!result) {
+    // Already in memref form (no result); nothing to bufferize.
+    return mlir::failure();
+  }
+
+  mlir::FailureOr<Value> srcBuffer =
+      mlir::bufferization::getBuffer(rewriter, getSrc(), options, state);
+  if (failed(srcBuffer)) {
+    return srcBuffer;
+  }
+  mlir::FailureOr<Value> dstBuffer =
+      mlir::bufferization::getBuffer(rewriter, getDst(), options, state);
+  if (failed(dstBuffer)) {
+    return dstBuffer;
+  }
+
+  // Use the explicit memref-form convenience builder.
+  rewriter.create<GatherCoreOp>(getLoc(), *srcBuffer, *dstBuffer,
+                                getGroupStartIndex(), getGroupShape(),
+                                getCollectorIndex());
+
+  // Wrap the dst buffer in a ToTensorOp so downstream tensor-form consumers
+  // can still resolve to the underlying memref via getBuffer().
+  auto toTensor = rewriter.create<bufferization::ToTensorOp>(
+      getLoc(), result.getType(), *dstBuffer);
+  rewriter.replaceAllUsesWith(result, toTensor.getResult());
+  rewriter.eraseOp(*this);
+  return mlir::success();
+}
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)
+
+bool GatherCoreOp::hasTensorSemantics() {
+  bool srcIsTensor = mlir::isa<RankedTensorType>(getSrc().getType());
+  bool dstIsTensor = mlir::isa<RankedTensorType>(getDst().getType());
+  Value result = getResult();
+  bool resultIsTensor = result && mlir::isa<RankedTensorType>(result.getType());
+  return srcIsTensor || dstIsTensor || resultIsTensor;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/FunctionTypes.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -19,36 +20,6 @@ namespace mlir::tt::d2m {
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 namespace {
-static SmallVector<Value>
-mapVirtualToPhysicalCoreIndex(OpBuilder &builder, Location loc,
-                              ttcore::GridAttr grid,
-                              ValueRange virtualCoreIndex) {
-  AffineMap map = grid.getVirtToPhysicalMap();
-  if (!map || map.isEmpty()) {
-    return SmallVector<Value>(virtualCoreIndex.begin(), virtualCoreIndex.end());
-  }
-
-  TT_assertv(map.getNumDims() == virtualCoreIndex.size(),
-             "Expected virtual-to-physical grid map input rank to match core "
-             "index rank.");
-  unsigned firstCoreResult =
-      map.getNumResults() == virtualCoreIndex.size() ? 0 : 1;
-  TT_assertv(map.getNumResults() >= firstCoreResult + virtualCoreIndex.size(),
-             "Expected virtual-to-physical grid map to have enough core "
-             "coordinate results.");
-
-  SmallVector<Value> physicalCoreIndex;
-  physicalCoreIndex.reserve(virtualCoreIndex.size());
-  for (unsigned i = 0; i < virtualCoreIndex.size(); ++i) {
-    AffineMap selectedMap = AffineMap::get(
-        map.getNumDims(), map.getNumSymbols(),
-        {map.getResult(firstCoreResult + i)}, builder.getContext());
-    physicalCoreIndex.push_back(builder.create<affine::AffineApplyOp>(
-        loc, selectedMap, virtualCoreIndex));
-  }
-  return physicalCoreIndex;
-}
-
 static void annotateCoreIndexOpsWithPhysicalToVirtualMaps(GenericOp generic) {
   AffineMap physicalToVirtualMap = generic.getGrid().getPhysicalToVirtMap();
   if (!physicalToVirtualMap || physicalToVirtualMap.isEmpty()) {
@@ -78,8 +49,9 @@ materializeCoreCoordinateOperandsInPhysicalSpace(GenericOp generic,
       return;
     }
     builder.setInsertionPoint(dmaWriteOp);
-    SmallVector<Value> physicalMcastStartIndex = mapVirtualToPhysicalCoreIndex(
-        builder, dmaWriteOp.getLoc(), grid, dmaWriteOp.getMcastStartIndex());
+    SmallVector<Value> physicalMcastStartIndex =
+        utils::mapVirtualToPhysicalCoreIndex(builder, dmaWriteOp.getLoc(), grid,
+                                             dmaWriteOp.getMcastStartIndex());
     dmaWriteOp.getMcastStartIndexMutable().assign(physicalMcastStartIndex);
   });
 
@@ -90,8 +62,9 @@ materializeCoreCoordinateOperandsInPhysicalSpace(GenericOp generic,
       return;
     }
     builder.setInsertionPoint(semaphoreOp);
-    SmallVector<Value> physicalDstCoreIndex = mapVirtualToPhysicalCoreIndex(
-        builder, semaphoreOp.getLoc(), grid, semaphoreOp.getDstCoreIndex());
+    SmallVector<Value> physicalDstCoreIndex =
+        utils::mapVirtualToPhysicalCoreIndex(
+            builder, semaphoreOp.getLoc(), grid, semaphoreOp.getDstCoreIndex());
     semaphoreOp.getDstCoreIndexMutable().assign(physicalDstCoreIndex);
   };
   generic.walk([&](SemaphoreSetOp semaphoreSetOp) {

--- a/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
@@ -200,10 +200,53 @@ private:
   bool debugCoalescingInference;
 
 public:
+  // Cross-core local-L1 read: %src is a plain local memref and srcCore
+  // selects the remote core to read from. The source memref has no grid
+  // component, so the expansion is a single fully-indexed read of the
+  // whole shard at offset 0 (or N reads if the local layout is not
+  // contiguous, but for V1 the only legal source kinds — scratch-style
+  // allocations and CB underlying memrefs — are flat). srcCore is
+  // preserved verbatim on the resulting dma_read; the actual NoC address
+  // construction happens in D2MToTTKernel.
+  static LogicalResult rewriteCrossCoreLocalRead(PatternRewriter &rewriter,
+                                                 DMAReadOp op) {
+    Location loc = op.getLoc();
+    Value src = op.getSrc();
+    Value dst = op.getDst();
+    ValueRange srcCore = op.getSrcCore();
+
+    MemRefType srcType = op.getSrcMemRefType();
+    ArrayRef<int64_t> shardShape = srcType.getShape();
+    size_t shardVolume = ttmlir::utils::volume(shardShape);
+
+    ttcore::DeviceAttr device = ttcore::lookupDevice(op);
+    AffineMap srcMemoryMap =
+        utils::getMemoryMap(device, src, /*isRemote=*/false);
+    AffineMap dstMemoryMap =
+        utils::getMemoryMap(device, dst, /*isRemote=*/false);
+
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexType(), rewriter.getIndexAttr(0));
+    SmallVector<Value> zeros(shardShape.size(), zero);
+    SmallVector<Value> srcIndices =
+        utils::applyMap(rewriter, loc, srcMemoryMap, zeros, false);
+    SmallVector<Value> dstIndices =
+        utils::applyMap(rewriter, loc, dstMemoryMap, zeros, false);
+
+    rewriter.replaceOpWithNewOp<DMAReadOp>(
+        op, src, srcIndices, dst, dstIndices,
+        rewriter.getI64IntegerAttr(shardVolume), srcCore);
+    return success();
+  }
+
   LogicalResult matchAndRewrite(DMAReadOp op,
                                 PatternRewriter &rewriter) const final {
     if (op.isFullyIndexed()) {
       return failure();
+    }
+
+    if (op.hasSrcCore()) {
+      return rewriteCrossCoreLocalRead(rewriter, op);
     }
 
     Location loc = op.getLoc();

--- a/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
@@ -200,14 +200,11 @@ private:
   bool debugCoalescingInference;
 
 public:
-  // Cross-core local-L1 read: %src is a plain local memref and srcCore
-  // selects the remote core to read from. The source memref has no grid
-  // component, so the expansion is a single fully-indexed read of the
-  // whole shard at offset 0 (or N reads if the local layout is not
-  // contiguous, but for V1 the only legal source kinds — scratch-style
-  // allocations and CB underlying memrefs — are flat). srcCore is
-  // preserved verbatim on the resulting dma_read; the actual NoC address
-  // construction happens in D2MToTTKernel.
+  // Cross-core local-L1 read: src is a plain local memref selected via
+  // srcCore. The source has no grid component, so a shard-level read
+  // collapses to a single fully-indexed read at offset 0 covering the
+  // whole shard. srcCore is preserved verbatim; NoC address construction
+  // happens in D2MToTTKernel.
   static LogicalResult rewriteCrossCoreLocalRead(PatternRewriter &rewriter,
                                                  DMAReadOp op) {
     Location loc = op.getLoc();

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::tt::d2m {
@@ -345,19 +346,58 @@ public:
     Value endX =
         rewriter.create<arith::AddIOp>(loc, groupStart[1], groupShape[1]);
 
-    // isCollector: virtual core index == collectorIdx on every axis.
+    // Compute the two per-core booleans we need to dispatch the gather
+    // protocol:
+    //
+    //   isInGroup  : this core's virtual coord is inside the gather group's
+    //                logical rectangle
+    //                [groupStart[0], groupStart[0] + groupShape[0]) ×
+    //                [groupStart[1], groupStart[1] + groupShape[1]).
+    //   isCollector: this core's virtual coord matches collectorIdx.
+    //
+    // The enclosing d2m.generic may be configured for a grid that strictly
+    // contains the gather group, in which case "not collector" is NOT the
+    // same as "I am a gather source". Without the explicit in-group gate,
+    // cores outside the group would still execute the source-side
+    // semaphore protocol (inc'ing sourceReady, waiting on collectorDone),
+    // which would (a) over-saturate sourceReady on the collector and (b)
+    // deadlock on collectorDone (the per-group fan-out only inc's group
+    // cores). Gating the whole isCollector if/else by isInGroup keeps
+    // non-group cores entirely out of the protocol.
+    //
+    // CB-level handshakes on the src CB (`d2m.wait`/`d2m.pop`, currently
+    // emitted unconditionally outside the if/else) are intentionally NOT
+    // gated: src CB allocation is per-core-uniform today, and every core's
+    // upstream compute thread pushes one element into it. Refining CB
+    // allocation so non-group cores can skip the CB entirely is tracked as
+    // a follow-up.
     AffineMap gridMapping = genericOp.getGrid().getPhysicalToVirtMap();
     Value isCollector;
-    for (auto [i, collIdx] : llvm::enumerate(collectorIdx)) {
+    Value isInGroup;
+    for (unsigned i = 0; i < 2u; ++i) {
       Value coreIdx = rewriter.create<CoreIndexOp>(loc, static_cast<int64_t>(i),
                                                    gridMapping);
-      Value cond = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(),
-                                                  arith::CmpIPredicate::eq,
-                                                  coreIdx, collIdx);
-      isCollector = isCollector
-                        ? rewriter.create<arith::AndIOp>(loc, isCollector, cond)
-                              .getResult()
-                        : cond;
+      Value collEq = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(),
+                                                    arith::CmpIPredicate::eq,
+                                                    coreIdx, collectorIdx[i]);
+      isCollector =
+          isCollector ? rewriter.create<arith::AndIOp>(loc, isCollector, collEq)
+                            .getResult()
+                      : collEq;
+
+      Value axisEnd = (i == 0) ? endY : endX;
+      Value geStart = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(),
+                                                     arith::CmpIPredicate::sge,
+                                                     coreIdx, groupStart[i]);
+      Value ltEnd = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(),
+                                                   arith::CmpIPredicate::slt,
+                                                   coreIdx, axisEnd);
+      Value axisInGroup = rewriter.create<arith::AndIOp>(loc, geStart, ltEnd);
+      isInGroup =
+          isInGroup
+              ? rewriter.create<arith::AndIOp>(loc, isInGroup, axisInGroup)
+                    .getResult()
+              : axisInGroup;
     }
 
     // Pre-compute physical coordinates we need across the branches:
@@ -368,74 +408,149 @@ public:
     SmallVector<Value> physCollector = utils::mapVirtualToPhysicalCoreIndex(
         rewriter, loc, genericOp.getGrid(), collectorIdx);
 
+    // Build the gather protocol body inside an `if (isInGroup)` gate. The
+    // body is the existing collector / source dispatch -- unchanged in
+    // shape, just lifted into an outer scf.if.
     rewriter.create<scf::IfOp>(
-        loc, isCollector,
-        [&](OpBuilder &builder, Location loc) {
-          // Collector branch: wait for sources, pull each source's payload,
-          // signal the entire group.
+        loc, isInGroup, [&](OpBuilder &groupBuilder, Location groupLoc) {
+          groupBuilder.create<scf::IfOp>(
+              groupLoc, isCollector,
+              [&](OpBuilder &builder, Location loc) {
+                // Collector branch: wait for sources, pull each source's
+                // payload, signal the entire group.
 
-          // Unwrap dst CB inside the collector branch only (option (c)):
-          // the dst CB is allocated on every core but only the collector
-          // performs the reserve/push.
-          Value dstLocal = dst;
-          if (dstCb) {
-            dstLocal = builder.create<ReserveOp>(loc, dstCb).getResult();
-          }
+                // Unwrap dst CB inside the collector branch only (option (c)):
+                // the dst CB is allocated on every core but only the collector
+                // performs the reserve/push.
+                Value dstLocal = dst;
+                if (dstCb) {
+                  dstLocal = builder.create<ReserveOp>(loc, dstCb).getResult();
+                }
 
-          builder.create<SemaphoreWaitOp>(loc, sourceReady, numSources, zero);
+                builder.create<SemaphoreWaitOp>(loc, sourceReady, numSources,
+                                                zero);
 
-          // Row-major iteration over the gather group. The collector's own
-          // coordinate is included; the resulting "self read" is correct
-          // (just slightly inefficient) and avoids an inner-loop branch.
-          builder.create<scf::ForOp>(
-              loc, groupStart[0], endY, one, ValueRange(),
-              [&](OpBuilder &yBuilder, Location yLoc, Value srcY, ValueRange) {
-                yBuilder.create<scf::ForOp>(
-                    yLoc, groupStart[1], endX, one, ValueRange(),
-                    [&](OpBuilder &xBuilder, Location xLoc, Value srcX,
+                // Row-major iteration over the gather group. The collector's
+                // own coordinate is included; the resulting "self read" is
+                // correct (just slightly inefficient) and avoids an inner-loop
+                // branch.
+                builder.create<scf::ForOp>(
+                    loc, groupStart[0], endY, one, ValueRange(),
+                    [&](OpBuilder &yBuilder, Location yLoc, Value srcY,
                         ValueRange) {
-                      SmallVector<Value> physSrc =
-                          utils::mapVirtualToPhysicalCoreIndex(
-                              xBuilder, xLoc, genericOp.getGrid(),
-                              {srcY, srcX});
-                      // Shard-level dma_read: read the entire src shard
-                      // from core[physSrc] into dst on the current core.
-                      // The expansion to fully indexed form (and the
-                      // srcCore-aware NoC lowering) is handled by the
-                      // downstream passes.
-                      Value tx = xBuilder.create<DMAReadOp>(
-                          xLoc, src, /*srcIndices=*/ValueRange(), dstLocal,
-                          /*srcCore=*/ValueRange(physSrc));
-                      xBuilder.create<DMAWaitOp>(xLoc, tx);
-                      xBuilder.create<scf::YieldOp>(xLoc);
+                      yBuilder.create<scf::ForOp>(
+                          yLoc, groupStart[1], endX, one, ValueRange(),
+                          [&](OpBuilder &xBuilder, Location xLoc, Value srcX,
+                              ValueRange) {
+                            SmallVector<Value> physSrc =
+                                utils::mapVirtualToPhysicalCoreIndex(
+                                    xBuilder, xLoc, genericOp.getGrid(),
+                                    {srcY, srcX});
+                            // Shard-level dma_read: read the entire src shard
+                            // from core[physSrc] into dst on the current core.
+                            // The expansion to fully indexed form (and the
+                            // srcCore-aware NoC lowering) is handled by the
+                            // downstream passes.
+                            Value tx = xBuilder.create<DMAReadOp>(
+                                xLoc, src, /*srcIndices=*/ValueRange(),
+                                dstLocal,
+                                /*srcCore=*/ValueRange(physSrc));
+                            xBuilder.create<DMAWaitOp>(xLoc, tx);
+                            xBuilder.create<scf::YieldOp>(xLoc);
+                          });
+                      yBuilder.create<scf::YieldOp>(yLoc);
                     });
-                yBuilder.create<scf::YieldOp>(yLoc);
+
+                // Signal collector-done to every core in the group.
+                //
+                // For non-degenerate groups (both groupShape axes statically ≥
+                // 2, or shape unknown at compile time) we emit a single
+                // multicast SemaphoreSet that covers the whole group in one NoC
+                // transaction. The collector itself is in this multicast region
+                // but does not wait on the semaphore.
+                //
+                // For groups that are statically degenerate on at least one
+                // axis (1×1, 1×N, or N×1), the multicast set would lower
+                // downstream to an
+                // ttkernel::experimental::get_noc_multicast_addr call whose
+                // start/end coords on the degenerate axis are the same SSA
+                // value (CSE collapses them after Canonicalize folds the `start
+                // + 1 - 1` end-coord arithmetic). The emitc.expression wrapper
+                // produced by mlir's FormExpressionsPass cannot roundtrip
+                // duplicate operands -- the printer shadows region arguments
+                // with operand SSA names and the re-parser rejects two block
+                // args with the same name. We sidestep that by emitting an
+                // equivalent loop of unicast SemaphoreInc calls.
+                //
+                // The two forms are observable-equivalent inside the gather
+                // protocol: collectorDone is zero-initialized, reset on each
+                // source's wait, and only ever published with value 1, so
+                // "set everyone in the group to 1" and "inc each group core's
+                // semaphore by 1" land on the same observed state. The
+                // unicast incs on cores other than the collector unblock the
+                // sources; the inc on the collector itself is harmless because
+                // the collector does not wait on collectorDone.
+                std::optional<int64_t> staticShapeY =
+                    getConstantIntValue(groupShape[0]);
+                std::optional<int64_t> staticShapeX =
+                    getConstantIntValue(groupShape[1]);
+                bool yIsOne = staticShapeY && *staticShapeY == 1;
+                bool xIsOne = staticShapeX && *staticShapeX == 1;
+                if (yIsOne && xIsOne) {
+                  // 1×1: a single unicast inc to the (only) group core, which
+                  // is the collector itself.
+                  builder.create<SemaphoreIncOp>(loc, collectorDone, one,
+                                                 physGroupStart);
+                } else if (yIsOne || xIsOne) {
+                  // 1×N or N×1: walk the non-degenerate axis and emit one
+                  // unicast inc per group core.
+                  Value lb = yIsOne ? groupStart[1] : groupStart[0];
+                  Value ub = yIsOne ? endX : endY;
+                  bool axisIsX = yIsOne;
+                  builder.create<scf::ForOp>(
+                      loc, lb, ub, one, ValueRange(),
+                      [&](OpBuilder &incBuilder, Location incLoc, Value iv,
+                          ValueRange) {
+                        Value virtY = axisIsX ? groupStart[0] : iv;
+                        Value virtX = axisIsX ? iv : groupStart[1];
+                        SmallVector<Value> physTarget =
+                            utils::mapVirtualToPhysicalCoreIndex(
+                                incBuilder, incLoc, genericOp.getGrid(),
+                                {virtY, virtX});
+                        incBuilder.create<SemaphoreIncOp>(incLoc, collectorDone,
+                                                          one, physTarget);
+                        incBuilder.create<scf::YieldOp>(incLoc);
+                      });
+                } else {
+                  // ≥2×≥2 (or fully dynamic): single mcast SET. Note that the
+                  // dynamic case can still hit the duplicate-operand bug if at
+                  // runtime an axis is 1, but in our pipeline group shapes are
+                  // typically constant; treat that as a follow-up.
+                  builder.create<SemaphoreSetOp>(
+                      loc, collectorDone, one, physGroupStart, groupShape,
+                      /*startDevice=*/ValueRange(),
+                      /*deviceMcastShape=*/ValueRange());
+                }
+
+                // After all reads are complete and the collector-done multicast
+                // has been issued, push the dst CB so the downstream compute
+                // thread on the collector can wait/pop it. Non-collector cores
+                // never reach this PushOp (option (c)).
+                if (dstCb) {
+                  builder.create<PushOp>(loc, dstCb);
+                }
+
+                builder.create<scf::YieldOp>(loc);
+              },
+              [&](OpBuilder &builder, Location loc) {
+                // Source branch: signal collector that we are ready, then
+                // wait until the collector has finished pulling us.
+                builder.create<SemaphoreIncOp>(loc, sourceReady, one,
+                                               physCollector);
+                builder.create<SemaphoreWaitOp>(loc, collectorDone, one, zero);
+                builder.create<scf::YieldOp>(loc);
               });
-
-          // Signal collector-done to every core in the group. The collector
-          // itself is in this multicast region but does not wait on the
-          // semaphore.
-          builder.create<SemaphoreSetOp>(loc, collectorDone, one,
-                                         physGroupStart, groupShape,
-                                         /*startDevice=*/ValueRange(),
-                                         /*deviceMcastShape=*/ValueRange());
-
-          // After all reads are complete and the collector-done multicast
-          // has been issued, push the dst CB so the downstream compute
-          // thread on the collector can wait/pop it. Non-collector cores
-          // never reach this PushOp (option (c)).
-          if (dstCb) {
-            builder.create<PushOp>(loc, dstCb);
-          }
-
-          builder.create<scf::YieldOp>(loc);
-        },
-        [&](OpBuilder &builder, Location loc) {
-          // Source branch: signal collector that we are ready, then wait
-          // until the collector has finished pulling us.
-          builder.create<SemaphoreIncOp>(loc, sourceReady, one, physCollector);
-          builder.create<SemaphoreWaitOp>(loc, collectorDone, one, zero);
-          builder.create<scf::YieldOp>(loc);
+          groupBuilder.create<scf::YieldOp>(groupLoc);
         });
 
     // Release the src CB on every group core (consumer-side pop). Safe

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -371,11 +371,9 @@ public:
               : axisInGroup;
     }
 
-    // Physical coords reused across branches.
-    SmallVector<Value> physGroupStart = utils::mapVirtualToPhysicalCoreIndex(
-        rewriter, loc, genericOp.getGrid(), groupStart);
-    SmallVector<Value> physCollector = utils::mapVirtualToPhysicalCoreIndex(
-        rewriter, loc, genericOp.getGrid(), collectorIdx);
+    // Semaphore targets stay in virtual grid space: GenericRegionsToFuncs maps
+    // them virt->phys once before D2MToTTKernel. DMARead srcCore is the
+    // exception since that pass leaves it untouched.
 
     // if (isInGroup) { if (isCollector) collectorBranch else sourceBranch }
     rewriter.create<scf::IfOp>(
@@ -435,7 +433,7 @@ public:
                 bool xIsOne = staticShapeX && *staticShapeX == 1;
                 if (yIsOne && xIsOne) {
                   builder.create<SemaphoreIncOp>(loc, collectorDone, one,
-                                                 physGroupStart);
+                                                 groupStart);
                 } else if (yIsOne || xIsOne) {
                   Value lb = yIsOne ? groupStart[1] : groupStart[0];
                   Value ub = yIsOne ? endX : endY;
@@ -446,17 +444,14 @@ public:
                           ValueRange) {
                         Value virtY = axisIsX ? groupStart[0] : iv;
                         Value virtX = axisIsX ? iv : groupStart[1];
-                        SmallVector<Value> physTarget =
-                            utils::mapVirtualToPhysicalCoreIndex(
-                                incBuilder, incLoc, genericOp.getGrid(),
-                                {virtY, virtX});
-                        incBuilder.create<SemaphoreIncOp>(incLoc, collectorDone,
-                                                          one, physTarget);
+                        incBuilder.create<SemaphoreIncOp>(
+                            incLoc, collectorDone, one,
+                            ValueRange{virtY, virtX});
                         incBuilder.create<scf::YieldOp>(incLoc);
                       });
                 } else {
                   builder.create<SemaphoreSetOp>(
-                      loc, collectorDone, one, physGroupStart, groupShape,
+                      loc, collectorDone, one, groupStart, groupShape,
                       /*startDevice=*/ValueRange(),
                       /*deviceMcastShape=*/ValueRange());
                 }
@@ -470,7 +465,7 @@ public:
                 // Source: signal the collector we are ready, then wait
                 // until it has pulled us.
                 builder.create<SemaphoreIncOp>(loc, sourceReady, one,
-                                               physCollector);
+                                               collectorIdx);
                 builder.create<SemaphoreWaitOp>(loc, collectorDone, one, zero);
                 builder.create<scf::YieldOp>(loc);
               });

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -271,18 +271,16 @@ public:
                                 PatternRewriter &rewriter) const final {
     Location loc = gather.getLoc();
 
-    // Tensors should have been bufferized by the time this pass runs.
-    // Either implicit memref form (both $src and $dst are memrefs) or
-    // explicit CB form (both $srcCb and $dstCb are CBs) is acceptable.
+    // Accept implicit memref form or explicit CB form; tensor form must have
+    // been bufferized by now.
     auto isMemRefOrAbsent = [](Value v) {
       return !v || mlir::isa<MemRefType>(v.getType());
     };
     if (!isMemRefOrAbsent(gather.getSrc()) ||
         !isMemRefOrAbsent(gather.getDst())) {
-      return rewriter.notifyMatchFailure(
-          gather,
-          "implicit-form src and dst must be memrefs at this stage in the "
-          "pipeline (tensors should have been bufferized)");
+      return rewriter.notifyMatchFailure(gather,
+                                         "implicit-form src/dst must be "
+                                         "memrefs at this stage");
     }
     if (gather.getSrcCb() &&
         !gather.getSrcCbType().getUnderlyingAs<MemRefType>()) {
@@ -298,14 +296,10 @@ public:
     auto genericOp = gather->getParentOfType<GenericOp>();
     TT_assertv(genericOp, "GatherCoreOp must be inside a GenericOp");
 
-    // Unwrap src: in CB form, materialize the underlying memref via a
-    // WaitOp on every group core (consumer-side handshake with the
-    // upstream compute thread, which has produced via PushOp). The same
-    // local memref is then used by both the collector (for its local
-    // self-read) and by the cross-core DMA reads (the L1 address is the
-    // uniform invariant). PopOp is emitted after the whole scf.if; by
-    // then the collector has done all reads and the source cores have
-    // waited on collectorDone.
+    // In CB form, materialize src's underlying memref via WaitOp on every
+    // group core (consumer-side handshake with the upstream compute thread).
+    // The matching PopOp is emitted after the scf.if, once both the
+    // collector's reads and the sources' wait on collectorDone are done.
     Value src = gather.getSrc();
     Value srcCb = gather.getSrcCb();
     if (srcCb) {
@@ -320,10 +314,8 @@ public:
                 collectorIdx.size() == 2),
                "GatherCoreOp must have 2D group / collector indices (V1)");
 
-    // Pre-allocated semaphores: sourceReady (sources -> collector) and
-    // collectorDone (collector -> sources). The same attribute scheme is
-    // used as for mcast remote loads, so getPreallocatedSemaphores works
-    // verbatim.
+    // Two preallocated local semaphores: sourceReady (sources -> collector)
+    // and collectorDone (collector -> sources).
     auto preallocatedSems = getPreallocatedSemaphores(gather);
     Value sourceReady = preallocatedSems.first;
     Value collectorDone = preallocatedSems.second;
@@ -333,44 +325,23 @@ public:
     Value one = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexType(),
                                                    rewriter.getIndexAttr(1));
 
-    // numSources = (groupShape[0] * groupShape[1]) - 1. The collector does
-    // not signal sourceReady on itself; mirrors the mcast lowering where
-    // the sender does not signal receiversReady on itself.
+    // The collector pulls from every group core (including itself) and so
+    // expects (groupVolume - 1) sourceReady signals.
     Value groupVolume =
         rewriter.create<arith::MulIOp>(loc, groupShape[0], groupShape[1]);
     Value numSources = rewriter.create<arith::SubIOp>(loc, groupVolume, one);
 
-    // Inner-loop bounds: end = start + size on each axis.
     Value endY =
         rewriter.create<arith::AddIOp>(loc, groupStart[0], groupShape[0]);
     Value endX =
         rewriter.create<arith::AddIOp>(loc, groupStart[1], groupShape[1]);
 
-    // Compute the two per-core booleans we need to dispatch the gather
-    // protocol:
-    //
-    //   isInGroup  : this core's virtual coord is inside the gather group's
-    //                logical rectangle
-    //                [groupStart[0], groupStart[0] + groupShape[0]) ×
-    //                [groupStart[1], groupStart[1] + groupShape[1]).
-    //   isCollector: this core's virtual coord matches collectorIdx.
-    //
-    // The enclosing d2m.generic may be configured for a grid that strictly
-    // contains the gather group, in which case "not collector" is NOT the
-    // same as "I am a gather source". Without the explicit in-group gate,
-    // cores outside the group would still execute the source-side
-    // semaphore protocol (inc'ing sourceReady, waiting on collectorDone),
-    // which would (a) over-saturate sourceReady on the collector and (b)
-    // deadlock on collectorDone (the per-group fan-out only inc's group
-    // cores). Gating the whole isCollector if/else by isInGroup keeps
-    // non-group cores entirely out of the protocol.
-    //
-    // CB-level handshakes on the src CB (`d2m.wait`/`d2m.pop`, currently
-    // emitted unconditionally outside the if/else) are intentionally NOT
-    // gated: src CB allocation is per-core-uniform today, and every core's
-    // upstream compute thread pushes one element into it. Refining CB
-    // allocation so non-group cores can skip the CB entirely is tracked as
-    // a follow-up.
+    // Build two per-core booleans:
+    //   isInGroup   - this core lies in [groupStart, groupStart + groupShape).
+    //   isCollector - this core matches collectorIdx.
+    // isInGroup gates the entire protocol so cores in the enclosing generic
+    // that are outside the gather group don't fan-in/fan-out (which would
+    // over-saturate sourceReady and deadlock on collectorDone).
     AffineMap gridMapping = genericOp.getGrid().getPhysicalToVirtMap();
     Value isCollector;
     Value isInGroup;
@@ -400,28 +371,21 @@ public:
               : axisInGroup;
     }
 
-    // Pre-compute physical coordinates we need across the branches:
-    // - physGroupStart: start of the multicast region for collectorDone.
-    // - physCollector: target of source-side semaphore_inc.
+    // Physical coords reused across branches.
     SmallVector<Value> physGroupStart = utils::mapVirtualToPhysicalCoreIndex(
         rewriter, loc, genericOp.getGrid(), groupStart);
     SmallVector<Value> physCollector = utils::mapVirtualToPhysicalCoreIndex(
         rewriter, loc, genericOp.getGrid(), collectorIdx);
 
-    // Build the gather protocol body inside an `if (isInGroup)` gate. The
-    // body is the existing collector / source dispatch -- unchanged in
-    // shape, just lifted into an outer scf.if.
+    // if (isInGroup) { if (isCollector) collectorBranch else sourceBranch }
     rewriter.create<scf::IfOp>(
         loc, isInGroup, [&](OpBuilder &groupBuilder, Location groupLoc) {
           groupBuilder.create<scf::IfOp>(
               groupLoc, isCollector,
               [&](OpBuilder &builder, Location loc) {
-                // Collector branch: wait for sources, pull each source's
-                // payload, signal the entire group.
-
-                // Unwrap dst CB inside the collector branch only (option (c)):
-                // the dst CB is allocated on every core but only the collector
-                // performs the reserve/push.
+                // Collector: reserve dst CB (only the collector pushes it),
+                // wait for sources, pull each source's payload, then
+                // fan out collectorDone to the group.
                 Value dstLocal = dst;
                 if (dstCb) {
                   dstLocal = builder.create<ReserveOp>(loc, dstCb).getResult();
@@ -430,10 +394,8 @@ public:
                 builder.create<SemaphoreWaitOp>(loc, sourceReady, numSources,
                                                 zero);
 
-                // Row-major iteration over the gather group. The collector's
-                // own coordinate is included; the resulting "self read" is
-                // correct (just slightly inefficient) and avoids an inner-loop
-                // branch.
+                // Row-major over the group; the collector's own iteration is
+                // a self-read, which is correct and avoids an inner branch.
                 builder.create<scf::ForOp>(
                     loc, groupStart[0], endY, one, ValueRange(),
                     [&](OpBuilder &yBuilder, Location yLoc, Value srcY,
@@ -446,11 +408,6 @@ public:
                                 utils::mapVirtualToPhysicalCoreIndex(
                                     xBuilder, xLoc, genericOp.getGrid(),
                                     {srcY, srcX});
-                            // Shard-level dma_read: read the entire src shard
-                            // from core[physSrc] into dst on the current core.
-                            // The expansion to fully indexed form (and the
-                            // srcCore-aware NoC lowering) is handled by the
-                            // downstream passes.
                             Value tx = xBuilder.create<DMAReadOp>(
                                 xLoc, src, /*srcIndices=*/ValueRange(),
                                 dstLocal,
@@ -461,35 +418,15 @@ public:
                       yBuilder.create<scf::YieldOp>(yLoc);
                     });
 
-                // Signal collector-done to every core in the group.
-                //
-                // For non-degenerate groups (both groupShape axes statically ≥
-                // 2, or shape unknown at compile time) we emit a single
-                // multicast SemaphoreSet that covers the whole group in one NoC
-                // transaction. The collector itself is in this multicast region
-                // but does not wait on the semaphore.
-                //
-                // For groups that are statically degenerate on at least one
-                // axis (1×1, 1×N, or N×1), the multicast set would lower
-                // downstream to an
-                // ttkernel::experimental::get_noc_multicast_addr call whose
-                // start/end coords on the degenerate axis are the same SSA
-                // value (CSE collapses them after Canonicalize folds the `start
-                // + 1 - 1` end-coord arithmetic). The emitc.expression wrapper
-                // produced by mlir's FormExpressionsPass cannot roundtrip
-                // duplicate operands -- the printer shadows region arguments
-                // with operand SSA names and the re-parser rejects two block
-                // args with the same name. We sidestep that by emitting an
-                // equivalent loop of unicast SemaphoreInc calls.
-                //
-                // The two forms are observable-equivalent inside the gather
-                // protocol: collectorDone is zero-initialized, reset on each
-                // source's wait, and only ever published with value 1, so
-                // "set everyone in the group to 1" and "inc each group core's
-                // semaphore by 1" land on the same observed state. The
-                // unicast incs on cores other than the collector unblock the
-                // sources; the inc on the collector itself is harmless because
-                // the collector does not wait on collectorDone.
+                // collectorDone fan-out. The general case is a single mcast
+                // SemaphoreSet over the group rectangle. We fall back to a
+                // loop of unicast SemaphoreInc on statically-degenerate
+                // group shapes (1xN, Nx1, 1x1) because the downstream
+                // get_noc_multicast_addr lowering folds start/end coords on
+                // a degenerate axis to the same SSA, which the emitc.expression
+                // printer cannot round-trip. The two forms are observable-
+                // equivalent: collectorDone is zero-initialized, reset on each
+                // source's wait, and only ever published with value 1.
                 std::optional<int64_t> staticShapeY =
                     getConstantIntValue(groupShape[0]);
                 std::optional<int64_t> staticShapeX =
@@ -497,13 +434,9 @@ public:
                 bool yIsOne = staticShapeY && *staticShapeY == 1;
                 bool xIsOne = staticShapeX && *staticShapeX == 1;
                 if (yIsOne && xIsOne) {
-                  // 1×1: a single unicast inc to the (only) group core, which
-                  // is the collector itself.
                   builder.create<SemaphoreIncOp>(loc, collectorDone, one,
                                                  physGroupStart);
                 } else if (yIsOne || xIsOne) {
-                  // 1×N or N×1: walk the non-degenerate axis and emit one
-                  // unicast inc per group core.
                   Value lb = yIsOne ? groupStart[1] : groupStart[0];
                   Value ub = yIsOne ? endX : endY;
                   bool axisIsX = yIsOne;
@@ -522,29 +455,20 @@ public:
                         incBuilder.create<scf::YieldOp>(incLoc);
                       });
                 } else {
-                  // ≥2×≥2 (or fully dynamic): single mcast SET. Note that the
-                  // dynamic case can still hit the duplicate-operand bug if at
-                  // runtime an axis is 1, but in our pipeline group shapes are
-                  // typically constant; treat that as a follow-up.
                   builder.create<SemaphoreSetOp>(
                       loc, collectorDone, one, physGroupStart, groupShape,
                       /*startDevice=*/ValueRange(),
                       /*deviceMcastShape=*/ValueRange());
                 }
 
-                // After all reads are complete and the collector-done multicast
-                // has been issued, push the dst CB so the downstream compute
-                // thread on the collector can wait/pop it. Non-collector cores
-                // never reach this PushOp (option (c)).
                 if (dstCb) {
                   builder.create<PushOp>(loc, dstCb);
                 }
-
                 builder.create<scf::YieldOp>(loc);
               },
               [&](OpBuilder &builder, Location loc) {
-                // Source branch: signal collector that we are ready, then
-                // wait until the collector has finished pulling us.
+                // Source: signal the collector we are ready, then wait
+                // until it has pulled us.
                 builder.create<SemaphoreIncOp>(loc, sourceReady, one,
                                                physCollector);
                 builder.create<SemaphoreWaitOp>(loc, collectorDone, one, zero);
@@ -553,10 +477,9 @@ public:
           groupBuilder.create<scf::YieldOp>(groupLoc);
         });
 
-    // Release the src CB on every group core (consumer-side pop). Safe
-    // after the if/else because the collector has finished all DMA reads
-    // by the end of its branch and source cores have waited on
-    // collectorDone before reaching this point.
+    // src CB pop on every group core: safe here because both branches have
+    // completed (collector finished its reads, sources waited on
+    // collectorDone).
     if (srcCb) {
       rewriter.create<PopOp>(loc, srcCb);
     }

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -362,9 +363,9 @@ public:
     // Pre-compute physical coordinates we need across the branches:
     // - physGroupStart: start of the multicast region for collectorDone.
     // - physCollector: target of source-side semaphore_inc.
-    SmallVector<Value> physGroupStart = mapVirtualToPhysicalCoreIndex(
+    SmallVector<Value> physGroupStart = utils::mapVirtualToPhysicalCoreIndex(
         rewriter, loc, genericOp.getGrid(), groupStart);
-    SmallVector<Value> physCollector = mapVirtualToPhysicalCoreIndex(
+    SmallVector<Value> physCollector = utils::mapVirtualToPhysicalCoreIndex(
         rewriter, loc, genericOp.getGrid(), collectorIdx);
 
     rewriter.create<scf::IfOp>(
@@ -394,9 +395,9 @@ public:
                     [&](OpBuilder &xBuilder, Location xLoc, Value srcX,
                         ValueRange) {
                       SmallVector<Value> physSrc =
-                          mapVirtualToPhysicalCoreIndex(xBuilder, xLoc,
-                                                        genericOp.getGrid(),
-                                                        {srcY, srcX});
+                          utils::mapVirtualToPhysicalCoreIndex(
+                              xBuilder, xLoc, genericOp.getGrid(),
+                              {srcY, srcX});
                       // Shard-level dma_read: read the entire src shard
                       // from core[physSrc] into dst on the current core.
                       // The expansion to fully indexed form (and the

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -270,17 +270,47 @@ public:
     Location loc = gather.getLoc();
 
     // Tensors should have been bufferized by the time this pass runs.
-    if (!mlir::isa<MemRefType>(gather.getSrc().getType()) ||
-        !mlir::isa<MemRefType>(gather.getDst().getType())) {
+    // Either implicit memref form (both $src and $dst are memrefs) or
+    // explicit CB form (both $srcCb and $dstCb are CBs) is acceptable.
+    auto isMemRefOrAbsent = [](Value v) {
+      return !v || mlir::isa<MemRefType>(v.getType());
+    };
+    if (!isMemRefOrAbsent(gather.getSrc()) ||
+        !isMemRefOrAbsent(gather.getDst())) {
       return rewriter.notifyMatchFailure(
-          gather, "src and dst must be memrefs at this stage in the pipeline");
+          gather,
+          "implicit-form src and dst must be memrefs at this stage in the "
+          "pipeline (tensors should have been bufferized)");
+    }
+    if (gather.getSrcCb() &&
+        !gather.getSrcCbType().getUnderlyingAs<MemRefType>()) {
+      return rewriter.notifyMatchFailure(
+          gather, "srcCb must have memref underlying type");
+    }
+    if (gather.getDstCb() &&
+        !gather.getDstCbType().getUnderlyingAs<MemRefType>()) {
+      return rewriter.notifyMatchFailure(
+          gather, "dstCb must have memref underlying type");
     }
 
     auto genericOp = gather->getParentOfType<GenericOp>();
     TT_assertv(genericOp, "GatherCoreOp must be inside a GenericOp");
 
+    // Unwrap src: in CB form, materialize the underlying memref via a
+    // WaitOp on every group core (consumer-side handshake with the
+    // upstream compute thread, which has produced via PushOp). The same
+    // local memref is then used by both the collector (for its local
+    // self-read) and by the cross-core DMA reads (the L1 address is the
+    // uniform invariant). PopOp is emitted after the whole scf.if; by
+    // then the collector has done all reads and the source cores have
+    // waited on collectorDone.
     Value src = gather.getSrc();
+    Value srcCb = gather.getSrcCb();
+    if (srcCb) {
+      src = rewriter.create<WaitOp>(loc, srcCb).getResult();
+    }
     Value dst = gather.getDst();
+    Value dstCb = gather.getDstCb();
     ValueRange groupStart = gather.getGroupStartIndex();
     ValueRange groupShape = gather.getGroupShape();
     ValueRange collectorIdx = gather.getCollectorIndex();
@@ -342,6 +372,15 @@ public:
         [&](OpBuilder &builder, Location loc) {
           // Collector branch: wait for sources, pull each source's payload,
           // signal the entire group.
+
+          // Unwrap dst CB inside the collector branch only (option (c)):
+          // the dst CB is allocated on every core but only the collector
+          // performs the reserve/push.
+          Value dstLocal = dst;
+          if (dstCb) {
+            dstLocal = builder.create<ReserveOp>(loc, dstCb).getResult();
+          }
+
           builder.create<SemaphoreWaitOp>(loc, sourceReady, numSources, zero);
 
           // Row-major iteration over the gather group. The collector's own
@@ -364,7 +403,7 @@ public:
                       // srcCore-aware NoC lowering) is handled by the
                       // downstream passes.
                       Value tx = xBuilder.create<DMAReadOp>(
-                          xLoc, src, /*srcIndices=*/ValueRange(), dst,
+                          xLoc, src, /*srcIndices=*/ValueRange(), dstLocal,
                           /*srcCore=*/ValueRange(physSrc));
                       xBuilder.create<DMAWaitOp>(xLoc, tx);
                       xBuilder.create<scf::YieldOp>(xLoc);
@@ -380,6 +419,14 @@ public:
                                          /*startDevice=*/ValueRange(),
                                          /*deviceMcastShape=*/ValueRange());
 
+          // After all reads are complete and the collector-done multicast
+          // has been issued, push the dst CB so the downstream compute
+          // thread on the collector can wait/pop it. Non-collector cores
+          // never reach this PushOp (option (c)).
+          if (dstCb) {
+            builder.create<PushOp>(loc, dstCb);
+          }
+
           builder.create<scf::YieldOp>(loc);
         },
         [&](OpBuilder &builder, Location loc) {
@@ -389,6 +436,14 @@ public:
           builder.create<SemaphoreWaitOp>(loc, collectorDone, one, zero);
           builder.create<scf::YieldOp>(loc);
         });
+
+    // Release the src CB on every group core (consumer-side pop). Safe
+    // after the if/else because the collector has finished all DMA reads
+    // by the end of its branch and source cores have waited on
+    // collectorDone before reaching this point.
+    if (srcCb) {
+      rewriter.create<PopOp>(loc, srcCb);
+    }
 
     rewriter.eraseOp(gather);
     return success();

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -261,6 +261,140 @@ public:
   }
 };
 
+class D2MLowerGatherCoreRewritePattern : public OpRewritePattern<GatherCoreOp> {
+public:
+  using OpRewritePattern<GatherCoreOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(GatherCoreOp gather,
+                                PatternRewriter &rewriter) const final {
+    Location loc = gather.getLoc();
+
+    // Tensors should have been bufferized by the time this pass runs.
+    if (!mlir::isa<MemRefType>(gather.getSrc().getType()) ||
+        !mlir::isa<MemRefType>(gather.getDst().getType())) {
+      return rewriter.notifyMatchFailure(
+          gather, "src and dst must be memrefs at this stage in the pipeline");
+    }
+
+    auto genericOp = gather->getParentOfType<GenericOp>();
+    TT_assertv(genericOp, "GatherCoreOp must be inside a GenericOp");
+
+    Value src = gather.getSrc();
+    Value dst = gather.getDst();
+    ValueRange groupStart = gather.getGroupStartIndex();
+    ValueRange groupShape = gather.getGroupShape();
+    ValueRange collectorIdx = gather.getCollectorIndex();
+    TT_assertv((groupStart.size() == 2 && groupShape.size() == 2 &&
+                collectorIdx.size() == 2),
+               "GatherCoreOp must have 2D group / collector indices (V1)");
+
+    // Pre-allocated semaphores: sourceReady (sources -> collector) and
+    // collectorDone (collector -> sources). The same attribute scheme is
+    // used as for mcast remote loads, so getPreallocatedSemaphores works
+    // verbatim.
+    auto preallocatedSems = getPreallocatedSemaphores(gather);
+    Value sourceReady = preallocatedSems.first;
+    Value collectorDone = preallocatedSems.second;
+
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexType(), rewriter.getIndexAttr(0));
+    Value one = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexType(),
+                                                   rewriter.getIndexAttr(1));
+
+    // numSources = (groupShape[0] * groupShape[1]) - 1. The collector does
+    // not signal sourceReady on itself; mirrors the mcast lowering where
+    // the sender does not signal receiversReady on itself.
+    Value groupVolume =
+        rewriter.create<arith::MulIOp>(loc, groupShape[0], groupShape[1]);
+    Value numSources = rewriter.create<arith::SubIOp>(loc, groupVolume, one);
+
+    // Inner-loop bounds: end = start + size on each axis.
+    Value endY =
+        rewriter.create<arith::AddIOp>(loc, groupStart[0], groupShape[0]);
+    Value endX =
+        rewriter.create<arith::AddIOp>(loc, groupStart[1], groupShape[1]);
+
+    // isCollector: virtual core index == collectorIdx on every axis.
+    AffineMap gridMapping = genericOp.getGrid().getPhysicalToVirtMap();
+    Value isCollector;
+    for (auto [i, collIdx] : llvm::enumerate(collectorIdx)) {
+      Value coreIdx = rewriter.create<CoreIndexOp>(loc, static_cast<int64_t>(i),
+                                                   gridMapping);
+      Value cond = rewriter.create<arith::CmpIOp>(loc, rewriter.getI1Type(),
+                                                  arith::CmpIPredicate::eq,
+                                                  coreIdx, collIdx);
+      isCollector = isCollector
+                        ? rewriter.create<arith::AndIOp>(loc, isCollector, cond)
+                              .getResult()
+                        : cond;
+    }
+
+    // Pre-compute physical coordinates we need across the branches:
+    // - physGroupStart: start of the multicast region for collectorDone.
+    // - physCollector: target of source-side semaphore_inc.
+    SmallVector<Value> physGroupStart = mapVirtualToPhysicalCoreIndex(
+        rewriter, loc, genericOp.getGrid(), groupStart);
+    SmallVector<Value> physCollector = mapVirtualToPhysicalCoreIndex(
+        rewriter, loc, genericOp.getGrid(), collectorIdx);
+
+    rewriter.create<scf::IfOp>(
+        loc, isCollector,
+        [&](OpBuilder &builder, Location loc) {
+          // Collector branch: wait for sources, pull each source's payload,
+          // signal the entire group.
+          builder.create<SemaphoreWaitOp>(loc, sourceReady, numSources, zero);
+
+          // Row-major iteration over the gather group. The collector's own
+          // coordinate is included; the resulting "self read" is correct
+          // (just slightly inefficient) and avoids an inner-loop branch.
+          builder.create<scf::ForOp>(
+              loc, groupStart[0], endY, one, ValueRange(),
+              [&](OpBuilder &yBuilder, Location yLoc, Value srcY, ValueRange) {
+                yBuilder.create<scf::ForOp>(
+                    yLoc, groupStart[1], endX, one, ValueRange(),
+                    [&](OpBuilder &xBuilder, Location xLoc, Value srcX,
+                        ValueRange) {
+                      SmallVector<Value> physSrc =
+                          mapVirtualToPhysicalCoreIndex(xBuilder, xLoc,
+                                                        genericOp.getGrid(),
+                                                        {srcY, srcX});
+                      // Shard-level dma_read: read the entire src shard
+                      // from core[physSrc] into dst on the current core.
+                      // The expansion to fully indexed form (and the
+                      // srcCore-aware NoC lowering) is handled by the
+                      // downstream passes.
+                      Value tx = xBuilder.create<DMAReadOp>(
+                          xLoc, src, /*srcIndices=*/ValueRange(), dst,
+                          /*srcCore=*/ValueRange(physSrc));
+                      xBuilder.create<DMAWaitOp>(xLoc, tx);
+                      xBuilder.create<scf::YieldOp>(xLoc);
+                    });
+                yBuilder.create<scf::YieldOp>(yLoc);
+              });
+
+          // Signal collector-done to every core in the group. The collector
+          // itself is in this multicast region but does not wait on the
+          // semaphore.
+          builder.create<SemaphoreSetOp>(loc, collectorDone, one,
+                                         physGroupStart, groupShape,
+                                         /*startDevice=*/ValueRange(),
+                                         /*deviceMcastShape=*/ValueRange());
+
+          builder.create<scf::YieldOp>(loc);
+        },
+        [&](OpBuilder &builder, Location loc) {
+          // Source branch: signal collector that we are ready, then wait
+          // until the collector has finished pulling us.
+          builder.create<SemaphoreIncOp>(loc, sourceReady, one, physCollector);
+          builder.create<SemaphoreWaitOp>(loc, collectorDone, one, zero);
+          builder.create<scf::YieldOp>(loc);
+        });
+
+    rewriter.eraseOp(gather);
+    return success();
+  }
+};
+
 class D2MLowerDMACopyRewritePattern : public OpRewritePattern<LocalCopyOp> {
 public:
   using OpRewritePattern<LocalCopyOp>::OpRewritePattern;
@@ -303,6 +437,7 @@ public:
     patterns.add<D2MLowerRemoteLoadRewritePattern>(&getContext());
     patterns.add<D2MLowerRemoteStoreRewritePattern>(&getContext());
     patterns.add<D2MLowerDMACopyRewritePattern>(&getContext());
+    patterns.add<D2MLowerGatherCoreRewritePattern>(&getContext());
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }

--- a/lib/Dialect/D2M/Transforms/PreallocateMcastSemaphores.cpp
+++ b/lib/Dialect/D2M/Transforms/PreallocateMcastSemaphores.cpp
@@ -18,7 +18,8 @@ namespace mlir::tt::d2m {
 
 namespace {
 
-// Attribute name for storing pre-allocated semaphore indices on RemoteLoadOp.
+// Attribute name for storing pre-allocated semaphore indices on a triggering
+// op (RemoteLoadOp with mcast, or GatherCoreOp).
 constexpr StringRef kPreallocatedSemaphoresAttr = "preallocated_semaphores";
 
 // Check if a RemoteLoadOp needs multicast semaphores.
@@ -28,19 +29,33 @@ static bool needsMcastSemaphores(RemoteLoadOp remoteLoad) {
          !remoteLoad.getMcastShape().empty();
 }
 
-// Recursively collect all RemoteLoadOps that need multicast semaphores.
-static void collectMcastRemoteLoads(Block *block,
-                                    SmallVectorImpl<RemoteLoadOp> &mcastLoads) {
+// Returns true if this op needs a local semaphore pair preallocated by this
+// pass. Currently: multicast RemoteLoadOp and any GatherCoreOp.
+static bool needsLocalSemaphorePair(Operation *op) {
+  if (auto remoteLoad = mlir::dyn_cast<RemoteLoadOp>(op)) {
+    return needsMcastSemaphores(remoteLoad);
+  }
+  if (mlir::isa<GatherCoreOp>(op)) {
+    return true;
+  }
+  return false;
+}
+
+// Recursively collect all ops that need a local semaphore pair. RemoteLoadOps
+// with mcast and GatherCoreOps are processed uniformly: each gets two local
+// semaphores appended to the parent generic's additionalArgs. The exact
+// meaning of those two semaphores is op-specific (sender/receiver handshake
+// for mcast loads, source/collector handshake for gathers), but the storage
+// and indexing scheme is identical.
+static void collectSemaphoreOps(Block *block,
+                                SmallVectorImpl<Operation *> &semaphoreOps) {
   for (Operation &op : block->getOperations()) {
     if (auto forOp = mlir::dyn_cast<scf::ForOp>(&op)) {
-      collectMcastRemoteLoads(forOp.getBody(), mcastLoads);
+      collectSemaphoreOps(forOp.getBody(), semaphoreOps);
       continue;
     }
-
-    if (auto remoteLoad = mlir::dyn_cast<RemoteLoadOp>(&op)) {
-      if (needsMcastSemaphores(remoteLoad)) {
-        mcastLoads.push_back(remoteLoad);
-      }
+    if (needsLocalSemaphorePair(&op)) {
+      semaphoreOps.push_back(&op);
     }
   }
 }
@@ -60,37 +75,37 @@ public:
 
 private:
   void processGenericOp(IRRewriter &rewriter, GenericOp generic) {
-    // Skip if already processed (any RemoteLoadOp has the attribute).
+    // Skip if already processed (any matching op has the attribute).
     for (Region &region : generic->getRegions()) {
       if (region.empty()) {
         continue;
       }
-      SmallVector<RemoteLoadOp> mcastLoads;
-      collectMcastRemoteLoads(&region.front(), mcastLoads);
-      for (RemoteLoadOp load : mcastLoads) {
-        if (load->hasAttr(kPreallocatedSemaphoresAttr)) {
+      SmallVector<Operation *> semaphoreOps;
+      collectSemaphoreOps(&region.front(), semaphoreOps);
+      for (Operation *op : semaphoreOps) {
+        if (op->hasAttr(kPreallocatedSemaphoresAttr)) {
           return;
         }
       }
     }
 
-    // Find all RemoteLoadOps that need multicast semaphores.
-    SmallVector<RemoteLoadOp> allMcastLoads;
+    // Collect all ops in this generic that need a semaphore pair.
+    SmallVector<Operation *> allSemaphoreOps;
     for (Region &region : generic->getRegions()) {
       if (region.empty()) {
         continue;
       }
-      collectMcastRemoteLoads(&region.front(), allMcastLoads);
+      collectSemaphoreOps(&region.front(), allSemaphoreOps);
     }
 
-    if (allMcastLoads.empty()) {
+    if (allSemaphoreOps.empty()) {
       return;
     }
 
     Location loc = generic.getLoc();
     LocalSemaphoreType semType = rewriter.getType<LocalSemaphoreType>();
 
-    for (RemoteLoadOp load : allMcastLoads) {
+    for (Operation *op : allSemaphoreOps) {
       unsigned argsIdx = generic.getNumOperands();
       int64_t sem0AbsIdx = static_cast<int64_t>(argsIdx);
       int64_t sem1AbsIdx = sem0AbsIdx + 1;
@@ -107,8 +122,8 @@ private:
       generic.getAdditionalArgsMutable().append(sem0.getResult());
       generic.getAdditionalArgsMutable().append(sem1.getResult());
 
-      load->setAttr(kPreallocatedSemaphoresAttr,
-                    rewriter.getI64ArrayAttr({sem0AbsIdx, sem1AbsIdx}));
+      op->setAttr(kPreallocatedSemaphoresAttr,
+                  rewriter.getI64ArrayAttr({sem0AbsIdx, sem1AbsIdx}));
     }
   }
 };

--- a/lib/Dialect/D2M/Transforms/PreallocateMcastSemaphores.cpp
+++ b/lib/Dialect/D2M/Transforms/PreallocateMcastSemaphores.cpp
@@ -29,24 +29,16 @@ static bool needsMcastSemaphores(RemoteLoadOp remoteLoad) {
          !remoteLoad.getMcastShape().empty();
 }
 
-// Returns true if this op needs a local semaphore pair preallocated by this
-// pass. Currently: multicast RemoteLoadOp and any GatherCoreOp.
+// Returns true for ops that need a fresh pair of local semaphores allocated
+// on the parent generic. Multicast RemoteLoadOp uses them as a sender/
+// receiver handshake; GatherCoreOp as a source/collector handshake.
 static bool needsLocalSemaphorePair(Operation *op) {
   if (auto remoteLoad = mlir::dyn_cast<RemoteLoadOp>(op)) {
     return needsMcastSemaphores(remoteLoad);
   }
-  if (mlir::isa<GatherCoreOp>(op)) {
-    return true;
-  }
-  return false;
+  return mlir::isa<GatherCoreOp>(op);
 }
 
-// Recursively collect all ops that need a local semaphore pair. RemoteLoadOps
-// with mcast and GatherCoreOps are processed uniformly: each gets two local
-// semaphores appended to the parent generic's additionalArgs. The exact
-// meaning of those two semaphores is op-specific (sender/receiver handshake
-// for mcast loads, source/collector handshake for gathers), but the storage
-// and indexing scheme is identical.
 static void collectSemaphoreOps(Block *block,
                                 SmallVectorImpl<Operation *> &semaphoreOps) {
   for (Operation &op : block->getOperations()) {

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -240,11 +240,8 @@ static LogicalResult processSharedBufferPairs(
     Block *computeBlock, PatternRewriter &rewriter,
     llvm::DenseMap<Value, utils::CBUsageInfo> &cbUsageInfo) {
   for (auto [localBuffer, usageInfo] : cbUsageInfo) {
-    // Stale entries can appear here: DM-thread synchronizable ops (e.g.
-    // gather_core) are cloned into the compute region by SplitUnifiedThread
-    // before the dead-op cleanup runs, so their operands surface in the
-    // compute-region cbUsageInfo without a matching compute-side pair.
-    // Skip such entries; the real DM-side handling happens elsewhere.
+    // Skip non-paired entries (e.g. DM-thread sync ops like gather_core
+    // cloned into the compute region before dead-op cleanup).
     if (usageInfo.producers.size() != 1 || usageInfo.consumers.size() != 1) {
       continue;
     }
@@ -305,11 +302,8 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
               synchronizedOp->getParentOfType<GenericOp>().getOperandIndex(
                   localBuffer);
 
-          // get the associated producer for this operand
-          // Assumes only one producer for this local buffer. Skip if the
-          // cbUsageInfo entry isn't a clean producer-consumer pair (can
-          // happen when cloned DM-thread sync ops are still in the
-          // compute region during this analysis).
+          // Skip non-paired entries (e.g. cloned DM-thread sync ops still
+          // visible in the compute region during this analysis).
           if (cbUsageInfo[localBuffer].producers.size() != 1 ||
               cbUsageInfo[localBuffer].consumers.size() != 1) {
             continue;
@@ -345,9 +339,7 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
               synchronizedOp->getParentOfType<GenericOp>().getOperandIndex(
                   localBuffer);
 
-          // Get the associated consumer for this operand.
-          // Assumes only one consumer for this local buffer. Skip if the
-          // cbUsageInfo entry isn't a clean producer-consumer pair.
+          // Skip non-paired entries (see processSharedBufferPairs).
           if (cbUsageInfo[localBuffer].producers.size() != 1 ||
               cbUsageInfo[localBuffer].consumers.size() != 1) {
             continue;
@@ -389,8 +381,7 @@ static LogicalResult eraseAliasedLoadStoreOps(
     PatternRewriter &rewriter,
     llvm::DenseMap<Value, utils::CBUsageInfo> &cbUsageInfo) {
   for (auto [localBuffer, usageInfo] : cbUsageInfo) {
-    // Skip entries that aren't clean producer-consumer pairs (defensive
-    // against stale entries from cross-region cloning).
+    // Skip non-paired entries (see processSharedBufferPairs).
     if (usageInfo.producers.size() != 1 || usageInfo.consumers.size() != 1) {
       continue;
     }
@@ -408,10 +399,9 @@ static LogicalResult eraseAliasedLoadStoreOps(
   return success();
 }
 
-// Returns true if `value` is a regular operand of `generic`. Unlike
-// `GenericOp::getOperandIndex`, this does not assert when the value is
-// absent. Used to gate buffer-to-CB conversion: only generic operands
-// (which have associated CB ports) can be converted via `getOrCreateCB`.
+// Returns true if `value` is a regular operand of `generic`. Used to gate
+// buffer-to-CB conversion (only generic operands carry CB ports);
+// `getOperandIndex` would assert if the value is not an operand.
 static bool isGenericOperand(GenericOp generic, Value value) {
   for (unsigned i = 0, e = generic.getNumOperands(); i < e; ++i) {
     if (generic.getOperand(i) == value) {
@@ -509,13 +499,10 @@ static LogicalResult convertDMAToExplicitCBForm(Block *dmBlock,
     rewriter.eraseOp(copyOp);
   }
 
-  // Convert implicit-form gather_core ops to explicit CB form, per side.
-  // Each side is converted independently: if a side's implicit operand is
-  // a generic operand of the parent generic (and therefore has an
-  // associated CB port), it becomes a `!d2m.cb<memref<...>>`; otherwise it
-  // is left as-is (typically a scratch alloc inside the DM block, which
-  // does not have a CB association at this stage). All four resulting
-  // forms are accepted by the verifier and the downstream lowering.
+  // gather_core: per-side conversion to explicit CB form. A side becomes
+  // a `!d2m.cb<...>` only when its implicit operand is a generic operand
+  // (i.e. it carries a CB port). Scratch allocs inside the DM block stay
+  // as memrefs.
   for (GatherCoreOp gatherOp : gathers) {
     GenericOp parentGeneric = gatherOp->getParentOfType<GenericOp>();
     Value src = gatherOp.getSrc();
@@ -549,8 +536,7 @@ static LogicalResult convertDMAToExplicitCBForm(Block *dmBlock,
         gatherOp.getLoc(), /*result=*/Type{}, newSrc, newDst, newSrcCb,
         newDstCb, gatherOp.getGroupStartIndex(), gatherOp.getGroupShape(),
         gatherOp.getCollectorIndex());
-    // Preserve preallocated semaphore indices set by
-    // D2MPreallocateMcastSemaphores (needed by LowerLoadStoreOpsToDMA).
+    // Preserve preallocated_semaphores so LowerLoadStoreOpsToDMA can find it.
     if (auto semAttr = gatherOp->getAttr("preallocated_semaphores")) {
       newGather->setAttr("preallocated_semaphores", semAttr);
     }
@@ -577,9 +563,8 @@ static void collectOpsToErase(Block *block, DenseSet<Operation *> &eraseSet,
       continue;
     }
 
-    // Datamovement-thread ops: shard-level DMA ops, the device-synchronize
-    // op, and gather_core (which is not a ShardDMAOpInterface op but lives
-    // exclusively in the DM thread).
+    // DM-thread-only ops: shard-level DMA, device-synchronize, and
+    // gather_core (lives in the DM thread but is not a ShardDMAOpInterface).
     bool isDMAOp =
         isa<ShardDMAOpInterface, DeviceSynchronizeOp, GatherCoreOp>(&op);
     bool isReplicated = isa<SemaphoreWaitOp>(&op);

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -240,8 +240,14 @@ static LogicalResult processSharedBufferPairs(
     Block *computeBlock, PatternRewriter &rewriter,
     llvm::DenseMap<Value, utils::CBUsageInfo> &cbUsageInfo) {
   for (auto [localBuffer, usageInfo] : cbUsageInfo) {
-    assert(usageInfo.producers.size() == 1 && usageInfo.consumers.size() == 1 &&
-           "Expected exactly one producer and one consumer for CB");
+    // Stale entries can appear here: DM-thread synchronizable ops (e.g.
+    // gather_core) are cloned into the compute region by SplitUnifiedThread
+    // before the dead-op cleanup runs, so their operands surface in the
+    // compute-region cbUsageInfo without a matching compute-side pair.
+    // Skip such entries; the real DM-side handling happens elsewhere.
+    if (usageInfo.producers.size() != 1 || usageInfo.consumers.size() != 1) {
+      continue;
+    }
     auto *producer = usageInfo.producers.front();
     auto *consumer = usageInfo.consumers.front();
 
@@ -300,10 +306,14 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
                   localBuffer);
 
           // get the associated producer for this operand
-          // Assumes only one producer for this local buffer
-          assert(cbUsageInfo[localBuffer].producers.size() == 1 &&
-                 cbUsageInfo[localBuffer].consumers.size() == 1 &&
-                 "Expected exactly one producer and one consumer for CB");
+          // Assumes only one producer for this local buffer. Skip if the
+          // cbUsageInfo entry isn't a clean producer-consumer pair (can
+          // happen when cloned DM-thread sync ops are still in the
+          // compute region during this analysis).
+          if (cbUsageInfo[localBuffer].producers.size() != 1 ||
+              cbUsageInfo[localBuffer].consumers.size() != 1) {
+            continue;
+          }
           auto *associatedProducer = cbUsageInfo[localBuffer].producers.front();
           rewriter.setInsertionPoint(synchronizedOp);
           auto cb = d2m::getOrCreateCB(
@@ -336,10 +346,12 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
                   localBuffer);
 
           // Get the associated consumer for this operand.
-          // Assumes only one consumer for this local buffer
-          assert(cbUsageInfo[localBuffer].consumers.size() == 1 &&
-                 cbUsageInfo[localBuffer].producers.size() == 1 &&
-                 "Expected exactly one producer and one consumer for CB");
+          // Assumes only one consumer for this local buffer. Skip if the
+          // cbUsageInfo entry isn't a clean producer-consumer pair.
+          if (cbUsageInfo[localBuffer].producers.size() != 1 ||
+              cbUsageInfo[localBuffer].consumers.size() != 1) {
+            continue;
+          }
           auto *associatedConsumer = cbUsageInfo[localBuffer].consumers.front();
           rewriter.setInsertionPoint(synchronizedOp);
           auto cb = d2m::getOrCreateCB(
@@ -377,8 +389,11 @@ static LogicalResult eraseAliasedLoadStoreOps(
     PatternRewriter &rewriter,
     llvm::DenseMap<Value, utils::CBUsageInfo> &cbUsageInfo) {
   for (auto [localBuffer, usageInfo] : cbUsageInfo) {
-    assert(usageInfo.producers.size() == 1 && usageInfo.consumers.size() == 1 &&
-           "Expected exactly one producer and one consumer for CB");
+    // Skip entries that aren't clean producer-consumer pairs (defensive
+    // against stale entries from cross-region cloning).
+    if (usageInfo.producers.size() != 1 || usageInfo.consumers.size() != 1) {
+      continue;
+    }
     auto *producer = usageInfo.producers.front();
     auto *consumer = usageInfo.consumers.front();
 
@@ -393,6 +408,19 @@ static LogicalResult eraseAliasedLoadStoreOps(
   return success();
 }
 
+// Returns true if `value` is a regular operand of `generic`. Unlike
+// `GenericOp::getOperandIndex`, this does not assert when the value is
+// absent. Used to gate buffer-to-CB conversion: only generic operands
+// (which have associated CB ports) can be converted via `getOrCreateCB`.
+static bool isGenericOperand(GenericOp generic, Value value) {
+  for (unsigned i = 0, e = generic.getNumOperands(); i < e; ++i) {
+    if (generic.getOperand(i) == value) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Convert remote_load/store to explicit CB form in the DMA thread.
 // Aliased ops are collected for deferred erasure (no DMA needed). Shared
 // buffer pairs use the output operand's CB for both ops.
@@ -401,9 +429,11 @@ static LogicalResult convertDMAToExplicitCBForm(Block *dmBlock,
   SmallVector<RemoteLoadOp> loads;
   SmallVector<RemoteStoreOp> stores;
   SmallVector<LocalCopyOp> localCopies;
+  SmallVector<GatherCoreOp> gathers;
   dmBlock->walk([&](RemoteLoadOp op) { loads.push_back(op); });
   dmBlock->walk([&](RemoteStoreOp op) { stores.push_back(op); });
   dmBlock->walk([&](LocalCopyOp op) { localCopies.push_back(op); });
+  dmBlock->walk([&](GatherCoreOp op) { gathers.push_back(op); });
 
   for (RemoteLoadOp loadOp : loads) {
     if (loadOp.isExplicitCBForm()) {
@@ -479,6 +509,55 @@ static LogicalResult convertDMAToExplicitCBForm(Block *dmBlock,
     rewriter.eraseOp(copyOp);
   }
 
+  // Convert implicit-form gather_core ops to explicit CB form, per side.
+  // Each side is converted independently: if a side's implicit operand is
+  // a generic operand of the parent generic (and therefore has an
+  // associated CB port), it becomes a `!d2m.cb<memref<...>>`; otherwise it
+  // is left as-is (typically a scratch alloc inside the DM block, which
+  // does not have a CB association at this stage). All four resulting
+  // forms are accepted by the verifier and the downstream lowering.
+  for (GatherCoreOp gatherOp : gathers) {
+    GenericOp parentGeneric = gatherOp->getParentOfType<GenericOp>();
+    Value src = gatherOp.getSrc();
+    Value dst = gatherOp.getDst();
+
+    bool convertSrc =
+        src && !gatherOp.getSrcCb() && isGenericOperand(parentGeneric, src);
+    bool convertDst =
+        dst && !gatherOp.getDstCb() && isGenericOperand(parentGeneric, dst);
+    if (!convertSrc && !convertDst) {
+      continue;
+    }
+
+    rewriter.setInsertionPoint(gatherOp);
+    Value newSrc = src;
+    Value newSrcCb = gatherOp.getSrcCb();
+    if (convertSrc) {
+      newSrcCb = d2m::getOrCreateCB(rewriter, parentGeneric, dmBlock,
+                                    parentGeneric.getOperandIndex(src));
+      newSrc = Value{};
+    }
+    Value newDst = dst;
+    Value newDstCb = gatherOp.getDstCb();
+    if (convertDst) {
+      newDstCb = d2m::getOrCreateCB(rewriter, parentGeneric, dmBlock,
+                                    parentGeneric.getOperandIndex(dst));
+      newDst = Value{};
+    }
+
+    auto newGather = rewriter.create<GatherCoreOp>(
+        gatherOp.getLoc(), /*result=*/Type{}, newSrc, newDst, newSrcCb,
+        newDstCb, gatherOp.getGroupStartIndex(), gatherOp.getGroupShape(),
+        gatherOp.getCollectorIndex());
+    // Preserve preallocated semaphore indices set by
+    // D2MPreallocateMcastSemaphores (needed by LowerLoadStoreOpsToDMA).
+    if (auto semAttr = gatherOp->getAttr("preallocated_semaphores")) {
+      newGather->setAttr("preallocated_semaphores", semAttr);
+    }
+    gatherOp->dropAllUses();
+    rewriter.eraseOp(gatherOp);
+  }
+
   return success();
 }
 
@@ -498,7 +577,11 @@ static void collectOpsToErase(Block *block, DenseSet<Operation *> &eraseSet,
       continue;
     }
 
-    bool isDMAOp = isa<ShardDMAOpInterface, DeviceSynchronizeOp>(&op);
+    // Datamovement-thread ops: shard-level DMA ops, the device-synchronize
+    // op, and gather_core (which is not a ShardDMAOpInterface op but lives
+    // exclusively in the DM thread).
+    bool isDMAOp =
+        isa<ShardDMAOpInterface, DeviceSynchronizeOp, GatherCoreOp>(&op);
     bool isReplicated = isa<SemaphoreWaitOp>(&op);
 
     if (isDatamovementThread && !isDMAOp && !isReplicated) {

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -992,9 +992,8 @@ SmallVector<Value> mapVirtualToPhysicalCoreIndex(OpBuilder &builder,
   TT_assertv(map.getNumDims() == virtualCoreIndex.size(),
              "Expected virtual-to-physical grid map input rank to match core "
              "index rank.");
-  // The map may either return purely core coordinates, or a leading device
-  // result followed by core coordinates. Skip the device result in the
-  // latter case.
+  // Maps that include a leading device result expose
+  // {device, coreY, coreX, ...}; skip the device result if present.
   unsigned firstCoreResult =
       map.getNumResults() == virtualCoreIndex.size() ? 0 : 1;
   TT_assertv(map.getNumResults() >= firstCoreResult + virtualCoreIndex.size(),

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -14,6 +14,7 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Utils.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/IR/AffineExpr.h"
 
@@ -977,6 +978,39 @@ getNocElementAlignment(Operation *op, ttcore::MemorySpace memorySpace,
 int32_t getNocElementAlignmentL1(
     Operation *op, const std::variant<RankedTensorType, MemRefType> &type) {
   return getNocElementAlignment(op, ttcore::MemorySpace::DeviceL1, type);
+}
+
+SmallVector<Value> mapVirtualToPhysicalCoreIndex(OpBuilder &builder,
+                                                 Location loc,
+                                                 ttcore::GridAttr grid,
+                                                 ValueRange virtualCoreIndex) {
+  AffineMap map = grid.getVirtToPhysicalMap();
+  if (!map || map.isEmpty()) {
+    return SmallVector<Value>(virtualCoreIndex.begin(), virtualCoreIndex.end());
+  }
+
+  TT_assertv(map.getNumDims() == virtualCoreIndex.size(),
+             "Expected virtual-to-physical grid map input rank to match core "
+             "index rank.");
+  // The map may either return purely core coordinates, or a leading device
+  // result followed by core coordinates. Skip the device result in the
+  // latter case.
+  unsigned firstCoreResult =
+      map.getNumResults() == virtualCoreIndex.size() ? 0 : 1;
+  TT_assertv(map.getNumResults() >= firstCoreResult + virtualCoreIndex.size(),
+             "Expected virtual-to-physical grid map to have enough core "
+             "coordinate results.");
+
+  SmallVector<Value> physicalCoreIndex;
+  physicalCoreIndex.reserve(virtualCoreIndex.size());
+  for (unsigned i = 0; i < virtualCoreIndex.size(); ++i) {
+    AffineMap selectedMap = AffineMap::get(
+        map.getNumDims(), map.getNumSymbols(),
+        {map.getResult(firstCoreResult + i)}, builder.getContext());
+    physicalCoreIndex.push_back(builder.create<affine::AffineApplyOp>(
+        loc, selectedMap, virtualCoreIndex));
+  }
+  return physicalCoreIndex;
 }
 
 } // namespace mlir::tt::d2m::utils

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form.mlir
@@ -150,6 +150,37 @@ module attributes {} {
     return
   }
 
+  // Test: Cross-core local-L1 shard-level read collapses to a single fully-indexed read.
+  // Both src and dst are local memrefs (no device layout); the only "remote"
+  // component is the explicit srcCore, which must be preserved verbatim on
+  // the rewritten op. numElems becomes the full shard volume (2*4 = 8 tiles).
+  // CHECK-LABEL: func.func @test_shard_level_read_cross_core
+  // CHECK-NOT: d2m.dma_read {{.*}}, <0>
+  func.func @test_shard_level_read_cross_core(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)  {
+    ^datamovement0:
+      %src = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      %dst = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      // CHECK: d2m.dma_read %{{.*}}[%{{.*}}] core[%{{.*}}, %{{.*}}], %{{.*}}[%{{.*}}], <8>
+      %tx = d2m.dma_read %src[] core[%c1, %c2], %dst, <0>
+            : (memref<2x4x!ttcore.tile<32x32, f32>, #l1>,
+               memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+      d2m.dma_wait %tx : !d2m.mem_tx<read>
+    }, {
+    ^compute0:
+    }
+    return
+  }
+
   // Test: Transposed src map breaks contiguity -> per-element DMA with coalescing=1.
   // CHECK-LABEL: func.func @test_local_copy_transposed_src
   func.func @test_local_copy_transposed_src() {

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form.mlir
@@ -150,10 +150,8 @@ module attributes {} {
     return
   }
 
-  // Test: Cross-core local-L1 shard-level read collapses to a single fully-indexed read.
-  // Both src and dst are local memrefs (no device layout); the only "remote"
-  // component is the explicit srcCore, which must be preserved verbatim on
-  // the rewritten op. numElems becomes the full shard volume (2*4 = 8 tiles).
+  // Cross-core local-L1 shard-level read collapses to a single fully-indexed
+  // read; srcCore is preserved, numElems becomes the shard volume (8 tiles).
   // CHECK-LABEL: func.func @test_shard_level_read_cross_core
   // CHECK-NOT: d2m.dma_read {{.*}}, <0>
   func.func @test_shard_level_read_cross_core(

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_gather_core_to_dma.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_gather_core_to_dma.mlir
@@ -1,0 +1,78 @@
+// RUN: ttmlir-opt --ttcore-register-device \
+// RUN:            --d2m-preallocate-mcast-semaphores \
+// RUN:            --d2m-lower-load-store-ops-to-dma %s | FileCheck %s
+
+// d2m.gather_core lowers (inside its hosting d2m.generic data-movement
+// region) to a collector/source handshake:
+//
+//   if isCollector:
+//     semaphore_wait %sourceReady,  numSources                      // sources signal in
+//     for sy in groupY:
+//       for sx in groupX:
+//         %tx = dma_read %src[] core[sy, sx], %dst, <0>             // shard-level read
+//         dma_wait %tx
+//     semaphore_set  %collectorDone, 1, core[groupStart] mcast[groupShape]
+//   else:
+//     semaphore_inc  %sourceReady,  1, core[collector]              // signal collector
+//     semaphore_wait %collectorDone, 1                              // wait for completion
+//
+// numSources = groupVolume - 1 because the collector does not signal itself
+// and pulls its own data via the self-iteration of the loop.
+
+#l1_ = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+
+module {
+  // Group: 1x4 starting at (0,0), collector at (0,0). groupVolume=4, so
+  // numSources = 3.
+  // CHECK-LABEL: func.func @test_lower_gather_core
+  // CHECK-NOT: d2m.gather_core
+  func.func @test_lower_gather_core(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)  {
+    ^datamovement0:
+      // CHECK: %[[SRC:.*]] = memref.alloc()
+      // CHECK: %[[DST:.*]] = memref.alloc()
+      %src = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %dst = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+
+      // isCollector = (core_index(0) == 0) && (core_index(1) == 0)
+      // CHECK: %[[Y:.*]] = d2m.core_index(0)
+      // CHECK: %[[YEQ:.*]] = arith.cmpi eq, %[[Y]],
+      // CHECK: %[[X:.*]] = d2m.core_index(1)
+      // CHECK: %[[XEQ:.*]] = arith.cmpi eq, %[[X]],
+      // CHECK: %[[IS_COLLECTOR:.*]] = arith.andi %[[YEQ]], %[[XEQ]]
+      // CHECK: scf.if %[[IS_COLLECTOR]] {
+      //   Collector branch.
+      //   numSources = groupVolume - 1 = 4 - 1 = 3.
+      //   CHECK:   d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
+      //   CHECK:   scf.for
+      //   CHECK:     scf.for %[[SX:.*]] =
+      //   CHECK:       %[[TX:.*]] = d2m.dma_read %[[SRC]][] core[%{{.*}}, %[[SX]]], %[[DST]], <0>
+      //   CHECK:       d2m.dma_wait %[[TX]]
+      //   CHECK:   d2m.semaphore_set %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}] mcast[%{{.*}}, %{{.*}}]
+      // CHECK: } else {
+      //   Source branch.
+      //   CHECK:   d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
+      //   CHECK:   d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
+      // CHECK: }
+      d2m.gather_core %src into %dst
+        group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+    }, {
+    ^compute0:
+    }
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_gather_core_to_dma.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_gather_core_to_dma.mlir
@@ -3,21 +3,45 @@
 // RUN:            --d2m-lower-load-store-ops-to-dma %s | FileCheck %s
 
 // d2m.gather_core lowers (inside its hosting d2m.generic data-movement
-// region) to a collector/source handshake:
+// region) to:
 //
-//   if isCollector:
-//     semaphore_wait %sourceReady,  numSources                      // sources signal in
-//     for sy in groupY:
-//       for sx in groupX:
-//         %tx = dma_read %src[] core[sy, sx], %dst, <0>             // shard-level read
-//         dma_wait %tx
-//     semaphore_set  %collectorDone, 1, core[groupStart] mcast[groupShape]
-//   else:
-//     semaphore_inc  %sourceReady,  1, core[collector]              // signal collector
-//     semaphore_wait %collectorDone, 1                              // wait for completion
+//   if isInGroup:                                                   // gate
+//     if isCollector:
+//       semaphore_wait %sourceReady,  numSources                    // sources signal in
+//       for sy in groupY:
+//         for sx in groupX:
+//           %tx = dma_read %src[] core[sy, sx], %dst, <0>           // shard-level read
+//           dma_wait %tx
+//       ; collectorDone fan-out:
+//       ;   groupShape statically 1x1 -> one unicast inc to the group core
+//       ;   groupShape statically 1xN or Nx1 -> loop of unicast incs
+//       ;   else -> single mcast semaphore_set
+//     else:
+//       semaphore_inc  %sourceReady,  1, core[collector]            // signal collector
+//       semaphore_wait %collectorDone, 1                            // wait for completion
 //
 // numSources = groupVolume - 1 because the collector does not signal itself
 // and pulls its own data via the self-iteration of the loop.
+//
+// The outer `if isInGroup` gate (V2) excludes cores outside the gather
+// group from the protocol entirely. Without it, those cores would still
+// execute the source-side path, over-saturate sourceReady and deadlock on
+// collectorDone (which is only fan-out to in-group cores). The src CB
+// `d2m.wait`/`d2m.pop` handshake (when in explicit CB form) is emitted
+// unconditionally outside the if, because the src CB allocation is per-
+// core-uniform today and every core's upstream compute thread pushes one
+// element into it.
+//
+// The degenerate-axis (1xN / Nx1) path exists because the downstream
+// emitc.expression wrapping of ttkernel::experimental::get_noc_multicast_addr
+// cannot roundtrip duplicate start/end SSA values on the degenerate axis
+// (Canonicalize folds the `start + 1 - 1` end-coord arithmetic, CSE then
+// collapses the two convert-logical calls, and emitc.expression's printer
+// shadows region args with operand names, producing two block args with
+// the same name -> AsmParser rejects the IR). The loop-of-incs form is
+// observable-equivalent inside this protocol because collectorDone is
+// zero-initialized, reset on the source's wait, and only ever published
+// with value 1.
 
 #l1_ = #ttcore.memory_space<l1>
 #map = affine_map<(d0, d1) -> (d0, d1)>
@@ -47,24 +71,28 @@ module {
       %c4 = arith.constant 4 : index
 
       // isCollector = (core_index(0) == 0) && (core_index(1) == 0)
-      // CHECK: %[[Y:.*]] = d2m.core_index(0)
-      // CHECK: %[[YEQ:.*]] = arith.cmpi eq, %[[Y]],
-      // CHECK: %[[X:.*]] = d2m.core_index(1)
-      // CHECK: %[[XEQ:.*]] = arith.cmpi eq, %[[X]],
-      // CHECK: %[[IS_COLLECTOR:.*]] = arith.andi %[[YEQ]], %[[XEQ]]
-      // CHECK: scf.if %[[IS_COLLECTOR]] {
+      // isInGroup   = (core_index(0) ∈ [0, 1)) && (core_index(1) ∈ [0, 4))
+      // CHECK: d2m.core_index(0)
+      // CHECK: d2m.core_index(1)
+      // The outer scf.if is the isInGroup gate; the inner is isCollector.
+      // CHECK: scf.if %{{.*}} {
+      // CHECK-NEXT: scf.if %{{.*}} {
       //   Collector branch.
       //   numSources = groupVolume - 1 = 4 - 1 = 3.
-      //   CHECK:   d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
-      //   CHECK:   scf.for
-      //   CHECK:     scf.for %[[SX:.*]] =
-      //   CHECK:       %[[TX:.*]] = d2m.dma_read %[[SRC]][] core[%{{.*}}, %[[SX]]], %[[DST]], <0>
-      //   CHECK:       d2m.dma_wait %[[TX]]
-      //   CHECK:   d2m.semaphore_set %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}] mcast[%{{.*}}, %{{.*}}]
-      // CHECK: } else {
+      //   CHECK:     d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
+      //   CHECK:     scf.for
+      //   CHECK:       scf.for %[[SX:.*]] =
+      //   CHECK:         %[[TX:.*]] = d2m.dma_read %[[SRC]][] core[%{{.*}}, %[[SX]]], %[[DST]], <0>
+      //   CHECK:         d2m.dma_wait %[[TX]]
+      //   1x4 group -> single scf.for over X, one unicast inc per group core.
+      //   CHECK:     scf.for %[[INCX:.*]] = %{{.*}} to %{{.*}} step %{{.*}}
+      //   CHECK:       d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %[[INCX]]]
+      //   CHECK-NOT: d2m.semaphore_set
+      // CHECK:   } else {
       //   Source branch.
-      //   CHECK:   d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
-      //   CHECK:   d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
+      //   CHECK:     d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
+      //   CHECK:     d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
+      // CHECK:   }
       // CHECK: }
       d2m.gather_core %src into %dst
         group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
@@ -106,24 +134,32 @@ module {
       %srcCb = d2m.get_cb(2) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>
       %dstCb = d2m.get_cb(3) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>
 
-      // CB-form lowering shape:
+      // CB-form lowering shape (wait/pop on src CB stay outside the
+      // isInGroup gate; reserve/push on dst CB live in the collector
+      // branch as before, so two levels of scf.if are visible inside the
+      // generic).
       // CHECK: %[[SRC_LOCAL:.*]] = d2m.wait %[[SRC_CB]]
       // CHECK: scf.if %{{.*}} {
-      //   Collector branch: reserve dst CB, wait for sources, DMA-read, mcast set, push dst CB.
-      //   CHECK:   %[[DST_LOCAL:.*]] = d2m.reserve %[[DST_CB]]
-      //   CHECK:   d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
-      //   CHECK:   scf.for
+      // CHECK-NEXT: scf.if %{{.*}} {
+      //   Collector branch: reserve dst CB, wait for sources, DMA-read,
+      //   loop of unicast incs (1x4 degenerate), push dst CB.
+      //   CHECK:     %[[DST_LOCAL:.*]] = d2m.reserve %[[DST_CB]]
+      //   CHECK:     d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
       //   CHECK:     scf.for
-      //   CHECK:       %[[TX:.*]] = d2m.dma_read %[[SRC_LOCAL]][] core[%{{.*}}, %{{.*}}], %[[DST_LOCAL]], <0>
-      //   CHECK:       d2m.dma_wait %[[TX]]
-      //   CHECK:   d2m.semaphore_set %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}] mcast[%{{.*}}, %{{.*}}]
-      //   CHECK:   d2m.push %[[DST_CB]]
-      // CHECK: } else {
-      //   Source branch: notify collector, wait for mcast set. No dst CB ops here.
-      //   CHECK:   d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
-      //   CHECK:   d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
-      //   CHECK-NOT:   d2m.reserve
-      //   CHECK-NOT:   d2m.push
+      //   CHECK:       scf.for
+      //   CHECK:         %[[TX:.*]] = d2m.dma_read %[[SRC_LOCAL]][] core[%{{.*}}, %{{.*}}], %[[DST_LOCAL]], <0>
+      //   CHECK:         d2m.dma_wait %[[TX]]
+      //   CHECK:     scf.for %[[INCX:.*]] = %{{.*}} to %{{.*}} step %{{.*}}
+      //   CHECK:       d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %[[INCX]]]
+      //   CHECK-NOT: d2m.semaphore_set
+      //   CHECK:     d2m.push %[[DST_CB]]
+      // CHECK:   } else {
+      //   Source branch: notify collector, wait for the per-core inc. No dst CB ops here.
+      //   CHECK:     d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
+      //   CHECK:     d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
+      //   CHECK-NOT:     d2m.reserve
+      //   CHECK-NOT:     d2m.push
+      // CHECK:   }
       // CHECK: }
       // After the branch, every core pops the src CB.
       // CHECK: d2m.pop %[[SRC_CB]]
@@ -131,6 +167,109 @@ module {
         group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
         : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>,
           !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>
+    }, {
+    ^compute0:
+    }
+    return
+  }
+
+  // Non-degenerate (2x2) gather group: the collectorDone fan-out keeps the
+  // single mcast semaphore_set form, no per-core loop of incs.
+  // CHECK-LABEL: func.func @test_lower_gather_core_2x2
+  // CHECK-NOT: d2m.gather_core
+  func.func @test_lower_gather_core_2x2(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)  {
+    ^datamovement0:
+      %src = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %dst = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      // CHECK: scf.if %{{.*}} {
+      // CHECK-NEXT: scf.if %{{.*}} {
+      //   Collector branch: 2x2 mcast fan-out stays as a single semaphore_set.
+      //   CHECK:     d2m.semaphore_set %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}] mcast[%{{.*}}, %{{.*}}]
+      //   CHECK-NOT: d2m.semaphore_inc %{{[^,]*}}, %{{[^,]*}}, core[
+      // CHECK:   } else {
+      d2m.gather_core %src into %dst
+        group [%c0, %c0] shape [%c2, %c2] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+    }, {
+    ^compute0:
+    }
+    return
+  }
+
+  // 1x1 gather group (degenerate on both axes): a single unicast inc, no scf.for.
+  // CHECK-LABEL: func.func @test_lower_gather_core_1x1
+  // CHECK-NOT: d2m.gather_core
+  func.func @test_lower_gather_core_1x1(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)  {
+    ^datamovement0:
+      %src = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %dst = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      // CHECK: scf.if %{{.*}} {
+      // CHECK-NEXT: scf.if %{{.*}} {
+      //   1x1 group: emit a single unicast inc to the (only) group core.
+      //   Any scf.for ops here come from the DMA loop only.
+      //   CHECK:     d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
+      //   CHECK-NOT: d2m.semaphore_set
+      // CHECK:   } else {
+      d2m.gather_core %src into %dst
+        group [%c0, %c0] shape [%c1, %c1] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+    }, {
+    ^compute0:
+    }
+    return
+  }
+
+  // Nx1 gather group: single scf.for over Y, one unicast inc per group core.
+  // CHECK-LABEL: func.func @test_lower_gather_core_4x1
+  // CHECK-NOT: d2m.gather_core
+  func.func @test_lower_gather_core_4x1(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)  {
+    ^datamovement0:
+      %src = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %dst = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      // CHECK: scf.if %{{.*}} {
+      // CHECK-NEXT: scf.if %{{.*}} {
+      //   Nx1 group: walk the non-degenerate axis (Y) and emit one inc per core.
+      //   CHECK:     scf.for %[[INCY:.*]] = %{{.*}} to %{{.*}} step %{{.*}}
+      //   CHECK:       d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%[[INCY]], %{{.*}}]
+      //   CHECK-NOT: d2m.semaphore_set
+      // CHECK:   } else {
+      d2m.gather_core %src into %dst
+        group [%c0, %c0] shape [%c4, %c1] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
     }, {
     ^compute0:
     }

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_gather_core_to_dma.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_gather_core_to_dma.mlir
@@ -75,4 +75,65 @@ module {
     }
     return
   }
+
+  // CB-form gather_core lowering: src is consumed via d2m.wait/d2m.pop on
+  // every core; the collector additionally d2m.reserves and d2m.pushes the
+  // dst CB (option (c): allocate the dst CB everywhere, only the collector
+  // executes its CB ops). The DMA reads and the semaphore handshake are the
+  // same as in the implicit-form lowering above.
+  //
+  // CHECK-LABEL: func.func @test_lower_gather_core_cb_form
+  // CHECK-NOT: d2m.gather_core
+  func.func @test_lower_gather_core_cb_form(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>) {
+    %srcAlloc = memref.alloc() {address = 5120 : i64, alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>
+    %dstAlloc = memref.alloc() {address = 6144 : i64, alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>
+
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)
+        additionalArgs(%srcAlloc, %dstAlloc : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>) {
+    ^datamovement0:
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      // CHECK: %[[SRC_CB:.*]] = d2m.get_cb(2)
+      // CHECK: %[[DST_CB:.*]] = d2m.get_cb(3)
+      %srcCb = d2m.get_cb(2) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>
+      %dstCb = d2m.get_cb(3) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>
+
+      // CB-form lowering shape:
+      // CHECK: %[[SRC_LOCAL:.*]] = d2m.wait %[[SRC_CB]]
+      // CHECK: scf.if %{{.*}} {
+      //   Collector branch: reserve dst CB, wait for sources, DMA-read, mcast set, push dst CB.
+      //   CHECK:   %[[DST_LOCAL:.*]] = d2m.reserve %[[DST_CB]]
+      //   CHECK:   d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
+      //   CHECK:   scf.for
+      //   CHECK:     scf.for
+      //   CHECK:       %[[TX:.*]] = d2m.dma_read %[[SRC_LOCAL]][] core[%{{.*}}, %{{.*}}], %[[DST_LOCAL]], <0>
+      //   CHECK:       d2m.dma_wait %[[TX]]
+      //   CHECK:   d2m.semaphore_set %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}] mcast[%{{.*}}, %{{.*}}]
+      //   CHECK:   d2m.push %[[DST_CB]]
+      // CHECK: } else {
+      //   Source branch: notify collector, wait for mcast set. No dst CB ops here.
+      //   CHECK:   d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
+      //   CHECK:   d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
+      //   CHECK-NOT:   d2m.reserve
+      //   CHECK-NOT:   d2m.push
+      // CHECK: }
+      // After the branch, every core pops the src CB.
+      // CHECK: d2m.pop %[[SRC_CB]]
+      d2m.gather_core from %srcCb into %dstCb
+        group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
+        : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>,
+          !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>
+    }, {
+    ^compute0:
+    }
+    return
+  }
 }

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_gather_core_to_dma.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_gather_core_to_dma.mlir
@@ -2,54 +2,29 @@
 // RUN:            --d2m-preallocate-mcast-semaphores \
 // RUN:            --d2m-lower-load-store-ops-to-dma %s | FileCheck %s
 
-// d2m.gather_core lowers (inside its hosting d2m.generic data-movement
-// region) to:
+// d2m.gather_core lowers to:
 //
-//   if isInGroup:                                                   // gate
+//   if isInGroup:
 //     if isCollector:
-//       semaphore_wait %sourceReady,  numSources                    // sources signal in
-//       for sy in groupY:
-//         for sx in groupX:
-//           %tx = dma_read %src[] core[sy, sx], %dst, <0>           // shard-level read
-//           dma_wait %tx
-//       ; collectorDone fan-out:
-//       ;   groupShape statically 1x1 -> one unicast inc to the group core
-//       ;   groupShape statically 1xN or Nx1 -> loop of unicast incs
-//       ;   else -> single mcast semaphore_set
+//       semaphore_wait %sourceReady, groupVolume - 1
+//       for sy in groupY: for sx in groupX:
+//         %tx = dma_read %src[] core[sy, sx], %dst, <0>
+//         dma_wait %tx
+//       ; collectorDone fan-out: mcast set (general) or loop of unicast
+//       ; incs (1x1 / 1xN / Nx1) -- see LowerLoadStoreOpsToDMA.cpp.
 //     else:
-//       semaphore_inc  %sourceReady,  1, core[collector]            // signal collector
-//       semaphore_wait %collectorDone, 1                            // wait for completion
+//       semaphore_inc  %sourceReady,  1, core[collector]
+//       semaphore_wait %collectorDone, 1
 //
-// numSources = groupVolume - 1 because the collector does not signal itself
-// and pulls its own data via the self-iteration of the loop.
-//
-// The outer `if isInGroup` gate (V2) excludes cores outside the gather
-// group from the protocol entirely. Without it, those cores would still
-// execute the source-side path, over-saturate sourceReady and deadlock on
-// collectorDone (which is only fan-out to in-group cores). The src CB
-// `d2m.wait`/`d2m.pop` handshake (when in explicit CB form) is emitted
-// unconditionally outside the if, because the src CB allocation is per-
-// core-uniform today and every core's upstream compute thread pushes one
-// element into it.
-//
-// The degenerate-axis (1xN / Nx1) path exists because the downstream
-// emitc.expression wrapping of ttkernel::experimental::get_noc_multicast_addr
-// cannot roundtrip duplicate start/end SSA values on the degenerate axis
-// (Canonicalize folds the `start + 1 - 1` end-coord arithmetic, CSE then
-// collapses the two convert-logical calls, and emitc.expression's printer
-// shadows region args with operand names, producing two block args with
-// the same name -> AsmParser rejects the IR). The loop-of-incs form is
-// observable-equivalent inside this protocol because collectorDone is
-// zero-initialized, reset on the source's wait, and only ever published
-// with value 1.
+// In CB form the src CB wait/pop straddles the isInGroup gate (every
+// group core consumes one src-CB element).
 
 #l1_ = #ttcore.memory_space<l1>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #ttcore.iterator_type<parallel>
 
 module {
-  // Group: 1x4 starting at (0,0), collector at (0,0). groupVolume=4, so
-  // numSources = 3.
+  // 1x4 group at (0,0), collector (0,0). numSources = 3.
   // CHECK-LABEL: func.func @test_lower_gather_core
   // CHECK-NOT: d2m.gather_core
   func.func @test_lower_gather_core(
@@ -70,26 +45,23 @@ module {
       %c1 = arith.constant 1 : index
       %c4 = arith.constant 4 : index
 
-      // isCollector = (core_index(0) == 0) && (core_index(1) == 0)
-      // isInGroup   = (core_index(0) ∈ [0, 1)) && (core_index(1) ∈ [0, 4))
+      // Outer scf.if = isInGroup, inner = isCollector.
       // CHECK: d2m.core_index(0)
       // CHECK: d2m.core_index(1)
-      // The outer scf.if is the isInGroup gate; the inner is isCollector.
       // CHECK: scf.if %{{.*}} {
       // CHECK-NEXT: scf.if %{{.*}} {
-      //   Collector branch.
-      //   numSources = groupVolume - 1 = 4 - 1 = 3.
+      //   Collector (numSources = 3 = 4 - 1).
       //   CHECK:     d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
       //   CHECK:     scf.for
       //   CHECK:       scf.for %[[SX:.*]] =
       //   CHECK:         %[[TX:.*]] = d2m.dma_read %[[SRC]][] core[%{{.*}}, %[[SX]]], %[[DST]], <0>
       //   CHECK:         d2m.dma_wait %[[TX]]
-      //   1x4 group -> single scf.for over X, one unicast inc per group core.
+      //   1xN: loop of unicast incs (no mcast set).
       //   CHECK:     scf.for %[[INCX:.*]] = %{{.*}} to %{{.*}} step %{{.*}}
       //   CHECK:       d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %[[INCX]]]
       //   CHECK-NOT: d2m.semaphore_set
       // CHECK:   } else {
-      //   Source branch.
+      //   Source.
       //   CHECK:     d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
       //   CHECK:     d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
       // CHECK:   }
@@ -104,12 +76,9 @@ module {
     return
   }
 
-  // CB-form gather_core lowering: src is consumed via d2m.wait/d2m.pop on
-  // every core; the collector additionally d2m.reserves and d2m.pushes the
-  // dst CB (option (c): allocate the dst CB everywhere, only the collector
-  // executes its CB ops). The DMA reads and the semaphore handshake are the
-  // same as in the implicit-form lowering above.
-  //
+  // CB-form: src CB wait/pop on every group core; dst CB reserve/push
+  // only on the collector. Reads + semaphore handshake unchanged from
+  // implicit form.
   // CHECK-LABEL: func.func @test_lower_gather_core_cb_form
   // CHECK-NOT: d2m.gather_core
   func.func @test_lower_gather_core_cb_form(
@@ -134,15 +103,11 @@ module {
       %srcCb = d2m.get_cb(2) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>
       %dstCb = d2m.get_cb(3) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1_>>
 
-      // CB-form lowering shape (wait/pop on src CB stay outside the
-      // isInGroup gate; reserve/push on dst CB live in the collector
-      // branch as before, so two levels of scf.if are visible inside the
-      // generic).
+      // src CB wait outside the gates; dst CB reserve/push inside the
+      // collector branch only.
       // CHECK: %[[SRC_LOCAL:.*]] = d2m.wait %[[SRC_CB]]
       // CHECK: scf.if %{{.*}} {
       // CHECK-NEXT: scf.if %{{.*}} {
-      //   Collector branch: reserve dst CB, wait for sources, DMA-read,
-      //   loop of unicast incs (1x4 degenerate), push dst CB.
       //   CHECK:     %[[DST_LOCAL:.*]] = d2m.reserve %[[DST_CB]]
       //   CHECK:     d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
       //   CHECK:     scf.for
@@ -154,14 +119,12 @@ module {
       //   CHECK-NOT: d2m.semaphore_set
       //   CHECK:     d2m.push %[[DST_CB]]
       // CHECK:   } else {
-      //   Source branch: notify collector, wait for the per-core inc. No dst CB ops here.
       //   CHECK:     d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
       //   CHECK:     d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
       //   CHECK-NOT:     d2m.reserve
       //   CHECK-NOT:     d2m.push
       // CHECK:   }
       // CHECK: }
-      // After the branch, every core pops the src CB.
       // CHECK: d2m.pop %[[SRC_CB]]
       d2m.gather_core from %srcCb into %dstCb
         group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
@@ -173,8 +136,7 @@ module {
     return
   }
 
-  // Non-degenerate (2x2) gather group: the collectorDone fan-out keeps the
-  // single mcast semaphore_set form, no per-core loop of incs.
+  // 2x2 group: collectorDone fan-out keeps the single mcast semaphore_set.
   // CHECK-LABEL: func.func @test_lower_gather_core_2x2
   // CHECK-NOT: d2m.gather_core
   func.func @test_lower_gather_core_2x2(
@@ -193,7 +155,6 @@ module {
       %c2 = arith.constant 2 : index
       // CHECK: scf.if %{{.*}} {
       // CHECK-NEXT: scf.if %{{.*}} {
-      //   Collector branch: 2x2 mcast fan-out stays as a single semaphore_set.
       //   CHECK:     d2m.semaphore_set %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}] mcast[%{{.*}}, %{{.*}}]
       //   CHECK-NOT: d2m.semaphore_inc %{{[^,]*}}, %{{[^,]*}}, core[
       // CHECK:   } else {
@@ -207,7 +168,7 @@ module {
     return
   }
 
-  // 1x1 gather group (degenerate on both axes): a single unicast inc, no scf.for.
+  // 1x1 group: single unicast inc, no scf.for for the fan-out.
   // CHECK-LABEL: func.func @test_lower_gather_core_1x1
   // CHECK-NOT: d2m.gather_core
   func.func @test_lower_gather_core_1x1(
@@ -226,8 +187,7 @@ module {
       %c1 = arith.constant 1 : index
       // CHECK: scf.if %{{.*}} {
       // CHECK-NEXT: scf.if %{{.*}} {
-      //   1x1 group: emit a single unicast inc to the (only) group core.
-      //   Any scf.for ops here come from the DMA loop only.
+      //   Single unicast inc; any scf.for here is from the DMA loop only.
       //   CHECK:     d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%{{.*}}, %{{.*}}]
       //   CHECK-NOT: d2m.semaphore_set
       // CHECK:   } else {
@@ -241,7 +201,7 @@ module {
     return
   }
 
-  // Nx1 gather group: single scf.for over Y, one unicast inc per group core.
+  // 4x1 group: loop over Y, one unicast inc per group core.
   // CHECK-LABEL: func.func @test_lower_gather_core_4x1
   // CHECK-NOT: d2m.gather_core
   func.func @test_lower_gather_core_4x1(
@@ -261,7 +221,6 @@ module {
       %c4 = arith.constant 4 : index
       // CHECK: scf.if %{{.*}} {
       // CHECK-NEXT: scf.if %{{.*}} {
-      //   Nx1 group: walk the non-degenerate axis (Y) and emit one inc per core.
       //   CHECK:     scf.for %[[INCY:.*]] = %{{.*}} to %{{.*}} step %{{.*}}
       //   CHECK:       d2m.semaphore_inc %{{.*}}, %{{.*}}, core[%[[INCY]], %{{.*}}]
       //   CHECK-NOT: d2m.semaphore_set

--- a/test/ttmlir/Dialect/D2M/Transforms/preallocate_gather_core_semaphores.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/preallocate_gather_core_semaphores.mlir
@@ -1,11 +1,9 @@
 // RUN: ttmlir-opt --ttcore-register-device --d2m-preallocate-mcast-semaphores -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// The PreallocateMcastSemaphores pass also handles d2m.gather_core: every
-// gather_core triggers allocation of a fresh local-semaphore pair, surfaced
-// via the generic's additionalArgs and recorded on the op as
-// `preallocated_semaphores = [<sem0Idx>, <sem1Idx>]` (absolute operand
-// indices, counted after ins + outs).
+// d2m-preallocate-mcast-semaphores allocates a fresh local-semaphore pair
+// per gather_core, surfaced in the generic's additionalArgs and recorded
+// on the op as preallocated_semaphores = [sem0Idx, sem1Idx].
 
 #l1_ = #ttcore.memory_space<l1>
 #dram = #ttcore.memory_space<dram>
@@ -14,19 +12,16 @@
 #reduction = #ttcore.iterator_type<reduction>
 
 module {
-  //===--------------------------------------------------------------------===//
-  // Single d2m.gather_core gets one preallocated semaphore pair.
-  //===--------------------------------------------------------------------===//
-
+  // Single gather_core: one preallocated semaphore pair.
   // CHECK-LABEL: func.func @test_single_gather_core
   func.func @test_single_gather_core(
       %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>,
       %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>) {
+    // ins+outs=2, so the two semaphores land at indices 2 and 3.
     // CHECK: %[[S0:.*]] = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
     // CHECK: %[[S1:.*]] = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
     // CHECK: d2m.generic
     // CHECK: additionalArgs(%[[S0]], %[[S1]] : !d2m.local_semaphore, !d2m.local_semaphore)
-    // ins+outs = 2, so the two semaphores land at absolute operand indices 2 and 3.
     // CHECK: d2m.gather_core {{.*}} {preallocated_semaphores = [2, 3]}
     d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
                  indexing_maps = [#map, #map],
@@ -50,11 +45,7 @@ module {
     return
   }
 
-  //===--------------------------------------------------------------------===//
-  // Two gather_cores in the same generic each get their own pair (absolute
-  // indices increase by 2 per pair).
-  //===--------------------------------------------------------------------===//
-
+  // Two gather_cores in the same generic: each gets its own pair.
   // CHECK-LABEL: func.func @test_two_gather_cores
   func.func @test_two_gather_cores(
       %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>,
@@ -95,11 +86,8 @@ module {
     return
   }
 
-  //===--------------------------------------------------------------------===//
-  // A gather_core and a multicast remote_load in the same generic each get
-  // their own pair: the pass collects both kinds of triggers uniformly.
-  //===--------------------------------------------------------------------===//
-
+  // gather_core + multicast remote_load in the same generic: each gets its
+  // own pair (both kinds are collected uniformly by this pass).
   // CHECK-LABEL: func.func @test_mixed_gather_and_mcast_remote_load
   func.func @test_mixed_gather_and_mcast_remote_load(
       %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>) {
@@ -126,11 +114,9 @@ module {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
       %c4 = arith.constant 4 : index
-      // Multicast remote_load: gets the first pair.
       d2m.remote_load %arg0[%c0, %c0] into %cb0 mcore[%c0, %c0] mshape[%c1, %c4]
         : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
           into !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>
-      // gather_core: gets the second pair.
       d2m.gather_core %scratch_src into %scratch_dst
         group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
         : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,

--- a/test/ttmlir/Dialect/D2M/Transforms/preallocate_gather_core_semaphores.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/preallocate_gather_core_semaphores.mlir
@@ -1,0 +1,143 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-preallocate-mcast-semaphores -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// The PreallocateMcastSemaphores pass also handles d2m.gather_core: every
+// gather_core triggers allocation of a fresh local-semaphore pair, surfaced
+// via the generic's additionalArgs and recorded on the op as
+// `preallocated_semaphores = [<sem0Idx>, <sem1Idx>]` (absolute operand
+// indices, counted after ins + outs).
+
+#l1_ = #ttcore.memory_space<l1>
+#dram = #ttcore.memory_space<dram>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#reduction = #ttcore.iterator_type<reduction>
+
+module {
+  //===--------------------------------------------------------------------===//
+  // Single d2m.gather_core gets one preallocated semaphore pair.
+  //===--------------------------------------------------------------------===//
+
+  // CHECK-LABEL: func.func @test_single_gather_core
+  func.func @test_single_gather_core(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>) {
+    // CHECK: %[[S0:.*]] = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    // CHECK: %[[S1:.*]] = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    // CHECK: d2m.generic
+    // CHECK: additionalArgs(%[[S0]], %[[S1]] : !d2m.local_semaphore, !d2m.local_semaphore)
+    // ins+outs = 2, so the two semaphores land at absolute operand indices 2 and 3.
+    // CHECK: d2m.gather_core {{.*}} {preallocated_semaphores = [2, 3]}
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)  {
+    ^datamovement0:
+      %src = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %dst = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      d2m.gather_core %src into %dst
+        group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+    }, {
+    ^compute0:
+    }
+    return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Two gather_cores in the same generic each get their own pair (absolute
+  // indices increase by 2 per pair).
+  //===--------------------------------------------------------------------===//
+
+  // CHECK-LABEL: func.func @test_two_gather_cores
+  func.func @test_two_gather_cores(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>) {
+    // CHECK: %[[S0:.*]] = d2m.create_local_semaphore
+    // CHECK: %[[S1:.*]] = d2m.create_local_semaphore
+    // CHECK: %[[S2:.*]] = d2m.create_local_semaphore
+    // CHECK: %[[S3:.*]] = d2m.create_local_semaphore
+    // CHECK: d2m.generic
+    // CHECK: additionalArgs(%[[S0]], %[[S1]], %[[S2]], %[[S3]] : !d2m.local_semaphore, !d2m.local_semaphore, !d2m.local_semaphore, !d2m.local_semaphore)
+    // CHECK: d2m.gather_core {{.*}} {preallocated_semaphores = [2, 3]}
+    // CHECK: d2m.gather_core {{.*}} {preallocated_semaphores = [4, 5]}
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)  {
+    ^datamovement0:
+      %srcA = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %dstA = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %srcB = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %dstB = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      d2m.gather_core %srcA into %dstA
+        group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      d2m.gather_core %srcB into %dstB
+        group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+    }, {
+    ^compute0:
+    }
+    return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // A gather_core and a multicast remote_load in the same generic each get
+  // their own pair: the pass collects both kinds of triggers uniformly.
+  //===--------------------------------------------------------------------===//
+
+  // CHECK-LABEL: func.func @test_mixed_gather_and_mcast_remote_load
+  func.func @test_mixed_gather_and_mcast_remote_load(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>) {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>
+
+    // CHECK: %[[S0:.*]] = d2m.create_local_semaphore
+    // CHECK: %[[S1:.*]] = d2m.create_local_semaphore
+    // CHECK: %[[S2:.*]] = d2m.create_local_semaphore
+    // CHECK: %[[S3:.*]] = d2m.create_local_semaphore
+    // CHECK: d2m.generic
+    // CHECK: additionalArgs(%[[S0]], %[[S1]], %[[S2]], %[[S3]] : !d2m.local_semaphore, !d2m.local_semaphore, !d2m.local_semaphore, !d2m.local_semaphore)
+    // CHECK: d2m.remote_load {{.*}} {preallocated_semaphores = [2, 3]}
+    // CHECK: d2m.gather_core {{.*}} {preallocated_semaphores = [4, 5]}
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #reduction],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>)
+        outs(%alloc : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)  {
+    ^datamovement0:
+      %cb0 = d2m.get_cb(0) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>
+      %scratch_src = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %scratch_dst = memref.alloc() {alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      // Multicast remote_load: gets the first pair.
+      d2m.remote_load %arg0[%c0, %c0] into %cb0 mcore[%c0, %c0] mshape[%c1, %c4]
+        : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+          into !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>
+      // gather_core: gets the second pair.
+      d2m.gather_core %scratch_src into %scratch_dst
+        group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+    }, {
+    ^compute0:
+    }
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
@@ -589,6 +589,50 @@ module attributes {ttcore.system_desc = #system_desc} {
     return
   }
 
+  // Test 14a: gather_core in a unified thread.
+  // Verifies: gather_core is moved to the DM thread and rewritten in explicit
+  // CB form; the compute thread is empty (gather_core is a pure DM op even
+  // though it implements D2M_SynchronizableOpInterface).
+  // CHECK-LABEL: func.func @test_gather_core_unified
+  func.func @test_gather_core_unified(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+    %src_buf = memref.alloc() {address = 5120 : i64, alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    %dst_buf = memref.alloc() {address = 6144 : i64, alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+
+    // CHECK: d2m.generic
+    // CHECK-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
+    // DM thread: gather_core appears once, in explicit CB form, with both
+    // src and dst replaced by d2m.get_cb results. The pass emits the dst CB
+    // first (its operand index in the generic is higher), then the src CB.
+    // CHECK: %[[DST_CB:.*]] = d2m.get_cb(3)
+    // CHECK: %[[SRC_CB:.*]] = d2m.get_cb(2)
+    // CHECK: d2m.gather_core from %[[SRC_CB]] into %[[DST_CB]] group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : !d2m.cb<{{.*}}>, !d2m.cb<{{.*}}>
+    // Compute thread: empty (gather_core is DM-only).
+    // CHECK: }, {
+    // CHECK-NEXT: }
+    // CHECK-NOT: d2m.gather_core
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<unified>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
+        additionalArgs(%src_buf, %dst_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) {
+    ^unified0:
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      d2m.gather_core %src_buf into %dst_buf
+        group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    }
+    memref.dealloc %src_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    memref.dealloc %dst_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    return
+  }
+
   // Test 14b: Full streaming load + store without d2m.blocking_loop
   // Regression test: scope inference from remote op placement must produce the
   // same split as Test 3, which relied on d2m.blocking_loop for scope anchoring.

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
@@ -589,10 +589,8 @@ module attributes {ttcore.system_desc = #system_desc} {
     return
   }
 
-  // Test 14a: gather_core in a unified thread.
-  // Verifies: gather_core is moved to the DM thread and rewritten in explicit
-  // CB form; the compute thread is empty (gather_core is a pure DM op even
-  // though it implements D2M_SynchronizableOpInterface).
+  // Test 14a: unified gather_core is moved to the DM thread and rewritten
+  // in explicit CB form; the compute thread is empty.
   // CHECK-LABEL: func.func @test_gather_core_unified
   func.func @test_gather_core_unified(
       %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>,
@@ -602,13 +600,9 @@ module attributes {ttcore.system_desc = #system_desc} {
 
     // CHECK: d2m.generic
     // CHECK-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
-    // DM thread: gather_core appears once, in explicit CB form, with both
-    // src and dst replaced by d2m.get_cb results. The pass emits the dst CB
-    // first (its operand index in the generic is higher), then the src CB.
     // CHECK: %[[DST_CB:.*]] = d2m.get_cb(3)
     // CHECK: %[[SRC_CB:.*]] = d2m.get_cb(2)
     // CHECK: d2m.gather_core from %[[SRC_CB]] into %[[DST_CB]] group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : !d2m.cb<{{.*}}>, !d2m.cb<{{.*}}>
-    // Compute thread: empty (gather_core is DM-only).
     // CHECK: }, {
     // CHECK-NEXT: }
     // CHECK-NOT: d2m.gather_core

--- a/test/ttmlir/Dialect/D2M/gather_core_asm_syntax.mlir
+++ b/test/ttmlir/Dialect/D2M/gather_core_asm_syntax.mlir
@@ -1,0 +1,84 @@
+// RUN: ttmlir-opt %s | FileCheck %s
+
+// Parse/print round-trip for d2m.gather_core (memref + tensor forms) and for
+// the cross-core local-L1 form of d2m.dma_read (shard-level + fully-indexed).
+// All ops live inside func.func per the D2M_GenericParent interface.
+
+#l1_ = #ttcore.memory_space<l1>
+
+//===----------------------------------------------------------------------===//
+// d2m.gather_core
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_gather_core_memref
+func.func @test_gather_core_memref(
+    %src: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+    %dst: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  // CHECK: d2m.gather_core %{{.*}} into %{{.*}} group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>, memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>
+  d2m.gather_core %src into %dst
+    group [%c0, %c0] shape [%c1, %c2] collector [%c0, %c0]
+    : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+      memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+
+  return
+}
+
+// CHECK-LABEL: @test_gather_core_tensor
+func.func @test_gather_core_tensor(
+    %src: tensor<2x4x!ttcore.tile<32x32, f32>>,
+    %dst: tensor<2x4x!ttcore.tile<32x32, f32>>) -> tensor<2x4x!ttcore.tile<32x32, f32>> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  // Tensor form is DPS: the result aliases %dst.
+  // CHECK: %{{.*}} = d2m.gather_core %{{.*}} into %{{.*}} group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : tensor<{{.*}}>, tensor<{{.*}}> -> tensor<{{.*}}>
+  %0 = d2m.gather_core %src into %dst
+    group [%c0, %c0] shape [%c1, %c2] collector [%c0, %c0]
+    : tensor<2x4x!ttcore.tile<32x32, f32>>,
+      tensor<2x4x!ttcore.tile<32x32, f32>>
+    -> tensor<2x4x!ttcore.tile<32x32, f32>>
+
+  return %0 : tensor<2x4x!ttcore.tile<32x32, f32>>
+}
+
+//===----------------------------------------------------------------------===//
+// d2m.dma_read core[...]
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_dma_read_cross_core_shard_level
+func.func @test_dma_read_cross_core_shard_level(
+    %src: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+    %dst: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  // Shard-level cross-core read: empty srcIndices, empty dstIndices, numElems=0.
+  // CHECK: d2m.dma_read %{{.*}}[] core[%{{.*}}, %{{.*}}], %{{.*}}, <0> : (memref<{{.*}}>, memref<{{.*}}>) -> !d2m.mem_tx<read>
+  %tx = d2m.dma_read %src[] core[%c1, %c2], %dst, <0>
+        : (memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+           memref<2x4x!ttcore.tile<32x32, f32>, #l1_>) -> !d2m.mem_tx<read>
+  d2m.dma_wait %tx : !d2m.mem_tx<read>
+  return
+}
+
+// CHECK-LABEL: @test_dma_read_cross_core_fully_indexed
+func.func @test_dma_read_cross_core_fully_indexed(
+    %src: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+    %dst: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  // Fully-indexed cross-core read: single linearized offset on each side, numElems>0.
+  // CHECK: d2m.dma_read %{{.*}}[%{{.*}}] core[%{{.*}}, %{{.*}}], %{{.*}}[%{{.*}}], <8> : (memref<{{.*}}>, memref<{{.*}}>) -> !d2m.mem_tx<read>
+  %tx = d2m.dma_read %src[%c0] core[%c1, %c2], %dst[%c0], <8>
+        : (memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+           memref<2x4x!ttcore.tile<32x32, f32>, #l1_>) -> !d2m.mem_tx<read>
+  d2m.dma_wait %tx : !d2m.mem_tx<read>
+  return
+}

--- a/test/ttmlir/Dialect/D2M/gather_core_asm_syntax.mlir
+++ b/test/ttmlir/Dialect/D2M/gather_core_asm_syntax.mlir
@@ -1,8 +1,7 @@
 // RUN: ttmlir-opt %s | FileCheck %s
 
-// Parse/print round-trip for d2m.gather_core (memref + tensor forms) and for
-// the cross-core local-L1 form of d2m.dma_read (shard-level + fully-indexed).
-// All ops live inside func.func per the D2M_GenericParent interface.
+// Parse/print round-trip for d2m.gather_core (all four forms) and for
+// d2m.dma_read core[...] (shard-level + fully-indexed).
 
 #l1_ = #ttcore.memory_space<l1>
 
@@ -35,7 +34,7 @@ func.func @test_gather_core_tensor(
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
 
-  // Tensor form is DPS: the result aliases %dst.
+  // Tensor form is DPS (result aliases %dst).
   // CHECK: %{{.*}} = d2m.gather_core %{{.*}} into %{{.*}} group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : tensor<{{.*}}>, tensor<{{.*}}> -> tensor<{{.*}}>
   %0 = d2m.gather_core %src into %dst
     group [%c0, %c0] shape [%c1, %c2] collector [%c0, %c0]
@@ -47,7 +46,7 @@ func.func @test_gather_core_tensor(
 }
 
 //===----------------------------------------------------------------------===//
-// d2m.gather_core: explicit CB forms (introduced by SplitUnifiedThread)
+// d2m.gather_core: explicit CB forms (post-SplitUnifiedThread)
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: @test_gather_core_src_cb_dst_cb
@@ -58,7 +57,6 @@ func.func @test_gather_core_src_cb_dst_cb(
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
 
-  // `from` toggles src-side to the CB; dst type also being a CB toggles dst-side.
   // CHECK: d2m.gather_core from %{{.*}} into %{{.*}} group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>>, !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>>
   d2m.gather_core from %srcCb into %dstCb
     group [%c0, %c0] shape [%c1, %c2] collector [%c0, %c0]
@@ -76,7 +74,6 @@ func.func @test_gather_core_src_cb_dst_memref(
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
 
-  // `from` keyword on src, no keyword on dst; dst type is a plain memref.
   // CHECK: d2m.gather_core from %{{.*}} into %{{.*}} group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>>, memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>
   d2m.gather_core from %srcCb into %dst
     group [%c0, %c0] shape [%c1, %c2] collector [%c0, %c0]
@@ -94,7 +91,6 @@ func.func @test_gather_core_src_memref_dst_cb(
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
 
-  // No `from` keyword on src; dst type is a CB.
   // CHECK: d2m.gather_core %{{.*}} into %{{.*}} group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>, !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>>
   d2m.gather_core %src into %dstCb
     group [%c0, %c0] shape [%c1, %c2] collector [%c0, %c0]
@@ -115,7 +111,7 @@ func.func @test_dma_read_cross_core_shard_level(
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
 
-  // Shard-level cross-core read: empty srcIndices, empty dstIndices, numElems=0.
+  // Shard-level: numElems = 0, no dst indices.
   // CHECK: d2m.dma_read %{{.*}}[] core[%{{.*}}, %{{.*}}], %{{.*}}, <0> : (memref<{{.*}}>, memref<{{.*}}>) -> !d2m.mem_tx<read>
   %tx = d2m.dma_read %src[] core[%c1, %c2], %dst, <0>
         : (memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
@@ -132,7 +128,7 @@ func.func @test_dma_read_cross_core_fully_indexed(
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
 
-  // Fully-indexed cross-core read: single linearized offset on each side, numElems>0.
+  // Fully-indexed: numElems > 0, single offset per side.
   // CHECK: d2m.dma_read %{{.*}}[%{{.*}}] core[%{{.*}}, %{{.*}}], %{{.*}}[%{{.*}}], <8> : (memref<{{.*}}>, memref<{{.*}}>) -> !d2m.mem_tx<read>
   %tx = d2m.dma_read %src[%c0] core[%c1, %c2], %dst[%c0], <8>
         : (memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,

--- a/test/ttmlir/Dialect/D2M/gather_core_asm_syntax.mlir
+++ b/test/ttmlir/Dialect/D2M/gather_core_asm_syntax.mlir
@@ -47,6 +47,64 @@ func.func @test_gather_core_tensor(
 }
 
 //===----------------------------------------------------------------------===//
+// d2m.gather_core: explicit CB forms (introduced by SplitUnifiedThread)
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_gather_core_src_cb_dst_cb
+func.func @test_gather_core_src_cb_dst_cb(
+    %srcCb: !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>,
+    %dstCb: !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  // `from` toggles src-side to the CB; dst type also being a CB toggles dst-side.
+  // CHECK: d2m.gather_core from %{{.*}} into %{{.*}} group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>>, !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>>
+  d2m.gather_core from %srcCb into %dstCb
+    group [%c0, %c0] shape [%c1, %c2] collector [%c0, %c0]
+    : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>,
+      !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>
+
+  return
+}
+
+// CHECK-LABEL: @test_gather_core_src_cb_dst_memref
+func.func @test_gather_core_src_cb_dst_memref(
+    %srcCb: !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>,
+    %dst: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  // `from` keyword on src, no keyword on dst; dst type is a plain memref.
+  // CHECK: d2m.gather_core from %{{.*}} into %{{.*}} group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>>, memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>
+  d2m.gather_core from %srcCb into %dst
+    group [%c0, %c0] shape [%c1, %c2] collector [%c0, %c0]
+    : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>,
+      memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+
+  return
+}
+
+// CHECK-LABEL: @test_gather_core_src_memref_dst_cb
+func.func @test_gather_core_src_memref_dst_cb(
+    %src: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+    %dstCb: !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  // No `from` keyword on src; dst type is a CB.
+  // CHECK: d2m.gather_core %{{.*}} into %{{.*}} group[%{{.*}}, %{{.*}}] shape[%{{.*}}, %{{.*}}] collector[%{{.*}}, %{{.*}}] : memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>, !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1{{.*}}>>
+  d2m.gather_core %src into %dstCb
+    group [%c0, %c0] shape [%c1, %c2] collector [%c0, %c0]
+    : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>,
+      !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>
+
+  return
+}
+
+//===----------------------------------------------------------------------===//
 // d2m.dma_read core[...]
 //===----------------------------------------------------------------------===//
 

--- a/test/ttmlir/Dialect/D2M/generic/gather_core_backend_pipeline.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/gather_core_backend_pipeline.mlir
@@ -48,12 +48,12 @@ module attributes {ttcore.system_desc = #system_desc} {
   // CHECK: ttkernel.noc_semaphore_set
   //
   // DMA loop: source coord comes from the loop iv (proves srcCore is
-  // carried end-to-end), not from my_logical_x.
+  // carried end-to-end), not from my_logical_x. The fully-indexed read
+  // embeds the translated coords directly in noc_async_read core[...].
   // CHECK: scf.for %[[SX:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
   // CHECK:   ttkernel.experimental::convert_logical_y_to_translated
   // CHECK:   ttkernel.experimental::convert_logical_x_to_translated(%[[SX]])
-  // CHECK:   ttkernel.get_noc_addr
-  // CHECK:   ttkernel.noc_async_read
+  // CHECK:   ttkernel.noc_async_read core[
   // CHECK:   ttkernel.noc_async_read_barrier
   // CHECK: }
   //

--- a/test/ttmlir/Dialect/D2M/generic/gather_core_backend_pipeline.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/gather_core_backend_pipeline.mlir
@@ -1,0 +1,137 @@
+// RUN: ttmlir-opt --d2m-be-pipeline --convert-d2m-to-ttkernel %s | FileCheck %s
+
+// End-to-end backend test for d2m.gather_core: takes a post-LowerToExplicitForm
+// fixture in unified-thread form, runs the entire D2M backend pipeline
+// (HoistCBAllocs -> SplitUnifiedThread -> PreallocateMcastSemaphores ->
+//  ScheduleDMA -> LowerLoadStoreOpsToDMA -> OptimizeDMA ->
+//  ExpandDMAReadCompositeView -> LowerDMAToFullyIndexedForm ->
+//  NormalizeThreadArgs -> GenericRegionsToFuncs), and finally the
+// D2M -> TTKernel conversion. This pins the full lowering chain for
+// gather_core in V1 (option (c) for dst CB asymmetry).
+//
+// Fixture: 4x4 worker grid, 1x4 gather group at (0,0), collector at (0,0).
+// Each source shard is 2x4 tiles. Src/dst CB scratch buffers are
+// pre-allocated (post-D2MAllocate shape).
+
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], dst_physical_size_tiles = 16, num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(7, 3), (0, 0), (3, 0), (4, 0), (0, 4), (7, 7), (1, 4), (6, 4), (5, 4), (2, 6), (3, 4), (4, 4)], dram_bank_to_logical_worker_noc1 = [(7, 3), (0, 0), (3, 0), (4, 0), (0, 4), (7, 7), (1, 4), (6, 4), (5, 4), (2, 6), (3, 4), (4, 4)]}], [0], [1 : i32], [ 0x0x0x0]>
+
+module attributes {ttcore.system_desc = #system_desc} {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+
+  // The backend pipeline lifts the d2m.generic into per-thread func.funcs
+  // via D2MGenericRegionsToFuncs. We expect one DM-thread kernel followed
+  // by one (empty) compute kernel.
+
+  // CHECK-LABEL: func.func private @datamovement_kernel0
+  //
+  // Compile-time arg spec: two local semaphores (collectorDone, sourceReady)
+  // and two CB ports (src + dst). All four surfaced via
+  // get_compile_time_arg_val + get_semaphore / get_cb.
+  // CHECK-SAME: ttkernel.arg_spec
+  // CHECK-SAME: arg_type = local_semaphore
+  // CHECK-SAME: arg_type = local_semaphore
+  // CHECK-SAME: arg_type = cb_port
+  // CHECK-SAME: arg_type = cb_port
+  //
+  // Both semaphores and both CB ports are materialized at the top of the
+  // kernel body. dst CB comes first (its operand index in the generic is
+  // higher); src CB second. We bind names to use them in later CHECKs.
+  // CHECK: %[[SEM_DONE:.*]] = ttkernel.get_semaphore
+  // CHECK: %[[SEM_READY:.*]] = ttkernel.get_semaphore
+  // CHECK: %[[DST_CB:.*]] = ttkernel.get_compile_time_arg_val({{.*}}) : () -> !ttkernel.cb
+  // CHECK: %[[SRC_CB:.*]] = ttkernel.get_compile_time_arg_val({{.*}}) : () -> !ttkernel.cb
+  //
+  // wait_front on the src CB happens outside the collector branch (every
+  // core in the group consumes one src-CB element).
+  // CHECK: ttkernel.cb_wait_front(%[[SRC_CB]], %{{.*}})
+  //
+  // isCollector test against (0, 0); these use my_logical_y/x (this core's
+  // own location), distinct from the gather-loop source coords below.
+  // CHECK: ttkernel.my_logical_y
+  // CHECK: ttkernel.my_logical_x
+  // CHECK: scf.if %{{.*}} {
+
+  // ---- Collector branch ----
+  // Reserve the dst CB (only the collector does this; option (c)).
+  // CHECK: ttkernel.cb_reserve_back(%[[DST_CB]], %{{.*}})
+  //
+  // Wait for the other (group_volume - 1) sources, then reset the counter.
+  // CHECK: ttkernel.experimental::semaphore_wait
+  // CHECK: ttkernel.noc_semaphore_set
+  //
+  // Gather loop: each iteration issues a cross-core dma_read whose virtual
+  // source coords come from the loop induction variable (via
+  // convert_logical_x_to_translated(%[[SX]])), NOT from my_logical_x. This
+  // proves the srcCore operand was carried end-to-end through
+  // LowerDMAToFullyIndexedForm and the D2MToTTKernel cross-core path.
+  // CHECK: scf.for %[[SX:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+  // CHECK:   ttkernel.experimental::convert_logical_y_to_translated
+  // CHECK:   ttkernel.experimental::convert_logical_x_to_translated(%[[SX]])
+  // CHECK:   ttkernel.get_noc_addr
+  // CHECK:   ttkernel.noc_async_read
+  // CHECK:   ttkernel.noc_async_read_barrier
+  // CHECK: }
+  //
+  // Multicast the collectorDone signal to the entire group (group_volume - 1
+  // peers receive it; the collector also writes its own copy locally first).
+  // CHECK: ttkernel.experimental::get_noc_multicast_addr
+  // CHECK: ttkernel.noc_semaphore_set
+  // CHECK: ttkernel.noc_semaphore_set_multicast(%[[SEM_DONE]],
+  //
+  // Push the dst CB (only the collector).
+  // CHECK: ttkernel.cb_push_back(%[[DST_CB]], %{{.*}})
+  // CHECK: } else {
+
+  // ---- Source branch ----
+  // Producers signal the collector and wait for the multicast release.
+  // No NoC reads, no dst-CB reserve/push (option (c)).
+  // CHECK: ttkernel.experimental::convert_logical_y_to_translated
+  // CHECK: ttkernel.experimental::convert_logical_x_to_translated
+  // CHECK: ttkernel.get_noc_addr
+  // CHECK: ttkernel.noc_semaphore_inc
+  // CHECK: ttkernel.experimental::semaphore_wait
+  // CHECK: ttkernel.noc_semaphore_set
+  // CHECK-NOT: ttkernel.noc_async_read
+  // CHECK-NOT: ttkernel.cb_reserve_back
+  // CHECK-NOT: ttkernel.cb_push_back
+  // CHECK: }
+  //
+  // pop_front on the src CB after the branch (every core pops, mirroring
+  // the wait_front before the branch).
+  // CHECK: ttkernel.cb_pop_front(%[[SRC_CB]], %{{.*}})
+
+  // The compute kernel is empty: gather_core lives entirely on the DM
+  // thread, so SplitUnifiedThread emits a no-op compute kernel.
+  // CHECK-LABEL: func.func private @compute_kernel1
+  // CHECK-NEXT: return
+
+  func.func @gather_core_backend(
+      %arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>,
+      %arg1: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+    %src_buf = memref.alloc() {address = 5120 : i64, alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    %dst_buf = memref.alloc() {address = 6144 : i64, alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>,
+                 indexing_maps = [#map, #map],
+                 iterator_types = [#parallel, #parallel],
+                 threads = [#d2m.thread<unified>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
+        outs(%arg1 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
+        additionalArgs(%src_buf, %dst_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) {
+    ^unified0:
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      d2m.gather_core %src_buf into %dst_buf
+        group [%c0, %c0] shape [%c1, %c4] collector [%c0, %c0]
+        : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>,
+          memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    }
+    memref.dealloc %src_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    memref.dealloc %dst_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/generic/gather_core_backend_pipeline.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/gather_core_backend_pipeline.mlir
@@ -12,6 +12,13 @@
 // Fixture: 4x4 worker grid, 1x4 gather group at (0,0), collector at (0,0).
 // Each source shard is 2x4 tiles. Src/dst CB scratch buffers are
 // pre-allocated (post-D2MAllocate shape).
+//
+// The 1x4 group is statically degenerate on the Y axis, so the collectorDone
+// fan-out lowers to a loop of unicast ttkernel.noc_semaphore_inc calls rather
+// than to a single experimental::get_noc_multicast_addr +
+// noc_semaphore_set_multicast. See `LowerLoadStoreOpsToDMA.cpp` for the
+// gather-local degenerate-axis dispatch. The non-degenerate mcast path is
+// pinned by `gather_core_backend_pipeline_mcast.mlir`.
 
 #l1 = #ttcore.memory_space<l1>
 #map = affine_map<(d0, d1) -> (d0, d1)>
@@ -48,13 +55,22 @@ module attributes {ttcore.system_desc = #system_desc} {
   // core in the group consumes one src-CB element).
   // CHECK: ttkernel.cb_wait_front(%[[SRC_CB]], %{{.*}})
   //
-  // isCollector test against (0, 0); these use my_logical_y/x (this core's
-  // own location), distinct from the gather-loop source coords below.
+  // Two nested scf.if gates:
+  //   - outer: isInGroup (this core's logical coord is within the gather
+  //     group's [groupStart, groupStart + groupShape) rectangle); cores
+  //     outside the group skip the gather protocol entirely.
+  //   - inner: isCollector (this core's logical coord matches collectorIdx).
+  // Both use my_logical_y/x for the per-core test. Canonicalize may fold
+  // trivially-true in-group axis comparisons when the generic's grid is
+  // contained in the gather group's range on that axis (e.g. the X axis
+  // is in [0, 4) on a 4x4 grid for a 1x4 group), so the exact set of
+  // arith.cmpi/andi ops here is not pinned.
   // CHECK: ttkernel.my_logical_y
   // CHECK: ttkernel.my_logical_x
   // CHECK: scf.if %{{.*}} {
+  // CHECK-NEXT: scf.if %{{.*}} {
 
-  // ---- Collector branch ----
+  // ---- Collector branch (inside both gates) ----
   // Reserve the dst CB (only the collector does this; option (c)).
   // CHECK: ttkernel.cb_reserve_back(%[[DST_CB]], %{{.*}})
   //
@@ -75,18 +91,25 @@ module attributes {ttcore.system_desc = #system_desc} {
   // CHECK:   ttkernel.noc_async_read_barrier
   // CHECK: }
   //
-  // Multicast the collectorDone signal to the entire group (group_volume - 1
-  // peers receive it; the collector also writes its own copy locally first).
-  // CHECK: ttkernel.experimental::get_noc_multicast_addr
-  // CHECK: ttkernel.noc_semaphore_set
-  // CHECK: ttkernel.noc_semaphore_set_multicast(%[[SEM_DONE]],
+  // Fan-out the collectorDone signal to every group core. The 1x4 group is
+  // statically degenerate on the Y axis, so this lowers to a loop of unicast
+  // noc_semaphore_inc calls (one per group core), NOT to
+  // experimental::get_noc_multicast_addr + noc_semaphore_set_multicast.
+  // CHECK: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+  // CHECK:   ttkernel.experimental::convert_logical_y_to_translated
+  // CHECK:   ttkernel.experimental::convert_logical_x_to_translated
+  // CHECK:   ttkernel.get_noc_addr
+  // CHECK:   ttkernel.noc_semaphore_inc(%{{.*}}, %{{.*}}) : (!ttkernel.noc_addr, index) -> ()
+  // CHECK: }
+  // CHECK-NOT: ttkernel.experimental::get_noc_multicast_addr
+  // CHECK-NOT: ttkernel.noc_semaphore_set_multicast
   //
   // Push the dst CB (only the collector).
   // CHECK: ttkernel.cb_push_back(%[[DST_CB]], %{{.*}})
   // CHECK: } else {
 
   // ---- Source branch ----
-  // Producers signal the collector and wait for the multicast release.
+  // Producers signal the collector and wait for the per-core inc.
   // No NoC reads, no dst-CB reserve/push (option (c)).
   // CHECK: ttkernel.experimental::convert_logical_y_to_translated
   // CHECK: ttkernel.experimental::convert_logical_x_to_translated
@@ -97,10 +120,12 @@ module attributes {ttcore.system_desc = #system_desc} {
   // CHECK-NOT: ttkernel.noc_async_read
   // CHECK-NOT: ttkernel.cb_reserve_back
   // CHECK-NOT: ttkernel.cb_push_back
+  // Close both the inner (isCollector) and outer (isInGroup) scf.if.
+  // CHECK: }
   // CHECK: }
   //
-  // pop_front on the src CB after the branch (every core pops, mirroring
-  // the wait_front before the branch).
+  // pop_front on the src CB after the gates (every core pops, mirroring
+  // the wait_front before the gates).
   // CHECK: ttkernel.cb_pop_front(%[[SRC_CB]], %{{.*}})
 
   // The compute kernel is empty: gather_core lives entirely on the DM

--- a/test/ttmlir/Dialect/D2M/generic/gather_core_backend_pipeline.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/gather_core_backend_pipeline.mlir
@@ -1,24 +1,12 @@
 // RUN: ttmlir-opt --d2m-be-pipeline --convert-d2m-to-ttkernel %s | FileCheck %s
 
-// End-to-end backend test for d2m.gather_core: takes a post-LowerToExplicitForm
-// fixture in unified-thread form, runs the entire D2M backend pipeline
-// (HoistCBAllocs -> SplitUnifiedThread -> PreallocateMcastSemaphores ->
-//  ScheduleDMA -> LowerLoadStoreOpsToDMA -> OptimizeDMA ->
-//  ExpandDMAReadCompositeView -> LowerDMAToFullyIndexedForm ->
-//  NormalizeThreadArgs -> GenericRegionsToFuncs), and finally the
-// D2M -> TTKernel conversion. This pins the full lowering chain for
-// gather_core in V1 (option (c) for dst CB asymmetry).
+// End-to-end backend test for d2m.gather_core: post-LowerToExplicitForm
+// fixture runs through the entire D2M backend pipeline + D2M->TTKernel.
 //
 // Fixture: 4x4 worker grid, 1x4 gather group at (0,0), collector at (0,0).
-// Each source shard is 2x4 tiles. Src/dst CB scratch buffers are
-// pre-allocated (post-D2MAllocate shape).
-//
-// The 1x4 group is statically degenerate on the Y axis, so the collectorDone
-// fan-out lowers to a loop of unicast ttkernel.noc_semaphore_inc calls rather
-// than to a single experimental::get_noc_multicast_addr +
-// noc_semaphore_set_multicast. See `LowerLoadStoreOpsToDMA.cpp` for the
-// gather-local degenerate-axis dispatch. The non-degenerate mcast path is
-// pinned by `gather_core_backend_pipeline_mcast.mlir`.
+// The 1x4 group is statically degenerate on Y, so collectorDone lowers to
+// a loop of unicast noc_semaphore_inc calls. The non-degenerate path is
+// pinned by gather_core_backend_pipeline_mcast.mlir.
 
 #l1 = #ttcore.memory_space<l1>
 #map = affine_map<(d0, d1) -> (d0, d1)>
@@ -28,61 +16,39 @@
 module attributes {ttcore.system_desc = #system_desc} {
   ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
 
-  // The backend pipeline lifts the d2m.generic into per-thread func.funcs
-  // via D2MGenericRegionsToFuncs. We expect one DM-thread kernel followed
-  // by one (empty) compute kernel.
-
   // CHECK-LABEL: func.func private @datamovement_kernel0
   //
-  // Compile-time arg spec: two local semaphores (collectorDone, sourceReady)
-  // and two CB ports (src + dst). All four surfaced via
-  // get_compile_time_arg_val + get_semaphore / get_cb.
+  // Compile-time args: two local semaphores + two CB ports.
   // CHECK-SAME: ttkernel.arg_spec
   // CHECK-SAME: arg_type = local_semaphore
   // CHECK-SAME: arg_type = local_semaphore
   // CHECK-SAME: arg_type = cb_port
   // CHECK-SAME: arg_type = cb_port
-  //
-  // Both semaphores and both CB ports are materialized at the top of the
-  // kernel body. dst CB comes first (its operand index in the generic is
-  // higher); src CB second. We bind names to use them in later CHECKs.
+  // dst CB binds first (higher operand index in the generic).
   // CHECK: %[[SEM_DONE:.*]] = ttkernel.get_semaphore
   // CHECK: %[[SEM_READY:.*]] = ttkernel.get_semaphore
   // CHECK: %[[DST_CB:.*]] = ttkernel.get_compile_time_arg_val({{.*}}) : () -> !ttkernel.cb
   // CHECK: %[[SRC_CB:.*]] = ttkernel.get_compile_time_arg_val({{.*}}) : () -> !ttkernel.cb
   //
-  // wait_front on the src CB happens outside the collector branch (every
-  // core in the group consumes one src-CB element).
+  // src CB wait sits outside the gates (every group core consumes one).
   // CHECK: ttkernel.cb_wait_front(%[[SRC_CB]], %{{.*}})
   //
-  // Two nested scf.if gates:
-  //   - outer: isInGroup (this core's logical coord is within the gather
-  //     group's [groupStart, groupStart + groupShape) rectangle); cores
-  //     outside the group skip the gather protocol entirely.
-  //   - inner: isCollector (this core's logical coord matches collectorIdx).
-  // Both use my_logical_y/x for the per-core test. Canonicalize may fold
-  // trivially-true in-group axis comparisons when the generic's grid is
-  // contained in the gather group's range on that axis (e.g. the X axis
-  // is in [0, 4) on a 4x4 grid for a 1x4 group), so the exact set of
-  // arith.cmpi/andi ops here is not pinned.
+  // Outer scf.if = isInGroup, inner = isCollector. Both gates rely on
+  // my_logical_y/x; Canonicalize may fold trivially-true axis tests when
+  // the generic's grid coincides with the gather group on that axis.
   // CHECK: ttkernel.my_logical_y
   // CHECK: ttkernel.my_logical_x
   // CHECK: scf.if %{{.*}} {
   // CHECK-NEXT: scf.if %{{.*}} {
 
-  // ---- Collector branch (inside both gates) ----
-  // Reserve the dst CB (only the collector does this; option (c)).
+  // Collector: dst CB reserve, sourceReady wait, gather DMA loop, then
+  // collectorDone fan-out, dst CB push.
   // CHECK: ttkernel.cb_reserve_back(%[[DST_CB]], %{{.*}})
-  //
-  // Wait for the other (group_volume - 1) sources, then reset the counter.
   // CHECK: ttkernel.experimental::semaphore_wait
   // CHECK: ttkernel.noc_semaphore_set
   //
-  // Gather loop: each iteration issues a cross-core dma_read whose virtual
-  // source coords come from the loop induction variable (via
-  // convert_logical_x_to_translated(%[[SX]])), NOT from my_logical_x. This
-  // proves the srcCore operand was carried end-to-end through
-  // LowerDMAToFullyIndexedForm and the D2MToTTKernel cross-core path.
+  // DMA loop: source coord comes from the loop iv (proves srcCore is
+  // carried end-to-end), not from my_logical_x.
   // CHECK: scf.for %[[SX:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
   // CHECK:   ttkernel.experimental::convert_logical_y_to_translated
   // CHECK:   ttkernel.experimental::convert_logical_x_to_translated(%[[SX]])
@@ -91,10 +57,7 @@ module attributes {ttcore.system_desc = #system_desc} {
   // CHECK:   ttkernel.noc_async_read_barrier
   // CHECK: }
   //
-  // Fan-out the collectorDone signal to every group core. The 1x4 group is
-  // statically degenerate on the Y axis, so this lowers to a loop of unicast
-  // noc_semaphore_inc calls (one per group core), NOT to
-  // experimental::get_noc_multicast_addr + noc_semaphore_set_multicast.
+  // 1x4 (degenerate Y): collectorDone fans out as a loop of unicast incs.
   // CHECK: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
   // CHECK:   ttkernel.experimental::convert_logical_y_to_translated
   // CHECK:   ttkernel.experimental::convert_logical_x_to_translated
@@ -104,13 +67,10 @@ module attributes {ttcore.system_desc = #system_desc} {
   // CHECK-NOT: ttkernel.experimental::get_noc_multicast_addr
   // CHECK-NOT: ttkernel.noc_semaphore_set_multicast
   //
-  // Push the dst CB (only the collector).
   // CHECK: ttkernel.cb_push_back(%[[DST_CB]], %{{.*}})
   // CHECK: } else {
 
-  // ---- Source branch ----
-  // Producers signal the collector and wait for the per-core inc.
-  // No NoC reads, no dst-CB reserve/push (option (c)).
+  // Source: signal collector, wait for the per-core inc. No reads/CB ops.
   // CHECK: ttkernel.experimental::convert_logical_y_to_translated
   // CHECK: ttkernel.experimental::convert_logical_x_to_translated
   // CHECK: ttkernel.get_noc_addr
@@ -120,16 +80,13 @@ module attributes {ttcore.system_desc = #system_desc} {
   // CHECK-NOT: ttkernel.noc_async_read
   // CHECK-NOT: ttkernel.cb_reserve_back
   // CHECK-NOT: ttkernel.cb_push_back
-  // Close both the inner (isCollector) and outer (isInGroup) scf.if.
+  // Close isCollector and isInGroup.
   // CHECK: }
   // CHECK: }
   //
-  // pop_front on the src CB after the gates (every core pops, mirroring
-  // the wait_front before the gates).
   // CHECK: ttkernel.cb_pop_front(%[[SRC_CB]], %{{.*}})
 
-  // The compute kernel is empty: gather_core lives entirely on the DM
-  // thread, so SplitUnifiedThread emits a no-op compute kernel.
+  // Compute kernel is empty: gather_core is DM-only.
   // CHECK-LABEL: func.func private @compute_kernel1
   // CHECK-NEXT: return
 


### PR DESCRIPTION
Introduces `d2m.gather_core`, a collective DM op that gathers per-core local-L1-scratch from every core in a 2D group into a designated collector core. The primary application is enabling fused multi-core reductions.

Cross-core synchronization uses two local semaphores: 

- `sourceReady`:  sources increment on the collector after publishing; collector waits for all sources.

- `collectorDone`: collector multicasts a set to the group after reading; sources wait before reusing the source buffer.

### What's changed

- A new `dma_read` mode. Same L1 layout as the local mode (no grid component, uniform L1 offset across cores), but the NoC source is some other core (`srcCore` operand). There is no device-layout requirement on the source buffer.
- Moved the static helper `mapVirtualToPhysicalCoreIndex` from `GenericRegionsToFuncs.cpp` to D2M Utils.
- `PreallocateMcastSemaphores` is extended to allocate a fresh local semaphore pair (sourceReady, collectorDone) per `gather_core`.
