### PR TITLE
Decompose distributed_rms_norm when the width-shard core grid would be non-rectangular.

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.h"
 
 #include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
@@ -39,6 +40,28 @@ bool isEligibleForFusedKernel(ttnn::DistributedRMSNormOp op) {
       return false;
     }
   }
+
+  // fused_rms_minimal deadlocks when the width-shard would land on a
+  // non-rectangular core grid. Mirror the numCores choice from
+  // DistributedRMSNormWidthShardInputRewritePattern and bail out so
+  // the explicit decomposition runs instead.
+  // tt-metal issue : https://github.com/tenstorrent/tt-metal/issues/45139
+  int64_t numWidthTiles = (shape.back() + TILE_WIDTH - 1) / TILE_WIDTH;
+  auto physicalGrid =
+      ttcore::getCurrentScopeSystemDesc(op).getChipDescs()[0].getGrid();
+  int64_t gridWidth = physicalGrid[0];
+  int64_t maxCores = physicalGrid[0] * physicalGrid[1];
+  int64_t numCores = 1;
+  for (int64_t c = std::min(maxCores, numWidthTiles); c >= 1; --c) {
+    if (numWidthTiles % c == 0) {
+      numCores = c;
+      break;
+    }
+  }
+  if (numCores > gridWidth && numCores % gridWidth != 0) {
+    return false;
+  }
+
   return true;
 }
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
@@ -7,6 +7,9 @@
 #ttnn_layout_supported = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout_supported_rank3 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout_unsupported_leading = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2 + d1, d2 * 128 + d3), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// last_dim = 896 → 28 width-tiles → non-rectangular shard on 8-wide grid.
+#ttnn_layout_nonrect = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 896 + d3), <1x1>, memref<1x28x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_weight_896 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x28x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
 // Test: Non-(1,1,32,M) shape decomposes into primitive ops.
 module @test_distributed_rms_norm_decomposition attributes {} {
@@ -91,6 +94,19 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
     %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x2x32x128xbf16, #ttnn_layout_unsupported_leading>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x2x32x128xbf16, #ttnn_layout_unsupported_leading>
     return %1 : tensor<1x2x32x128xbf16, #ttnn_layout_unsupported_leading>
+  }
+
+  func.func public @test_decompose_non_rectangular_shard(
+      %arg0: tensor<1x1x32x896xbf16, #ttnn_layout_nonrect>,
+      %arg1: tensor<896xbf16, #ttnn_layout_weight_896>) -> tensor<1x1x32x896xbf16, #ttnn_layout_nonrect> {
+    // CHECK-LABEL: func.func public @test_decompose_non_rectangular_shard
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.mean"
+    // CHECK: "ttnn.all_gather"
+    // CHECK-NOT: "ttnn.distributed_rms_norm"
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x32x896xbf16, #ttnn_layout_nonrect>, tensor<896xbf16, #ttnn_layout_weight_896>, !ttnn.device) -> tensor<1x1x32x896xbf16, #ttnn_layout_nonrect>
+    return %1 : tensor<1x1x32x896xbf16, #ttnn_layout_nonrect>
   }
 
   func.func public @test_decompose_with_residual(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/45139
https://github.com/tenstorrent/tt-xla/issues/4565

### Problem description
ttnn.distributed_rms_norm's fused kernel (fused_rms_minimal / rms_allgather) deadlocks when the width shard lands on a non-rectangular core grid. 
e.g. kimi-k2 decode batch=128 -> last_dim=896 -> 28 tiles -> on an 8-wide grid this is 8*3 + 4 (non-rectangular) -> first invocation hangs. 
Rectangular shards where numCores divides the grid width (e.g. Llama-70B) are unaffected.

### What's changed
Predict the numCores choice in the decomposition pass with the same logic the width-shard workaround uses, and bail out of the fused-kernel path when it would land on a non-rectangular grid, the op then takes the existing rms_norm + all_gather + ... decomposition. Frontend workaround until tt-metal fixes the kernel.

### Checklist
- [ ] New/Existing tests provide coverage for changes
