### PR TITLE
remap Local Semaphore while lower spatial

### DIFF
--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -654,6 +654,7 @@ private:
     DenseMap<Value, size_t> ioToUnifiedIdx_;
     DenseMap<LocalKey, size_t> ioArgMap_;
     DenseMap<LocalKey, size_t> globalSemaphoreArgMap_;
+    DenseMap<LocalKey, size_t> localSemaphoreArgMap_;
 
   public:
     void addEnqueueArgs(ttmetal::EnqueueProgramOp enqueueProgram) {
@@ -664,6 +665,11 @@ private:
           size_t unifiedIdx = unifiedArgs_.size();
           unifiedArgs_.push_back(arg);
           globalSemaphoreArgMap_.insert({{op, localIdx}, unifiedIdx});
+          continue;
+        } else if (mlir::isa<ttmetal::LocalSemaphoreType>(arg.getType())) {
+          size_t unifiedIdx = unifiedArgs_.size();
+          unifiedArgs_.push_back(arg);
+          localSemaphoreArgMap_.insert({{op, localIdx}, unifiedIdx});
           continue;
         }
 
@@ -701,6 +707,17 @@ private:
       }
       return std::nullopt;
     }
+
+    std::optional<size_t>
+    lookupLocalSemaphore(ttmetal::EnqueueProgramOp enqueueProgram,
+                         size_t localIdx) const {
+      auto it =
+          localSemaphoreArgMap_.find({enqueueProgram.getOperation(), localIdx});
+      if (it != localSemaphoreArgMap_.end()) {
+        return it->second;
+      }
+      return std::nullopt;
+    }
   };
 
   static KernelArgAttr remapKernelArg(Builder &builder, KernelArgAttr kernelArg,
@@ -715,6 +732,11 @@ private:
     } else if (kernelArg.getType() == ttkernel::ArgType::GlobalSemaphore) {
       if (auto unified =
               remapTable.lookupGlobalSemaphore(enqueueProgram, operandIndex)) {
+        operandIndex = *unified;
+      }
+    } else if (kernelArg.getType() == ttkernel::ArgType::LocalSemaphore) {
+      if (auto unified =
+              remapTable.lookupLocalSemaphore(enqueueProgram, operandIndex)) {
         operandIndex = *unified;
       }
     } else if (kernelArg.getType() == ttkernel::ArgType::CBPort) {

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -666,7 +666,8 @@ private:
           unifiedArgs_.push_back(arg);
           globalSemaphoreArgMap_.insert({{op, localIdx}, unifiedIdx});
           continue;
-        } else if (mlir::isa<ttmetal::LocalSemaphoreType>(arg.getType())) {
+        }
+        if (mlir::isa<ttmetal::LocalSemaphoreType>(arg.getType())) {
           size_t unifiedIdx = unifiedArgs_.size();
           unifiedArgs_.push_back(arg);
           localSemaphoreArgMap_.insert({{op, localIdx}, unifiedIdx});

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -8,6 +8,7 @@
 // 3) Non-origin core-range derivation from d2m.generic grid maps.
 // 4) BufferAddress arg index remap.
 // 5) CBPort remap into merged cbs list (and sequential hardware cb_ports).
+// 6) LocalSemaphore arg index remap during spatial merge.
 
 // Single-region merge smoke test.
 #l1 = #ttcore.memory_space<l1>
@@ -269,6 +270,71 @@ module {
     return
   }
   func.func private @dm_cbport_r1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+}
+
+// -----
+
+// Two-region LocalSemaphore arg index remap test.
+#l1 = #ttcore.memory_space<l1>
+#vgm_11_inv = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#vgm_11_fwd = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK-LABEL: func.func @spatial_two_regions_local_semaphore_arg_remap
+  // CHECK-COUNT-1: "ttmetal.enqueue_program"
+  // CHECK: kernelConfigs = [
+  // CHECK-DAG: @dm_ls_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <local_semaphore[2]>, <local_semaphore[3]>]>
+  // CHECK-DAG: @cp_ls_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <local_semaphore[2]>, <local_semaphore[3]>]>
+  // CHECK-DAG: @dm_ls_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>, <local_semaphore[6]>, <local_semaphore[7]>]>
+  // CHECK-DAG: @cp_ls_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>, <local_semaphore[6]>, <local_semaphore[7]>]>
+  // CHECK-NOT: d2m.spatial
+  func.func @spatial_two_regions_local_semaphore_arg_remap(
+      %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+      %arg1: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      -> (memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+          memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+    %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1500} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2500, d2m.virtualGridInverseMapping = #vgm_11_inv, d2m.virtualGridForwardMapping = #vgm_11_fwd} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %ls_r0_0 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    %ls_r0_1 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    %ls_r1_0 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    %ls_r1_1 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    %cb_ls_r0_0 = memref.alloc() {address = 0x8000 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
+    %cb_ls_r0_1 = memref.alloc() {address = 0x8100 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
+    %cb_ls_r1_0 = memref.alloc() {address = 0x8200 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
+    %cb_ls_r1_1 = memref.alloc() {address = 0x8300 : i64, alignment = 16 : i64} : memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>
+
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+        ins(%arg0, %arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+        outs(%out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_ls_r0, noc = 0>, #d2m.thread<compute, @cp_ls_r0>]}
+            ins(%arg0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            additionalArgs(%ls_r0_0, %ls_r0_1, %cb_ls_r0_0, %cb_ls_r0_1 : !d2m.local_semaphore, !d2m.local_semaphore, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
+      }, {
+      ^region_1:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_ls_r1, noc = 0>, #d2m.thread<compute, @cp_ls_r1>]}
+            ins(%arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            additionalArgs(%ls_r1_0, %ls_r1_1, %cb_ls_r1_0, %cb_ls_r1_1 : !d2m.local_semaphore, !d2m.local_semaphore, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
+      }
+
+    return %out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+  }
+
+  func.func private @dm_ls_r0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 4>, <arg_type = cb_port, operand_index = 5>, <arg_type = local_semaphore, operand_index = 2>, <arg_type = local_semaphore, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @cp_ls_r0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 4>, <arg_type = cb_port, operand_index = 5>, <arg_type = local_semaphore, operand_index = 2>, <arg_type = local_semaphore, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    return
+  }
+  func.func private @dm_ls_r1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 4>, <arg_type = cb_port, operand_index = 5>, <arg_type = local_semaphore, operand_index = 2>, <arg_type = local_semaphore, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @cp_ls_r1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 4>, <arg_type = cb_port, operand_index = 5>, <arg_type = local_semaphore, operand_index = 2>, <arg_type = local_semaphore, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<compute>} {
     return
   }
 }


### PR DESCRIPTION
### Ticket
closes #8550

### Problem description
When lowering `d2m.spatial` to a merged `ttmetal.enqueue_program`, kernel arg remapping handled `BufferAddress`, `GlobalSemaphore`, and `CBPort`, but did not handle `LocalSemaphore`.
This left stale operand indices for local semaphores after merge, causing runtime failures (type mismatch/assert during kernel arg decoding).

### What's changed
Updated spatial merge remapping in D2MToTTMetal:
 - Added local semaphore mapping table in SpatialRemapTable
 - Recorded !ttmetal.local_semaphore args during enqueue arg collection
 - Added ttkernel::ArgType::LocalSemaphore remap branch in remapKernelArg

### Checklist
- [ ] New/Existing tests provide coverage for changes
