### PR TITLE
[TTNN] Enable L1 const-eval through an opt-in

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/BFInterleavedPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/BFInterleavedPolicy.h
@@ -40,8 +40,8 @@ public:
   void run() final;
 
 private:
-  // Effective L1 cache size scaled by tensorL1UsageCap from module attribute.
-  // Calculated once at the start of run() using utils::getTensorL1UsageCap().
+  // Effective available L1 cache size.
+  // Calculated once at the start of run() using utils::getUsableL1PerCore().
   uint64_t usableL1CacheSize;
 
   // Check if the op is analyzable. Op is analyzable if it has at least one

--- a/include/ttmlir/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.h
@@ -73,8 +73,8 @@ public:
   void run() final;
 
 private:
-  // Effective L1 cache size scaled by tensorL1UsageCap from module attribute.
-  // Calculated once at the start of run() using utils::getTensorL1UsageCap().
+  // Effective available L1 cache size.
+  // Calculated once at the start of run() using utils::getUsableL1PerCore().
   uint64_t usableL1CacheSize;
 
   // Check if the op is analyzable. Op is analyzable if it has at least one

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -15,14 +15,34 @@
 namespace mlir::tt::ttnn::utils {
 
 // Attribute name for storing tensor L1 usage cap during optimizer passes.
-// This attribute is set by DevicePassesWrapper and read by validation
-// and analysis passes to avoid parameter threading through pass infrastructure.
+// This attribute is set by DevicePassesWrapper and read by
+// getUsableL1PerCore (through getTensorL1UsageCap).
 inline constexpr llvm::StringLiteral g_TensorL1UsageCapAttrName =
     "ttnn.tensor_l1_usage_cap";
+
+// Attribute name for storing the per-core L1 usage of const-eval tensors in a
+// module, in bytes. This attribute is set by ConstEvalHoistTransform and read
+// by getUsableL1PerCore (through getReservedL1Usage).
+inline constexpr llvm::StringLiteral g_L1ConstEvalUsageAttrName =
+    "ttnn.l1_const_eval_usage";
+
+// Per-op tag opting an L1-resident op into const-eval hoisting.
+// L1-resident ops without this tag will lead to a compilation error, in order
+// to avoid accidental L1 exhaustion by unintentional candidates.
+inline constexpr llvm::StringLiteral g_ConstEvalAllowedAttrName =
+    "ttnn.const_eval_allowed";
 
 // Helper function to retrieve tensor L1 usage cap from module attribute.
 // Returns the configured cap if found, otherwise returns the default value.
 float getTensorL1UsageCap(Operation *op, float defaultValue = 0.95f);
+
+// Helper function to retrieve the per-core L1 usage reserved for the retained
+// (permanent) tensors.
+uint64_t getReservedL1Usage(Operation *op);
+
+// Helper function to retrieve the usable L1 size per core:
+// usableL1PerCore = totalL1PerCore * tensorL1UsageCap - reservedL1Usage
+uint64_t getUsableL1PerCore(Operation *op);
 
 bool isTensorOnDevice(::mlir::RankedTensorType tensorType);
 

--- a/lib/Dialect/TTNN/Analysis/BFInterleavedPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/BFInterleavedPolicy.cpp
@@ -17,13 +17,7 @@ namespace mlir::tt::ttnn {
 void BFInterleavedPolicy::run() {
   // Calculate effective L1 limit from module attribute (single source of
   // truth). This matches the pattern used in OpConstraintValidation.
-  const float tensorL1UsageCap = utils::getTensorL1UsageCap(rootOp);
-  ttcore::SystemDescAttr systemDesc = mlir::cast<ttcore::SystemDescAttr>(
-      rootOp->getParentOfType<ModuleOp>()->getAttr(
-          ttcore::SystemDescAttr::name));
-  ttcore::ChipDescAttr chipDesc = systemDesc.getChipDescs()[0];
-  usableL1CacheSize =
-      static_cast<uint64_t>(tensorL1UsageCap * chipDesc.getUsableL1Size());
+  usableL1CacheSize = utils::getUsableL1PerCore(rootOp);
 
   for (Operation &funcOp : rootOp->getRegion(0).getOps()) {
     func::FuncOp func = dyn_cast<func::FuncOp>(funcOp);

--- a/lib/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.cpp
@@ -138,13 +138,7 @@ GreedyL1InterleavedPolicy::getGreedyConfig(
 void GreedyL1InterleavedPolicy::run() {
   // Calculate effective L1 limit from module attribute (single source of
   // truth). This matches the pattern used in OpConstraintValidation.
-  const float tensorL1UsageCap = utils::getTensorL1UsageCap(rootOp);
-  ttcore::SystemDescAttr systemDesc = mlir::cast<ttcore::SystemDescAttr>(
-      rootOp->getParentOfType<ModuleOp>()->getAttr(
-          ttcore::SystemDescAttr::name));
-  ttcore::ChipDescAttr chipDesc = systemDesc.getChipDescs()[0];
-  usableL1CacheSize =
-      static_cast<uint64_t>(tensorL1UsageCap * chipDesc.getUsableL1Size());
+  usableL1CacheSize = utils::getUsableL1PerCore(rootOp);
 
   for (Operation &funcOp : rootOp->getRegion(0).getOps()) {
     func::FuncOp func = dyn_cast<func::FuncOp>(funcOp);

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/Analysis/LegalOpLayoutAnalysis.h"
@@ -86,6 +87,26 @@ static TTNNLayoutAttr getOutputLayoutForResult(const BeamCandidate &c,
 /// Delegates to per-op rule files via OpRuleBook.
 static LayoutFilterFn getInputLayoutFilter(Operation *op, unsigned operandIdx) {
   return getRuleBook(op).getInputLayoutFilter(operandIdx);
+}
+
+/// Returns true if the operand is already "constant" from the optimizer's
+/// perspective: it is either the result of a ttcore.load_cached (already
+/// const-evaled by a prior ConstEvalHoist pass) or a func block argument
+/// whose ArgumentType is anything other than Input.
+static bool isConstantDerivedOperand(Value operand) {
+  if (Operation *def = operand.getDefiningOp()) {
+    return mlir::isa<ttcore::LoadCachedOp>(def);
+  }
+  auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(operand);
+  if (!blockArg) {
+    return false;
+  }
+  auto funcOp = mlir::dyn_cast_or_null<mlir::func::FuncOp>(
+      blockArg.getOwner()->getParentOp());
+  if (!funcOp) {
+    return false;
+  }
+  return !ttcore::isInputArgumentType(funcOp, blockArg.getArgNumber());
 }
 
 /// Check if a layout is sharded.
@@ -328,10 +349,9 @@ void MemoryLayoutPropagation::run() {
     // These ops (e.g., BFP8 typecast on weights) will be re-hoisted into
     // const_eval functions. Promoting their output to L1 would cause the
     // const_eval to return L1 tensors that starve other ops of L1 budget.
-    bool allFromConstEval = op->getNumOperands() > 0 &&
-                            llvm::all_of(op->getOperands(), [](Value operand) {
-                              return ttcore::valueTracesToConstantArgs(operand);
-                            });
+    bool allFromConstEval =
+        op->getNumOperands() > 0 &&
+        llvm::all_of(op->getOperands(), isConstantDerivedOperand);
     if (allFromConstEval) {
       TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                    "[op {0}] Skipping {1} @{2}: all operands from const_eval",
@@ -724,9 +744,8 @@ void MemoryLayoutPropagation::addReshardCandidates(
     Value operand, TTNNLayoutAttr currentLayout, RankedTensorType tensorType,
     const llvm::SmallVector<BeamCandidate, 0> *producerBeam,
     Operation *producerOp, size_t resultIdx, size_t maxCandidates) {
-  // Skip reshards for operands derived from constant/parameter arguments.
-  // These will be re-hoisted into const_eval.
-  if (ttcore::valueTracesToConstantArgs(operand)) {
+
+  if (isConstantDerivedOperand(operand)) {
     return;
   }
   if (!shouldExploreReshards(op)) {

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -43,18 +43,17 @@ public:
 
     ModuleOp moduleOp = getOperation();
 
-    // Get L1 budget from system description and usage cap.
     ttcore::GridAttr deviceGrid =
         ttcore::lookupDevice(moduleOp).getWorkerGrid();
-    ttcore::ChipDescAttr chipDesc = ttcore::getOpChipDescAttr(moduleOp);
-    float tensorL1UsageCap = utils::getTensorL1UsageCap(moduleOp);
-    uint64_t l1BudgetPerCore =
-        static_cast<uint64_t>(tensorL1UsageCap * chipDesc.getUsableL1Size());
+    uint64_t l1BudgetPerCore = utils::getUsableL1PerCore(moduleOp);
 
     TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                  "L1 spill management: budget per core = {0} bytes "
-                 "(usable = {1}, cap = {2})",
-                 l1BudgetPerCore, chipDesc.getUsableL1Size(), tensorL1UsageCap);
+                 "(usable = {1}, cap = {2}, reserved = {3})",
+                 l1BudgetPerCore,
+                 ttcore::getOpChipDescAttr(moduleOp).getUsableL1Size(),
+                 utils::getTensorL1UsageCap(moduleOp),
+                 utils::getReservedL1Usage(moduleOp));
 
     moduleOp->walk([&](func::FuncOp func) {
       if (!ttmlir::utils::isForwardDeviceFunc(func)) {

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
+#include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
@@ -57,10 +58,10 @@ uint64_t getUsableL1PerCore(Operation *op) {
   ttcore::ChipDescAttr chipDesc = ttcore::getOpChipDescAttr(op);
   const uint64_t capped =
       static_cast<uint64_t>(cap * chipDesc.getUsableL1Size());
-
   const uint64_t reserved = getReservedL1Usage(op);
+  TT_assertv(reserved <= capped, "Reserved L1 usage exceeds capped value");
 
-  return reserved >= capped ? 0 : capped - reserved;
+  return capped - reserved;
 }
 
 bool isTensorOnDevice(::mlir::RankedTensorType tensorType) {

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -4,6 +4,8 @@
 
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Utils.h"
@@ -34,6 +36,31 @@ float getTensorL1UsageCap(Operation *op, float defaultValue) {
   }
 
   return defaultValue;
+}
+
+uint64_t getReservedL1Usage(Operation *op) {
+  ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
+
+  if (moduleOp) {
+    if (auto attr =
+            moduleOp->getAttrOfType<IntegerAttr>(g_L1ConstEvalUsageAttrName)) {
+      return attr.getValue().getZExtValue();
+    }
+  }
+
+  return 0;
+}
+
+uint64_t getUsableL1PerCore(Operation *op) {
+  const float cap = getTensorL1UsageCap(op);
+
+  ttcore::ChipDescAttr chipDesc = ttcore::getOpChipDescAttr(op);
+  const uint64_t capped =
+      static_cast<uint64_t>(cap * chipDesc.getUsableL1Size());
+
+  const uint64_t reserved = getReservedL1Usage(op);
+
+  return reserved >= capped ? 0 : capped - reserved;
 }
 
 bool isTensorOnDevice(::mlir::RankedTensorType tensorType) {

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -129,16 +129,7 @@ checkConstraintsResult(Operation *contextOp,
   auto [cbPeakUsage, l1BuffersPeakUsage, overallPeakL1Usage,
         outputTensorUsagePerCore, outputLayouts] = constraints.get();
 
-  const float tensorL1UsageCap = utils::getTensorL1UsageCap(contextOp);
-
-  ttcore::SystemDescAttr systemDesc = mlir::cast<ttcore::SystemDescAttr>(
-      contextOp->getParentOfType<ModuleOp>()->getAttr(
-          ttcore::SystemDescAttr::name));
-  ttcore::ChipDescAttr chipDesc = systemDesc.getChipDescs()[0];
-  uint64_t usableL1CacheSize = chipDesc.getUsableL1Size();
-
-  uint64_t effectiveL1Limit =
-      static_cast<uint64_t>(tensorL1UsageCap * usableL1CacheSize);
+  uint64_t effectiveL1Limit = utils::getUsableL1PerCore(contextOp);
   uint64_t totalL1Usage = overallPeakL1Usage + additionalL1Usage;
 
   if (totalL1Usage > effectiveL1Limit) {

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -3,9 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreTraits.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/FunctionTypes.h"
 #include "ttmlir/Transforms/Passes.h"
 #include "ttmlir/Utils.h"
@@ -113,6 +116,8 @@ public:
     buildConstEvalSubgraphs();
   }
 
+  bool failed() const { return analysisFailed; }
+
   ConstEvalAnalysisResults getAnalysisResults() {
     llvm::DenseMap<mlir::Value, size_t> rootToId;
     llvm::DenseMap<size_t, ConstEvalSubgraph> idToSubgraph;
@@ -193,22 +198,6 @@ private:
       return;
     }
 
-    // Skip ops whose results are in L1. Const-eval functions persist their
-    // outputs across function boundaries, so L1 allocations from const-eval
-    // would consume L1 budget during @main execution without the
-    // L1SpillManagement pass being able to account for them.
-    for (auto result : op->getResults()) {
-      if (auto tensorType =
-              mlir::dyn_cast<mlir::RankedTensorType>(result.getType())) {
-        if (auto layoutAttr = mlir::dyn_cast_or_null<ttnn::TTNNLayoutAttr>(
-                tensorType.getEncoding())) {
-          if (layoutAttr.hasL1BufferType()) {
-            return;
-          }
-        }
-      }
-    }
-
     auto operandConstEval = [&](mlir::Value operand) {
       if (auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(operand)) {
         return constParams.contains(blockArg);
@@ -223,6 +212,34 @@ private:
 
     // Check if all operands can be const-eval'ed.
     if (!llvm::all_of(op->getOperands(), operandConstEval)) {
+      return;
+    }
+
+    // L1-resident results must opt in via "ttnn.const_eval_allowed";
+    // const-eval outputs persist, so untagged L1 reservations would silently
+    // steal budget from the forward function.
+    bool anyResultInL1 = false;
+
+    for (auto result : op->getResults()) {
+      if (auto tensorType =
+              mlir::dyn_cast<mlir::RankedTensorType>(result.getType())) {
+        if (auto layoutAttr = mlir::dyn_cast_or_null<ttnn::TTNNLayoutAttr>(
+                tensorType.getEncoding())) {
+          if (layoutAttr.hasL1BufferType()) {
+            anyResultInL1 = true;
+            break;
+          }
+        }
+      }
+    }
+
+    if (anyResultInL1 &&
+        !op->hasAttr(mlir::tt::ttnn::utils::g_ConstEvalAllowedAttrName)) {
+      op->emitError("result of an op resides in L1, and the op is a const-eval "
+                    "candidate, but it is not tagged with '")
+          << mlir::tt::ttnn::utils::g_ConstEvalAllowedAttrName
+          << "'; tag the op or change its memory space";
+      analysisFailed = true;
       return;
     }
 
@@ -267,6 +284,8 @@ private:
 
   // Set of ops which every subgraph + original graph must duplicate.
   llvm::SmallVector<mlir::Operation *, 1> sharedOps;
+
+  bool analysisFailed = false;
 };
 } // namespace
 
@@ -455,6 +474,50 @@ public:
 } // namespace
 
 namespace {
+// Sums per-core L1 footprint of const-eval function outputs. Returns nullopt
+// when no device is registered.
+static std::optional<uint64_t> computeL1ConstEvalUsage(mlir::ModuleOp module) {
+  auto deviceOp = ttcore::lookupDeviceOp(module);
+  if (!deviceOp) {
+    return std::nullopt;
+  }
+  ttcore::GridAttr workerGrid = deviceOp.getDeviceAttr().getWorkerGrid();
+  uint64_t numCores =
+      static_cast<uint64_t>(ttmlir::utils::volume(workerGrid.getShape()));
+  if (numCores == 0) {
+    return std::nullopt;
+  }
+
+  uint64_t total = 0;
+  module.walk([&](mlir::func::FuncOp funcOp) {
+    if (!ttmlir::utils::isConstEvalFunc(funcOp)) {
+      return;
+    }
+    auto &entryBlock = funcOp.getBody().front();
+    auto returnOp =
+        mlir::dyn_cast<mlir::func::ReturnOp>(entryBlock.getTerminator());
+    if (!returnOp) {
+      return;
+    }
+    for (mlir::Value operand : returnOp.getOperands()) {
+      auto tensorType =
+          mlir::dyn_cast<mlir::RankedTensorType>(operand.getType());
+      if (!tensorType) {
+        continue;
+      }
+      auto layout = mlir::dyn_cast_or_null<ttnn::TTNNLayoutAttr>(
+          tensorType.getEncoding());
+      if (!layout || !layout.hasL1BufferType()) {
+        continue;
+      }
+      total += ttnn::utils::getPerCoreL1Usage(layout, numCores);
+    }
+  });
+  return total;
+}
+} // namespace
+
+namespace {
 // Transform pass to hoist const-eval subgraphs into separate funcs, invoked
 // w/ ttcore.load_cached ops.
 class ConstEvalHoistTransform
@@ -482,22 +545,42 @@ public:
     }
 
     // Collect functions that need processing
-    module.walk([&](func::FuncOp funcOp) { processFunction(funcOp); });
+    bool failed = false;
+    module.walk([&](func::FuncOp funcOp) {
+      if (!processFunction(funcOp)) {
+        failed = true;
+      }
+    });
+
+    if (failed) {
+      signalPassFailure();
+      return;
+    }
+
+    if (auto usage = computeL1ConstEvalUsage(module)) {
+      OpBuilder builder(&getContext());
+      auto u64 = mlir::IntegerType::get(&getContext(), 64,
+                                        mlir::IntegerType::Unsigned);
+      module->setAttr(ttnn::utils::g_L1ConstEvalUsageAttrName,
+                      builder.getIntegerAttr(u64, *usage));
+    }
   }
 
 private:
-  // Process a single function for const-eval hoisting
-  void processFunction(func::FuncOp funcOp) {
+  bool processFunction(func::FuncOp funcOp) {
     if (ttmlir::utils::isConstEvalFunc(funcOp)) {
-      return;
+      return true;
     }
     // Skip kernel functions: load_cached only supports tensor results, but
     // kernel const-eval may return !emitc.size_t, i32, etc.
     if (ttmlir::utils::isKernelFunc(funcOp)) {
-      return;
+      return true;
     }
     // Run the analysis to identify const-eval subgraphs
     ConstEvalAnalyze analyzer(funcOp);
+    if (analyzer.failed()) {
+      return false;
+    }
     ConstEvalAnalysisResults analysisResults = analyzer.getAnalysisResults();
     llvm::SmallVector<ConstEvalSubgraph, 4> subgraphs =
         std::move(analysisResults.subgraphs);
@@ -505,7 +588,7 @@ private:
         std::move(analysisResults.sharedOps);
 
     if (subgraphs.empty()) {
-      return;
+      return true;
     }
 
     // Create new functions for each subgraph
@@ -515,6 +598,7 @@ private:
       // Create a new function for this const-eval subgraph
       createConstEvalFunction(funcOp, subgraph, sharedOps, i);
     }
+    return true;
   }
 
   // Create a new function for a const-eval subgraph and replace the original

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -561,8 +561,10 @@ public:
       OpBuilder builder(&getContext());
       auto u64 = mlir::IntegerType::get(&getContext(), 64,
                                         mlir::IntegerType::Unsigned);
+      constexpr uint64_t kCushion = 1024;
+      uint64_t alignedUsage = llvm::alignTo(*usage + kCushion, kCushion);
       module->setAttr(ttnn::utils::g_L1ConstEvalUsageAttrName,
-                      builder.getIntegerAttr(u64, *usage));
+                      builder.getIntegerAttr(u64, alignedUsage));
     }
   }
 

--- a/test/ttmlir/Dialect/TTNN/const-eval/const-eval-l1-untagged-error.mlir
+++ b/test/ttmlir/Dialect/TTNN/const-eval/const-eval-l1-untagged-error.mlir
@@ -1,0 +1,23 @@
+// RUN: not ttmlir-opt --ttcore-register-device --const-eval-hoist-transform %s 2>&1 | FileCheck %s
+
+// An L1-resident op that satisfies the const-eval criteria (operands trace to
+// constant/parameter args) but lacks `ttnn.const_eval_allowed` must fail the
+// pass — its L1 reservation would otherwise be invisible to L1 budget
+// accounting.
+
+#l1 = #ttnn.buffer_type<l1>
+
+#l1_sharded = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <block_sharded>, core_ranges = <[#ttnn.core_range<(0, 0), (0, 0)>]>>
+
+module {
+  func.func @untagged_l1(
+      %arg0: tensor<32x32xbf16, #l1_sharded> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %arg1: tensor<32x32xbf16, #l1_sharded> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %arg2: tensor<32x32xbf16, #l1_sharded> {ttcore.argument_type = #ttcore.argument_type<parameter>}
+  ) -> tensor<32x32xbf16, #l1_sharded> {
+    // CHECK: error: {{.*}}const-eval candidate{{.*}}not tagged with 'ttnn.const_eval_allowed'
+    %untagged = "ttnn.add"(%arg1, %arg2) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<32x32xbf16, #l1_sharded>, tensor<32x32xbf16, #l1_sharded>) -> tensor<32x32xbf16, #l1_sharded>
+    %result = "ttnn.add"(%arg0, %untagged) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<32x32xbf16, #l1_sharded>, tensor<32x32xbf16, #l1_sharded>) -> tensor<32x32xbf16, #l1_sharded>
+    return %result : tensor<32x32xbf16, #l1_sharded>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/const-eval/const-eval-l1.mlir
+++ b/test/ttmlir/Dialect/TTNN/const-eval/const-eval-l1.mlir
@@ -1,0 +1,35 @@
+// RUN: ttmlir-opt --ttcore-register-device --const-eval-hoist-transform %s -o %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// Verifies the L1 const-eval infra:
+//   (1) An L1-resident op tagged with `ttnn.const_eval_allowed` is hoisted
+//       into a const-eval function.
+//   (2) The pass records the per-core L1 footprint of const-eval outputs in
+//       the module attribute `ttnn.l1_const_eval_usage`.
+//
+// Sharded layout footprint per core = getShardSizeInBytes() =
+//   shard_shape (1x1 tiles) * tile (32x32 bf16) = 32*32*2 bytes = 2048 bytes.
+
+#l1 = #ttnn.buffer_type<l1>
+
+#l1_sharded = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <block_sharded>, core_ranges = <[#ttnn.core_range<(0, 0), (0, 0)>]>>
+
+// CHECK: module attributes {{.*}}ttnn.l1_const_eval_usage = 2048 : ui64
+module {
+  // CHECK-LABEL: func.func private @tagged_l1_const_eval_0
+  // CHECK: "ttnn.add"
+  // CHECK: return
+
+  // CHECK-LABEL: func.func @tagged_l1(
+  func.func @tagged_l1(
+      %arg0: tensor<32x32xbf16, #l1_sharded> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %arg1: tensor<32x32xbf16, #l1_sharded> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %arg2: tensor<32x32xbf16, #l1_sharded> {ttcore.argument_type = #ttcore.argument_type<parameter>}
+  ) -> tensor<32x32xbf16, #l1_sharded> {
+    // CHECK: ttcore.load_cached(@tagged_l1_const_eval_0, [%arg1, %arg2])
+    %tagged = "ttnn.add"(%arg1, %arg2) <{dtype = #ttcore.supportedDataTypes<bf16>}> {ttnn.const_eval_allowed} : (tensor<32x32xbf16, #l1_sharded>, tensor<32x32xbf16, #l1_sharded>) -> tensor<32x32xbf16, #l1_sharded>
+    // CHECK: "ttnn.add"(%arg0
+    %result = "ttnn.add"(%arg0, %tagged) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<32x32xbf16, #l1_sharded>, tensor<32x32xbf16, #l1_sharded>) -> tensor<32x32xbf16, #l1_sharded>
+    return %result : tensor<32x32xbf16, #l1_sharded>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/const-eval/const-eval-l1.mlir
+++ b/test/ttmlir/Dialect/TTNN/const-eval/const-eval-l1.mlir
@@ -8,13 +8,14 @@
 //       the module attribute `ttnn.l1_const_eval_usage`.
 //
 // Sharded layout footprint per core = getShardSizeInBytes() =
-//   shard_shape (1x1 tiles) * tile (32x32 bf16) = 32*32*2 bytes = 2048 bytes.
+//   shard_shape (1x1 tiles) * tile (32x32 bf16) = 32*32*2 bytes = 2048 bytes;
+//   aligned with cushion = 2048 + 1024 = 3072 bytes.
 
 #l1 = #ttnn.buffer_type<l1>
 
 #l1_sharded = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <block_sharded>, core_ranges = <[#ttnn.core_range<(0, 0), (0, 0)>]>>
 
-// CHECK: module attributes {{.*}}ttnn.l1_const_eval_usage = 2048 : ui64
+// CHECK: module attributes {{.*}}ttnn.l1_const_eval_usage = 3072 : ui64
 module {
   // CHECK-LABEL: func.func private @tagged_l1_const_eval_0
   // CHECK: "ttnn.add"

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/multichip_kv_cache.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/multichip_kv_cache.mlir
@@ -15,7 +15,7 @@ module {
     // CHECK-LABEL: func.func private @run_and_capture_trace_0_main
     // Constant args come first.
     // CHECK-SAME: %arg0:
-    // CHECK-SAME: ttcore.argument_type = #ttcore.argument_type<constant>
+    // CHECK-SAME: ttcore.argument_type = #ttcore.argument_type<input>
     // CHECK-SAME: %arg1:
     // CHECK-SAME: ttcore.argument_type = #ttcore.argument_type<constant>
     // The regular input arg should be on system_memory (host).
@@ -36,13 +36,13 @@ module {
     // CHECK: "ttnn.mesh_shard"
     func.func @main(
         %arg0: tensor<10x128x512xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<presharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<5x128x512xbf16>>} loc("p0.2"),
-        %cache: tensor<2x32x64x512xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<presharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x32x64x512xbf16>>} loc("p1.3")
+        %cache: tensor<2x32x64x512xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<presharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x32x64x512xbf16>>} loc("p1.3"),
+        %update_input: tensor<1x32x1x512xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x32x1x512xbf16>>}
     ) -> (tensor<10x128x512xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<10x128x512xbf16>>},
           tensor<2x32x64x512xbf16> {ttcore.shard_status = #ttcore.shard_status<presharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x32x64x512xbf16>>}) {
         %0 = "ttir.mesh_shard"(%arg0) <{shard_dims = array<i64: -1, 0>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 1, 1>, shard_type = #ttcore.shard_type<identity>}> : (tensor<10x128x512xbf16>) -> tensor<5x128x512xbf16>
         %sharded_cache = "ttir.mesh_shard"(%cache) <{shard_dims = array<i64: -1, 0>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 1, 1, 1>, shard_type = #ttcore.shard_type<identity>}> : (tensor<2x32x64x512xbf16>) -> tensor<1x32x64x512xbf16>
         %idx = "ttir.constant"() <{value = dense<0> : tensor<1xi32>}> : () -> tensor<1xi32>
-        %update_input = "ttir.constant"() <{value = dense<1.0> : tensor<1x32x1x512xbf16>}> : () -> tensor<1x32x1x512xbf16>
         %updated_cache = "ttir.update_cache"(%sharded_cache, %update_input, %idx) <{batch_offset = 0 : i32}> : (tensor<1x32x64x512xbf16>, tensor<1x32x1x512xbf16>, tensor<1xi32>) -> tensor<1x32x64x512xbf16>
         %1 = "ttir.add"(%0, %0) : (tensor<5x128x512xbf16>, tensor<5x128x512xbf16>) -> tensor<5x128x512xbf16>
         %2 = "ttir.mesh_shard"(%1) <{shard_dims = array<i64: -1, 0>, shard_direction = #ttcore.shard_direction<shard_to_full>, shard_shape = array<i64: 2, 1, 1>, shard_type = #ttcore.shard_type<identity>}> : (tensor<5x128x512xbf16>) -> tensor<10x128x512xbf16>


### PR DESCRIPTION
### Ticket
#8164

### Problem description
Operations produced as part of some TTNN workarounds (and potentially other TTNN passes) which have results residing in L1 should be const-evaluated, since these often represent configurations / preprocessed weights used throughout the graph, and it would be wasteful to transfer them to L1 on every forward pass.

However, const-evaluation of L1-residing tensors is a double-edged sword: transfer-induced performance penalty gets mitigated, but there is a risk of accidentally using up a large portion of L1 storage for const-evaluated tensors (since these are retained and never deallocated).

We've decided to make the L1-const-eval an explicit opt-in, and fail the compilation if a L1-residing const-eval candidate appears:
- If the op's result **should** be in L1, the pattern / pass which produces the op should tag it in order to opt-in
- If the op's result **shouldn't** be in L1 (because it would take up too much space), this op will introduce a performance penalty in each forward pass, and the decision to make it L1-residing should be explicitly reconsidered

### What's changed
- Introduced attribute for explicit L1 const-eval opt-in
- Modified `ConstEvalHoist` pass
  - Validating L1 opt-in
  - Calculating total L1 usage at the end of the pass
- Centralized the derivation of usable L1 per core 

### Checklist
- [x] New/Existing tests provide coverage for changes

<!-- xla-validate -->
---
### tt-xla Validation

**Base (uplifted, prior):** `2bd6701`
**Base (uplifted, current):** `297f7eb`

| Test Suite | Run | Status |
|------------|-----|--------|
| full-mlir-uplift-qualification.json | [Run #26355300244](https://github.com/tenstorrent/tt-xla/actions/runs/26355300244) | :white_check_mark: passed |
| Performance Benchmark | [Run #26356068548](https://github.com/tenstorrent/tt-xla/actions/runs/26356068548) | :x: failed |
| Performance Benchmark (retry, rebased to `297f7eb`) | [Run #26398128142](https://github.com/tenstorrent/tt-xla/actions/runs/26398128142) | :x: failed |

#### Failures (Performance Benchmark, first run)

| Test | Error | Status |
|------|-------|------|
| `perf tiiuae_falcon3-7b-base` | `TT_FATAL: Out of Memory: Not enough space to allocate 25067520 B L1 buffer` | ✅  already fails on [nightly](https://github.com/tenstorrent/tt-xla/actions/runs/26377088770/job/77639195465) |
| `perf unet` | Samples/sec regression > 5.0% detected (dropped by 5.9046%) | ✅  seems like a temporary hiccup, as the same test passed with no regressions on the second perf benchmark run |
| `perf vllm_*` (14 jobs: llama_3_2_3b, llama_3_2_3b_batch32, llama_3_2_1b_instruct, qwen2_5_0_5b_instruct, qwen2_5_1_5b_instruct, qwen2_5_3b_instruct, qwen3_0_6b, qwen3_1_7b, phi_1, phi_1_5, phi_2, falcon3_1b_base, falcon3_3b_base, opt_125m_batch32_opt1) | `TT_FATAL: Writes are not supported during trace capture. trace id: 7` → `RuntimeError: Engine core initialization failed` | ✅  all 14 pass on the second perf benchmark run |

#### Failures (Performance Benchmark, second run)

| Test | Error | Status |
|------|-------|------|
| [`perf tiiuae_falcon3-7b-base`](https://github.com/tenstorrent/tt-xla/actions/runs/26398128142/job/77706226997) | `TT_FATAL: Out of Memory: Not enough space to allocate 25067520 B L1 buffer` | ✅  same pre-existing nightly failure as in the first run |
| [`perf vllm_opt_125m_batch32_opt1`](https://github.com/tenstorrent/tt-xla/actions/runs/26398128142/job/77706226969) | benchmark step xfails as expected (pre-existing `SmallVector<BeamCandidate>` assertion); job then exits non-zero in a later CI step (`FileNotFoundError: perf_report_*.json`) | ✅  benchmark itself xfails as expected; the non-zero job exit is a CI-side handling gap for xfailed tests — not a regression from this PR |
| [`perf vllm_falcon3_1b_base_opt1`](https://github.com/tenstorrent/tt-xla/actions/runs/26398128142/job/77706227012) | `HTTP 503 Service Unavailable` from `download.pytorch.org` during dependency install (never reached the benchmark step) | ✅  infrastructure flake — unrelated to this PR |
<!-- /xla-validate -->



