### PR TITLE
[d2m] matmul l1 accumulation fix

### DIFF
--- a/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
+++ b/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
@@ -139,9 +139,9 @@ bool allTileMatmulOutputsSupportPackerL1Acc(Operation *loopOp);
 // iterations accumulate into the same output L1 slot, and is therefore the
 // correct trigger for switching the packer to L1-acc mode.
 //
-// Returns nullptr if there is no such reduction loop, or if the candidate
-// reduction loop has a constant trip count <= 1 (in which case L1-acc is
-// not needed and the trigger comparison would never fire correctly).
+// Returns nullptr if there is no qualifying reduction loop with trip count > 1.
+// Reduction loops with constant trip count <= 1 are skipped because L1-acc is
+// not needed for them.
 Value findClosestReductionLoopIVForL1Acc(Operation *acquireDstOp,
                                          const CopyInfoMap &copyInfos);
 

--- a/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
+++ b/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
@@ -133,17 +133,17 @@ bool isPackerL1AccumulationSupportedDataType(ttcore::DataType dt);
 // gating on `hasTileMatmul`).
 bool allTileMatmulOutputsSupportPackerL1Acc(Operation *loopOp);
 
-// Find the outermost ancestor reduction loop IV of `acquireDst`, where
+// Find the closest ancestor reduction loop IV of `acquireDst`, where
 // "reduction" means: no output store recorded in `copyInfos` depends on the
-// loop's induction variable. This is the loop whose iterations accumulate
-// into the same output L1 slot, and is therefore the correct trigger for
-// switching the packer to L1-acc mode.
+// loop's induction variable. The closest such loop is the loop whose adjacent
+// iterations accumulate into the same output L1 slot, and is therefore the
+// correct trigger for switching the packer to L1-acc mode.
 //
 // Returns nullptr if there is no such reduction loop, or if the candidate
 // reduction loop has a constant trip count <= 1 (in which case L1-acc is
 // not needed and the trigger comparison would never fire correctly).
-Value findOutermostReductionLoopIVForL1Acc(Operation *acquireDstOp,
-                                           const CopyInfoMap &copyInfos);
+Value findClosestReductionLoopIVForL1Acc(Operation *acquireDstOp,
+                                         const CopyInfoMap &copyInfos);
 
 // Stamp a pass-allocated scratch slice onto the op's `dst_scratch_index`
 // attribute for the TTKernel lowering to consume.  Today only supports ops

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
@@ -278,17 +278,17 @@ static std::optional<int64_t> tryGetConstantTripCount(Operation *loopOp) {
   return std::nullopt;
 }
 
-Value findOutermostReductionLoopIVForL1Acc(Operation *acquireDstOp,
-                                           const CopyInfoMap &copyInfos) {
+Value findClosestReductionLoopIVForL1Acc(Operation *acquireDstOp,
+                                         const CopyInfoMap &copyInfos) {
   // `collectAncestorLoopIVs` returns IVs in outermost-to-innermost order
   // (it reverses the upward walk).
   SmallVector<Value> ancestorIVs = collectAncestorLoopIVs(acquireDstOp);
-  for (Value iv : ancestorIVs) {
+  for (Value iv : llvm::reverse(ancestorIVs)) {
     if (anyOutputStoreDependsOnIV(copyInfos, iv)) {
       // This loop indexes the output -- it is parallel, not a reduction.
       continue;
     }
-    // Found the outermost reduction loop. Only enable L1-acc if the loop
+    // Found the closest reduction loop. Only enable L1-acc if the loop
     // actually iterates more than once (otherwise the per-iteration
     // accumulation guard would never fire and we'd just emit dead code).
     Operation *loopOp = nullptr;
@@ -296,11 +296,11 @@ Value findOutermostReductionLoopIVForL1Acc(Operation *acquireDstOp,
       loopOp = blockArg.getOwner()->getParentOp();
     }
     if (!loopOp) {
-      return nullptr;
+      continue;
     }
     std::optional<int64_t> tripCount = tryGetConstantTripCount(loopOp);
     if (tripCount.has_value() && *tripCount <= 1) {
-      return nullptr;
+      continue;
     }
     return iv;
   }
@@ -317,57 +317,47 @@ void setDstScratchIndex(OperandLoadStoreRegisterOpInterface computeOp,
                   mlir::IntegerType::get(op->getContext(), 64), scratchSlice));
 }
 
-static Value getSecondIterationValue(PatternRewriter &rewriter, Location loc,
-                                     Value loopIV) {
-  auto one = rewriter.create<arith::ConstantOp>(
+static Value getFirstIterationValue(PatternRewriter &rewriter, Location loc,
+                                    Value loopIV) {
+  auto zero = rewriter.create<arith::ConstantOp>(
       loc, rewriter.getIndexType(),
-      rewriter.getIntegerAttr(rewriter.getIndexType(), 1));
+      rewriter.getIntegerAttr(rewriter.getIndexType(), 0));
 
   auto ivBlockArg = mlir::dyn_cast<BlockArgument>(loopIV);
   if (!ivBlockArg) {
-    return one;
+    return zero;
   }
 
   auto *ownerBlock = ivBlockArg.getOwner();
   if (!ownerBlock) {
-    return one;
+    return zero;
   }
 
   auto *ownerOp = ownerBlock->getParentOp();
   if (!ownerOp) {
-    return one;
+    return zero;
   }
 
   if (auto scfFor = mlir::dyn_cast<scf::ForOp>(ownerOp)) {
-    return rewriter.create<arith::AddIOp>(loc, scfFor.getLowerBound(),
-                                          scfFor.getStep());
+    return scfFor.getLowerBound();
   }
 
   if (auto affineFor = mlir::dyn_cast<affine::AffineForOp>(ownerOp)) {
-    Value lb = nullptr;
     if (affineFor.hasConstantLowerBound()) {
-      lb = rewriter.create<arith::ConstantOp>(
+      return rewriter.create<arith::ConstantOp>(
           loc, rewriter.getIndexType(),
           rewriter.getIntegerAttr(rewriter.getIndexType(),
                                   affineFor.getConstantLowerBound()));
-    } else {
-      AffineMap lowerBoundMap = affineFor.getLowerBoundMap();
-      if (lowerBoundMap.getNumResults() == 1) {
-        lb = rewriter.create<affine::AffineApplyOp>(
-            loc, lowerBoundMap, affineFor.getLowerBoundOperands());
-      }
     }
 
-    if (lb) {
-      Value step = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getIndexType(),
-          rewriter.getIntegerAttr(rewriter.getIndexType(),
-                                  affineFor.getStepAsInt()));
-      return rewriter.create<arith::AddIOp>(loc, lb, step);
+    AffineMap lowerBoundMap = affineFor.getLowerBoundMap();
+    if (lowerBoundMap.getNumResults() == 1) {
+      return rewriter.create<affine::AffineApplyOp>(
+          loc, lowerBoundMap, affineFor.getLowerBoundOperands());
     }
   }
 
-  return one;
+  return zero;
 }
 
 // ---------------------------------------------------------------------------
@@ -1085,14 +1075,16 @@ buildIndices(PatternRewriter &rewriter, Location loc,
 void insertPackerL1AccGuard(PatternRewriter &rewriter, Location loc,
                             AcquireDstOp acquireDst, Value loopIV) {
   rewriter.setInsertionPointAfter(acquireDst);
-  Value secondIterationValue = getSecondIterationValue(rewriter, loc, loopIV);
-  Value cond = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                              loopIV, secondIterationValue);
-  auto ifOp = rewriter.create<scf::IfOp>(loc, cond);
-  rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+  Value firstIterationValue = getFirstIterationValue(rewriter, loc, loopIV);
+  Value isFirstIteration = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::eq, loopIV, firstIterationValue);
+  Value disableFlag = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(0));
   Value enableFlag = rewriter.create<arith::ConstantOp>(
       loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(1));
-  rewriter.create<SetL1AccumulateOp>(loc, enableFlag);
+  Value flag = rewriter.create<arith::SelectOp>(loc, isFirstIteration,
+                                                disableFlag, enableFlag);
+  rewriter.create<SetL1AccumulateOp>(loc, flag);
 }
 
 // ---------------------------------------------------------------------------
@@ -1127,15 +1119,12 @@ bool insertDstRegisterAccessFinalize(
 
   Value l1AccLoopIV = nullptr;
   if (!disableL1Acc) {
-    // L1-acc must be triggered by the outermost ancestor *reduction* loop --
-    // i.e. an outer loop that does NOT index the output store. Using the
-    // outermost ancestor unconditionally is incorrect for batched matmuls,
-    // where the outermost loop is parallel (e.g. the batch dim) and turning
-    // on L1-acc on its second iteration would cause the packer to accumulate
-    // a fresh batch's tile into uninitialized L1 contents at a different
-    // output address.
-    l1AccLoopIV = findOutermostReductionLoopIVForL1Acc(
-        acquireDst.getOperation(), copyInfos);
+    // L1-acc must be triggered by the closest ancestor reduction loop: the
+    // innermost enclosing loop that does NOT index the output store. Outer
+    // parallel loops, and outer loops that only look reduction-like because
+    // the immediate store is to a scratch buffer, are not valid triggers.
+    l1AccLoopIV = findClosestReductionLoopIVForL1Acc(acquireDst.getOperation(),
+                                                     copyInfos);
     if (!l1AccLoopIV) {
       LDBG() << "Skipping L1 accumulation insertion: no outer reduction loop "
                 "with trip count > 1";

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_l1_acc.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_l1_acc.mlir
@@ -8,12 +8,16 @@
 // Tests L1 accumulation guard insertion in the unscheduled pass (with the
 // default disable-l1-acc=false, i.e. L1 accumulation enabled):
 //
-// 1. `matmul_l1_acc`: with an outer K-block reduction loop wrapping a
+// 1. `matmul_l1_acc`: with a K-block reduction loop wrapping a
 //    tile_matmul root, expect a d2m.set_l1_accumulate guarded by an
-//    scf.if on the K-block IV (the outermost ancestor whose IV the
+//    scf.if on the K-block IV (the closest ancestor whose IV the
 //    output store does NOT depend on).
 //
-// 2. `matmul_no_outer_reduction`: when the only ancestor loops of
+// 2. `matmul_l1_acc_nested_parallel_scratch`: when a scratch output store
+//    makes an outer parallel loop look reduction-like, still use the closest
+//    K-block reduction loop as the trigger.
+//
+// 3. `matmul_no_outer_reduction`: when the only ancestor loops of
 //    acquire_dst are *parallel* (output indexed by them), L1-acc must
 //    NOT be enabled. Using the outermost loop unconditionally is
 //    incorrect for cases like batched matmuls where the outermost loop
@@ -66,16 +70,62 @@ module {
   // acquire_dst placed inside the K-block scf.for:
   // CHECK: scf.for %[[K_BLOCK:.*]] = %c0
   // CHECK:   %[[DST:.*]] = d2m.acquire_dst() : memref<{{[0-9]+}}x!ttcore.tile<32x32, f16>, #dst>
-  // L1 accumulation guard: triggers when %k_block != 0 (i.e. on second
-  // iteration of the K-block reduction loop):
-  // CHECK:   %[[CMP:.*]] = arith.cmpi eq, %[[K_BLOCK]]
-  // CHECK:   scf.if %[[CMP]]
-  // CHECK:     d2m.set_l1_accumulate
+  // L1 accumulation is explicitly disabled on the first K-block iteration and
+  // enabled on later K-block iterations. The flag must be reset this way
+  // because the packer setting persists across outer output-tile iterations.
+  // CHECK:   %[[NOT_FIRST:.*]] = arith.cmpi ne, %[[K_BLOCK]], %c0
+  // CHECK:   %[[L1_ACC_FLAG:.*]] = arith.extui %[[NOT_FIRST]] : i1 to i32
+  // CHECK:   d2m.set_l1_accumulate(%[[L1_ACC_FLAG]])
   // Compute loop with matmul:
   // CHECK:   affine.for
   // CHECK:     affine.for
   // CHECK:       affine.for
   // CHECK:         "d2m.tile_matmul"
+
+  // CHECK-LABEL: func.func @matmul_l1_acc_nested_parallel_scratch
+  func.func @matmul_l1_acc_nested_parallel_scratch(
+      %in0: memref<1x1x4x4x!ttcore.tile<32x32, f16>, #ttcore.shard<8192x2048, 1>, #l1_>,
+      %in1: memref<1x1x4x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048, 1>, #l1_>,
+      %out0: memref<1x1x2x2x!ttcore.tile<32x32, f16>, #ttcore.shard<2048x2048, 1>, #l1_>) {
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%in0, %in1 : memref<1x1x4x4x!ttcore.tile<32x32, f16>, #ttcore.shard<8192x2048, 1>, #l1_>, memref<1x1x4x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048, 1>, #l1_>)
+        outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f16>, #ttcore.shard<2048x2048, 1>, #l1_>) {
+    ^unified0:
+      %cb0_raw = d2m.get_cb(0) : !d2m.cb<memref<4x4x!ttcore.tile<32x32, f16>, #l1_>>
+      %cb1_raw = d2m.get_cb(1) : !d2m.cb<memref<4x2x!ttcore.tile<32x32, f16>, #l1_>>
+      %cb0 = d2m.wait %cb0_raw : !d2m.cb<memref<4x4x!ttcore.tile<32x32, f16>, #l1_>> -> memref<4x4x!ttcore.tile<32x32, f16>, #l1_>
+      %cb1 = d2m.wait %cb1_raw : !d2m.cb<memref<4x2x!ttcore.tile<32x32, f16>, #l1_>> -> memref<4x2x!ttcore.tile<32x32, f16>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      %c4 = arith.constant 4 : index
+      scf.for %tile_j = %c0 to %c4 step %c2 {
+        %scratch = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f16>, #l1_>
+        scf.for %k_block = %c0 to %c4 step %c2 {
+          %sv0 = memref.subview %cb0[%c0, %k_block] [2, 2] [1, 1] : memref<4x4x!ttcore.tile<32x32, f16>, #l1_> to memref<2x2x!ttcore.tile<32x32, f16>, strided<[4, 1], offset: ?>, #l1_>
+          %sv1 = memref.subview %cb1[%k_block, %c0] [2, 2] [1, 1] : memref<4x2x!ttcore.tile<32x32, f16>, #l1_> to memref<2x2x!ttcore.tile<32x32, f16>, strided<[2, 1], offset: ?>, #l1_>
+          affine.for %i = 0 to 2 {
+            affine.for %j = 0 to 2 {
+              affine.for %k = 0 to 2 {
+                %a = affine.load %sv0[%i, %k] : memref<2x2x!ttcore.tile<32x32, f16>, strided<[4, 1], offset: ?>, #l1_>
+                %b = affine.load %sv1[%k, %j] : memref<2x2x!ttcore.tile<32x32, f16>, strided<[2, 1], offset: ?>, #l1_>
+                %c = affine.load %scratch[%i, %j] : memref<2x2x!ttcore.tile<32x32, f16>, #l1_>
+                %r = "d2m.tile_matmul"(%a, %b, %c) : (!ttcore.tile<32x32, f16>, !ttcore.tile<32x32, f16>, !ttcore.tile<32x32, f16>) -> !ttcore.tile<32x32, f16>
+                affine.store %r, %scratch[%i, %j] : memref<2x2x!ttcore.tile<32x32, f16>, #l1_>
+              }
+            }
+          } {d2m.linalg_root}
+        }
+      }
+    }
+    return
+  }
+  // CHECK: scf.for %[[TILE_J:.*]] = %c0
+  // CHECK:   scf.for %[[K_BLOCK:.*]] = %c0
+  // CHECK:     %[[DST:.*]] = d2m.acquire_dst()
+  // CHECK-NOT: arith.cmpi eq, %[[TILE_J]]
+  // CHECK:     %[[NOT_FIRST:.*]] = arith.cmpi ne, %[[K_BLOCK]], %c0
+  // CHECK:     %[[L1_ACC_FLAG:.*]] = arith.extui %[[NOT_FIRST]] : i1 to i32
+  // CHECK:     d2m.set_l1_accumulate(%[[L1_ACC_FLAG]])
 
   // CHECK-LABEL: func.func @matmul_no_outer_reduction
   func.func @matmul_no_outer_reduction(

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_l1_acc.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_l1_acc.mlir
@@ -9,9 +9,9 @@
 // default disable-l1-acc=false, i.e. L1 accumulation enabled):
 //
 // 1. `matmul_l1_acc`: with a K-block reduction loop wrapping a
-//    tile_matmul root, expect a d2m.set_l1_accumulate guarded by an
-//    scf.if on the K-block IV (the closest ancestor whose IV the
-//    output store does NOT depend on).
+//    tile_matmul root, expect d2m.set_l1_accumulate to receive a flag
+//    derived from the K-block IV (the closest ancestor whose IV the output
+//    store does NOT depend on).
 //
 // 2. `matmul_l1_acc_nested_parallel_scratch`: when a scratch output store
 //    makes an outer parallel loop look reduction-like, still use the closest


### PR DESCRIPTION
### Problem description
Some large matmuls found in qwen that go dram to dram exposed a bug in l1 accumulation

### What's changed
- Changed L1 accumulation loop selection from the outermost reduction looking ancestor loop to the closest enclosing reduction loop, so the packer flag is driven by the actual K-block accumulation loop rather than an outer output/scratch loop that can appear reduction like
- Added builder and lit tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
