### PR TITLE
Add TTNNCollectPerfMetrics to optimizer team CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -217,6 +217,9 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 /lib/Dialect/TTNN/Transforms/TTNNFusing.cpp @tenstorrent/forge-developers-mlir-core @odjuricicTT @mvasiljevicTT
 /test/ttmlir/Dialect/TTNN/fusing/ @tenstorrent/forge-developers-mlir-core @odjuricicTT @mvasiljevicTT
 
+# TTNN Collect Perf Metrics
+/lib/Dialect/TTNN/Transforms/TTNNCollectPerfMetrics.cpp @tenstorrent/forge-developers-mlir-optimizer
+
 # LLVM Target
 /include/ttmlir/Target/LLVM/ @tenstorrent/forge-developers-mlir-core
 /lib/Target/LLVM/ @tenstorrent/forge-developers-mlir-core


### PR DESCRIPTION
### Ticket
N/A — CODEOWNERS housekeeping.

### Problem description
`lib/Dialect/TTNN/Transforms/TTNNCollectPerfMetrics.cpp` currently falls
under the broad `/lib/Dialect/TTNN/` ownership of
`@tenstorrent/forge-developers-mlir-core`. The pass is owned/iterated on
by the optimizer team in practice (sharding analysis, perf targets,
related metrics) and changes to it should be reviewed there.

### What's changed
Adds an explicit entry pinning ownership of `TTNNCollectPerfMetrics.cpp`
to `@tenstorrent/forge-developers-mlir-optimizer`. Follows the existing
pattern used for `TTNNFusing.cpp`.

### Checklist
- [x] New/Existing tests provide coverage for changes — N/A, CODEOWNERS-only.