### PR TITLE
Fix various conv op args in ttnn->emitpy

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1363,7 +1363,7 @@ public:
         emitter.emit(srcOp.getOutputDtype()),
         emitter.emit(srcOp.getConv2dConfig()),
         emitter.emit(srcOp.getComputeConfig()),
-        /*dram_slice_config=*/emitter.emit(std::nullopt),
+        emitter.emit(srcOp.getConv2dSliceConfig()),
     };
 
     emitter.replaceOp(*this, args);
@@ -1421,6 +1421,7 @@ public:
         emitter.emit(srcOp.getOutputDtype()),
         emitter.emit(srcOp.getConv2dConfig()),
         emitter.emit(srcOp.getComputeConfig()),
+        emitter.emit(srcOp.getConv2dSliceConfig()),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1547,6 +1547,7 @@ public:
         emitter.template emit<std::vector<uint32_t>>(conv2dOp.getDilationAttr(),
                                                      "dilation"),
         emitter.emit(conv2dOp.getGroups(), "groups"),
+        emitter.emit(conv2dOp.getDtype(), "dtype"),
         emitter.emit(conv2dOp.getBias(), "bias_tensor"),
         emitter.emit(conv2dOp.getConv2dConfig(), "conv_config"),
         emitter.emit(conv2dOp.getComputeConfig(), "compute_config"),
@@ -1757,7 +1758,7 @@ public:
         emitter.emit(srcOp.getOutputDtype(), "output_dtype"),
         emitter.emit(srcOp.getConv2dConfig(), "conv_config"),
         emitter.emit(srcOp.getComputeConfig(), "compute_config"),
-        emitter.emit(std::nullopt, "slice_config"),
+        emitter.emit(srcOp.getConv2dSliceConfig(), "slice_config"),
     };
 
     emitter.replaceOp(*this, args);
@@ -1817,6 +1818,7 @@ public:
         emitter.emit(srcOp.getOutputDtype(), "output_dtype"),
         emitter.emit(srcOp.getConv2dConfig(), "conv_config"),
         emitter.emit(srcOp.getComputeConfig(), "compute_config"),
+        emitter.emit(srcOp.getConv2dSliceConfig(), "slice_config"),
     };
 
     emitter.replaceOp(*this, args);


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/8457

### Problem description
Couple args in conv-related ops (conv2d, prepare_weights, etc.) were missing.

### What's changed
Added the args.

### Checklist
- [ ] New/Existing tests provide coverage for changes
