### PR TITLE
[Fix] `ttnn::max_pool2d` shape-contract mismatch that crashed `binary_ng` broadcasting downstream

### DIFF
--- a/runtime/lib/ttnn/operations/pool/pool2d.cpp
+++ b/runtime/lib/ttnn/operations/pool/pool2d.cpp
@@ -135,7 +135,23 @@ void runMaxPool2dOp(
              ::ttnn::Layout::ROW_MAJOR,
              /*config_tensor_in_dram=*/op->config_tensors_in_dram());
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), results[0]);
+  // tt-metal's ttnn::max_pool2d returns a [N, H_out, W_out, C] tensor, but
+  // tt-mlir declares the result type with the NHW-flattened shape
+  // [1, 1, N*H_out*W_out, C]. Reshape so downstream ops see the declared
+  // logical_shape and broadcast classifiers (e.g. binary_ng) don't misfire.
+  ::ttnn::Tensor out = results[0];
+  const auto *fbShape = op->out()->desc()->shape();
+  std::vector<int32_t> declaredShape(fbShape->begin(), fbShape->end());
+  bool shapeMatches = out.logical_shape().size() == declaredShape.size();
+  for (size_t i = 0; shapeMatches && i < declaredShape.size(); ++i) {
+    shapeMatches =
+        static_cast<int32_t>(out.logical_shape()[i]) == declaredShape[i];
+  }
+  if (!shapeMatches) {
+    out = ::ttnn::reshape(out, declaredShape);
+  }
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 
 void run(const ::tt::target::ttnn::Pool2dOp *op, ProgramContext &context) {


### PR DESCRIPTION
Fixes : [Issue Link](https://github.com/tenstorrent/tt-mlir/issues/8559)

## Bug

MapTR Nano R18 110e crashes at runtime during inference:

```
TT_THROW: Invalid subtile broadcast type: a_h=144000 a_w=64 b_h=200 b_w=64
RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13
```

`144000 = N*H_out*W_out = 6*120*200` for MapTR's stem maxpool on input `[6, 240, 400, 64]`. The failing op is a `ttnn.add` (residual connection) consuming the maxpool output directly. The underlying contract mismatch could affect any model with the same residual-add-after-maxpool pattern, but only MapTR Nano R18 110e was directly observed to fail this way in this investigation.

## Root cause



## Fix

In `runMaxPool2dOp`, reshape the tt-metal output to match the declared flatbuffer shape before inserting it into the tensor pool. Guarded by a shape-equality check so it only fires on mismatch; `ttnn::reshape` on a row-major interleaved DRAM tensor with same total volume is metadata-only (no data movement) and is correctness-preserving on sharded tensors via internal `sharded → interleaved → reshape → interleaved → sharded` round-trips with shard-spec recomputation.

This is a runtime workaround. A principled compile-time fix in `TTIRToTTNN.cpp` (emit an explicit `ttnn.reshape` after `ttnn.max_pool2d` in the IR) is left to a follow-up PR — the runtime fix is the smallest diff that unblocks production tt-xla execution.

## Verification

### Isolated MaxPool sanity (torchvision ResNet-18 backbone on MapTR-shaped input)

**Before:**

[maxpool_sanity_BEFORE_FIX.log](https://github.com/user-attachments/files/27985659/maxpool_sanity_BEFORE_FIX.log)

**After:**

[maxpool_sanity_AFTER_FIX.log](https://github.com/user-attachments/files/27985665/maxpool_sanity_AFTER_FIX.log)

### MapTR Nano R18 110e end-to-end pytest

```
pytest -svv tests/runner/test_models.py::test_all_models_torch[maptr/pytorch-Nano_R18_110e-single_device-inference]
```

**Before** (no fixes, model crashes):

[maptr_full_BEFORE_FIX.log](https://github.com/user-attachments/files/27985640/maptr_full_BEFORE_FIX.log)

**After** (this PR applied, LayerNorm fix not yet applied):

[maptr_full_AFTER_FIX.log](https://github.com/user-attachments/files/27985650/maptr_full_AFTER_FIX.log)

Model now compiles, runs end-to-end, and reaches the PCC comparison step. PCC = 0.0519 here because of a separate LayerNorm SSA-aliasing bug.
