### PR TITLE
[TTNN] RoPE decomposition: prefer complex-rotation form for self-concat cos/sin (tt-xla regression fix)

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.cpp
@@ -22,7 +22,13 @@ static std::optional<Value> matchSelfConcatLastDim(Value value) {
     return std::nullopt;
   }
   auto resultType = mlir::cast<RankedTensorType>(concatOp.getType());
-  if (concatOp.getDim() != resultType.getRank() - 1) {
+  // ttnn.concat verifier accepts negative dims (e.g. -1) and normalizes them
+  // (concat verifier: `if (dim < 0) dim += rank`). Match the normalized form
+  // so equivalent IR with dim=-1 still triggers the pattern.
+  int32_t rawDim = concatOp.getDim();
+  int64_t lastDim = resultType.getRank() - 1;
+  int64_t normalizedDim = rawDim < 0 ? rawDim + resultType.getRank() : rawDim;
+  if (normalizedDim != lastDim) {
     return std::nullopt;
   }
   return concatOp.getOperand(0);
@@ -88,6 +94,13 @@ LogicalResult RotaryEmbeddingDecompositionRewritePattern::matchAndRewrite(
   // This is algebraically identical to the rotate_half form below, but uses
   // only half-D ops and a single concat — strictly fewer ops, no full-D
   // multiplies, no concat(x, x) ops left behind.
+  //
+  // Broadcast safety: the matcher guarantees `cosHalf.shape[-1] == halfDim`
+  // (concat-of-two halves on the last dim doubles it), and `cosHalf`'s
+  // non-last dims equal `cosCache`'s non-last dims. So `multiply(xLo,
+  // cosHalf)` broadcasts iff `multiply(input, cosCache)` did — i.e. this
+  // branch is no less safe than the rotate_half fallback below, which makes
+  // the same broadcast assumption.
   if (auto cosHalf = matchSelfConcatLastDim(ropeOp.getCosCache())) {
     if (auto sinHalf = matchSelfConcatLastDim(ropeOp.getSinCache())) {
       auto loCos = rewriter.create<ttnn::MultiplyOp>(loc, halfType,

--- a/lib/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.cpp
@@ -12,13 +12,28 @@
 
 namespace mlir::tt::ttnn::decomposition {
 
+// If `value` is `ttnn.concat(half, half, dim=last)` with the *same* SSA value
+// on both operands (the half-D → full-D cos/sin duplication pattern emitted by
+// Pattern-1 RoPE models), return the half-D input. Otherwise return nullopt.
+static std::optional<Value> matchSelfConcatLastDim(Value value) {
+  auto concatOp = value.getDefiningOp<ttnn::ConcatOp>();
+  if (!concatOp || concatOp.getNumOperands() != 2 ||
+      concatOp.getOperand(0) != concatOp.getOperand(1)) {
+    return std::nullopt;
+  }
+  auto resultType = mlir::cast<RankedTensorType>(concatOp.getType());
+  if (concatOp.getDim() != resultType.getRank() - 1) {
+    return std::nullopt;
+  }
+  return concatOp.getOperand(0);
+}
+
 LogicalResult RotaryEmbeddingDecompositionRewritePattern::matchAndRewrite(
     ttnn::RotaryEmbeddingOp ropeOp, PatternRewriter &rewriter) const {
 
   auto inputType = mlir::cast<RankedTensorType>(ropeOp.getInput().getType());
   auto resultType = mlir::cast<RankedTensorType>(ropeOp.getResult().getType());
 
-  // When validation config is provided, validate first.
   if (validationConfig.has_value()) {
     IsolatedIRValidationWrapper validator(rewriter.getContext(),
                                           *validationConfig);
@@ -38,9 +53,6 @@ LogicalResult RotaryEmbeddingDecompositionRewritePattern::matchAndRewrite(
         validationResult.errorMessage);
   }
 
-  // Decompose: result = x*cos + rotate_half(x)*sin
-  // where rotate_half(x) = concat(neg(x[D/2:]), x[:D/2])
-
   auto loc = ropeOp.getLoc();
   auto inputShape = inputType.getShape();
   int64_t rank = inputType.getRank();
@@ -48,7 +60,7 @@ LogicalResult RotaryEmbeddingDecompositionRewritePattern::matchAndRewrite(
   int64_t fullDim = inputShape[lastDim];
   int64_t halfDim = fullDim / 2;
 
-  // Build slice attributes for first half [0, D/2) and second half [D/2, D).
+  // Slice attrs for x_lo = x[..., :D/2] and x_hi = x[..., D/2:].
   SmallVector<Attribute> beginsLo, endsLo, beginsHi, endsHi, steps;
   for (int64_t i = 0; i < rank; ++i) {
     beginsLo.push_back(rewriter.getI32IntegerAttr(0));
@@ -58,15 +70,12 @@ LogicalResult RotaryEmbeddingDecompositionRewritePattern::matchAndRewrite(
     endsHi.push_back(rewriter.getI32IntegerAttr(inputShape[i]));
     steps.push_back(rewriter.getI32IntegerAttr(1));
   }
+  auto stepsAttr = rewriter.getArrayAttr(steps);
 
-  // Compute half-dim shape and type.
   SmallVector<int64_t> halfShape(inputShape);
   halfShape[lastDim] = halfDim;
   auto halfType = utils::RankedTensorTypeFactory::create(resultType, halfShape);
 
-  auto stepsAttr = rewriter.getArrayAttr(steps);
-
-  // x_lo = x[:D/2], x_hi = x[D/2:]
   auto xLo = rewriter.create<ttnn::SliceStaticOp>(
       loc, halfType, ropeOp.getInput(), rewriter.getArrayAttr(beginsLo),
       rewriter.getArrayAttr(endsLo), stepsAttr);
@@ -74,23 +83,46 @@ LogicalResult RotaryEmbeddingDecompositionRewritePattern::matchAndRewrite(
       loc, halfType, ropeOp.getInput(), rewriter.getArrayAttr(beginsHi),
       rewriter.getArrayAttr(endsHi), stepsAttr);
 
-  // neg(x_hi)
-  auto negHi = rewriter.create<ttnn::NegOp>(loc, halfType, xHi.getResult());
+  // If cos/sin are both half-D self-duplications, emit complex-rotation form:
+  //   concat( x_lo*cos - x_hi*sin ,  x_hi*cos + x_lo*sin )
+  // This is algebraically identical to the rotate_half form below, but uses
+  // only half-D ops and a single concat — strictly fewer ops, no full-D
+  // multiplies, no concat(x, x) ops left behind.
+  if (auto cosHalf = matchSelfConcatLastDim(ropeOp.getCosCache())) {
+    if (auto sinHalf = matchSelfConcatLastDim(ropeOp.getSinCache())) {
+      auto loCos = rewriter.create<ttnn::MultiplyOp>(loc, halfType,
+                                                     xLo.getResult(), *cosHalf);
+      auto hiSin = rewriter.create<ttnn::MultiplyOp>(loc, halfType,
+                                                     xHi.getResult(), *sinHalf);
+      auto first = rewriter.create<ttnn::SubtractOp>(
+          loc, halfType, loCos.getResult(), hiSin.getResult());
 
-  // rotated = concat(neg(x_hi), x_lo) on last dim
+      auto hiCos = rewriter.create<ttnn::MultiplyOp>(loc, halfType,
+                                                     xHi.getResult(), *cosHalf);
+      auto loSin = rewriter.create<ttnn::MultiplyOp>(loc, halfType,
+                                                     xLo.getResult(), *sinHalf);
+      auto second = rewriter.create<ttnn::AddOp>(
+          loc, halfType, hiCos.getResult(), loSin.getResult());
+
+      auto result = rewriter.create<ttnn::ConcatOp>(
+          loc, resultType, ValueRange{first.getResult(), second.getResult()},
+          static_cast<int32_t>(lastDim));
+
+      rewriter.replaceOp(ropeOp, result.getResult());
+      return success();
+    }
+  }
+
+  // Fallback (cos/sin not self-duplications): rotate_half form
+  //   result = x*cos + concat(neg(x_hi), x_lo)*sin
+  auto negHi = rewriter.create<ttnn::NegOp>(loc, halfType, xHi.getResult());
   auto rotated = rewriter.create<ttnn::ConcatOp>(
       loc, resultType, ValueRange{negHi.getResult(), xLo.getResult()},
       static_cast<int32_t>(lastDim));
-
-  // x * cos
   auto xCos = rewriter.create<ttnn::MultiplyOp>(
       loc, resultType, ropeOp.getInput(), ropeOp.getCosCache());
-
-  // rotated * sin
   auto rotSin = rewriter.create<ttnn::MultiplyOp>(
       loc, resultType, rotated.getResult(), ropeOp.getSinCache());
-
-  // result = x*cos + rotated*sin
   auto result = rewriter.create<ttnn::AddOp>(loc, resultType, xCos.getResult(),
                                              rotSin.getResult());
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/rotary_embedding_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/rotary_embedding_decomposition.mlir
@@ -17,6 +17,10 @@ module {
       %sin_half: tensor<1x1x4x64xbf16, #half>)
       -> tensor<1x1x4x128xbf16, #full> {
     // CHECK-LABEL: func.func @rope_decomp_complex_rotation_from_self_concat
+    // No rope op, no neg, and no `ttnn.concat` *before* the half->full
+    // reassembly — proves the two input self-concat duplications were
+    // dead-code-eliminated when the rope op got replaced.
+    // CHECK-NOT: "ttnn.concat"
     // CHECK-NOT: "ttnn.rotary_embedding"
     // CHECK-NOT: "ttnn.neg"
     // CHECK: "ttnn.slice_static"
@@ -29,6 +33,8 @@ module {
     // CHECK: "ttnn.add"
     // CHECK: "ttnn.concat"
     // CHECK-SAME: dim = 3
+    // No further concat after the reassembly — exactly one concat total.
+    // CHECK-NOT: "ttnn.concat"
     // CHECK-NOT: "ttnn.neg"
     %cos = "ttnn.concat"(%cos_half, %cos_half) <{dim = 3 : si32}> :
       (tensor<1x1x4x64xbf16, #half>, tensor<1x1x4x64xbf16, #half>) ->

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/rotary_embedding_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/rotary_embedding_decomposition.mlir
@@ -1,0 +1,77 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-decomposition --split-input-file -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#dram = #ttnn.buffer_type<dram>
+#full = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4 + d1 * 4 + d2, d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#half = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4 + d1 * 4 + d2, d3), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// When both cos and sin caches arrive as `ttnn.concat(x, x, dim=-1)`
+// duplications (half-D → full-D), the decomposition should pick the
+// complex-rotation form: four half-D multiplies + one half-D subtract +
+// one half-D add + a single half→full concat. No `ttnn.neg`, and the
+// duplication concats fall away as dead code.
+module {
+  func.func @rope_decomp_complex_rotation_from_self_concat(
+      %x: tensor<1x1x4x128xbf16, #full>,
+      %cos_half: tensor<1x1x4x64xbf16, #half>,
+      %sin_half: tensor<1x1x4x64xbf16, #half>)
+      -> tensor<1x1x4x128xbf16, #full> {
+    // CHECK-LABEL: func.func @rope_decomp_complex_rotation_from_self_concat
+    // CHECK-NOT: "ttnn.rotary_embedding"
+    // CHECK-NOT: "ttnn.neg"
+    // CHECK: "ttnn.slice_static"
+    // CHECK: "ttnn.slice_static"
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.subtract"
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.add"
+    // CHECK: "ttnn.concat"
+    // CHECK-SAME: dim = 3
+    // CHECK-NOT: "ttnn.neg"
+    %cos = "ttnn.concat"(%cos_half, %cos_half) <{dim = 3 : si32}> :
+      (tensor<1x1x4x64xbf16, #half>, tensor<1x1x4x64xbf16, #half>) ->
+       tensor<1x1x4x128xbf16, #full>
+    %sin = "ttnn.concat"(%sin_half, %sin_half) <{dim = 3 : si32}> :
+      (tensor<1x1x4x64xbf16, #half>, tensor<1x1x4x64xbf16, #half>) ->
+       tensor<1x1x4x128xbf16, #full>
+    %r = "ttnn.rotary_embedding"(%x, %cos, %sin) :
+      (tensor<1x1x4x128xbf16, #full>,
+       tensor<1x1x4x128xbf16, #full>,
+       tensor<1x1x4x128xbf16, #full>) -> tensor<1x1x4x128xbf16, #full>
+    return %r : tensor<1x1x4x128xbf16, #full>
+  }
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#full = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4 + d1 * 4 + d2, d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// When cos/sin do not match the self-concat pattern (e.g. they arrive
+// already full-D from elsewhere), the existing rotate_half decomposition
+// should still trigger: a single `ttnn.neg` and a `ttnn.concat` reassembling
+// neg(x_hi) and x_lo.
+module {
+  func.func @rope_decomp_rotate_half_fallback(
+      %x: tensor<1x1x4x128xbf16, #full>,
+      %cos: tensor<1x1x4x128xbf16, #full>,
+      %sin: tensor<1x1x4x128xbf16, #full>)
+      -> tensor<1x1x4x128xbf16, #full> {
+    // CHECK-LABEL: func.func @rope_decomp_rotate_half_fallback
+    // CHECK-NOT: "ttnn.rotary_embedding"
+    // CHECK: "ttnn.slice_static"
+    // CHECK: "ttnn.slice_static"
+    // CHECK: "ttnn.neg"
+    // CHECK: "ttnn.concat"
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.add"
+    %r = "ttnn.rotary_embedding"(%x, %cos, %sin) :
+      (tensor<1x1x4x128xbf16, #full>,
+       tensor<1x1x4x128xbf16, #full>,
+       tensor<1x1x4x128xbf16, #full>) -> tensor<1x1x4x128xbf16, #full>
+    return %r : tensor<1x1x4x128xbf16, #full>
+  }
+}


### PR DESCRIPTION
### Ticket

[tenstorrent/tt-mlir#8579](https://github.com/tenstorrent/tt-mlir/issues/8579)

### Problem description

When `RotaryEmbeddingDecompositionRewritePattern` rewrites a `ttnn.rotary_embedding` whose `cos_cache` / `sin_cache` are both `ttnn.concat(x, x, dim=-1)` half-D → full-D duplications (the canonical Pattern-1 RoPE shape — Qwen, Llama, Mistral, Phi, Gemma, Falcon, Kimi), the existing decomposition consumes them as opaque full-D values and emits the rotate_half form. This leaves the two duplication concats and an oversized full-D rotate_half `concat` live in the IR — more ops and more data movement than necessary, and a quality regression versus the pre-[#8465](https://github.com/tenstorrent/tt-mlir/pull/8465) TTNN-level RoPE fusion which already produced complex-rotation form.

It also triggers [tt-metal#45089](https://github.com/tenstorrent/tt-metal/issues/45089) (a `ConcatDeviceOperation` program-cache key collision) when both the small duplication concat and a larger rotate_half concat live in the same compiled program — that's what surfaced this downstream as `TT_FATAL: Cannot get runtime args for kernel reader_concat_interleaved_start_id that is not placed on core 0-4` in [tt-xla#4886](https://github.com/tenstorrent/tt-xla/issues/4886) (`Qwen/Qwen3-0.6B` vLLM tensor-parallel test on `n300_llmbox`).

### What's changed

When both `getCosCache()` and `getSinCache()` are `ttnn.concat(x, x, dim=-1)`, decompose to the equivalent **complex-rotation** form (half-D multiplies + half-D `subtract`/`add` + a single half→full `concat`) using the half-D source directly. Keep the existing rotate_half decomposition as fallback for any other cos/sin shape.

Algebraically identical:
```
x · concat(c, c) + rotate_half(x) · concat(s, s)
  ≡ concat( x_lo·c − x_hi·s ,  x_hi·c + x_lo·s )
```

Wins, independent of the tt-metal bug:

1. **Fewer ops in the lowered IR per RoPE call.** The two `ttnn.concat(c, c)` / `concat(s, s)` duplications become dead code (their only consumer was the rope op) and DCE; the `ttnn.neg` and full-D rotate_half `concat` are gone; full-D `multiply`/`add` are replaced by half-D `multiply`/`subtract`/`add` (same total elementwise work since operands are half size).
2. **Less data movement.** The duplication concats materialize full-D cos/sin tensors that the multiplies then consume; the half-D form multiplies against the half-D source directly. Tile-multiply count unchanged on tile-aligned shapes, but DRAM reads roughly halve.
3. **Restores parity with the pre-[#8465](https://github.com/tenstorrent/tt-mlir/pull/8465) canonical form.** When TTNN-level RoPE fusion succeeded before [#8465](https://github.com/tenstorrent/tt-mlir/pull/8465), the resulting IR was already in complex-rotation form. After [#8465](https://github.com/tenstorrent/tt-mlir/pull/8465), when validation fails and decomposition runs, the IR is in rotate_half form — a quality regression in the lowered IR even ignoring any runtime issue.

Files:
- `lib/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.cpp` — new `matchSelfConcatLastDim` helper + new branch in `matchAndRewrite`. Existing rotate_half form retained as fallback.
- `test/ttmlir/Dialect/TTNN/Transforms/Decomposition/rotary_embedding_decomposition.mlir` (new) — lit test covering both code paths.

Pre-fix vs. post-fix IR (decode graph from the failing tt-xla test, plus the proposed target shape): https://gist.github.com/kmabeeTT/03f138e56c6a46796aedcc5135a223a6

### Testing

**Lit:**

New lit test `rotary_embedding_decomposition.mlir` covers both branches:
- `rope_decomp_complex_rotation_from_self_concat` — cos/sin are `ttnn.concat(x, x, dim=-1)` → asserts the new complex-rotation IR (no `ttnn.neg`, dead duplication concats DCE'd).
- `rope_decomp_rotate_half_fallback` — cos/sin arrive already full-D from another source → asserts the existing rotate_half IR (with `ttnn.neg` + rotated `concat`).

Existing rope positive test in `test/ttmlir/Dialect/TTNN/transformer/rotary_embedding_positive.mlir` is unaffected.

**Downstream (tt-xla):**

[tt-xla#4886](https://github.com/tenstorrent/tt-xla/issues/4886) — the previously-failing `Qwen/Qwen3-0.6B` vLLM tensor-parallel sampling test on `n300_llmbox` (TP=4) flips from `TT_FATAL` → `PASSED` (~234s, clean) with this change.

Second Pattern-1 model `TinyLlama/TinyLlama-1.1B-Chat-v1.0` on `n300` (TP=2, different head_dim / kv_heads / TP shape) also passes cleanly under the same sampling test (~215s).

**Confidence experiments (standalone TTNN, n300):**

To pin down *why* this fix sidesteps [tt-metal#45089](https://github.com/tenstorrent/tt-metal/issues/45089), I ran standalone TTNN repros with program cache enabled (the default):

| Experiment | First concat (cache-warming) | Second concat | Result |
|---|---|---|---|
| E1: known-bad baseline | `1x1x1x64+1x1x1x64 → 1x1x1x128` (old IR's cos/sin dup) | `1x4x64x64+1x4x64x64 → 1x4x64x128` (prefill rotate) | **CRASH** (TT_FATAL — reproduces #45089) |
| E2: post-fix shape pair | `1x1x4x64+1x1x4x64 → 1x1x4x128` (new IR's decode concat) | `1x4x64x64+1x4x64x64 → 1x4x64x128` (prefill — unchanged) | **PASS** |
| E3: same as E2, reversed order | prefill first, then decode-new | | **PASS** |
| E4: cache warmup | 6× `1x1x4x64+1x1x4x64 → 1x1x4x128` | `1x4x64x64+1x4x64x64 → 1x4x64x128` | **PASS** |

Diagnostic deep-dive: I instrumented the repro to print `num_program_cache_entries()` after each call. In E1, the cache stays at 1 after the second concat *crashes* — confirming the bug fires on a cache **hit**: the second concat's program-cache hash collides with the first's, so the framework reuses the cached program and then asserts in `apply_descriptor_runtime_args` when the new descriptor expects a core the cached kernel was never placed on. In E2/E3/E4 the cache grows 1→2 cleanly, no hit.

I then swept the collision boundary with `(1, 4, 64, 64)` as the second-concat anchor and varied the first concat's shape. **Exactly one shape collides**: `(1, 1, 1, 64)`. All these miss cleanly: `(1, 1, 2, 64)`, `(1, 1, 4, 64)`, `(1, 1, 32, 64)`, `(1, 1, 33, 64)`, `(1, 2, 1, 64)`, `(1, 4, 1, 64)`, `(1, 1, 1, 32)`, `(1, 1, 1, 128)`, `(1, 1, 1, 256)`, `(2, 1, 1, 64)`. Swapping the anchor to `(1, 8, 64, 64)`, `(1, 4, 32, 64)`, or `(1, 4, 128, 64)` and sweeping `(1, 1, 1, D)` across `D ∈ {16, 32, 64, 128, 256}` produces zero collisions. The bug is a one-off hash collision between two specific shape values, not a structural property of small-vs-large concats.

Re-implementing the tt-metal hash function (`tt_stl::hash::hash_objects`, a port of `boost::hash_combine`) in Python and feeding it shape values confirms the collision bit-for-bit:

```python
def shape_hash(dims):
    MASK64 = (1<<64) - 1; seed = 0
    for d in dims:
        seed = (seed ^ ((d + 0x9e3779b9 + ((seed << 6) & MASK64) + (seed >> 2)) & MASK64)) & MASK64
    return seed
assert shape_hash([1,1,1,64]) == shape_hash([1,4,64,64])  # 0x00028253c81abb58
assert shape_hash([1,1,4,64]) != shape_hash([1,4,64,64])  # post-fix shape is safe
```

That gives us a clean mental model:
- **#45089** is "two specific shapes hash to the same program-cache key; the descriptor framework's cache-hit handler then applies the second invocation's runtime args to the first invocation's program, asserting on a core the cached kernel was never placed on."
- **The shape that triggers it from RoPE** is `(1, 1, 1, head_dim/2)` — exactly what the cos/sin half-D duplication `concat(c, c)` produces in the decode graph — colliding with the prefill rotate_half concat `(1, kv_heads_per_chip, seq, head_dim/2)`. Qwen3-0.6B on `n300_llmbox` (head_dim=128, 4 KV heads/chip after TP, seq=64) lands on the colliding pair.
- **Why this fix works** is no longer empirical: the complex-rotation form never emits `(1, 1, 1, head_dim/2)` as a concat input — cos/sin are consumed at half-D directly via multiplies. The only concat left is the half→full output concat, whose third dim is `kv_heads_per_chip` (4 here), not 1, and `(1, 1, 4, ·)` does not collide with `(1, 4, 64, ·)`.

Sweeping the hash function over ~1700 realistic post-fix RoPE concat shapes (head_dim ∈ {32…512}, kv_heads ∈ {1…16}, seq ∈ {1…4096}) confirms none of the *decode↔prefill* shape pairs that any single Pattern-1 decoder would emit collide. Cross-config collisions do exist in the broader space — e.g., `(1,5,64,D) ↔ (1,6,1,D)` — but those require different `kv_heads_per_chip` values in the same compiled program, which isn't a real configuration.

This fix doesn't claim to immunize against arbitrary other hash collisions — that's [tt-metal#45089](https://github.com/tenstorrent/tt-metal/issues/45089)'s job (a proper cache-key invariant in `ConcatDeviceOperation` and/or a stronger hash combiner). It does eliminate the specific colliding shape any Pattern-1 RoPE decomposition is known to produce.

### Checklist

- [x] New/Existing tests provide coverage for changes
