### PR TITLE
Fix Falcon3 -30% decode regression: ungating RoPEDecodeFusing from enableRoPEFusion

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -325,8 +325,16 @@ public:
                                                    validationConfig);
         patterns.add<fusing::RoPEExpandedFusing>(&getContext(),
                                                  validationConfig);
-        patterns.add<fusing::RoPEDecodeFusing>(&getContext());
       }
+      // RoPEDecodeFusing must always run (not gated by enableRoPEFusion)
+      // because it rearranges the [2,0,1,3] permutes that
+      // NLPCreateQKVHeadsDecodeFusing depends on. When TTIR-level RoPE fusion
+      // is active (enableRoPEFusion=false), the RotaryEmbeddingOp already
+      // exists from TTIR lowering — RoPEDecodeFusing detects the decode
+      // signature and sets token_index, enabling the decode QKV upgrade.
+      // TODO(sdjordjevic): #8598 Decouple NLPCreateQKVHeadsDecodeFusing from
+      // RoPEDecodeFusing
+      patterns.add<fusing::RoPEDecodeFusing>(&getContext());
       patterns.add<fusing::SDPAFusing>(&getContext(), validationConfig);
       patterns.add<NLPConcatHeadsDecodeFusing>(&getContext());
       patterns.add<fusing::SplitQueryKeyValueAndSplitHeadsFusing<MatmulOp>>(


### PR DESCRIPTION
### Ticket
tt-xla issue:
https://github.com/tenstorrent/tt-xla/issues/4907#event-25931575200

### Summary
Ungates RoPEDecodeFusing from the enableRoPEFusion flag so it always runs when op-constraints are enabled
Fixes a -30.46% perf regression on Falcon3-1B decode graphs bisected to #8465

### Context
PR #8465 moved structural RoPE fusion from TTNN to TTIR and disabled TTNN-level RoPE fusion by default (enable-rope-fusion=false). This inadvertently gated RoPEDecodeFusing behind the same flag, but RoPEDecodeFusing is not a structural fusion — it rearranges Permute[2,0,1,3] ops around already-fused RotaryEmbeddingOps to:
1. Set token_index = 0 (enabling the faster decode kernel path)
2.  Make the permute the direct user of SplitQueryKeyValueAndSplitHeadsOp outputs, which NLPCreateQKVHeadsDecodeFusing requires to upgrade to nlp_create_qkv_heads_decode

Without this, decode graphs lost both optimizations: no token_index, no decode QKV head op, and 54 extra reshapes per graph.

### Note
Verified fix on a local machine:
| Model: pytorch_Falcon_3_1B_Base_nlp_causal_lm_huggingface
| Model type: text-generation
| Dataset name: Random Data
| Date: 25-05-2026
| Machine name: bgd-lab-t3001-special-sdjordjevic-for-reservation-23222
| Total execution time: 1.970305794
| Total samples: 110
| Sample per second: 55.82889738992464
| TTFT (ms): 288.890455
| Batch size: 32
| Data format: bfloat16
| Input sequence length: 128

### Checklist
- [x] New/Existing tests provide coverage for changes
