### PR TITLE
[StableHLOToTTIR] Fix scatter index reshape when index_vector_dim is unaligned with update_window_dims

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -6881,36 +6881,59 @@ private:
 
   Value extractElementWiseScatterIndices(mlir::stablehlo::ScatterOp op,
                                          PatternRewriter &rewriter) const {
-    // Indices need to match updates tensor.
+    // Build an index tensor shape-aligned with the update tensor: size-1 at
+    // each update_window_dim, and the index batch dims (all dims except
+    // index_vector_dim) at the remaining positions. Window axes are then
+    // expanded via repeat.
     TypedValue<RankedTensorType> indexTensor = op.getScatterIndices();
     RankedTensorType updateType =
         mlir::cast<RankedTensorType>(op.getUpdates()[0].getType());
     RankedTensorType indexType = indexTensor.getType();
-    llvm::SmallVector<int64_t> indexShape(indexType.getShape());
+    ArrayRef<int64_t> origIndexShape = indexType.getShape();
     ArrayRef<int64_t> updateShape = updateType.getShape();
 
-    if (indexShape.size() < updateShape.size()) {
-      // Need to reshape indices by appending 1s to the shape.
-      llvm::SmallVector<int64_t> newShape(indexShape.begin(), indexShape.end());
-      newShape.resize(updateShape.size(), 1);
-
-      indexTensor = ttir::utils::createReshapeOp(rewriter, op.getLoc(),
-                                                 indexTensor, newShape);
-      indexType = mlir::cast<RankedTensorType>(indexTensor.getType());
-      indexShape = newShape;
-    }
-
-    // Repeat along update_window_dims to match update tensor shape.
+    int64_t indexVectorDim =
+        op.getScatterDimensionNumbers().getIndexVectorDim();
     ArrayRef<int64_t> updateWindowDims =
         op.getScatterDimensionNumbers().getUpdateWindowDims();
-    llvm::SmallVector<int64_t> repeatDims(indexShape.size(), 1);
-    bool needsRepeat = false;
 
-    // For each update_window_dim, set repeat factor to match update tensor
-    // size.
-    for (auto dimAttr : updateWindowDims) {
-      int64_t dim = dimAttr;
-      if (indexShape[dim] != updateShape[dim]) {
+    // Collect the scatter-batch dims of the original index tensor (all dims
+    // except index_vector_dim). For implicit index_vector_dim (== rank), no
+    // dim is excluded.
+    llvm::SmallVector<int64_t> indexBatchShape;
+    indexBatchShape.reserve(origIndexShape.size());
+    for (int64_t i = 0; i < static_cast<int64_t>(origIndexShape.size()); ++i) {
+      if (i != indexVectorDim) {
+        indexBatchShape.push_back(origIndexShape[i]);
+      }
+    }
+
+    // Compose the reshape target: size-1 at each update_window_dim, and the
+    // index batch dims at the remaining positions.
+    llvm::DenseSet<int64_t> windowDimSet(updateWindowDims.begin(),
+                                         updateWindowDims.end());
+    llvm::SmallVector<int64_t> reshapedIndexShape(updateShape.size(), 1);
+    size_t batchIdx = 0;
+    for (size_t i = 0; i < updateShape.size(); ++i) {
+      if (windowDimSet.contains(static_cast<int64_t>(i))) {
+        continue;
+      }
+      if (batchIdx < indexBatchShape.size()) {
+        reshapedIndexShape[i] = indexBatchShape[batchIdx++];
+      }
+    }
+
+    if (origIndexShape != ArrayRef<int64_t>(reshapedIndexShape)) {
+      indexTensor = ttir::utils::createReshapeOp(
+          rewriter, op.getLoc(), indexTensor, reshapedIndexShape);
+      indexType = mlir::cast<RankedTensorType>(indexTensor.getType());
+    }
+
+    // Repeat each update_window_dim from 1 up to updateShape[dim].
+    llvm::SmallVector<int64_t> repeatDims(updateShape.size(), 1);
+    bool needsRepeat = false;
+    for (int64_t dim : updateWindowDims) {
+      if (reshapedIndexShape[dim] != updateShape[dim]) {
         repeatDims[dim] = updateShape[dim];
         needsRepeat = true;
       }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
@@ -144,6 +144,27 @@ module @jit_scatter attributes {} {
         return %0 : tensor<2x4x3xbf16>
     }
 
+    func.func public @test_scatter_unaligned_index_vector_dim(%operand: tensor<3x394xi64>, %indices: tensor<394x1xi64>, %updates: tensor<3x394xi64>) -> tensor<3x394xi64> {
+        // CHECK-LABEL: func.func public @test_scatter_unaligned_index_vector_dim
+        // CHECK: [[RS:%[0-9]+]] = "ttir.reshape"(%arg1)
+        // CHECK-SAME: (tensor<394x1xi64>) -> tensor<1x394xi64>
+        // CHECK: [[RP:%[0-9]+]] = "ttir.repeat"([[RS]])
+        // CHECK-SAME: <{repeat_dimensions = array<i64: 3, 1>}> : (tensor<1x394xi64>) -> tensor<3x394xi64>
+        // CHECK: "ttir.scatter"(%arg0, [[RP]], %arg2)
+        // CHECK-SAME: <{dim = 1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}>
+        %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{
+          scatter_dimension_numbers = #stablehlo.scatter<
+            update_window_dims = [0],
+            inserted_window_dims = [1],
+            scatter_dims_to_operand_dims = [1],
+            index_vector_dim = 1>
+        }> ({
+        ^bb0(%a: tensor<i64>, %b: tensor<i64>):
+          stablehlo.return %b : tensor<i64>
+        }) : (tensor<3x394xi64>, tensor<394x1xi64>, tensor<3x394xi64>) -> tensor<3x394xi64>
+        return %0 : tensor<3x394xi64>
+    }
+
     func.func @test_multidim_scatter_with_window_extracted_from_model(%arg186: tensor<1x2xbf16>, %arg187: tensor<1xi64>, %arg188: tensor<1xi64>) -> (tensor<1x7x2xbf16>) {
         // CHECK: "ttir.scatter"
         // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>


### PR DESCRIPTION
### Ticket
[#4803](https://github.com/tenstorrent/tt-xla/issues/4803)

### Problem description
`StableHLOToTTIRScatterOpConversionPattern::extractElementWiseScatterIndices` lowers a `stablehlo.scatter` into a `ttir.scatter` whose index tensor is shape-aligned with the update tensor. To get that alignment, it inserts a ttir.reshape followed by a ttir.repeat that expands size-1 axes at each update_window_dim position. The existing logic only emitted the reshape when indices.rank < updates.rank, in which case it padded the index shape with trailing 1s. This assumed the size-1 axis at index_vector_dim always sits at a position aligned with an update_window_dim — true for the common (K, 1) → (K, D) layout, but false when the size-1 index_vector_dim lives at a non-window position and the index batch dim lives at a window position.
GLM image vision/text encoder's compute_3d_position_ids produces exactly this layout:

```
stablehlo.scatter(
  operand:  tensor<3x394xi64>,
  indices:  tensor<394x1xi64>,
  updates:  tensor<3x394xi64>
) <{
  update_window_dims       = [0],
  inserted_window_dims     = [1],
  scatter_dims_to_operand_dims = [1],
  index_vector_dim         = 1
}>
```
indices and updates are both rank 2, so no reshape was emitted. The lowering then tried to ttir.repeat (394, 1) to (3, 394) with repeat_dimensions = [3, 1] — invalid, since dim 0 of the input is already 394, not 1. The verifier failed with:

`loc("scatter.25"): error: 'ttir.repeat' op Input tensor shape (394,1) at index 0 does not repeat to output (3,394) using repeat value 3.`
The same shape-alignment hole would fire on any scatter whose index_vector_dim size-1 axis does not happen to coincide with an update_window_dim.

### What's changed
In `extractElementWiseScatterIndices`, the reshape target has been derived from the scatter dimension numbers instead of relying on rank-padding alone. Collect the index batch shape as origIndexShape minus the index_vector_dim axis, then build a target shape of rank updates.rank with size-1 at every update_window_dim position and the index batch dims at the remaining positions. Emit the ttir.reshape whenever the original index shape differs from this target. The subsequent ttir.repeat then only expands the size-1 window axes and remains correct in all layouts. Existing cases that previously needed no reshape (e.g. (K, 1) → (K, D) with update_window_dims = [1]) still produce a no-op alignment and emit only the repeat.

Added `test_scatter_unaligned_index_vector_dim` to `test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir `covering the unaligned-index_vector_dim case (operand 3x394xi64, indices 394x1xi64, updates 3x394xi64, update_window_dims = [0], scatter_dims_to_operand_dims = [1], index_vector_dim = 1), checking that the lowering emits ttir.reshape (394x1) → (1x394), ttir.repeat <repeat_dimensions = [3, 1]> (1x394) → (3x394), and ttir.scatter <dim = 1>.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs

[glm_image_vision_text_encoder_before_fix.log](https://github.com/user-attachments/files/28190088/glm_image_vision_text_encoder_before_fix.log)

[glm_vision_encoder_text_encoder_after_fix.log](https://github.com/user-attachments/files/28190101/glm_vision_encoder_text_encoder_after_fix.log)
