### PR TITLE
[D2M] Unify `DstAccess` data model in `InsertDstRegisterAccess`

### DIFF
--- a/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
+++ b/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
@@ -43,47 +43,70 @@ struct DstRegionOpClassification {
   bool hasMarkedAffineLoops = false;
 };
 
-template <typename LoadOrStoreTy>
-struct LoadStoreRecord {
-  LoadOrStoreTy loadStore = nullptr;
-  std::optional<d2m::TileBcastOp> bcast = std::nullopt;
+enum class DstAccessKind : uint8_t {
+  AffineLoad,
+  AffineStore,
+  MemrefLoad,
+  MemrefStore,
+};
+
+struct DstAccess {
+  Operation *op = nullptr;
+  DstAccessKind kind = DstAccessKind::AffineLoad;
   int dstSlice = -1;
+  std::optional<d2m::TileBcastOp> bcast = std::nullopt;
   SmallVector<Value> guardIVs = {};
 
-  LoadStoreRecord(LoadOrStoreTy loadStore,
-                  std::optional<d2m::TileBcastOp> bcast, int dstSlice,
-                  ArrayRef<Value> guardIVs)
-      : loadStore(loadStore), bcast(bcast), dstSlice(dstSlice),
-        guardIVs(guardIVs.begin(), guardIVs.end()) {}
+  DstAccess() = default;
+  DstAccess(Operation *opIn, DstAccessKind kindIn, int dstSliceIn,
+            std::optional<d2m::TileBcastOp> bcastIn, ArrayRef<Value> guardIVsIn)
+      : op(opIn), kind(kindIn), dstSlice(dstSliceIn), bcast(bcastIn),
+        guardIVs(guardIVsIn.begin(), guardIVsIn.end()) {}
+
+  bool isLoad() const {
+    return kind == DstAccessKind::AffineLoad ||
+           kind == DstAccessKind::MemrefLoad;
+  }
+  bool isStore() const {
+    return kind == DstAccessKind::AffineStore ||
+           kind == DstAccessKind::MemrefStore;
+  }
+  bool isAffine() const {
+    return kind == DstAccessKind::AffineLoad ||
+           kind == DstAccessKind::AffineStore;
+  }
+  bool isMemref() const {
+    return kind == DstAccessKind::MemrefLoad ||
+           kind == DstAccessKind::MemrefStore;
+  }
+
+  Location getLoc() const { return op->getLoc(); }
+  Value getMemRef() const;
+  MemRefType getMemRefType() const;
+
+  AffineMap getAffineMap() const;
+  ValueRange getAffineIndices() const;
+  ValueRange getMemrefIndices() const;
+
+  affine::AffineLoadOp getAsAffineLoad() const;
+  affine::AffineStoreOp getAsAffineStore() const;
+  memref::LoadOp getAsMemrefLoad() const;
+  memref::StoreOp getAsMemrefStore() const;
 };
 
 struct CopyInfo {
+  void record(DstAccess access);
+
   void record(affine::AffineLoadOp load, int dstSlice,
-              ArrayRef<Value> guardIVs) {
-    loads.emplace_back(load, std::nullopt, dstSlice, guardIVs);
-  }
-
+              ArrayRef<Value> guardIVs);
   void record(affine::AffineLoadOp load, d2m::TileBcastOp bcast, int dstSlice,
-              ArrayRef<Value> guardIVs) {
-    loads.emplace_back(load, bcast, dstSlice, guardIVs);
-  }
+              ArrayRef<Value> guardIVs);
+  void record(affine::AffineStoreOp store, int dstSlice, ArrayRef<Value>);
+  void record(memref::LoadOp load, int dstSlice, ArrayRef<Value> guardIVs);
+  void record(memref::StoreOp store, int dstSlice, ArrayRef<Value>);
 
-  void record(affine::AffineStoreOp store, int dstSlice, ArrayRef<Value>) {
-    stores.emplace_back(store, std::nullopt, dstSlice, ArrayRef<Value>{});
-  }
-
-  void record(memref::LoadOp load, int dstSlice, ArrayRef<Value> guardIVs) {
-    memrefLoads.emplace_back(load, std::nullopt, dstSlice, guardIVs);
-  }
-
-  void record(memref::StoreOp store, int dstSlice, ArrayRef<Value>) {
-    memrefStores.emplace_back(store, std::nullopt, dstSlice, ArrayRef<Value>{});
-  }
-
-  SmallVector<LoadStoreRecord<affine::AffineLoadOp>> loads;
-  SmallVector<LoadStoreRecord<affine::AffineStoreOp>> stores;
-  SmallVector<LoadStoreRecord<memref::LoadOp>> memrefLoads;
-  SmallVector<LoadStoreRecord<memref::StoreOp>> memrefStores;
+  SmallVector<DstAccess> loads;
+  SmallVector<DstAccess> stores;
 };
 
 // `MapVector` is used (instead of `DenseMap`) so that iteration order is
@@ -245,6 +268,23 @@ void collectDstLoadWithAccumAnalysis(memref::LoadOp loadOp, int64_t operandIdx,
                                      Operation *outermostInnerComputeLoop,
                                      bool noAccumGuard = false);
 
+void replaceLoadWithDst(PatternRewriter &rewriter, DstAccess &access, Value dst,
+                        AffineMap dstAccessMap, ValueRange dstAccessIndices);
+
+void replaceStoreWithDst(PatternRewriter &rewriter, DstAccess &access,
+                         Value dst, AffineMap dstAccessMap,
+                         ValueRange dstAccessIndices);
+
+void generateLoadSideCopy(PatternRewriter &rewriter, DstAccess &access,
+                          Value dst, AffineMap l1AccessMap,
+                          ValueRange l1AccessIndices, AffineMap dstAccessMap,
+                          ValueRange dstAccessIndices);
+
+void generateStoreSideCopy(PatternRewriter &rewriter, DstAccess &access,
+                           Value dst, AffineMap l1AccessMap,
+                           ValueRange l1AccessIndices, AffineMap dstAccessMap,
+                           ValueRange dstAccessIndices);
+
 scf::IfOp createLoadLoopGuard(PatternRewriter &rewriter, Location loc,
                               ValueRange guardIVs, bool isBcastGuard);
 
@@ -255,30 +295,14 @@ scf::IfOp createLoadLoopGuard(PatternRewriter &rewriter, Location loc,
 std::pair<Operation *, mlir::IRMapping>
 cloneAffineLoopSkeleton(PatternRewriter &rewriter, Operation *loopNestOrOp);
 
-// Shared "wrap a compute loop with a cloned CB<->DST copy nest" emitter
-// used by both the scheduled and unscheduled paths.
-//
-// For each record in `loadStoreRecords`, this:
-//   1. Emits a copy op via `copyGenerator` inside a clone of `loopNestOrOp`
-//      (the *shared* clone built once up front); records that carry a
-//      non-empty `guardIVs` get a fresh, per-record clone wrapped in an
-//      `scf.if` (accumulation / bcast init guard).
-//   2. Rewrites the original load/store via `accessReplacer` so it now
-//      goes through the DST register.
-//
-// `disableL1Acc=false` (i.e. L1 acc on) skips the upfront copy nest
-// entirely (the L1 acc guard preserves the running tile).
-template <typename LoadOrStoreTy>
-void emitDstCopyNest(
-    PatternRewriter &rewriter, Operation *loopNestOrOp,
-    ArrayRef<LoadStoreRecord<LoadOrStoreTy>> loadStoreRecords,
-    llvm::function_ref<void(PatternRewriter &, LoadStoreRecord<LoadOrStoreTy>,
-                            AffineMap, ValueRange, AffineMap, ValueRange)>
-        copyGenerator,
-    llvm::function_ref<void(PatternRewriter &, LoadStoreRecord<LoadOrStoreTy>,
-                            AffineMap, ValueRange)>
-        accessReplacer,
-    bool disableL1Acc = true);
+// Shared CB<->DST copy nest emitter used by both scheduled and unscheduled
+// paths.  When `cloneLoopNest` is true (unscheduled), affine accesses are
+// wrapped in a cloned affine.for skeleton; when false (scheduled in-place),
+// copy ops are emitted at each access site.  Memref accesses always use the
+// in-place path with a constant DST slice map.
+void emitDstCopyNest(PatternRewriter &rewriter, Operation *loopNestOrOp,
+                     Value dst, ArrayRef<DstAccess> accesses, bool isLoadSide,
+                     bool cloneLoopNest, bool disableL1Acc = true);
 
 std::pair<AffineMap, SmallVector<Value>>
 buildLinearizedDstAccess(PatternRewriter &rewriter, Operation *op, int dstSlice,
@@ -292,8 +316,7 @@ bool isDstScopeIV(Value iv, Operation *linalgRoot);
 
 std::tuple<AffineMap, SmallVector<Value>, AffineMap, SmallVector<Value>>
 buildIndices(PatternRewriter &rewriter, Location loc,
-             const mlir::IRMapping &irMapper, ValueRange currentIndices,
-             int dstSlice, AffineMap map, MemRefType cbType,
+             const mlir::IRMapping &irMapper, DstAccess &access,
              Operation *linalgRoot = nullptr);
 
 void insertPackerL1AccGuard(PatternRewriter &rewriter, Location loc,

--- a/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
+++ b/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
@@ -63,35 +63,18 @@ struct DstAccess {
       : op(opIn), kind(kindIn), dstSlice(dstSliceIn), bcast(bcastIn),
         guardIVs(guardIVsIn.begin(), guardIVsIn.end()) {}
 
-  bool isLoad() const {
-    return kind == DstAccessKind::AffineLoad ||
-           kind == DstAccessKind::MemrefLoad;
-  }
-  bool isStore() const {
-    return kind == DstAccessKind::AffineStore ||
-           kind == DstAccessKind::MemrefStore;
-  }
-  bool isAffine() const {
-    return kind == DstAccessKind::AffineLoad ||
-           kind == DstAccessKind::AffineStore;
-  }
-  bool isMemref() const {
-    return kind == DstAccessKind::MemrefLoad ||
-           kind == DstAccessKind::MemrefStore;
-  }
+  bool isLoad() const;
+  bool isStore() const;
+  bool isAffine() const;
+  bool isMemref() const;
 
-  Location getLoc() const { return op->getLoc(); }
+  Location getLoc() const;
   Value getMemRef() const;
   MemRefType getMemRefType() const;
 
   AffineMap getAffineMap() const;
   ValueRange getAffineIndices() const;
   ValueRange getMemrefIndices() const;
-
-  affine::AffineLoadOp getAsAffineLoad() const;
-  affine::AffineStoreOp getAsAffineStore() const;
-  memref::LoadOp getAsMemrefLoad() const;
-  memref::StoreOp getAsMemrefStore() const;
 };
 
 struct CopyInfo {
@@ -268,19 +251,20 @@ void collectDstLoadWithAccumAnalysis(memref::LoadOp loadOp, int64_t operandIdx,
                                      Operation *outermostInnerComputeLoop,
                                      bool noAccumGuard = false);
 
-void replaceLoadWithDst(PatternRewriter &rewriter, DstAccess &access, Value dst,
-                        AffineMap dstAccessMap, ValueRange dstAccessIndices);
+void replaceLoadWithDst(PatternRewriter &rewriter, const DstAccess &access,
+                        Value dst, AffineMap dstAccessMap,
+                        ValueRange dstAccessIndices);
 
-void replaceStoreWithDst(PatternRewriter &rewriter, DstAccess &access,
+void replaceStoreWithDst(PatternRewriter &rewriter, const DstAccess &access,
                          Value dst, AffineMap dstAccessMap,
                          ValueRange dstAccessIndices);
 
-void generateLoadSideCopy(PatternRewriter &rewriter, DstAccess &access,
+void generateLoadSideCopy(PatternRewriter &rewriter, const DstAccess &access,
                           Value dst, AffineMap l1AccessMap,
                           ValueRange l1AccessIndices, AffineMap dstAccessMap,
                           ValueRange dstAccessIndices);
 
-void generateStoreSideCopy(PatternRewriter &rewriter, DstAccess &access,
+void generateStoreSideCopy(PatternRewriter &rewriter, const DstAccess &access,
                            Value dst, AffineMap l1AccessMap,
                            ValueRange l1AccessIndices, AffineMap dstAccessMap,
                            ValueRange dstAccessIndices);
@@ -316,7 +300,7 @@ bool isDstScopeIV(Value iv, Operation *linalgRoot);
 
 std::tuple<AffineMap, SmallVector<Value>, AffineMap, SmallVector<Value>>
 buildIndices(PatternRewriter &rewriter, Location loc,
-             const mlir::IRMapping &irMapper, DstAccess &access,
+             const mlir::IRMapping &irMapper, const DstAccess &access,
              Operation *linalgRoot = nullptr);
 
 void insertPackerL1AccGuard(PatternRewriter &rewriter, Location loc,

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Scheduled.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Scheduled.cpp
@@ -28,83 +28,6 @@ namespace {
 using namespace detail;
 
 // ---------------------------------------------------------------------------
-// Scheduled-only: in-place data copy generation (no loop cloning)
-// ---------------------------------------------------------------------------
-
-template <typename LoadStoreOpTy>
-static void dataCopyGenerateScheduledInPlace(
-    PatternRewriter &rewriter, Operation *loopNestOrOp,
-    ArrayRef<LoadStoreRecord<LoadStoreOpTy>> loadStoreOps,
-    llvm::function_ref<void(PatternRewriter &, Location, Value, AffineMap,
-                            ValueRange, AffineMap, ValueRange)>
-        loadStoreDstAccessGenerator,
-    llvm::function_ref<void(PatternRewriter &, LoadStoreOpTy, AffineMap,
-                            ValueRange)>
-        dstAccessReplacement,
-    bool disableL1Acc = true) {
-  if (loadStoreOps.empty()) {
-    return;
-  }
-
-  // NB: structured binding here is by copy because MLIR op accessors
-  // (.getLoc(), .getIndices(), ...) are not const-marked, so a const-ref
-  // binding to an ArrayRef element would fail to compile.  Each element is
-  // a small POD-ish LoadStoreRecord, so copying is cheap.
-  for (auto [loadStore, bcast, dstSliceIndex, guardIVs] : loadStoreOps) {
-    mlir::IRMapping emptyIRMapper;
-
-    auto [l1AccessMap, l1AccessIndices, dstAccessMap, dstAccessIndices] =
-        buildIndices(rewriter, loadStore.getLoc(), emptyIRMapper,
-                     loadStore.getIndices(), dstSliceIndex, loadStore.getMap(),
-                     loadStore.getMemRefType(), loopNestOrOp);
-
-    rewriter.setInsertionPoint(loadStore);
-
-    if (disableL1Acc) {
-      loadStoreDstAccessGenerator(
-          rewriter, loadStore.getLoc(), loadStore.getMemRef(), l1AccessMap,
-          l1AccessIndices, dstAccessMap, dstAccessIndices);
-    }
-
-    dstAccessReplacement(rewriter, loadStore, dstAccessMap, dstAccessIndices);
-  }
-}
-
-// Thin adapter so the existing scheduled callers (which were written
-// against `(loc, cb, ...)` for the copy callback and `(op, ...)` for the
-// rewriter) keep working on top of the shared `emitDstCopyNest`.
-//
-// The shared helper passes the full `LoadStoreRecord` to both callbacks;
-// here we re-derive `loc` / `cb` / `op` from `record.loadStore` for the
-// adapter callbacks the scheduled pass already had.
-template <typename LoadStoreOpTy>
-static void dataCopyGenerateWithClone(
-    PatternRewriter &rewriter, Operation *loopNestOrOp,
-    ArrayRef<LoadStoreRecord<LoadStoreOpTy>> loadStoreOps,
-    llvm::function_ref<void(PatternRewriter &, Location, Value, AffineMap,
-                            ValueRange, AffineMap, ValueRange)>
-        loadStoreDstAccessGenerator,
-    llvm::function_ref<void(PatternRewriter &, LoadStoreOpTy, AffineMap,
-                            ValueRange)>
-        dstAccessReplacement) {
-  emitDstCopyNest<LoadStoreOpTy>(
-      rewriter, loopNestOrOp, loadStoreOps,
-      [&](PatternRewriter &rw, LoadStoreRecord<LoadStoreOpTy> record,
-          AffineMap l1AccessMap, ValueRange l1AccessIndices,
-          AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-        loadStoreDstAccessGenerator(
-            rw, record.loadStore.getLoc(), record.loadStore.getMemRef(),
-            l1AccessMap, l1AccessIndices, dstAccessMap, dstAccessIndices);
-      },
-      [&](PatternRewriter &rw, LoadStoreRecord<LoadStoreOpTy> record,
-          AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-        dstAccessReplacement(rw, record.loadStore, dstAccessMap,
-                             dstAccessIndices);
-      },
-      /*disableL1Acc=*/true);
-}
-
-// ---------------------------------------------------------------------------
 // Scheduled-only: DST access collection (stack allocator)
 // ---------------------------------------------------------------------------
 
@@ -117,9 +40,10 @@ collectDstAccessesScheduled(GenericOp op, Region &region,
   DstIntermediatesMap dstIntermediates;
   region.walk<WalkOrder::PreOrder>(
       [&](OperandLoadStoreRegisterOpInterface computeOp) {
-        auto notDstMemspace = [](auto op) {
-          return op && ttcore::getMemorySpace(op.getMemRef()) !=
-                           ttcore::MemorySpace::RegisterDst;
+        auto notDstMemspace = [](auto loadStoreOp) {
+          return loadStoreOp &&
+                 ttcore::getMemorySpace(loadStoreOp.getMemRef()) !=
+                     ttcore::MemorySpace::RegisterDst;
         };
 
         int numLoads = 0;
@@ -270,120 +194,13 @@ static void dataCopyGenerateScheduledAll(PatternRewriter &rewriter,
     auto insertionPointAfterLoopNest = rewriter.saveInsertionPoint();
 
     rewriter.setInsertionPoint(loopNestOrOp);
-
-    // Process affine loads in-place.
-    dataCopyGenerateScheduledInPlace<affine::AffineLoadOp>(
-        rewriter, loopNestOrOp, copyInfo.loads,
-        [&](PatternRewriter &rewriter, Location loc, Value cb,
-            AffineMap l1AccessMap, ValueRange l1AccessIndices,
-            AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-          auto l1Load = rewriter.create<affine::AffineLoadOp>(
-              loc, cb, l1AccessMap, l1AccessIndices);
-          rewriter.create<affine::AffineStoreOp>(
-              loc, l1Load.getResult(), dst, dstAccessMap, dstAccessIndices);
-        },
-        [&](PatternRewriter &rewriter, affine::AffineLoadOp op,
-            AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-          rewriter.replaceOpWithNewOp<affine::AffineLoadOp>(
-              op, dst, dstAccessMap, dstAccessIndices);
-        },
-        /*disableL1Acc=*/disableL1Acc);
-
-    // Process memref loads (scheduled path with scf.for loops).
-    for (auto [loadOp, bcast, dstSliceIndex, guardIVs] : copyInfo.memrefLoads) {
-      AffineMap dstAccessMap =
-          AffineMap::getConstantMap(dstSliceIndex, rewriter.getContext());
-
-      rewriter.setInsertionPoint(loadOp);
-
-      if (disableL1Acc) {
-        auto cbLoad = rewriter.create<memref::LoadOp>(
-            loadOp.getLoc(), loadOp.getMemRef(), loadOp.getIndices());
-        rewriter.create<affine::AffineStoreOp>(loadOp.getLoc(),
-                                               cbLoad.getResult(), dst,
-                                               dstAccessMap, ValueRange{});
-      }
-
-      auto dstLoad = rewriter.create<affine::AffineLoadOp>(
-          loadOp.getLoc(), dst, dstAccessMap, ValueRange{});
-      rewriter.replaceOp(loadOp, dstLoad.getResult());
-    }
+    emitDstCopyNest(rewriter, loopNestOrOp, dst, copyInfo.loads,
+                    /*isLoadSide=*/true, /*cloneLoopNest=*/false, disableL1Acc);
 
     rewriter.restoreInsertionPoint(insertionPointAfterLoopNest);
-
-    // Process affine stores (clones loop skeleton for separate store nest).
-    dataCopyGenerateWithClone<affine::AffineStoreOp>(
-        rewriter, loopNestOrOp, copyInfo.stores,
-        [&](PatternRewriter &rewriter, Location loc, Value cb,
-            AffineMap l1AccessMap, ValueRange l1AccessIndices,
-            AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-          auto dstLoad = rewriter.create<affine::AffineLoadOp>(
-              loc, dst, dstAccessMap, dstAccessIndices);
-          Value valueToStore = dstLoad.getResult();
-
-          auto cbType = mlir::cast<MemRefType>(cb.getType());
-          if (valueToStore.getType() != cbType.getElementType()) {
-            valueToStore = rewriter
-                               .create<d2m::DstReinterpretCastOp>(
-                                   loc, cbType.getElementType(), valueToStore)
-                               .getResult();
-          }
-
-          rewriter.create<affine::AffineStoreOp>(loc, valueToStore, cb,
-                                                 l1AccessMap, l1AccessIndices);
-        },
-        [&](PatternRewriter &rewriter, affine::AffineStoreOp op,
-            AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-          Value valueToStore = op.getValue();
-          auto dstType = mlir::cast<MemRefType>(dst.getType());
-          if (valueToStore.getType() != dstType.getElementType()) {
-            valueToStore =
-                rewriter
-                    .create<d2m::DstReinterpretCastOp>(
-                        op.getLoc(), dstType.getElementType(), valueToStore)
-                    .getResult();
-          }
-
-          rewriter.replaceOpWithNewOp<affine::AffineStoreOp>(
-              op, valueToStore, dst, dstAccessMap, dstAccessIndices);
-        });
-
-    // Process memref stores (scheduled path with scf.for loops).
-    for (auto [storeOp, bcast, dstSliceIndex, guardIVs] :
-         copyInfo.memrefStores) {
-      AffineMap dstAccessMap =
-          AffineMap::getConstantMap(dstSliceIndex, rewriter.getContext());
-
-      rewriter.setInsertionPoint(storeOp);
-
-      Value valueToStore = storeOp.getValue();
-      auto dstType = mlir::cast<MemRefType>(dst.getType());
-      if (valueToStore.getType() != dstType.getElementType()) {
-        valueToStore =
-            rewriter
-                .create<d2m::DstReinterpretCastOp>(
-                    storeOp.getLoc(), dstType.getElementType(), valueToStore)
-                .getResult();
-      }
-
-      rewriter.create<affine::AffineStoreOp>(storeOp.getLoc(), valueToStore,
-                                             dst, dstAccessMap, ValueRange{});
-
-      auto dstLoad = rewriter.create<affine::AffineLoadOp>(
-          storeOp.getLoc(), dst, dstAccessMap, ValueRange{});
-      Value packValue = dstLoad.getResult();
-      auto cbType = mlir::cast<MemRefType>(storeOp.getMemRef().getType());
-      if (packValue.getType() != cbType.getElementType()) {
-        packValue =
-            rewriter
-                .create<d2m::DstReinterpretCastOp>(
-                    storeOp.getLoc(), cbType.getElementType(), packValue)
-                .getResult();
-      }
-
-      rewriter.replaceOpWithNewOp<memref::StoreOp>(
-          storeOp, packValue, storeOp.getMemRef(), storeOp.getIndices());
-    }
+    emitDstCopyNest(rewriter, loopNestOrOp, dst, copyInfo.stores,
+                    /*isLoadSide=*/false, /*cloneLoopNest=*/true,
+                    /*disableL1Acc=*/true);
   }
 }
 

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
@@ -24,8 +24,6 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
 
-#include <type_traits>
-
 #define DEBUG_TYPE "D2MInsertDstRegisterAccess"
 
 namespace mlir::tt::d2m {
@@ -257,12 +255,30 @@ static bool accessDependsOnIV(memref::StoreOp storeOp, Value iv) {
                       [&](Value idx) { return valueDependsOnIV(idx, iv); });
 }
 
-template <typename LoadOrStoreTy>
-static SmallVector<Value> getGuardLoopIVs(LoadOrStoreTy loadOrStore,
+static bool accessDependsOnIV(Operation *op, DstAccessKind kind, Value iv) {
+  switch (kind) {
+  case DstAccessKind::AffineLoad:
+    return accessDependsOnIV(cast<affine::AffineLoadOp>(op), iv);
+  case DstAccessKind::AffineStore:
+    return accessDependsOnIV(cast<affine::AffineStoreOp>(op), iv);
+  case DstAccessKind::MemrefLoad:
+    return accessDependsOnIV(cast<memref::LoadOp>(op), iv);
+  case DstAccessKind::MemrefStore:
+    return accessDependsOnIV(cast<memref::StoreOp>(op), iv);
+  }
+  llvm_unreachable("unknown DstAccessKind");
+}
+
+static bool accessDependsOnIV(const DstAccess &access, Value iv) {
+  return accessDependsOnIV(access.op, access.kind, iv);
+}
+
+static SmallVector<Value> getGuardLoopIVs(Operation *loadOrStore,
+                                          DstAccessKind kind,
                                           Operation *contextOp) {
   SmallVector<Value> guardIVs;
   for (Value loopIV : collectAncestorLoopIVs(contextOp)) {
-    if (!accessDependsOnIV(loadOrStore, loopIV)) {
+    if (!accessDependsOnIV(loadOrStore, kind, loopIV)) {
       guardIVs.push_back(loopIV);
     }
   }
@@ -322,18 +338,12 @@ bool allTileMatmulOutputsSupportPackerL1Acc(Operation *loopOp) {
   return allSupported;
 }
 
-// Returns true iff any AffineStore (in `copyInfos.stores`) or memref::StoreOp
-// (in `copyInfos.memrefStores`) recorded for this region depends on `iv`.
+// Returns true iff any store recorded for this region depends on `iv`.
 // "Depends on" includes transitive dependence through subview indices.
 static bool anyOutputStoreDependsOnIV(const CopyInfoMap &copyInfos, Value iv) {
   for (const auto &[loopOrOp, copyInfo] : copyInfos) {
-    for (const auto &record : copyInfo.stores) {
-      if (record.loadStore && accessDependsOnIV(record.loadStore, iv)) {
-        return true;
-      }
-    }
-    for (const auto &record : copyInfo.memrefStores) {
-      if (record.loadStore && accessDependsOnIV(record.loadStore, iv)) {
+    for (const auto &access : copyInfo.stores) {
+      if (access.op && accessDependsOnIV(access, iv)) {
         return true;
       }
     }
@@ -503,17 +513,11 @@ std::pair<Type, int> inferDstInfoFromAllAccesses(const CopyInfoMap &copyInfos) {
   };
 
   for (auto [loopNest, copyInfo] : copyInfos) {
-    for (auto &[loadOp, bcastOp, idx, guardIVs] : copyInfo.loads) {
-      updateInfo(loadOp.getMemRefType(), idx);
+    for (const auto &access : copyInfo.loads) {
+      updateInfo(access.getMemRefType(), access.dstSlice);
     }
-    for (auto &[storeOp, bcastOp, idx, guardIVs] : copyInfo.stores) {
-      updateInfo(storeOp.getMemRefType(), idx);
-    }
-    for (auto &[loadOp, bcastOp, idx, guardIVs] : copyInfo.memrefLoads) {
-      updateInfo(loadOp.getMemRefType(), idx);
-    }
-    for (auto &[storeOp, bcastOp, idx, guardIVs] : copyInfo.memrefStores) {
-      updateInfo(storeOp.getMemRefType(), idx);
+    for (const auto &access : copyInfo.stores) {
+      updateInfo(access.getMemRefType(), access.dstSlice);
     }
   }
   TT_assert(elementType != nullptr);
@@ -667,9 +671,108 @@ getAccumClassificationOperandIndices(OperandLoadStoreRegisterOpInterface op) {
   return operandIndices;
 }
 
+// ---------------------------------------------------------------------------
+// DstAccess / CopyInfo
+// ---------------------------------------------------------------------------
+
+Value DstAccess::getMemRef() const {
+  switch (kind) {
+  case DstAccessKind::AffineLoad:
+    return getAsAffineLoad().getMemref();
+  case DstAccessKind::AffineStore:
+    return getAsAffineStore().getMemref();
+  case DstAccessKind::MemrefLoad:
+    return getAsMemrefLoad().getMemRef();
+  case DstAccessKind::MemrefStore:
+    return getAsMemrefStore().getMemRef();
+  }
+  llvm_unreachable("unknown DstAccessKind");
+}
+
+MemRefType DstAccess::getMemRefType() const {
+  return cast<MemRefType>(getMemRef().getType());
+}
+
+AffineMap DstAccess::getAffineMap() const {
+  TT_assert(isAffine());
+  if (kind == DstAccessKind::AffineLoad) {
+    return getAsAffineLoad().getAffineMap();
+  }
+  return getAsAffineStore().getAffineMap();
+}
+
+ValueRange DstAccess::getAffineIndices() const {
+  TT_assert(isAffine());
+  if (kind == DstAccessKind::AffineLoad) {
+    return getAsAffineLoad().getIndices();
+  }
+  return getAsAffineStore().getIndices();
+}
+
+ValueRange DstAccess::getMemrefIndices() const {
+  TT_assert(isMemref());
+  if (kind == DstAccessKind::MemrefLoad) {
+    return getAsMemrefLoad().getIndices();
+  }
+  return getAsMemrefStore().getIndices();
+}
+
+affine::AffineLoadOp DstAccess::getAsAffineLoad() const {
+  return cast<affine::AffineLoadOp>(op);
+}
+
+affine::AffineStoreOp DstAccess::getAsAffineStore() const {
+  return cast<affine::AffineStoreOp>(op);
+}
+
+memref::LoadOp DstAccess::getAsMemrefLoad() const {
+  return cast<memref::LoadOp>(op);
+}
+
+memref::StoreOp DstAccess::getAsMemrefStore() const {
+  return cast<memref::StoreOp>(op);
+}
+
+void CopyInfo::record(DstAccess access) {
+  if (access.isLoad()) {
+    loads.push_back(std::move(access));
+  } else {
+    stores.push_back(std::move(access));
+  }
+}
+
+void CopyInfo::record(affine::AffineLoadOp load, int dstSlice,
+                      ArrayRef<Value> guardIVs) {
+  record(DstAccess(load.getOperation(), DstAccessKind::AffineLoad, dstSlice,
+                   std::nullopt, guardIVs));
+}
+
+void CopyInfo::record(affine::AffineLoadOp load, d2m::TileBcastOp bcast,
+                      int dstSlice, ArrayRef<Value> guardIVs) {
+  record(DstAccess(load.getOperation(), DstAccessKind::AffineLoad, dstSlice,
+                   bcast, guardIVs));
+}
+
+void CopyInfo::record(affine::AffineStoreOp store, int dstSlice,
+                      ArrayRef<Value>) {
+  record(DstAccess(store.getOperation(), DstAccessKind::AffineStore, dstSlice,
+                   std::nullopt, {}));
+}
+
+void CopyInfo::record(memref::LoadOp load, int dstSlice,
+                      ArrayRef<Value> guardIVs) {
+  record(DstAccess(load.getOperation(), DstAccessKind::MemrefLoad, dstSlice,
+                   std::nullopt, guardIVs));
+}
+
+void CopyInfo::record(memref::StoreOp store, int dstSlice, ArrayRef<Value>) {
+  record(DstAccess(store.getOperation(), DstAccessKind::MemrefStore, dstSlice,
+                   std::nullopt, {}));
+}
+
 // Core recording logic: record a load/store with an optional guard.
-template <typename LoadOrStoreTy>
-static void recordDstAccessImpl(LoadOrStoreTy loadOrStore,
+static void recordDstAccessImpl(Operation *loadOrStore, DstAccessKind kind,
+                                std::optional<d2m::TileBcastOp> bcast,
                                 CopyInfoMap &copyInfos, int dstSlice,
                                 Operation *outermostInnerComputeLoop,
                                 bool emitGuard) {
@@ -678,58 +781,67 @@ static void recordDstAccessImpl(LoadOrStoreTy loadOrStore,
   }
 
   auto [iter, _] = copyInfos.try_emplace(outermostInnerComputeLoop);
-  Value assocCB = lookThroughSubView(loadOrStore.getMemRef());
 
-  SmallVector<Value> guardIVs;
-  if (assocCB && emitGuard) {
-    guardIVs = getGuardLoopIVs(loadOrStore, outermostInnerComputeLoop);
+  Value memref;
+  switch (kind) {
+  case DstAccessKind::AffineLoad:
+    memref = cast<affine::AffineLoadOp>(loadOrStore).getMemref();
+    break;
+  case DstAccessKind::AffineStore:
+    memref = cast<affine::AffineStoreOp>(loadOrStore).getMemref();
+    break;
+  case DstAccessKind::MemrefLoad:
+    memref = cast<memref::LoadOp>(loadOrStore).getMemRef();
+    break;
+  case DstAccessKind::MemrefStore:
+    memref = cast<memref::StoreOp>(loadOrStore).getMemRef();
+    break;
   }
 
-  iter->second.record(loadOrStore, dstSlice, guardIVs);
+  SmallVector<Value> guardIVs;
+  if (lookThroughSubView(memref) && emitGuard) {
+    guardIVs = getGuardLoopIVs(loadOrStore, kind, outermostInnerComputeLoop);
+  }
+
+  iter->second.record(DstAccess(loadOrStore, kind, dstSlice, bcast, guardIVs));
 }
 
 void recordDstAccess(affine::AffineLoadOp op, CopyInfoMap &copyInfos,
                      int dstSlice, Operation *outermostInnerComputeLoop,
                      bool emitGuard) {
-  recordDstAccessImpl(op, copyInfos, dstSlice, outermostInnerComputeLoop,
-                      emitGuard);
+  recordDstAccessImpl(op.getOperation(), DstAccessKind::AffineLoad,
+                      std::nullopt, copyInfos, dstSlice,
+                      outermostInnerComputeLoop, emitGuard);
 }
 
 void recordDstAccess(affine::AffineStoreOp op, CopyInfoMap &copyInfos,
                      int dstSlice, Operation *outermostInnerComputeLoop,
                      bool emitGuard) {
-  recordDstAccessImpl(op, copyInfos, dstSlice, outermostInnerComputeLoop,
-                      emitGuard);
+  recordDstAccessImpl(op.getOperation(), DstAccessKind::AffineStore,
+                      std::nullopt, copyInfos, dstSlice,
+                      outermostInnerComputeLoop, emitGuard);
 }
 
 void recordDstAccess(memref::LoadOp op, CopyInfoMap &copyInfos, int dstSlice,
                      Operation *outermostInnerComputeLoop, bool emitGuard) {
-  recordDstAccessImpl(op, copyInfos, dstSlice, outermostInnerComputeLoop,
-                      emitGuard);
+  recordDstAccessImpl(op.getOperation(), DstAccessKind::MemrefLoad,
+                      std::nullopt, copyInfos, dstSlice,
+                      outermostInnerComputeLoop, emitGuard);
 }
 
 void recordDstAccess(memref::StoreOp op, CopyInfoMap &copyInfos, int dstSlice,
                      Operation *outermostInnerComputeLoop, bool emitGuard) {
-  recordDstAccessImpl(op, copyInfos, dstSlice, outermostInnerComputeLoop,
-                      emitGuard);
+  recordDstAccessImpl(op.getOperation(), DstAccessKind::MemrefStore,
+                      std::nullopt, copyInfos, dstSlice,
+                      outermostInnerComputeLoop, emitGuard);
 }
 
 void recordDstAccess(affine::AffineLoadOp loadOp, d2m::TileBcastOp bcastOp,
                      CopyInfoMap &copyInfos, int dstSlice,
                      Operation *outermostInnerComputeLoop, bool emitGuard) {
-  if (!outermostInnerComputeLoop) {
-    outermostInnerComputeLoop = loadOp;
-  }
-
-  auto [iter, _] = copyInfos.try_emplace(outermostInnerComputeLoop);
-  Value assocCB = lookThroughSubView(loadOp.getMemRef());
-
-  SmallVector<Value> guardIVs;
-  if (assocCB && emitGuard) {
-    guardIVs = getGuardLoopIVs(loadOp, outermostInnerComputeLoop);
-  }
-
-  iter->second.record(loadOp, bcastOp, dstSlice, guardIVs);
+  recordDstAccessImpl(loadOp.getOperation(), DstAccessKind::AffineLoad, bcastOp,
+                      copyInfos, dstSlice, outermostInnerComputeLoop,
+                      emitGuard);
 }
 
 // Heuristically identify CB loads that feed a loop-carried accumulator tile.
@@ -767,39 +879,39 @@ static bool shouldGuardDstLoadForAccumulation(
 }
 
 // Record a store that drains a computed DST tile back to memory.
-template <typename StoreTy>
-static void collectDstStoreAccessImpl(StoreTy storeOp, CopyInfoMap &copyInfos,
-                                      int dstSlice,
+static void collectDstStoreAccessImpl(Operation *storeOp, DstAccessKind kind,
+                                      CopyInfoMap &copyInfos, int dstSlice,
                                       Operation *outermostInnerComputeLoop) {
-  recordDstAccessImpl(storeOp, copyInfos, dstSlice, outermostInnerComputeLoop,
-                      /*emitGuard=*/false);
+  recordDstAccessImpl(storeOp, kind, std::nullopt, copyInfos, dstSlice,
+                      outermostInnerComputeLoop, /*emitGuard=*/false);
 }
 
 void collectDstStoreAccess(affine::AffineStoreOp storeOp,
                            CopyInfoMap &copyInfos, int dstSlice,
                            Operation *outermostInnerComputeLoop) {
-  collectDstStoreAccessImpl(storeOp, copyInfos, dstSlice,
-                            outermostInnerComputeLoop);
+  collectDstStoreAccessImpl(storeOp.getOperation(), DstAccessKind::AffineStore,
+                            copyInfos, dstSlice, outermostInnerComputeLoop);
 }
 
 void collectDstStoreAccess(memref::StoreOp storeOp, CopyInfoMap &copyInfos,
                            int dstSlice, Operation *outermostInnerComputeLoop) {
-  collectDstStoreAccessImpl(storeOp, copyInfos, dstSlice,
-                            outermostInnerComputeLoop);
+  collectDstStoreAccessImpl(storeOp.getOperation(), DstAccessKind::MemrefStore,
+                            copyInfos, dstSlice, outermostInnerComputeLoop);
 }
 
 // Collect a single load access and determine whether it needs an accumulation
 // guard.
 template <typename LoadTy>
 static void collectDstLoadWithAccumAnalysisImpl(
-    LoadTy loadOp, int64_t operandIdx, ValueRange carriedOutputRegions,
-    ArrayRef<int64_t> accumOperandIndices, CopyInfoMap &copyInfos, int dstSlice,
-    Operation *outermostInnerComputeLoop, bool noAccumGuard) {
+    LoadTy loadOp, DstAccessKind kind, int64_t operandIdx,
+    ValueRange carriedOutputRegions, ArrayRef<int64_t> accumOperandIndices,
+    CopyInfoMap &copyInfos, int dstSlice, Operation *outermostInnerComputeLoop,
+    bool noAccumGuard) {
   const bool emitGuard = shouldGuardDstLoadForAccumulation(
       loadOp, operandIdx, carriedOutputRegions, accumOperandIndices,
       noAccumGuard);
-  recordDstAccessImpl(loadOp, copyInfos, dstSlice, outermostInnerComputeLoop,
-                      emitGuard);
+  recordDstAccessImpl(loadOp.getOperation(), kind, std::nullopt, copyInfos,
+                      dstSlice, outermostInnerComputeLoop, emitGuard);
 }
 
 void collectDstLoadWithAccumAnalysis(affine::AffineLoadOp loadOp,
@@ -809,7 +921,8 @@ void collectDstLoadWithAccumAnalysis(affine::AffineLoadOp loadOp,
                                      CopyInfoMap &copyInfos, int dstSlice,
                                      Operation *outermostInnerComputeLoop,
                                      bool noAccumGuard) {
-  collectDstLoadWithAccumAnalysisImpl(loadOp, operandIdx, carriedOutputRegions,
+  collectDstLoadWithAccumAnalysisImpl(loadOp, DstAccessKind::AffineLoad,
+                                      operandIdx, carriedOutputRegions,
                                       accumOperandIndices, copyInfos, dstSlice,
                                       outermostInnerComputeLoop, noAccumGuard);
 }
@@ -820,7 +933,8 @@ void collectDstLoadWithAccumAnalysis(memref::LoadOp loadOp, int64_t operandIdx,
                                      CopyInfoMap &copyInfos, int dstSlice,
                                      Operation *outermostInnerComputeLoop,
                                      bool noAccumGuard) {
-  collectDstLoadWithAccumAnalysisImpl(loadOp, operandIdx, carriedOutputRegions,
+  collectDstLoadWithAccumAnalysisImpl(loadOp, DstAccessKind::MemrefLoad,
+                                      operandIdx, carriedOutputRegions,
                                       accumOperandIndices, copyInfos, dstSlice,
                                       outermostInnerComputeLoop, noAccumGuard);
 }
@@ -842,48 +956,224 @@ cloneAffineLoopSkeleton(PatternRewriter &rewriter, Operation *loopNestOrOp) {
   return {skeleton, mapper};
 }
 
-template <typename LoadOrStoreTy>
-void emitDstCopyNest(
-    PatternRewriter &rewriter, Operation *loopNestOrOp,
-    ArrayRef<LoadStoreRecord<LoadOrStoreTy>> loadStoreRecords,
-    llvm::function_ref<void(PatternRewriter &, LoadStoreRecord<LoadOrStoreTy>,
-                            AffineMap, ValueRange, AffineMap, ValueRange)>
-        copyGenerator,
-    llvm::function_ref<void(PatternRewriter &, LoadStoreRecord<LoadOrStoreTy>,
-                            AffineMap, ValueRange)>
-        accessReplacer,
-    bool disableL1Acc) {
-  if (loadStoreRecords.empty()) {
+void replaceLoadWithDst(PatternRewriter &rewriter, DstAccess &access, Value dst,
+                        AffineMap dstAccessMap, ValueRange dstAccessIndices) {
+  switch (access.kind) {
+  case DstAccessKind::AffineLoad: {
+    auto dstLoad = rewriter.create<affine::AffineLoadOp>(
+        access.getLoc(), dst, dstAccessMap, dstAccessIndices);
+    if (access.bcast.has_value()) {
+      access.bcast->getResult().replaceAllUsesWith(dstLoad.getResult());
+      rewriter.eraseOp(*access.bcast);
+    } else {
+      rewriter.replaceOp(access.op, dstLoad.getResult());
+    }
+    break;
+  }
+  case DstAccessKind::MemrefLoad: {
+    auto dstLoad = rewriter.create<affine::AffineLoadOp>(
+        access.getLoc(), dst, dstAccessMap, dstAccessIndices);
+    rewriter.replaceOp(access.op, dstLoad.getResult());
+    break;
+  }
+  default:
+    llvm_unreachable("replaceLoadWithDst expects a load access");
+  }
+}
+
+void replaceStoreWithDst(PatternRewriter &rewriter, DstAccess &access,
+                         Value dst, AffineMap dstAccessMap,
+                         ValueRange dstAccessIndices) {
+  switch (access.kind) {
+  case DstAccessKind::AffineStore: {
+    auto storeOp = access.getAsAffineStore();
+    Value valueToStore = storeOp.getValue();
+    auto dstType = cast<MemRefType>(dst.getType());
+    if (valueToStore.getType() != dstType.getElementType()) {
+      valueToStore =
+          rewriter
+              .create<d2m::DstReinterpretCastOp>(
+                  storeOp.getLoc(), dstType.getElementType(), valueToStore)
+              .getResult();
+    }
+    rewriter.replaceOpWithNewOp<affine::AffineStoreOp>(
+        storeOp, valueToStore, dst, dstAccessMap, dstAccessIndices);
+    break;
+  }
+  case DstAccessKind::MemrefStore: {
+    auto storeOp = access.getAsMemrefStore();
+    Value valueToStore = storeOp.getValue();
+    auto dstType = cast<MemRefType>(dst.getType());
+    if (valueToStore.getType() != dstType.getElementType()) {
+      valueToStore =
+          rewriter
+              .create<d2m::DstReinterpretCastOp>(
+                  storeOp.getLoc(), dstType.getElementType(), valueToStore)
+              .getResult();
+    }
+    rewriter.create<affine::AffineStoreOp>(storeOp.getLoc(), valueToStore, dst,
+                                           dstAccessMap, dstAccessIndices);
+
+    auto dstLoad = rewriter.create<affine::AffineLoadOp>(
+        storeOp.getLoc(), dst, dstAccessMap, dstAccessIndices);
+    Value packValue = dstLoad.getResult();
+    auto cbType = cast<MemRefType>(storeOp.getMemRef().getType());
+    if (packValue.getType() != cbType.getElementType()) {
+      packValue = rewriter
+                      .create<d2m::DstReinterpretCastOp>(
+                          storeOp.getLoc(), cbType.getElementType(), packValue)
+                      .getResult();
+    }
+    rewriter.replaceOpWithNewOp<memref::StoreOp>(
+        storeOp, packValue, storeOp.getMemRef(), storeOp.getIndices());
+    break;
+  }
+  default:
+    llvm_unreachable("replaceStoreWithDst expects a store access");
+  }
+}
+
+void generateLoadSideCopy(PatternRewriter &rewriter, DstAccess &access,
+                          Value dst, AffineMap l1AccessMap,
+                          ValueRange l1AccessIndices, AffineMap dstAccessMap,
+                          ValueRange dstAccessIndices) {
+  auto loc = access.getLoc();
+  Value cb = access.getMemRef();
+
+  switch (access.kind) {
+  case DstAccessKind::AffineLoad: {
+    auto cbLoad = rewriter.create<affine::AffineLoadOp>(loc, cb, l1AccessMap,
+                                                        l1AccessIndices);
+    Value valueToStore = cbLoad.getResult();
+    if (access.bcast.has_value()) {
+      rewriter.setInsertionPointAfter(cbLoad);
+      auto *clonedBcast = rewriter.clone(*(access.bcast->getOperation()));
+      clonedBcast->setOperand(0, valueToStore);
+      valueToStore = clonedBcast->getResult(0);
+    }
+    rewriter.create<affine::AffineStoreOp>(loc, valueToStore, dst, dstAccessMap,
+                                           dstAccessIndices);
+    break;
+  }
+  case DstAccessKind::MemrefLoad: {
+    auto cbLoad =
+        rewriter.create<memref::LoadOp>(loc, cb, access.getMemrefIndices());
+    rewriter.create<affine::AffineStoreOp>(loc, cbLoad.getResult(), dst,
+                                           dstAccessMap, dstAccessIndices);
+    break;
+  }
+  default:
+    llvm_unreachable("generateLoadSideCopy expects a load access");
+  }
+}
+
+void generateStoreSideCopy(PatternRewriter &rewriter, DstAccess &access,
+                           Value dst, AffineMap l1AccessMap,
+                           ValueRange l1AccessIndices, AffineMap dstAccessMap,
+                           ValueRange dstAccessIndices) {
+  auto loc = access.getLoc();
+  Value cb = access.getMemRef();
+
+  switch (access.kind) {
+  case DstAccessKind::AffineStore: {
+    auto dstLoad = rewriter.create<affine::AffineLoadOp>(loc, dst, dstAccessMap,
+                                                         dstAccessIndices);
+    Value valueToStore = dstLoad.getResult();
+    auto cbType = cast<MemRefType>(cb.getType());
+    if (valueToStore.getType() != cbType.getElementType()) {
+      valueToStore = rewriter
+                         .create<d2m::DstReinterpretCastOp>(
+                             loc, cbType.getElementType(), valueToStore)
+                         .getResult();
+    }
+    rewriter.create<affine::AffineStoreOp>(loc, valueToStore, cb, l1AccessMap,
+                                           l1AccessIndices);
+    break;
+  }
+  case DstAccessKind::MemrefStore:
+    // Memref stores use in-place replaceStoreWithDst only (no upfront CB copy).
+    break;
+  default:
+    llvm_unreachable("generateStoreSideCopy expects a store access");
+  }
+}
+
+void emitDstCopyNest(PatternRewriter &rewriter, Operation *loopNestOrOp,
+                     Value dst, ArrayRef<DstAccess> accesses, bool isLoadSide,
+                     bool cloneLoopNest, bool disableL1Acc) {
+  if (accesses.empty()) {
     return;
   }
 
-  // Pre-clone the unguarded copy nest (shared by all records that don't
-  // need a per-IV guard).
   Operation *copyLoop = nullptr;
   mlir::IRMapping copyLoopMapper;
-  if (disableL1Acc) {
+  if (disableL1Acc && cloneLoopNest) {
     std::tie(copyLoop, copyLoopMapper) =
         cloneAffineLoopSkeleton(rewriter, loopNestOrOp);
   }
 
-  for (auto record : loadStoreRecords) {
-    auto loadStoreLoc = record.loadStore.getLoc();
-    auto loadStoreIndices = record.loadStore.getIndices();
-    auto loadStoreMap = record.loadStore.getMap();
-    auto loadStoreMemRefType = record.loadStore.getMemRefType();
+  for (DstAccess access : accesses) {
+    const bool useInPlace = !cloneLoopNest || access.isMemref();
+
+    if (useInPlace) {
+      mlir::IRMapping emptyIRMapper;
+      rewriter.setInsertionPoint(access.op);
+
+      AffineMap l1AccessMap;
+      SmallVector<Value> l1AccessIndices;
+      AffineMap dstAccessMap;
+      SmallVector<Value> dstAccessIndices;
+
+      if (access.isMemref()) {
+        dstAccessMap =
+            AffineMap::getConstantMap(access.dstSlice, rewriter.getContext());
+        l1AccessIndices = llvm::to_vector(
+            llvm::map_range(access.getMemrefIndices(), [&](Value index) {
+              return emptyIRMapper.lookupOrDefault(index);
+            }));
+      } else {
+        std::tie(l1AccessMap, l1AccessIndices, dstAccessMap, dstAccessIndices) =
+            buildIndices(rewriter, access.getLoc(), emptyIRMapper, access,
+                         loopNestOrOp);
+      }
+
+      if (disableL1Acc) {
+        if (isLoadSide) {
+          generateLoadSideCopy(rewriter, access, dst, l1AccessMap,
+                               l1AccessIndices, dstAccessMap, dstAccessIndices);
+        } else if (access.isAffine()) {
+          generateStoreSideCopy(rewriter, access, dst, l1AccessMap,
+                                l1AccessIndices, dstAccessMap,
+                                dstAccessIndices);
+        }
+      }
+
+      if (isLoadSide) {
+        replaceLoadWithDst(rewriter, access, dst, dstAccessMap,
+                           dstAccessIndices);
+      } else {
+        replaceStoreWithDst(rewriter, access, dst, dstAccessMap,
+                            dstAccessIndices);
+      }
+      continue;
+    }
+
+    // Cloned affine loop nest path (unscheduled loads/stores).
+    TT_assert(access.isAffine());
+    auto loadStoreLoc = access.getLoc();
 
     if (disableL1Acc) {
       mlir::IRMapping irMapper = copyLoopMapper;
-      if (!record.guardIVs.empty()) {
-        const bool isBcastGuard = record.bcast.has_value();
+      if (!access.guardIVs.empty()) {
+        const bool isBcastGuard = access.bcast.has_value();
         // TODO(wenbinlyuTT): #6516 WA to put all bcast inits to the top of
         // the compute tiling loops.
         if (isBcastGuard && copyLoop) {
           rewriter.setInsertionPoint(copyLoop);
         }
         if (!isBcastGuard) {
-          auto guard = createLoadLoopGuard(rewriter, record.loadStore.getLoc(),
-                                           record.guardIVs, isBcastGuard);
+          auto guard = createLoadLoopGuard(rewriter, access.getLoc(),
+                                           access.guardIVs, isBcastGuard);
           rewriter.setInsertionPointToStart(&guard.getThenRegion().front());
           auto [_, guardedMapper] =
               cloneAffineLoopSkeleton(rewriter, loopNestOrOp);
@@ -892,7 +1182,7 @@ void emitDstCopyNest(
         }
       }
 
-      Block *fromScope = record.loadStore->getBlock();
+      Block *fromScope = access.op->getBlock();
       Block *toScope = irMapper.lookupOrNull(fromScope);
       if (toScope) {
         Operation *terminator = toScope->getTerminator();
@@ -904,46 +1194,33 @@ void emitDstCopyNest(
       }
 
       auto [l1AccessMap, l1AccessIndices, dstAccessMap, dstAccessIndices] =
-          buildIndices(rewriter, loadStoreLoc, irMapper, loadStoreIndices,
-                       record.dstSlice, loadStoreMap, loadStoreMemRefType,
-                       loopNestOrOp);
-      copyGenerator(rewriter, record, l1AccessMap, l1AccessIndices,
-                    dstAccessMap, dstAccessIndices);
+          buildIndices(rewriter, loadStoreLoc, irMapper, access, loopNestOrOp);
+
+      if (isLoadSide) {
+        generateLoadSideCopy(rewriter, access, dst, l1AccessMap,
+                             l1AccessIndices, dstAccessMap, dstAccessIndices);
+      } else {
+        generateStoreSideCopy(rewriter, access, dst, l1AccessMap,
+                              l1AccessIndices, dstAccessMap, dstAccessIndices);
+      }
     }
 
     {
       mlir::IRMapping dummyIRMapper;
-      rewriter.setInsertionPoint(record.loadStore);
+      rewriter.setInsertionPoint(access.op);
       auto [l1AccessMap, l1AccessIndices, dstAccessMap, dstAccessIndices] =
-          buildIndices(rewriter, loadStoreLoc, dummyIRMapper, loadStoreIndices,
-                       record.dstSlice, loadStoreMap, loadStoreMemRefType,
+          buildIndices(rewriter, loadStoreLoc, dummyIRMapper, access,
                        loopNestOrOp);
-      accessReplacer(rewriter, record, dstAccessMap, dstAccessIndices);
+      if (isLoadSide) {
+        replaceLoadWithDst(rewriter, access, dst, dstAccessMap,
+                           dstAccessIndices);
+      } else {
+        replaceStoreWithDst(rewriter, access, dst, dstAccessMap,
+                            dstAccessIndices);
+      }
     }
   }
 }
-
-// Explicit instantiations for the four LoadStoreOpTy variants used.
-template void emitDstCopyNest<affine::AffineLoadOp>(
-    PatternRewriter &, Operation *,
-    ArrayRef<LoadStoreRecord<affine::AffineLoadOp>>,
-    llvm::function_ref<void(PatternRewriter &,
-                            LoadStoreRecord<affine::AffineLoadOp>, AffineMap,
-                            ValueRange, AffineMap, ValueRange)>,
-    llvm::function_ref<void(PatternRewriter &,
-                            LoadStoreRecord<affine::AffineLoadOp>, AffineMap,
-                            ValueRange)>,
-    bool);
-template void emitDstCopyNest<affine::AffineStoreOp>(
-    PatternRewriter &, Operation *,
-    ArrayRef<LoadStoreRecord<affine::AffineStoreOp>>,
-    llvm::function_ref<void(PatternRewriter &,
-                            LoadStoreRecord<affine::AffineStoreOp>, AffineMap,
-                            ValueRange, AffineMap, ValueRange)>,
-    llvm::function_ref<void(PatternRewriter &,
-                            LoadStoreRecord<affine::AffineStoreOp>, AffineMap,
-                            ValueRange)>,
-    bool);
 
 scf::IfOp createLoadLoopGuard(PatternRewriter &rewriter, Location loc,
                               ValueRange guardIVs, bool isBcastGuard) {
@@ -1101,9 +1378,14 @@ bool isDstScopeIV(Value iv, Operation *linalgRoot) {
 
 std::tuple<AffineMap, SmallVector<Value>, AffineMap, SmallVector<Value>>
 buildIndices(PatternRewriter &rewriter, Location loc,
-             const mlir::IRMapping &irMapper, ValueRange currentIndices,
-             int dstSlice, AffineMap map, MemRefType cbType,
+             const mlir::IRMapping &irMapper, DstAccess &access,
              Operation *linalgRoot) {
+  TT_assert(access.isAffine());
+  AffineMap map = access.getAffineMap();
+  ValueRange currentIndices = access.getAffineIndices();
+  int dstSlice = access.dstSlice;
+  MemRefType cbType = access.getMemRefType();
+
   AffineMap l1AccessMap = map;
   SmallVector<Value> l1AccessIndices =
       llvm::to_vector(llvm::map_range(currentIndices, [&](Value index) {

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
@@ -675,16 +675,37 @@ getAccumClassificationOperandIndices(OperandLoadStoreRegisterOpInterface op) {
 // DstAccess / CopyInfo
 // ---------------------------------------------------------------------------
 
+bool DstAccess::isLoad() const {
+  return kind == DstAccessKind::AffineLoad || kind == DstAccessKind::MemrefLoad;
+}
+
+bool DstAccess::isStore() const {
+  return kind == DstAccessKind::AffineStore ||
+         kind == DstAccessKind::MemrefStore;
+}
+
+bool DstAccess::isAffine() const {
+  return kind == DstAccessKind::AffineLoad ||
+         kind == DstAccessKind::AffineStore;
+}
+
+bool DstAccess::isMemref() const {
+  return kind == DstAccessKind::MemrefLoad ||
+         kind == DstAccessKind::MemrefStore;
+}
+
+Location DstAccess::getLoc() const { return op->getLoc(); }
+
 Value DstAccess::getMemRef() const {
   switch (kind) {
   case DstAccessKind::AffineLoad:
-    return getAsAffineLoad().getMemref();
+    return cast<affine::AffineLoadOp>(op).getMemref();
   case DstAccessKind::AffineStore:
-    return getAsAffineStore().getMemref();
+    return cast<affine::AffineStoreOp>(op).getMemref();
   case DstAccessKind::MemrefLoad:
-    return getAsMemrefLoad().getMemRef();
+    return cast<memref::LoadOp>(op).getMemRef();
   case DstAccessKind::MemrefStore:
-    return getAsMemrefStore().getMemRef();
+    return cast<memref::StoreOp>(op).getMemRef();
   }
   llvm_unreachable("unknown DstAccessKind");
 }
@@ -696,41 +717,25 @@ MemRefType DstAccess::getMemRefType() const {
 AffineMap DstAccess::getAffineMap() const {
   TT_assert(isAffine());
   if (kind == DstAccessKind::AffineLoad) {
-    return getAsAffineLoad().getAffineMap();
+    return cast<affine::AffineLoadOp>(op).getAffineMap();
   }
-  return getAsAffineStore().getAffineMap();
+  return cast<affine::AffineStoreOp>(op).getAffineMap();
 }
 
 ValueRange DstAccess::getAffineIndices() const {
   TT_assert(isAffine());
   if (kind == DstAccessKind::AffineLoad) {
-    return getAsAffineLoad().getIndices();
+    return cast<affine::AffineLoadOp>(op).getIndices();
   }
-  return getAsAffineStore().getIndices();
+  return cast<affine::AffineStoreOp>(op).getIndices();
 }
 
 ValueRange DstAccess::getMemrefIndices() const {
   TT_assert(isMemref());
   if (kind == DstAccessKind::MemrefLoad) {
-    return getAsMemrefLoad().getIndices();
+    return cast<memref::LoadOp>(op).getIndices();
   }
-  return getAsMemrefStore().getIndices();
-}
-
-affine::AffineLoadOp DstAccess::getAsAffineLoad() const {
-  return cast<affine::AffineLoadOp>(op);
-}
-
-affine::AffineStoreOp DstAccess::getAsAffineStore() const {
-  return cast<affine::AffineStoreOp>(op);
-}
-
-memref::LoadOp DstAccess::getAsMemrefLoad() const {
-  return cast<memref::LoadOp>(op);
-}
-
-memref::StoreOp DstAccess::getAsMemrefStore() const {
-  return cast<memref::StoreOp>(op);
+  return cast<memref::StoreOp>(op).getIndices();
 }
 
 void CopyInfo::record(DstAccess access) {
@@ -956,15 +961,19 @@ cloneAffineLoopSkeleton(PatternRewriter &rewriter, Operation *loopNestOrOp) {
   return {skeleton, mapper};
 }
 
-void replaceLoadWithDst(PatternRewriter &rewriter, DstAccess &access, Value dst,
-                        AffineMap dstAccessMap, ValueRange dstAccessIndices) {
+void replaceLoadWithDst(PatternRewriter &rewriter, const DstAccess &access,
+                        Value dst, AffineMap dstAccessMap,
+                        ValueRange dstAccessIndices) {
   switch (access.kind) {
   case DstAccessKind::AffineLoad: {
     auto dstLoad = rewriter.create<affine::AffineLoadOp>(
         access.getLoc(), dst, dstAccessMap, dstAccessIndices);
     if (access.bcast.has_value()) {
-      access.bcast->getResult().replaceAllUsesWith(dstLoad.getResult());
-      rewriter.eraseOp(*access.bcast);
+      // Rewrites IR only; `access` is not mutated (bcast op is erased).
+      Operation *bcastOp = *access.bcast;
+      cast<d2m::TileBcastOp>(bcastOp).getResult().replaceAllUsesWith(
+          dstLoad.getResult());
+      rewriter.eraseOp(bcastOp);
     } else {
       rewriter.replaceOp(access.op, dstLoad.getResult());
     }
@@ -981,12 +990,12 @@ void replaceLoadWithDst(PatternRewriter &rewriter, DstAccess &access, Value dst,
   }
 }
 
-void replaceStoreWithDst(PatternRewriter &rewriter, DstAccess &access,
+void replaceStoreWithDst(PatternRewriter &rewriter, const DstAccess &access,
                          Value dst, AffineMap dstAccessMap,
                          ValueRange dstAccessIndices) {
   switch (access.kind) {
   case DstAccessKind::AffineStore: {
-    auto storeOp = access.getAsAffineStore();
+    auto storeOp = cast<affine::AffineStoreOp>(access.op);
     Value valueToStore = storeOp.getValue();
     auto dstType = cast<MemRefType>(dst.getType());
     if (valueToStore.getType() != dstType.getElementType()) {
@@ -1001,7 +1010,7 @@ void replaceStoreWithDst(PatternRewriter &rewriter, DstAccess &access,
     break;
   }
   case DstAccessKind::MemrefStore: {
-    auto storeOp = access.getAsMemrefStore();
+    auto storeOp = cast<memref::StoreOp>(access.op);
     Value valueToStore = storeOp.getValue();
     auto dstType = cast<MemRefType>(dst.getType());
     if (valueToStore.getType() != dstType.getElementType()) {
@@ -1033,7 +1042,7 @@ void replaceStoreWithDst(PatternRewriter &rewriter, DstAccess &access,
   }
 }
 
-void generateLoadSideCopy(PatternRewriter &rewriter, DstAccess &access,
+void generateLoadSideCopy(PatternRewriter &rewriter, const DstAccess &access,
                           Value dst, AffineMap l1AccessMap,
                           ValueRange l1AccessIndices, AffineMap dstAccessMap,
                           ValueRange dstAccessIndices) {
@@ -1047,7 +1056,8 @@ void generateLoadSideCopy(PatternRewriter &rewriter, DstAccess &access,
     Value valueToStore = cbLoad.getResult();
     if (access.bcast.has_value()) {
       rewriter.setInsertionPointAfter(cbLoad);
-      auto *clonedBcast = rewriter.clone(*(access.bcast->getOperation()));
+      Operation *bcastOp = *access.bcast;
+      auto *clonedBcast = rewriter.clone(*bcastOp);
       clonedBcast->setOperand(0, valueToStore);
       valueToStore = clonedBcast->getResult(0);
     }
@@ -1067,7 +1077,7 @@ void generateLoadSideCopy(PatternRewriter &rewriter, DstAccess &access,
   }
 }
 
-void generateStoreSideCopy(PatternRewriter &rewriter, DstAccess &access,
+void generateStoreSideCopy(PatternRewriter &rewriter, const DstAccess &access,
                            Value dst, AffineMap l1AccessMap,
                            ValueRange l1AccessIndices, AffineMap dstAccessMap,
                            ValueRange dstAccessIndices) {
@@ -1112,7 +1122,7 @@ void emitDstCopyNest(PatternRewriter &rewriter, Operation *loopNestOrOp,
         cloneAffineLoopSkeleton(rewriter, loopNestOrOp);
   }
 
-  for (DstAccess access : accesses) {
+  for (const DstAccess &access : accesses) {
     const bool useInPlace = !cloneLoopNest || access.isMemref();
 
     if (useInPlace) {
@@ -1127,10 +1137,10 @@ void emitDstCopyNest(PatternRewriter &rewriter, Operation *loopNestOrOp,
       if (access.isMemref()) {
         dstAccessMap =
             AffineMap::getConstantMap(access.dstSlice, rewriter.getContext());
-        l1AccessIndices = llvm::to_vector(
-            llvm::map_range(access.getMemrefIndices(), [&](Value index) {
-              return emptyIRMapper.lookupOrDefault(index);
-            }));
+        l1AccessIndices.reserve(access.getMemrefIndices().size());
+        for (Value index : access.getMemrefIndices()) {
+          l1AccessIndices.push_back(emptyIRMapper.lookupOrDefault(index));
+        }
       } else {
         std::tie(l1AccessMap, l1AccessIndices, dstAccessMap, dstAccessIndices) =
             buildIndices(rewriter, access.getLoc(), emptyIRMapper, access,
@@ -1378,7 +1388,7 @@ bool isDstScopeIV(Value iv, Operation *linalgRoot) {
 
 std::tuple<AffineMap, SmallVector<Value>, AffineMap, SmallVector<Value>>
 buildIndices(PatternRewriter &rewriter, Location loc,
-             const mlir::IRMapping &irMapper, DstAccess &access,
+             const mlir::IRMapping &irMapper, const DstAccess &access,
              Operation *linalgRoot) {
   TT_assert(access.isAffine());
   AffineMap map = access.getAffineMap();

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Unscheduled.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Unscheduled.cpp
@@ -208,97 +208,14 @@ static void dataCopyGenerate(PatternRewriter &rewriter, Location loc, Value dst,
     rewriter.setInsertionPointAfter(loopNestOrOp);
     auto insertionPointAfterLoopNest = rewriter.saveInsertionPoint();
 
-    // Step 1: load copy loop.
     rewriter.setInsertionPoint(loopNestOrOp);
-    auto loadAccessGenerator = [&](PatternRewriter &rewriter,
-                                   LoadStoreRecord<affine::AffineLoadOp> record,
-                                   AffineMap l1AccessMap,
-                                   ValueRange l1AccessIndices,
-                                   AffineMap dstAccessMap,
-                                   ValueRange dstAccessIndices) {
-      auto loc = record.loadStore.getLoc();
-      Value cb = record.loadStore.getMemref();
+    emitDstCopyNest(rewriter, loopNestOrOp, dst, copyInfo.loads,
+                    /*isLoadSide=*/true, /*cloneLoopNest=*/true, disableL1Acc);
 
-      auto cbLoad = rewriter.create<affine::AffineLoadOp>(loc, cb, l1AccessMap,
-                                                          l1AccessIndices);
-      Value valueToStore = cbLoad.getResult();
-
-      if (record.bcast.has_value()) {
-        rewriter.setInsertionPointAfter(cbLoad);
-        auto *clonedBcast = rewriter.clone(*(record.bcast->getOperation()));
-        clonedBcast->setOperand(0, valueToStore);
-        valueToStore = clonedBcast->getResult(0);
-      }
-
-      rewriter.create<affine::AffineStoreOp>(loc, valueToStore, dst,
-                                             dstAccessMap, dstAccessIndices);
-    };
-
-    auto loadAccessRewriter = [&](PatternRewriter &rewriter,
-                                  LoadStoreRecord<affine::AffineLoadOp> record,
-                                  AffineMap dstAccessMap,
-                                  ValueRange dstAccessIndices) {
-      auto dstLoad = rewriter.create<affine::AffineLoadOp>(
-          record.loadStore.getLoc(), dst, dstAccessMap, dstAccessIndices);
-      if (record.bcast.has_value()) {
-        record.bcast->getResult().replaceAllUsesWith(dstLoad.getResult());
-        rewriter.eraseOp(*record.bcast);
-      } else {
-        rewriter.replaceOp(record.loadStore, dstLoad.getResult());
-      }
-    };
-
-    emitDstCopyNest<affine::AffineLoadOp>(rewriter, loopNestOrOp,
-                                          copyInfo.loads, loadAccessGenerator,
-                                          loadAccessRewriter,
-                                          /*disableL1Acc=*/disableL1Acc);
-
-    // Step 2: store copy loop.
     rewriter.restoreInsertionPoint(insertionPointAfterLoopNest);
-    auto storeAccessGenerator =
-        [&](PatternRewriter &rewriter,
-            LoadStoreRecord<affine::AffineStoreOp> record,
-            AffineMap l1AccessMap, ValueRange l1AccessIndices,
-            AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-          auto loc = record.loadStore.getLoc();
-          Value cb = record.loadStore.getMemref();
-          auto dstLoad = rewriter.create<affine::AffineLoadOp>(
-              loc, dst, dstAccessMap, dstAccessIndices);
-          Value valueToStore = dstLoad.getResult();
-
-          auto cbType = mlir::cast<MemRefType>(cb.getType());
-          if (valueToStore.getType() != cbType.getElementType()) {
-            valueToStore = rewriter
-                               .create<d2m::DstReinterpretCastOp>(
-                                   loc, cbType.getElementType(), valueToStore)
-                               .getResult();
-          }
-
-          rewriter.create<affine::AffineStoreOp>(loc, valueToStore, cb,
-                                                 l1AccessMap, l1AccessIndices);
-        };
-
-    auto storeAccessRewriter =
-        [&](PatternRewriter &rewriter,
-            LoadStoreRecord<affine::AffineStoreOp> record,
-            AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-          Value valueToStore = record.loadStore.getValue();
-          auto dstType = mlir::cast<MemRefType>(dst.getType());
-          if (valueToStore.getType() != dstType.getElementType()) {
-            valueToStore = rewriter
-                               .create<d2m::DstReinterpretCastOp>(
-                                   record.loadStore.getLoc(),
-                                   dstType.getElementType(), valueToStore)
-                               .getResult();
-          }
-          rewriter.replaceOpWithNewOp<affine::AffineStoreOp>(
-              record.loadStore, valueToStore, dst, dstAccessMap,
-              dstAccessIndices);
-        };
-
-    emitDstCopyNest<affine::AffineStoreOp>(
-        rewriter, loopNestOrOp, copyInfo.stores, storeAccessGenerator,
-        storeAccessRewriter);
+    emitDstCopyNest(rewriter, loopNestOrOp, dst, copyInfo.stores,
+                    /*isLoadSide=*/false, /*cloneLoopNest=*/true,
+                    /*disableL1Acc=*/true);
   }
 }
 


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/8346

### Problem description
Unifies the DST-access collection model in `InsertDstRegisterAccess*`.

- Replaces four `LoadStoreRecord<T>` vectors (`loads` / `stores` / `memrefLoads` / `memrefStores`) with a tagged `DstAccess` + two buckets (`loads`, `stores`).
- Adds centralized `replaceLoadWithDst` / `replaceStoreWithDst` and a single `emitDstCopyNest` over `ArrayRef<DstAccess>`.
- Collapses Scheduled memref copy/replace manual loops into the shared emitter.
- No intentional semantic change to acquire_dst placement, bcast/accum guards, L1-acc, scratch slices, or intermediate-DST fixup.

### Checklist
- [X] New/Existing tests provide coverage for changes
