### PR TITLE
[StableHLOToTTIR] Handle 3D input in group_norm composite lowering

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -720,8 +720,41 @@ public:
     namedAttrs.push_back(rewriter.getNamedAttr(
         "operandSegmentSizes", rewriter.getDenseI32ArrayAttr(segmentSizes)));
 
-    rewriter.replaceOpWithNewOp<ttir::GroupNormOp>(
-        srcOp, outputType, adaptor.getOperands(), namedAttrs);
+    // ttir.group_norm requires 4D; reshape rank<4 to 4D by appending
+    // trailing unit dims (keeps channel_dim at the same index), then
+    // reshape the result back to the original rank.
+    Value input = adaptor.getOperands()[0];
+    auto inputType = mlir::cast<RankedTensorType>(input.getType());
+    int64_t inputRank = inputType.getRank();
+    if (inputRank > 4) {
+      return rewriter.notifyMatchFailure(srcOp, "input rank must be <= 4");
+    }
+
+    if (inputRank == 4) {
+      rewriter.replaceOpWithNewOp<ttir::GroupNormOp>(
+          srcOp, outputType, adaptor.getOperands(), namedAttrs);
+      return success();
+    }
+
+    SmallVector<int64_t> paddedShape(inputType.getShape().begin(),
+                                     inputType.getShape().end());
+    paddedShape.append(4 - inputRank, 1);
+    auto paddedType =
+        RankedTensorType::get(paddedShape, inputType.getElementType());
+
+    SmallVector<Value> gnOperands(adaptor.getOperands().begin(),
+                                  adaptor.getOperands().end());
+    gnOperands[0] = rewriter.create<ttir::ReshapeOp>(
+        srcOp.getLoc(), paddedType, input,
+        rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(paddedShape)));
+
+    Value gnResult = rewriter.create<ttir::GroupNormOp>(
+        srcOp.getLoc(), paddedType, gnOperands, namedAttrs);
+
+    rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
+        srcOp, outputType, gnResult,
+        rewriter.getI32ArrayAttr(
+            llvm::to_vector_of<int32_t>(outputType.getShape())));
     return success();
   }
 };

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_group_norm_rank3.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_group_norm_rank3.mlir
@@ -1,0 +1,49 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func @gn_rank3(
+      %x: tensor<1x512x16384xf32>,
+      %w: tensor<512xf32>,
+      %b: tensor<512xf32>) -> tensor<1x512x16384xf32> {
+    // CHECK-LABEL: func.func @gn_rank3
+    // CHECK: %[[X4D:[0-9]+]] = "ttir.reshape"
+    // CHECK-SAME: shape = [1 : i32, 512 : i32, 16384 : i32, 1 : i32]
+    // CHECK-SAME: (tensor<1x512x16384xf32>{{.*}}) -> tensor<1x512x16384x1xf32>
+    // CHECK: %[[GN:[0-9]+]] = "ttir.group_norm"(%[[X4D]]
+    // CHECK-SAME: -> tensor<1x512x16384x1xf32>
+    // CHECK: "ttir.reshape"(%[[GN]])
+    // CHECK-SAME: shape = [1 : i32, 512 : i32, 16384 : i32]
+    // CHECK-SAME: (tensor<1x512x16384x1xf32>{{.*}}) -> tensor<1x512x16384xf32>
+    %0 = stablehlo.composite "tenstorrent.group_norm" %x, %w, %b {
+        composite_attributes = {channel_dim = 1 : i64, epsilon = 9.99999997E-7 : f32, num_groups = 32 : i64},
+        decomposition = @gn_impl_rank3
+    } : (tensor<1x512x16384xf32>, tensor<512xf32>, tensor<512xf32>) -> tensor<1x512x16384xf32>
+    return %0 : tensor<1x512x16384xf32>
+  }
+
+  func.func @gn_rank4(
+      %x: tensor<1x480x1x64xbf16>,
+      %w: tensor<480xbf16>,
+      %b: tensor<480xbf16>) -> tensor<1x480x1x64xbf16> {
+    // CHECK-LABEL: func.func @gn_rank4
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: "ttir.group_norm"
+    %0 = stablehlo.composite "tenstorrent.group_norm" %x, %w, %b {
+        composite_attributes = {channel_dim = 1 : i64, epsilon = 9.99999974E-6 : f32, num_groups = 8 : i64},
+        decomposition = @gn_impl_rank4
+    } : (tensor<1x480x1x64xbf16>, tensor<480xbf16>, tensor<480xbf16>) -> tensor<1x480x1x64xbf16>
+    return %0 : tensor<1x480x1x64xbf16>
+  }
+
+  func.func private @gn_impl_rank3(
+      %arg0: tensor<1x512x16384xf32>, %arg1: tensor<512xf32>, %arg2: tensor<512xf32>) -> tensor<1x512x16384xf32> {
+    return %arg0 : tensor<1x512x16384xf32>
+  }
+
+  func.func private @gn_impl_rank4(
+      %arg0: tensor<1x480x1x64xbf16>, %arg1: tensor<480xbf16>, %arg2: tensor<480xbf16>) -> tensor<1x480x1x64xbf16> {
+    return %arg0 : tensor<1x480x1x64xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4801
- https://github.com/tenstorrent/tt-xla/issues/4710

### Problem description

- The `stablehlo.composite "tenstorrent.group_norm"` lowering passes the input through unchanged. `torch.nn.GroupNorm` accepts rank-3 `(N, C, S)` tensors, but `ttir.group_norm` requires a 4D input, so the conversion fails with `'ttir.group_norm' op input must be a 4D tensor, got rank 3`.

### What's changed

- In `TenstorrentGroupNormConversionPattern`, reshape the input to 4D by appending trailing unit dims when its rank is `< 4` before constructing the TTIR op, and reshape the result back to the original rank afterwards. Trailing (vs leading) unit dims are appended so `channel_dim` stays at the same index (no attribute rewrite needed) and the per-group reduction math is unchanged. Ranks `> 4` are rejected via `notifyMatchFailure`. 4D inputs are unchanged (no extra reshape) — pre-existing callers are unaffected.
- Added `test/ttmlir/Conversion/StableHLOToTTIR/composite/test_group_norm_rank3.mlir` covering both the rank-3 → 4D promotion (with reshape-back) and the 4D pass-through regression guard.
- Post this fix, both the model and sanity are passed


### Checklist

- [x] Verify the changes through local testing in N150

### Logs

- [may21_gn_rank_issue_before_fix.log](https://github.com/user-attachments/files/28112054/may21_gn_rank_issue.log)
- [may21_gn_rank_issue_after_fix.log](https://github.com/user-attachments/files/28112052/may21_gn_rank_issue_after_fix.log)
- [may21_playground_v2_5_vae_decoder_fp32_gn_composite_before_fix.log](https://github.com/user-attachments/files/28112057/may21_playground_v2_5_vae_decoder_fp32_gn_composite.log)
- [may21_playground_v2_5_vae_decoder_fp32_gn_composite_after_fix.log](https://github.com/user-attachments/files/28112056/may21_playground_v2_5_vae_decoder_fp32_after_fix.log)


