### PR TITLE
[TTIRToTTNN] Decompose integer ttnn.prod to avoid bf16 downcast

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/IntegerProdOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/IntegerProdOpRewritePattern.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_INTEGERPRODOPREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_INTEGERPRODOPREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// Works around a tt-metal bug where `ttnn.prod` computes internally in bf16,
+// silently rounding integer intermediates that lack an exact bf16
+// representation (e.g. 2204 -> 2208). Decomposes a single-dim `ttnn.prod`
+// on a statically-sized integer tensor into a chain of `ttnn.slice_static`
+// + `ttnn.multiply` (and a trailing `ttnn.reshape` when keep_dim=false) so
+// the computation stays in integer arithmetic. Remove once the metal-side
+// fix lands.
+// Issue: https://github.com/tenstorrent/tt-metal/issues/44942
+class IntegerProdOpRewritePattern : public OpRewritePattern<ttnn::ProdOp> {
+public:
+  using OpRewritePattern<ttnn::ProdOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::ProdOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_INTEGERPRODOPREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -61,6 +61,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
         Workarounds/Decomposition/GroupNormAffineReshapeRewritePattern.cpp
         Workarounds/Decomposition/GroupNormChannelPadRewritePattern.cpp
+        Workarounds/Decomposition/IntegerProdOpRewritePattern.cpp
         Workarounds/Decomposition/LinearOpRewritePattern.cpp
         Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.cpp
         Workarounds/Decomposition/ReduceScatterOpRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/IntegerProdOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/IntegerProdOpRewritePattern.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/IntegerProdOpRewritePattern.h"
+
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+static constexpr int64_t kMaxIntegerProdUnrollSize = 16;
+
+LogicalResult
+IntegerProdOpRewritePattern::matchAndRewrite(ttnn::ProdOp op,
+                                             PatternRewriter &rewriter) const {
+  // Only integer inputs hit the bf16 rounding bug; float prod is already
+  // exact enough through the metal kernel.
+  RankedTensorType inputType = op.getInput().getType();
+  Type elemType = inputType.getElementType();
+  if (!mlir::isa<IntegerType>(elemType)) {
+    return failure();
+  }
+
+  // The integer-prod bug doesn't surface on the full-tensor reduction path in
+  // practice, so we don't bother with a separate decomposition for it.
+  std::optional<int64_t> dimArg = op.getDimArg();
+  if (!dimArg) {
+    return failure();
+  }
+
+  int64_t inputRank = inputType.getRank();
+  int64_t reduceDim = *dimArg;
+  if (reduceDim < 0) {
+    reduceDim += inputRank;
+  }
+  if (reduceDim < 0 || reduceDim >= inputRank) {
+    return failure();
+  }
+
+  // Dynamic / non-positive sizes can't be unrolled statically.
+  ArrayRef<int64_t> inShape = inputType.getShape();
+  int64_t reduceSize = inShape[reduceDim];
+  if (reduceSize == ShapedType::kDynamic || reduceSize <= 0 ||
+      reduceSize > kMaxIntegerProdUnrollSize) {
+    return failure();
+  }
+
+  Location loc = op.getLoc();
+
+  // Reusing the size-1 slice shape as the type of every intermediate keeps the
+  // multiply chain shape-stable, so we only reshape once at the end.
+  SmallVector<int64_t> sliceShape(inShape.begin(), inShape.end());
+  sliceShape[reduceDim] = 1;
+  RankedTensorType sliceType =
+      ttnn::utils::RankedTensorTypeFactory::create(inputType, sliceShape);
+
+  SmallVector<int32_t> stepAttr(inputRank, 1);
+  auto makeSlice = [&](int64_t i) -> Value {
+    SmallVector<int32_t> begins(inputRank, 0);
+    SmallVector<int32_t> ends(inputRank);
+    for (int64_t d = 0; d < inputRank; ++d) {
+      ends[d] = static_cast<int32_t>(inShape[d]);
+    }
+    begins[reduceDim] = static_cast<int32_t>(i);
+    ends[reduceDim] = static_cast<int32_t>(i + 1);
+    return rewriter
+        .create<ttnn::SliceStaticOp>(
+            ttmlir::utils::appendLocationSuffix(loc, "_int_prod_slice_" +
+                                                         std::to_string(i)),
+            sliceType, op.getInput(), rewriter.getI32ArrayAttr(begins),
+            rewriter.getI32ArrayAttr(ends), rewriter.getI32ArrayAttr(stepAttr))
+        .getResult();
+  };
+
+  // A balanced tree would give shorter dependency chains, but at N <= 16 the
+  // extra IR machinery isn't worth it.
+  Value running = makeSlice(0);
+  for (int64_t i = 1; i < reduceSize; ++i) {
+    Value next = makeSlice(i);
+    running = rewriter
+                  .create<ttnn::MultiplyOp>(
+                      ttmlir::utils::appendLocationSuffix(
+                          loc, "_int_prod_mul_" + std::to_string(i)),
+                      sliceType, running, next)
+                  .getResult();
+  }
+
+  // `running` already has the reduce dim as size 1, so dropping it is a pure
+  // metadata reshape with no data movement.
+  if (!op.getKeepDim()) {
+    RankedTensorType outType = op.getResult().getType();
+    SmallVector<int32_t> outShapeI32;
+    outShapeI32.reserve(outType.getRank());
+    for (int64_t d : outType.getShape()) {
+      outShapeI32.push_back(static_cast<int32_t>(d));
+    }
+    running =
+        rewriter
+            .create<ttnn::ReshapeOp>(
+                ttmlir::utils::appendLocationSuffix(loc, "_int_prod_reshape"),
+                outType, running, rewriter.getI32ArrayAttr(outShapeI32))
+            .getResult();
+  }
+
+  rewriter.replaceOp(op, running);
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -21,6 +21,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/FillCacheInputPadRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormAffineReshapeRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormChannelPadRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/IntegerProdOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PadHighDimRewritePattern.h"
@@ -650,6 +651,7 @@ public:
           workarounds::decomposition::EmbeddingOpSqueezeWeightRewritePattern,
           workarounds::decomposition::GroupNormChannelPadRewritePattern,
           workarounds::decomposition::GroupNormAffineReshapeRewritePattern,
+          workarounds::decomposition::IntegerProdOpRewritePattern,
           workarounds::decomposition::ArgMaxOpDimRewritePattern,
           workarounds::decomposition::UpsampleOpBilinearPaddingRewritePattern,
           workarounds::decomposition::RotaryEmbeddingOpRewritePattern,

--- a/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
+++ b/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
@@ -1372,3 +1372,63 @@ def test_paged_sdpa_decode_l1_overflow_with_workaround(
         target=target,
         device=device,
     )
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # Reduce dim 4 with values whose product (2*2*19*29 = 2204) has no
+        # exact bf16 representation and rounds to 2208.
+        (1, 4),
+    ],
+    ids=shape_str,
+)
+@pytest.mark.parametrize("dtype", [torch.int32], ids=["si32"])
+@pytest.mark.parametrize("dim_arg", [[1]])
+@pytest.mark.parametrize("keep_dim", [False])
+@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.xfail(
+    reason="ttnn.prod computes internally in bf16; integer intermediates "
+    "without exact bf16 representation silently round (2204 -> 2208). "
+    "Without IntegerProdOpRewritePattern the integer reduction is not "
+    "decomposed into slice+multiply chain. "
+    "Metal issue: https://github.com/tenstorrent/tt-metal/issues/44942"
+)
+def test_prod_without_workaround(
+    shape: Shape,
+    dtype: torch.dtype,
+    dim_arg: List[int],
+    keep_dim: bool,
+    target: str,
+    request,
+    device,
+):
+    """
+    Test integer prod with workarounds disabled.
+    Workaround: IntegerProdOpRewritePattern - decomposes single-dim
+    `ttnn.prod` on integer tensors into a `ttnn.slice_static` +
+    `ttnn.multiply` chain so the computation stays in integer arithmetic.
+    Trigger condition: integer element type, single static dim_arg,
+    reduce-dim size <= 16.
+    """
+    torch_input = torch.tensor([[2, 2, 19, 29]], dtype=torch.int32)
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [dtype])
+        def prod_no_workaround_wrapper(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            builder.set_goldens({in0: torch_input})
+            return builder.prod(
+                in0, dim_arg=dim_arg, keep_dim=keep_dim, unit_attrs=unit_attrs
+            )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        pipeline_options=["enable-decomposition-workaround-pass=false"],
+    )

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/integer_prod_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/integer_prod_workaround.mlir
@@ -1,0 +1,21 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+
+module {
+  // CHECK-LABEL: @test_integer_prod
+  // CHECK-NOT: "ttnn.prod"
+  // CHECK: "ttnn.slice_static"
+  // CHECK: "ttnn.slice_static"
+  // CHECK: "ttnn.multiply"
+  // CHECK: "ttnn.slice_static"
+  // CHECK: "ttnn.multiply"
+  // CHECK: "ttnn.reshape"
+  func.func public @test_integer_prod(%arg0: tensor<1x3xsi32, #ttnn_layout>) -> tensor<1xsi32, #ttnn_layout1> {
+    %0 = "ttnn.prod"(%arg0) <{dim_arg = 1 : i64, keep_dim = false}> : (tensor<1x3xsi32, #ttnn_layout>) -> tensor<1xsi32, #ttnn_layout1>
+    return %0 : tensor<1xsi32, #ttnn_layout1>
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/44942)

### Problem description
ttnn.prod is implemented internally in bfloat16. bf16's 8-bit mantissa only represents integers exactly within [-256, 256], so reducing an integer tensor with ttnn.prod silently returns incorrect results once any intermediate product exceeds that range. Float prod is unaffected. This surfaces in various models including Qwen2.5_vl, qwen3.5,  where small integer reductions are used for shape/index arithmetic.

### What's changed
Adds IntegerProdOpRewritePattern to the --ttnn-workaround pass. When ttnn.prod is matched on an integer tensor with a single static reduce dimension, it is rewritten into:
- N ttnn.slice_static ops, each isolating one position along the reduce dim (size-1 slice, other dims unchanged).
- N-1 ttnn.multiply ops chained left-to-right over the slices.
- One trailing ttnn.reshape when keep_dim=false to drop the size-1 reduce dim (metadata only, no data movement).

**Match conditions:**
- Element type is IntegerType (float prod stays on the existing path).
- dim_arg is set (full-tensor reduction is left alone; the bug does not surface there in practice).
- Reduce-dim size is static and ≤ 16 to bound IR growth (each element generates one slice + one multiply).

### Checklist
- [ ] New/Existing tests provide coverage for changes
