### PR TITLE
[TTNN] Add SDPA decomposition patterns

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_SDPADECODEDECOMPOSITIONPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_SDPADECODEDECOMPOSITIONPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+#include <optional>
+
+namespace mlir::tt::ttnn::decomposition {
+
+// Decomposes ttnn::ScaledDotProductAttentionDecodeOp by permuting Q from
+// [1, B, H, D] to [B, H, 1, D], emitting a ScaledDotProductAttentionOp (which
+// the SDPADecompositionPattern can then further decompose if needed), and
+// permuting the result back. When validationConfig is provided, decomposition
+// only occurs if op-model validation fails. When validationConfig is
+// std::nullopt, decomposition is unconditional.
+class SDPADecodeDecompositionPattern
+    : public OpRewritePattern<ttnn::ScaledDotProductAttentionDecodeOp> {
+public:
+  SDPADecodeDecompositionPattern(mlir::MLIRContext *context)
+      : OpRewritePattern<ttnn::ScaledDotProductAttentionDecodeOp>(context) {}
+
+  SDPADecodeDecompositionPattern(mlir::MLIRContext *context,
+                                 const OpValidationConfig &validationConfig)
+      : OpRewritePattern<ttnn::ScaledDotProductAttentionDecodeOp>(context),
+        validationConfig(validationConfig) {}
+
+  LogicalResult matchAndRewrite(ttnn::ScaledDotProductAttentionDecodeOp op,
+                                PatternRewriter &rewriter) const override;
+
+private:
+  std::optional<OpValidationConfig> validationConfig;
+};
+
+} // namespace mlir::tt::ttnn::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_SDPADECODEDECOMPOSITIONPATTERN_H

--- a/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_SDPADECOMPOSITIONPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_SDPADECOMPOSITIONPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+#include <optional>
+
+namespace mlir::tt::ttnn::decomposition {
+
+// Decomposes ttnn::ScaledDotProductAttentionOp into a sequence of primitive
+// TTNN ops (transpose + matmul + scale + mask + softmax + matmul, with GQA
+// head expansion and optional attention sink). When validationConfig is
+// provided, decomposition only occurs if op-model validation fails. When
+// validationConfig is std::nullopt, decomposition is unconditional.
+class SDPADecompositionPattern
+    : public OpRewritePattern<ttnn::ScaledDotProductAttentionOp> {
+public:
+  SDPADecompositionPattern(mlir::MLIRContext *context)
+      : OpRewritePattern<ttnn::ScaledDotProductAttentionOp>(context) {}
+
+  SDPADecompositionPattern(mlir::MLIRContext *context,
+                           const OpValidationConfig &validationConfig)
+      : OpRewritePattern<ttnn::ScaledDotProductAttentionOp>(context),
+        validationConfig(validationConfig) {}
+
+  LogicalResult matchAndRewrite(ttnn::ScaledDotProductAttentionOp op,
+                                PatternRewriter &rewriter) const override;
+
+private:
+  std::optional<OpValidationConfig> validationConfig;
+};
+
+} // namespace mlir::tt::ttnn::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_SDPADECOMPOSITIONPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -30,6 +30,8 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Decomposition/DistributedLayerNormDecompositionRewritePattern.cpp
         Decomposition/GroupNormDecompositionRewritePattern.cpp
         Decomposition/RotaryEmbeddingDecompositionRewritePattern.cpp
+        Decomposition/SDPADecodeDecompositionPattern.cpp
+        Decomposition/SDPADecompositionPattern.cpp
         Decomposition/TopKDecompositionRewritePattern.cpp
         Decomposition/TTNNDecompositionPass.cpp
         OpValidator.cpp

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
@@ -35,7 +35,6 @@ static Value createPermute(Value input, ArrayRef<int64_t> permutation,
 
   return rewriter.create<PermuteOp>(loc, outputType, input,
                                     rewriter.getDenseI64ArrayAttr(permutation),
-                                    /*memory_config=*/nullptr,
                                     /*pad_value=*/mlir::FloatAttr());
 }
 

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Utils.h"
 
 #include <cmath>
+#include <limits>
 
 namespace mlir::tt::ttnn::decomposition {
 
@@ -69,30 +70,41 @@ LogicalResult SDPADecodeDecompositionPattern::matchAndRewrite(
   Value permutedQuery =
       createPermute(op.getQuery(), kToSDPAPermutation, rewriter, loc);
 
-  // The two SDPA ops have different mask conventions at the API level:
-  //   - decode: result = softmax(scale * (QK + mask))   = softmax(scale*QK +
-  //   scale*mask)
-  //   - prefill: result = softmax(scale * QK + mask) (PyTorch-style)
-  // Both kernels internally compute softmax(scale*(QK + mask)); prefill's host
-  // wrapper compensates by pre-dividing the user mask by scale, decode's does
-  // not. To make a prefill op produce the decode result on the same mask m,
-  // we feed prefill m' = scale * m; then prefill computes
-  //   softmax(scale*QK + scale*m) == decode(m).
+  // Common scalars: scale value, device handle, Q's data type.
+  float scaleValue;
+  if (op.getScaleAttr()) {
+    scaleValue = op.getScaleAttr().getValueAsDouble();
+  } else {
+    int64_t headDim = qType.getShape().back();
+    scaleValue = 1.0f / std::sqrt(static_cast<float>(headDim));
+  }
+  Value device =
+      utils::getOrInsertDevice(rewriter, op.getOperation()).getResult();
+
+  ttcore::DataType qDataType = ttcore::DataType::BFloat16;
+  if (auto qLayoutAttr =
+          mlir::dyn_cast_if_present<TTNNLayoutAttr>(qType.getEncoding())) {
+    qDataType = qLayoutAttr.getDataType();
+  }
+
+  // Q is [1, B, Hq, D]; K is [B, Hkv, Sk, D].
+  int64_t batch = qType.getShape()[1];
+  auto kType = mlir::cast<RankedTensorType>(op.getKey().getType());
+  int64_t seqLenKV = kType.getShape()[2];
+
   Value scaledMask = op.getAttentionMask();
   if (scaledMask) {
-    float scaleValue;
-    if (op.getScaleAttr()) {
-      scaleValue = op.getScaleAttr().getValueAsDouble();
-    } else {
-      int64_t headDim = qType.getShape().back();
-      scaleValue = 1.0f / std::sqrt(static_cast<float>(headDim));
-    }
+    // The two SDPA ops have different mask conventions at the API level:
+    //   decode:  softmax(scale * (QK + mask)) = softmax(scale*QK + scale*mask)
+    //   prefill: softmax(scale * QK + mask)                  (PyTorch-style)
+    // Both kernels internally compute softmax(scale*(QK + mask)); prefill's
+    // host wrapper compensates by pre-dividing the user mask by scale, decode
+    // does not. To make a prefill op produce the decode result on the same
+    // mask m, feed prefill m' = scale * m.
     auto maskType = mlir::cast<RankedTensorType>(scaledMask.getType());
     llvm::SmallVector<int64_t> scalarShape(maskType.getRank(), 1);
     RankedTensorType scalarType =
         ttnn::utils::RankedTensorTypeFactory::create(maskType, scalarShape);
-    Value device =
-        utils::getOrInsertDevice(rewriter, op.getOperation()).getResult();
     Value scaleTensor =
         rewriter
             .create<FullOp>(loc, scalarType,
@@ -107,15 +119,142 @@ LogicalResult SDPADecodeDecompositionPattern::matchAndRewrite(
     // Permute dims 1 and 2 to bridge the convention difference.
     scaledMask =
         createPermute(scaledMask, kMaskToSDPAPermutation, rewriter, loc);
+  } else if (op.getIsCausal() && op.getCurPosTensor()) {
+    // Synthesize a per-batch causal mask from cur_pos_tensor: positions
+    // j > cur_pos[b] are -inf, otherwise 0. Shape [B, 1, 1, Sk] aligns with
+    // the prefill mask convention (heads dim broadcast).
+    Value curPos = op.getCurPosTensor();
+    auto curPosType = mlir::cast<RankedTensorType>(curPos.getType());
+
+    // 1. Reshape cur_pos [B] -> [B, 1, 1, 1] so it broadcasts against arange.
+    llvm::SmallVector<int64_t> reshapedCurPosShape = {batch, 1, 1, 1};
+    auto reshapedCurPosType = ttnn::utils::RankedTensorTypeFactory::create(
+        curPosType, reshapedCurPosShape);
+    llvm::SmallVector<int32_t> reshapeShapeI32 = {static_cast<int32_t>(batch),
+                                                  1, 1, 1};
+    curPos =
+        rewriter
+            .create<ttnn::ReshapeOp>(loc, reshapedCurPosType, curPos,
+                                     rewriter.getI32ArrayAttr(reshapeShapeI32))
+            .getResult();
+
+    // 2. Cast cur_pos from int32 to Q's dtype so comparison with arange works.
+    auto castedCurPosType = ttnn::utils::RankedTensorTypeFactory::create(
+        reshapedCurPosType, qDataType);
+    curPos = rewriter
+                 .create<TypecastOp>(loc, castedCurPosType, curPos,
+                                     ttcore::DataTypeAttr::get(
+                                         rewriter.getContext(), qDataType))
+                 .getResult();
+
+    // 3. Arange [0..Sk) -> rank-1 [Sk] in Q's dtype (ttnn.arange verifier
+    // requires rank-1 output), then reshape to [1, 1, 1, Sk] for broadcast.
+    auto arange1dType = ttnn::utils::RankedTensorTypeFactory::create(
+        qType, llvm::SmallVector<int64_t>{seqLenKV});
+    ttnn::LayoutAttr tileLayoutAttr =
+        ttnn::LayoutAttr::get(rewriter.getContext(), ttnn::Layout::Tile);
+    auto qDtypeAttr =
+        ttcore::DataTypeAttr::get(rewriter.getContext(), qDataType);
+    Value indices =
+        rewriter
+            .create<ttnn::ArangeOp>(loc, arange1dType, device, /*start=*/0,
+                                    /*end=*/seqLenKV, /*step=*/1, qDtypeAttr,
+                                    tileLayoutAttr)
+            .getResult();
+
+    auto arange4dType = ttnn::utils::RankedTensorTypeFactory::create(
+        qType, llvm::SmallVector<int64_t>{1, 1, 1, seqLenKV});
+    llvm::SmallVector<int32_t> arange4dShapeI32 = {
+        1, 1, 1, static_cast<int32_t>(seqLenKV)};
+    indices =
+        rewriter
+            .create<ttnn::ReshapeOp>(loc, arange4dType, indices,
+                                     rewriter.getI32ArrayAttr(arange4dShapeI32))
+            .getResult();
+
+    // 4. gt(arange, cur_pos): broadcasts to [B, 1, 1, Sk]. The result is in
+    // Q's dtype carrying 0.0/1.0 (TTNN comparison ops follow input dtype).
+    auto maskShape = llvm::SmallVector<int64_t>{batch, 1, 1, seqLenKV};
+    auto maskType =
+        ttnn::utils::RankedTensorTypeFactory::create(qType, maskShape);
+    Value isMasked =
+        rewriter.create<GreaterThanOp>(loc, maskType, indices, curPos)
+            .getResult();
+
+    // 5. Zeros and -inf at full mask shape. ttnn.where doesn't reliably
+    // broadcast scalar branches against a multi-dim condition, so the t/f
+    // branches must be pre-broadcast to match the condition's shape.
+    Value zeros = rewriter
+                      .create<FullOp>(loc, maskType,
+                                      rewriter.getF32FloatAttr(0.0f), device)
+                      .getResult();
+    Value negInf =
+        rewriter
+            .create<FullOp>(loc, maskType,
+                            rewriter.getF32FloatAttr(
+                                -std::numeric_limits<float>::infinity()),
+                            device)
+            .getResult();
+
+    // 6. where(isMasked, -inf, 0) -> [B, 1, 1, Sk] mask in prefill convention.
+    // The mask is in {0, -inf} so pre-scaling by `scale` is a no-op
+    // (scale*0=0, scale*-inf=-inf); no MultiplyOp needed.
+    scaledMask =
+        rewriter.create<WhereOp>(loc, maskType, isMasked, negInf, zeros)
+            .getResult();
+  }
+
+  // Attention sink: decode layout is [Hq, 32] (tile-padded), prefill expects
+  // [1, Hq, 1, 1]. Take column 0 of the tile (the meaningful per-head value)
+  // and add the broadcast dims.
+  Value attentionSink = op.getAttentionSink();
+  if (attentionSink) {
+    auto sinkType = mlir::cast<RankedTensorType>(attentionSink.getType());
+    auto sinkShape = sinkType.getShape();
+    if (sinkShape.size() == 2) {
+      int64_t numHeadsQ = sinkShape[0];
+      int64_t tileCols = sinkShape[1];
+
+      // Reshape [Hq, tileCols] -> [1, Hq, 1, tileCols].
+      llvm::SmallVector<int64_t> sink4dShape = {1, numHeadsQ, 1, tileCols};
+      auto sink4dType =
+          ttnn::utils::RankedTensorTypeFactory::create(sinkType, sink4dShape);
+      llvm::SmallVector<int32_t> sink4dShapeI32 = {
+          1, static_cast<int32_t>(numHeadsQ), 1,
+          static_cast<int32_t>(tileCols)};
+      attentionSink =
+          rewriter
+              .create<ttnn::ReshapeOp>(loc, sink4dType, attentionSink,
+                                       rewriter.getI32ArrayAttr(sink4dShapeI32))
+              .getResult();
+
+      // Slice column 0: [1, Hq, 1, tileCols] -> [1, Hq, 1, 1].
+      llvm::SmallVector<int64_t> slicedSinkShape = {1, numHeadsQ, 1, 1};
+      auto slicedSinkType = ttnn::utils::RankedTensorTypeFactory::create(
+          sinkType, slicedSinkShape);
+      llvm::SmallVector<int32_t> begins = {0, 0, 0, 0};
+      llvm::SmallVector<int32_t> ends = {1, static_cast<int32_t>(numHeadsQ), 1,
+                                         1};
+      llvm::SmallVector<int32_t> steps = {1, 1, 1, 1};
+      attentionSink =
+          rewriter
+              .create<SliceStaticOp>(loc, slicedSinkType, attentionSink,
+                                     rewriter.getI32ArrayAttr(begins),
+                                     rewriter.getI32ArrayAttr(ends),
+                                     rewriter.getI32ArrayAttr(steps))
+              .getResult();
+    }
   }
 
   // Create ScaledDotProductAttentionOp.
   // Result type matches permuted Q shape: [B, H, 1, D].
+  // is_causal is always false because causality, when present, has been
+  // baked into the synthesized mask via cur_pos_tensor.
   auto sdpaOp = rewriter.create<ttnn::ScaledDotProductAttentionOp>(
       loc, permutedQuery.getType(), permutedQuery, op.getKey(), op.getValue(),
       scaledMask,
       /*is_causal=*/rewriter.getBoolAttr(false), op.getScaleAttr(),
-      /*sliding_window_size=*/IntegerAttr(), op.getAttentionSink());
+      /*sliding_window_size=*/IntegerAttr(), attentionSink);
 
   // Permute result back from [B, H, 1, D] to [1, B, H, D].
   Value finalResult =

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
@@ -4,9 +4,12 @@
 
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.h"
 
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Support/Logger.h"
 #include "ttmlir/Utils.h"
+
+#include <cmath>
 
 namespace mlir::tt::ttnn::decomposition {
 
@@ -16,6 +19,10 @@ namespace mlir::tt::ttnn::decomposition {
 static constexpr std::array<int64_t, 4> kToSDPAPermutation = {1, 2, 0, 3};
 // Inverse: [2, 0, 1, 3] maps [B, H, 1, D] -> [1, B, H, D]
 static constexpr std::array<int64_t, 4> kFromSDPAPermutation = {2, 0, 1, 3};
+// SDPADecode mask shape: [B, 1, Hq, Sk]   (heads at dim 2)
+// SDPA      mask shape: [B, Hq, Sq, Sk]   (heads at dim 1, Sq=1 after dispatch)
+// Permutation: [0, 2, 1, 3] maps [B, 1, Hq, Sk] -> [B, Hq, 1, Sk]
+static constexpr std::array<int64_t, 4> kMaskToSDPAPermutation = {0, 2, 1, 3};
 
 static Value createPermute(Value input, ArrayRef<int64_t> permutation,
                            PatternRewriter &rewriter, Location loc) {
@@ -58,19 +65,53 @@ LogicalResult SDPADecodeDecompositionPattern::matchAndRewrite(
 
   Location loc = op.getLoc();
 
-  // Step 1: Permute Q from [1, B, H, D] to [B, H, 1, D].
+  // Permute Q from [1, B, H, D] to [B, H, 1, D].
   Value permutedQuery =
       createPermute(op.getQuery(), kToSDPAPermutation, rewriter, loc);
 
-  // Step 2: Create ScaledDotProductAttentionOp.
+  // Decode applies the mask as softmax(scale*(QK + mask)), but regular SDPA
+  // applies it as softmax(scale*QK + mask). Pre-scale the mask so the
+  // downstream regular SDPA produces decode-equivalent values.
+  Value scaledMask = op.getAttentionMask();
+  if (scaledMask) {
+    float scaleValue;
+    if (op.getScaleAttr()) {
+      scaleValue = op.getScaleAttr().getValueAsDouble();
+    } else {
+      int64_t headDim = qType.getShape().back();
+      scaleValue = 1.0f / std::sqrt(static_cast<float>(headDim));
+    }
+    auto maskType = mlir::cast<RankedTensorType>(scaledMask.getType());
+    llvm::SmallVector<int64_t> scalarShape(maskType.getRank(), 1);
+    RankedTensorType scalarType =
+        ttnn::utils::RankedTensorTypeFactory::create(maskType, scalarShape);
+    Value device =
+        utils::getOrInsertDevice(rewriter, op.getOperation()).getResult();
+    Value scaleTensor =
+        rewriter
+            .create<FullOp>(loc, scalarType,
+                            rewriter.getF32FloatAttr(scaleValue), device)
+            .getResult();
+    scaledMask = rewriter
+                     .create<MultiplyOp>(loc, maskType, scaledMask, scaleTensor)
+                     .getResult();
+
+    // Decode mask layout is [B, 1, Hq, Sk] (heads at dim 2). The downstream
+    // regular SDPA op expects [B, Hq, Sq, Sk] (heads at dim 1, Sq=1 here).
+    // Permute dims 1 and 2 to bridge the convention difference.
+    scaledMask =
+        createPermute(scaledMask, kMaskToSDPAPermutation, rewriter, loc);
+  }
+
+  // Create ScaledDotProductAttentionOp.
   // Result type matches permuted Q shape: [B, H, 1, D].
   auto sdpaOp = rewriter.create<ttnn::ScaledDotProductAttentionOp>(
       loc, permutedQuery.getType(), permutedQuery, op.getKey(), op.getValue(),
-      op.getAttentionMask(),
+      scaledMask,
       /*is_causal=*/rewriter.getBoolAttr(false), op.getScaleAttr(),
       /*sliding_window_size=*/IntegerAttr(), op.getAttentionSink());
 
-  // Step 3: Permute result back from [B, H, 1, D] to [1, B, H, D].
+  // Permute result back from [B, H, 1, D] to [1, B, H, D].
   Value finalResult =
       createPermute(sdpaOp.getResult(), kFromSDPAPermutation, rewriter, loc);
 

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
@@ -17,21 +17,13 @@ static constexpr std::array<int64_t, 4> kToSDPAPermutation = {1, 2, 0, 3};
 // Inverse: [2, 0, 1, 3] maps [B, H, 1, D] -> [1, B, H, D]
 static constexpr std::array<int64_t, 4> kFromSDPAPermutation = {2, 0, 1, 3};
 
-// Create a permute op. Uses RankedTensorTypeFactory when TTNN layout encoding
-// is present, falls back to plain RankedTensorType otherwise.
 static Value createPermute(Value input, ArrayRef<int64_t> permutation,
                            PatternRewriter &rewriter, Location loc) {
   auto inputType = mlir::cast<RankedTensorType>(input.getType());
   llvm::SmallVector<int64_t> outputShape =
       ttmlir::utils::applyPermutation(inputType.getShape(), permutation);
-
-  RankedTensorType outputType;
-  if (inputType.getEncoding()) {
-    outputType =
-        ttnn::utils::RankedTensorTypeFactory::create(inputType, outputShape);
-  } else {
-    outputType = RankedTensorType::get(outputShape, inputType.getElementType());
-  }
+  RankedTensorType outputType =
+      ttnn::utils::RankedTensorTypeFactory::create(inputType, outputShape);
 
   return rewriter.create<PermuteOp>(loc, outputType, input,
                                     rewriter.getDenseI64ArrayAttr(permutation),

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.h"
+
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Support/Logger.h"
+#include "ttmlir/Utils.h"
+
+namespace mlir::tt::ttnn::decomposition {
+
+// SDPADecode Q shape: [1, B, H, D]
+// SDPA Q shape:       [B, H, Sq, D]
+// Permutation: [1, 2, 0, 3] maps [1, B, H, D] -> [B, H, 1, D]
+static constexpr std::array<int64_t, 4> kToSDPAPermutation = {1, 2, 0, 3};
+// Inverse: [2, 0, 1, 3] maps [B, H, 1, D] -> [1, B, H, D]
+static constexpr std::array<int64_t, 4> kFromSDPAPermutation = {2, 0, 1, 3};
+
+// Create a permute op. Uses RankedTensorTypeFactory when TTNN layout encoding
+// is present, falls back to plain RankedTensorType otherwise.
+static Value createPermute(Value input, ArrayRef<int64_t> permutation,
+                           PatternRewriter &rewriter, Location loc) {
+  auto inputType = mlir::cast<RankedTensorType>(input.getType());
+  llvm::SmallVector<int64_t> outputShape =
+      ttmlir::utils::applyPermutation(inputType.getShape(), permutation);
+
+  RankedTensorType outputType;
+  if (inputType.getEncoding()) {
+    outputType =
+        ttnn::utils::RankedTensorTypeFactory::create(inputType, outputShape);
+  } else {
+    outputType = RankedTensorType::get(outputShape, inputType.getElementType());
+  }
+
+  return rewriter.create<PermuteOp>(loc, outputType, input,
+                                    rewriter.getDenseI64ArrayAttr(permutation),
+                                    /*memory_config=*/nullptr,
+                                    /*pad_value=*/mlir::FloatAttr());
+}
+
+LogicalResult SDPADecodeDecompositionPattern::matchAndRewrite(
+    ttnn::ScaledDotProductAttentionDecodeOp op,
+    PatternRewriter &rewriter) const {
+
+  auto qType = mlir::cast<RankedTensorType>(op.getQuery().getType());
+
+  if (validationConfig.has_value()) {
+    IsolatedIRValidationWrapper validator(rewriter.getContext(),
+                                          *validationConfig);
+
+    auto validationResult =
+        validator.validateOp<ttnn::ScaledDotProductAttentionDecodeOp>(
+            op.getOperation(), op.getLoc(), {qType}, op.getQuery(), op.getKey(),
+            op.getValue(), op.getIsCausalAttr(), op.getAttentionMask(),
+            op.getCurPosTensor(), op.getAttentionSink(), op.getScaleAttr(),
+            op.getProgramConfigAttr());
+
+    if (validationResult.isSuccess()) {
+      return failure();
+    }
+
+    TTMLIR_DEBUG(ttmlir::LogComponent::IsolatedIRValidationWrapper,
+                 "SDPA decode decomposition triggered (validation failed): {0}",
+                 validationResult.errorMessage);
+  }
+
+  Location loc = op.getLoc();
+
+  // Step 1: Permute Q from [1, B, H, D] to [B, H, 1, D].
+  Value permutedQuery =
+      createPermute(op.getQuery(), kToSDPAPermutation, rewriter, loc);
+
+  // Step 2: Create ScaledDotProductAttentionOp.
+  // Result type matches permuted Q shape: [B, H, 1, D].
+  auto sdpaOp = rewriter.create<ttnn::ScaledDotProductAttentionOp>(
+      loc, permutedQuery.getType(), permutedQuery, op.getKey(), op.getValue(),
+      op.getAttentionMask(),
+      /*is_causal=*/rewriter.getBoolAttr(false), op.getScaleAttr(),
+      /*sliding_window_size=*/IntegerAttr(), op.getAttentionSink());
+
+  // Step 3: Permute result back from [B, H, 1, D] to [1, B, H, D].
+  Value finalResult =
+      createPermute(sdpaOp.getResult(), kFromSDPAPermutation, rewriter, loc);
+
+  rewriter.replaceOp(op, finalResult);
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::decomposition

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
@@ -69,9 +69,15 @@ LogicalResult SDPADecodeDecompositionPattern::matchAndRewrite(
   Value permutedQuery =
       createPermute(op.getQuery(), kToSDPAPermutation, rewriter, loc);
 
-  // Decode applies the mask as softmax(scale*(QK + mask)), but regular SDPA
-  // applies it as softmax(scale*QK + mask). Pre-scale the mask so the
-  // downstream regular SDPA produces decode-equivalent values.
+  // The two SDPA ops have different mask conventions at the API level:
+  //   - decode: result = softmax(scale * (QK + mask))   = softmax(scale*QK +
+  //   scale*mask)
+  //   - prefill: result = softmax(scale * QK + mask) (PyTorch-style)
+  // Both kernels internally compute softmax(scale*(QK + mask)); prefill's host
+  // wrapper compensates by pre-dividing the user mask by scale, decode's does
+  // not. To make a prefill op produce the decode result on the same mask m,
+  // we feed prefill m' = scale * m; then prefill computes
+  //   softmax(scale*QK + scale*m) == decode(m).
   Value scaledMask = op.getAttentionMask();
   if (scaledMask) {
     float scaleValue;
@@ -92,9 +98,9 @@ LogicalResult SDPADecodeDecompositionPattern::matchAndRewrite(
             .create<FullOp>(loc, scalarType,
                             rewriter.getF32FloatAttr(scaleValue), device)
             .getResult();
-    scaledMask = rewriter
-                     .create<MultiplyOp>(loc, maskType, scaledMask, scaleTensor)
-                     .getResult();
+    scaledMask =
+        rewriter.create<MultiplyOp>(loc, maskType, scaledMask, scaleTensor)
+            .getResult();
 
     // Decode mask layout is [B, 1, Hq, Sk] (heads at dim 2). The downstream
     // regular SDPA op expects [B, Hq, Sq, Sk] (heads at dim 1, Sq=1 here).

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
@@ -307,9 +307,6 @@ SDPADecompositionPattern::matchAndRewrite(ttnn::ScaledDotProductAttentionOp op,
                  .create<ConcatOp>(loc, concatType, concatInputs,
                                    static_cast<int32_t>(-1))
                  .getResult();
-
-    // Update seqLenKV to reflect concatenated dimension.
-    seqLenKV += sinkCols;
   }
 
   // ---- Softmax ----

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
@@ -68,15 +68,20 @@ static Value generateSlidingWindowMask(PatternRewriter &rewriter, Location loc,
                                        uint32_t windowSize, bool isCausal,
                                        RankedTensorType referenceType,
                                        Value device) {
+  // Window topology must match the tt-metal kernel:
+  //   causal:     j in [i - W + 1, i]                  (last W tokens)
+  //   non-causal: j in [i - W/2,   i + W/2] inclusive  (W+1 tokens centered)
+  int64_t halfWindow = static_cast<int64_t>(windowSize) / 2;
   llvm::SmallVector<float> maskData;
   maskData.reserve(seqLenQ * seqLenKV);
   for (int64_t i = 0; i < seqLenQ; i++) {
     for (int64_t j = 0; j < seqLenKV; j++) {
       int64_t diff = i - j;
-      bool inWindow = diff >= 0 && diff < static_cast<int64_t>(windowSize);
-      if (!isCausal) {
-        // Bidirectional: window centered on position
-        inWindow = std::abs(diff) < static_cast<int64_t>(windowSize);
+      bool inWindow;
+      if (isCausal) {
+        inWindow = diff >= 0 && diff < static_cast<int64_t>(windowSize);
+      } else {
+        inWindow = diff >= -halfWindow && diff <= halfWindow;
       }
       maskData.push_back(inWindow ? 0.0f
                                   : -std::numeric_limits<float>::infinity());
@@ -264,18 +269,42 @@ LogicalResult SDPADecompositionPattern::matchAndRewrite(
   }
 
   // ---- Attention sink (concat) ----
-  // If attention_sink is present, concatenate it along the last dimension.
+  // Kernel computes softmax([scale*QK, scale*sink]) — the user-provided sink
+  // is in raw logit units (same coord frame as raw QK). Pre-scale the sink so
+  // it lives in the same units as the already-scaled scores before concat.
+  // The sink is broadcast across batch and Sq before concat since ttnn.concat
+  // requires matching non-concat dimensions (unlike the fused kernel which
+  // broadcasts implicitly).
   Value attentionSink = op.getAttentionSink();
   int64_t originalSeqLenKV = seqLenKV;
   if (attentionSink) {
     auto sinkType = mlir::cast<RankedTensorType>(attentionSink.getType());
     int64_t sinkCols = sinkType.getShape().back();
 
+    Value scaledSink =
+        rewriter
+            .create<MultiplyOp>(loc, sinkType, attentionSink, scaleTensor)
+            .getResult();
+
+    // Broadcast sink [1, Hq, 1, sinkCols] -> [B, Hq, Sq, sinkCols].
+    llvm::SmallVector<int64_t> broadcastSinkShape = {batch, numHeads, seqLenQ,
+                                                     sinkCols};
+    if (sinkType.getShape() != ArrayRef<int64_t>(broadcastSinkShape)) {
+      auto broadcastSinkType = createResultType(qType, broadcastSinkShape);
+      llvm::SmallVector<int64_t> sinkRepeatDims = {batch, 1, seqLenQ, 1};
+      scaledSink =
+          rewriter
+              .create<RepeatOp>(
+                  loc, broadcastSinkType, scaledSink,
+                  ShapeAttr::get(rewriter.getContext(), sinkRepeatDims))
+              .getResult();
+    }
+
     llvm::SmallVector<int64_t> concatShape = {batch, numHeads, seqLenQ,
                                               seqLenKV + sinkCols};
     auto concatType = createResultType(qType, concatShape);
 
-    SmallVector<Value> concatInputs = {scores, attentionSink};
+    SmallVector<Value> concatInputs = {scores, scaledSink};
     scores = rewriter
                  .create<ConcatOp>(loc, concatType, concatInputs,
                                    static_cast<int32_t>(-1))
@@ -286,10 +315,15 @@ LogicalResult SDPADecompositionPattern::matchAndRewrite(
   }
 
   // ---- Softmax ----
+  // numericStable=true subtracts rowwise max before exp, matching the fused
+  // kernel's online-softmax. Required because scale·QK can exceed bf16's exp
+  // range (e.g. head_dim=256 with non-standard scale produces scores ~100, and
+  // exp(100) overflows bf16) — without max subtraction softmax returns NaN.
   auto softmaxInputType = mlir::cast<RankedTensorType>(scores.getType());
   Value softmaxOut =
       rewriter
-          .create<SoftmaxOp>(loc, softmaxInputType, scores, /*dimension=*/-1)
+          .create<SoftmaxOp>(loc, softmaxInputType, scores, /*dimension=*/-1,
+                             /*numericStable=*/true)
           .getResult();
 
   // ---- Slice to remove sink columns ----

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
@@ -19,13 +19,9 @@ static constexpr int64_t kNumHeadsDim = 1;
 static constexpr int64_t kSeqLenDim = 2;
 static constexpr int64_t kHeadDim = 3;
 
-// Create a RankedTensorType preserving TTNN layout encoding when present.
 static RankedTensorType createResultType(RankedTensorType sourceType,
                                          ArrayRef<int64_t> newShape) {
-  if (sourceType.getEncoding()) {
-    return ttnn::utils::RankedTensorTypeFactory::create(sourceType, newShape);
-  }
-  return RankedTensorType::get(newShape, sourceType.getElementType());
+  return ttnn::utils::RankedTensorTypeFactory::create(sourceType, newShape);
 }
 
 /// Generate a causal mask [1, 1, Sq, Skv] as a compile-time constant.

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
@@ -106,8 +106,9 @@ static Value generateSlidingWindowMask(PatternRewriter &rewriter, Location loc,
                                      dtypeAttr, tensorLayoutAttr);
 }
 
-LogicalResult SDPADecompositionPattern::matchAndRewrite(
-    ttnn::ScaledDotProductAttentionOp op, PatternRewriter &rewriter) const {
+LogicalResult
+SDPADecompositionPattern::matchAndRewrite(ttnn::ScaledDotProductAttentionOp op,
+                                          PatternRewriter &rewriter) const {
 
   auto qType = mlir::cast<RankedTensorType>(op.getQuery().getType());
 
@@ -248,8 +249,7 @@ LogicalResult SDPADecompositionPattern::matchAndRewrite(
                  .getResult();
     }
 
-    scores =
-        rewriter.create<AddOp>(loc, scoresType, scores, mask).getResult();
+    scores = rewriter.create<AddOp>(loc, scoresType, scores, mask).getResult();
   }
 
   // Generate positional mask (sliding window and/or causal).
@@ -282,8 +282,7 @@ LogicalResult SDPADecompositionPattern::matchAndRewrite(
     int64_t sinkCols = sinkType.getShape().back();
 
     Value scaledSink =
-        rewriter
-            .create<MultiplyOp>(loc, sinkType, attentionSink, scaleTensor)
+        rewriter.create<MultiplyOp>(loc, sinkType, attentionSink, scaleTensor)
             .getResult();
 
     // Broadcast sink [1, Hq, 1, sinkCols] -> [B, Hq, Sq, sinkCols].
@@ -292,12 +291,11 @@ LogicalResult SDPADecompositionPattern::matchAndRewrite(
     if (sinkType.getShape() != ArrayRef<int64_t>(broadcastSinkShape)) {
       auto broadcastSinkType = createResultType(qType, broadcastSinkShape);
       llvm::SmallVector<int64_t> sinkRepeatDims = {batch, 1, seqLenQ, 1};
-      scaledSink =
-          rewriter
-              .create<RepeatOp>(
-                  loc, broadcastSinkType, scaledSink,
-                  ShapeAttr::get(rewriter.getContext(), sinkRepeatDims))
-              .getResult();
+      scaledSink = rewriter
+                       .create<RepeatOp>(loc, broadcastSinkType, scaledSink,
+                                         ShapeAttr::get(rewriter.getContext(),
+                                                        sinkRepeatDims))
+                       .getResult();
     }
 
     llvm::SmallVector<int64_t> concatShape = {batch, numHeads, seqLenQ,

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
@@ -61,8 +61,7 @@ static Value generateCausalMask(PatternRewriter &rewriter, Location loc,
         LayoutAttr::get(rewriter.getContext(), layoutAttr.getLayout());
   }
   return rewriter.create<ConstantOp>(loc, maskType, device, denseAttr,
-                                     dtypeAttr, tensorLayoutAttr,
-                                     /*memory_config=*/MemoryConfigAttr());
+                                     dtypeAttr, tensorLayoutAttr);
 }
 
 /// Generate a sliding window mask [1, 1, Sq, Skv] as a compile-time constant.
@@ -103,8 +102,7 @@ static Value generateSlidingWindowMask(PatternRewriter &rewriter, Location loc,
         LayoutAttr::get(rewriter.getContext(), layoutAttr.getLayout());
   }
   return rewriter.create<ConstantOp>(loc, maskType, device, denseAttr,
-                                     dtypeAttr, tensorLayoutAttr,
-                                     /*memory_config=*/MemoryConfigAttr());
+                                     dtypeAttr, tensorLayoutAttr);
 }
 
 LogicalResult SDPADecompositionPattern::matchAndRewrite(
@@ -169,16 +167,14 @@ LogicalResult SDPADecompositionPattern::matchAndRewrite(
     key = rewriter
               .create<RepeatInterleaveOp>(
                   loc, expandedKType, key, rewriter.getUI32IntegerAttr(repeats),
-                  rewriter.getSI32IntegerAttr(kNumHeadsDim),
-                  /*memory_config=*/MemoryConfigAttr())
+                  rewriter.getSI32IntegerAttr(kNumHeadsDim))
               .getResult();
 
     value =
         rewriter
             .create<RepeatInterleaveOp>(
                 loc, expandedVType, value, rewriter.getUI32IntegerAttr(repeats),
-                rewriter.getSI32IntegerAttr(kNumHeadsDim),
-                /*memory_config=*/MemoryConfigAttr())
+                rewriter.getSI32IntegerAttr(kNumHeadsDim))
             .getResult();
   }
 
@@ -247,8 +243,7 @@ LogicalResult SDPADecompositionPattern::matchAndRewrite(
       mask = rewriter
                  .create<RepeatOp>(
                      loc, broadcastType, mask,
-                     ShapeAttr::get(rewriter.getContext(), repeatDims),
-                     /*memory_config=*/MemoryConfigAttr())
+                     ShapeAttr::get(rewriter.getContext(), repeatDims))
                  .getResult();
     }
 
@@ -287,8 +282,7 @@ LogicalResult SDPADecompositionPattern::matchAndRewrite(
     SmallVector<Value> concatInputs = {scores, attentionSink};
     scores = rewriter
                  .create<ConcatOp>(loc, concatType, concatInputs,
-                                   static_cast<int32_t>(-1),
-                                   /*memory_config=*/MemoryConfigAttr())
+                                   static_cast<int32_t>(-1))
                  .getResult();
 
     // Update seqLenKV to reflect concatenated dimension.

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.h"
+
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Support/Logger.h"
+
+#include <cmath>
+#include <limits>
+
+namespace mlir::tt::ttnn::decomposition {
+
+// Dimension indices for 4D attention tensors [B, H, S, D].
+static constexpr int64_t kBatchDim = 0; // [B, H, S, D]
+static constexpr int64_t kNumHeadsDim = 1;
+static constexpr int64_t kSeqLenDim = 2;
+static constexpr int64_t kHeadDim = 3;
+
+// Create a RankedTensorType preserving TTNN layout encoding when present.
+static RankedTensorType createResultType(RankedTensorType sourceType,
+                                         ArrayRef<int64_t> newShape) {
+  if (sourceType.getEncoding()) {
+    return ttnn::utils::RankedTensorTypeFactory::create(sourceType, newShape);
+  }
+  return RankedTensorType::get(newShape, sourceType.getElementType());
+}
+
+/// Generate a causal mask [1, 1, Sq, Skv] as a compile-time constant.
+/// Lower triangle = 0.0, upper triangle = -inf.
+static Value generateCausalMask(PatternRewriter &rewriter, Location loc,
+                                int64_t seqLenQ, int64_t seqLenKV,
+                                RankedTensorType referenceType, Value device) {
+  // Build the mask data at compile time.
+  llvm::SmallVector<float> maskData;
+  maskData.reserve(seqLenQ * seqLenKV);
+  for (int64_t i = 0; i < seqLenQ; i++) {
+    for (int64_t j = 0; j < seqLenKV; j++) {
+      maskData.push_back((i >= j) ? 0.0f
+                                  : -std::numeric_limits<float>::infinity());
+    }
+  }
+
+  // Create dense attribute with f32 type (encoding-free).
+  auto maskShape = llvm::SmallVector<int64_t>{1, 1, seqLenQ, seqLenKV};
+  auto plainMaskType = RankedTensorType::get(maskShape, rewriter.getF32Type());
+  auto denseAttr = DenseFPElementsAttr::get(plainMaskType, maskData);
+
+  // Create ConstantOp with TTNN-encoded result type.
+  // Extract dtype and layout from encoding for the verifier.
+  auto maskType = createResultType(referenceType, maskShape);
+  ttcore::DataTypeAttr dtypeAttr;
+  LayoutAttr tensorLayoutAttr;
+  if (auto layoutAttr = mlir::dyn_cast_if_present<TTNNLayoutAttr>(
+          referenceType.getEncoding())) {
+    dtypeAttr = ttcore::DataTypeAttr::get(rewriter.getContext(),
+                                          layoutAttr.getDataType());
+    tensorLayoutAttr =
+        LayoutAttr::get(rewriter.getContext(), layoutAttr.getLayout());
+  }
+  return rewriter.create<ConstantOp>(loc, maskType, device, denseAttr,
+                                     dtypeAttr, tensorLayoutAttr,
+                                     /*memory_config=*/MemoryConfigAttr());
+}
+
+/// Generate a sliding window mask [1, 1, Sq, Skv] as a compile-time constant.
+/// Positions where (row - col) < 0 or (row - col) >= windowSize are -inf.
+/// If isCausal is true, also masks future positions (row < col).
+static Value generateSlidingWindowMask(PatternRewriter &rewriter, Location loc,
+                                       int64_t seqLenQ, int64_t seqLenKV,
+                                       uint32_t windowSize, bool isCausal,
+                                       RankedTensorType referenceType,
+                                       Value device) {
+  llvm::SmallVector<float> maskData;
+  maskData.reserve(seqLenQ * seqLenKV);
+  for (int64_t i = 0; i < seqLenQ; i++) {
+    for (int64_t j = 0; j < seqLenKV; j++) {
+      int64_t diff = i - j;
+      bool inWindow = diff >= 0 && diff < static_cast<int64_t>(windowSize);
+      if (!isCausal) {
+        // Bidirectional: window centered on position
+        inWindow = std::abs(diff) < static_cast<int64_t>(windowSize);
+      }
+      maskData.push_back(inWindow ? 0.0f
+                                  : -std::numeric_limits<float>::infinity());
+    }
+  }
+
+  auto maskShape = llvm::SmallVector<int64_t>{1, 1, seqLenQ, seqLenKV};
+  auto plainMaskType = RankedTensorType::get(maskShape, rewriter.getF32Type());
+  auto denseAttr = DenseFPElementsAttr::get(plainMaskType, maskData);
+
+  auto maskType = createResultType(referenceType, maskShape);
+  ttcore::DataTypeAttr dtypeAttr;
+  LayoutAttr tensorLayoutAttr;
+  if (auto layoutAttr = mlir::dyn_cast_if_present<TTNNLayoutAttr>(
+          referenceType.getEncoding())) {
+    dtypeAttr = ttcore::DataTypeAttr::get(rewriter.getContext(),
+                                          layoutAttr.getDataType());
+    tensorLayoutAttr =
+        LayoutAttr::get(rewriter.getContext(), layoutAttr.getLayout());
+  }
+  return rewriter.create<ConstantOp>(loc, maskType, device, denseAttr,
+                                     dtypeAttr, tensorLayoutAttr,
+                                     /*memory_config=*/MemoryConfigAttr());
+}
+
+LogicalResult SDPADecompositionPattern::matchAndRewrite(
+    ttnn::ScaledDotProductAttentionOp op, PatternRewriter &rewriter) const {
+
+  auto qType = mlir::cast<RankedTensorType>(op.getQuery().getType());
+
+  // When validation config is provided, validate the SDPA op using
+  // IsolatedIRValidationWrapper. If validation succeeds, keep the op as-is.
+  if (validationConfig.has_value()) {
+    IsolatedIRValidationWrapper validator(rewriter.getContext(),
+                                          *validationConfig);
+
+    auto validationResult =
+        validator.validateOp<ttnn::ScaledDotProductAttentionOp>(
+            op.getOperation(), op.getLoc(), {qType}, op.getQuery(), op.getKey(),
+            op.getValue(), op.getAttentionMask(), op.getIsCausalAttr(),
+            op.getScaleAttr(), op.getSlidingWindowSizeAttr(),
+            op.getAttentionSink());
+
+    if (validationResult.isSuccess()) {
+      // Op is valid — keep it as-is.
+      return failure();
+    }
+
+    TTMLIR_DEBUG(ttmlir::LogComponent::IsolatedIRValidationWrapper,
+                 "SDPA decomposition triggered (validation failed): {0}",
+                 validationResult.errorMessage);
+  }
+
+  Location loc = op.getLoc();
+
+  auto kType = mlir::cast<RankedTensorType>(op.getKey().getType());
+
+  auto qShape = qType.getShape();
+  auto kShape = kType.getShape();
+
+  int64_t numHeads = qShape[kNumHeadsDim];
+  int64_t numKVHeads = kShape[kNumHeadsDim];
+  int64_t seqLenQ = qShape[kSeqLenDim];
+  int64_t seqLenKV = kShape[kSeqLenDim];
+  int64_t headDim = qShape[kHeadDim];
+  int64_t batch = qShape[kBatchDim];
+
+  Value query = op.getQuery();
+  Value key = op.getKey();
+  Value value = op.getValue();
+
+  // ---- GQA head expansion ----
+  // If num_heads != num_kv_heads, repeat K and V along the heads dimension.
+  if (numHeads != numKVHeads) {
+    assert(numHeads % numKVHeads == 0 &&
+           "num_heads must be divisible by num_kv_heads");
+    uint32_t repeats = static_cast<uint32_t>(numHeads / numKVHeads);
+
+    llvm::SmallVector<int64_t> expandedKVShape = {batch, numHeads, seqLenKV,
+                                                  headDim};
+    auto expandedKType = createResultType(kType, expandedKVShape);
+    auto expandedVType = createResultType(
+        mlir::cast<RankedTensorType>(value.getType()), expandedKVShape);
+
+    key = rewriter
+              .create<RepeatInterleaveOp>(
+                  loc, expandedKType, key, rewriter.getUI32IntegerAttr(repeats),
+                  rewriter.getSI32IntegerAttr(kNumHeadsDim),
+                  /*memory_config=*/MemoryConfigAttr())
+              .getResult();
+
+    value =
+        rewriter
+            .create<RepeatInterleaveOp>(
+                loc, expandedVType, value, rewriter.getUI32IntegerAttr(repeats),
+                rewriter.getSI32IntegerAttr(kNumHeadsDim),
+                /*memory_config=*/MemoryConfigAttr())
+            .getResult();
+  }
+
+  // ---- Transpose K ----
+  // K: [B, H, Skv, D] -> [B, H, D, Skv]
+  llvm::SmallVector<int64_t> kTransposedShape = {batch, numHeads, headDim,
+                                                 seqLenKV};
+  auto kTransposedType = createResultType(
+      mlir::cast<RankedTensorType>(key.getType()), kTransposedShape);
+
+  Value kTransposed = rewriter
+                          .create<TransposeOp>(loc, kTransposedType, key,
+                                               rewriter.getSI32IntegerAttr(-2),
+                                               rewriter.getSI32IntegerAttr(-1))
+                          .getResult();
+
+  // ---- Matmul Q @ K^T ----
+  // [B, H, Sq, D] x [B, H, D, Skv] -> [B, H, Sq, Skv]
+  llvm::SmallVector<int64_t> scoresShape = {batch, numHeads, seqLenQ, seqLenKV};
+  auto scoresType = createResultType(qType, scoresShape);
+
+  Value scores =
+      rewriter
+          .create<MatmulOp>(loc, scoresType, query, kTransposed,
+                            /*transpose_a=*/false, /*transpose_b=*/false,
+                            /*matmul_program_config=*/nullptr,
+                            /*activation=*/nullptr)
+          .getResult();
+
+  // ---- Scale ----
+  // Use provided scale or default 1/sqrt(D).
+  float scaleValue;
+  if (op.getScaleAttr()) {
+    scaleValue = op.getScaleAttr().getValueAsDouble();
+  } else {
+    scaleValue = 1.0f / std::sqrt(static_cast<float>(headDim));
+  }
+
+  // Create a scalar tensor filled with the scale value.
+  llvm::SmallVector<int64_t> scalarShape = {1, 1, 1, 1};
+  auto scalarType = createResultType(qType, scalarShape);
+  Value device =
+      utils::getOrInsertDevice(rewriter, op.getOperation()).getResult();
+  Value scaleTensor =
+      rewriter
+          .create<FullOp>(loc, scalarType, rewriter.getF32FloatAttr(scaleValue),
+                          device)
+          .getResult();
+
+  scores = rewriter.create<MultiplyOp>(loc, scoresType, scores, scaleTensor)
+               .getResult();
+
+  // ---- Add attention mask ----
+  if (op.getAttentionMask()) {
+    Value mask = op.getAttentionMask();
+
+    // Broadcast mask along the heads dimension if needed.
+    // Mask may be [B, 1, Sq, Skv] while scores are [B, H, Sq, Skv].
+    auto maskType = mlir::cast<RankedTensorType>(mask.getType());
+    auto maskShape = maskType.getShape();
+    if (maskShape[kNumHeadsDim] == 1 && numHeads > 1) {
+      llvm::SmallVector<int64_t> broadcastShape(maskShape);
+      broadcastShape[kNumHeadsDim] = numHeads;
+      auto broadcastType = createResultType(maskType, broadcastShape);
+      llvm::SmallVector<int64_t> repeatDims = {1, numHeads, 1, 1};
+      mask = rewriter
+                 .create<RepeatOp>(
+                     loc, broadcastType, mask,
+                     ShapeAttr::get(rewriter.getContext(), repeatDims),
+                     /*memory_config=*/MemoryConfigAttr())
+                 .getResult();
+    }
+
+    scores =
+        rewriter.create<AddOp>(loc, scoresType, scores, mask).getResult();
+  }
+
+  // Generate positional mask (sliding window and/or causal).
+  if (op.getSlidingWindowSizeAttr()) {
+    uint32_t windowSize = op.getSlidingWindowSizeAttr().getUInt();
+    Value windowMask =
+        generateSlidingWindowMask(rewriter, loc, seqLenQ, seqLenKV, windowSize,
+                                  op.getIsCausal(), qType, device);
+    scores =
+        rewriter.create<AddOp>(loc, scoresType, scores, windowMask).getResult();
+  } else if (!op.getAttentionMask() && op.getIsCausal()) {
+    // Causal-only mask (no sliding window, no explicit mask).
+    Value causalMask =
+        generateCausalMask(rewriter, loc, seqLenQ, seqLenKV, qType, device);
+    scores =
+        rewriter.create<AddOp>(loc, scoresType, scores, causalMask).getResult();
+  }
+
+  // ---- Attention sink (concat) ----
+  // If attention_sink is present, concatenate it along the last dimension.
+  Value attentionSink = op.getAttentionSink();
+  int64_t originalSeqLenKV = seqLenKV;
+  if (attentionSink) {
+    auto sinkType = mlir::cast<RankedTensorType>(attentionSink.getType());
+    int64_t sinkCols = sinkType.getShape().back();
+
+    llvm::SmallVector<int64_t> concatShape = {batch, numHeads, seqLenQ,
+                                              seqLenKV + sinkCols};
+    auto concatType = createResultType(qType, concatShape);
+
+    SmallVector<Value> concatInputs = {scores, attentionSink};
+    scores = rewriter
+                 .create<ConcatOp>(loc, concatType, concatInputs,
+                                   static_cast<int32_t>(-1),
+                                   /*memory_config=*/MemoryConfigAttr())
+                 .getResult();
+
+    // Update seqLenKV to reflect concatenated dimension.
+    seqLenKV += sinkCols;
+  }
+
+  // ---- Softmax ----
+  auto softmaxInputType = mlir::cast<RankedTensorType>(scores.getType());
+  Value softmaxOut =
+      rewriter
+          .create<SoftmaxOp>(loc, softmaxInputType, scores, /*dimension=*/-1)
+          .getResult();
+
+  // ---- Slice to remove sink columns ----
+  if (attentionSink) {
+    // Slice back to [B, H, Sq, originalSeqLenKV] removing the sink columns.
+    llvm::SmallVector<int64_t> slicedShape = {batch, numHeads, seqLenQ,
+                                              originalSeqLenKV};
+    auto slicedType = createResultType(qType, slicedShape);
+
+    SmallVector<int32_t> begins = {0, 0, 0, 0};
+    SmallVector<int32_t> ends = {
+        static_cast<int32_t>(batch), static_cast<int32_t>(numHeads),
+        static_cast<int32_t>(seqLenQ), static_cast<int32_t>(originalSeqLenKV)};
+    SmallVector<int32_t> steps = {1, 1, 1, 1};
+
+    softmaxOut = rewriter
+                     .create<SliceStaticOp>(loc, slicedType, softmaxOut,
+                                            rewriter.getI32ArrayAttr(begins),
+                                            rewriter.getI32ArrayAttr(ends),
+                                            rewriter.getI32ArrayAttr(steps))
+                     .getResult();
+  }
+
+  // ---- Matmul softmax_out @ V ----
+  // [B, H, Sq, Skv] x [B, H, Skv, D] -> [B, H, Sq, D]
+  llvm::SmallVector<int64_t> resultShape = {batch, numHeads, seqLenQ, headDim};
+  auto resultType = createResultType(qType, resultShape);
+
+  Value result =
+      rewriter
+          .create<MatmulOp>(loc, resultType, softmaxOut, value,
+                            /*transpose_a=*/false, /*transpose_b=*/false,
+                            /*matmul_program_config=*/nullptr,
+                            /*activation=*/nullptr)
+          .getResult();
+
+  rewriter.replaceOp(op, result);
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::decomposition

--- a/lib/Dialect/TTNN/Transforms/Decomposition/TTNNDecompositionPass.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/TTNNDecompositionPass.cpp
@@ -7,6 +7,8 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/RotaryEmbeddingDecompositionRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 
@@ -42,6 +44,10 @@ public:
           &getContext(), validationConfig);
       patterns.add<decomposition::RotaryEmbeddingDecompositionRewritePattern>(
           &getContext(), validationConfig);
+      patterns.add<decomposition::SDPADecompositionPattern>(&getContext(),
+                                                            validationConfig);
+      patterns.add<decomposition::SDPADecodeDecompositionPattern>(
+          &getContext(), validationConfig);
     } else {
       patterns.add<decomposition::TopKDecompositionRewritePattern>(
           &getContext());
@@ -50,6 +56,9 @@ public:
       patterns.add<decomposition::GroupNormDecompositionRewritePattern>(
           &getContext());
       patterns.add<decomposition::RotaryEmbeddingDecompositionRewritePattern>(
+          &getContext());
+      patterns.add<decomposition::SDPADecompositionPattern>(&getContext());
+      patterns.add<decomposition::SDPADecodeDecompositionPattern>(
           &getContext());
     }
 

--- a/test/python/golden/ttir_ops/decomposition/test_sdpa_decomposition.py
+++ b/test/python/golden/ttir_ops/decomposition/test_sdpa_decomposition.py
@@ -258,6 +258,13 @@ def test_sdpa_decode_decomposition_causal_no_mask(
             builder: TTIRBuilder,
             unit_attrs: Optional[List[str]] = None,
         ):
+            # Use a non-terminal cur_pos so the synthesized causal mask in the
+            # decomposition actually masks future positions. cur_pos = kv_seq-1
+            # would make the mask all-zeros and hide bugs in cur_pos handling.
+            # NOTE: set_goldens must precede the SDPA call so the golden uses
+            # the override (the SDPA's golden is computed at builder time).
+            cur_pos_data = torch.full((batch,), kv_seq // 2, dtype=torch.int32)
+            builder.set_goldens({cur_pos_tensor: cur_pos_data})
             result = builder.scaled_dot_product_attention_decode(
                 query,
                 key,
@@ -267,8 +274,6 @@ def test_sdpa_decode_decomposition_causal_no_mask(
                 scale=scale,
                 unit_attrs=unit_attrs,
             )
-            cur_pos_data = torch.full((batch,), kv_seq - 1, dtype=torch.int32)
-            builder.set_goldens({cur_pos_tensor: cur_pos_data})
             return result
 
     mlir_path = compile_decomposed(module, target, request)
@@ -278,11 +283,6 @@ def test_sdpa_decode_decomposition_causal_no_mask(
 # ---------------------------------------------------------------------------
 # Attention sink and sliding window (prefill only)
 # ---------------------------------------------------------------------------
-#
-# Decode + attention_sink is NOT covered here yet: the decode op accepts sink
-# as [Hq, 32] but the decode->prefill decomposition forwards it to the prefill
-# op which expects [1, Hq, 1, 1]. A shape conversion in the decomposition is
-# needed before this path can be tested via the builder.
 
 
 @pytest.mark.parametrize(

--- a/test/python/golden/ttir_ops/decomposition/test_sdpa_decomposition.py
+++ b/test/python/golden/ttir_ops/decomposition/test_sdpa_decomposition.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Optional
+
+import pytest
+import torch
+
+from builder.base.builder_utils import Operand, Shape, DeferredDevice
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_and_execute_ttir
+from conftest import get_request_kwargs
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def compile_decomposed(module_fn, target, request):
+    # enable-optimizer=false routes through TTNNPipelines.cpp:349, which adds
+    # bare createTTNNDecomposition() with no validation config — SDPA gets
+    # decomposed unconditionally regardless of shape.
+    return compile_and_execute_ttir(
+        module_fn,
+        target=target,
+        **get_request_kwargs(request),
+        device=DeferredDevice(request),
+        pipeline_options=["enable-optimizer=false"],
+        save_artifacts=True,
+    )
+
+
+def check_op(mlir_file: str, op_name: str) -> bool:
+    qualified = "ttnn." + op_name
+    with open(mlir_file, "r") as f:
+        for line in f:
+            if qualified in line:
+                return True
+    return False
+
+
+def assert_decomposed(mlir_path: str):
+    # SDPA ops fully decomposed away.
+    assert not check_op(
+        mlir_path, "scaled_dot_product_attention"
+    ), "ttnn.scaled_dot_product_attention should not be present after decomposition"
+    assert not check_op(
+        mlir_path, "scaled_dot_product_attention_decode"
+    ), "ttnn.scaled_dot_product_attention_decode should not be present after decomposition"
+    # Primitive ops produced by the rewrite present.
+    assert check_op(mlir_path, "matmul"), "expected ttnn.matmul in decomposed IR"
+    assert check_op(mlir_path, "softmax"), "expected ttnn.softmax in decomposed IR"
+
+
+# ---------------------------------------------------------------------------
+# Prefill / non-decode tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "shapes,mask_shape,is_causal,scale",
+    [
+        # MHA + explicit mask (mirrors sdpa_mha_with_mask in the lit test).
+        (
+            [(1, 8, 64, 64), (1, 8, 64, 64), (1, 8, 64, 64)],
+            (1, 1, 64, 64),
+            False,
+            0.125,
+        ),
+        # GQA, 4:1 (mirrors sdpa_gqa in the lit test).
+        (
+            [(1, 32, 64, 64), (1, 8, 64, 64), (1, 8, 64, 64)],
+            (1, 1, 64, 64),
+            False,
+            0.125,
+        ),
+    ],
+    ids=["mha_with_mask", "gqa"],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_sdpa_decomposition_with_mask(
+    shapes: List[Shape],
+    mask_shape: Shape,
+    is_causal: bool,
+    scale: float,
+    target: str,
+    request,
+):
+    all_shapes = shapes + [mask_shape]
+    dtypes = [torch.bfloat16] * len(all_shapes)
+
+    def module(builder: TTIRBuilder):
+        @builder.func(all_shapes, dtypes)
+        def sdpa(
+            query: Operand,
+            key: Operand,
+            value: Operand,
+            attention_mask: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attention_mask=attention_mask,
+                is_causal=is_causal,
+                scale=scale,
+                unit_attrs=unit_attrs,
+            )
+
+    mlir_path = compile_decomposed(module, target, request)
+    assert_decomposed(mlir_path)
+
+
+@pytest.mark.parametrize(
+    "shapes,scale",
+    [
+        # Causal SDPA without an explicit mask (mirrors sdpa_causal_no_mask
+        # in the lit test). is_causal=True forces the pattern to synthesize
+        # a causal mask via the constant + add path.
+        (
+            [(1, 8, 64, 64), (1, 8, 64, 64), (1, 8, 64, 64)],
+            0.125,
+        ),
+    ],
+    ids=["causal_no_mask"],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_sdpa_decomposition_causal_no_mask(
+    shapes: List[Shape],
+    scale: float,
+    target: str,
+    request,
+):
+    dtypes = [torch.bfloat16] * len(shapes)
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def sdpa(
+            query: Operand,
+            key: Operand,
+            value: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                is_causal=True,
+                scale=scale,
+                unit_attrs=unit_attrs,
+            )
+
+    mlir_path = compile_decomposed(module, target, request)
+    assert_decomposed(mlir_path)
+
+
+# ---------------------------------------------------------------------------
+# Decode tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "shapes,mask_shape,scale",
+    [
+        # Decode MHA (mirrors sdpa_decode_mha in the lit test).
+        (
+            [(1, 32, 32, 64), (32, 32, 128, 64), (32, 32, 128, 64), (32,)],
+            (32, 1, 1, 128),
+            0.125,
+        ),
+    ],
+    ids=["decode_mha"],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_sdpa_decode_decomposition_with_mask(
+    shapes: List[Shape],
+    mask_shape: Shape,
+    scale: float,
+    target: str,
+    request,
+):
+    batch = shapes[0][1]
+    kv_seq = shapes[1][2]
+    all_shapes = shapes + [mask_shape]
+    dtypes = [
+        torch.bfloat16,
+        torch.bfloat16,
+        torch.bfloat16,
+        torch.int32,
+        torch.bfloat16,
+    ]
+
+    def module(builder: TTIRBuilder):
+        @builder.func(all_shapes, dtypes)
+        def sdpa_decode(
+            query: Operand,
+            key: Operand,
+            value: Operand,
+            cur_pos_tensor: Operand,
+            attention_mask: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            result = builder.scaled_dot_product_attention_decode(
+                query,
+                key,
+                value,
+                cur_pos_tensor,
+                attention_mask=attention_mask,
+                is_causal=False,
+                scale=scale,
+                unit_attrs=unit_attrs,
+            )
+            cur_pos_data = torch.full((batch,), kv_seq - 1, dtype=torch.int32)
+            builder.set_goldens({cur_pos_tensor: cur_pos_data})
+            return result
+
+    mlir_path = compile_decomposed(module, target, request)
+    assert_decomposed(mlir_path)
+
+
+@pytest.mark.parametrize(
+    "shapes,scale",
+    [
+        # Decode causal, no mask (mirrors sdpa_decode_causal in the lit test).
+        (
+            [(1, 32, 32, 64), (32, 32, 128, 64), (32, 32, 128, 64), (32,)],
+            0.125,
+        ),
+    ],
+    ids=["decode_causal"],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_sdpa_decode_decomposition_causal_no_mask(
+    shapes: List[Shape],
+    scale: float,
+    target: str,
+    request,
+):
+    batch = shapes[0][1]
+    kv_seq = shapes[1][2]
+    dtypes = [torch.bfloat16, torch.bfloat16, torch.bfloat16, torch.int32]
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def sdpa_decode(
+            query: Operand,
+            key: Operand,
+            value: Operand,
+            cur_pos_tensor: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            result = builder.scaled_dot_product_attention_decode(
+                query,
+                key,
+                value,
+                cur_pos_tensor,
+                is_causal=True,
+                scale=scale,
+                unit_attrs=unit_attrs,
+            )
+            cur_pos_data = torch.full((batch,), kv_seq - 1, dtype=torch.int32)
+            builder.set_goldens({cur_pos_tensor: cur_pos_data})
+            return result
+
+    mlir_path = compile_decomposed(module, target, request)
+    assert_decomposed(mlir_path)
+
+
+# ---------------------------------------------------------------------------
+# Attention sink and sliding window (prefill only)
+# ---------------------------------------------------------------------------
+#
+# Decode + attention_sink is NOT covered here yet: the decode op accepts sink
+# as [Hq, 32] but the decode->prefill decomposition forwards it to the prefill
+# op which expects [1, Hq, 1, 1]. A shape conversion in the decomposition is
+# needed before this path can be tested via the builder.
+
+
+@pytest.mark.parametrize(
+    "shapes,mask_shape,sink_shape,scale",
+    [
+        # Prefill MHA + attention_sink (mirrors sdpa_with_attention_sink in
+        # the lit test). Sink shape [1, Hq, 1, 1] per op definition.
+        (
+            [(1, 8, 64, 64), (1, 8, 64, 64), (1, 8, 64, 64)],
+            (1, 1, 64, 64),
+            (1, 8, 1, 1),
+            0.125,
+        ),
+    ],
+    ids=["mha_with_sink"],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_sdpa_decomposition_with_attention_sink(
+    shapes: List[Shape],
+    mask_shape: Shape,
+    sink_shape: Shape,
+    scale: float,
+    target: str,
+    request,
+):
+    all_shapes = shapes + [mask_shape, sink_shape]
+    dtypes = [torch.bfloat16] * len(all_shapes)
+
+    def module(builder: TTIRBuilder):
+        @builder.func(all_shapes, dtypes)
+        def sdpa(
+            query: Operand,
+            key: Operand,
+            value: Operand,
+            attention_mask: Operand,
+            attention_sink: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attention_mask=attention_mask,
+                attention_sink=attention_sink,
+                is_causal=False,
+                scale=scale,
+                unit_attrs=unit_attrs,
+            )
+
+    mlir_path = compile_decomposed(module, target, request)
+    assert_decomposed(mlir_path)
+    # Sink decomposition emits a concat (sink columns) then a slice afterwards.
+    assert check_op(mlir_path, "concat"), "expected ttnn.concat for sink path"
+    assert check_op(
+        mlir_path, "slice_static"
+    ), "expected ttnn.slice_static for sink path"
+
+
+@pytest.mark.parametrize(
+    "shapes,is_causal,sliding_window_size,scale",
+    [
+        # Prefill causal sliding window (mirrors sdpa_sliding_window in the
+        # lit test). Window covers last W=32 tokens.
+        (
+            [(1, 8, 64, 64), (1, 8, 64, 64), (1, 8, 64, 64)],
+            True,
+            32,
+            0.125,
+        ),
+        # Prefill non-causal (bidirectional) sliding window. Window of size
+        # W=32 centered on each query position. Exercises the non-causal
+        # branch of generateSlidingWindowMask, which previously had a width
+        # bug (used 2W-1 instead of W+1).
+        (
+            [(1, 8, 64, 64), (1, 8, 64, 64), (1, 8, 64, 64)],
+            False,
+            32,
+            0.125,
+        ),
+    ],
+    ids=["causal_sliding_window", "noncausal_sliding_window"],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_sdpa_decomposition_sliding_window(
+    shapes: List[Shape],
+    is_causal: bool,
+    sliding_window_size: int,
+    scale: float,
+    target: str,
+    request,
+):
+    dtypes = [torch.bfloat16] * len(shapes)
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def sdpa(
+            query: Operand,
+            key: Operand,
+            value: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                is_causal=is_causal,
+                scale=scale,
+                sliding_window_size=sliding_window_size,
+                unit_attrs=unit_attrs,
+            )
+
+    mlir_path = compile_decomposed(module, target, request)
+    assert_decomposed(mlir_path)
+    # Window mask is emitted as a ttnn.constant + add.
+    assert check_op(mlir_path, "constant"), "expected ttnn.constant for window mask"

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/sdpa_decode_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/sdpa_decode_decomposition.mlir
@@ -1,0 +1,61 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-layout --ttnn-decomposition %s | FileCheck %s
+
+module {
+  // Test 1: SDPADecode MHA — full cascade to component ops via SDPA
+  // Q: [1, B, H, D] -> permute -> SDPA decomposed -> permute back
+  func.func @sdpa_decode_mha(
+    %query: tensor<1x32x32x64xbf16>,
+    %key: tensor<32x32x128x64xbf16>,
+    %value: tensor<32x32x128x64xbf16>,
+    %mask: tensor<32x1x1x128xbf16>
+  ) -> tensor<1x32x32x64xbf16> {
+    // CHECK-LABEL: func.func @sdpa_decode_mha
+    // No SDPA ops should remain — fully decomposed.
+    // CHECK-NOT: ttnn.scaled_dot_product_attention_decode
+    // CHECK-NOT: ttnn.scaled_dot_product_attention
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 1, 2, 0, 3>
+    // CHECK: "ttnn.transpose"
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.full"
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.add"
+    // CHECK: "ttnn.softmax"
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 2, 0, 1, 3>
+    %result = "ttnn.scaled_dot_product_attention_decode"(%query, %key, %value, %mask) <{
+      operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0>,
+      is_causal = false,
+      scale = 0.125 : f32
+    }> : (tensor<1x32x32x64xbf16>, tensor<32x32x128x64xbf16>,
+         tensor<32x32x128x64xbf16>, tensor<32x1x1x128xbf16>)
+      -> tensor<1x32x32x64xbf16>
+    return %result : tensor<1x32x32x64xbf16>
+  }
+
+  // Test 2: SDPADecode causal — is_causal becomes false in decomposed form
+  func.func @sdpa_decode_causal(
+    %query: tensor<1x32x32x64xbf16>,
+    %key: tensor<32x32x128x64xbf16>,
+    %value: tensor<32x32x128x64xbf16>
+  ) -> tensor<1x32x32x64xbf16> {
+    // CHECK-LABEL: func.func @sdpa_decode_causal
+    // CHECK-NOT: ttnn.scaled_dot_product_attention_decode
+    // CHECK-NOT: ttnn.scaled_dot_product_attention
+    // CHECK: "ttnn.permute"
+    // CHECK: "ttnn.transpose"
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.softmax"
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.permute"
+    %result = "ttnn.scaled_dot_product_attention_decode"(%query, %key, %value) <{
+      operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 0>,
+      is_causal = true,
+      scale = 0.125 : f32
+    }> : (tensor<1x32x32x64xbf16>, tensor<32x32x128x64xbf16>,
+         tensor<32x32x128x64xbf16>)
+      -> tensor<1x32x32x64xbf16>
+    return %result : tensor<1x32x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/sdpa_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/sdpa_decomposition.mlir
@@ -67,7 +67,7 @@ module {
     %key: tensor<1x8x64x64xbf16>,
     %value: tensor<1x8x64x64xbf16>,
     %mask: tensor<1x1x64x64xbf16>,
-    %sink: tensor<1x8x64x1xbf16>
+    %sink: tensor<1x8x1x1xbf16>
   ) -> tensor<1x8x64x64xbf16> {
     // CHECK-LABEL: func.func @sdpa_with_attention_sink
     // CHECK: "ttnn.transpose"
@@ -84,7 +84,7 @@ module {
       scale = 0.125 : f32
     }> : (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
          tensor<1x8x64x64xbf16>, tensor<1x1x64x64xbf16>,
-         tensor<1x8x64x1xbf16>)
+         tensor<1x8x1x1xbf16>)
       -> tensor<1x8x64x64xbf16>
     return %result : tensor<1x8x64x64xbf16>
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/sdpa_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/sdpa_decomposition.mlir
@@ -1,0 +1,145 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-layout --ttnn-decomposition %s | FileCheck %s
+
+module {
+  // Test 1: Basic MHA SDPA with mask and explicit scale
+  func.func @sdpa_mha_with_mask(
+    %query: tensor<1x8x64x64xbf16>,
+    %key: tensor<1x8x64x64xbf16>,
+    %value: tensor<1x8x64x64xbf16>,
+    %mask: tensor<1x1x64x64xbf16>
+  ) -> tensor<1x8x64x64xbf16> {
+    // CHECK-LABEL: func.func @sdpa_mha_with_mask
+    // CHECK: "ttnn.transpose"
+    // CHECK-SAME: dim0 = -2 : si32
+    // CHECK-SAME: dim1 = -1 : si32
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.full"
+    // CHECK-SAME: fill_value = 1.250000e-01
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.add"
+    // CHECK: "ttnn.softmax"
+    // CHECK-SAME: dimension = -1
+    // CHECK: "ttnn.matmul"
+    %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value, %mask) <{
+      operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>,
+      is_causal = false,
+      scale = 0.125 : f32
+    }> : (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+         tensor<1x8x64x64xbf16>, tensor<1x1x64x64xbf16>)
+      -> tensor<1x8x64x64xbf16>
+    return %result : tensor<1x8x64x64xbf16>
+  }
+
+  // Test 2: GQA — 32 query heads, 8 KV heads (4:1 ratio)
+  func.func @sdpa_gqa(
+    %query: tensor<1x32x64x64xbf16>,
+    %key: tensor<1x8x64x64xbf16>,
+    %value: tensor<1x8x64x64xbf16>,
+    %mask: tensor<1x1x64x64xbf16>
+  ) -> tensor<1x32x64x64xbf16> {
+    // CHECK-LABEL: func.func @sdpa_gqa
+    // CHECK: "ttnn.repeat_interleave"
+    // CHECK-SAME: dim = 1 : si32
+    // CHECK-SAME: repeats = 4 : ui32
+    // CHECK: "ttnn.repeat_interleave"
+    // CHECK-SAME: dim = 1 : si32
+    // CHECK-SAME: repeats = 4 : ui32
+    // CHECK: "ttnn.transpose"
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.full"
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.add"
+    // CHECK: "ttnn.softmax"
+    // CHECK: "ttnn.matmul"
+    %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value, %mask) <{
+      operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>,
+      is_causal = false,
+      scale = 0.125 : f32
+    }> : (tensor<1x32x64x64xbf16>, tensor<1x8x64x64xbf16>,
+         tensor<1x8x64x64xbf16>, tensor<1x1x64x64xbf16>)
+      -> tensor<1x32x64x64xbf16>
+    return %result : tensor<1x32x64x64xbf16>
+  }
+
+  // Test 3: SDPA with attention_sink
+  func.func @sdpa_with_attention_sink(
+    %query: tensor<1x8x64x64xbf16>,
+    %key: tensor<1x8x64x64xbf16>,
+    %value: tensor<1x8x64x64xbf16>,
+    %mask: tensor<1x1x64x64xbf16>,
+    %sink: tensor<1x8x64x1xbf16>
+  ) -> tensor<1x8x64x64xbf16> {
+    // CHECK-LABEL: func.func @sdpa_with_attention_sink
+    // CHECK: "ttnn.transpose"
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.add"
+    // CHECK: "ttnn.concat"
+    // CHECK: "ttnn.softmax"
+    // CHECK: "ttnn.slice_static"
+    // CHECK: "ttnn.matmul"
+    %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value, %mask, %sink) <{
+      operandSegmentSizes = array<i32: 1, 1, 1, 1, 1>,
+      is_causal = false,
+      scale = 0.125 : f32
+    }> : (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+         tensor<1x8x64x64xbf16>, tensor<1x1x64x64xbf16>,
+         tensor<1x8x64x1xbf16>)
+      -> tensor<1x8x64x64xbf16>
+    return %result : tensor<1x8x64x64xbf16>
+  }
+
+  // Test 4: Causal SDPA — is_causal=true, no explicit mask
+  // Should generate causal mask via arange + ge + where
+  func.func @sdpa_causal_no_mask(
+    %query: tensor<1x8x64x64xbf16>,
+    %key: tensor<1x8x64x64xbf16>,
+    %value: tensor<1x8x64x64xbf16>
+  ) -> tensor<1x8x64x64xbf16> {
+    // CHECK-LABEL: func.func @sdpa_causal_no_mask
+    // CHECK: "ttnn.transpose"
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.full"
+    // CHECK: "ttnn.multiply"
+    // Causal mask generated as compile-time constant + add
+    // CHECK: "ttnn.constant"
+    // CHECK: "ttnn.add"
+    // CHECK: "ttnn.softmax"
+    // CHECK: "ttnn.matmul"
+    %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value) <{
+      operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>,
+      is_causal = true,
+      scale = 0.125 : f32
+    }> : (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+         tensor<1x8x64x64xbf16>)
+      -> tensor<1x8x64x64xbf16>
+    return %result : tensor<1x8x64x64xbf16>
+  }
+
+  // Test 5: SDPA with sliding_window_size
+  func.func @sdpa_sliding_window(
+    %query: tensor<1x8x64x64xbf16>,
+    %key: tensor<1x8x64x64xbf16>,
+    %value: tensor<1x8x64x64xbf16>
+  ) -> tensor<1x8x64x64xbf16> {
+    // CHECK-LABEL: func.func @sdpa_sliding_window
+    // CHECK: "ttnn.transpose"
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.full"
+    // CHECK: "ttnn.multiply"
+    // Sliding window mask as compile-time constant
+    // CHECK: "ttnn.constant"
+    // CHECK: "ttnn.add"
+    // CHECK: "ttnn.softmax"
+    // CHECK: "ttnn.matmul"
+    %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value) <{
+      operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>,
+      is_causal = true,
+      scale = 0.125 : f32,
+      sliding_window_size = 32 : ui32
+    }> : (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+         tensor<1x8x64x64xbf16>)
+      -> tensor<1x8x64x64xbf16>
+    return %result : tensor<1x8x64x64xbf16>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention.mlir
@@ -1,5 +1,5 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-ttnn-decomposition-pass=false" %s > %t.mlir
 //
 // RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline %t.mlir > %t_rt.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t_rt.mlir > %basename_t.ttnn

--- a/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
@@ -1,5 +1,5 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-ttnn-decomposition-pass=false" %s > %t.mlir
 //
 // RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline %t.mlir > %t_rt.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t_rt.mlir > %basename_t.ttnn

--- a/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-ttnn-decomposition-pass=false" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 

--- a/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention_decode.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-ttnn-decomposition-pass=false" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -15446,6 +15446,8 @@ class TTIRBuilder(Builder):
         attention_mask: Optional[Operand] = None,
         is_causal: bool = True,
         scale: Optional[float] = None,
+        sliding_window_size: Optional[int] = None,
+        attention_sink: Optional[Operand] = None,
         output_type: Optional[torch.dtype] = None,
         loc: Optional[str] = None,
         unit_attrs: Optional[List[str]] = None,
@@ -15459,6 +15461,11 @@ class TTIRBuilder(Builder):
 
         is_causal_attr = BoolAttr.get(is_causal)
         scale_attr = FloatAttr.get_f32(scale) if scale is not None else None
+        sliding_window_size_attr = (
+            IntegerAttr.get(IntegerType.get_unsigned(32), sliding_window_size)
+            if sliding_window_size is not None
+            else None
+        )
 
         query_golden = self._get_golden_tensor(query)
         key_golden = self._get_golden_tensor(key)
@@ -15466,6 +15473,11 @@ class TTIRBuilder(Builder):
         mask_golden = (
             self._get_golden_tensor(attention_mask)
             if attention_mask is not None
+            else None
+        )
+        sink_golden = (
+            self._get_golden_tensor(attention_sink)
+            if attention_sink is not None
             else None
         )
 
@@ -15478,6 +15490,8 @@ class TTIRBuilder(Builder):
             is_causal_attr,
             scale_attr,
             mlir_output_type,
+            sliding_window_size_attr=sliding_window_size_attr,
+            attention_sink=sink_golden,
         )
         result = self._create_ranked_tensor_type(golden_output.shape, mlir_output_type)
 
@@ -15492,8 +15506,10 @@ class TTIRBuilder(Builder):
             key,
             value,
             attention_mask=attention_mask,
+            attention_sink=attention_sink,
             is_causal=is_causal_attr,
             scale=scale_attr,
+            sliding_window_size=sliding_window_size_attr,
             loc=loc,
         )
         op_result = op.result

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -7712,16 +7712,30 @@ def ttir_sdpa_golden(
     is_causal_attr: BoolAttr,
     scale_attr: Optional[FloatAttr],
     output_type_mlir: Type,
+    sliding_window_size_attr: Optional[IntegerAttr] = None,
+    attention_sink: Optional[GoldenMapTensor] = None,
 ) -> GoldenMapTensor:
     """
     Matches tt-metal's SDPA implementation, which follows PyTorch semantics:
     softmax(QK * scale + mask). The kernel folds scale into exp, but the host
     wrapper pre-multiplies any user attn_mask by 1/scale to compensate.
     Supports standard attention and Grouped-Query Attention (GQA).
+
+    sliding_window_size: kernel-derived {0, -inf} mask added after scaling.
+      causal:     window covers last W tokens [i-W+1, i]
+      non-causal: window covers [i-W/2, i+W/2] (inclusive, W+1 tokens)
+    attention_sink: per-head logit treated as a virtual K column. Kernel
+      applies scale to it just like raw QK, so the golden pre-scales it
+      before concat-softmax-slice.
     """
     output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
     is_causal = unpack_mlir_attr(is_causal_attr)
     scale = unpack_mlir_attr(scale_attr) if scale_attr is not None else None
+    sliding_window_size = (
+        unpack_mlir_attr(sliding_window_size_attr)
+        if sliding_window_size_attr is not None
+        else None
+    )
 
     q_heads = query.shape[1]
     kv_heads = key.shape[1]
@@ -7738,7 +7752,24 @@ def ttir_sdpa_golden(
     qk = torch.matmul(query.float(), key.float().transpose(-2, -1))
     qk = torch.mul(qk, scale)
 
-    if is_causal and attention_mask is None:
+    # When sliding_window_size is set, the kernel uses only the window mask
+    # (which already encodes the causal constraint via its topology). The
+    # separate causal mask path is skipped, matching the decomposition's
+    # if/else-if structure.
+    if sliding_window_size is not None:
+        seq_len_q = qk.shape[-2]
+        seq_len_k = qk.shape[-1]
+        i_idx = torch.arange(seq_len_q).unsqueeze(1)
+        j_idx = torch.arange(seq_len_k).unsqueeze(0)
+        diff = i_idx - j_idx
+        if is_causal:
+            in_window = (diff >= 0) & (diff < sliding_window_size)
+        else:
+            half = sliding_window_size // 2
+            in_window = (diff >= -half) & (diff <= half)
+        window_mask = torch.where(in_window, 0.0, float("-inf"))
+        qk = torch.add(qk, window_mask)
+    elif is_causal and attention_mask is None:
         seq_len_q = qk.shape[-2]
         seq_len_k = qk.shape[-1]
         causal_mask = torch.triu(
@@ -7749,7 +7780,22 @@ def ttir_sdpa_golden(
     if attention_mask is not None:
         qk = torch.add(qk, attention_mask.float())
 
-    attn_weights = torch.softmax(qk, dim=-1)
+    if attention_sink is not None:
+        # Sink shape: [1, Hq, 1, 1]; broadcast to [B, Hq, Sq, 1] and scale.
+        # GoldenMapTensor routes torch ops through __torch_function__ but
+        # doesn't override Python `*` or mutating methods like .expand — use
+        # torch.* free functions instead.
+        sink = torch.mul(attention_sink.float(), scale)
+        sink = torch.broadcast_to(
+            sink, (qk.shape[0], qk.shape[1], qk.shape[2], sink.shape[-1])
+        )
+        sink_cols = sink.shape[-1]
+        extended = torch.cat([qk, sink], dim=-1)
+        attn_weights = torch.softmax(extended, dim=-1)
+        attn_weights = attn_weights[..., :-sink_cols]
+    else:
+        attn_weights = torch.softmax(qk, dim=-1)
+
     output = torch.matmul(attn_weights, value.float())
 
     return output.to(output_dtype)

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -1823,6 +1823,15 @@ def sdpa_decode_golden(
     # Mask is in decode layout [B, 1, H, S], permute to [B, H, 1, S] to match qk
     if attention_mask is not None:
         qk = torch.add(qk, attention_mask.float().permute(0, 2, 1, 3))
+    elif is_causal and cur_pos_tensor is not None:
+        # Synthesize a per-batch causal mask: positions j > cur_pos[b] are -inf.
+        b, _, _, seq_len = qk.shape
+        causal_mask = torch.zeros((b, 1, 1, seq_len), dtype=torch.float32)
+        cur_t = _gmt_leaf_torch(cur_pos_tensor)
+        for i in range(b):
+            start_idx = int(cur_t[i].item())
+            causal_mask[i, :, :, start_idx + 1 :] = float("-inf")
+        qk = torch.add(qk, causal_mask)
 
     # Scale AFTER masking (tt-metal fuses scale into exp)
     if scale is not None:


### PR DESCRIPTION
## Summary

Adds decomposition patterns for `ttnn.scaled_dot_product_attention` and
`ttnn.scaled_dot_product_attention_decode`. When the fused kernel can't handle
a shape (validation failure), the pattern rewrites the op into primitive TTNN
ops (transpose, matmul, multiply, add, softmax).

Motivation: prerequisite for migrating the SDPA fusing pattern to TTIR — with
decomposition available as a fallback, fusing can be moved upstream without
losing coverage on shapes the fused kernel rejects.

## Test plan

- [x] `pytest test/python/golden/ttir_ops/decomposition/test_sdpa_decomposition.py`
- [x] `pytest test/python/golden/ttir_ops/attention/`
- [x] `pytest test/python/golden/ttir_ops/fusing/test_sdpa_fusing.py`
- [x] `llvm-lit test/ttmlir/Dialect/TTNN/Transforms/Decomposition/sdpa{,_decode}_decomposition.mlir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)