### PR TITLE
[Optimizer] Fix PagedUpdateCache sharding rules

### DIFF
--- a/.github/test_scripts/op_model.sh
+++ b/.github/test_scripts/op_model.sh
@@ -13,6 +13,8 @@ echo "Running op-model test Interface"
 $BUILD_DIR/test/unittests/OpModel/TTNN/Op/TestOpModelInterface
 echo "Running op-model test MockDevice"
 $BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice
+echo "Running op-model tripwire tests"
+$BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires
 
 echo
 echo "Run Optimizer Models Perf Tests"

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
@@ -44,7 +44,7 @@ struct OpRuleBook {
     return nullptr;
   }
 
-  virtual LayoutFilterFn getInputLayoutFilter(Operation *op,
+  virtual LayoutFilterFn getInputLayoutFilter(RankedTensorType inputType,
                                               unsigned operandIdx) const {
     return getInputLayoutFilter(operandIdx);
   }

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
@@ -44,6 +44,11 @@ struct OpRuleBook {
     return nullptr;
   }
 
+  virtual LayoutFilterFn getInputLayoutFilter(Operation *op,
+                                              unsigned operandIdx) const {
+    return getInputLayoutFilter(operandIdx);
+  }
+
   /// Whether to generate reshard candidates for this op's inputs.
   /// This is a compile-time optimization: returning false skips
   /// O(K * reshardCandidates) backend validation calls. Use false when

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -82,7 +82,7 @@ struct SplitQKVRuleBook : OpRuleBook {
 /// height-sharded on a {numUsers, 1} virtual grid, where numUsers is the
 /// batch size (input1.shape[1]).
 struct PagedUpdateCacheRuleBook : OpRuleBook {
-  LayoutFilterFn getInputLayoutFilter(Operation *op,
+  LayoutFilterFn getInputLayoutFilter(RankedTensorType inputType,
                                       unsigned operandIdx) const override;
 };
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -79,9 +79,11 @@ struct SplitQKVRuleBook : OpRuleBook {
 };
 
 /// PagedUpdateCache constraint: the fill-value (operand 1) must be L1
-/// height-sharded.
+/// height-sharded on a {numUsers, 1} virtual grid, where numUsers is the
+/// batch size (input1.shape[1]).
 struct PagedUpdateCacheRuleBook : OpRuleBook {
-  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+  LayoutFilterFn getInputLayoutFilter(Operation *op,
+                                      unsigned operandIdx) const override;
 };
 
 /// FillCache / PagedFillCache constraint: the cache buffer (operand 0) is

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -86,7 +86,7 @@ static TTNNLayoutAttr getOutputLayoutForResult(const BeamCandidate &c,
 /// Returns nullptr when no filtering is needed (all layouts accepted).
 /// Delegates to per-op rule files via OpRuleBook.
 static LayoutFilterFn getInputLayoutFilter(Operation *op, unsigned operandIdx) {
-  return getRuleBook(op).getInputLayoutFilter(operandIdx);
+  return getRuleBook(op).getInputLayoutFilter(op, operandIdx);
 }
 
 /// Returns true if the operand is already "constant" from the optimizer's

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -86,7 +86,9 @@ static TTNNLayoutAttr getOutputLayoutForResult(const BeamCandidate &c,
 /// Returns nullptr when no filtering is needed (all layouts accepted).
 /// Delegates to per-op rule files via OpRuleBook.
 static LayoutFilterFn getInputLayoutFilter(Operation *op, unsigned operandIdx) {
-  return getRuleBook(op).getInputLayoutFilter(op, operandIdx);
+  auto inputType =
+      mlir::cast<RankedTensorType>(op->getOperand(operandIdx).getType());
+  return getRuleBook(op).getInputLayoutFilter(inputType, operandIdx);
 }
 
 /// Returns true if the operand is already "constant" from the optimizer's

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -105,8 +105,8 @@ PagedUpdateCacheRuleBook::getInputLayoutFilter(Operation *op,
                                                unsigned operandIdx) const {
   // Operand 1 (fill value) must be L1 height-sharded on a {numUsers, 1}
   // virtual grid.  Any other grid causes PCC degradation;
-  // TODO(): relax when tt-metal enforces this and raises an error for
-  // PCC-degrading layouts.
+  // https://github.com/tenstorrent/tt-metal/issues/44923 relax when tt-metal
+  // enforces this and raises an error for PCC-degrading layouts.
   if (operandIdx == 1) {
     int64_t numUsers =
         mlir::cast<RankedTensorType>(op->getOperand(1).getType()).getShape()[1];

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -103,10 +103,18 @@ OutputHints SplitQKVRuleBook::getOutputHints(
 LayoutFilterFn
 PagedUpdateCacheRuleBook::getInputLayoutFilter(RankedTensorType inputType,
                                                unsigned operandIdx) const {
-  // Operand 1 (fill value) must be L1 height-sharded on a {numUsers, 1}
-  // virtual grid.  Any other grid causes PCC degradation;
-  // https://github.com/tenstorrent/tt-metal/issues/44923 relax when tt-metal
-  // enforces this and raises an error for PCC-degrading layouts.
+  // Operand 1 (fill value): L1 height-sharded with virtual grid
+  // {numUsers, 1}, where numUsers = input1.shape[1].  Any other grid
+  // silently produced PCC=0 for upper users
+  // (https://github.com/tenstorrent/tt-metal/issues/44923).  HS in tt-mlir
+  // IR is pinned to {M, 1}, so this is the canonical (and only) HS grid
+  // shape with num_cores == numUsers.
+  //
+  // TODO(bmalesevic): once tt-metal PR #45016 is uplifted, metal enforces
+  // `grid.num_cores() == padded_shape()[1]` from its side and this rule
+  // can be removed; the tripwire at
+  // test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp will fail
+  // and signal the point.
   if (operandIdx == 1) {
     int64_t numUsers = inputType.getShape()[1];
     return [numUsers](TTNNLayoutAttr layout) -> bool {

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -5,6 +5,8 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h"
 
+#include "mlir/IR/BuiltinTypes.h"
+
 namespace mlir::tt::ttnn {
 
 //===----------------------------------------------------------------------===//
@@ -99,15 +101,22 @@ OutputHints SplitQKVRuleBook::getOutputHints(
 //===----------------------------------------------------------------------===//
 
 LayoutFilterFn
-PagedUpdateCacheRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
-  // Operand 1 (fill value) must be L1 height-sharded.
-  // Reject interleaved and all other sharding types so the beam search
-  // is forced to explore HeightSharded reshard candidates.
+PagedUpdateCacheRuleBook::getInputLayoutFilter(Operation *op,
+                                               unsigned operandIdx) const {
+  // Operand 1 (fill value) must be L1 height-sharded on a {numUsers, 1}
+  // virtual grid.  Any other grid causes PCC degradation;
+  // TODO(): relax when tt-metal enforces this and raises an error for
+  // PCC-degrading layouts.
   if (operandIdx == 1) {
-    return [](TTNNLayoutAttr layout) -> bool {
+    int64_t numUsers =
+        mlir::cast<RankedTensorType>(op->getOperand(1).getType()).getShape()[1];
+    return [numUsers](TTNNLayoutAttr layout) -> bool {
       auto ml = layout.getMemLayout();
+      auto gridShape = layout.getGridShape();
       return layout.hasL1BufferType() && ml &&
-             ml.getValue() == TensorMemoryLayout::HeightSharded;
+             ml.getValue() == TensorMemoryLayout::HeightSharded &&
+             gridShape.size() == 2 && gridShape[0] == numUsers &&
+             gridShape[1] == 1;
     };
   }
   return nullptr;

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -101,22 +101,22 @@ OutputHints SplitQKVRuleBook::getOutputHints(
 //===----------------------------------------------------------------------===//
 
 LayoutFilterFn
-PagedUpdateCacheRuleBook::getInputLayoutFilter(Operation *op,
+PagedUpdateCacheRuleBook::getInputLayoutFilter(RankedTensorType inputType,
                                                unsigned operandIdx) const {
   // Operand 1 (fill value) must be L1 height-sharded on a {numUsers, 1}
   // virtual grid.  Any other grid causes PCC degradation;
   // https://github.com/tenstorrent/tt-metal/issues/44923 relax when tt-metal
   // enforces this and raises an error for PCC-degrading layouts.
   if (operandIdx == 1) {
-    int64_t numUsers =
-        mlir::cast<RankedTensorType>(op->getOperand(1).getType()).getShape()[1];
+    int64_t numUsers = inputType.getShape()[1];
     return [numUsers](TTNNLayoutAttr layout) -> bool {
       auto ml = layout.getMemLayout();
+      assert(ml && "expected non-null memory layout");
       auto gridShape = layout.getGridShape();
-      return layout.hasL1BufferType() && ml &&
+      assert(gridShape.size() == 2 && "expected 2D grid shape");
+      return layout.hasL1BufferType() &&
              ml.getValue() == TensorMemoryLayout::HeightSharded &&
-             gridShape.size() == 2 && gridShape[0] == numUsers &&
-             gridShape[1] == 1;
+             gridShape[0] == numUsers && gridShape[1] == 1;
     };
   }
   return nullptr;

--- a/test/unittests/OpModel/TTNN/Lib/CMakeLists.txt
+++ b/test/unittests/OpModel/TTNN/Lib/CMakeLists.txt
@@ -53,4 +53,33 @@ target_link_libraries(TestOpModelLibMockDevice
     TTMLIRTestUtils
 )
 
+# Tripwire tests: small, standalone, expected to fail when a specific upstream
+# tt-metal change lands.  Built as its own target so it compiles fast and the
+# whole file/target can be removed once the upstream change arrives.
+add_executable(TestOpModelLibTripwires
+TestOpModelLibTripwires.cpp
+)
+
+target_compile_options(TestOpModelLibTripwires
+    PRIVATE
+    -fno-rtti
+)
+
+target_include_directories(TestOpModelLibTripwires
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/lib/OpModel/TTNN/
+    ${PROJECT_SOURCE_DIR}/test/unittests/OpModel/TTNN/
+)
+
+target_link_libraries(TestOpModelLibTripwires
+    PRIVATE
+    gtest
+    gtest_main
+    TTNNOpModelLib
+    MLIRTTCoreDialect
+    MLIRTTNNDialect
+    MLIRTTTransforms
+    TTMLIRTestUtils
+)
+
 endif()

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -5602,6 +5602,47 @@ TEST_F(OpModelTest, PagedUpdateCacheOpWithoutPageTable) {
   }
 }
 
+// Tripwire for tt-metal grid validation on PagedUpdateCacheOp operand 1.
+// The kernel requires input1 ("fill value") to be L1 height-sharded on a
+// {numUsers, 1} virtual grid, where numUsers = input1.shape[1]. Any other
+// grid silently produced PCC=0 for the upper users.
+//
+// tt-mlir's PagedUpdateCacheRuleBook still pins to {numUsers, 1} because
+// tt-metal does not reject other grids
+// (https://github.com/tenstorrent/tt-metal/issues/44923).  This test
+// constructs a non-{numUsers, 1} grid and asserts that OpModel currently
+// accepts it.  When tt-metal adds the assert, this EXPECT will start
+// failing, which is the signal to flip it to EXPECT_FALSE and relax the
+// rule.
+TEST_F(OpModelTest, PagedUpdateCacheOpWrongGridTripwire) {
+  const llvm::SmallVector<int64_t> cacheShape = {8, 4, 32, 256};
+  const llvm::SmallVector<int64_t> inputShape = {1, 8, 12, 256};
+  const llvm::SmallVector<int64_t> updateIndexShape = {8};
+  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
+
+  // numUsers = inputShape[1] = 8.  Correct virtual grid is {8, 1}; we use
+  // {4, 1} (evenly divides numUsers, but not equal to it).
+  const llvm::SmallVector<int64_t> wrongVirtualGrid = {4, 1};
+
+  const TTNNLayoutAttr cacheLayout = CreateTiledLayout(
+      cacheShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr inputLayoutWrongGrid =
+      CreateTiledLayout(inputShape, BufferType::L1,
+                        TensorMemoryLayout::HeightSharded, wrongVirtualGrid);
+  const TTNNLayoutAttr updateIndexLayout = CreateRowMajorLayoutInt32(
+      updateIndexShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<PagedUpdateCacheOp>::getOpConstraints(
+      workerGrid, cacheShape, cacheLayout, inputShape, inputLayoutWrongGrid,
+      updateIndexShape, updateIndexLayout, std::nullopt, std::nullopt, false,
+      cacheLayout);
+  const bool ok = static_cast<bool>(constraintsExp);
+  if (!ok) {
+    llvm::consumeError(constraintsExp.takeError());
+  }
+  EXPECT_TRUE(ok);
+}
+
 TEST_F(OpModelTest, PagedFillCacheOp) {
   // Test basic PagedUpdateCacheOp with DRAM cache, input, update_index, and
   // page_table tensors

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tripwire tests: pass today, expected to fail when a specific tt-metal
+// change lands.  Each test's comment names the metal issue/PR to track.
+// Kept in a separate target so it compiles fast and the whole file can be
+// removed once the upstream change arrives.
+
+#include "OpModelFixture.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace mlir::tt::ttnn::op_model {
+
+class OpModelTripwireTest : public OpModelFixture {};
+
+// PagedUpdateCacheOp operand 1 must be L1 height-sharded with virtual grid
+// {numUsers, 1} = {input1.shape[1], 1}; other grids silently produced
+// PCC=0 for upper users
+// (https://github.com/tenstorrent/tt-metal/issues/44923).
+//
+// tt-metal PR #45016 adds the matching TT_FATAL
+// (`grid.num_cores() == padded_shape()[1]`).  Until that uplift, metal
+// still accepts PCC-degrading grids: this test feeds {4, 1} for
+// numUsers = 8 and asserts OpModel accepts it today.  When the uplift
+// lands, EXPECT_TRUE flips to fail -- signal to delete this file + target
+// and drop the operand-1 rule in PagedUpdateCacheRuleBook (metal will
+// enforce it from its side).
+TEST_F(OpModelTripwireTest, PagedUpdateCacheOpWrongGrid) {
+  const llvm::SmallVector<int64_t> cacheShape = {8, 4, 32, 256};
+  const llvm::SmallVector<int64_t> inputShape = {1, 8, 12, 256};
+  const llvm::SmallVector<int64_t> updateIndexShape = {8};
+  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
+
+  // numUsers = inputShape[1] = 8; the only valid HS grid in tt-mlir IR is
+  // {8, 1}.  We use {4, 1} (num_cores = 4) so the new TT_FATAL rejects it
+  // once #45016 is uplifted.
+  const llvm::SmallVector<int64_t> wrongVirtualGrid = {4, 1};
+
+  const TTNNLayoutAttr cacheLayout = CreateTiledLayout(
+      cacheShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr inputLayoutWrongGrid =
+      CreateTiledLayout(inputShape, BufferType::L1,
+                        TensorMemoryLayout::HeightSharded, wrongVirtualGrid);
+  const TTNNLayoutAttr updateIndexLayout = CreateRowMajorLayoutInt32(
+      updateIndexShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<PagedUpdateCacheOp>::getOpConstraints(
+      workerGrid, cacheShape, cacheLayout, inputShape, inputLayoutWrongGrid,
+      updateIndexShape, updateIndexLayout, std::nullopt, std::nullopt, false,
+      cacheLayout);
+  const bool ok = static_cast<bool>(constraintsExp);
+  if (!ok) {
+    llvm::consumeError(constraintsExp.takeError());
+  }
+  EXPECT_TRUE(ok);
+}
+
+} // namespace mlir::tt::ttnn::op_model


### PR DESCRIPTION
### Ticket
#8479

### Problem description
 PagedUpdateCacheRuleBook::getInputLayoutFilter previously accepted any L1 height-sharded layout for the fill-value (operand 1). The tt-metal kernel silently produces PCC-degraded outputs unless the input is height-sharded on the exact {numUsers, 1} virtual grid (one user per row, single column), so the optimizer was free to pick a layout that compiles cleanly but corrupts results.
This operand's grid and layout are already forced via workaround at optimization_level < 2. We want to avoid that workaround as it causes other problems on optimization_level = 2.
### What's changed
- OpRuleBook: added an input-tensor-type-aware getInputLayoutFilter(RankedTensorType inputTensorType, unsigned operandIdx) virtual that defaults to delegating to the existing (unsigned operandIdx) overload — every rule book that doesn't need the tensor type is untouched.
- PagedUpdateCacheRuleBook: overrides the new overload; captures numUsers = input.shape[1] (batch size) and tightens the filter to require gridShape == {numUsers, 1} on top of L1 height-sharded.
- MemoryLayoutPropagation: caller now forwards the operand tensor type to the rule book.

tt-metal fix addressed at: tenstorrent/tt-metal#44923.

### Checklist
- [x] Check most printed outputs for Users1+ are correct, without perf degradation or new errors:
  - Results on base tt-mlir commit: https://github.com/tenstorrent/tt-xla/actions/runs/26226350407 
  - Results on this branch: https://github.com/tenstorrent/tt-xla/actions/runs/26219348710
  - Both actually seemed to have the ticket solved
- [x] Made a branch with reverted commit [[Optimizer] Fix L1 sharding non-determinism: stable sort + ordered maps in beam and reshard candidate generation ](https://github.com/tenstorrent/tt-mlir/commit/fe1f20899a4f9f6447254b6ec0fb95489a61b13f) (which accidentally picks the right grid for now) to prove this fix fixes user outputs 16, 20, 24, 28 if the heuristics were to change again:
   - without fix sharding rules: https://github.com/tenstorrent/tt-xla/actions/runs/26280793115
   - with fix sharding rules: https://github.com/tenstorrent/tt-xla/actions/runs/26292149358/job/77397404892