### PR TITLE
Fix torch.sqrt accuracy on CPU

### DIFF
--- a/tools/tt-alchemist/templates/python/local/ttir_cpu.py
+++ b/tools/tt-alchemist/templates/python/local/ttir_cpu.py
@@ -216,6 +216,11 @@ def sin(t, **_):
 
 
 def sqrt(t, **_):
+    # torch.sqrt(f32) routes through MKL VML (1-ULP-bounded), which disagrees
+    # with LLVM-compiled vsqrtss (correctly rounded) used on the runtime path.
+    # Compute via f64 to get the correctly-rounded f32 result.
+    if t.dtype == torch.float32:
+        return t.to(torch.float64).sqrt().to(torch.float32)
     return torch.sqrt(t)
 
 

--- a/tools/tt-alchemist/templates/python/local/ttir_cpu.py
+++ b/tools/tt-alchemist/templates/python/local/ttir_cpu.py
@@ -220,7 +220,7 @@ def sqrt(t, **_):
     # with LLVM-compiled vsqrtss (correctly rounded) used on the runtime path.
     # Compute via f64 to get the correctly-rounded f32 result.
     if t.dtype == torch.float32:
-        return t.to(torch.float64).sqrt().to(torch.float32)
+        return torch.sqrt(t.to(torch.float64)).to(torch.float32)
     return torch.sqrt(t)
 
 


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/8533

### Problem description
`ttir_cpu.py`'s `torch.sqrt()` is inaccurate on f32 inputs

### What's changed
@dmilinkovicTT's fix upcasts to `f64` -> run `torch.sqrt()` on `f64` -> downcast to `f32`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
