### PR TITLE
[Fix] SSA aliasing in StableHLOToBatchNormTrainingOpConversionPattern

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -822,11 +822,21 @@ public:
     // Default momentum for batch norm training
     FloatAttr momentumAttr = rewriter.getF32FloatAttr(1.0f);
 
-    auto runningMean = rewriter.create<ttir::ZerosOp>(
-        loc, meanType, llvm::to_vector_of<int32_t>(meanType.getShape()));
-    auto runningVariance = rewriter.create<ttir::OnesOp>(
-        loc, varianceType,
-        llvm::to_vector_of<int32_t>(varianceType.getShape()));
+    // stablehlo.batch_norm_training has no running-stats operands (it returns
+    // batch_mean/batch_var as results), but ttnn.batch_norm_training requires
+    // them and declares them [MemWrite] (updated in place). Use ttir.empty
+    // (NonCacheableTrait) rather than ttir.zeros / ttir.ones so CSE cannot
+    // merge these scratch buffers with the scale=ones / offset=zeros constants
+    // that XLA passes in. Without this, the same SSA value can end up in both
+    // a [MemWrite] running-stats slot and the read-only weight/bias slot, and
+    // tt-metal's training-mode batch_norm clobbers weight/bias when it updates
+    // running stats in place — producing output_std == input_std^2 instead of
+    // ~1.0 (root cause of MapTR PCC=0.05 and any LayerNorm-via-XLA model).
+    // Uninitialized values are safe here because momentum=1.0 below means
+    // new_running = 1.0*batch + 0.0*old_running, and the running stats are
+    // not returned to the XLA caller.
+    auto runningMean = rewriter.create<ttir::EmptyOp>(loc, meanType);
+    auto runningVariance = rewriter.create<ttir::EmptyOp>(loc, varianceType);
 
     rewriter.replaceOpWithNewOp<mlir::tt::ttir::BatchNormTrainingOp>(
         srcOp, TypeRange{outputType, meanType, varianceType},

--- a/test/ttmlir/Conversion/StableHLOToTTIR/batch_norm_training_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/batch_norm_training_op.mlir
@@ -7,8 +7,14 @@ module @jit_batch_norm attributes {} {
       epsilon = 0.0 : f32,
       feature_index = 1 : i64
     } : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
-    // CHECK: [[VAL0:%[0-9]+]] = "ttir.zeros"() <{shape = array<i32: 2>}> : () -> tensor<2xf32>
-    // CHECK: [[VAL1:%[0-9]+]] = "ttir.ones"() <{shape = array<i32: 2>}> : () -> tensor<2xf32>
+    // The synthetic running_mean/running_var must be ttir.empty (NonCacheable,
+    // declares Allocate memory effect) — NOT ttir.zeros / ttir.ones. Using
+    // zero/one-initialized constants here would let CSE merge them with the
+    // user-side scale=ones / offset=zeros constants in subsequent lowering,
+    // causing SSA aliasing on the ttnn.batch_norm_training [MemWrite] operands
+    // and clobbering weight/bias when tt-metal updates running stats in place.
+    // CHECK: [[VAL0:%[0-9]+]] = ttir.empty() : tensor<2xf32>
+    // CHECK: [[VAL1:%[0-9]+]] = ttir.empty() : tensor<2xf32>
     // CHECK: [[RESULT:%[a-z_]+]], [[MEAN:%[a-z_]+]], [[VAR:%[a-z_]+]] = "ttir.batch_norm_training"(%arg0, %arg1, %arg2, [[VAL0]], [[VAL1]]) <{dimension = 1 : i32, epsilon = 0.000000e+00 : f32, momentum = 1.000000e+00 : f32}> : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
     return %result, %batch_mean, %batch_variance : tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>
     // CHECK: return [[RESULT]], [[MEAN]], [[VAR]] : tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>


### PR DESCRIPTION
Github issue: [Link](https://github.com/tenstorrent/tt-mlir/issues/8561)

### Bug

`torch.nn.LayerNorm` on tt-xla silently produced `output_std ≈ input_std²` instead of normalized output. Invisible to unit-variance Gaussian tests (`1² = 1`) but catastrophic for transformer activations whose stddev is in the tens-to-thousands.


**Verified affected:** MapTR Nano R18 110e (end-to-end PCC = 0.0519 pre-fix).

**Scope by mechanism (not empirically tested beyond MapTR):**
- Bug fires for `torch.nn.LayerNorm` via the `torch_xla` eager dispatch path (the path used by `tests/runner/test_models.py`). PCC stays high for a single LayerNorm because magnitudes scale uniformly; failure becomes visible when multiple LayerNorms stack or the inflated values flow into ops that overflow.
- Does not fire for `torch.compile(backend="tt")` (Dynamo decomposes `LayerNorm` into primitive ops before StableHLO emission).
- Does not fire for `torch.nn.BatchNorm1d/2d` callers (they pass real, distinct weight/bias parameters; no CSE aliasing).

## Root cause

PyTorch/XLA lowers `nn.LayerNorm` to `aten::native_batch_norm` → `stablehlo.batch_norm_training` with synthetic-ones scale / synthetic-zeros offset. `ttnn.batch_norm_training` requires `running_mean` / `running_var` operands (declared `[MemWrite]`), but `stablehlo.batch_norm_training` doesn't supply them — the conversion synthesized them as `ttir.zeros` and `ttir.ones`. After lowering, CSE merged these with the user-side scale=ones / offset=zeros constants (identical values), so the same SSA value ended up in both a `[MemWrite]` running-stats slot and the read-only weight/bias slot. tt-metal's `batch_norm` in training mode then clobbered weight/bias while updating running stats in place, producing `output = input × input_std`.

## Fix

Replace the synthetic `ttir.zeros` / `ttir.ones` running stats with `ttir.empty`. `ttir::EmptyOp` declares a `MemoryEffects::Allocate` effect that CSE respects, so it stays distinct from the scale/offset constants. Safe because momentum=1.0 makes the running-stats update independent of the initial value, and the running stats aren't returned to the XLA caller.

## Verification

### Isolated LayerNorm sanity

**Before:**

[layernorm_sanity_BEFORE_FIX.log](https://github.com/user-attachments/files/27985574/layernorm_sanity_BEFORE_FIX.log)

**After:**

[layernorm_sanity_AFTER_FIX.log](https://github.com/user-attachments/files/27985568/layernorm_sanity_AFTER_FIX.log)

### MapTR Nano R18 110e end-to-end pytest

```
 pytest -svv tests/runner/test_models.py::test_all_models_torch[maptr/pytorch-Nano_R18_110e-single_device-inference]
```

**Before** (Attach maxpool PR):

[maptr_full_BEFORE_FIX.log](https://github.com/user-attachments/files/27985530/maptr_full_BEFORE_FIX.log)


**After** :

[maptr_full_AFTER_FIX.log](https://github.com/user-attachments/files/27985518/maptr_full_AFTER_FIX.log)


MapTR end-to-end PCC: 0.0519 → 0.4978. Per-stage outputs (img_backbone, img_neck, transformer, pts_bbox_head) match CPU at PCC = 0.9999 — the model math is correct. The remaining 0.4978 → 0.99 gap is a top-k tie-break sensitivity in `pts_bbox_head.get_bboxes()` post-processing.

