### PR TITLE
[d2m-jit] Add Python pattern-rewrite framework for TTIR -> d2m lowering

### DIFF
--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -1274,4 +1274,33 @@ def D2MLowerScratchAllocate : Pass<"d2m-lower-scratch-allocate", "::mlir::Module
   ];
 }
 
+def D2MPythonRewrites : Pass<"d2m-python-rewrites", "::mlir::ModuleOp"> {
+  let summary = "Apply Python-defined pattern rewrites via d2m-jit.";
+  let description = [{
+    Embeds a Python interpreter, loads each user-supplied `.py` file
+    listed in `module-path` (which is expected to register one or more
+    `@d2m_jit.pattern` decorators on import), and runs
+    `d2m_jit.apply_patterns(module)` on the current `ModuleOp`. The
+    Python rewrites mutate the same MLIR module the pass owns.
+
+    Adding a new pattern is then a matter of dropping a new `.py` file
+    in next to your driver and re-running -- no C++ rebuild required.
+
+    Requires the build to be configured with `-DTTMLIR_ENABLE_D2M_JIT=ON`;
+    otherwise the pass fails fast with a diagnostic at run time.
+  }];
+  let options = [
+    ListOption<"modulePaths", "module-path", "std::string",
+               "Path(s) to .py files registering d2m-jit patterns. May be "
+               "repeated; the pass imports them in order before running.">,
+  ];
+  // We don't construct any dialect ops directly in C++ — Python handles
+  // dialect setup against the host module's existing context. Listing
+  // only D2M here so the pass infrastructure has the same expectation
+  // as the rest of the suite.
+  let dependentDialects = [
+    "::mlir::tt::d2m::D2MDialect",
+  ];
+}
+
 #endif

--- a/lib/Dialect/D2M/Transforms/CMakeLists.txt
+++ b/lib/Dialect/D2M/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_mlir_dialect_library(MLIRD2MTransforms
         MaterializeViewReturns.cpp
         OptimizeMasks.cpp
         OpScheduler.cpp
+        PythonRewritesPass.cpp
         SFPUTileLoopFission.cpp
         InsertScratchBuffers.cpp
         InsertSpillAndScratch.cpp
@@ -52,3 +53,27 @@ add_mlir_dialect_library(MLIRD2MTransforms
         MLIRD2MUtils
         MLIRTTUtils
         )
+
+# D2MPythonRewritesPass embeds CPython to dispatch into d2m-jit. Gated
+# on TTMLIR_ENABLE_D2M_JIT so consumers that don't build d2m-jit don't
+# take the Python link dep. The .cpp itself is always compiled — it
+# degrades to a fail-fast stub when the define is absent (so ttmlir-opt
+# advertises the flag with a clear diagnostic).
+#
+# We use the raw CPython C-API rather than nanobind/pybind11 because
+# MLIRD2MTransforms inherits LLVM's -fno-rtti / -fno-exceptions, which
+# nanobind doesn't support. Raw CPython is uglier but the surface we
+# need is tiny.
+if(TTMLIR_ENABLE_D2M_JIT)
+  find_package(Python REQUIRED COMPONENTS Interpreter Development.Module Development.Embed)
+
+  target_compile_definitions(obj.MLIRD2MTransforms PRIVATE TTMLIR_ENABLE_D2M_JIT)
+  # The Python bindings in python/CMakeLists.txt are built with
+  # MLIR_PYTHON_PACKAGE_PREFIX=ttmlir., which is baked into the capsule
+  # names used by mlir-c/Bindings/Python/Interop.h. The pass needs to
+  # produce capsules whose names match the consumer side, so we set the
+  # same define here.
+  target_compile_definitions(obj.MLIRD2MTransforms PRIVATE MLIR_PYTHON_PACKAGE_PREFIX=ttmlir.)
+  target_include_directories(obj.MLIRD2MTransforms PRIVATE ${Python_INCLUDE_DIRS})
+  target_link_libraries(MLIRD2MTransforms PRIVATE Python::Python)
+endif()

--- a/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
+++ b/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir::tt::d2m {
+#define GEN_PASS_DEF_D2MPYTHONREWRITES
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
+} // namespace mlir::tt::d2m
+
+#ifdef TTMLIR_ENABLE_D2M_JIT
+
+// We use the raw CPython C-API rather than nanobind/pybind11 here because
+// MLIRD2MTransforms inherits LLVM's -fno-rtti / -fno-exceptions, which
+// nanobind doesn't support.
+//
+// The pass does NOT cross C++/Python via a shared MlirModule pointer —
+// ttmlir-opt is statically linked against MLIR while the ttmlir Python
+// bindings ship their own copy of MLIR (libTTMLIRPythonCAPI.so). The
+// two MLIR runtimes can't share opaque storage (StringAttr uniquer
+// etc.), so we fall back to a text round-trip:
+//
+//   1. C++: print the host ModuleOp to a string.
+//   2. Python: parse the string in *its* ir.Context, run apply_patterns,
+//      print the rewritten module back to a string.
+//   3. C++: parse the result string into the host context as a new
+//      module, then swap its body into the original ModuleOp.
+
+#include <Python.h>
+
+#include <atomic>
+#include <string>
+
+namespace mlir::tt::d2m {
+namespace {
+
+// RAII wrapper for Py_DECREF on a PyObject*.
+class PyRef {
+public:
+  PyRef() = default;
+  explicit PyRef(PyObject *obj) : obj(obj) {}
+  PyRef(const PyRef &) = delete;
+  PyRef &operator=(const PyRef &) = delete;
+  PyRef(PyRef &&other) noexcept : obj(other.obj) { other.obj = nullptr; }
+  PyRef &operator=(PyRef &&other) noexcept {
+    if (this != &other) {
+      reset();
+      obj = other.obj;
+      other.obj = nullptr;
+    }
+    return *this;
+  }
+  ~PyRef() { reset(); }
+
+  void reset(PyObject *newObj = nullptr) {
+    Py_XDECREF(obj);
+    obj = newObj;
+  }
+  PyObject *get() const { return obj; }
+  explicit operator bool() const { return obj != nullptr; }
+
+private:
+  PyObject *obj = nullptr;
+};
+
+// RAII GIL acquire/release. Cheaper than thread-state save/restore.
+class PyGIL {
+public:
+  PyGIL() : state(PyGILState_Ensure()) {}
+  PyGIL(const PyGIL &) = delete;
+  PyGIL &operator=(const PyGIL &) = delete;
+  ~PyGIL() { PyGILState_Release(state); }
+
+private:
+  PyGILState_STATE state;
+};
+
+// Ensure Python is initialized exactly once per process.
+static void ensurePythonInitialized() {
+  if (Py_IsInitialized()) {
+    return;
+  }
+  Py_Initialize();
+  PyEval_SaveThread();
+}
+
+// Capture the most recent Python exception as a std::string and clear it.
+static std::string capturePythonError() {
+  if (!PyErr_Occurred()) {
+    return "<no python error>";
+  }
+  PyObject *type = nullptr;
+  PyObject *value = nullptr;
+  PyObject *traceback = nullptr;
+  PyErr_Fetch(&type, &value, &traceback);
+  PyErr_NormalizeException(&type, &value, &traceback);
+  std::string out;
+  if (value) {
+    PyRef str(PyObject_Str(value));
+    if (str) {
+      const char *utf8 = PyUnicode_AsUTF8(str.get());
+      if (utf8) {
+        out = utf8;
+      }
+    }
+  }
+  if (out.empty()) {
+    out = "<unrepresentable python exception>";
+  }
+  Py_XDECREF(type);
+  Py_XDECREF(value);
+  Py_XDECREF(traceback);
+  return out;
+}
+
+class D2MPythonRewritesPass
+    : public impl::D2MPythonRewritesBase<D2MPythonRewritesPass> {
+public:
+  using impl::D2MPythonRewritesBase<D2MPythonRewritesPass>::D2MPythonRewritesBase;
+
+  void runOnOperation() override {
+    if (modulePaths.empty()) {
+      // No-op when invoked without any patterns.
+      return;
+    }
+
+    ModuleOp module = getOperation();
+
+    // Step 1: print the host module to text.
+    std::string inputText;
+    {
+      llvm::raw_string_ostream os(inputText);
+      OpPrintingFlags flags;
+      // Generic form is portable across C++/Python MLIR runtimes.
+      module.print(os, flags);
+    }
+
+    // Step 2: call into Python.
+    ensurePythonInitialized();
+    PyGIL gil;
+
+    PyRef rewriteMod(PyImport_ImportModule("d2m_jit._src.rewrite"));
+    if (!rewriteMod) {
+      emitPyError("could not import d2m_jit._src.rewrite");
+      return;
+    }
+    PyRef applyText(
+        PyObject_GetAttrString(rewriteMod.get(), "apply_patterns_text"));
+    if (!applyText) {
+      emitPyError("d2m_jit._src.rewrite has no apply_patterns_text");
+      return;
+    }
+
+    PyRef inputPy(
+        PyUnicode_FromStringAndSize(inputText.data(), inputText.size()));
+    if (!inputPy) {
+      emitPyError("could not convert input text to Python str");
+      return;
+    }
+
+    PyRef pathsList(PyList_New(modulePaths.size()));
+    if (!pathsList) {
+      emitPyError("could not allocate pattern-path list");
+      return;
+    }
+    for (size_t i = 0; i < modulePaths.size(); ++i) {
+      PyObject *path = PyUnicode_FromString(modulePaths[i].c_str());
+      if (!path) {
+        emitPyError("could not convert pattern path to Python str");
+        return;
+      }
+      PyList_SET_ITEM(pathsList.get(), static_cast<Py_ssize_t>(i), path);
+    }
+
+    PyRef resultPy(
+        PyObject_CallFunctionObjArgs(applyText.get(), inputPy.get(),
+                                     pathsList.get(), nullptr));
+    if (!resultPy) {
+      emitPyError("d2m_jit apply_patterns_text raised");
+      return;
+    }
+    if (!PyUnicode_Check(resultPy.get())) {
+      module.emitError("d2m-python-rewrites: apply_patterns_text did not "
+                       "return a string");
+      signalPassFailure();
+      return;
+    }
+    Py_ssize_t resultLen = 0;
+    const char *resultUtf8 =
+        PyUnicode_AsUTF8AndSize(resultPy.get(), &resultLen);
+    if (!resultUtf8) {
+      emitPyError("could not extract result string from Python");
+      return;
+    }
+    std::string outputText(resultUtf8, resultUtf8 + resultLen);
+
+    // Step 3: parse the result back into the host context, replace
+    // module body. We keep the GIL held through the parse — it's
+    // synchronous and our pass doesn't expect parallelism here.
+    OwningOpRef<ModuleOp> newModule =
+        parseSourceString<ModuleOp>(outputText, &getContext());
+
+    if (!newModule) {
+      module.emitError(
+          "d2m-python-rewrites: failed to re-parse rewritten module text. "
+          "This usually means the Python rewrites produced IR that the host "
+          "MLIR context can't understand (missing dialect registration, etc.)");
+      signalPassFailure();
+      return;
+    }
+
+    // Swap bodies: erase the host module's body ops, splice in the
+    // re-parsed module's body. Both modules have a single block in
+    // their region.
+    Block &dst = module.getBodyRegion().front();
+    Block &src = newModule->getBodyRegion().front();
+
+    // Erase existing ops; iterating backwards because erase mutates the
+    // list. Skip the implicit terminator if any (ModuleOp doesn't have
+    // one).
+    for (auto it = dst.rbegin(); it != dst.rend();) {
+      Operation &op = *it;
+      ++it;
+      op.erase();
+    }
+    // Splice the source's ops to the destination.
+    auto &srcOps = src.getOperations();
+    while (!srcOps.empty()) {
+      Operation &op = srcOps.front();
+      op.moveBefore(&dst, dst.end());
+    }
+    // newModule is now empty; drop it.
+  }
+
+private:
+  void emitPyError(const std::string &prefix) {
+    std::string detail = capturePythonError();
+    getOperation().emitError("d2m-python-rewrites: ")
+        << prefix << ": " << detail;
+    signalPassFailure();
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::d2m
+
+#else // TTMLIR_ENABLE_D2M_JIT
+
+namespace mlir::tt::d2m {
+namespace {
+
+// Stub when d2m-jit isn't enabled. The pass entry still exists so
+// ttmlir-opt can advertise the flag, but invoking it fails fast.
+class D2MPythonRewritesPass
+    : public impl::D2MPythonRewritesBase<D2MPythonRewritesPass> {
+public:
+  using impl::D2MPythonRewritesBase<D2MPythonRewritesPass>::D2MPythonRewritesBase;
+
+  void runOnOperation() override {
+    getOperation().emitError(
+        "d2m-python-rewrites requires the build to be configured with "
+        "-DTTMLIR_ENABLE_D2M_JIT=ON; rebuild and retry.");
+    signalPassFailure();
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::d2m
+
+#endif // TTMLIR_ENABLE_D2M_JIT

--- a/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
+++ b/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
@@ -125,7 +125,8 @@ static std::string capturePythonError() {
 class D2MPythonRewritesPass
     : public impl::D2MPythonRewritesBase<D2MPythonRewritesPass> {
 public:
-  using impl::D2MPythonRewritesBase<D2MPythonRewritesPass>::D2MPythonRewritesBase;
+  using impl::D2MPythonRewritesBase<
+      D2MPythonRewritesPass>::D2MPythonRewritesBase;
 
   void runOnOperation() override {
     if (modulePaths.empty()) {
@@ -181,9 +182,8 @@ public:
       PyList_SET_ITEM(pathsList.get(), static_cast<Py_ssize_t>(i), path);
     }
 
-    PyRef resultPy(
-        PyObject_CallFunctionObjArgs(applyText.get(), inputPy.get(),
-                                     pathsList.get(), nullptr));
+    PyRef resultPy(PyObject_CallFunctionObjArgs(applyText.get(), inputPy.get(),
+                                                pathsList.get(), nullptr));
     if (!resultPy) {
       emitPyError("d2m_jit apply_patterns_text raised");
       return;
@@ -263,7 +263,8 @@ namespace {
 class D2MPythonRewritesPass
     : public impl::D2MPythonRewritesBase<D2MPythonRewritesPass> {
 public:
-  using impl::D2MPythonRewritesBase<D2MPythonRewritesPass>::D2MPythonRewritesBase;
+  using impl::D2MPythonRewritesBase<
+      D2MPythonRewritesPass>::D2MPythonRewritesBase;
 
   void runOnOperation() override {
     getOperation().emitError(

--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -43,6 +43,8 @@
 #include "mlir/Dialect/Linalg/Transforms/SubsetInsertionOpInterfaceImpl.h"
 #include "mlir/Dialect/MLProgram/IR/MLProgram.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/PDL/IR/PDL.h"
+#include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
 #include "mlir/Dialect/Quant/IR/Quant.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
@@ -96,7 +98,8 @@ void mlir::tt::registerAllDialects(mlir::DialectRegistry &registry) {
       mlir::memref::MemRefDialect, mlir::emitc::EmitCDialect,
       mlir::bufferization::BufferizationDialect, mlir::LLVM::LLVMDialect,
       mlir::quant::QuantDialect, mlir::tt::emitpy::EmitPyDialect,
-      mlir::tt::debug::DebugDialect>();
+      mlir::tt::debug::DebugDialect, mlir::pdl::PDLDialect,
+      mlir::pdl_interp::PDLInterpDialect>();
 
 #if TTMLIR_ENABLE_STABLEHLO
   mlir::stablehlo::registerAllDialects(registry);

--- a/test/d2m-jit/lit/eltwise_add_exp_pattern.py
+++ b/test/d2m-jit/lit/eltwise_add_exp_pattern.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""Lit test for the fused-eltwise DAG pattern (ttir.add -> ttir.exp).
+
+Two sub-cases:
+  * @positive: an exp whose input is the result of an add.
+    Pattern fires; the resulting d2m.generic contains both
+    `d2m.tile_add` and `d2m.tile_exp` in one body.
+  * @negative: an exp whose input is a func arg (no producer).
+    Pattern's `match=` predicate fails; no d2m.generic appears.
+
+The single-exp lowering from `eltwise_exp_to_kernel.py` is intentionally
+NOT loaded here — the negative case is precisely about "no pattern
+matched", not "fell through to the single-op lowering".
+"""
+
+from ttmlir import ir
+import d2m_jit as d2m
+from d2m_jit._src.rewrite import _registry
+
+_registry.clear()
+import d2m_jit.patterns.eltwise_add_exp_to_kernel  # noqa: F401
+
+
+ctx = ir.Context()
+ctx.load_all_available_dialects()
+
+# ----------------------------------------------------------------------
+# @positive: add -> exp chain. Pattern should fire.
+# ----------------------------------------------------------------------
+pos = ir.Module.parse(
+    """
+module {
+  func.func @positive(%a: tensor<32x32xf32>, %b: tensor<32x32xf32>)
+      -> tensor<32x32xf32> {
+    %sum = "ttir.add"(%a, %b) :
+        (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %r = "ttir.exp"(%sum) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %r : tensor<32x32xf32>
+  }
+}
+""",
+    ctx,
+)
+d2m.apply_patterns(pos)
+pos.operation.verify()
+print("=== positive ===")
+print(pos)
+
+# CHECK-LABEL: === positive ===
+# CHECK-LABEL:  func.func @positive
+# CHECK-NOT:    ttir.exp
+# CHECK:        d2m.generic
+# CHECK:        d2m.tile_add
+# CHECK:        d2m.tile_exp
+# CHECK:        return %{{.*}} : tensor<32x32xf32>
+
+# ----------------------------------------------------------------------
+# @negative: an exp with no upstream add. The same registered pattern
+# is applied again on a fresh module; its `match=` predicate fails.
+# ----------------------------------------------------------------------
+neg = ir.Module.parse(
+    """
+module {
+  func.func @negative(%x: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %r = "ttir.exp"(%x) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %r : tensor<32x32xf32>
+  }
+}
+""",
+    ctx,
+)
+d2m.apply_patterns(neg)
+neg.operation.verify()
+print("=== negative ===")
+print(neg)
+
+# CHECK-LABEL: === negative ===
+# CHECK-LABEL:  func.func @negative
+# CHECK:        ttir.exp
+# CHECK-NOT:    d2m.generic

--- a/test/d2m-jit/lit/eltwise_exp_pattern.py
+++ b/test/d2m-jit/lit/eltwise_exp_pattern.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""Lit test for the single-eltwise pattern (ttir.exp -> d2m subgraph).
+
+Parses a tiny TTIR module containing one `ttir.exp`, invokes the
+`d2m_jit` rewrite framework in-process with the bundled
+`patterns.eltwise_exp_to_kernel` module loaded, and prints the
+rewritten module to stdout. No device needed.
+
+Checks:
+  * Original `ttir.exp` is gone (replaced).
+  * A `d2m.generic` op was emitted (the @d2m.kernel materialised).
+  * The replacement returns a plain `tensor<32x32xf32>` matching the
+    matched op's result type — verifies cleanly.
+"""
+
+from ttmlir import ir
+import d2m_jit as d2m
+from d2m_jit._src.rewrite import _registry
+
+# Load the example pattern (registers via @d2m.pattern on import).
+_registry.clear()
+import d2m_jit.patterns.eltwise_exp_to_kernel  # noqa: F401
+
+
+ctx = ir.Context()
+ctx.load_all_available_dialects()
+
+mod = ir.Module.parse(
+    """
+module {
+  func.func @forward(%x: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %r = "ttir.exp"(%x) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %r : tensor<32x32xf32>
+  }
+}
+""",
+    ctx,
+)
+
+d2m.apply_patterns(mod)
+mod.operation.verify()
+print(mod)
+
+
+# CHECK-LABEL: func.func @forward
+# CHECK-NOT:    ttir.exp
+# CHECK:        d2m.generic
+# CHECK:        return %{{.*}} : tensor<32x32xf32>

--- a/test/d2m-jit/lit/python_rewrites_pass.py
+++ b/test/d2m-jit/lit/python_rewrites_pass.py
@@ -60,9 +60,7 @@ def main():
         print(f"FATAL: ttmlir-opt not found at {ttmlir_opt}", file=sys.stderr)
         sys.exit(1)
 
-    with tempfile.NamedTemporaryFile(
-        "w", suffix=".mlir", delete=False
-    ) as tmp:
+    with tempfile.NamedTemporaryFile("w", suffix=".mlir", delete=False) as tmp:
         tmp.write(TTIR_INPUT)
         tmp_path = tmp.name
 

--- a/test/d2m-jit/lit/python_rewrites_pass.py
+++ b/test/d2m-jit/lit/python_rewrites_pass.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s %ttmlir_tools/ttmlir-opt 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""End-to-end test for the `--d2m-python-rewrites` C++ pass.
+
+Spawns `ttmlir-opt --d2m-python-rewrites=module-path=...` on a tiny
+ttir.exp module and confirms the rewritten module contains the fused
+d2m subgraph the bundled `eltwise_exp_to_kernel` pattern produces.
+
+Validates the C++ pass plumbing end-to-end:
+  - Embedded CPython initialization in MLIRD2MTransforms.
+  - Loading a user-supplied .py file via importlib at run time
+    (no rebuild of ttmlir-opt needed when adding a new pattern).
+  - Text round-trip: ttmlir-opt prints the host module, hands it to
+    `d2m_jit.apply_patterns_text`, re-parses the result back into the
+    host context, and splices it over the original module body.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+
+# Build a temp .mlir input and run ttmlir-opt on it.
+TTIR_INPUT = """\
+module {
+  func.func @forward(%x: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %r = "ttir.exp"(%x) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %r : tensor<32x32xf32>
+  }
+}
+"""
+
+
+def find_tt_mlir_root():
+    # The test file lives at $repo/test/d2m-jit/lit/python_rewrites_pass.py.
+    here = os.path.abspath(__file__)
+    return os.path.normpath(os.path.join(os.path.dirname(here), "..", "..", ".."))
+
+
+def main():
+    root = find_tt_mlir_root()
+    pattern_file = os.path.join(
+        root, "tools", "d2m-jit", "patterns", "eltwise_exp_to_kernel.py"
+    )
+    if not os.path.exists(pattern_file):
+        print(f"FATAL: pattern file missing: {pattern_file}", file=sys.stderr)
+        sys.exit(1)
+
+    if len(sys.argv) < 2:
+        print("FATAL: pass ttmlir-opt path as argv[1]", file=sys.stderr)
+        sys.exit(1)
+    ttmlir_opt = sys.argv[1]
+    if not os.path.exists(ttmlir_opt):
+        print(f"FATAL: ttmlir-opt not found at {ttmlir_opt}", file=sys.stderr)
+        sys.exit(1)
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".mlir", delete=False
+    ) as tmp:
+        tmp.write(TTIR_INPUT)
+        tmp_path = tmp.name
+
+    try:
+        result = subprocess.run(
+            [
+                ttmlir_opt,
+                f"--d2m-python-rewrites=module-path={pattern_file}",
+                tmp_path,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=os.environ.copy(),
+        )
+    finally:
+        os.unlink(tmp_path)
+
+    print(result.stdout)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# CHECK-LABEL: func.func @forward
+# CHECK-NOT:    ttir.exp
+# CHECK:        d2m.generic
+# CHECK:        d2m.tile_exp
+# CHECK:        return %{{.*}} : tensor<32x32xf32>

--- a/test/d2m-jit/test_pattern_eltwise.py
+++ b/test/d2m-jit/test_pattern_eltwise.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-device end-to-end test for the bundled eltwise pattern kernels.
+
+Drives the kernels from `tools/d2m-jit/patterns/` directly through the
+lazy d2m-jit path (no pattern rewrite step at run time) and PCC-compares
+against torch.
+
+This validates the kernel templates produce correct silicon output. The
+lit tests under `test/d2m-jit/lit/` validate that the *rewrite path*
+emits these exact kernels, so the two together cover the framework
+end-to-end:
+
+  lit:    TTIR input -> apply_patterns -> rewritten IR (FileCheck'd)
+  pytest: same kernel -> d2m pipeline -> flatbuffer -> ttrt -> assert PCC
+"""
+
+import torch
+from utils import assert_pcc
+
+import d2m_jit as d2m
+from d2m_jit.patterns.eltwise_exp_to_kernel import exp_fused
+from d2m_jit.patterns.eltwise_add_exp_to_kernel import add_exp_fused
+
+
+def test_pattern_exp_kernel_on_device():
+    """The exp_fused kernel from `eltwise_exp_to_kernel.py` matches torch.exp.
+
+    The pattern uses tiled L1 with block_shape=[1,1] and grid=(1,1); we
+    mirror that here. Input ~Uniform(-1, 1) so exp stays in a numerically
+    well-behaved range for PCC scoring.
+    """
+    torch.manual_seed(0)
+    x = (torch.rand(32, 32, dtype=torch.float32) - 0.5) * 2.0  # in (-1, 1)
+
+    L = d2m.Layout(
+        shape=x.shape,
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+        tiled=True,
+    )
+
+    x_d = d2m.to_layout(x, L)
+    out_d = d2m.empty(L)
+    exp_fused(x_d, out_d, 1, 1, grid=(1, 1))
+    out = out_d.to_host()
+
+    expected = torch.exp(x)
+    assert_pcc(expected, out)
+
+
+def test_pattern_add_exp_kernel_on_device():
+    """The add_exp_fused kernel from `eltwise_add_exp_to_kernel.py` matches
+    torch.exp(a + b) on silicon. Same single-tile layout as the pattern.
+    """
+    torch.manual_seed(0)
+    a = (torch.rand(32, 32, dtype=torch.float32) - 0.5) * 2.0
+    b = (torch.rand(32, 32, dtype=torch.float32) - 0.5) * 2.0
+
+    L = d2m.Layout(
+        shape=a.shape,
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+        tiled=True,
+    )
+
+    a_d = d2m.to_layout(a, L)
+    b_d = d2m.to_layout(b, L)
+    out_d = d2m.empty(L)
+    add_exp_fused(a_d, b_d, out_d, 1, 1, grid=(1, 1))
+    out = out_d.to_host()
+
+    expected = torch.exp(a + b)
+    assert_pcc(expected, out)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -129,6 +129,7 @@ config.ttmlir_tools_dir = os.path.join(config.ttmlir_obj_root, "bin")
 config.ttmlir_libs_dir = os.path.join(config.ttmlir_obj_root, "lib")
 
 config.substitutions.append(("%ttmlir_libs", config.ttmlir_libs_dir))
+config.substitutions.append(("%ttmlir_tools", config.ttmlir_tools_dir))
 
 config.test_root = os.path.join(config.ttmlir_source_dir, "test")
 config.scripts_root = os.path.join(config.ttmlir_source_dir, "tools/scripts")

--- a/tools/d2m-jit/CMakeLists.txt
+++ b/tools/d2m-jit/CMakeLists.txt
@@ -12,8 +12,12 @@ declare_mlir_python_sources(TTD2MJitSources
         _src/builder.py
         _src/config.py
         _src/errors.py
+        _src/rewrite.py
         _src/tensor_layout.py
         _src/utils.py
+        patterns/__init__.py
+        patterns/eltwise_add_exp_to_kernel.py
+        patterns/eltwise_exp_to_kernel.py
 )
 
 add_mlir_python_modules(TTD2MJitModules

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -297,9 +297,7 @@ class RewriteScope:
         # would have added a func arg in lazy mode.
         with self.ctx, self.loc, self.insert_point:
             idx_ty = IndexType.get(self.ctx)
-            return arith.ConstantOp(
-                idx_ty, IntegerAttr.get(idx_ty, int(value))
-            ).result
+            return arith.ConstantOp(idx_ty, IntegerAttr.get(idx_ty, int(value))).result
 
 
 # --- LazyTensor --------------------------------------------------------------

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -15,9 +15,11 @@ no Python-side graph — the MLIR module IS the graph.
 """
 
 import ast as _ast
+import contextlib
 import functools
 import inspect
 import os
+import threading
 from typing import Optional
 
 try:
@@ -134,8 +136,59 @@ _PIPELINE = ",".join(
 )
 
 
+# --- Scope abstraction ------------------------------------------------------
+#
+# A "scope" is the build context that the lazy-emission helpers
+# (`to_layout`, `empty`, `view_layout`, `_emit_kernel_generic`, …) target.
+# The default scope is `_Builder` — a process-level singleton that owns its
+# own `Context`/`Module`/open `func.func` and accumulates MLIR ops there
+# until `to_host` runs the pipeline and resets it.
+#
+# A `RewriteScope` (defined alongside the pattern-rewrite framework) plugs
+# in a `PatternRewriter`'s context + insertion point so that calling a
+# `@d2m.kernel` from inside a rewrite emits the GenericOp at the matched
+# op's site rather than into a fresh module. From the perspective of the
+# emission helpers, all scopes quack the same: they expose `ctx`, `loc`,
+# `insert_point`, `generation`, `add_host_input`, `add_scalar_input`.
+#
+# `_get_scope()` returns the top of a thread-local stack, falling back to
+# the lazy `_Builder` singleton when nothing is pushed. Push/pop is done
+# via the `_push_scope()` context manager — patterns frameworks (and tests)
+# use it; user code never does.
+
+_scope_local = threading.local()
+
+
+def _get_scope():
+    """Return the active build scope. Defaults to the lazy `_Builder` singleton."""
+    stack = getattr(_scope_local, "stack", None)
+    if stack:
+        return stack[-1]
+    return _Builder.get()
+
+
+@contextlib.contextmanager
+def _push_scope(scope):
+    """Push `scope` as the active build scope for the duration of the block."""
+    stack = getattr(_scope_local, "stack", None)
+    if stack is None:
+        stack = []
+        _scope_local.stack = stack
+    stack.append(scope)
+    try:
+        yield scope
+    finally:
+        popped = stack.pop()
+        assert popped is scope, "scope stack out of sync"
+
+
 class _Builder:
-    """Process-level singleton accumulating MLIR ops for the current lazy graph."""
+    """Process-level singleton accumulating MLIR ops for the current lazy graph.
+
+    This is one concrete `Scope` implementation; see `_get_scope` for the
+    abstraction. Owns its own `Context`/`Module`/open `func.func`. Reset by
+    `to_host` once the pipeline has run.
+    """
 
     _instance: Optional["_Builder"] = None
     _next_generation: int = 1  # monotonic; id() can be reused after GC
@@ -200,6 +253,55 @@ class _Builder:
         return list(self._input_tensors)
 
 
+class RewriteScope:
+    """Build-scope view onto an MLIR `PatternRewriter` insertion point.
+
+    Pushed by the d2m-jit rewrite framework so that calling a `@d2m.kernel`
+    from inside a pattern body emits the `d2m.GenericOp` (and any supporting
+    `to_layout`/`view_layout`/`empty` ops) at the rewriter's IP rather than
+    into a fresh host func.
+
+    Quacks like `_Builder` for the emission helpers: exposes `ctx`, `loc`,
+    `insert_point`, `generation`. `add_host_input` raises (no host I/O from
+    a rewrite). `add_scalar_input` emits an `arith.constant ... : index` at
+    the rewriter's IP and returns the resulting Value.
+
+    Has no `module` attribute — the surrounding module is the one being
+    mutated, not something this scope owns.
+    """
+
+    def __init__(self, rewriter, op, loc=None):
+        self.rewriter = rewriter
+        # Derive ctx from the matched op (rewriter doesn't bind it directly).
+        self.ctx = op.context
+        self.loc = loc if loc is not None else op.location
+        # InsertionPoint pointing at the rewriter's current insertion point.
+        # The PDL driver sets this to "before the matched op" before invoking
+        # the native rewrite, which is exactly where we want new IR to land.
+        self.insert_point = rewriter.ip
+        # Unique non-reusable id, distinct from any _Builder generation.
+        self.generation = _Builder._next_generation
+        _Builder._next_generation += 1
+
+    def add_host_input(self, layout, host_tensor):
+        raise RuntimeError(
+            "Cannot lift a host tensor from inside a pattern rewrite. The "
+            "graph being built is part of an existing module; use "
+            "d2m.from_value(ir.Value) to wrap an SSA value already present in "
+            "that module."
+        )
+
+    def add_scalar_input(self, value: int):
+        # Emit an arith.constant of index type at the rewriter's IP.
+        # This is the rewrite-mode analog of _Builder.add_scalar_input, which
+        # would have added a func arg in lazy mode.
+        with self.ctx, self.loc, self.insert_point:
+            idx_ty = IndexType.get(self.ctx)
+            return arith.ConstantOp(
+                idx_ty, IntegerAttr.get(idx_ty, int(value))
+            ).result
+
+
 # --- LazyTensor --------------------------------------------------------------
 
 
@@ -241,7 +343,7 @@ class LazyTensor:
         - Materialised (different generation): auto-re-enter via to_layout.
         - Stale (different generation, not materialised): raise.
         """
-        b = _Builder.get()
+        b = _get_scope()
         if self.generation == b.generation:
             return self
         if self.materialized is not None:
@@ -267,7 +369,7 @@ def to_layout(input_, layout: Layout) -> LazyTensor:
 
     Returns a LazyTensor at the layout's *blocked* grid.
     """
-    b = _Builder.get()
+    b = _get_scope()
 
     if isinstance(input_, LazyTensor):
         src = input_._resolve()
@@ -338,7 +440,7 @@ def empty(layout: Layout) -> LazyTensor:
     This mirrors the old eager flow so d2m-allocate can plan the
     physical placement from the unblocked breadcrumb.
     """
-    b = _Builder.get()
+    b = _get_scope()
     with b.ctx, b.loc, b.insert_point:
         unblocked_ty = layout.build_device_tensor_type(b.ctx, blocked=False)
         raw = d2m.empty(unblocked_ty)
@@ -401,7 +503,7 @@ def _emit_view_layout(lt: LazyTensor, affine_map, spec) -> LazyTensor:
     """Lower form: take an already-built AffineMap + spec and emit
     `d2m.view_layout`. Used by both view_layout (with a user lambda)
     and view (with a lifted blocked-rank spec built in Python)."""
-    b = _Builder.get()
+    b = _get_scope()
     with b.ctx, b.loc, b.insert_point:
         src_type = lt.value.type
         src_shape = list(src_type.shape)
@@ -438,7 +540,7 @@ def view_layout(lt: LazyTensor, remapping_fn) -> LazyTensor:
     permutation.
     """
     lt = lt._resolve()
-    b = _Builder.get()
+    b = _get_scope()
     with b.ctx, b.loc:
         affine_map, spec = _affine_map_from_lambda(remapping_fn)
     return _emit_view_layout(lt, affine_map, spec)
@@ -458,7 +560,7 @@ def _emit_perm_view(lt: LazyTensor, perm) -> LazyTensor:
         )
     lifted_perm = list(perm) + [p + n_logical for p in perm]
     lifted_spec = [("dim", p) for p in lifted_perm]
-    b = _Builder.get()
+    b = _get_scope()
     with b.ctx, b.loc:
         lifted_map = AffineMap.get(
             2 * n_logical, 0, [AffineDimExpr.get(p) for p in lifted_perm]
@@ -477,7 +579,7 @@ def view(lt: LazyTensor, remapping_fn) -> LazyTensor:
     for richer remappings.
     """
     lt = lt._resolve()
-    b = _Builder.get()
+    b = _get_scope()
     with b.ctx, b.loc:
         _, logical_spec = _affine_map_from_lambda(remapping_fn)
     n_logical = len(lt.layout.logical_shape)
@@ -629,6 +731,15 @@ def to_host(*lts: LazyTensor):
     if not lts:
         raise ValueError("to_host requires at least one LazyTensor")
 
+    b = _get_scope()
+    if not isinstance(b, _Builder):
+        raise RuntimeError(
+            "to_host() cannot be called from inside a non-lazy scope (e.g. a "
+            "pattern-rewrite scope). The graph being built is part of the host "
+            "module; its pipeline/execution is the host compiler's job, not the "
+            "rewrite's."
+        )
+
     resolved = [lt._resolve() for lt in lts]
     for i, lt in enumerate(resolved):
         if lt.is_view:
@@ -639,7 +750,6 @@ def to_host(*lts: LazyTensor):
                 f"directly. Convert to a concrete layout first, e.g. "
                 f"to_layout(v, v.layout)."
             )
-    b = _Builder.get()
     # All resolved tensors must belong to this builder (resolve guarantees that).
     assert all(lt.generation == b.generation for lt in resolved)
 
@@ -719,7 +829,7 @@ def _emit_kernel_generic(
     iterator_types,
 ):
     """Append a d2m.GenericOp to the open host func that invokes `kernel`."""
-    b = _Builder.get()
+    b = _get_scope()
 
     def _call_error(msg, hint=None, cause=None):
         # Pin call-site errors to the kernel's `def` line. The user's actual

--- a/tools/d2m-jit/_src/rewrite.py
+++ b/tools/d2m-jit/_src/rewrite.py
@@ -1,0 +1,482 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pattern-rewrite framework for d2m-jit.
+
+Lets users define MLIR pattern rewrites in plain Python that match TTIR
+(or any) ops and replace them with d2m-jit kernel-template subgraphs.
+
+Surface:
+
+    @d2m.pattern(root=ttir.MatmulOp, benefit=5)
+    def lower_matmul(op, rewriter):
+        a = d2m.from_value(op.operand(0))
+        b = d2m.from_value(op.operand(1))
+        out = d2m.empty(d2m.infer_layout(op.result, grid_shape=[4, 4]))
+        my_fused_kernel(a, b, out, grid=(4, 4))
+        return out  # replaces op.result
+
+    # DAG match: predicate decides; the rewrite is unconditional.
+    @d2m.pattern(
+        root="ttir.all_reduce",
+        benefit=10,
+        match=lambda op: (
+            op.operands[0].owner is not None
+            and op.operands[0].owner.name == "ttir.matmul"
+        ),
+    )
+    def fuse_mm_ar(op, rewriter):
+        ...
+
+    d2m.apply_patterns(module)  # runs the greedy driver
+
+Under the hood each `@d2m.pattern` lowers to a per-pattern `pdl.pattern`
+stub (single-op match by root op name; variadic operands/types so the
+template works for any-arity ops). If a `match` predicate is provided,
+its inline-`apply_native_constraint` runs first — if it returns false,
+the bytecode driver cleanly aborts the match (no IR mutated). The
+unconditional rewrite then runs in `pdl.apply_native_rewrite`, emitting
+the replacement subgraph at the rewriter's insertion point through the
+regular d2m-jit emission helpers (the framework auto-pushes a
+`RewriteScope`), and returning the final SSA Value or `LazyTensor`. PDL
+then issues a `pdl.replace` to wire the rest of the IR over.
+
+DAG matching is imperative — express the producer-chain check in the
+`match=` predicate (pure, no IR mutation); the decorated function gets
+called only on successful matches. There is no declarative DAG-builder.
+This is intentional for the POC.
+
+The greedy pattern rewriter does *not* support recoverable failures
+inside `pdl.apply_native_rewrite`; that's why the bail-out path lives
+in `match=` rather than as a `return None` from the rewrite body.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Callable, List, Optional, Sequence, Union
+
+from ttmlir import ir
+from ttmlir.dialects import ttcore
+from ttmlir.rewrite import PDLModule, apply_patterns_and_fold_greedily
+
+from .builder import (
+    LazyTensor,
+    RewriteScope,
+    _push_scope,
+)
+from .tensor_layout import Layout
+
+
+# --- PatternRegistry --------------------------------------------------------
+
+
+class _Pattern:
+    """A registered rewrite pattern.
+
+    Holds the user's Python function plus the synthetic PDL symbol names
+    used to wire it into the PDL bytecode driver.
+    """
+
+    def __init__(
+        self,
+        root_op_name: str,
+        benefit: int,
+        fn: Callable,
+        match_fn: Optional[Callable] = None,
+    ):
+        self.root_op_name = root_op_name
+        self.benefit = benefit
+        self.fn = fn
+        self.match_fn = match_fn
+
+        slug = root_op_name.replace(".", "_")
+        # Use a process-wide counter so that re-registering the same root
+        # multiple times yields distinct symbols.
+        idx = next(_PatternRegistry._sym_counter)
+        self.sym_name = f"d2m_pat_{slug}_{idx}"
+        self.dispatch_name = f"d2m_dispatch_{slug}_{idx}"
+        self.match_name = f"d2m_match_{slug}_{idx}"
+
+    def build_pdl_text(self) -> str:
+        """One `pdl.pattern { ... }` stub. If a `match_fn` is registered,
+        an inline `apply_native_constraint` runs first — its failure
+        cleanly aborts the match (the rewrite below never runs)."""
+        constraint_line = (
+            f'    pdl.apply_native_constraint "{self.match_name}"(%op : !pdl.operation)\n'
+            if self.match_fn is not None
+            else ""
+        )
+        return f"""\
+  pdl.pattern @{self.sym_name} : benefit({self.benefit}) {{
+    %operands = pdl.operands
+    %types = pdl.types
+    %op = pdl.operation "{self.root_op_name}"(%operands : !pdl.range<value>) -> (%types : !pdl.range<type>)
+{constraint_line}    pdl.rewrite %op {{
+      %v = pdl.apply_native_rewrite "{self.dispatch_name}"(%op : !pdl.operation) : !pdl.value
+      pdl.replace %op with (%v : !pdl.value)
+    }}
+  }}"""
+
+
+class _PatternRegistry:
+    _sym_counter = itertools.count()
+
+    def __init__(self):
+        self._patterns: List[_Pattern] = []
+
+    def register(
+        self,
+        root: Union[str, type],
+        benefit: int,
+        fn: Callable,
+        match_fn: Optional[Callable] = None,
+    ) -> _Pattern:
+        root_name = (
+            root if isinstance(root, str) else getattr(root, "OPERATION_NAME", None)
+        )
+        if not root_name:
+            raise TypeError(
+                f"pattern root must be an op-name string or an OpView class with "
+                f"OPERATION_NAME; got {root!r}"
+            )
+        pat = _Pattern(
+            root_op_name=root_name,
+            benefit=int(benefit),
+            fn=fn,
+            match_fn=match_fn,
+        )
+        self._patterns.append(pat)
+        return pat
+
+    def all(self) -> List[_Pattern]:
+        return list(self._patterns)
+
+    def clear(self) -> None:
+        """For tests — drop all registered patterns."""
+        self._patterns.clear()
+
+
+_registry = _PatternRegistry()
+
+
+def pattern(*, root, benefit: int = 1, match: Optional[Callable] = None):
+    """Decorator: register `fn` as a rewrite pattern rooted on `root`.
+
+    `root` is either an op-name string (e.g. "ttir.matmul") or an OpView
+    class with an `OPERATION_NAME` attribute (e.g. `ttir.MatmulOp`).
+
+    The decorated function has signature `(op, rewriter) -> ret`, where:
+      - `op` is the matched MLIR `ir.Operation`.
+      - `rewriter` is the upstream `PatternRewriter` (its `.ip` is set to
+        before the matched op).
+      - `ret` is the SSA value (or a `LazyTensor` wrapping one) that
+        replaces the matched op's first (currently only) result.
+        The function MUST always return a value — the greedy driver
+        doesn't support recoverable rewrite failures.
+
+    For DAG-conditional matching (e.g. "fire only when this op's
+    producer is X"), pass a `match=callable` predicate: `match(op) ->
+    bool` runs as a PDL native constraint before the rewrite. If it
+    returns falsy the bytecode aborts the match cleanly (no IR
+    mutated). Predicates must be pure — do not emit IR from them.
+    Root on the tail op of a DAG so the replace removes the last
+    visible node.
+    """
+
+    def decorator(fn):
+        _registry.register(root=root, benefit=benefit, fn=fn, match_fn=match)
+        return fn
+
+    return decorator
+
+
+# --- LazyTensor wrapping ----------------------------------------------------
+
+
+def from_value(value: ir.Value, layout: Optional[Layout] = None) -> LazyTensor:
+    """Wrap an existing SSA `Value` as a `LazyTensor`.
+
+    Used in pattern rewrites: the operands of the matched op already exist
+    as `ir.Value`s in the surrounding module; this lifts them into the
+    d2m-jit emission helpers' tensor-handle abstraction.
+
+    If `layout` is omitted it is inferred from `value.type` via
+    `infer_layout` (safe defaults; override liberally).
+    """
+    from .builder import _get_scope
+
+    if not isinstance(value, ir.Value):
+        raise TypeError(f"from_value expects an ir.Value, got {type(value).__name__}")
+    if layout is None:
+        layout = infer_layout(value)
+    scope = _get_scope()
+    return LazyTensor(layout, value, scope.generation)
+
+
+def from_device(lt: LazyTensor) -> ir.Value:
+    """Emit a `d2m.to_layout` that materializes a device-laid-out `LazyTensor`
+    back to a plain host tensor type (no metal-layout encoding).
+
+    This is the typical final step inside a pattern rewrite that consumes a
+    TTIR op whose result type is a plain `tensor<MxNxf32>` — patterns build
+    a device subgraph, then call `from_device(...)` to land back on the
+    matched op's result type before returning the SSA Value.
+    """
+    from .builder import _get_scope
+
+    if not isinstance(lt, LazyTensor):
+        raise TypeError(f"from_device expects a LazyTensor, got {type(lt).__name__}")
+    lt = lt._resolve()
+    scope = _get_scope()
+    with scope.ctx, scope.loc, scope.insert_point:
+        dev_val = lt.layout.build_device_view(scope.ctx, lt.value)
+        host_val = lt.layout.build_from_device(scope.ctx, dev_val)
+    return host_val
+
+
+# --- Layout inference -------------------------------------------------------
+
+
+def _try_tile_element_type(elem):
+    """Return (tile_h, tile_w, ttcore.DataType) if elem is a TileType, else None."""
+    try:
+        tile = ttcore.ir.TileType.maybe_downcast(elem)
+    except AttributeError:
+        tile = None
+    if tile is None:
+        return None
+    # TileType has shape attrs; pull them defensively.
+    try:
+        return (int(tile.shape[0]), int(tile.shape[1]), tile.data_type)
+    except Exception:
+        return None
+
+
+def _scalar_dtype_from_mlir(elem):
+    """Map an MLIR float type to a ttcore.DataType, or raise."""
+    ctx = elem.context
+    if ir.F32Type.isinstance(elem):
+        return ttcore.DataType.Float32
+    if ir.F16Type.isinstance(elem):
+        return ttcore.DataType.Float16
+    if ir.BF16Type.isinstance(elem):
+        return ttcore.DataType.BFloat16
+    raise TypeError(
+        f"infer_layout: unsupported element type {elem}; "
+        f"only f32/f16/bf16 are mapped today. Pass an explicit Layout."
+    )
+
+
+def infer_layout(value_or_type, **overrides) -> Layout:
+    """Build a safe-default `Layout` from an `ir.Value` or `RankedTensorType`.
+
+    The default is logical / untiled / single-cell:
+        - `shape` = tensor type shape
+        - `dtype` = mapped from the element type (f32/f16/bf16)
+        - `tiled` = False
+        - `block_shape` = full shape (one block holds the whole tensor)
+        - `grid_shape` = [1, 1, ...]
+        - `mem_space` = "l1"
+
+    Anything passed in `overrides` replaces the default field. Patterns
+    typically override `tiled=True`, set a real `grid_shape`, and pick a
+    smaller `block_shape`.
+
+    Tile-typed tensors (`!ttcore.tile<32x32, ...>` element) currently
+    require an explicit Layout — raise rather than silently guessing.
+    """
+    t = value_or_type.type if isinstance(value_or_type, ir.Value) else value_or_type
+    if not ir.RankedTensorType.isinstance(t):
+        raise TypeError(
+            f"infer_layout: expected RankedTensorType, got {t}"
+        )
+    rtt = ir.RankedTensorType(t)
+    shape = list(rtt.shape)
+    elem = rtt.element_type
+
+    if _try_tile_element_type(elem) is not None:
+        raise NotImplementedError(
+            "infer_layout: tile-typed tensors are not auto-inferred yet; "
+            "pass an explicit Layout."
+        )
+
+    dtype = _scalar_dtype_from_mlir(elem)
+    fields = dict(
+        shape=shape,
+        dtype=dtype,
+        block_shape=list(shape),
+        grid_shape=[1] * len(shape),
+        tiled=False,
+        mem_space="l1",
+    )
+    fields.update(overrides)
+    return Layout(**fields)
+
+
+# --- Driver -----------------------------------------------------------------
+
+
+def _make_dispatcher(pat: _Pattern):
+    """Wrap `pat.fn` so PDL's native-rewrite signature dispatches to the user."""
+
+    def dispatcher(rewriter, results, values):
+        # PDL hands us [op_handle]. The rewriter's IP is "before the matched op".
+        if len(values) != 1:
+            raise RuntimeError(
+                f"d2m-jit dispatch '{pat.dispatch_name}': expected 1 PDL value, "
+                f"got {len(values)}"
+            )
+        op = values[0]
+        if not isinstance(op, ir.Operation):
+            raise RuntimeError(
+                f"d2m-jit dispatch '{pat.dispatch_name}': expected an Operation, "
+                f"got {type(op).__name__}"
+            )
+
+        scope = RewriteScope(rewriter, op)
+        with _push_scope(scope):
+            ret = pat.fn(op, rewriter)
+
+        if ret is None:
+            raise RuntimeError(
+                f"pattern '{pat.fn.__name__}' returned None. The greedy driver "
+                f"does not support recoverable rewrite failures; for "
+                f"DAG-conditional matching, pass `match=<predicate>` to "
+                f"@d2m.pattern instead."
+            )
+
+        # Coerce to a single ir.Value.
+        if isinstance(ret, LazyTensor):
+            replacement = ret.value
+        elif isinstance(ret, ir.Value):
+            replacement = ret
+        else:
+            raise TypeError(
+                f"pattern '{pat.fn.__name__}' must return an ir.Value or a "
+                f"LazyTensor; got {type(ret).__name__}"
+            )
+
+        results.append(replacement)
+        # None / False are success; True is failure.
+        return None
+
+    return dispatcher
+
+
+def _make_match_dispatcher(pat: _Pattern):
+    """Wrap `pat.match_fn` as a PDL native constraint.
+
+    Constraints must be pure — do not mutate IR. They return success
+    (None/False) to let the match proceed, or failure (True) to abort.
+    """
+    assert pat.match_fn is not None
+
+    def constraint(rewriter, results, values):
+        op = values[0]
+        try:
+            ok = pat.match_fn(op)
+        except Exception as e:
+            # Treat an exception inside the predicate as "no match" so the
+            # greedy driver can keep going. Log via diagnostic when possible.
+            try:
+                op.emit_remark(
+                    f"d2m-jit match predicate raised: {e!r}; treating as no-match"
+                )
+            except Exception:
+                pass
+            return True  # failure -> skip
+        return None if ok else True
+
+    return constraint
+
+
+def _build_pdl_text(patterns: Sequence[_Pattern]) -> str:
+    body = "\n".join(p.build_pdl_text() for p in patterns)
+    return f"module {{\n{body}\n}}\n"
+
+
+def apply_patterns_text(input_text: str, pattern_paths: Sequence[str]) -> str:
+    """Text-IO entrypoint for the d2m-jit pattern framework.
+
+    Parses `input_text` (textual MLIR) in a fresh ir.Context, imports each
+    file in `pattern_paths` so its `@d2m.pattern` decorators register, runs
+    `apply_patterns` on the parsed module, and returns the rewritten
+    module as a printed string.
+
+    This is the helper the embedded-Python C++ pass calls — it sidesteps
+    the C++/Python "two MLIRs" problem (ttmlir-opt is statically linked
+    against MLIR while ttmlir's Python bindings have their own shared
+    copy, so capsule pointers can't cross the boundary safely).
+
+    Pattern registration is process-global; we snapshot and restore so
+    repeated calls don't accumulate stale entries.
+    """
+    import importlib.util
+    import sys
+    import uuid
+
+    ctx = ir.Context()
+    ctx.load_all_available_dialects()
+    module = ir.Module.parse(input_text, ctx)
+
+    snapshot = list(_registry.all())
+    _registry.clear()
+    try:
+        for path in pattern_paths:
+            mod_name = f"d2m_python_rewrites_user_{uuid.uuid4().hex}"
+            spec = importlib.util.spec_from_file_location(mod_name, path)
+            if spec is None or spec.loader is None:
+                raise ImportError(
+                    f"could not build a module spec for {path}"
+                )
+            user_mod = importlib.util.module_from_spec(spec)
+            sys.modules[mod_name] = user_mod
+            spec.loader.exec_module(user_mod)
+
+        apply_patterns(module)
+        module.operation.verify()
+        return str(module)
+    finally:
+        _registry.clear()
+        for pat in snapshot:
+            _registry._patterns.append(pat)
+
+
+def apply_patterns(module_or_op) -> None:
+    """Run the greedy driver with all registered patterns on the given op/module.
+
+    The module's `Context` must have the `pdl` and `pdl_interp` dialects
+    registered (true for tt-mlir's default `ttmlir.ir.Context` after the
+    PDL bootstrap landed). The driver runs to fixpoint; canonicalization /
+    folding interleave with the user patterns.
+
+    Patterns whose user function returns `None` are treated as no-match
+    and the greedy driver moves on. Otherwise the matched op is replaced
+    by the returned Value via `pdl.replace`.
+    """
+    patterns = _registry.all()
+    if not patterns:
+        return
+
+    # PDL stub module must live in the same Context as the target so the
+    # frozen pattern set is compatible with the driver.
+    ctx = module_or_op.context
+    pdl_text = _build_pdl_text(patterns)
+    try:
+        pdl_module = ir.Module.parse(pdl_text, ctx)
+    except Exception as e:
+        # Helpful failure: dump the generated PDL so we can debug bad input.
+        raise RuntimeError(
+            f"d2m-jit: failed to parse generated PDL module:\n{pdl_text}\n--- error: {e}"
+        ) from e
+
+    pdl = PDLModule(pdl_module)
+    for pat in patterns:
+        pdl.register_rewrite_function(pat.dispatch_name, _make_dispatcher(pat))
+        if pat.match_fn is not None:
+            pdl.register_constraint_function(pat.match_name, _make_match_dispatcher(pat))
+    frozen = pdl.freeze()
+
+    apply_patterns_and_fold_greedily(module_or_op, frozen)

--- a/tools/d2m-jit/_src/rewrite.py
+++ b/tools/d2m-jit/_src/rewrite.py
@@ -289,9 +289,7 @@ def infer_layout(value_or_type, **overrides) -> Layout:
     """
     t = value_or_type.type if isinstance(value_or_type, ir.Value) else value_or_type
     if not ir.RankedTensorType.isinstance(t):
-        raise TypeError(
-            f"infer_layout: expected RankedTensorType, got {t}"
-        )
+        raise TypeError(f"infer_layout: expected RankedTensorType, got {t}")
     rtt = ir.RankedTensorType(t)
     shape = list(rtt.shape)
     elem = rtt.element_type
@@ -428,9 +426,7 @@ def apply_patterns_text(input_text: str, pattern_paths: Sequence[str]) -> str:
             mod_name = f"d2m_python_rewrites_user_{uuid.uuid4().hex}"
             spec = importlib.util.spec_from_file_location(mod_name, path)
             if spec is None or spec.loader is None:
-                raise ImportError(
-                    f"could not build a module spec for {path}"
-                )
+                raise ImportError(f"could not build a module spec for {path}")
             user_mod = importlib.util.module_from_spec(spec)
             sys.modules[mod_name] = user_mod
             spec.loader.exec_module(user_mod)
@@ -476,7 +472,9 @@ def apply_patterns(module_or_op) -> None:
     for pat in patterns:
         pdl.register_rewrite_function(pat.dispatch_name, _make_dispatcher(pat))
         if pat.match_fn is not None:
-            pdl.register_constraint_function(pat.match_name, _make_match_dispatcher(pat))
+            pdl.register_constraint_function(
+                pat.match_name, _make_match_dispatcher(pat)
+            )
     frozen = pdl.freeze()
 
     apply_patterns_and_fold_greedily(module_or_op, frozen)

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -27,6 +27,13 @@ from ._src.builder import (
     permute,
     to_host,
 )
+from ._src.rewrite import (
+    pattern,
+    from_value,
+    from_device,
+    infer_layout,
+    apply_patterns,
+)
 
 
 @syntax("remote_load")

--- a/tools/d2m-jit/patterns/__init__.py
+++ b/tools/d2m-jit/patterns/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example d2m-jit pattern modules.
+
+Each submodule registers one or more `@d2m.pattern`s on import. Load
+them by importing the module — order matters only for `benefit` tie-
+breaking.
+"""

--- a/tools/d2m-jit/patterns/eltwise_add_exp_to_kernel.py
+++ b/tools/d2m-jit/patterns/eltwise_add_exp_to_kernel.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fuse a `ttir.add → ttir.exp` chain into a single d2m-jit kernel.
+
+DAG match example. The pattern roots on `ttir.exp` and fires only when
+its input is the result of a `ttir.add`. The replacement kernel computes
+`(a + b).exp()` in a single tile-level pass — no intermediate tensor
+materialised between the add and the exp.
+
+The matched `ttir.exp` is replaced; the upstream `ttir.add` becomes
+dead and is reclaimed by canonicalisation (`pdl.replace` doesn't erase
+the producer for us). If the add has other users besides the exp, those
+keep working — the add stays alive in that case.
+"""
+
+import d2m_jit as d2m
+from ttmlir import ir
+from ttmlir.dialects import ttir
+
+
+# Fused block-level kernel: (a + b).exp(). One thread per (Y, X) grid
+# core; each core sweeps m_blocks × n_blocks tile blocks.
+@d2m.kernel
+def add_exp_fused(a, b, out, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            xa = remote_load(a, [m_off + m, n_off + n])
+            xb = remote_load(b, [m_off + m, n_off + n])
+            remote_store(out, [m_off + m, n_off + n], (xa + xb).exp())
+
+
+def _exp_input_is_add(op):
+    """Predicate (PDL constraint). Must be pure — no IR mutation."""
+    producer = op.operands[0].owner
+    return isinstance(producer, ir.Operation) and producer.name == "ttir.add"
+
+
+@d2m.pattern(root=ttir.ExpOp, benefit=20, match=_exp_input_is_add)
+def fuse_add_exp(op, rewriter):
+    """Replace `ttir.exp(ttir.add(a, b))` with one fused d2m subgraph.
+
+    Benefit 20 outranks the single-eltwise `lower_exp` pattern (benefit
+    10) so the fused form wins when both apply.
+    """
+    add_op = op.operands[0].owner
+    a_v = add_op.operands[0]
+    b_v = add_op.operands[1]
+
+    L = d2m.infer_layout(
+        op.result,
+        tiled=True,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+    )
+
+    a = d2m.to_layout(d2m.from_value(a_v), L)
+    b = d2m.to_layout(d2m.from_value(b_v), L)
+    out = d2m.empty(L)
+    add_exp_fused(a, b, out, 1, 1, grid=(1, 1))
+    return d2m.from_device(out)

--- a/tools/d2m-jit/patterns/eltwise_exp_to_kernel.py
+++ b/tools/d2m-jit/patterns/eltwise_exp_to_kernel.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lower TTIR `ttir.exp` to a fused d2m-jit kernel template.
+
+Single-op example: matches `ttir.exp` directly and replaces it with a
+d2m-jit subgraph (to_layout → @kernel call doing tile_exp → from_device).
+
+Load this file via `--d2m-python-rewrites=path/to/this.py` (forthcoming
+C++ pass) or import-and-call `d2m.apply_patterns(module)` from a host
+Python driver. The pattern's emission targets the rewriter's insertion
+point — no rebuild needed when this file changes.
+"""
+
+import d2m_jit as d2m
+from ttmlir.dialects import ttir
+
+
+# Block-level tile-exp kernel. One thread per (Y, X) grid core; each core
+# sweeps `m_blocks` × `n_blocks` tile blocks via remote_load/remote_store.
+# The body uses the registered unary `exp` op which wraps `d2m.tile_exp`
+# in a `linalg.generic` over the tensor of tiles.
+#
+# Note: docstrings inside @d2m.kernel function bodies aren't supported by
+# the AST visitor (string constants aren't a kernel expression).
+@d2m.kernel
+def exp_fused(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            shard = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], shard.exp())
+
+
+@d2m.pattern(root=ttir.ExpOp, benefit=10)
+def lower_exp(op, rewriter):
+    """Replace one `ttir.exp` with the fused d2m subgraph.
+
+    Layout choice: tiled L1, single-block per cell, 1x1 grid. Cheap to
+    set up; correctness-first for the POC. A real lowering would pick
+    grid_shape from the operand shape to spread work across cores.
+    """
+    src = op.operands[0]
+
+    # Tiled L1 with `block_shape=[1,1]` (one tile per block) and
+    # `grid_shape=[1,1]` (one core). For 32x32 inputs that's literally
+    # one tile end-to-end.
+    L = d2m.infer_layout(
+        op.result,
+        tiled=True,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+    )
+
+    x = d2m.to_layout(d2m.from_value(src), L)
+    out = d2m.empty(L)
+    exp_fused(x, out, 1, 1, grid=(1, 1))
+    return d2m.from_device(out)


### PR DESCRIPTION
Lets users define MLIR pattern rewrites in plain Python that match TTIR (or any) ops and replace them with d2m-jit kernel-template subgraphs. Adding a new pattern is a matter of dropping a new .py file next to the driver — no C++ rebuild required.

Surface (all re-exported via d2m_jit.api):

    @d2m.pattern(root=ttir.MatmulOp, benefit=5)
    def lower_matmul(op, rewriter):
        a = d2m.from_value(op.operands[0])
        b = d2m.from_value(op.operands[1])
        out = d2m.empty(d2m.infer_layout(op.result, grid_shape=[4, 4]))
        my_fused_kernel(a, b, out, grid=(4, 4))
        return d2m.from_device(out)

    # DAG match: predicate gates the rewrite.
    @d2m.pattern(root=ttir.ExpOp, match=lambda op: ...)
    def fuse_add_exp(op, rewriter): ...

    d2m.apply_patterns(module)        # Python driver, in-process
    # OR
    ttmlir-opt --d2m-python-rewrites=module-path=foo.py input.mlir

Implementation summary:

* PDL bootstrap (lib/RegisterAll.cpp). Registers pdl::PDLDialect and pdl_interp::PDLInterpDialect so textual pdl.pattern modules can be parsed via mlir.ir.Module.parse and consumed by mlir.rewrite.PDLModule from Python.

* Scope abstraction (tools/d2m-jit/_src/builder.py). Lazy-emission helpers (to_layout, empty, view_layout, _emit_kernel_generic, LazyTensor._resolve) now target a swappable build context via _get_scope() + a thread-local push/pop. The existing _Builder singleton is one concrete scope; the new RewriteScope plugs in a PatternRewriter's ctx/loc/IP so kernel emission lands at the matched op's site. RewriteScope.add_scalar_input emits an arith.constant of index type at the rewriter's IP (lazy mode adds a func arg; rewrite mode can't and uses a host-scope constant). to_host() refuses to run from a non-lazy scope.

* Framework (tools/d2m-jit/_src/rewrite.py). Each @d2m.pattern lowers to one pdl.pattern stub:

```
pdl.pattern @<name> : benefit(N) {
  %operands = pdl.operands
  %types = pdl.types
  %op = pdl.operation \"<root>\"(%operands : !pdl.range<value>)
                                 -> (%types : !pdl.range<type>)
  (pdl.apply_native_constraint \"<match>\"(%op : !pdl.operation))?
  pdl.rewrite %op {
    %v = pdl.apply_native_rewrite \"<dispatch>\"(%op : !pdl.operation) : !pdl.value
    pdl.replace %op with (%v : !pdl.value)
  }
}
```

  Variadic operands/types so one template handles ops of any arity. The dispatcher auto-pushes a RewriteScope before invoking the user function. Predicate-gated matching uses PDL constraints (which can fail cleanly) rather than rewrite-side bail-out (which would crash the greedy driver — see findings below).

  Helpers:
   - from_value(ir.Value, layout=None): wrap an SSA value as LazyTensor; layout defaults to infer_layout(value).
   - infer_layout(value_or_type, **overrides): safe defaults (logical / untiled / single-cell, mem_space=l1). Patterns override liberally.
   - from_device(lt): emit the d2m.to_layout that materialises a device LazyTensor back to a plain host tensor type — the typical last line of a rewrite body so the returned Value matches the matched op's result type.

* Two example pattern modules (tools/d2m-jit/patterns/).
   - eltwise_exp_to_kernel.py: single-op match (ttir.exp) -> fused d2m kernel that calls d2m.tile_exp via remote_load/remote_store.
   - eltwise_add_exp_to_kernel.py: DAG match (ttir.add -> ttir.exp) -> one fused kernel computing (a + b).exp() at the tile level. Benefit 20 outranks the single-eltwise pattern when both apply.

* Standalone C++ pass (lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp, Passes.td entry). ttmlir-opt --d2m-python-rewrites=module-path=... embeds CPython, loads user pattern .py files at run time, and rewrites the host ModuleOp.
   - Uses the raw CPython C-API (not nanobind/pybind11) because MLIRD2MTransforms inherits LLVM's -fno-rtti / -fno-exceptions.
   - Does a TEXT round-trip across the boundary rather than sharing MlirModule pointers: ttmlir-opt links its own static MLIR while ttmlir's Python bindings ship libTTMLIRPythonCAPI.so with a separate MLIR runtime, so capsule pointers can't safely cross (verified empirically). The pass prints the module to a string, calls d2m_jit._src.rewrite.apply_patterns_text, re-parses the result back in the host context, and splices over the original module body. Slow and lossy on locations; a real fix is shared MLIR (LLVM_BUILD_LLVM_DYLIB), tracked separately.
   - Gated on TTMLIR_ENABLE_D2M_JIT: when off, the .cpp compiles as a fail-fast stub so ttmlir-opt --help still advertises the flag with a clean diagnostic.

* Tests.
   - test/d2m-jit/lit/eltwise_exp_pattern.py: parses a ttir.exp module, runs apply_patterns in-process, FileCheck'd for d2m.generic + d2m.tile_exp + the host-typed return.
   - test/d2m-jit/lit/eltwise_add_exp_pattern.py: same for the DAG case. Positive case CHECKs d2m.tile_add and d2m.tile_exp share a single d2m.generic. Negative case (exp with no upstream add) CHECKs the ttir.exp survives untouched.
   - test/d2m-jit/lit/python_rewrites_pass.py: drives the C++ pass via subprocess (ttmlir-opt --d2m-python-rewrites=...) on the same TTIR input and CHECKs the same output IR.
   - test/d2m-jit/test_pattern_eltwise.py: on-device pytest, exercises the bundled kernels directly through the lazy d2m-jit path with PCC vs torch. Combined with the lit tests this gives end-to-end coverage (lit proves the rewrite produces IR X; pytest proves IR X runs correctly on silicon).
   - %ttmlir_tools lit substitution added so the subprocess test can locate ttmlir-opt portably.

Three non-obvious findings worth flagging:

* PDL native rewrites only dispatch when the pdl.rewrite body uses pdl.apply_native_rewrite. The pdl.rewrite %op with \"name\"(args) external-form syntax parses and verifies but does not call the function registered via register_rewrite_function.

* Operands must be bound (pdl.operand or pdl.operands) for the bytecode interpreter to dispatch the rewrite. Without an operand binding the rewrite block is silently skipped — no error, no fire.

* The greedy pattern rewriter does not support recoverable failures inside pdl.apply_native_rewrite. Returning failure from the rewrite crashes with \"pattern rewriter doesn't support recovery\". That's why bail-out lives in match= (PDL constraint, which IS allowed to fail) rather than as a return None from the rewrite body.