### PR TITLE
Add workaround for all_reduce op with 1D tensors

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllReduceReshapeOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllReduceReshapeOpRewritePattern.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_ALLREDUCERESHAPEOPREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_ALLREDUCERESHAPEOPREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// AllReduceOp in TTNN currently does not support 1d tensors because it is
+// decomposed into reduce_scatter + all_gather, and reduce_scatter requires
+// tensors of rank >= 2.
+// As a temporary workaround, we insert reshape ops front and back
+// to make the tensor at least two dimensional.
+class TTNNAllReduceReshapeWorkarounds
+    : public OpRewritePattern<ttnn::AllReduceOp> {
+public:
+  using OpRewritePattern<ttnn::AllReduceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::AllReduceOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_ALLREDUCERESHAPEOPREWRITEPATTERN_H

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -5467,7 +5467,7 @@ mlir::OpFoldResult mlir::tt::ttir::RepeatInterleaveOp::fold(FoldAdaptor fold) {
 
   // Currently TTIR only supports the sum reduce types.
   if (reduceType != ::mlir::tt::ttcore::ReduceType::Sum) {
-    return emitOpError("Invalid reduction op for all reduce op.");
+    return emitOpError("Invalid reduction type for all reduce op.");
   }
 
   return success();
@@ -5483,7 +5483,7 @@ mlir::OpFoldResult mlir::tt::ttir::RepeatInterleaveOp::fold(FoldAdaptor fold) {
 
   // Currently TTIR only supports the sum reduce types.
   if (reduceType != ::mlir::tt::ttcore::ReduceType::Sum) {
-    return emitOpError("Invalid reduction op for all reduce async op.");
+    return emitOpError("Invalid reduction type for all reduce async op.");
   }
 
   return success();
@@ -5503,7 +5503,7 @@ mlir::OpFoldResult mlir::tt::ttir::RepeatInterleaveOp::fold(FoldAdaptor fold) {
   if (reduceType != ::mlir::tt::ttcore::ReduceType::Sum &&
       reduceType != ::mlir::tt::ttcore::ReduceType::Max &&
       reduceType != ::mlir::tt::ttcore::ReduceType::Min) {
-    return emitOpError("Invalid reduction op for reduce scatter op.");
+    return emitOpError("Invalid reduction type for reduce scatter op.");
   }
 
   if (scatterDim >= inputType.getRank() || scatterDim < -inputType.getRank()) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3525,7 +3525,7 @@ static ::mlir::LogicalResult verifyTTNNBatchNormOp(OpType op) {
   // to model the full ReduceType list but only the 'Sum' reduce type can be
   // lowered into TTNN.
   if (reduceType != ::mlir::tt::ttcore::ReduceType::Sum) {
-    return emitOpError("Invalid reduction op for reduce scatter op.");
+    return emitOpError("Invalid reduction type for reduce scatter op.");
   }
 
   return success();
@@ -3635,7 +3635,7 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
 
   // Currently TTNN only supports the sum reduce types.
   if (reduceType != ::mlir::tt::ttcore::ReduceType::Sum) {
-    return emitOpError("Invalid reduction op for all reduce op.");
+    return emitOpError("Invalid reduction type for all reduce op.");
   }
 
   return success();
@@ -3662,7 +3662,7 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
 
   // Currently TTNN only supports the sum reduce types.
   if (reduceType != ::mlir::tt::ttcore::ReduceType::Sum) {
-    return emitOpError("Invalid reduction op for all reduce async op.");
+    return emitOpError("Invalid reduction type for all reduce async op.");
   }
 
   return success();

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -47,6 +47,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNWeightDtypeConversion.cpp
         TTNNKVCacheDtypeConversion.cpp
         Workarounds/Decomposition/AllGatherOpRewritePattern.cpp
+        Workarounds/Decomposition/AllReduceReshapeOpRewritePattern.cpp
         Workarounds/Decomposition/AllToAllDispatchMetadataDrainCoreRewritePattern.cpp
         Workarounds/Decomposition/ArgMaxOpDimRewritePattern.cpp
         Workarounds/Decomposition/ConcatOpRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllReduceReshapeOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllReduceReshapeOpRewritePattern.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllReduceReshapeOpRewritePattern.h"
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+LogicalResult TTNNAllReduceReshapeWorkarounds::matchAndRewrite(
+    ttnn::AllReduceOp op, PatternRewriter &rewriter) const {
+  RankedTensorType inputType = op.getInput().getType();
+  int64_t rank = inputType.getRank();
+
+  // Only apply workaround for 1D tensors.
+  if (rank != 1) {
+    return failure();
+  }
+
+  RankedTensorType outputType = op.getResult().getType();
+  ArrayRef<int64_t> outputShape = outputType.getShape();
+
+  // Create padded shape by adding a leading dimension of size 1.
+  SmallVector<int64_t> paddedInputShape = {1};
+  paddedInputShape.append(inputType.getShape().begin(),
+                          inputType.getShape().end());
+
+  SmallVector<int64_t> paddedOutputShape = {1};
+  paddedOutputShape.append(outputShape.begin(), outputShape.end());
+
+  // Reshape input 1D -> 2D.
+  auto reshapeInput = ttir_to_ttnn::utils::generateReshape(
+      op.getInput(), paddedInputShape, rewriter,
+      ttmlir::utils::appendLocationSuffix(op.getLoc(), "_reshape_to_2d"));
+
+  // Create 2D output tensor type.
+  RankedTensorType paddedOutputType =
+      ttnn::utils::RankedTensorTypeFactory::create(outputType,
+                                                   paddedOutputShape);
+
+  // Create the all_reduce operation on 2D tensors.
+  auto allReduce2D = rewriter.create<ttnn::AllReduceOp>(
+      ttmlir::utils::appendLocationSuffix(op.getLoc(), "_all_reduce_2d"),
+      paddedOutputType, reshapeInput.getResult(), op.getReduceType(),
+      op.getClusterAxis(), op.getSubDeviceIdAttr(), op.getNumLinksAttr(),
+      op.getTopologyAttr());
+
+  // Reshape back to original 1D shape.
+  rewriter.replaceOp(op, ttir_to_ttnn::utils::generateReshape(
+                             allReduce2D.getResult(), outputShape, rewriter,
+                             ttmlir::utils::appendLocationSuffix(
+                                 op.getLoc(), "_reshape_to_1d")));
+
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllReduceReshapeOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllToAllDispatchMetadataDrainCoreRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpDimRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpRewritePattern.h"
@@ -640,6 +641,7 @@ public:
       RewritePatternSet patterns(&getContext());
       patterns.add<
           GatherSi32Workaround, TTNNAllReduceWorkarounds,
+          workarounds::decomposition::TTNNAllReduceReshapeWorkarounds,
           workarounds::decomposition::TTNNAllGatherWorkarounds,
           workarounds::decomposition::TTNNReduceScatterWorkarounds,
           workarounds::decomposition::TTNNScatterWorkarounds,

--- a/test/python/golden/ttir_ops/ccl/test_all_reduce.py
+++ b/test/python/golden/ttir_ops/ccl/test_all_reduce.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from collections import OrderedDict
+from typing import Tuple
+
+from builder.base.builder_utils import Operand, Shape
+from builder.base.builder_enums import (
+    MeshShardDirection,
+    MeshShardType,
+    ReduceType,
+)
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_and_execute_ttir
+from conftest import get_request_kwargs
+from test_utils import shape_str, make_shard_shape
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+@pytest.mark.parametrize(
+    "test_shape",
+    [
+        (1, 32, 32, 32),
+        (1, 32, 32, 1),
+        (32, 32, 1, 1),
+        (1, 32, 32),
+        (32, 32),
+        (32, 40),
+        (40, 32),
+    ],
+    ids=shape_str,
+)
+@pytest.mark.parametrize(
+    "mesh_shape", [(2, 4), (1, 8), (1, 2), (1, 32), (8, 4)], ids=shape_str
+)
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+@pytest.mark.parametrize(
+    "reduce_type",
+    # TTIR currently only supports Sum for all_reduce.
+    [ReduceType.Sum],
+    ids=["sum"],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_all_reduce(
+    test_shape: Shape,
+    mesh_shape: Tuple[int, int],
+    cluster_axis: int,
+    reduce_type: ReduceType,
+    dtype: torch.dtype,
+    request,
+    device,
+):
+    if mesh_shape[cluster_axis] == 1:
+        pytest.skip("all_reduce across 1 device is meaningless")
+
+    rank_in = len(test_shape)
+    rank_mesh = len(mesh_shape)
+
+    if rank_mesh > rank_in:
+        raise ValueError(
+            f"Mesh shape {mesh_shape} has {rank_mesh} dimensions, but test shape "
+            f"{test_shape} only has {rank_in} dimensions. Cannot shard more "
+            f"dimensions than exist in the tensor."
+        )
+
+    # Take the last `rank_mesh` dims as sharded dims
+    shard_dims = list(range(rank_in - rank_mesh, rank_in))
+    shard_shape = make_shard_shape(rank_in, shard_dims, mesh_shape)
+
+    full_input_shape = list(test_shape)
+    for d, factor in zip(shard_dims, mesh_shape):
+        full_input_shape[d] *= factor
+
+    def module(builder: TTIRBuilder):
+        @builder.func([full_input_shape], [dtype])
+        def all_reduce(in0: Operand, builder: TTIRBuilder):
+            in_shard = builder.mesh_shard(
+                in0,
+                shard_direction=MeshShardDirection.FullToShard.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape,
+                shard_dims=shard_dims,
+            )
+
+            all_reduce0 = builder.all_reduce(
+                in_shard,
+                cluster_axis=cluster_axis,
+                reduce_type=reduce_type.value,
+            )
+
+            return builder.mesh_shard(
+                all_reduce0,
+                shard_direction=MeshShardDirection.ShardToFull.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape,
+                shard_dims=shard_dims,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        mesh_name="mesh",
+        device=device,
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        **get_request_kwargs(request),
+    )
+
+
+@pytest.mark.parametrize("test_size", [32, 64, 128])
+@pytest.mark.parametrize(
+    "mesh_shape",
+    [(1, 2), (1, 4), (1, 8), (2, 1), (4, 1), (8, 1)],
+    ids=shape_str,
+)
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+@pytest.mark.parametrize(
+    "reduce_type",
+    # TTIR currently only supports Sum for all_reduce.
+    [ReduceType.Sum],
+    ids=["sum"],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_all_reduce_1d(
+    test_size: int,
+    mesh_shape: Tuple[int, int],
+    cluster_axis: int,
+    reduce_type: ReduceType,
+    dtype: torch.dtype,
+    request,
+    device,
+):
+    if mesh_shape[cluster_axis] == 1:
+        pytest.skip("all_reduce across 1 device is meaningless")
+
+    # The runtime mesh_shard cannot handle 1D tensors with a 2D mesh (the
+    # ShardToFull composer requires unique dims, but a 1D tensor only has dim 0).
+    # Work around this by sharding a 2D (1, N) tensor, reshaping to 1D before
+    # all_reduce (which exercises the compiler's 1D reshape workaround), then
+    # reshaping back to 2D to unshard.
+    shard_dims = [0, 1]
+    shard_shape_2d = make_shard_shape(2, shard_dims, mesh_shape)
+
+    full_input_shape = [1 * mesh_shape[0], test_size * mesh_shape[1]]
+    shard_test_shape_1d = [test_size]
+    # all_reduce keeps the per-device shape (unlike all_gather which grows it),
+    # so reshape back to the shard shape, not the full shape.
+    reduced_shape_2d = [1, test_size]
+
+    def module(builder: TTIRBuilder):
+        @builder.func([full_input_shape], [dtype])
+        def all_reduce(in0: Operand, builder: TTIRBuilder):
+            in_shard = builder.mesh_shard(
+                in0,
+                shard_direction=MeshShardDirection.FullToShard.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape_2d,
+                shard_dims=shard_dims,
+            )
+
+            # Reshape to 1D to exercise the all_reduce 1D workaround.
+            in_1d = builder.reshape(in_shard, shape=shard_test_shape_1d)
+
+            all_reduce0 = builder.all_reduce(
+                in_1d,
+                cluster_axis=cluster_axis,
+                reduce_type=reduce_type.value,
+            )
+
+            # Reshape back to 2D so mesh_shard can unshard.
+            out_2d = builder.reshape(all_reduce0, shape=reduced_shape_2d)
+
+            return builder.mesh_shard(
+                out_2d,
+                shard_direction=MeshShardDirection.ShardToFull.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape_2d,
+                shard_dims=shard_dims,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        mesh_name="mesh",
+        device=device,
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        **get_request_kwargs(request),
+    )

--- a/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
+++ b/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
@@ -555,6 +555,80 @@ def test_all_gather_1d_no_workaround(
     )
 
 
+@pytest.mark.parametrize("test_size", [64])
+@pytest.mark.parametrize(
+    "mesh_shape",
+    [(1, 2), (2, 1)],
+    ids=shape_str,
+)
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.xfail(
+    reason="ttnn.all_reduce decomposes into reduce_scatter + all_gather, and "
+    "reduce_scatter does not support 1D tensors. Without the workaround, "
+    "reshape ops are not inserted to make the tensor at least 2D. "
+    "Metal issue: https://github.com/tenstorrent/tt-metal/issues/45024"
+)
+def test_all_reduce_1d_no_workaround(
+    test_size: int,
+    mesh_shape: Tuple[int, int],
+    cluster_axis: int,
+    dtype: torch.dtype,
+    request,
+    device,
+):
+    if mesh_shape[cluster_axis] == 1:
+        pytest.skip("all_reduce across 1 device is meaningless")
+
+    shard_dims = [0, 1]
+    shard_shape_2d = make_shard_shape(2, shard_dims, mesh_shape)
+
+    full_input_shape = [1 * mesh_shape[0], test_size * mesh_shape[1]]
+    shard_test_shape_1d = [test_size]
+    # all_reduce keeps the per-device shape, so reshape back to the shard shape.
+    reduced_shape_2d = [1, test_size]
+
+    def module(builder: TTIRBuilder):
+        @builder.func([full_input_shape], [dtype])
+        def all_reduce(in0: Operand, builder: TTIRBuilder):
+            in_shard = builder.mesh_shard(
+                in0,
+                shard_direction=MeshShardDirection.FullToShard.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape_2d,
+                shard_dims=shard_dims,
+            )
+
+            # Reshape to 1D to exercise the all_reduce 1D workaround.
+            in_1d = builder.reshape(in_shard, shape=shard_test_shape_1d)
+
+            all_reduce0 = builder.all_reduce(
+                in_1d,
+                cluster_axis=cluster_axis,
+                reduce_type=ReduceType.Sum.value,
+            )
+
+            # Reshape back to 2D so mesh_shard can unshard.
+            out_2d = builder.reshape(all_reduce0, shape=reduced_shape_2d)
+
+            return builder.mesh_shard(
+                out_2d,
+                shard_direction=MeshShardDirection.ShardToFull.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape_2d,
+                shard_dims=shard_dims,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        mesh_name="mesh",
+        device=device,
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        **get_request_kwargs(request),
+        pipeline_options=["enable-decomposition-workaround-pass=false"],
+    )
+
+
 @pytest.mark.parametrize(
     "shape,scatter_dim",
     [

--- a/test/ttmlir/Dialect/TTIR/ccl/all_reduce/all_reduce_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/all_reduce/all_reduce_negative.mlir
@@ -7,7 +7,7 @@ module attributes {} {
     return %1 : tensor<1x1x256x256xf32>
   }
 }
-// CHECK: error: 'ttir.all_reduce' op Invalid reduction op for all reduce op
+// CHECK: error: 'ttir.all_reduce' op Invalid reduction type for all reduce op
 
 // -----
 
@@ -17,7 +17,7 @@ module attributes {} {
     return %1 : tensor<1x1x256x256xf32>
   }
 }
-// CHECK: error: 'ttir.all_reduce' op Invalid reduction op for all reduce op
+// CHECK: error: 'ttir.all_reduce' op Invalid reduction type for all reduce op
 
 // -----
 
@@ -27,4 +27,4 @@ module attributes {} {
     return %1 : tensor<1x1x256x256xf32>
   }
 }
-// CHECK: error: 'ttir.all_reduce' op Invalid reduction op for all reduce op
+// CHECK: error: 'ttir.all_reduce' op Invalid reduction type for all reduce op

--- a/test/ttmlir/Dialect/TTIR/ccl/reduce_scatter/reduce_scatter_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/reduce_scatter/reduce_scatter_negative.mlir
@@ -9,7 +9,7 @@ module attributes {} {
     return %1 : tensor<1x1x8192x256xf32>
   }
 }
-// CHECK: error: 'ttir.reduce_scatter' op Invalid reduction op for reduce scatter op
+// CHECK: error: 'ttir.reduce_scatter' op Invalid reduction type for reduce scatter op
 
 // -----
 
@@ -19,7 +19,7 @@ module attributes {} {
     return %1 : tensor<1x1x8192x256xf32>
   }
 }
-// CHECK: error: 'ttir.reduce_scatter' op Invalid reduction op for reduce scatter op
+// CHECK: error: 'ttir.reduce_scatter' op Invalid reduction type for reduce scatter op
 
 // -----
 
@@ -29,7 +29,7 @@ module attributes {} {
     return %1 : tensor<1x1x8192x256xf32>
   }
 }
-// CHECK: error: 'ttir.reduce_scatter' op Invalid reduction op for reduce scatter op
+// CHECK: error: 'ttir.reduce_scatter' op Invalid reduction type for reduce scatter op
 
 // -----
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/all_reduce_1d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/all_reduce_1d_workaround.mlir
@@ -1,0 +1,53 @@
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,2" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+// Unit tests for all_reduce 1D tensor reshape workaround
+
+// Verify that 1D tensor all_reduce is reshaped to 2D, then decomposed into
+// reduce_scatter + all_gather (by TTNNAllReduceWorkarounds and
+// ReduceScatterOpRewritePattern which further pads to 4D), then reshaped
+// back to 1D.
+
+// -----
+
+module attributes {} {
+  // CHECK-LABEL: all_reduce_1d_reshape_workaround_128
+  func.func @all_reduce_1d_reshape_workaround_128(%arg0: tensor<128xbf16>) -> tensor<128xbf16> {
+    %0 = "ttir.all_reduce"(%arg0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<128xbf16>) -> tensor<128xbf16>
+    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.reduce_scatter"
+    // CHECK: "ttnn.all_gather"
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [128 : i32]
+    return %0 : tensor<128xbf16>
+  }
+}
+
+// -----
+
+module attributes {} {
+  // CHECK-LABEL: all_reduce_1d_reshape_workaround_64
+  func.func @all_reduce_1d_reshape_workaround_64(%arg0: tensor<64xbf16>) -> tensor<64xbf16> {
+    %0 = "ttir.all_reduce"(%arg0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<64xbf16>) -> tensor<64xbf16>
+    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.reduce_scatter"
+    // CHECK: "ttnn.all_gather"
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [64 : i32]
+    return %0 : tensor<64xbf16>
+  }
+}
+
+// -----
+
+module attributes {} {
+  // CHECK-LABEL: all_reduce_1d_reshape_workaround_256
+  func.func @all_reduce_1d_reshape_workaround_256(%arg0: tensor<256xbf16>) -> tensor<256xbf16> {
+    %0 = "ttir.all_reduce"(%arg0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<256xbf16>) -> tensor<256xbf16>
+    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.reduce_scatter"
+    // CHECK: "ttnn.all_gather"
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [256 : i32]
+    return %0 : tensor<256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_negative.mlir
@@ -9,7 +9,7 @@ module @all_reduce_negative_invalid_reduce_type_mean attributes {mhlo.num_partit
     return %1 : tensor<4096x16384xf32, #ttnn_layout1>
   }
 }
-// CHECK: error: 'ttnn.all_reduce' op Invalid reduction op for all reduce op.
+// CHECK: error: 'ttnn.all_reduce' op Invalid reduction type for all reduce op.
 
 // -----
 
@@ -21,7 +21,7 @@ module @all_reduce_negative_invalid_reduce_type_std attributes {mhlo.num_partiti
     return %1 : tensor<4096x16384xf32, #ttnn_layout1>
   }
 }
-// CHECK: error: 'ttnn.all_reduce' op Invalid reduction op for all reduce op.
+// CHECK: error: 'ttnn.all_reduce' op Invalid reduction type for all reduce op.
 
 // -----
 
@@ -33,4 +33,4 @@ module @all_reduce_negative_invalid_reduce_type_var attributes {mhlo.num_partiti
     return %1 : tensor<4096x16384xf32, #ttnn_layout1>
   }
 }
-// CHECK: error: 'ttnn.all_reduce' op Invalid reduction op for all reduce op.
+// CHECK: error: 'ttnn.all_reduce' op Invalid reduction type for all reduce op.

--- a/test/ttmlir/Dialect/TTNN/ccl/reduce_scatter/reduce_scatter_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/reduce_scatter/reduce_scatter_negative.mlir
@@ -9,7 +9,7 @@ module @reduce_scatter_negative_invalid_reduce_type_mean attributes {mhlo.num_pa
     return %1 : tensor<4096x16384xf32, #ttnn_layout1>
   }
 }
-// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction op for reduce scatter op
+// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction type for reduce scatter op
 
 // -----
 
@@ -21,7 +21,7 @@ module @reduce_scatter_negative_invalid_reduce_type_std attributes {mhlo.num_par
     return %1 : tensor<4096x16384xf32, #ttnn_layout1>
   }
 }
-// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction op for reduce scatter op
+// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction type for reduce scatter op
 
 // -----
 
@@ -33,7 +33,7 @@ module @reduce_scatter_negative_invalid_reduce_type_var attributes {mhlo.num_par
     return %1 : tensor<4096x16384xf32, #ttnn_layout1>
   }
 }
-// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction op for reduce scatter op
+// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction type for reduce scatter op
 
 // -----
 
@@ -45,7 +45,7 @@ module @reduce_scatter_negative_invalid_reduce_type_var attributes {mhlo.num_par
     return %1 : tensor<4096x16384xf32, #ttnn_layout1>
   }
 }
-// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction op for reduce scatter op
+// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction type for reduce scatter op
 
 // -----
 
@@ -57,7 +57,7 @@ module @reduce_scatter_negative_invalid_reduce_type_var attributes {mhlo.num_par
     return %1 : tensor<4096x16384xf32, #ttnn_layout1>
   }
 }
-// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction op for reduce scatter op
+// CHECK: error: 'ttnn.reduce_scatter' op Invalid reduction type for reduce scatter op
 
 // -----
 


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/8565

### Summary
- Add `TTNNAllReduceReshapeWorkarounds` pattern that reshapes 1D tensors to 2D before `ttnn.all_reduce`, then reshapes back after. This mirrors the existing `AllGatherOpRewritePattern` workaround for `ttnn.all_gather`.
- `ttnn.all_reduce` is decomposed into `reduce_scatter` + `all_gather`, both of which require rank >= 2. Without this workaround, 1D inputs crash at runtime.
- Fix minor typo in verifier error messages ("reduction op" → "reduction type").

### Checklist
- [ ] New/Existing tests provide coverage for changes
