### PR TITLE
[TTNN] Enable `MeshPartition` layout workarounds with optimizer

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -751,5 +751,10 @@ const std::set<mlir::StringRef>
         ttnn::TopKOp::getOperationName(),
         // PrepareConv3dWeightsOp is needed for conv3d and it requires ROW_MAJOR
         // layout. See #8411.
-        ttnn::PrepareConv3dWeightsOp::getOperationName()};
+        ttnn::PrepareConv3dWeightsOp::getOperationName(),
+        // MeshPartition's operands and result workaround forces RowMajor inputs
+        // and outputs; without it, opt_level>=1 layout propagation picks Tiled.
+        // See #8558.
+        ttnn::MeshPartitionOp::getOperationName()};
+
 } // namespace mlir::tt::ttnn


### PR DESCRIPTION
### Ticket
#8558 

### Problem description
TTNN layout workarounds enforce `RowMajor` layout for `ttnn.mesh_parition` inputs and outputs.

However, with `optimization_level >= 1`, this workaround doesn't get triggered, since the op isn't explicitly allow-listed.

### What's changed
Added the `MeshPartitionOp` into `enabledOpsForWorkaroundWithOptimizer` set.

### Checklist
- [ ] New/Existing tests provide coverage for changes

<!-- xla-validate -->
---
### tt-xla Validation

**Base (uplifted):** `b4871ad1`

| Test Suite | Run | Status |
|------------|-----|--------|
| full-mlir-uplift-qualification.json | [Run #26408468395](https://github.com/tenstorrent/tt-xla/actions/runs/26408468395) | ✅  passed |
<!-- /xla-validate -->
