### PR TITLE
Videogen memory optimization patterns

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
@@ -881,6 +881,279 @@ public:
   }
 };
 
+class PermuteRowMajorAdjusting : public OpRewritePattern<ttnn::PermuteOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::PermuteOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op->hasOneUse()) {
+      return failure();
+    }
+
+    Operation *user = *op->user_begin();
+    ttnn::RepeatOp repeatUser = mlir::dyn_cast<ttnn::RepeatOp>(user);
+    ttnn::ReshapeOp reshapeUser = mlir::dyn_cast<ttnn::ReshapeOp>(user);
+    if (!reshapeUser) {
+      if (!repeatUser || !repeatUser->hasOneUse()) {
+        return failure();
+      }
+      reshapeUser = mlir::dyn_cast<ttnn::ReshapeOp>(*repeatUser->user_begin());
+    }
+    if (!reshapeUser) {
+      return failure();
+    }
+
+    auto resultType = mlir::cast<RankedTensorType>(op.getResult().getType());
+    auto resultLayout =
+        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(resultType.getEncoding());
+    if (!resultLayout || !resultLayout.isTiled()) {
+      return failure();
+    }
+
+    auto paddedShape =
+        ttnn::utils::getTilePaddedShape(op.getResult().getType().getShape());
+
+    int64_t tiledVolume = ttmlir::utils::volume(llvm::ArrayRef(paddedShape));
+    int64_t rmVolume =
+        ttmlir::utils::volume(op.getResult().getType().getShape());
+
+    RankedTensorType repeatResultType;
+    ttnn::TTNNLayoutAttr repeatResultLayout;
+    if (repeatUser) {
+      repeatResultType =
+          mlir::cast<RankedTensorType>(repeatUser.getResult().getType());
+      repeatResultLayout =
+          mlir::dyn_cast<ttnn::TTNNLayoutAttr>(repeatResultType.getEncoding());
+      if (!repeatResultLayout || !repeatResultLayout.isTiled()) {
+        return failure();
+      }
+
+      auto repeatPaddedShape =
+          ttnn::utils::getTilePaddedShape(repeatResultType.getShape());
+      tiledVolume =
+          std::max(tiledVolume,
+                   ttmlir::utils::volume(llvm::ArrayRef(repeatPaddedShape)));
+      rmVolume = std::max(rmVolume,
+                          ttmlir::utils::volume(repeatResultType.getShape()));
+    }
+
+    // If the difference is less than 1GB, nothing to do.
+    if (tiledVolume - rmVolume < 1LL * 1024LL * 1024LL * 1024LL) {
+      return failure();
+    }
+
+    auto rowMajorLayout =
+        TTNNLayoutAttr::Builder(resultLayout, resultType.getShape())
+            .setLayout(ttnn::Layout::RowMajor)
+            .build();
+    if (rowMajorLayout == resultLayout) {
+      return failure();
+    }
+
+    RankedTensorType rowMajorResultType =
+        resultType.cloneWithEncoding(rowMajorLayout);
+
+    RankedTensorType rowMajorRepeatResultType;
+    if (repeatUser) {
+      auto rowMajorRepeatLayout =
+          TTNNLayoutAttr::Builder(repeatResultLayout,
+                                  repeatResultType.getShape())
+              .setLayout(ttnn::Layout::RowMajor)
+              .build();
+      rowMajorRepeatResultType =
+          repeatResultType.cloneWithEncoding(rowMajorRepeatLayout);
+    }
+
+    auto reshapeResultType =
+        mlir::cast<RankedTensorType>(reshapeUser.getResult().getType());
+    auto reshapeResultLayout =
+        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(reshapeResultType.getEncoding());
+    if (!reshapeResultLayout || !reshapeResultLayout.isTiled()) {
+      return failure();
+    }
+
+    RankedTensorType rowMajorReshapeResultType;
+    if (!repeatUser) {
+      auto rowMajorReshapeLayout =
+          TTNNLayoutAttr::Builder(reshapeResultLayout,
+                                  reshapeResultType.getShape())
+              .setLayout(ttnn::Layout::RowMajor)
+              .build();
+      rowMajorReshapeResultType =
+          reshapeResultType.cloneWithEncoding(rowMajorReshapeLayout);
+    }
+
+    Value permuteInput = op.getInput();
+    if (!permuteInput.getDefiningOp<ttnn::ToLayoutOp>()) {
+      auto inputType = mlir::cast<RankedTensorType>(permuteInput.getType());
+      auto inputLayout =
+          mlir::dyn_cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+
+      if (inputLayout && inputLayout.isTiled()) {
+        auto rowMajorInput = utils::createToLayoutOp(
+            op, mlir::cast<mlir::TypedValue<RankedTensorType>>(permuteInput),
+            rewriter, Layout::RowMajor, inputLayout.getBufferType(),
+            inputLayout.getMemLayout(), inputLayout.getDataType(),
+            "_input_row_major");
+        permuteInput = rowMajorInput.getResult();
+      }
+    }
+
+    auto newPermuteOp = rewriter.create<ttnn::PermuteOp>(
+        op.getLoc(), rowMajorResultType, permuteInput, op.getPermutation(),
+        op.getPadValue());
+
+    if (repeatUser) {
+      auto newRepeatOp = rewriter.create<ttnn::RepeatOp>(
+          repeatUser.getLoc(), rowMajorRepeatResultType,
+          newPermuteOp.getResult(), repeatUser.getRepeatDims());
+
+      auto restoredRepeatLayout = utils::createToLayoutOp(
+          repeatUser,
+          mlir::cast<mlir::TypedValue<RankedTensorType>>(
+              newRepeatOp.getResult()),
+          rewriter, repeatResultLayout.getLayout(),
+          repeatResultLayout.getBufferType(), repeatResultLayout.getMemLayout(),
+          repeatResultLayout.getDataType(), "_restore_repeat_layout");
+
+      auto newReshapeOp = rewriter.create<ttnn::ReshapeOp>(
+          reshapeUser.getLoc(), reshapeResultType,
+          restoredRepeatLayout.getResult(), reshapeUser.getShapeAttr());
+      rewriter.replaceOp(reshapeUser, newReshapeOp.getResult());
+      rewriter.eraseOp(repeatUser);
+    } else {
+      auto newReshapeOp = rewriter.create<ttnn::ReshapeOp>(
+          reshapeUser.getLoc(), rowMajorReshapeResultType,
+          newPermuteOp.getResult(), reshapeUser.getShapeAttr());
+
+      auto restoredLayout = utils::createToLayoutOp(
+          reshapeUser,
+          mlir::cast<mlir::TypedValue<RankedTensorType>>(
+              newReshapeOp.getResult()),
+          rewriter, reshapeResultLayout.getLayout(),
+          reshapeResultLayout.getBufferType(),
+          reshapeResultLayout.getMemLayout(), reshapeResultLayout.getDataType(),
+          "_restore_layout");
+      rewriter.replaceOp(reshapeUser, restoredLayout.getResult());
+    }
+
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
+class ReshapeRowMajorAdjusting : public OpRewritePattern<ttnn::ReshapeOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::ReshapeOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op->hasOneUse()) {
+      return failure();
+    }
+
+    auto permuteUser = mlir::dyn_cast<ttnn::PermuteOp>(*op->user_begin());
+    if (!permuteUser) {
+      return failure();
+    }
+
+    auto reshapeResultType =
+        mlir::cast<RankedTensorType>(op.getResult().getType());
+    auto reshapeResultLayout =
+        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(reshapeResultType.getEncoding());
+    if (!reshapeResultLayout || !reshapeResultLayout.isTiled()) {
+      return failure();
+    }
+
+    auto permuteResultType =
+        mlir::cast<RankedTensorType>(permuteUser.getResult().getType());
+    auto permuteResultLayout =
+        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(permuteResultType.getEncoding());
+    if (!permuteResultLayout || !permuteResultLayout.isTiled()) {
+      return failure();
+    }
+
+    int64_t reshapeTiledVolume = getTiledVolume(reshapeResultType.getShape());
+    int64_t reshapeRmVolume =
+        ttmlir::utils::volume(reshapeResultType.getShape());
+    int64_t permuteTiledVolume = getTiledVolume(permuteResultType.getShape());
+    int64_t permuteRmVolume =
+        ttmlir::utils::volume(permuteResultType.getShape());
+
+    if (permuteTiledVolume != permuteRmVolume) {
+      return failure();
+    }
+
+    // If the difference is less than 1GB, nothing to do.
+    if (reshapeTiledVolume - reshapeRmVolume < 1LL * 1024LL * 1024LL * 1024LL) {
+      return failure();
+    }
+
+    auto rowMajorReshapeLayout =
+        TTNNLayoutAttr::Builder(reshapeResultLayout,
+                                reshapeResultType.getShape())
+            .setLayout(ttnn::Layout::RowMajor)
+            .build();
+    if (rowMajorReshapeLayout == reshapeResultLayout) {
+      return failure();
+    }
+
+    auto rowMajorPermuteLayout =
+        TTNNLayoutAttr::Builder(permuteResultLayout,
+                                permuteResultType.getShape())
+            .setLayout(ttnn::Layout::RowMajor)
+            .build();
+    if (rowMajorPermuteLayout == permuteResultLayout) {
+      return failure();
+    }
+
+    RankedTensorType rowMajorReshapeResultType =
+        reshapeResultType.cloneWithEncoding(rowMajorReshapeLayout);
+    RankedTensorType rowMajorPermuteResultType =
+        permuteResultType.cloneWithEncoding(rowMajorPermuteLayout);
+
+    Value reshapeInput = op.getInput();
+    if (!reshapeInput.getDefiningOp<ttnn::ToLayoutOp>()) {
+      auto inputType = mlir::cast<RankedTensorType>(reshapeInput.getType());
+      auto inputLayout =
+          mlir::dyn_cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+
+      if (inputLayout && inputLayout.isTiled()) {
+        auto rowMajorInput = utils::createToLayoutOp(
+            op, mlir::cast<mlir::TypedValue<RankedTensorType>>(reshapeInput),
+            rewriter, Layout::RowMajor, inputLayout.getBufferType(),
+            inputLayout.getMemLayout(), inputLayout.getDataType(),
+            "_input_row_major");
+        reshapeInput = rowMajorInput.getResult();
+      }
+    }
+
+    auto newReshapeOp =
+        rewriter.create<ttnn::ReshapeOp>(op.getLoc(), rowMajorReshapeResultType,
+                                         reshapeInput, op.getShapeAttr());
+
+    auto newPermuteOp = rewriter.create<ttnn::PermuteOp>(
+        permuteUser.getLoc(), rowMajorPermuteResultType,
+        newReshapeOp.getResult(), permuteUser.getPermutation(),
+        permuteUser.getPadValue());
+
+    auto restoredLayout = utils::createToLayoutOp(
+        permuteUser,
+        mlir::cast<mlir::TypedValue<RankedTensorType>>(
+            newPermuteOp.getResult()),
+        rewriter, permuteResultLayout.getLayout(),
+        permuteResultLayout.getBufferType(), permuteResultLayout.getMemLayout(),
+        permuteResultLayout.getDataType(), "_restore_layout");
+
+    rewriter.replaceOp(permuteUser, restoredLayout.getResult());
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
 class TTNNMemoryManagement
     : public impl::TTNNMemoryManagementBase<TTNNMemoryManagement> {
 public:
@@ -899,7 +1172,8 @@ public:
              RepeatReshapeAdjusting, ReshapeElementwiseAdjusting<ttnn::AddOp>,
              ReshapeElementwiseAdjusting<ttnn::MultiplyOp>,
              ReshapeElementwiseAdjusting<ttnn::SubtractOp>,
-             ReshapeElementwiseAdjusting<ttnn::DivideOp>>(&getContext());
+             ReshapeElementwiseAdjusting<ttnn::DivideOp>,
+             PermuteRowMajorAdjusting, ReshapeRowMajorAdjusting>(&getContext());
 
     GreedyRewriteConfig config;
     config.setUseTopDownTraversal(true);

--- a/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
@@ -973,16 +973,13 @@ public:
       return failure();
     }
 
-    RankedTensorType rowMajorReshapeResultType;
-    if (!repeatUser) {
-      auto rowMajorReshapeLayout =
-          TTNNLayoutAttr::Builder(reshapeResultLayout,
-                                  reshapeResultType.getShape())
-              .setLayout(ttnn::Layout::RowMajor)
-              .build();
-      rowMajorReshapeResultType =
-          reshapeResultType.cloneWithEncoding(rowMajorReshapeLayout);
-    }
+    auto rowMajorReshapeLayout =
+        TTNNLayoutAttr::Builder(reshapeResultLayout,
+                                reshapeResultType.getShape())
+            .setLayout(ttnn::Layout::RowMajor)
+            .build();
+    RankedTensorType rowMajorReshapeResultType =
+        reshapeResultType.cloneWithEncoding(rowMajorReshapeLayout);
 
     Value permuteInput = op.getInput();
     if (!permuteInput.getDefiningOp<ttnn::ToLayoutOp>()) {
@@ -1004,40 +1001,30 @@ public:
         op.getLoc(), rowMajorResultType, permuteInput, op.getPermutation(),
         op.getPadValue());
 
+    Value reshapeInput = newPermuteOp.getResult();
     if (repeatUser) {
       auto newRepeatOp = rewriter.create<ttnn::RepeatOp>(
           repeatUser.getLoc(), rowMajorRepeatResultType,
           newPermuteOp.getResult(), repeatUser.getRepeatDims());
-
-      auto restoredRepeatLayout = utils::createToLayoutOp(
-          repeatUser,
-          mlir::cast<mlir::TypedValue<RankedTensorType>>(
-              newRepeatOp.getResult()),
-          rewriter, repeatResultLayout.getLayout(),
-          repeatResultLayout.getBufferType(), repeatResultLayout.getMemLayout(),
-          repeatResultLayout.getDataType(), "_restore_repeat_layout");
-
-      auto newReshapeOp = rewriter.create<ttnn::ReshapeOp>(
-          reshapeUser.getLoc(), reshapeResultType,
-          restoredRepeatLayout.getResult(), reshapeUser.getShapeAttr());
-      rewriter.replaceOp(reshapeUser, newReshapeOp.getResult());
-      rewriter.eraseOp(repeatUser);
-    } else {
-      auto newReshapeOp = rewriter.create<ttnn::ReshapeOp>(
-          reshapeUser.getLoc(), rowMajorReshapeResultType,
-          newPermuteOp.getResult(), reshapeUser.getShapeAttr());
-
-      auto restoredLayout = utils::createToLayoutOp(
-          reshapeUser,
-          mlir::cast<mlir::TypedValue<RankedTensorType>>(
-              newReshapeOp.getResult()),
-          rewriter, reshapeResultLayout.getLayout(),
-          reshapeResultLayout.getBufferType(),
-          reshapeResultLayout.getMemLayout(), reshapeResultLayout.getDataType(),
-          "_restore_layout");
-      rewriter.replaceOp(reshapeUser, restoredLayout.getResult());
+      reshapeInput = newRepeatOp.getResult();
     }
 
+    auto newReshapeOp = rewriter.create<ttnn::ReshapeOp>(
+        reshapeUser.getLoc(), rowMajorReshapeResultType, reshapeInput,
+        reshapeUser.getShapeAttr());
+
+    auto restoredLayout = utils::createToLayoutOp(
+        reshapeUser,
+        mlir::cast<mlir::TypedValue<RankedTensorType>>(
+            newReshapeOp.getResult()),
+        rewriter, reshapeResultLayout.getLayout(),
+        reshapeResultLayout.getBufferType(), reshapeResultLayout.getMemLayout(),
+        reshapeResultLayout.getDataType(), "_restore_layout");
+
+    rewriter.replaceOp(reshapeUser, restoredLayout.getResult());
+    if (repeatUser) {
+      rewriter.eraseOp(repeatUser);
+    }
     rewriter.eraseOp(op);
 
     return success();

--- a/test/ttmlir/Transforms/memory_management.mlir
+++ b/test/ttmlir/Transforms/memory_management.mlir
@@ -17,11 +17,9 @@
 #layout_r_1x1x1x16 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0, d1, d2, d3), <1x1>, memref<16xf32, #dram>, <interleaved>>
 #layout_r_1x1x1x1024 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0, d1, d2, d3), <1x1>, memref<1024xf32, #dram>, <interleaved>>
 #layout_r_1x1x32x32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0, d1, d2, d3), <1x1>, memref<1024xf32, #dram>, <interleaved>>
-<<<<<<< HEAD
 #layout_mm_1x8190x6x3072 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 262080 + d1 * 32 + d2, d3), <1x1>, memref<8190x96x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_mm_1x8190x3072 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 8192 + d1, d2), <1x1>, memref<256x96x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_mm_1x49140x3072 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 49152 + d1, d2), <1x1>, memref<1536x96x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-=======
 #layout_1x67M_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2097152x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_67Mx1_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_67Mx2_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
@@ -29,7 +27,6 @@
 #layout_8192x16384_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<256x512x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_4d_1x1x8192x8192_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 * 8192 + d2, d3), <1x1>, memref<256x256x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_4d_8192x8192x1x1_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 + d2, d3), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
->>>>>>> 50e575d247 (Videogen memory optimization patterns.)
 
 module {
   // sliceReshape
@@ -116,6 +113,7 @@ module {
     %2 = "ttnn.slice_static"(%arg0) <{begins = [0 : i32, 0 : i32, 3 : i32, 0 : i32], ends = [1 : i32, 8190 : i32, 4 : i32, 3072 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1x8190x6x3072xf32, #layout_mm_1x8190x6x3072>) -> tensor<1x8190x1x3072xf32, #layout_mm_1x8190x6x3072>
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 8190 : i32, 3072 : i32]}> : (tensor<1x8190x1x3072xf32, #layout_mm_1x8190x6x3072>) -> tensor<1x8190x3072xf32, #layout_mm_1x8190x3072>
     return %1, %3 : tensor<1x8190x3072xf32, #layout_mm_1x8190x3072>, tensor<1x8190x3072xf32, #layout_mm_1x8190x3072>
+  }
   // permute-reshape row-major adjust:
   // CHECK-LABEL: func.func @permute_reshape_row_major_adjusting
   // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>}>
@@ -140,10 +138,10 @@ module {
   // CHECK-SAME: -> tensor<67108864x1xf32
   // CHECK: %[[REPEAT:.*]] = "ttnn.repeat"(%[[PERM]]) <{repeat_dims = #ttnn.shape<1x2>}>
   // CHECK-SAME: -> tensor<67108864x2xf32
-  // CHECK: %[[RESTORED_REPEAT:.*]] = "ttnn.to_layout"(%[[REPEAT]]) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>}>
-  // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[RESTORED_REPEAT]]) <{shape = [8192 : i32, 16384 : i32]}>
+  // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[REPEAT]]) <{shape = [8192 : i32, 16384 : i32]}>
   // CHECK-SAME: -> tensor<8192x16384xf32
-  // CHECK: return %[[RESHAPE]]
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[RESHAPE]]) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>}>
+  // CHECK: return %[[RESTORED]]
   func.func @permute_repeat_reshape_row_major_adjusting(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<8192x16384xf32, #layout_8192x16384_tile> {
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
     %1 = "ttnn.repeat"(%0) <{repeat_dims = #ttnn.shape<1x2>}> : (tensor<67108864x1xf32, #layout_67Mx1_tile>) -> tensor<67108864x2xf32, #layout_67Mx2_tile>

--- a/test/ttmlir/Transforms/memory_management.mlir
+++ b/test/ttmlir/Transforms/memory_management.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttnn-memory-management -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-memory-management -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #dram = #ttnn.buffer_type<dram>
@@ -17,9 +17,19 @@
 #layout_r_1x1x1x16 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0, d1, d2, d3), <1x1>, memref<16xf32, #dram>, <interleaved>>
 #layout_r_1x1x1x1024 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0, d1, d2, d3), <1x1>, memref<1024xf32, #dram>, <interleaved>>
 #layout_r_1x1x32x32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0, d1, d2, d3), <1x1>, memref<1024xf32, #dram>, <interleaved>>
+<<<<<<< HEAD
 #layout_mm_1x8190x6x3072 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 262080 + d1 * 32 + d2, d3), <1x1>, memref<8190x96x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_mm_1x8190x3072 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 8192 + d1, d2), <1x1>, memref<256x96x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_mm_1x49140x3072 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 49152 + d1, d2), <1x1>, memref<1536x96x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+=======
+#layout_1x67M_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2097152x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_67Mx1_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_67Mx2_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_8192x8192_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<256x256x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_8192x16384_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<256x512x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_4d_1x1x8192x8192_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 * 8192 + d2, d3), <1x1>, memref<256x256x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_4d_8192x8192x1x1_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 + d2, d3), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+>>>>>>> 50e575d247 (Videogen memory optimization patterns.)
 
 module {
   // sliceReshape
@@ -106,5 +116,54 @@ module {
     %2 = "ttnn.slice_static"(%arg0) <{begins = [0 : i32, 0 : i32, 3 : i32, 0 : i32], ends = [1 : i32, 8190 : i32, 4 : i32, 3072 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1x8190x6x3072xf32, #layout_mm_1x8190x6x3072>) -> tensor<1x8190x1x3072xf32, #layout_mm_1x8190x6x3072>
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 8190 : i32, 3072 : i32]}> : (tensor<1x8190x1x3072xf32, #layout_mm_1x8190x6x3072>) -> tensor<1x8190x3072xf32, #layout_mm_1x8190x3072>
     return %1, %3 : tensor<1x8190x3072xf32, #layout_mm_1x8190x3072>, tensor<1x8190x3072xf32, #layout_mm_1x8190x3072>
+  // permute-reshape row-major adjust:
+  // CHECK-LABEL: func.func @permute_reshape_row_major_adjusting
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>}>
+  // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RM_IN]])
+  // CHECK-SAME: permutation = array<i64: 1, 0>
+  // CHECK-SAME: -> tensor<67108864x1xf32
+  // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[PERM]]) <{shape = [8192 : i32, 8192 : i32]}>
+  // CHECK-SAME: -> tensor<8192x8192xf32
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[RESHAPE]]) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>}>
+  // CHECK: return %[[RESTORED]]
+  func.func @permute_reshape_row_major_adjusting(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<8192x8192xf32, #layout_8192x8192_tile> {
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
+    %1 = "ttnn.reshape"(%0) <{shape = [8192 : i32, 8192 : i32]}> : (tensor<67108864x1xf32, #layout_67Mx1_tile>) -> tensor<8192x8192xf32, #layout_8192x8192_tile>
+    return %1 : tensor<8192x8192xf32, #layout_8192x8192_tile>
+  }
+
+  // permute-repeat-reshape row-major adjust:
+  // CHECK-LABEL: func.func @permute_repeat_reshape_row_major_adjusting
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>}>
+  // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RM_IN]])
+  // CHECK-SAME: permutation = array<i64: 1, 0>
+  // CHECK-SAME: -> tensor<67108864x1xf32
+  // CHECK: %[[REPEAT:.*]] = "ttnn.repeat"(%[[PERM]]) <{repeat_dims = #ttnn.shape<1x2>}>
+  // CHECK-SAME: -> tensor<67108864x2xf32
+  // CHECK: %[[RESTORED_REPEAT:.*]] = "ttnn.to_layout"(%[[REPEAT]]) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>}>
+  // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[RESTORED_REPEAT]]) <{shape = [8192 : i32, 16384 : i32]}>
+  // CHECK-SAME: -> tensor<8192x16384xf32
+  // CHECK: return %[[RESHAPE]]
+  func.func @permute_repeat_reshape_row_major_adjusting(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<8192x16384xf32, #layout_8192x16384_tile> {
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
+    %1 = "ttnn.repeat"(%0) <{repeat_dims = #ttnn.shape<1x2>}> : (tensor<67108864x1xf32, #layout_67Mx1_tile>) -> tensor<67108864x2xf32, #layout_67Mx2_tile>
+    %2 = "ttnn.reshape"(%1) <{shape = [8192 : i32, 16384 : i32]}> : (tensor<67108864x2xf32, #layout_67Mx2_tile>) -> tensor<8192x16384xf32, #layout_8192x16384_tile>
+    return %2 : tensor<8192x16384xf32, #layout_8192x16384_tile>
+  }
+
+  // reshape-permute row-major adjust:
+  // CHECK-LABEL: func.func @reshape_permute_row_major_adjusting
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>}>
+  // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[RM_IN]]) <{shape = [8192 : i32, 8192 : i32, 1 : i32, 1 : i32]}>
+  // CHECK-SAME: -> tensor<8192x8192x1x1xf32
+  // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RESHAPE]])
+  // CHECK-SAME: permutation = array<i64: 2, 3, 0, 1>
+  // CHECK-SAME: -> tensor<1x1x8192x8192xf32
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[PERM]]) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>}>
+  // CHECK: return %[[RESTORED]]
+  func.func @reshape_permute_row_major_adjusting(%arg0: tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>) -> tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile> {
+    %0 = "ttnn.reshape"(%arg0) <{shape = [8192 : i32, 8192 : i32, 1 : i32, 1 : i32]}> : (tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>) -> tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>
+    %1 = "ttnn.permute"(%0) <{permutation = array<i64: 2, 3, 0, 1>}> : (tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>) -> tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>
+    return %1 : tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>
   }
 }


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/7729

### Problem description
During upsampling problematic patterns of permutes occur that have very small dimensions and are not tile aligned. Those reshapes and permutes are always followed by other TMs that have different  more tile friendly shape.

### What's changed
Added patterns that surround blocks of problematic TMs with toLayout(RowMajor) and toLayout(Tile) afterward.

### Checklist
- [x] New/Existing tests provide coverage for changes
