### PR TITLE
TTIR to TTNN: gate SDPA decode dispatch on Sk % 32 == 0

### DIFF
--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3362,11 +3362,15 @@ private:
   // [B, 1, Hq, Sk].
   static constexpr int64_t kDecodeMaskNumHeadsDim = 2;
 
-  // Determine if the decode op should be used based on query sequence length.
-  // SDPA decode is optimized for autoregressive decoding where seq_len == 1.
+  // Decode kernel requires Sq == 1 and Sk % 32 == 0 (k_chunk_size constraint);
+  // otherwise fall back to the generic prefill op.
   bool shouldUseDecode(ttir::ScaledDotProductAttentionOp op) const {
     auto queryType = mlir::cast<RankedTensorType>(op.getQuery().getType());
-    return queryType.getDimSize(kSeqLenDim) == 1;
+    if (queryType.getDimSize(kSeqLenDim) != 1) {
+      return false;
+    }
+    auto keyType = mlir::cast<RankedTensorType>(op.getKey().getType());
+    return keyType.getDimSize(kSeqLenDim) % 32 == 0;
   }
 
   // Materialize the heads dim of the decode mask. The decode kernel currently

--- a/test/ttmlir/Dialect/TTNN/transformer/scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Dialect/TTNN/transformer/scaled_dot_product_attention.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+module {
+  func.func @decode_sk_not_multiple_of_32(%query: tensor<1x8x1x64xbf16>, %key: tensor<1x8x16x64xbf16>, %value: tensor<1x8x16x64xbf16>) -> tensor<1x8x1x64xbf16> {
+    // CHECK-LABEL: @decode_sk_not_multiple_of_32
+    // CHECK: "ttnn.scaled_dot_product_attention"
+    // CHECK-NOT: scaled_dot_product_attention_decode
+    %1 = "ttir.scaled_dot_product_attention"(%query, %key, %value) <{operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>, is_causal = false, scale = 1.0 : f32}> : (tensor<1x8x1x64xbf16>, tensor<1x8x16x64xbf16>, tensor<1x8x16x64xbf16>) -> tensor<1x8x1x64xbf16>
+    return %1 : tensor<1x8x1x64xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket

### Problem description
`ScaledDotProductAttentionOpConversionPattern::shouldUseDecode` in
`lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp` lowered any `Sq == 1` TTIR SDPA
to `ttnn.scaled_dot_product_attention_decode`. The decode kernel's
internal `k_chunk_size = min(512, largest_pow2_divisor(Sk))` must be a
multiple of 32 (equivalent to `Sk % 32 == 0`), or tt-metal `TT_FATAL`s at
runtime in
`ttnn/.../sdpa_decode/sdpa_decode.cpp:64-67`
(`"Chunk size must be multiple of 32, ..."`). This is an intentional
kernel design — decode is for tile-aligned KV caches — so the fix lives
in the compiler.

### What's changed
`shouldUseDecode` also requires `Sk % 32 == 0`. Anything else falls
through to `lowerToSDPAOp` and is handled by the generic prefill
`ttnn.scaled_dot_product_attention`, which supports arbitrary `Sk`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
`test/ttmlir/Dialect/TTNN/transformer/scaled_dot_product_attention.mlir`
  (`Sq=1`, `Sk=16` → prefill, not decode).