### PR TITLE
[d2m-jit] Add float reductions

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -29,6 +29,7 @@
 - [Optimizer](./optimizer.md)
 - [PyKernel](./pykernel.md)
 - [ttnn-jit](./ttnn-jit.md)
+- [d2m-jit](./d2m-jit.md)
 - [Creating bug repros for TTNN](./ttnn-bug-repros.md)
 - [Python Bindings](./python-bindings.md)
 - [Flatbuffers](./flatbuffers.md)

--- a/docs/src/d2m-jit.md
+++ b/docs/src/d2m-jit.md
@@ -1,0 +1,32 @@
+# d2m-jit
+
+`d2m-jit` is a Python DSL testbed for authoring block-level D2M kernels and
+running them through the D2M to TTMetal pipeline. It is aimed at compiler
+developers who need to prototype D2M dialect behavior directly, not at general
+model authors.
+
+The DSL operates on tensors of `!ttcore.tile` values inside `@d2m.kernel`
+functions. It supports remote shard load/store, Python `for`/`if` lowering,
+async `yield`/`await`, semaphores, block-level elementwise ops, `where`,
+metadata views (`view`, `view_layout`, `permute`), layout conversion helpers,
+single-tile matmul with an explicit zero-filled output, and float per-tile
+reductions (`reduce_sum`, `reduce_max`, `reduce_mean`).
+
+Float reductions reduce one tile axis at a time using torch/numpy-style dims:
+`dim=0` or `-2` reduces rows, and `dim=1` or `-1` reduces columns. The result
+keeps the same tile shape with the hardware reduce result lanes populated.
+Cross-tile reductions, collapsed-output helpers, integer SFPU reductions, and
+broadcast-back are still follow-up work.
+
+Build and test it with:
+
+```bash
+source env/activate
+cmake -G Ninja -B build -DTTMLIR_ENABLE_D2M_JIT=ON
+cmake --build build --target d2m-jit
+pytest test/d2m-jit/
+llvm-lit build/test/d2m-jit/
+```
+
+See the full tool documentation in [`tools/d2m-jit/README.md`](../../tools/d2m-jit/README.md)
+and the active gap list in [`tools/d2m-jit/TODO.md`](../../tools/d2m-jit/TODO.md).

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -8,3 +8,4 @@ The `ttmlir` project currently exposes the following tools:
 - [`ttir-builder`](./ttir-builder/ttir-builder.md): This tool is for creating ttir operations. It provides support for those ops to be compiled into modules or directly to flatbuffer files.
 - [`tt-explorer`](./tt-explorer/tt-explorer.md): Visualizer tool for `ttmlir`-powered compiler results. Visualizes from emitted `.mlir` files to display compiled model, attributes, performance results, and provide a platform for human-driven overrides to _gamify_ model tuning.
 - [`ttnn-standalone`](./ttnn-standalone.md): This tool is used to run C++ TTNN code outside of the compiler environment.
+- [`d2m-jit`](./d2m-jit.md): Python DSL testbed for authoring block-level D2M kernels and exercising the D2M to TTMetal pipeline.

--- a/test/d2m-jit/lit/reductions.py
+++ b/test/d2m-jit/lit/reductions.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR-shape coverage for d2m-jit float reductions.
+
+This stays below `to_host()` so lit can validate the builder contract without
+requiring device execution.
+"""
+
+import torch
+import d2m_jit as d2m
+
+from d2m_jit._src.builder import _Builder
+
+_L = d2m.Layout(
+    shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
+)
+
+
+@d2m.kernel
+def k(in_t, out_t):
+    x = remote_load(in_t, [0, 0])
+    s = reduce_sum(x, 1)
+    m = x.reduce_max(0)
+    a = reduce_mean(x, -1)
+    y = s.add(m).add(a)
+    remote_store(out_t, [0, 0], y)
+
+
+t = torch.arange(32 * 32, dtype=torch.float32).reshape(32, 32)
+k(d2m.to_layout(t, _L), d2m.empty(_L), grid=(1, 1))
+print(_Builder.get().module)
+_Builder.reset()
+
+
+# CHECK: "func.func"
+# CHECK: d2m.to_layout
+# CHECK: "d2m.generic"
+# CHECK: d2m.remote_load
+# CHECK: d2m.tile_reduce_sum
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
+# CHECK: d2m.tile_reduce_max
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim C>
+# CHECK: d2m.tile_reduce_mean
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim R>

--- a/test/d2m-jit/test_reductions.py
+++ b/test/d2m-jit/test_reductions.py
@@ -15,7 +15,10 @@ def k_reduce_sum_cols(in_t, out_t, m_blocks, n_blocks):
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, n_off + n], reduce_sum(x, 1))
+            # Keep the reduction in a temporary so call-site reduction
+            # detection cannot rely on it being nested under remote_store.
+            reduced = reduce_sum(x, 1)
+            remote_store(out_t, [m_off + m, n_off + n], reduced)
 
 
 @d2m.kernel
@@ -26,6 +29,16 @@ def k_reduce_max_rows(in_t, out_t, m_blocks, n_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
             remote_store(out_t, [m_off + m, n_off + n], x.reduce_max(0))
+
+
+@d2m.kernel
+def k_reduce_mean_cols_negative_dim(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], reduce_mean(x, -1))
 
 
 def _make_layout():
@@ -63,3 +76,13 @@ def test_reduce_max_rows_method_form():
     expected = tensor.max(dim=0).values
     diff = (expected - result[0, :]).abs().max().item()
     assert diff < 0.05, f"reduce_max(dim=0): max diff {diff}"
+
+
+def test_reduce_mean_cols_negative_dim():
+    tensor = torch.arange(32 * 32, dtype=torch.float32).reshape(32, 32)
+    tensor = tensor / 100.0
+    result = _run(k_reduce_mean_cols_negative_dim, tensor)
+
+    expected = tensor.mean(dim=1)
+    diff = (expected - result[:, 0]).abs().max().item()
+    assert diff < 0.05, f"reduce_mean(dim=-1): max diff {diff}"

--- a/test/d2m-jit/test_reductions.py
+++ b/test/d2m-jit/test_reductions.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Float tile reductions exposed through the d2m-jit block DSL."""
+
+import torch
+import d2m_jit as d2m
+
+
+@d2m.kernel
+def k_reduce_sum_cols(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], reduce_sum(x, 1))
+
+
+@d2m.kernel
+def k_reduce_max_rows(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], x.reduce_max(0))
+
+
+def _make_layout():
+    return d2m.Layout(
+        shape=(32, 32),
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+    )
+
+
+def _run(kernel, tensor):
+    layout = _make_layout()
+    out = d2m.empty(layout)
+    kernel(d2m.to_layout(tensor, layout), out, 1, 1, grid=(1, 1))
+    return out.to_host()
+
+
+def test_reduce_sum_cols():
+    tensor = torch.arange(32, dtype=torch.float32).reshape(32, 1).repeat(1, 32)
+    tensor = tensor / 100.0
+    result = _run(k_reduce_sum_cols, tensor)
+
+    expected = tensor.sum(dim=1)
+    diff = (expected - result[:, 0]).abs().max().item()
+    assert diff < 0.05, f"reduce_sum(dim=1): max diff {diff}"
+
+
+def test_reduce_max_rows_method_form():
+    row_bias = torch.linspace(-0.5, 0.5, 32, dtype=torch.float32).reshape(32, 1)
+    col_values = torch.linspace(-1.0, 1.0, 32, dtype=torch.float32).reshape(1, 32)
+    tensor = row_bias + col_values
+    result = _run(k_reduce_max_rows, tensor)
+
+    expected = tensor.max(dim=0).values
+    diff = (expected - result[0, :]).abs().max().item()
+    assert diff < 0.05, f"reduce_max(dim=0): max diff {diff}"

--- a/tools/d2m-jit/KERNEL_AUDIT.md
+++ b/tools/d2m-jit/KERNEL_AUDIT.md
@@ -24,7 +24,7 @@ Status legend matches [TODO.md](TODO.md): 🔴 blocker · 🟡 missing surface
 | **Views** (`view`, `view_layout`, `permute`) | ✅ | Metadata reinterpretation, no data movement |
 | `tilize` / `untilize` / `to_layout` | ✅ | Layout conversions |
 | `zeros`, `full`, `empty` | ✅ | Host-side fill + `to_layout` |
-| Reductions (`tile_reduce_*`) | 🔴 | Not exposed in `api.py` |
+| Float reductions (`reduce_sum`, `reduce_max`, `reduce_mean`) | ✅ | Per-tile row/col reductions using `tile_reduce_*`; same-shape output lanes |
 | Broadcast (`tile_bcast`) | 🔴 | Not exposed |
 | In-kernel typecast (`tile_typecast`) | 🔴 | Host-side only via `tilize(dtype=...)` |
 | Per-tile transpose (`tile_transpose`) | 🔴 | Not exposed — but logical permute via views is free |
@@ -83,14 +83,17 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 - **Per-shard outer product / hadamard** patterns.
 - **KV-cache writeback** at a computed index via `remote_store`.
 - **Pointwise quant/dequant** (mul + add + `floor`).
+- **Single-tile reductions:** row/column `sum`, `max`, and `mean` within each
+  32x32 tile. The result lanes can feed later elementwise work, but broadcast
+  back to a full tile is still missing.
 
 ### 🟡 Buildable with workarounds / scope cuts
 
 - **SDPA at 1-tile granularity** (S ≤ 32, single head): Q×Kᵀ via
-  permute-view + zeros-prefilled matmul + softmax… stops at softmax
-  because reduce/bcast are missing.
+  permute-view + zeros-prefilled matmul + softmax scaffolding. Reductions now
+  cover row max/sum, but softmax still needs broadcast-back.
 - **Multi-head attention scaffolding:** per-head views are free; the
-  *compute* hits the reduction wall.
+  *compute* hits broadcast and matmul-accumulator limits.
 - **MoE expert MLP body** (linear + GELU + linear): chained via views,
   but only single-tile shards until the matmul accumulator bug lands.
 - **Embedding lookup:** doable via `remote_load` with computed indices
@@ -98,9 +101,10 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ### 🔴 Blocked on missing pieces
 
-- **Softmax** — needs reduce + bcast. Blocks every attention,
-  MoE-gating, and cross-entropy-loss kernel.
-- **LayerNorm / RMSNorm / GroupNorm** — same: reductions + broadcast.
+- **Softmax** — reductions are exposed, but it still needs broadcast-back.
+  Blocks every attention, MoE-gating, and cross-entropy-loss kernel.
+- **LayerNorm / RMSNorm / GroupNorm** — same: reduction lanes exist, but
+  broadcast-back and cross-tile accumulation are still missing.
 - **Flash Attention** — needs softmax + multi-K matmul accumulation
   ([TODO §1](TODO.md)) + multicast on real grids
   ([TODO §2](TODO.md)) + online-softmax state across blocks.
@@ -113,24 +117,24 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ---
 
-## 4. Concrete kernel sketches with a proposed reduce + bcast surface
+## 4. Concrete kernel sketches with reduce + proposed bcast surface
 
-These sketches assume a small, named-keyword API along these lines:
+These sketches use the landed reduction API and a proposed broadcast API:
 
 ```python
-# Per-tile reductions: reduce over the tile's row or col axis. The
-# result is a partial tile (32x1 for dim="col", 1x32 for dim="row"),
-# matching the d2m.tile_reduce_* op semantics.
-d2m.reduce_sum(x, dim)     # dim in {"row", "col"}
+# Per-tile reductions: reduce over one tile axis. `dim` follows torch/numpy
+# numbering (`0`/`-2`, `1`/`-1`) and keeps the same tile shape with reduce
+# lanes populated by the hardware op.
+d2m.reduce_sum(x, dim)
 d2m.reduce_max(x, dim)
 d2m.reduce_mean(x, dim)
 
 # Broadcast a partial tile back to a full 32x32 tile.
-d2m.bcast(x, dim)          # dim in {"row", "col", "scalar"}
+d2m.bcast(x, dim)          # proposed: dim in {"row", "col", "scalar"}
 ```
 
-The exact spelling is a placeholder; the point of the sketches is the
-**kernel shape**, not the bikeshed.
+The broadcast spelling is a placeholder; the point of the sketches is the
+**kernel shape**.
 
 ### 4.1 Row-wise softmax (within-tile)
 
@@ -147,11 +151,11 @@ def softmax_row(x, out, m_blocks, n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
 
             # Numerically-stable softmax: subtract row max, exp, divide.
-            row_max = reduce_max(t, dim="row")           # 32x1
-            t_shift = t - bcast(row_max, dim="row")      # 32x32
+            row_max = reduce_max(t, dim=1)               # 32x1
+            t_shift = t - bcast(row_max, dim=1)          # 32x32
             t_exp   = exp(t_shift)
-            row_sum = reduce_sum(t_exp, dim="row")       # 32x1
-            t_out   = t_exp * bcast(recip(row_sum), dim="row")
+            row_sum = reduce_sum(t_exp, dim=1)           # 32x1
+            t_out   = t_exp * bcast(recip(row_sum), dim=1)
 
             remote_store(out, [m_off + m, n_off + n], t_out)
 ```
@@ -174,16 +178,16 @@ def softmax_row_wide(x, out, m_blocks, n_blocks):
         row_max = NEG_INF
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            row_max = maximum(row_max, bcast(reduce_max(t, dim="row"),
-                                             dim="row"))
+            row_max = maximum(row_max, bcast(reduce_max(t, dim=1),
+                                             dim=1))
 
         # Pass 2: row sum of shifted exp.
         row_sum = full_tile(value=0.0)
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
             t_exp = exp(t - row_max)
-            row_sum = row_sum + bcast(reduce_sum(t_exp, dim="row"),
-                                      dim="row")
+            row_sum = row_sum + bcast(reduce_sum(t_exp, dim=1),
+                                      dim=1)
         row_inv = recip(row_sum)
 
         # Pass 3: normalise and write back.
@@ -218,8 +222,8 @@ def rmsnorm(x, gamma, out, m_blocks, n_blocks, eps_tile):
         sum_sq = full_tile(value=0.0)
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            sum_sq = sum_sq + bcast(reduce_sum(t * t, dim="row"),
-                                    dim="row")
+            sum_sq = sum_sq + bcast(reduce_sum(t * t, dim=1),
+                                    dim=1)
         inv_rms = rsqrt(sum_sq * INV_N + eps_tile)
 
         # Pass 2: scale and write.
@@ -293,16 +297,16 @@ def flash_attn_inner(Q, K, V, O, l_state, m_state, S_q, S_kv, D):
 
         # 2. running max
         m_prev = m_state
-        m_cur  = maximum(m_prev, bcast(reduce_max(s, dim="row"),
-                                       dim="row"))
+        m_cur  = maximum(m_prev, bcast(reduce_max(s, dim=1),
+                                       dim=1))
 
         # 3. correction factor for previous accumulator
         alpha  = exp(m_prev - m_cur)
 
         # 4. exp of shifted scores, partial sum
         p      = exp(s - m_cur)
-        l_cur  = alpha * l_state + bcast(reduce_sum(p, dim="row"),
-                                         dim="row")
+        l_cur  = alpha * l_state + bcast(reduce_sum(p, dim=1),
+                                         dim=1)
 
         # 5. update O: O = alpha * O + p @ V
         O      = alpha * O + (p @ V_blk)

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -133,6 +133,8 @@ on single tile scalars, so elementwise ops in the DSL are wrapped in
 `linalg.generic` over the tensor of tiles (`_eltwise_block` in `api.py`).
 Matmul follows the same pattern but with parallel/parallel/reduction iterators
 over (M, N, K) and `d2m.tile_matmul` in the body (`_matmul_block`).
+Float reductions use `d2m.tile_reduce_*` with an automatically generated
+unit-scaler tensor input (`_reduce_block`).
 
 ### Views
 
@@ -237,6 +239,29 @@ Ternary:
 | Symbol | What |
 | --- | --- |
 | `d2m.where(cond, t, f)` | Elementwise select: `cond ? t : f`. All three blocks must have the same type. `cond` is interpreted elementwise (non-zero ⇒ `t`, zero ⇒ `f`). Also available as `cond.where(t, f)`. |
+
+### Float reduction block-level ops
+
+`reduce_sum`, `reduce_max`, and `reduce_mean` are registered as free functions
+and `TensorBlock` methods:
+
+```python
+row_sum = d2m.reduce_sum(x, 1)  # or x.reduce_sum(1)
+col_max = x.reduce_max(0)
+row_avg = x.reduce_mean(-1)
+```
+
+`dim` follows torch/numpy axis numbering for a 2D tile block:
+
+| `dim` | D2M reduce dim | Result lane checked by tests |
+| --- | --- | --- |
+| `0` / `-2` | `#d2m<reduce_dim C>` | `result[0, :]` |
+| `1` / `-1` | `#d2m<reduce_dim R>` | `result[:, 0]` |
+
+The output block has the same tensor-of-tiles shape as the input. These ops are
+float-only (`f32`, `f16`, `bf16`) and use synthetic 1x1 scaler tensors,
+matching the D2M float tile-reduce signature `reduce(a * b, c)`. Sum/max use
+a unit scaler; mean uses a `1/32` scaler for one tile axis.
 
 ### Python operators on `TensorBlock`
 
@@ -352,6 +377,9 @@ have been dropped — the DSL emits the post-legalisation form directly.
   generation that was not passed to `to_host` raises on re-use. If you need
   multiple values out, pass them all to a single `to_host`.
 - **Matmul accumulator is currently undefined.** See the matmul note above.
+- **Float reductions are per tile.** They reduce rows/columns within each
+  loaded tile and do not yet collapse a logical tensor dimension across tiles.
+  Use multiple kernel passes for cross-tile reductions.
 - **Argument order in a `@kernel` call.** All `LazyTensor` arguments first,
   then any `int` scalar arguments. Mixing raises a `TypeError`. The last
   `num_outs` `LazyTensor`s (default 1) are treated as outputs.
@@ -369,5 +397,5 @@ have been dropped — the DSL emits the post-legalisation form directly.
 ## Known issues / TODO
 
 See [TODO.md](TODO.md) for active pipeline gaps (matmul accumulator init,
-host-scope `linalg.generic`), missing API surface (reductions, broadcast,
-in-kernel typecast, DMA primitives, ...), and other follow-ups.
+host-scope `linalg.generic`), missing API surface (broadcast, in-kernel
+typecast, DMA primitives, ...), and other follow-ups.

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -127,82 +127,13 @@ speculatively.
 | `tile_transpose(x)` | per-tile (32×32) element transpose -- distinct from logical `permute` / `view` | naming question — collides with `permute` / `view` semantics if called `transpose` |
 | `tile_bcast(x, bcast_type)` | broadcast row / col / scalar tile to full tile | needs a `BcastTypeAttr` argument; small but bespoke |
 
-### 🟡 Reductions (scoped — float blocked, int viable)
+### 🟡 Reduction follow-ups
 
-`tile_reduce_sum`, `tile_reduce_max`, `tile_reduce_mean` (float) and
-`tile_sfpu_reduce_sum`, `tile_sfpu_reduce_max` (int).
-
-**Locked V1 design** (deferred behind blockers below):
-
-- Free functions `reduce_sum / reduce_max / reduce_mean(block, dim)`
-  reducing along numpy-style axis (`dim=0 → R`, `dim=1 → C`).
-- Two flavours per op: same-shape broadcast-back (default, for
-  `x - x.max(dim, keepdims=True)`-style softmax/layernorm prefixes) and
-  `*_collapse` (output axis collapsed to a single tile).
-- Float vs int auto-dispatch via tile-element-type inspection.
-- Multi-dim (RC) reduction deferred — call twice if needed.
-- Anchor test: softmax-prefix `exp(x - max(x))` on a single shard.
-
-#### Blocker A: float reductions need a scaler `b` operand
-
-`tile_reduce_*` (float) signature is `(a, b, c, dim) -> reduce(a*b)+c`.
-TTIR-to-D2M lowering supplies `b` as a separate 1×1-tile **tensor input**
-to the outer `d2m.GenericOp`, built by a *separate* `d2m.GenericOp` whose
-body fills the tile with `1.0` via `tile_fill`. The scaler is loaded into
-the reduce kernel via `remote_load(scaler, [0, 0])`.
-
-#### Blocker B: inline `tile_fill` in the reduce body fails to lower
-
-Attempted shortcut: emit `tile_fill(1.0)` and `tile_reduce_sum` as
-sibling ops inside the same `linalg.generic` body, so no host-side
-scaler tensor is needed. Builds clean IR but `D2MToTTKernel` cannot fold
-the resulting conversion cast:
-
-```
-error: failed to legalize unresolved materialization from
-  ('memref<4x!ttcore.tile<32x32, f32>, #ttcore.memory_space<dst>>')
-  to ('index')
-  that remained live after conversion
-```
-
-Root cause: `D2MTileFillRewriter` replaces the tile_fill result with a
-DST-register index, but the reduce rewriter's `getCB(op.getB())` call
-expects `b` to be a CB-backed tile (not a DST tile). Same family as the
-matmul accumulator init bug above.
-
-#### What V1 would actually cost
-
-If we go with the host-allocated scaler (the only path that lowers
-today):
-
-1. Walk the kernel AST at call time and detect `reduce_*` calls.
-2. Auto-host-allocate a 1×1-grid scaler tensor via
-   `d2m.full((32, 32), 1.0)`.
-3. Append the scaler to the outer `d2m.GenericOp` inputs and to the
-   inner kernel func signature as a synthetic argument.
-4. Inside the reduce primitive, emit `remote_load(scaler, [0, 0])`
-   once at body entry and cache the resulting tile (re-used across
-   multiple reduce calls in the same kernel).
-5. Plumb compiler state (thread-local or `D2MCompiler.symbol_tables`
-   sentinel) so the primitive can find the scaler from inside
-   `visit_Call`.
-6. Handle dtype matching (scaler must match the input tile's float
-   dtype: f32 vs bf16 vs f16).
-
-Estimated cost: **2–3 days** of DSL plumbing. Plus risk: the
-`remote_load(scaler, [0, 0])` from a >1×1 grid is structurally a
-multicast read from shard (0,0), which exercises the same path that
-SplitUnifiedThread blows up on (see TODO above). So grid>1×1 float
-reductions are likely blocked behind the same compiler bug.
-
-#### Recommended near-term
-
-- Land int-only `reduce_sum / reduce_max` via `tile_sfpu_reduce_*` (no
-  scaler). ~30 min of work. Provides the API shape for users to mirror.
-- Defer float reductions until either (a) `D2MToTTKernel` accepts a
-  tile_fill-produced `b` operand directly (Blocker B fix), or (b) the
-  scaler plumbing in the DSL is worth the 2–3 day investment.
-- Defer softmax/layernorm anchor tests until float lands.
+- Integer reductions via `tile_sfpu_reduce_sum` / `tile_sfpu_reduce_max`.
+- Collapsed-output helpers (`*_collapse`) for APIs that want a logical
+  single-row or single-column result rather than same-shape reduce lanes.
+- Cross-tile or multi-dim (RC) reductions; call kernels in multiple passes for
+  now.
 
 ### 🟡 Lower-level kernel primitives (advanced)
 

--- a/tools/d2m-jit/_src/ast.py
+++ b/tools/d2m-jit/_src/ast.py
@@ -590,6 +590,18 @@ class D2MCompiler(ast.NodeVisitor):
                 )
 
     def visit_UnaryOp(self, node):
+        as_attr = getattr(node, "_ttkernel_as_attr", False)
+        if callable(as_attr):
+            return as_attr(node)
+
+        if (
+            isinstance(node.op, ast.USub)
+            and isinstance(node.operand, ast.Constant)
+            and isinstance(node.operand.value, int)
+            and not isinstance(node.operand.value, bool)
+        ):
+            return arith.ConstantOp(IndexType.get(self.ctx), -node.operand.value)
+
         operand = self.visit(node.operand)
         if not operand:
             raise ValueError("Unary operand not found")

--- a/tools/d2m-jit/_src/ast.py
+++ b/tools/d2m-jit/_src/ast.py
@@ -19,7 +19,6 @@ from .errors import D2mJitError, closest_match
 from .utils import _discover_dialect_ops, _cast, _get_type_str
 from .tensor_layout import Layout
 
-
 _D2M_KERNEL_TYPES = {None, "datamovement", "noc", "compute", "unified"}
 
 
@@ -34,6 +33,7 @@ class D2MCompiler(ast.NodeVisitor):
 
     # Populated at import time by the @syntax decorator.
     _syntax = {}
+    _current = None
 
     _SUPPORTED_NODES = (
         # Variables
@@ -106,6 +106,8 @@ class D2MCompiler(ast.NodeVisitor):
         source_file=None,
         source_firstlineno=None,
         source_lines=None,
+        synthetic_args=None,
+        synthetic_arg_insert_index=None,
         **kwargs,
     ):
         assert kernel_type in _D2M_KERNEL_TYPES, f"Invalid kernel type {kernel_type}"
@@ -114,6 +116,10 @@ class D2MCompiler(ast.NodeVisitor):
         self.kernel_type = kernel_type
         self.captures = captures if captures is not None else {}
         self.args = args
+        self.synthetic_args = list(synthetic_args or [])
+        self.synthetic_arg_insert_index = synthetic_arg_insert_index
+        self.synthetic_symbol_table = {}
+        self.reduce_scaler_cache = {}
 
         # Source metadata used to build D2mJitError messages and to pin each
         # emitted op to a file_line_col Location.
@@ -135,6 +141,10 @@ class D2MCompiler(ast.NodeVisitor):
         self.symbol_tables = []
         self.supported_nodes = list(self._SUPPORTED_NODES)
         self._fn_map = dict(self._syntax)
+
+    @classmethod
+    def current(cls):
+        return cls._current
 
     # --- Error / source-location helpers ----------------------------------
 
@@ -182,6 +192,9 @@ class D2MCompiler(ast.NodeVisitor):
             names.update(tbl.keys())
         return names
 
+    def get_synthetic_arg(self, name):
+        return self.synthetic_symbol_table.get(name)
+
     def _hint_for_function(self, name):
         match = closest_match(name, self._fn_map.keys())
         return f"did you mean `{match}`?" if match else None
@@ -222,6 +235,8 @@ class D2MCompiler(ast.NodeVisitor):
         params = inspect.signature(visitor).parameters
         filtered_kwargs = {k: v for k, v in kwargs.items() if k in params}
         loc = self._mlir_loc(node)
+        prev_current = D2MCompiler._current
+        D2MCompiler._current = self
         try:
             with loc:
                 if filtered_kwargs:
@@ -232,6 +247,8 @@ class D2MCompiler(ast.NodeVisitor):
             raise
         except Exception as orig:
             raise self._format_error(node, orig) from orig
+        finally:
+            D2MCompiler._current = prev_current
 
     # --- Module / function entry ------------------------------------------
 
@@ -244,8 +261,13 @@ class D2MCompiler(ast.NodeVisitor):
         assert not self.func_entry, "Cannot declare function within a function"
 
         func_operand_types = []
-        for i, arg in enumerate(node.args.args):
-            rt_arg = self.args[i]
+        func_arg_names = []
+        user_arg_idx = 0
+        synthetic_insert_idx = self.synthetic_arg_insert_index
+        if synthetic_insert_idx is None:
+            synthetic_insert_idx = len(node.args.args)
+
+        def append_arg(arg_name, rt_arg, synthetic=False):
             if isinstance(rt_arg, Layout):
                 func_operand_types.append(
                     rt_arg.build_device_tensor_type(self.ctx, blocked=True)
@@ -254,8 +276,24 @@ class D2MCompiler(ast.NodeVisitor):
                 func_operand_types.append(IndexType.get(self.ctx))
             else:
                 raise TypeError(
-                    f"Unknown kernel argument type {type(rt_arg)} for argument {arg.arg}"
+                    f"Unknown kernel argument type {type(rt_arg)} for argument "
+                    f"{arg_name}"
                 )
+            func_arg_names.append((arg_name, synthetic))
+
+        for i, arg in enumerate(node.args.args):
+            if i == synthetic_insert_idx:
+                for synthetic_name, synthetic_layout in self.synthetic_args:
+                    append_arg(synthetic_name, synthetic_layout, synthetic=True)
+            rt_arg = self.args[user_arg_idx]
+            user_arg_idx += 1
+            append_arg(arg.arg, rt_arg)
+
+        if synthetic_insert_idx >= len(node.args.args):
+            for synthetic_name, synthetic_layout in self.synthetic_args:
+                append_arg(synthetic_name, synthetic_layout, synthetic=True)
+
+        assert user_arg_idx == len(self.args)
 
         self.func_entry = func.FuncOp(name=node.name, type=(func_operand_types, []))
         self.func_entry.attributes[d2m.ir.ThreadAttr.name] = d2m.ir.ThreadAttr.get(
@@ -264,8 +302,11 @@ class D2MCompiler(ast.NodeVisitor):
 
         self.symbol_tables.append({})
         func_bb = self.func_entry.add_entry_block()
-        for i, bb_arg in enumerate(func_bb.arguments):
-            self.symbol_tables[-1][node.args.args[i].arg] = bb_arg
+        for (arg_name, synthetic), bb_arg in zip(func_arg_names, func_bb.arguments):
+            if synthetic:
+                self.synthetic_symbol_table[arg_name] = bb_arg
+            else:
+                self.symbol_tables[-1][arg_name] = bb_arg
         self.module_symbol_table = SymbolTable(self.module.operation)
 
         with InsertionPoint(func_bb):

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -132,8 +132,9 @@ _PIPELINE = ",".join(
     ]
 )
 
-_REDUCE_SCALER_ARG = "__d2m_reduce_scaler"
-_FLOAT_REDUCTION_NAMES = {"reduce_sum", "reduce_max"}
+_REDUCE_UNIT_SCALER_ARG = "__d2m_reduce_unit_scaler"
+_REDUCE_MEAN_SCALER_ARG = "__d2m_reduce_mean_scaler"
+_FLOAT_REDUCTION_NAMES = {"reduce_sum", "reduce_max", "reduce_mean"}
 
 
 class _Builder:
@@ -711,22 +712,26 @@ def _affine_map_from_lambda(fn):
     return AffineMap.get(len(dims), 0, exprs), spec
 
 
-def _kernel_uses_float_reductions(kernel_ast):
+def _kernel_float_reductions(kernel_ast):
     class _ReductionUseVisitor(_ast.NodeVisitor):
         def __init__(self):
-            self.found = False
+            self.names = set()
 
         def visit_Call(self, node):
             if isinstance(node.func, _ast.Name):
-                self.found = node.func.id in _FLOAT_REDUCTION_NAMES
+                name = node.func.id
             elif isinstance(node.func, _ast.Attribute):
-                self.found = node.func.attr in _FLOAT_REDUCTION_NAMES
-            if not self.found:
-                self.generic_visit(node)
+                name = node.func.attr
+            else:
+                name = None
+
+            if name in _FLOAT_REDUCTION_NAMES:
+                self.names.add(name)
+            self.generic_visit(node)
 
     visitor = _ReductionUseVisitor()
     visitor.visit(kernel_ast)
-    return visitor.found
+    return visitor.names
 
 
 def _emit_kernel_generic(
@@ -801,24 +806,32 @@ def _emit_kernel_generic(
 
     synthetic_lts = []
     synthetic_args = []
-    if _kernel_uses_float_reductions(kernel._ast):
+    reduction_names = _kernel_float_reductions(kernel._ast)
+    if reduction_names:
         if not input_lts:
             raise _call_error(
                 "float reductions require at least one input tensor argument",
                 cause=ValueError(),
             )
         first_input_layout = input_lts[0].layout
-        scaler_layout = Layout(
-            shape=(32, 32),
-            dtype=first_input_layout.dtype,
-            block_shape=[1, 1],
-            grid_shape=[1, 1],
-            tiled=True,
-            collapse=first_input_layout.collapse,
-            mem_space=first_input_layout.mem_space,
-        )
-        synthetic_lts.append(full(scaler_layout, 1.0)._resolve())
-        synthetic_args.append((_REDUCE_SCALER_ARG, scaler_layout))
+
+        def add_scaler(name, value):
+            scaler_layout = Layout(
+                shape=(32, 32),
+                dtype=first_input_layout.dtype,
+                block_shape=[1, 1],
+                grid_shape=[1, 1],
+                tiled=True,
+                collapse=first_input_layout.collapse,
+                mem_space=first_input_layout.mem_space,
+            )
+            synthetic_lts.append(full(scaler_layout, value)._resolve())
+            synthetic_args.append((name, scaler_layout))
+
+        if reduction_names & {"reduce_sum", "reduce_max"}:
+            add_scaler(_REDUCE_UNIT_SCALER_ARG, 1.0)
+        if "reduce_mean" in reduction_names:
+            add_scaler(_REDUCE_MEAN_SCALER_ARG, 1.0 / 32.0)
 
     # Compile the kernel body in the current builder's context. D2MCompiler
     # picks up b.ctx via get_default_loc_context.

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -42,7 +42,6 @@ from .errors import D2mJitError
 from .tensor_layout import Layout
 from .utils import _cleanup_source_code
 
-
 # Reverse of ttcore.DataType for picking output torch dtypes.
 _TTCORE_TO_TORCH = None  # lazy-init since torch may be missing
 
@@ -132,6 +131,9 @@ _PIPELINE = ",".join(
         "d2m-to-ttmetal-pipeline",
     ]
 )
+
+_REDUCE_SCALER_ARG = "__d2m_reduce_scaler"
+_FLOAT_REDUCTION_NAMES = {"reduce_sum", "reduce_max"}
 
 
 class _Builder:
@@ -709,6 +711,24 @@ def _affine_map_from_lambda(fn):
     return AffineMap.get(len(dims), 0, exprs), spec
 
 
+def _kernel_uses_float_reductions(kernel_ast):
+    class _ReductionUseVisitor(_ast.NodeVisitor):
+        def __init__(self):
+            self.found = False
+
+        def visit_Call(self, node):
+            if isinstance(node.func, _ast.Name):
+                self.found = node.func.id in _FLOAT_REDUCTION_NAMES
+            elif isinstance(node.func, _ast.Attribute):
+                self.found = node.func.attr in _FLOAT_REDUCTION_NAMES
+            if not self.found:
+                self.generic_visit(node)
+
+    visitor = _ReductionUseVisitor()
+    visitor.visit(kernel_ast)
+    return visitor.found
+
+
 def _emit_kernel_generic(
     kernel: "CompiledKernel",
     args,
@@ -779,6 +799,27 @@ def _emit_kernel_generic(
     input_lts = lazy_args[: len(lazy_args) - num_outs]
     output_lts = lazy_args[len(lazy_args) - num_outs :]
 
+    synthetic_lts = []
+    synthetic_args = []
+    if _kernel_uses_float_reductions(kernel._ast):
+        if not input_lts:
+            raise _call_error(
+                "float reductions require at least one input tensor argument",
+                cause=ValueError(),
+            )
+        first_input_layout = input_lts[0].layout
+        scaler_layout = Layout(
+            shape=(32, 32),
+            dtype=first_input_layout.dtype,
+            block_shape=[1, 1],
+            grid_shape=[1, 1],
+            tiled=True,
+            collapse=first_input_layout.collapse,
+            mem_space=first_input_layout.mem_space,
+        )
+        synthetic_lts.append(full(scaler_layout, 1.0)._resolve())
+        synthetic_args.append((_REDUCE_SCALER_ARG, scaler_layout))
+
     # Compile the kernel body in the current builder's context. D2MCompiler
     # picks up b.ctx via get_default_loc_context.
     with b.ctx, b.loc:
@@ -791,6 +832,8 @@ def _emit_kernel_generic(
             source_file=kernel._source_file,
             source_firstlineno=kernel._source_firstlineno,
             source_lines=kernel._source_lines,
+            synthetic_args=synthetic_args,
+            synthetic_arg_insert_index=len(input_lts),
         )
         compiler.visit(kernel._ast)
         compiler.module.operation.verify()
@@ -800,7 +843,7 @@ def _emit_kernel_generic(
         # Scalars are sourced from func args (not host-scope constants) so the
         # GenericOp's region stays isolated-from-above.
         additional = [b.add_scalar_input(s) for s in scalar_args]
-        inputs = [lt.value for lt in input_lts]
+        inputs = [lt.value for lt in input_lts] + [lt.value for lt in synthetic_lts]
         outputs = [lt.value for lt in output_lts]
         output_types = [v.type for v in outputs]
 

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ttmlir.ir import *
-from ttmlir.dialects import d2m, arith, linalg
+from ttmlir.dialects import d2m, arith, linalg, ttcore
 
 from ._src.utils import _asindex
 from ._src.ast import D2MCompiler, syntax
@@ -26,6 +26,7 @@ from ._src.builder import (
     view,
     permute,
     to_host,
+    _REDUCE_SCALER_ARG,
 )
 
 
@@ -434,6 +435,36 @@ def matmul(lhs, rhs):
     return _matmul_block(lhs, rhs)
 
 
+@syntax("reduce_sum")
+def reduce_sum(input, dim):
+    """Block-level float sum reduction over one tile axis.
+
+    `dim` follows torch/numpy axis numbering for a 2D tile block:
+    `0` reduces rows and `1` reduces columns.
+    """
+    return _reduce_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_sum(a.type, a, b, c, reduce_dim),
+        input,
+        dim,
+        0.0,
+    )
+
+
+@syntax("reduce_max")
+def reduce_max(input, dim):
+    """Block-level float max reduction over one tile axis.
+
+    `dim` follows torch/numpy axis numbering for a 2D tile block:
+    `0` reduces rows and `1` reduces columns.
+    """
+    return _reduce_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_max(a.type, a, b, c, reduce_dim),
+        input,
+        dim,
+        float("-inf"),
+    )
+
+
 @syntax("!tensor")
 class TensorBlock:
     """The DSL-side host class for a tile-typed tensor block.
@@ -698,6 +729,14 @@ class TensorBlock:
         """Same as `d2m.matmul(self, rhs)`."""
         return matmul(ast_self, rhs)
 
+    def reduce_sum(ast_self: TensorBlock, dim) -> TensorBlock:
+        """Same as `d2m.reduce_sum(self, dim)`."""
+        return reduce_sum(ast_self, dim)
+
+    def reduce_max(ast_self: TensorBlock, dim) -> TensorBlock:
+        """Same as `d2m.reduce_max(self, dim)`."""
+        return reduce_max(ast_self, dim)
+
     def store(ast_self: TensorBlock, rhs: TensorBlock) -> TensorBlock:
         return d2m.store(ast_self, rhs)
 
@@ -772,6 +811,123 @@ def _eltwise_block(tile_op_fn, *blocks):
     body = Block.create_at_start(generic.regions[0], body_arg_tys, body_arg_locs)
     with InsertionPoint(body):
         result = tile_op_fn(*body.arguments[: len(blocks)])
+        if hasattr(result, "result"):
+            result = result.result
+        linalg.yield_([result])
+    return generic.result
+
+
+def _dim_to_reduce_dim_attr(dim):
+    if isinstance(dim, arith.ConstantOp):
+        dim = IntegerAttr(dim.value).value
+    elif isinstance(dim, IntegerAttr):
+        dim = dim.value
+    elif isinstance(dim, Attribute):
+        return dim
+
+    if dim in (0, -2):
+        return Attribute.parse("#d2m<reduce_dim C>")
+    if dim in (1, -1):
+        return Attribute.parse("#d2m<reduce_dim R>")
+    raise ValueError(f"reduce dim must be 0/1 or -2/-1, got {dim}")
+
+
+def _float_scalar_type_for_tile(tile_type):
+    ctx = tile_type.context
+    tile_type = ttcore.ir.TileType.maybe_downcast(tile_type)
+    if tile_type is None:
+        raise TypeError(f"expected a ttcore.tile element type, got {tile_type}")
+    data_type = tile_type.data_type_as_int
+    if data_type == int(ttcore.DataType.Float32):
+        return F32Type.get(ctx)
+    if data_type == int(ttcore.DataType.Float16):
+        return F16Type.get(ctx)
+    if data_type == int(ttcore.DataType.BFloat16):
+        return BF16Type.get(ctx)
+    raise TypeError(
+        "float reductions require f32, f16, or bf16 tile element types; "
+        f"got {tile_type}"
+    )
+
+
+def _tile_fill_float(tile_type, value):
+    scalar_type = _float_scalar_type_for_tile(tile_type)
+    scalar_attr = FloatAttr.get(scalar_type, value)
+    scalar = arith.ConstantOp(scalar_type, scalar_attr).result
+    return d2m.tile_fill(tile_type, scalar)
+
+
+def _get_reduce_scaler_block(input_block):
+    compiler = D2MCompiler.current()
+    if compiler is None:
+        raise RuntimeError("reduce_sum/reduce_max can only be used inside @kernel")
+
+    key = (str(input_block.type.element_type), id(InsertionPoint.current.block))
+    cached = compiler.reduce_scaler_cache.get(key)
+    if cached is not None:
+        return cached
+
+    scaler = compiler.get_synthetic_arg(_REDUCE_SCALER_ARG)
+    if scaler is None:
+        raise RuntimeError("internal error: missing synthetic reduction scaler")
+
+    zero = arith.ConstantOp(IndexType.get(scaler.context), 0).result
+    scaler_block = remote_load(scaler, [zero, zero])
+    if scaler_block.type.element_type != input_block.type.element_type:
+        raise TypeError(
+            "reduction scaler tile type mismatch: "
+            f"{scaler_block.type.element_type} vs {input_block.type.element_type}"
+        )
+    compiler.reduce_scaler_cache[key] = scaler_block
+    return scaler_block
+
+
+def _reduce_block(tile_op_fn, input, dim, identity_value):
+    """Wrap a float d2m.tile_reduce_* op in a per-block linalg.generic.
+
+    The generated result has the same block shape as `input`. The reduction is
+    within each tile; lanes outside the reduced row/column follow the hardware
+    tile_reduce_* result layout.
+    """
+    block_ty = input.type
+    if not isinstance(block_ty, RankedTensorType):
+        raise TypeError(f"reduce input must be a ranked tensor, got {block_ty}")
+
+    rank = block_ty.rank
+    elem_ty = block_ty.element_type
+    reduce_dim = _dim_to_reduce_dim_attr(dim)
+    scaler = _get_reduce_scaler_block(input)
+
+    output = d2m.empty(block_ty)
+    identity = AffineMap.get_identity(rank)
+    zero = AffineConstantExpr.get(0)
+    scaler_map = AffineMap.get(rank, 0, [zero, zero])
+    indexing_maps = ArrayAttr.get(
+        [
+            AffineMapAttr.get(identity),
+            AffineMapAttr.get(scaler_map),
+            AffineMapAttr.get(identity),
+        ]
+    )
+    parallel = Attribute.parse("#linalg.iterator_type<parallel>")
+    iterator_types = ArrayAttr.get([parallel] * rank)
+
+    generic = linalg.GenericOp(
+        [block_ty],
+        [input, scaler],
+        [output],
+        indexing_maps,
+        iterator_types,
+    )
+    body = Block.create_at_start(
+        generic.regions[0],
+        [elem_ty, elem_ty, elem_ty],
+        [Location.unknown()] * 3,
+    )
+    with InsertionPoint(body):
+        input_tile, scaler_tile, _ = body.arguments
+        accumulator = _tile_fill_float(elem_ty, identity_value)
+        result = tile_op_fn(input_tile, scaler_tile, accumulator, reduce_dim)
         if hasattr(result, "result"):
             result = result.result
         linalg.yield_([result])

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import ast as _ast
+
 from ttmlir.ir import *
 from ttmlir.dialects import d2m, arith, linalg, ttcore
 
@@ -26,7 +28,8 @@ from ._src.builder import (
     view,
     permute,
     to_host,
-    _REDUCE_SCALER_ARG,
+    _REDUCE_MEAN_SCALER_ARG,
+    _REDUCE_UNIT_SCALER_ARG,
 )
 
 
@@ -435,7 +438,22 @@ def matmul(lhs, rhs):
     return _matmul_block(lhs, rhs)
 
 
-@syntax("reduce_sum")
+def _int_attr_from_ast(node):
+    if isinstance(node, _ast.Constant) and isinstance(node.value, int):
+        value = node.value
+    elif (
+        isinstance(node, _ast.UnaryOp)
+        and isinstance(node.op, _ast.USub)
+        and isinstance(node.operand, _ast.Constant)
+        and isinstance(node.operand.value, int)
+    ):
+        value = -node.operand.value
+    else:
+        raise TypeError("expected integer literal")
+    return IntegerAttr.get(IntegerType.get_signless(64), value)
+
+
+@syntax("reduce_sum", args_as_attr=[False, _int_attr_from_ast])
 def reduce_sum(input, dim):
     """Block-level float sum reduction over one tile axis.
 
@@ -446,11 +464,12 @@ def reduce_sum(input, dim):
         lambda a, b, c, reduce_dim: d2m.tile_reduce_sum(a.type, a, b, c, reduce_dim),
         input,
         dim,
+        _REDUCE_UNIT_SCALER_ARG,
         0.0,
     )
 
 
-@syntax("reduce_max")
+@syntax("reduce_max", args_as_attr=[False, _int_attr_from_ast])
 def reduce_max(input, dim):
     """Block-level float max reduction over one tile axis.
 
@@ -461,7 +480,24 @@ def reduce_max(input, dim):
         lambda a, b, c, reduce_dim: d2m.tile_reduce_max(a.type, a, b, c, reduce_dim),
         input,
         dim,
+        _REDUCE_UNIT_SCALER_ARG,
         float("-inf"),
+    )
+
+
+@syntax("reduce_mean", args_as_attr=[False, _int_attr_from_ast])
+def reduce_mean(input, dim):
+    """Block-level float mean reduction over one tile axis.
+
+    `dim` follows torch/numpy axis numbering for a 2D tile block:
+    `0` reduces rows and `1` reduces columns.
+    """
+    return _reduce_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_mean(a.type, a, b, c, reduce_dim),
+        input,
+        dim,
+        _REDUCE_MEAN_SCALER_ARG,
+        0.0,
     )
 
 
@@ -737,6 +773,10 @@ class TensorBlock:
         """Same as `d2m.reduce_max(self, dim)`."""
         return reduce_max(ast_self, dim)
 
+    def reduce_mean(ast_self: TensorBlock, dim) -> TensorBlock:
+        """Same as `d2m.reduce_mean(self, dim)`."""
+        return reduce_mean(ast_self, dim)
+
     def store(ast_self: TensorBlock, rhs: TensorBlock) -> TensorBlock:
         return d2m.store(ast_self, rhs)
 
@@ -857,17 +897,23 @@ def _tile_fill_float(tile_type, value):
     return d2m.tile_fill(tile_type, scalar)
 
 
-def _get_reduce_scaler_block(input_block):
+def _get_reduce_scaler_block(input_block, scaler_arg_name):
     compiler = D2MCompiler.current()
     if compiler is None:
-        raise RuntimeError("reduce_sum/reduce_max can only be used inside @kernel")
+        raise RuntimeError(
+            "reduce_sum/reduce_max/reduce_mean can only be used inside @kernel"
+        )
 
-    key = (str(input_block.type.element_type), id(InsertionPoint.current.block))
+    key = (
+        scaler_arg_name,
+        str(input_block.type.element_type),
+        id(InsertionPoint.current.block),
+    )
     cached = compiler.reduce_scaler_cache.get(key)
     if cached is not None:
         return cached
 
-    scaler = compiler.get_synthetic_arg(_REDUCE_SCALER_ARG)
+    scaler = compiler.get_synthetic_arg(scaler_arg_name)
     if scaler is None:
         raise RuntimeError("internal error: missing synthetic reduction scaler")
 
@@ -882,7 +928,7 @@ def _get_reduce_scaler_block(input_block):
     return scaler_block
 
 
-def _reduce_block(tile_op_fn, input, dim, identity_value):
+def _reduce_block(tile_op_fn, input, dim, scaler_arg_name, identity_value):
     """Wrap a float d2m.tile_reduce_* op in a per-block linalg.generic.
 
     The generated result has the same block shape as `input`. The reduction is
@@ -896,7 +942,7 @@ def _reduce_block(tile_op_fn, input, dim, identity_value):
     rank = block_ty.rank
     elem_ty = block_ty.element_type
     reduce_dim = _dim_to_reduce_dim_attr(dim)
-    scaler = _get_reduce_scaler_block(input)
+    scaler = _get_reduce_scaler_block(input, scaler_arg_name)
 
     output = d2m.empty(block_ty)
     identity = AffineMap.get_identity(rank)


### PR DESCRIPTION
## Summary
- Add d2m-jit block-level float reduction support coverage for `reduce_sum`, `reduce_max`, and `reduce_mean`, including synthetic scaler handling for unit vs mean reductions.
- Add lit IR-shape coverage and expanded on-device pytest coverage for reduction free-function, method, temporary, and negative-dim forms.
- Update d2m-jit README, audit notes, TODOs, and docs index/tool page to describe the supported reduction surface and remaining gaps.

## Test plan
- `source env/activate && cmake --build build --target d2m-jit && llvm-lit -v build/test/d2m-jit/lit/reductions.py && pytest -q test/d2m-jit/test_reductions.py`
- `source env/activate && llvm-lit -v build/test/d2m-jit/lit`
- `source env/activate && pytest -q test/d2m-jit`


Made with [Cursor](https://cursor.com)