### PR TITLE
[TTNN] Fix DistributedRMSNormWidthShardInput grid_size index on non-square grids

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
@@ -247,8 +247,15 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
   auto scalarShardShape = desiredInputLayout.getScalarShardShape();
   int64_t blockH = scalarShardShape[0] / tileWidth;
   int64_t blockW = scalarShardShape[1] / tileWidth;
-  int64_t gridW = std::min(numCores, physicalGrid[0]);
-  int64_t gridH = (numCores + physicalGrid[0] - 1) / physicalGrid[0];
+  // physicalGrid is [H, W]; canonical width-sharded placement (see
+  // deriveCanonicalL1CoreRangeSet) lays cores out row-major across the worker
+  // grid *width*, so grid_size must use [1] (W), not [0] (H). On square grids
+  // (Wormhole 8x8) both happen to be equal; on non-square grids (Blackhole
+  // p300c is 10x11 after harvesting) using [0] under-sizes grid_size.x and
+  // the strict `bbox.end - bbox.start < grid_size` assert in tt-metal's
+  // rms_allgather_device_operation.cpp:151 fires.
+  int64_t gridW = std::min(numCores, physicalGrid[1]);
+  int64_t gridH = (numCores + physicalGrid[1] - 1) / physicalGrid[1];
   auto programConfigAttr =
       ttnn::LayerNormShardedMultiCoreProgramConfigAttr::get(
           rewriter.getContext(),


### PR DESCRIPTION
`physicalGrid` is `[H, W]`, but `DistributedRMSNormWidthShardInputRewritePattern` was using `physicalGrid[0]` (height) when computing `compute_with_storage_grid_size.x`. Silent on square Wormhole grids; on Blackhole 10×11 it under-sizes `grid_size.x` and trips the strict `<` assert in tt-metal's fused `rms_allgather` kernel.

Fixes #8585.
