### PR TITLE
Fix lit test after stale merge

### DIFF
--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -310,13 +310,13 @@ module {
         ins(%arg0, %arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
         outs(%out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
       ^region_0:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_ls_r0, noc = 0>, #d2m.thread<compute, @cp_ls_r0>]}
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_ls_r0, processor = 1>, #d2m.thread<compute, @cp_ls_r0>]}
             ins(%arg0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             additionalArgs(%ls_r0_0, %ls_r0_1, %cb_ls_r0_0, %cb_ls_r0_1 : !d2m.local_semaphore, !d2m.local_semaphore, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)
       }, {
       ^region_1:
-        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_ls_r1, noc = 0>, #d2m.thread<compute, @cp_ls_r1>]}
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_ls_r1, processor = 1>, #d2m.thread<compute, @cp_ls_r1>]}
             ins(%arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             outs(%out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
             additionalArgs(%ls_r1_0, %ls_r1_1, %cb_ls_r1_0, %cb_ls_r1_1 : !d2m.local_semaphore, !d2m.local_semaphore, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1>)


### PR DESCRIPTION

### Problem description
Lit test failed in `spatial_lowering.mlir` due to a stale merge.

### What's changed
Updated `spatial_lowering.mlir`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
