### PR TITLE
Fix #8582 - handle nan/inf/-inf values properly in ttir->cpu(emitpy)

### DIFF
--- a/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
+++ b/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
@@ -116,6 +116,14 @@ static SmallVector<int32_t, 4> getI32Quad(Attribute attr) {
 }
 
 static std::string formatAPFloat(llvm::APFloat value) {
+  // APFloat::toString prints non-finite values as "Inf"/"-Inf"/"NaN", which
+  // are not valid Python literals. Emit float('...') for those cases.
+  if (value.isInfinity()) {
+    return value.isNegative() ? "float('-inf')" : "float('inf')";
+  }
+  if (value.isNaN()) {
+    return "float('nan')";
+  }
   // Default precision (0) prints enough decimal digits that parsing the
   // string back yields the exact same float bits.
   llvm::SmallString<32> buf;

--- a/test/ttmlir/EmitPy/cpu_hoisted_full_nonfinite.mlir
+++ b/test/ttmlir/EmitPy/cpu_hoisted_full_nonfinite.mlir
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline -o %t.mlir %s
+// RUN: ttmlir-translate --mlir-to-python -o %t.py %t.mlir
+// RUN: FileCheck %s --input-file=%t.py
+
+// Full op with non-finite fill_value. Scalar FloatAttr holding inf/-inf/nan
+// must emit valid Python literals (float('inf'), float('-inf'), float('nan')),
+// not MLIR's textual form (Inf, -Inf, NaN), which would raise NameError at
+// import time.
+
+// CHECK-LABEL: def cpu_hoisted_ttir_full_{{.*}}
+// CHECK: ttir_cpu.full(
+// CHECK-SAME: fill_value=float('-inf')
+// CHECK-LABEL: def full_neg_inf_validation
+// CHECK: cpu_hoisted_ttir_full_{{.*}}
+func.func @full_neg_inf_validation(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %cpu_result = "ttir.full"() <{shape = array<i32: 32, 32>, fill_value = 0xFF800000 : f32}> {ttir.should_hoist} : () -> tensor<32x32xf32>
+  %out = "ttir.add"(%cpu_result, %arg0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %out : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: def cpu_hoisted_ttir_full_{{.*}}
+// CHECK: ttir_cpu.full(
+// CHECK-SAME: fill_value=float('inf')
+// CHECK-LABEL: def full_pos_inf_validation
+// CHECK: cpu_hoisted_ttir_full_{{.*}}
+func.func @full_pos_inf_validation(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %cpu_result = "ttir.full"() <{shape = array<i32: 32, 32>, fill_value = 0x7F800000 : f32}> {ttir.should_hoist} : () -> tensor<32x32xf32>
+  %out = "ttir.add"(%cpu_result, %arg0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %out : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: def cpu_hoisted_ttir_full_{{.*}}
+// CHECK: ttir_cpu.full(
+// CHECK-SAME: fill_value=float('nan')
+// CHECK-LABEL: def full_nan_validation
+// CHECK: cpu_hoisted_ttir_full_{{.*}}
+func.func @full_nan_validation(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %cpu_result = "ttir.full"() <{shape = array<i32: 32, 32>, fill_value = 0x7FC00000 : f32}> {ttir.should_hoist} : () -> tensor<32x32xf32>
+  %out = "ttir.add"(%cpu_result, %arg0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %out : tensor<32x32xf32>
+}


### PR DESCRIPTION
### Ticket
Closes #8582

### Problem description
Special float values (inf/-inf/nan) were not converted properly.

### What's changed
Now properly converted. Added a test

### Checklist
- [x] New/Existing tests provide coverage for changes
