### PR TITLE
[Optimizer] Fix address simulation to correctly track inserted reshards

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -328,8 +328,7 @@ private:
 
   /// OOM recovery: evict farthest-last-use tensors or demote self to DRAM.
   void handleOOM(Operation *op, int64_t pos,
-                 llvm::ArrayRef<OpResult> tensorResults,
-                 ScheduleData &data,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
                  std::function<void(uint64_t)> addResultsToLiveSet);
 
   /// Evict all live L1 tensors. Used when encountering ops without OpModel
@@ -353,10 +352,14 @@ private:
   bool evictUntil(int64_t pos, ScheduleData &data,
                   std::function<bool()> shouldStop);
 
-  /// Evict a specific live value: spill to DRAM, update tracker, insert
-  /// reshards for already-processed consumers. Used by evictUntil and by
-  /// sibling-operand eviction paths.
-  void evictValue(Value victim, int64_t pos, ScheduleData &data);
+  /// Evict a specific live value: spill to DRAM, update tracker, and insert
+  /// reshards for consumers that still require the L1 layout. Sibling-operand
+  /// eviction passes skipReshardConsumer=op: it spills all operands of that op
+  /// to give it homogeneous DRAM inputs, so resharding one back to L1 would
+  /// defeat the purpose. The op's other (past/future) consumers are still
+  /// restored.
+  void evictValue(Value victim, int64_t pos, ScheduleData &data,
+                  Operation *skipReshardConsumer = nullptr);
 
   /// Insert a ToMemoryConfigOp before an already-processed consumer to
   /// convert the DRAM spill output back to the consumer's expected L1 layout.

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -353,10 +353,9 @@ private:
                   std::function<bool()> shouldStop);
 
   /// Evict a specific live value: spill to DRAM, update tracker, and insert
-  /// reshards for consumers that still require the L1 layout. Sibling-operand
-  /// eviction passes skipReshardConsumer=op: it spills all operands of that op
-  /// to give it homogeneous DRAM inputs, so resharding one back to L1 would
-  /// defeat the purpose. The op's other (past/future) consumers are still
+  /// reshards for consumers that still require the L1 layout. If
+  /// skipReshardConsumer is non-null, that one consumer is left reading the
+  /// DRAM spill (no reshard inserted for it); all other consumers are still
   /// restored.
   void evictValue(Value victim, int64_t pos, ScheduleData &data,
                   Operation *skipReshardConsumer = nullptr);

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -227,6 +227,13 @@ private:
   /// selected as eviction victims.
   llvm::DenseMap<Value, size_t> allocEventIndex;
 
+  /// Results of reshards inserted by insertReshardIntoSchedule (future
+  /// consumers). These must never be selected as eviction victims — evicting
+  /// them defeats the purpose of the reshard. A DenseSet rather than checking
+  /// isa<ToMemoryConfigOp> avoids falsely blocking regular to_memory_config
+  /// ops from MemoryLayoutPropagation, which ARE valid eviction candidates.
+  llvm::DenseSet<Value> insertedReshardValues;
+
   /// Mark victim's alloc/dealloc events as skipped, restore the snapshot
   /// taken before victim's alloc, then replay all subsequent non-skipped
   /// events to rebuild a consistent address-simulation state. Reshard

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -201,6 +201,9 @@ private:
   /// Event log entry for address reconstruction. Records every L1 allocation
   /// and deallocation in schedule order so that eviction can replay the full
   /// history (including dead tensors) to compute accurate addresses.
+  /// Reshards inserted for past consumers also get kAlloc/kDealloc entries
+  /// (via insertEventIntoLog) so future replays account for their transient
+  /// slot without needing a separate injection map.
   struct L1Event {
     enum Kind { kAlloc, kDealloc };
     Kind kind;
@@ -213,17 +216,26 @@ private:
   llvm::SmallVector<L1Event> l1EventLog;
 
   /// Snapshots of tracker state taken before each alloc event, keyed by
-  /// event-log index. Used as starting points for replay after eviction.
+  /// event-log index. Invariant: addressSnapshots[i] = tracker state
+  /// immediately before event i fires. Maintained by insertEventIntoLog.
+  /// Used as starting points for replay after eviction.
   llvm::DenseMap<size_t, typename MemoryTracker::Snapshot> addressSnapshots;
 
-  /// Maps each tensor Value to its alloc event index in l1EventLog.
-  /// Provides O(1) lookup in markEvictedAndRebuild instead of linear scan.
+  /// Maps each live-tensor Value to its alloc event index in l1EventLog.
+  /// O(1) restore-point lookup in markEvictedAndRebuild. NOT populated for
+  /// reshard events for past consumers — irrelevant as reshards are never
+  /// selected as eviction victims.
   llvm::DenseMap<Value, size_t> allocEventIndex;
 
-  /// Mark all events for a tensor as skipped and rebuild from its alloc
-  /// snapshot. Updates snapshots during replay so future evictions start
-  /// from accurate state.
+  /// Mark victim's alloc/dealloc events as skipped, restore the snapshot
+  /// taken before victim's alloc, then replay all subsequent non-skipped
+  /// events to rebuild a consistent address-simulation state. Reshard
+  /// kAlloc/kDealloc pairs in the log are replayed naturally.
   void markEvictedAndRebuild(Value victim);
+
+  /// Insert event at pos in l1EventLog and shift all allocEventIndex entries
+  /// and addressSnapshots keys >= pos by 1, preserving the index invariants.
+  void insertEventIntoLog(size_t pos, L1Event event);
 
   /// Extract OpConfig from op's current IR state (result type + op-specific
   /// attrs like Conv2dConfig, MatmulProgramConfig).
@@ -271,6 +283,13 @@ private:
   /// Build schedule, last-use positions, death schedule, and position map.
   ScheduleData buildScheduleData();
 
+  /// Insert a reshard op into the schedule at consumerPos (shifting the
+  /// consumer and all later ops by +1), updating positionMap, lastUsePositions,
+  /// and deathSchedule so the forward sweep processes the reshard naturally.
+  void insertReshardIntoSchedule(Operation *reshardOp, Value reshardResult,
+                                 uint64_t reshardSizePerCore,
+                                 int64_t consumerPos, ScheduleData &data);
+
   /// Remove result tensors whose last use was the previous position.
   void processDeadTensors(int64_t pos, const ScheduleData &data);
 
@@ -285,33 +304,32 @@ private:
   /// Output cannot fit contiguously in the free list. Evict farthest-last-use
   /// tensors until the output fits, then re-validate. Returns L1 bytes to add
   /// to live set (0 if demoted to DRAM).
-  uint64_t handleNoFit(Operation *op, int64_t pos, const ScheduleData &data,
+  uint64_t handleNoFit(Operation *op, int64_t pos, ScheduleData &data,
                        uint64_t outputL1Size);
 
   /// CB fragmentation recovery: evict tensors in the CB danger zone,
   /// re-validate, or demote output to DRAM. Returns L1 bytes to add to live
   /// set (0 if demoted).
-  uint64_t handleFragmentation(Operation *op, int64_t pos,
-                               const ScheduleData &data, uint64_t cbPeakUsage,
-                               uint64_t outputL1Size);
+  uint64_t handleFragmentation(Operation *op, int64_t pos, ScheduleData &data,
+                               uint64_t cbPeakUsage, uint64_t outputL1Size);
 
   /// Run contiguous-fit and CB-fragmentation checks on a validated op's
   /// output. Returns the (possibly updated) L1 size to add to the live set,
   /// or 0 if the output was demoted to DRAM.
-  uint64_t ensureFitsL1(Operation *op, int64_t pos, const ScheduleData &data,
+  uint64_t ensureFitsL1(Operation *op, int64_t pos, ScheduleData &data,
                         uint64_t cbPeakUsage, uint64_t l1Size);
 
   /// OOM recovery: evict farthest-last-use tensors or demote self to DRAM.
   void handleOOM(Operation *op, int64_t pos,
                  llvm::ArrayRef<OpResult> tensorResults,
-                 const ScheduleData &data,
+                 ScheduleData &data,
                  std::function<void(uint64_t)> addResultsToLiveSet);
 
   /// Evict all live L1 tensors. Used when encountering ops without OpModel
   /// support — since we cannot know their L1 requirements, the only safe
   /// choice is a full flush. Spill ops are inserted right before triggerOp
   /// (the CCL op) so earlier consumers can still read from L1.
-  void evictAllFromL1(int64_t pos, const ScheduleData &data,
+  void evictAllFromL1(int64_t pos, ScheduleData &data,
                       Operation *triggerOp = nullptr);
 
   /// Evict live tensors (farthest-last-use first) until no tensor's simulated
@@ -319,19 +337,19 @@ private:
   /// evictTensorsBelow, which was incorrect after address rebuild (addresses
   /// shift, making the threshold check stale).
   void evictForCBOverlap(uint64_t cushionedCBUsage, int64_t pos,
-                         const ScheduleData &data);
+                         ScheduleData &data);
 
   /// Evict tensors (farthest-last-use first) until shouldStop() returns true
   /// or the live set is empty. Returns true if shouldStop was satisfied.
   /// After each eviction, rebuilds address simulation and inserts reshards
   /// for already-processed consumers.
-  bool evictUntil(int64_t pos, const ScheduleData &data,
+  bool evictUntil(int64_t pos, ScheduleData &data,
                   std::function<bool()> shouldStop);
 
   /// Evict a specific live value: spill to DRAM, update tracker, insert
   /// reshards for already-processed consumers. Used by evictUntil and by
   /// sibling-operand eviction paths.
-  void evictValue(Value victim, int64_t pos, const ScheduleData &data);
+  void evictValue(Value victim, int64_t pos, ScheduleData &data);
 
   /// Insert a ToMemoryConfigOp before an already-processed consumer to
   /// convert the DRAM spill output back to the consumer's expected L1 layout.
@@ -345,8 +363,7 @@ private:
   /// to the shard, not in the static CB region) to locally_allocated (bottom-up
   /// in the static CB region), which can significantly increase the CB
   /// footprint.
-  void evictForDramCBGrowth(Operation *op, int64_t pos,
-                            const ScheduleData &data);
+  void evictForDramCBGrowth(Operation *op, int64_t pos, ScheduleData &data);
 
   /// Collect downstream consumers of an op, following through spill ops.
   static llvm::SmallVector<Operation *>

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -338,19 +338,11 @@ Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
       continue;
     }
 
-    // Skip inserted reshards (ToMemoryConfigOp with L1 output): they reload
-    // spilled tensors and must stay live until their immediate consumer runs.
-    // Belady naturally deprioritizes them (lastUse = immediate consumer, so
-    // they sit at the bottom of the max-heap), but the exclusion guards against
-    // the pathological case where they are the only remaining live values.
-    if (auto *defOp = candidateVal.getDefiningOp()) {
-      if (isa<ToMemoryConfigOp>(defOp)) {
-        auto lo = mlir::dyn_cast_or_null<TTNNLayoutAttr>(
-            mlir::cast<RankedTensorType>(candidateVal.getType()).getEncoding());
-        if (lo && lo.hasL1BufferType()) {
-          continue;
-        }
-      }
+    // Skip reshards we inserted for future consumers — evicting them defeats
+    // their purpose. Regular ToMemoryConfigOp outputs from MemoryLayoutPropagation
+    // are NOT in this set and remain valid eviction candidates.
+    if (insertedReshardValues.count(candidateVal)) {
+      continue;
     }
 
     liveValues.erase(candidateVal);
@@ -918,6 +910,9 @@ template <typename MemoryTracker>
 void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
     Operation *reshardOp, Value reshardResult, uint64_t reshardSizePerCore,
     int64_t consumerPos, ScheduleData &data) {
+  // Register so evictFarthestUse and sibling eviction guards know not to
+  // evict this value — it exists specifically to feed its consumer.
+  insertedReshardValues.insert(reshardResult);
 
   // Insert the reshard before the consumer in the schedule vector, shifting
   // the consumer and all subsequent ops by +1.
@@ -956,18 +951,12 @@ void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
 template <typename MemoryTracker>
 bool L1SpillManagement<MemoryTracker>::evictUntil(
     int64_t pos, ScheduleData &data, std::function<bool()> shouldStop) {
-  // Helper: true if every remaining live value is a non-evictable reshard.
-  // Avoids exhausting the liveSet heap through stale entries when no
-  // evictable candidates exist.
+  // Helper: true if every remaining live value is a non-evictable inserted
+  // reshard. Avoids exhausting the liveSet heap through stale entries when
+  // no evictable candidates exist.
   auto onlyReshardsRemain = [&]() {
-    return llvm::all_of(liveValues, [](Value v) {
-      auto *defOp = v.getDefiningOp();
-      if (!defOp || !isa<ToMemoryConfigOp>(defOp)) {
-        return false;
-      }
-      auto lo = mlir::dyn_cast_or_null<TTNNLayoutAttr>(
-          mlir::cast<RankedTensorType>(v.getType()).getEncoding());
-      return lo && lo.hasL1BufferType();
+    return llvm::all_of(liveValues, [&](Value v) {
+      return insertedReshardValues.count(v) > 0;
     });
   };
 
@@ -1108,16 +1097,10 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
       if (!liveValues.count(operand)) {
         continue;
       }
-      // Never evict an inserted reshard (ToMemoryConfigOp with L1 output) —
-      // it was placed here specifically to feed this op.
-      if (auto *defOp = operand.getDefiningOp()) {
-        if (isa<ToMemoryConfigOp>(defOp)) {
-          auto lo = mlir::dyn_cast_or_null<TTNNLayoutAttr>(
-              mlir::cast<RankedTensorType>(operand.getType()).getEncoding());
-          if (lo && lo.hasL1BufferType()) {
-            continue;
-          }
-        }
+      // Never evict an inserted reshard — it was placed here specifically
+      // to feed this op. Regular to_memory_config ops are NOT protected.
+      if (insertedReshardValues.count(operand)) {
+        continue;
       }
       toEvict.push_back(operand);
     }

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -339,8 +339,9 @@ Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
     }
 
     // Skip reshards we inserted for future consumers — evicting them defeats
-    // their purpose. Regular ToMemoryConfigOp outputs from MemoryLayoutPropagation
-    // are NOT in this set and remain valid eviction candidates.
+    // their purpose. Regular ToMemoryConfigOp outputs from
+    // MemoryLayoutPropagation are NOT in this set and remain valid eviction
+    // candidates.
     if (insertedReshardValues.count(candidateVal)) {
       continue;
     }

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -339,9 +339,7 @@ Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
     }
 
     // Skip reshards we inserted for future consumers — evicting them defeats
-    // their purpose. Regular ToMemoryConfigOp outputs from
-    // MemoryLayoutPropagation are NOT in this set and remain valid eviction
-    // candidates.
+    // their purpose.
     if (insertedReshardValues.count(candidateVal)) {
       continue;
     }
@@ -578,9 +576,11 @@ void L1SpillManagement<MemoryTracker>::processDeadTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(
-    Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
-    uint64_t l1Size) {
+uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
+                                                        int64_t pos,
+                                                        ScheduleData &data,
+                                                        uint64_t cbPeakUsage,
+                                                        uint64_t l1Size) {
   auto speculativeAddr = memoryTracker.wouldAllocateAt(l1Size);
   if (!speculativeAddr) {
     l1Size = handleNoFit(op, pos, data, l1Size);
@@ -606,8 +606,7 @@ uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(
 template <typename MemoryTracker>
 void L1SpillManagement<MemoryTracker>::handleOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
-    ScheduleData &data,
-    std::function<void(uint64_t)> addResultsToLiveSet) {
+    ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "    OOM: validation failed, trying demotion/eviction");
@@ -637,7 +636,9 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
       // tensors that would collide with the op's CB region.
       evictForDramCBGrowth(op, pos, data);
     }
-    if (l1Size > 0) {
+    // Skip allocation if eviction inserted a reshard for `op` and shifted it
+    // past `pos`; run()'s sweep reprocesses the reshard and then `op`.
+    if (l1Size > 0 && data.schedule[pos] == op) {
       addResultsToLiveSet(l1Size);
       observer_->onLiveAdded(op, pos, l1Size, pos,
                              memoryTracker.getOccupiedL1());
@@ -713,11 +714,7 @@ void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
   memoryTracker.restoreSnapshot(snapIt->second);
 
   // Replay events from the alloc point forward, skipping evicted tensors.
-  // Reshard kAlloc/kDealloc pairs that evictValue inserted into the log are
-  // replayed here like any other event — the reshard is allocated before the
-  // consumer's alloc (correct address for the consumer) and freed after. When
-  // the consumer's own kAlloc events are skipped (consumer later evicted), the
-  // reshard kDealloc still fires and reclaims the slot, so it is never stuck.
+  // Update snapshots during replay so future evictions see accurate state.
   for (size_t i = allocIdx; i < l1EventLog.size(); ++i) {
     if (l1EventLog[i].skipped) {
       continue;
@@ -747,8 +744,9 @@ void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
-                                                  ScheduleData &data) {
+void L1SpillManagement<MemoryTracker>::evictValue(
+    Value victim, int64_t pos, ScheduleData &data,
+    Operation *skipReshardConsumer) {
   liveValues.erase(victim);
   Operation *victimOp = victim.getDefiningOp();
   uint64_t freedBytes = memoryTracker.getTensorSize(victim);
@@ -798,10 +796,13 @@ void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
   llvm::SmallVector<TransientInsertion> transientInsertions;
 
   if (originalL1Layout.hasL1BufferType()) {
-    uint64_t reshardSizePerCore = utils::getPerCoreL1Usage(
-        originalL1Layout,
-        ttmlir::utils::volume(originalL1Layout.getGridShape()));
     for (Operation *consumer : collectDownstreamConsumers(victimOp)) {
+      // Sibling-spill passes the op it is making all-DRAM here: don't reshard
+      // its operand back to L1. Other (past/future) consumers of the operand
+      // are still restored below — they need the L1 layout.
+      if (consumer == skipReshardConsumer) {
+        continue;
+      }
       auto posIt = data.positionMap.find(consumer);
       if (posIt == data.positionMap.end()) {
         continue;
@@ -825,7 +826,10 @@ void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
         continue;
       }
 
-      bool isPastConsumer = posIt->second < pos;
+      // Capture the position now: insertReshardIntoSchedule below adds a key to
+      // positionMap, which can rehash and invalidate posIt.
+      int64_t consumerPos = posIt->second;
+      bool isPastConsumer = consumerPos < pos;
       bool needsReshard = isPastConsumer;
       if (!needsReshard) {
         auto consumerInputs = utils::extractInputLayouts(consumer);
@@ -836,55 +840,72 @@ void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
         needsReshard = consumerResult.isMetalBackendError();
       }
 
-      if (needsReshard) {
-        for (unsigned i : spilledOperandIdx) {
-          TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                       "    RESHARD: inserting L1 reshard before {0} "
-                       "(operand {1} changed L1→DRAM after eviction of {2})",
-                       consumer->getName(), i, ttmlir::opToString(victimOp));
-          insertReshardForConsumer(consumer, i, originalL1Layout);
-          Value reshardResult = consumer->getOperand(i);
-          if (isPastConsumer) {
-            // Find the consumer's first and last output alloc event indices so
-            // we can bracket the reshard's transient occupation in the log.
-            size_t firstAllocIdx = std::numeric_limits<size_t>::max();
-            size_t lastAllocIdx = 0;
-            for (auto result : consumer->getResults()) {
-              auto logIt = allocEventIndex.find(result);
-              if (logIt != allocEventIndex.end()) {
-                firstAllocIdx = std::min(firstAllocIdx, logIt->second);
-                lastAllocIdx = std::max(lastAllocIdx, logIt->second);
-              }
+      if (!needsReshard) {
+        continue;
+      }
+
+      for (unsigned i : spilledOperandIdx) {
+        TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                     "    RESHARD: inserting L1 reshard before {0} "
+                     "(operand {1} changed L1→DRAM after eviction of {2})",
+                     consumer->getName(), i, ttmlir::opToString(victimOp));
+        insertReshardForConsumer(consumer, i, originalL1Layout);
+        Value reshardResult = consumer->getOperand(i);
+        Operation *reshardOp = reshardResult.getDefiningOp();
+
+        // Aligned per-core L1 size from validating the inserted reshard;
+        // fall back to the layout estimate if validation can't model it.
+        auto reshardValidation = op_constraint_validation::validateOperation(
+            reshardOp, utils::extractInputLayouts(reshardOp),
+            extractOpConfigFromIR(reshardOp), /*additionalL1Usage=*/0);
+        uint64_t reshardSizePerCore =
+            reshardValidation.isSuccess()
+                ? reshardValidation.outputL1Usage
+                : utils::getPerCoreL1Usage(
+                      originalL1Layout,
+                      ttmlir::utils::volume(originalL1Layout.getGridShape()));
+
+        if (isPastConsumer) {
+          // Find the consumer's first and last output alloc event indices so
+          // we can bracket the reshard's transient occupation in the log.
+          size_t firstAllocIdx = std::numeric_limits<size_t>::max();
+          size_t lastAllocIdx = 0;
+          for (auto result : consumer->getResults()) {
+            auto logIt = allocEventIndex.find(result);
+            if (logIt != allocEventIndex.end()) {
+              firstAllocIdx = std::min(firstAllocIdx, logIt->second);
+              lastAllocIdx = std::max(lastAllocIdx, logIt->second);
             }
-            // If the consumer has no L1 results (all DRAM outputs), it has no
-            // allocEventIndex entries and we cannot bracket the reshard in the
-            // log. The reshard is still inserted in the IR for correctness, but
-            // its transient slot goes untracked in the address simulation. This
-            // is a known gap: the CB overlap check for this consumer was done
-            // when it was originally processed (with the victim at its then-
-            // current address), but subsequent evictions may have rearranged
-            // the free list so the reshard lands at a lower address at runtime.
-            if (firstAllocIdx != std::numeric_limits<size_t>::max()) {
-              // kAlloc goes at firstAllocIdx (just before consumer's first
-              // result alloc) and kDealloc goes at lastAllocIdx+1 (just after
-              // consumer's last result alloc). Inserting largest-first keeps
-              // firstAllocIdx valid when the kDealloc insertion is processed.
-              // Note: reshardResult is NOT added to allocEventIndex — it should
-              // anyway never appear as an eviction victim.
-              transientInsertions.push_back(
-                  {lastAllocIdx + 1,
-                   {L1Event::kDealloc, reshardResult, 0, false}});
-              transientInsertions.push_back({firstAllocIdx,
-                                             {L1Event::kAlloc, reshardResult,
-                                              reshardSizePerCore, false}});
-            }
-          } else {
-            // Insert the reshard into the schedule so the forward sweep
-            // processes it naturally, adding it to liveValues and the tracker.
-            insertReshardIntoSchedule(reshardResult.getDefiningOp(),
-                                      reshardResult, reshardSizePerCore,
-                                      posIt->second, data);
           }
+          // If the consumer has no L1 results (all DRAM outputs), it has no
+          // allocEventIndex entries and we cannot bracket the reshard in the
+          // log. The reshard is still inserted in the IR for correctness, but
+          // its transient slot goes untracked in the address simulation. This
+          // is a known gap: the CB overlap check for this consumer was done
+          // when it was originally processed (with the victim at its then-
+          // current address), but subsequent evictions may have rearranged
+          // the free list so the reshard lands at a lower address at runtime.
+          if (firstAllocIdx != std::numeric_limits<size_t>::max()) {
+            // kAlloc goes at firstAllocIdx (just before consumer's first
+            // result alloc) and kDealloc goes at lastAllocIdx+1 (just after
+            // consumer's last result alloc). Inserting largest-first keeps
+            // firstAllocIdx valid when the kDealloc insertion is processed.
+            // Note: reshardResult is NOT added to allocEventIndex — it should
+            // anyway never appear as an eviction victim.
+            transientInsertions.push_back(
+                {lastAllocIdx + 1,
+                 {L1Event::kDealloc, reshardResult, 0, false}});
+            transientInsertions.push_back(
+                {firstAllocIdx,
+                 {L1Event::kAlloc, reshardResult, reshardSizePerCore, false}});
+          }
+        } else {
+          // Insert the reshard into the schedule so the forward sweep processes
+          // it naturally, adding it to liveValues and the tracker. Each
+          // insertion shifts the consumer right by one, so advance consumerPos.
+          insertReshardIntoSchedule(reshardOp, reshardResult,
+                                    reshardSizePerCore, consumerPos, data);
+          ++consumerPos;
         }
       }
     }
@@ -927,10 +948,12 @@ void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
   }
   data.positionMap[reshardOp] = consumerPos;
 
-  // Keep lastUsePositions in original-coordinate space so liveSet heap entries
-  // pushed before and after this insertion stay comparable (no priority drift).
-  // deathSchedule is maintained separately in shifted space and owns correctness
-  // for processDeadTensors; lastUsePositions is only used for liveSet priorities.
+  // Existing lastUsePositions are not shifted. An insertion adds 1 to every
+  // position at or after consumerPos, which preserves their relative order,
+  // and relative order is all liveSet's farthest-last-use priority needs. The
+  // reshard's own priority is arbitrary (reshards are never evicted; see
+  // evictFarthestUse), so consumerPos is just convenient. deathSchedule
+  // (shifted) owns freeing.
   int64_t reshardLastUse = consumerPos + 1;
   data.lastUsePositions[reshardResult] = consumerPos;
 
@@ -1091,22 +1114,21 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
     // while iterating op operands via liveSet).
     llvm::SmallVector<Value> toEvict;
     for (Value operand : op->getOperands()) {
-      if (!liveValues.count(operand)) {
-        continue;
+      if (liveValues.count(operand)) {
+        toEvict.push_back(operand);
       }
-      // Never evict an inserted reshard — it was placed here specifically
-      // to feed this op. Regular to_memory_config ops are NOT protected.
-      if (insertedReshardValues.count(operand)) {
-        continue;
-      }
-      toEvict.push_back(operand);
     }
     for (Value victim : toEvict) {
       TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                    "    SPILL_SIBLING_OPERAND: evicting {0} to DRAM to "
                    "resolve backend constraint failure for {1}",
                    ttmlir::opToString(victim.getDefiningOp()), op->getName());
-      evictValue(victim, pos, data);
+      // skipReshardConsumer=op: don't reshard `op`'s operand back to L1.
+      // Validating after spilling one operand (others still L1) would report a
+      // mixed-input failure and reshard it straight back, defeating the
+      // homogeneous spill. Past/future consumers of the operand are still
+      // restored, so their IR stays valid.
+      evictValue(victim, pos, data, /*skipReshardConsumer=*/op);
     }
   }
 
@@ -1279,6 +1301,13 @@ void L1SpillManagement<MemoryTracker>::run() {
       for (auto r : tensorResults) {
         Value val = r;
         auto luIt = data.lastUsePositions.find(val);
+        // Every scheduled op (original or inserted reshard) gets an entry at
+        // build time or in insertReshardIntoSchedule. A miss would give `val` a
+        // shifted-space priority via the fallback below, corrupting
+        // farthest-last-use ordering — assert loudly; the fallback only keeps
+        // release builds defined.
+        assert(luIt != data.lastUsePositions.end() &&
+               "scheduled value missing its lastUsePositions entry");
         int64_t resultLastUse =
             (luIt != data.lastUsePositions.end()) ? luIt->second : pos;
         // Snapshot before allocation and record event for replay.
@@ -1332,6 +1361,13 @@ void L1SpillManagement<MemoryTracker>::run() {
                    ttmlir::opToString(op), result.cbPeakUsage, l1Size);
 
       l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
+      // Eviction may have inserted a reshard for `op` itself, shifting `op`
+      // past `pos`. Rewind to the first inserted reshard (always at `pos`); the
+      // loop walks forward through any others, then reprocesses `op`.
+      if (data.schedule[pos] != op) {
+        --pos;
+        continue;
+      }
       if (l1Size == 0) {
         continue;
       }
@@ -1362,6 +1398,11 @@ void L1SpillManagement<MemoryTracker>::run() {
     }
 
     handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
+    // As above: if handleOOM's eviction inserted a reshard for `op`, rewind so
+    // the sweep reprocesses the inserted reshard(s) and then `op`.
+    if (data.schedule[pos] != op) {
+      --pos;
+    }
   }
 
   // Print final memory view summary.

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -927,16 +927,12 @@ void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
   }
   data.positionMap[reshardOp] = consumerPos;
 
-  // Shift lastUsePositions for all values whose last use is now past the
-  // insertion point, so processDeadTensors frees them at the right time.
-  for (auto &[val, lastUse] : data.lastUsePositions) {
-    if (lastUse >= consumerPos) {
-      ++lastUse;
-    }
-  }
-  // Reshard's last use is the consumer (now at consumerPos + 1).
+  // Keep lastUsePositions in original-coordinate space so liveSet heap entries
+  // pushed before and after this insertion stay comparable (no priority drift).
+  // deathSchedule is maintained separately in shifted space and owns correctness
+  // for processDeadTensors; lastUsePositions is only used for liveSet priorities.
   int64_t reshardLastUse = consumerPos + 1;
-  data.lastUsePositions[reshardResult] = reshardLastUse;
+  data.lastUsePositions[reshardResult] = consumerPos;
 
   // Rebuild deathSchedule with shifted keys (simpler than in-place shift on a
   // DenseMap where keys can't be updated).

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -636,9 +636,12 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
       // tensors that would collide with the op's CB region.
       evictForDramCBGrowth(op, pos, data);
     }
-    // Skip allocation if eviction inserted a reshard for `op` and shifted it
-    // past `pos`; run()'s sweep reprocesses the reshard and then `op`.
-    if (l1Size > 0 && data.schedule[pos] == op) {
+    // Eviction may have inserted a reshard for `op`, shifting it past `pos`;
+    // bail so run()'s sweep reprocesses the reshard and then `op`.
+    if (data.schedule[pos] != op) {
+      return;
+    }
+    if (l1Size > 0) {
       addResultsToLiveSet(l1Size);
       observer_->onLiveAdded(op, pos, l1Size, pos,
                              memoryTracker.getOccupiedL1());
@@ -1214,6 +1217,18 @@ void L1SpillManagement<MemoryTracker>::run() {
        ++pos) {
     Operation *op = data.schedule[pos];
 
+    // Eviction can insert a reshard for `op`, shifting `op` past `pos`. Rewind
+    // to the first inserted reshard (always at `pos`) so the sweep processes it
+    // (and any others) before reprocessing `op`. Returns true when the caller
+    // should `continue` the sweep.
+    auto rewindIfScheduleShifted = [&]() {
+      if (data.schedule[pos] == op) {
+        return false;
+      }
+      --pos;
+      return true;
+    };
+
     processDeadTensors(pos, data);
 
     // Sink ops (paged_fill_cache / paged_update_cache / fill_cache) are in
@@ -1301,15 +1316,9 @@ void L1SpillManagement<MemoryTracker>::run() {
       for (auto r : tensorResults) {
         Value val = r;
         auto luIt = data.lastUsePositions.find(val);
-        // Every scheduled op (original or inserted reshard) gets an entry at
-        // build time or in insertReshardIntoSchedule. A miss would give `val` a
-        // shifted-space priority via the fallback below, corrupting
-        // farthest-last-use ordering — assert loudly; the fallback only keeps
-        // release builds defined.
         assert(luIt != data.lastUsePositions.end() &&
                "scheduled value missing its lastUsePositions entry");
-        int64_t resultLastUse =
-            (luIt != data.lastUsePositions.end()) ? luIt->second : pos;
+        int64_t resultLastUse = luIt->second;
         // Snapshot before allocation and record event for replay.
         allocEventIndex[val] = l1EventLog.size();
         addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
@@ -1361,11 +1370,7 @@ void L1SpillManagement<MemoryTracker>::run() {
                    ttmlir::opToString(op), result.cbPeakUsage, l1Size);
 
       l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
-      // Eviction may have inserted a reshard for `op` itself, shifting `op`
-      // past `pos`. Rewind to the first inserted reshard (always at `pos`); the
-      // loop walks forward through any others, then reprocesses `op`.
-      if (data.schedule[pos] != op) {
-        --pos;
+      if (rewindIfScheduleShifted()) {
         continue;
       }
       if (l1Size == 0) {
@@ -1398,10 +1403,8 @@ void L1SpillManagement<MemoryTracker>::run() {
     }
 
     handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
-    // As above: if handleOOM's eviction inserted a reshard for `op`, rewind so
-    // the sweep reprocesses the inserted reshard(s) and then `op`.
-    if (data.schedule[pos] != op) {
-      --pos;
+    if (rewindIfScheduleShifted()) {
+      continue;
     }
   }
 

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -338,6 +338,21 @@ Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
       continue;
     }
 
+    // Skip inserted reshards (ToMemoryConfigOp with L1 output): they reload
+    // spilled tensors and must stay live until their immediate consumer runs.
+    // Belady naturally deprioritizes them (lastUse = immediate consumer, so
+    // they sit at the bottom of the max-heap), but the exclusion guards against
+    // the pathological case where they are the only remaining live values.
+    if (auto *defOp = candidateVal.getDefiningOp()) {
+      if (isa<ToMemoryConfigOp>(defOp)) {
+        auto lo = mlir::dyn_cast_or_null<TTNNLayoutAttr>(
+            mlir::cast<RankedTensorType>(candidateVal.getType()).getEncoding());
+        if (lo && lo.hasL1BufferType()) {
+          continue;
+        }
+      }
+    }
+
     liveValues.erase(candidateVal);
     return candidateVal;
   }
@@ -571,7 +586,7 @@ void L1SpillManagement<MemoryTracker>::processDeadTensors(
 
 template <typename MemoryTracker>
 uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(
-    Operation *op, int64_t pos, const ScheduleData &data, uint64_t cbPeakUsage,
+    Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
     uint64_t l1Size) {
   auto speculativeAddr = memoryTracker.wouldAllocateAt(l1Size);
   if (!speculativeAddr) {
@@ -598,7 +613,7 @@ uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(
 template <typename MemoryTracker>
 void L1SpillManagement<MemoryTracker>::handleOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
-    const ScheduleData &data,
+    ScheduleData &data,
     std::function<void(uint64_t)> addResultsToLiveSet) {
   observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -651,6 +666,30 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
 }
 
 //===----------------------------------------------------------------------===//
+// insertEventIntoLog
+//===----------------------------------------------------------------------===//
+
+template <typename MemoryTracker>
+void L1SpillManagement<MemoryTracker>::insertEventIntoLog(size_t pos,
+                                                          L1Event event) {
+  // Insert the event and shift every index >= pos in both index structures
+  // so the invariant "addressSnapshots[i] = state before event i" and
+  // "allocEventIndex[v] = i <=> l1EventLog[i] is v's kAlloc" are preserved.
+  l1EventLog.insert(l1EventLog.begin() + pos, event);
+  for (auto &[val, idx] : allocEventIndex) {
+    if (idx >= pos) {
+      ++idx;
+    }
+  }
+  decltype(addressSnapshots) shifted;
+  shifted.reserve(addressSnapshots.size());
+  for (auto &[key, snap] : addressSnapshots) {
+    shifted[key >= pos ? key + 1 : key] = std::move(snap);
+  }
+  addressSnapshots = std::move(shifted);
+}
+
+//===----------------------------------------------------------------------===//
 // markEvictedAndRebuild
 //===----------------------------------------------------------------------===//
 
@@ -681,7 +720,11 @@ void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
   memoryTracker.restoreSnapshot(snapIt->second);
 
   // Replay events from the alloc point forward, skipping evicted tensors.
-  // Update snapshots during replay so future evictions see accurate state.
+  // Reshard kAlloc/kDealloc pairs that evictValue inserted into the log are
+  // replayed here like any other event — the reshard is allocated before the
+  // consumer's alloc (correct address for the consumer) and freed after. When
+  // the consumer's own kAlloc events are skipped (consumer later evicted), the
+  // reshard kDealloc still fires and reclaims the slot, so it is never stuck.
   for (size_t i = allocIdx; i < l1EventLog.size(); ++i) {
     if (l1EventLog[i].skipped) {
       continue;
@@ -712,7 +755,7 @@ void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
 
 template <typename MemoryTracker>
 void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
-                                                  const ScheduleData &data) {
+                                                  ScheduleData &data) {
   liveValues.erase(victim);
   Operation *victimOp = victim.getDefiningOp();
   uint64_t freedBytes = memoryTracker.getTensorSize(victim);
@@ -729,19 +772,42 @@ void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
 
   spillToDram(victim);
   memoryTracker.removeTensorFromSizes(victim);
-  markEvictedAndRebuild(victim);
 
   // Restore the original L1-sharded layout for consumers that need it:
   // - Past consumers (pos < currentPos): always restore. They were already
   //   validated assuming L1-sharded input; without reshard the IR is broken.
+  //   Log a kAlloc for the reshard just before the consumer's first alloc event
+  //   and a kDealloc just after its last alloc event. Because the victim is
+  //   always scheduled before its consumers, allocIdx < consumerFirstAllocIdx,
+  //   so the markEvictedAndRebuild replay below always passes through both
+  //   events and updates the consumer's alloc snapshots to include the
+  //   reshard's slot. Future replays then handle the reshard naturally: it is
+  //   allocated before the consumer (correct addresses) and freed after (no
+  //   stuck slot). Neither event is added to allocEventIndex, so the reshard
+  //   can never be selected as an eviction victim.
   // - Future consumers (pos >= currentPos): probe the consumer's layout
   //   constraints with the new (DRAM-after-spill) inputs in isolation
   //   (additionalL1Usage=0 — we don't know what L1 will be occupied at the
   //   consumer's position yet). If a hard input-layout constraint rejects
-  //   it (e.g. paged_update_cache requires sharded input), insert reshard.
+  //   it (e.g. paged_update_cache requires sharded input), insert reshard into
+  //   IR and schedule so the forward sweep processes it naturally, logging it
+  //   like any other live tensor.
+  //
   //   Otherwise leave the consumer to read DRAM — that's the actual L1
   //   saving the spill bought us.
+
+  // Collect all insertions first; apply largest-position-first so that
+  // inserting later events does not shift the positions of earlier ones.
+  struct TransientInsertion {
+    size_t pos;
+    L1Event event;
+  };
+  llvm::SmallVector<TransientInsertion> transientInsertions;
+
   if (originalL1Layout.hasL1BufferType()) {
+    uint64_t reshardSizePerCore = utils::getPerCoreL1Usage(
+        originalL1Layout,
+        ttmlir::utils::volume(originalL1Layout.getGridShape()));
     for (Operation *consumer : collectDownstreamConsumers(victimOp)) {
       auto posIt = data.positionMap.find(consumer);
       if (posIt == data.positionMap.end()) {
@@ -766,7 +832,8 @@ void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
         continue;
       }
 
-      bool needsReshard = posIt->second < pos;
+      bool isPastConsumer = posIt->second < pos;
+      bool needsReshard = isPastConsumer;
       if (!needsReshard) {
         auto consumerInputs = utils::extractInputLayouts(consumer);
         auto consumerConfig = extractOpConfigFromIR(consumer);
@@ -783,16 +850,128 @@ void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
                        "(operand {1} changed L1→DRAM after eviction of {2})",
                        consumer->getName(), i, ttmlir::opToString(victimOp));
           insertReshardForConsumer(consumer, i, originalL1Layout);
+          Value reshardResult = consumer->getOperand(i);
+          if (isPastConsumer) {
+            // Find the consumer's first and last output alloc event indices so
+            // we can bracket the reshard's transient occupation in the log.
+            size_t firstAllocIdx = std::numeric_limits<size_t>::max();
+            size_t lastAllocIdx = 0;
+            for (auto result : consumer->getResults()) {
+              auto logIt = allocEventIndex.find(result);
+              if (logIt != allocEventIndex.end()) {
+                firstAllocIdx = std::min(firstAllocIdx, logIt->second);
+                lastAllocIdx = std::max(lastAllocIdx, logIt->second);
+              }
+            }
+            // If the consumer has no L1 results (all DRAM outputs), it has no
+            // allocEventIndex entries and we cannot bracket the reshard in the
+            // log. The reshard is still inserted in the IR for correctness, but
+            // its transient slot goes untracked in the address simulation. This
+            // is a known gap: the CB overlap check for this consumer was done
+            // when it was originally processed (with the victim at its then-
+            // current address), but subsequent evictions may have rearranged
+            // the free list so the reshard lands at a lower address at runtime.
+            if (firstAllocIdx != std::numeric_limits<size_t>::max()) {
+              // kAlloc goes at firstAllocIdx (just before consumer's first
+              // result alloc) and kDealloc goes at lastAllocIdx+1 (just after
+              // consumer's last result alloc). Inserting largest-first keeps
+              // firstAllocIdx valid when the kDealloc insertion is processed.
+              // Note: reshardResult is NOT added to allocEventIndex — it should
+              // anyway never appear as an eviction victim.
+              transientInsertions.push_back(
+                  {lastAllocIdx + 1,
+                   {L1Event::kDealloc, reshardResult, 0, false}});
+              transientInsertions.push_back({firstAllocIdx,
+                                             {L1Event::kAlloc, reshardResult,
+                                              reshardSizePerCore, false}});
+            }
+          } else {
+            // Insert the reshard into the schedule so the forward sweep
+            // processes it naturally, adding it to liveValues and the tracker.
+            insertReshardIntoSchedule(reshardResult.getDefiningOp(),
+                                      reshardResult, reshardSizePerCore,
+                                      posIt->second, data);
+          }
         }
       }
     }
   }
+
+  // Apply transient event insertions largest-position-first so earlier
+  // positions are not invalidated by later insertions.
+  llvm::sort(transientInsertions,
+             [](const TransientInsertion &a, const TransientInsertion &b) {
+               return a.pos > b.pos;
+             });
+  for (const auto &ins : transientInsertions) {
+    insertEventIntoLog(ins.pos, ins.event);
+  }
+
+  markEvictedAndRebuild(victim);
+}
+
+//===----------------------------------------------------------------------===//
+// insertReshardIntoSchedule
+//===----------------------------------------------------------------------===//
+
+template <typename MemoryTracker>
+void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
+    Operation *reshardOp, Value reshardResult, uint64_t reshardSizePerCore,
+    int64_t consumerPos, ScheduleData &data) {
+
+  // Insert the reshard before the consumer in the schedule vector, shifting
+  // the consumer and all subsequent ops by +1.
+  data.schedule.insert(data.schedule.begin() + consumerPos, reshardOp);
+
+  // Shift positionMap for all ops at positions >= consumerPos.
+  for (auto &[op, opPos] : data.positionMap) {
+    if (opPos >= consumerPos) {
+      ++opPos;
+    }
+  }
+  data.positionMap[reshardOp] = consumerPos;
+
+  // Shift lastUsePositions for all values whose last use is now past the
+  // insertion point, so processDeadTensors frees them at the right time.
+  for (auto &[val, lastUse] : data.lastUsePositions) {
+    if (lastUse >= consumerPos) {
+      ++lastUse;
+    }
+  }
+  // Reshard's last use is the consumer (now at consumerPos + 1).
+  int64_t reshardLastUse = consumerPos + 1;
+  data.lastUsePositions[reshardResult] = reshardLastUse;
+
+  // Rebuild deathSchedule with shifted keys (simpler than in-place shift on a
+  // DenseMap where keys can't be updated).
+  llvm::DenseMap<int64_t, llvm::SmallVector<Value>> newDeathSchedule;
+  for (auto &[deathPos, vals] : data.deathSchedule) {
+    int64_t shiftedPos = (deathPos >= consumerPos) ? deathPos + 1 : deathPos;
+    newDeathSchedule[shiftedPos] = std::move(vals);
+  }
+  newDeathSchedule[reshardLastUse].push_back(reshardResult);
+  data.deathSchedule = std::move(newDeathSchedule);
 }
 
 template <typename MemoryTracker>
 bool L1SpillManagement<MemoryTracker>::evictUntil(
-    int64_t pos, const ScheduleData &data, std::function<bool()> shouldStop) {
-  while (!shouldStop() && !liveValues.empty()) {
+    int64_t pos, ScheduleData &data, std::function<bool()> shouldStop) {
+  // Helper: true if every remaining live value is a non-evictable reshard.
+  // Avoids exhausting the liveSet heap through stale entries when no
+  // evictable candidates exist.
+  auto onlyReshardsRemain = [&]() {
+    return llvm::all_of(liveValues, [](Value v) {
+      auto *defOp = v.getDefiningOp();
+      if (!defOp || !isa<ToMemoryConfigOp>(defOp)) {
+        return false;
+      }
+      auto lo = mlir::dyn_cast_or_null<TTNNLayoutAttr>(
+          mlir::cast<RankedTensorType>(v.getType()).getEncoding());
+      return lo && lo.hasL1BufferType();
+    });
+  };
+
+  while (!shouldStop() && !liveValues.empty() && !onlyReshardsRemain()) {
     Value victim = evictFarthestUse();
     if (!victim) {
       break;
@@ -809,7 +988,7 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
 template <typename MemoryTracker>
 uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
                                                        int64_t pos,
-                                                       const ScheduleData &data,
+                                                       ScheduleData &data,
                                                        uint64_t outputL1Size) {
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "    NO_FIT: output {0} bytes can't fit contiguously, evicting",
@@ -853,7 +1032,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
 
 template <typename MemoryTracker>
 uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
-    Operation *op, int64_t pos, const ScheduleData &data, uint64_t cbPeakUsage,
+    Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
     uint64_t outputL1Size) {
   // Add the same safety cushion as wouldCBsOverlapTensors to account for
   // unmodeled runtime fragmentation from transient internal op allocations.
@@ -926,9 +1105,21 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
     // while iterating op operands via liveSet).
     llvm::SmallVector<Value> toEvict;
     for (Value operand : op->getOperands()) {
-      if (liveValues.count(operand)) {
-        toEvict.push_back(operand);
+      if (!liveValues.count(operand)) {
+        continue;
       }
+      // Never evict an inserted reshard (ToMemoryConfigOp with L1 output) —
+      // it was placed here specifically to feed this op.
+      if (auto *defOp = operand.getDefiningOp()) {
+        if (isa<ToMemoryConfigOp>(defOp)) {
+          auto lo = mlir::dyn_cast_or_null<TTNNLayoutAttr>(
+              mlir::cast<RankedTensorType>(operand.getType()).getEncoding());
+          if (lo && lo.hasL1BufferType()) {
+            continue;
+          }
+        }
+      }
+      toEvict.push_back(operand);
     }
     for (Value victim : toEvict) {
       TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1282,7 +1473,7 @@ void L1SpillManagement<MemoryTracker>::demoteToDram(Operation *op) {
 
 template <typename MemoryTracker>
 void L1SpillManagement<MemoryTracker>::evictAllFromL1(int64_t pos,
-                                                      const ScheduleData &data,
+                                                      ScheduleData &data,
                                                       Operation *triggerOp) {
   llvm::SmallVector<Operation *> evictedOps;
   for (Value victim : liveValues) {
@@ -1316,7 +1507,7 @@ void L1SpillManagement<MemoryTracker>::evictAllFromL1(int64_t pos,
 
 template <typename MemoryTracker>
 void L1SpillManagement<MemoryTracker>::evictForCBOverlap(
-    uint64_t cushionedCBUsage, int64_t pos, const ScheduleData &data) {
+    uint64_t cushionedCBUsage, int64_t pos, ScheduleData &data) {
   evictUntil(pos, data, [&]() {
     return cushionedCBUsage <= memoryTracker.getLowestOccupiedAddress();
   });
@@ -1328,7 +1519,7 @@ void L1SpillManagement<MemoryTracker>::evictForCBOverlap(
 
 template <typename MemoryTracker>
 void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
-    Operation *op, int64_t pos, const ScheduleData &data) {
+    Operation *op, int64_t pos, ScheduleData &data) {
 
   auto inputLayouts = utils::extractInputLayouts(op);
   auto config = extractOpConfigFromIR(op);


### PR DESCRIPTION
### Ticket
[XLA issue Falcon3-7B L1 OOM fragmentation
](https://github.com/tenstorrent/tt-xla/issues/4394)
https://github.com/tenstorrent/tt-mlir/issues/8515

## Summary

- Fix `L1SpillManagement` address simulation to correctly track reshards
  inserted for already-processed consumers in the event log, preventing
  stuck address slots and stale CB-overlap checks
- Add `insertReshardIntoSchedule` so reshards inserted for not-yet-processed
  consumers are handled naturally by the forward sweep
- Rewind the sweep when a reshard is inserted for the op currently being
  processed, so the reshard and the op are processed in the correct order
- Guard inserted reshards from being selected as eviction victims, except in
  `handleFragmentation`'s sibling-operand eviction path (to align all siblings
  to DRAM)

## Changes

**`insertEventIntoLog(pos, event)`**
Inserts an `L1Event` at an arbitrary position in `l1EventLog` and shifts all
`allocEventIndex` entries and `addressSnapshots` keys `≥ pos` by 1, preserving
both index invariants.

**Past-consumer reshards**
When `evictValue` inserts a reshard for an already-processed consumer, it now
also inserts a `kAlloc` event just before the consumer's first alloc in the log
and a `kDealloc` just after its last. Since the victim is always scheduled
before its consumers, the immediately-following `markEvictedAndRebuild` replay
always passes through both events and refreshes the consumer's alloc snapshots.
Every subsequent replay then:
- Allocates the reshard's slot before the consumer (correct addresses).
- Frees it after — if the consumer is itself later evicted, its kAlloc is
  skipped but the reshard kDealloc still fires and reclaims the slot.

Past-consumer reshards are not added to `allocEventIndex` so they can never be selected as
eviction victims.

**Future-consumer reshards**
`insertReshardIntoSchedule` splices the reshard op into `data.schedule` at the
consumer's position and updates `positionMap` and `deathSchedule` so the forward
sweep processes it like any other L1 op, logging its kAlloc/kDealloc naturally.
Its per-core L1 size is taken from validating the inserted reshard. We don't
shift `lastUsePositions` for existing ops, because that map only drives 
farthest-last-use eviction heuristic and insertions preserve relative ordering;
the reshard's own `lastUsePositions` value is irrelevant since it is
purposefully never chosen for eviction.

**Reshard for the op currently being processed (schedule rewind)**
A reshard can also be inserted for the op being processed *right now* (its
operand was just spilled and the op hard-requires the L1 layout).
`insertReshardIntoSchedule` then splices the reshard at the current sweep position, shifting the op forward. `run()` detects this (`data.schedule[pos] !=
op`), rewinds `pos` by one and continues, so the sweep processes the inserted
reshard(s) and then reprocesses the op (now reading the reshard's L1 output). A
single `--pos` suffices regardless of how many reshards were inserted — they
land contiguously from the original position and the loop walks forward through
all of them.

**Reshard eviction guard**
Future-consumer reshards live in `liveValues`, so `evictFarthestUse` skips them
(they exist to feed their consumer). The exception is `handleFragmentation`'s
sibling-operand spill: when an op (e.g. concat) needs all operands in DRAM to be
valid, every L1 operand — inserted reshards included — is spilled. `evictValue`
is passed `skipReshardConsumer=op` so it spills *without* re-resharding that op
back to L1 (which validation would otherwise trigger mid-loop, seeing still-mixed
inputs and defeating the homogeneous spill). The op's other past/future
consumers are still restored.

**Known limitation**
Past consumers with DRAM-only outputs have no `allocEventIndex` anchor, so the
reshard's slot cannot be bracketed in the log. The reshard is still inserted in
the IR; the address simulation is slightly optimistic around that consumer's
execution window not to have CB-overlap due to input address change. Documented
in source comments.

### Checklist
- [x] Falcon3-7B passes without OOM L1 fragmentation on CI
- [x] No significant regressions on other perf benchmark tests (the other "improvements" are not really improvements but random fails)
  - on base commit: https://github.com/tenstorrent/tt-xla/actions/runs/26399822651
  - this change on top: https://github.com/tenstorrent/tt-xla/actions/runs/26401785210
<img width="1950" height="1692" alt="image" src="https://github.com/user-attachments/assets/d35d0b27-2af4-46eb-a1ce-9eac89113df5" />

- [x] Same result on newer version of base + changes on branch:
  - on base commit: https://github.com/tenstorrent/tt-xla/actions/runs/26826927936
  - this change on top: https://github.com/tenstorrent/tt-xla/actions/runs/26820846632
 
### Future related work
- Add tests through new test infra when added by https://github.com/tenstorrent/tt-mlir/issues/8514