### PR TITLE
[TTNN] Preserve TopK at opt_level=0 instead of decomposing to sort+slice (fix tt-xla regression)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.h
@@ -17,8 +17,11 @@ namespace mlir::tt::ttnn::decomposition {
 
 // Decomposes ttnn::TopKOp back into ttnn::SortOp + ttnn::SliceStaticOp.
 // When validationConfig is provided, decomposition only occurs if op-model
-// validation fails. When validationConfig is std::nullopt, decomposition
-// is unconditional.
+// validation fails. When validationConfig is std::nullopt (e.g. optimizer
+// disabled / opt_level=0), the TopK is preserved as-is — TTNN runtime
+// supports TopK natively, and regenerating sort+slice with default attributes
+// (stable=false, null memory_config) can break downstream paths such as
+// trace capture.
 class TopKDecompositionRewritePattern : public OpRewritePattern<ttnn::TopKOp> {
 public:
   TopKDecompositionRewritePattern(mlir::MLIRContext *context)

--- a/lib/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.cpp
@@ -43,6 +43,14 @@ LogicalResult TopKDecompositionRewritePattern::matchAndRewrite(
     TTMLIR_DEBUG(ttmlir::LogComponent::IsolatedIRValidationWrapper,
                  "TopK decomposition triggered (validation failed): {0}",
                  validationResult.errorMessage);
+  } else {
+    // No validator available (e.g. optimizer disabled / opt_level=0).
+    // Preserve the TopK rather than regenerating sort+slice with default
+    // attributes — the regenerated ops can differ from the original sort+slice
+    // (e.g. stable=false, null memory_config) and break downstream paths such
+    // as trace capture. TopK has native TTNN runtime support, so keeping it
+    // is safe.
+    return failure();
   }
 
   // Decompose TopK back into Sort + SliceStatic.

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/topk_no_validator_preserve.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/topk_no_validator_preserve.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Regression test for tt-mlir issue #8575.
+// At opt_level=0 (the default), the TTNN decomposition pass has no OpModel
+// validator available, so ttnn.topk must be preserved as-is. Decomposing it
+// back to ttnn.sort + ttnn.slice_static would regenerate the sort with
+// stable=false and a null memory_config, which differs from the original IR
+// and breaks downstream paths such as trace capture.
+
+module {
+  func.func @test_topk_preserved_at_opt_level_0(%arg0: tensor<32x32768xf32>) -> (tensor<32x32xf32>, tensor<32x32xi64>) {
+    // CHECK-LABEL: func.func @test_topk_preserved_at_opt_level_0
+    // CHECK: "ttnn.topk"
+    // CHECK-NOT: "ttnn.sort"
+    %values, %indices = "ttir.topk"(%arg0) <{dim = -1 : i32, k = 32 : i32, largest = true, sorted = true}> : (tensor<32x32768xf32>) -> (tensor<32x32xf32>, tensor<32x32xi64>)
+    return %values, %indices : tensor<32x32xf32>, tensor<32x32xi64>
+  }
+}


### PR DESCRIPTION
## Ticket

- tt-mlir #8575
- tt-xla https://github.com/tenstorrent/tt-xla/issues/4878

## Problem

vLLM tests with trace enabled (e.g. OPT-125m `test_opt_generation_trace`) crash at runtime with:

```
TT_FATAL: Writes are not supported during trace capture. trace id: 7
@ tt_metal/distributed/fd_mesh_command_queue.cpp:590: !trace_id_.has_value()
```

Root cause: after #8299, `TopKDecompositionRewritePattern` unconditionally decomposed `ttnn.topk` back into `ttnn.sort + ttnn.slice_static` whenever the OpModel validator was unavailable (i.e. `opt_level=0`, the default). The regenerated sort hardcodes `stable=false` and a null `memory_config`, which differs from the original IR and breaks trace capture downstream.

## Fix (the one-liner)

When `validationConfig` is `std::nullopt`, return `failure()` from the pattern so `ttnn.topk` is preserved as-is. TopK has native TTNN runtime, flatbuffer, EmitC, EmitPy, and OpModel support, so keeping it is safe — and avoids regenerating sort+slice with mismatched attributes.

```cpp
// lib/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.cpp
if (validationConfig.has_value()) {
    // ... validate, decompose only on validation failure (unchanged)
} else {
    // No validator available (e.g. optimizer disabled / opt_level=0).
    // Preserve the TopK rather than regenerating sort+slice with default
    // attributes — the regenerated ops can differ from the original sort+slice
    // (e.g. stable=false, null memory_config) and break downstream paths such
    // as trace capture. TopK has native TTNN runtime support, so keeping it
    // is safe.
    return failure();
}
```

This restores opt_level=0 behavior to be functionally equivalent to pre-#8299, where TopK fusing was gated on `enableOpConstraints` and never ran without a validator.

## What's changed

- **`lib/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.cpp`** — add `else` branch returning `failure()` when no validator. opt_level≥1 path unchanged.
- **`include/ttmlir/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.h`** — update class doc-comment to match the new contract.
- **`test/ttmlir/Dialect/TTNN/Transforms/Decomposition/topk_no_validator_preserve.mlir`** — new lit regression test: runs default pipeline (opt_level=0), checks that `ttnn.topk` is preserved and no `ttnn.sort` is generated.

## Verification

- Failing test (`tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py::test_llama3_3b_generation_trace` and locally cooked up test`tests/integrations/vllm_plugin/generative/test_opt_generation.py::test_opt_generation_trace`) passes with the fix.
- All opmodel-free TopK lit tests pass (`topk_fusing`, `negative_topk`, `simple_topk`, `simple_topk_router_gpt`, `topk_op` StableHLO conversion, four `Workarounds/topk_*` tests).
- The opt_level≥1 code path (validator available) is unchanged.

## Checklist

- [x] New/existing tests provide coverage for changes
- [x] `pre-commit run` on changed files passes
- [x] Linked issues: tt-mlir #8575, tt-xla #4878
