### PR TITLE
Fix #8464 - Implement TTNN->EmitPy/C conversions for Semaphore ops

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -4027,11 +4027,13 @@ def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore", [TTCore_Cr
 
       Example:
       ```mlir
-      %semaphore = "ttnn.create_global_semaphore"() <{initial_value = 0 : ui32, core_range = #ttnn.core_range<(0,0), (7,7)>}> : () -> !ttnn.global_semaphore
+      %semaphore = "ttnn.create_global_semaphore"(%device) <{initial_value = 0 : ui32, core_range = #ttnn.core_range<(0,0), (7,7)>}> : (!ttnn.device) -> !ttnn.global_semaphore
       ```
     }];
 
-    let arguments = (ins OptionalAttr<UI32Attr>:$initial_value, TTNN_CoreRangeAttr:$core_range);
+    let arguments = (ins TTNN_Device:$device,
+                         OptionalAttr<UI32Attr>:$initial_value,
+                         TTNN_CoreRangeSetAttr:$core_range_set);
     let results = (outs TTNN_GlobalSemaphore:$result);
 }
 
@@ -4046,7 +4048,8 @@ def TTNN_ResetGlobalSemaphoreOp : TTNN_Op<"reset_global_semaphore", [OpModelExem
       ```
     }];
 
-    let arguments = (ins TTNN_GlobalSemaphore:$semaphore, UI32Attr:$value);
+    let arguments = (ins TTNN_GlobalSemaphore:$semaphore,
+                         UI32Attr:$value);
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -4027,7 +4027,7 @@ def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore", [TTCore_Cr
 
       Example:
       ```mlir
-      %semaphore = "ttnn.create_global_semaphore"(%device) <{initial_value = 0 : ui32, core_range = #ttnn.core_range<(0,0), (7,7)>}> : (!ttnn.device) -> !ttnn.global_semaphore
+      %semaphore = "ttnn.create_global_semaphore"(%device) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,7)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
       ```
     }];
 

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -559,11 +559,15 @@ handleD2MCreateGlobalSemaphore(d2m::CreateGlobalSemaphoreOp op,
       ttnn::CoreCoordAttr::get(rewriter.getContext(), 0, 0),
       ttnn::CoreCoordAttr::get(rewriter.getContext(), gridShape[0] - 1,
                                gridShape[1] - 1));
+  auto coreRangeSet = ttnn::CoreRangeSetAttr::get(
+      rewriter.getContext(), llvm::ArrayRef<ttnn::CoreRangeAttr>{coreRange});
+
+  auto device = ttnn::utils::getOrInsertDevice(rewriter, op);
 
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointAfter(op);
   auto ttnnOp = rewriter.create<ttnn::CreateGlobalSemaphoreOp>(
-      op.getLoc(), op.getValueAttr(), coreRange);
+      op.getLoc(), device, op.getValueAttr(), coreRangeSet);
   valueMapping[op.getResult()] = ttnnOp.getResult();
   return success();
 }

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2033,26 +2033,9 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::CreateGlobalSemaphoreOp>
         emitter(srcOp, adaptor, rewriter);
 
-    // Find the device value from a preceding GetDeviceOp in the parent
-    // function and get its converted (adapted) value.
-    mlir::Value deviceValue;
-    srcOp->getParentOfType<func::FuncOp>().walk(
-        [&](mlir::tt::ttnn::GetDeviceOp getDeviceOp) {
-          deviceValue = getDeviceOp.getResult();
-        });
-    if (!deviceValue) {
-      return srcOp.emitOpError(
-          "could not find a ttnn.get_device op in the parent function");
-    }
-    mlir::Value convertedDevice = rewriter.getRemappedValue(deviceValue);
-    if (!convertedDevice) {
-      convertedDevice = deviceValue;
-    }
-
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(convertedDevice,
-                     static_cast<uint32_t>(srcOp->getNumOperands())),
-        emitter.emit(srcOp.getCoreRange()),
+        emitter.emit<::ttnn::distributed::MeshDevice>(srcOp.getDevice()),
+        emitter.emit(srcOp.getCoreRangeSet()),
         emitter.emit(srcOp.getInitialValue()),
     };
 

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3760,9 +3760,9 @@ public:
     auto weightIndexAttr = emitter.emit(srcOp.getWeight());
     auto residualIndexAttr = emitter.emit(srcOp.getResidual());
     auto statsIndexAttr = emitter.emit(srcOp.getStats());
+    auto semaphoreIndexAttr = emitter.emit(srcOp.getSemaphore());
     auto deviceIndexAttr =
         emitter.emit<::ttnn::distributed::MeshDevice>(srcOp.getDevice());
-    auto semaphoreIndexAttr = emitter.emit(srcOp.getSemaphore());
 
     llvm::SmallVector<mlir::Attribute> args{
         inputIndexAttr,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2006,6 +2006,102 @@ public:
 };
 } // namespace
 
+// CreateGlobalSemaphoreOp conversion pattern
+//
+namespace {
+class CreateGlobalSemaphoreOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::CreateGlobalSemaphoreOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.create_global_semaphore";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn::global_semaphore::create_global_semaphore";
+  }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::CreateGlobalSemaphoreOp>::
+      TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::CreateGlobalSemaphoreOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::CreateGlobalSemaphoreOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    // Find the device value from a preceding GetDeviceOp in the parent
+    // function and get its converted (adapted) value.
+    mlir::Value deviceValue;
+    srcOp->getParentOfType<func::FuncOp>().walk(
+        [&](mlir::tt::ttnn::GetDeviceOp getDeviceOp) {
+          deviceValue = getDeviceOp.getResult();
+        });
+    if (!deviceValue) {
+      return srcOp.emitOpError(
+          "could not find a ttnn.get_device op in the parent function");
+    }
+    mlir::Value convertedDevice = rewriter.getRemappedValue(deviceValue);
+    if (!convertedDevice) {
+      convertedDevice = deviceValue;
+    }
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(convertedDevice,
+                     static_cast<uint32_t>(srcOp->getNumOperands())),
+        emitter.emit(srcOp.getCoreRange()),
+        emitter.emit(srcOp.getInitialValue()),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
+// ResetGlobalSemaphoreOp conversion pattern
+//
+namespace {
+class ResetGlobalSemaphoreOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::ResetGlobalSemaphoreOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.reset_global_semaphore";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn::global_semaphore::reset_global_semaphore_value";
+  }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::ResetGlobalSemaphoreOp>::
+      TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::ResetGlobalSemaphoreOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::ResetGlobalSemaphoreOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getSemaphore()),
+        emitter.emit(srcOp.getValue()),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // ToDeviceOp conversion pattern
 //
 namespace {
@@ -5263,7 +5359,9 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   // Device ops
   //
   patterns.add<TTDeviceOpConversionPattern>(typeConverter, ctx);
-  patterns.add<GetDeviceOpConversionPattern>(typeConverter, ctx);
+  patterns.add<GetDeviceOpConversionPattern,
+               CreateGlobalSemaphoreOpConversionPattern,
+               ResetGlobalSemaphoreOpConversionPattern>(typeConverter, ctx);
 
   // Memory ops
   //

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2034,7 +2034,7 @@ public:
         emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit<::ttnn::distributed::MeshDevice>(srcOp.getDevice()),
+        emitter.emit<::ttnn::distributed::MeshDevice *>(srcOp.getDevice()),
         emitter.emit(srcOp.getCoreRangeSet()),
         emitter.emit(srcOp.getInitialValue()),
     };

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
@@ -50,6 +50,10 @@ public:
       return emitc::OpaqueType::get(ctx,
                                     ttnn_to_emitc::TypeNameV<::ttnn::Tensor>);
     });
+    addConversion(
+        [ctx](mlir::tt::ttnn::GlobalSemaphoreType type) -> emitc::OpaqueType {
+          return emitc::OpaqueType::get(ctx, "::ttnn::GlobalSemaphore");
+        });
     addConversion([ctx](mlir::TupleType type) -> emitc::OpaqueType {
       return emitc::OpaqueType::get(
           ctx, ttnn_to_emitc::TypeNameV<std::vector<::ttnn::Tensor>>);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1060,8 +1060,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getDevice(), "mesh_device"),
-        emitter.emit<::ttnn::CoreRangeSet>(srcOp.getCoreRangeSet(),
-                                           "core_range_set"),
+        emitter.emit<::ttnn::CoreRangeSet>(srcOp.getCoreRangeSet(), "cores"),
         emitter.emit(srcOp.getInitialValue(), "initial_value"),
     };
 

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1058,25 +1058,10 @@ public:
     ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::CreateGlobalSemaphoreOp>
         emitter(srcOp, adaptor, rewriter);
 
-    // Find the device value from a preceding GetDeviceOp in the parent
-    // function and get its converted (adapted) value.
-    mlir::Value deviceValue;
-    srcOp->getParentOfType<func::FuncOp>().walk(
-        [&](mlir::tt::ttnn::GetDeviceOp getDeviceOp) {
-          deviceValue = getDeviceOp.getResult();
-        });
-    if (!deviceValue) {
-      return srcOp.emitOpError(
-          "could not find a ttnn.get_device op in the parent function");
-    }
-    mlir::Value convertedDevice = rewriter.getRemappedValue(deviceValue);
-    if (!convertedDevice) {
-      convertedDevice = deviceValue;
-    }
-
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(convertedDevice, "mesh_device", srcOp->getNumOperands()),
-        emitter.emit<::ttnn::CoreRange>(srcOp.getCoreRange(), "core_range_set"),
+        emitter.emit(srcOp.getDevice(), "mesh_device"),
+        emitter.emit<::ttnn::CoreRangeSet>(srcOp.getCoreRangeSet(),
+                                           "core_range_set"),
         emitter.emit(srcOp.getInitialValue(), "initial_value"),
     };
 

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1039,6 +1039,93 @@ public:
 };
 } // namespace
 
+// CreateGlobalSemaphoreOp conversion pattern
+//
+namespace {
+class CreateGlobalSemaphoreOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::CreateGlobalSemaphoreOp> {
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::CreateGlobalSemaphoreOp>::
+      TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::CreateGlobalSemaphoreOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::CreateGlobalSemaphoreOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    // Find the device value from a preceding GetDeviceOp in the parent
+    // function and get its converted (adapted) value.
+    mlir::Value deviceValue;
+    srcOp->getParentOfType<func::FuncOp>().walk(
+        [&](mlir::tt::ttnn::GetDeviceOp getDeviceOp) {
+          deviceValue = getDeviceOp.getResult();
+        });
+    if (!deviceValue) {
+      return srcOp.emitOpError(
+          "could not find a ttnn.get_device op in the parent function");
+    }
+    mlir::Value convertedDevice = rewriter.getRemappedValue(deviceValue);
+    if (!convertedDevice) {
+      convertedDevice = deviceValue;
+    }
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(convertedDevice, "mesh_device", srcOp->getNumOperands()),
+        emitter.emit<::ttnn::CoreRange>(srcOp.getCoreRange(), "core_range_set"),
+        emitter.emit(srcOp.getInitialValue(), "initial_value"),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
+// ResetGlobalSemaphoreOp conversion pattern
+//
+namespace {
+class ResetGlobalSemaphoreOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::ResetGlobalSemaphoreOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.reset_global_semaphore";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn.reset_global_semaphore_value";
+  }
+
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::ResetGlobalSemaphoreOp>::
+      TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::ResetGlobalSemaphoreOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::ResetGlobalSemaphoreOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getSemaphore()),
+        emitter.emit(srcOp.getValue(), "value"),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // ToDeviceOp conversion pattern
 //
 namespace {
@@ -5009,7 +5096,9 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   //
   // clang-format off
   patterns.add<GetDeviceOpConversionPattern,
-               TTDeviceOpConversionPattern
+               TTDeviceOpConversionPattern,
+               CreateGlobalSemaphoreOpConversionPattern,
+               ResetGlobalSemaphoreOpConversionPattern
               >(typeConverter, ctx);
   // clang-format on
 

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPyPass.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPyPass.cpp
@@ -39,6 +39,10 @@ public:
       return emitpy::OpaqueType::get(
           ctx, ttnn_to_emitpy::TypeNameV<std::vector<::ttnn::Tensor>>);
     });
+    addConversion(
+        [ctx](tt::ttnn::GlobalSemaphoreType type) -> emitpy::OpaqueType {
+          return emitpy::OpaqueType::get(ctx, "ttnn.GlobalSemaphore");
+        });
     addConversion([ctx](tt::ttcore::DictType type) -> emitpy::DictType {
       return emitpy::DictType::get(ctx, Type(), Type());
     });

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3308,9 +3308,14 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
   {
     OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPointAfter(device);
+    auto semaphoreCoreRangeSet = CoreRangeSetAttr::get(
+        rewriter.getContext(),
+        llvm::ArrayRef<CoreRangeAttr>{*semaphoreCoreRange});
     semaphoreOp = rewriter.create<ttnn::CreateGlobalSemaphoreOp>(
         getLoc(), GlobalSemaphoreType::get(rewriter.getContext()),
-        /*initial_value=*/rewriter.getUI32IntegerAttr(0), *semaphoreCoreRange);
+        device.getResult(),
+        /*initial_value=*/rewriter.getUI32IntegerAttr(0),
+        semaphoreCoreRangeSet);
   }
 
   rewriter.modifyOpInPlace(

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -342,8 +342,7 @@ createOp(FlatbufferObjectCache &cache, CreateGlobalSemaphoreOp op) {
   auto output =
       cache.getOrCreate(op.getResult(), globalSemaphoreValueToFlatbuffer);
   auto coreRangeSet = ::tt::target::ttnn::CreateCoreRangeSet(
-      *cache.fbb, toFlatbuffer(cache, llvm::ArrayRef<ttnn::CoreRangeAttr>{
-                                          op.getCoreRange()}));
+      *cache.fbb, toFlatbuffer(cache, op.getCoreRangeSet().getCoreRanges()));
   return ::tt::target::ttnn::CreateCreateGlobalSemaphoreOp(
       *cache.fbb, coreRangeSet, op.getInitialValue(), output);
 }

--- a/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast_sem_inc.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast_sem_inc.mlir
@@ -20,7 +20,7 @@ module attributes {} {
     %out2 = "ttnn.distribute_tensor"(%out1, %0) <{mapper_config = #ttnn.mesh_mapper_config<placements = [<shard, 0 : i64>, <shard, 1 : i64>]>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_host_tile_shard>
     %out3 = "ttnn.to_device"(%out2, %0) : (tensor<32x32xbf16, #ttnn_layout_host_tile_shard>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_device_tile_sharded>
 
-    %semaphore = "ttnn.create_global_semaphore"() <{initial_value = 10 : ui32, core_range = #ttnn.core_range<(0,0), (7,7)>}> : () -> !ttnn.global_semaphore
+    %semaphore = "ttnn.create_global_semaphore"(%0) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,7)>]>, initial_value = 10 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
     "ttnn.reset_global_semaphore"(%semaphore) <{value = 0 : ui32}> : (!ttnn.global_semaphore) -> ()
 
     "ttnn.generic"(%3, %out3, %semaphore) <{

--- a/test/python/golden/ttir_ops/ccl/test_moe_ccls.py
+++ b/test/python/golden/ttir_ops/ccl/test_moe_ccls.py
@@ -26,7 +26,7 @@ def shape_str(val):
 # --- MoE CCL pipeline test (multi-device, dispatch → combine) ---
 
 
-@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+@pytest.mark.parametrize("target", ["ttnn"])
 @pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=shape_str)
 def test_moe_dispatch_combine(
     target: str, mesh_shape: Tuple[int, int], request, device

--- a/test/python/golden/ttir_ops/normalization/test_normalization.py
+++ b/test/python/golden/ttir_ops/normalization/test_normalization.py
@@ -393,24 +393,6 @@ def test_distributed_rms_norm(
     2. RMS normalization
     3. All-gather collective communication
     """
-    if (
-        target in ("emitpy", "emitc")
-        and has_weight
-        and shape
-        in [
-            (1, 1, 32, 128),
-            (1, 1, 32, 512),
-            (1, 1, 32, 4096),
-            (1, 1, 32, 8192),
-            (32, 128),
-            (1, 32, 128),
-        ]
-    ):
-        pytest.skip(
-            "EmitPy/EmitC: missing ttnn.create_global_semaphore conversion. "
-            "Issue: https://github.com/tenstorrent/tt-mlir/issues/8464"
-        )
-
     # Determine input shapes
     shapes = [shape]
     weight_shape = (shape[-1],)  # Weight matches last dimension

--- a/test/ttmlir/Conversion/D2MToTTNN/global_semaphore.mlir
+++ b/test/ttmlir/Conversion/D2MToTTNN/global_semaphore.mlir
@@ -12,7 +12,7 @@ module {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK-NOT: memref.alloc
     %alloc = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #ttcore.memory_space<l1>>
-    // CHECK: %[[SEM:.*]] = "ttnn.create_global_semaphore"() <{core_range = #ttnn.core_range<(0,0), (7,7)>, initial_value = 0 : ui32}> : () -> !ttnn.global_semaphore
+    // CHECK: %[[SEM:.*]] = "ttnn.create_global_semaphore"(%{{.*}}) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,7)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
     %sem = d2m.create_global_semaphore(%alloc) {value = 0 : ui32}
       : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #ttcore.memory_space<l1>> -> !d2m.global_semaphore
     // CHECK: "ttnn.reset_global_semaphore"(%[[SEM]]) <{value = 0 : ui32}> : (!ttnn.global_semaphore) -> ()

--- a/test/ttmlir/EmitC/TTNN/global_semaphore.mlir
+++ b/test/ttmlir/EmitC/TTNN/global_semaphore.mlir
@@ -8,7 +8,7 @@ module {
   func.func @test_global_semaphore() {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: emitc.call_opaque "ttnn::global_semaphore::create_global_semaphore"
-    %sem = "ttnn.create_global_semaphore"() <{initial_value = 0 : ui32, core_range = #ttnn.core_range<(0,0), (7,7)>}> : () -> !ttnn.global_semaphore
+    %sem = "ttnn.create_global_semaphore"(%0) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,7)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
     // CHECK: emitc.call_opaque "ttnn::global_semaphore::reset_global_semaphore_value"
     "ttnn.reset_global_semaphore"(%sem) <{value = 0 : ui32}> : (!ttnn.global_semaphore) -> ()
     return

--- a/test/ttmlir/EmitC/TTNN/global_semaphore.mlir
+++ b/test/ttmlir/EmitC/TTNN/global_semaphore.mlir
@@ -4,8 +4,11 @@ module {
   func.func @test_global_semaphore() {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: emitc.call_opaque "ttnn::global_semaphore::create_global_semaphore"
+    // CHECK-SAME: #emitc.opaque<"::ttnn::CoreRangeSet
+    // CHECK-SAME: !emitc.opaque<"::ttnn::GlobalSemaphore">
     %sem = "ttnn.create_global_semaphore"(%0) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,7)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
     // CHECK: emitc.call_opaque "ttnn::global_semaphore::reset_global_semaphore_value"
+    // CHECK-SAME: #emitc.opaque<"0">
     "ttnn.reset_global_semaphore"(%sem) <{value = 0 : ui32}> : (!ttnn.global_semaphore) -> ()
     return
   }

--- a/test/ttmlir/EmitC/TTNN/global_semaphore.mlir
+++ b/test/ttmlir/EmitC/TTNN/global_semaphore.mlir
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --convert-ttnn-to-emitc %s | FileCheck %s
+
+module {
+  func.func @test_global_semaphore() {
+    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    // CHECK: emitc.call_opaque "ttnn::global_semaphore::create_global_semaphore"
+    %sem = "ttnn.create_global_semaphore"() <{initial_value = 0 : ui32, core_range = #ttnn.core_range<(0,0), (7,7)>}> : () -> !ttnn.global_semaphore
+    // CHECK: emitc.call_opaque "ttnn::global_semaphore::reset_global_semaphore_value"
+    "ttnn.reset_global_semaphore"(%sem) <{value = 0 : ui32}> : (!ttnn.global_semaphore) -> ()
+    return
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/global_semaphore.mlir
+++ b/test/ttmlir/EmitC/TTNN/global_semaphore.mlir
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
 // RUN: ttmlir-opt --convert-ttnn-to-emitc %s | FileCheck %s
 
 module {

--- a/test/ttmlir/EmitPy/global_semaphore.mlir
+++ b/test/ttmlir/EmitPy/global_semaphore.mlir
@@ -4,7 +4,7 @@ module {
   func.func @test_global_semaphore() {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: emitpy.call_opaque "ttnn.create_global_semaphore"
-    // CHECK-SAME: keyword_args = ["mesh_device", "core_range_set", "initial_value"]
+    // CHECK-SAME: keyword_args = ["mesh_device", "cores", "initial_value"]
     // CHECK-SAME: !emitpy.opaque<"ttnn.GlobalSemaphore">
     %sem = "ttnn.create_global_semaphore"(%0) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,7)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
     // CHECK: emitpy.call_opaque "ttnn.reset_global_semaphore_value"

--- a/test/ttmlir/EmitPy/global_semaphore.mlir
+++ b/test/ttmlir/EmitPy/global_semaphore.mlir
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
 // RUN: ttmlir-opt --convert-ttnn-to-emitpy %s | FileCheck %s
 
 module {

--- a/test/ttmlir/EmitPy/global_semaphore.mlir
+++ b/test/ttmlir/EmitPy/global_semaphore.mlir
@@ -4,8 +4,11 @@ module {
   func.func @test_global_semaphore() {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: emitpy.call_opaque "ttnn.create_global_semaphore"
+    // CHECK-SAME: keyword_args = ["mesh_device", "core_range_set", "initial_value"]
+    // CHECK-SAME: !emitpy.opaque<"ttnn.GlobalSemaphore">
     %sem = "ttnn.create_global_semaphore"(%0) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,7)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
     // CHECK: emitpy.call_opaque "ttnn.reset_global_semaphore_value"
+    // CHECK-SAME: keyword_args = ["", "value"]
     "ttnn.reset_global_semaphore"(%sem) <{value = 0 : ui32}> : (!ttnn.global_semaphore) -> ()
     return
   }

--- a/test/ttmlir/EmitPy/global_semaphore.mlir
+++ b/test/ttmlir/EmitPy/global_semaphore.mlir
@@ -8,7 +8,7 @@ module {
   func.func @test_global_semaphore() {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: emitpy.call_opaque "ttnn.create_global_semaphore"
-    %sem = "ttnn.create_global_semaphore"() <{initial_value = 0 : ui32, core_range = #ttnn.core_range<(0,0), (7,7)>}> : () -> !ttnn.global_semaphore
+    %sem = "ttnn.create_global_semaphore"(%0) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,7)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
     // CHECK: emitpy.call_opaque "ttnn.reset_global_semaphore_value"
     "ttnn.reset_global_semaphore"(%sem) <{value = 0 : ui32}> : (!ttnn.global_semaphore) -> ()
     return

--- a/test/ttmlir/EmitPy/global_semaphore.mlir
+++ b/test/ttmlir/EmitPy/global_semaphore.mlir
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --convert-ttnn-to-emitpy %s | FileCheck %s
+
+module {
+  func.func @test_global_semaphore() {
+    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    // CHECK: emitpy.call_opaque "ttnn.create_global_semaphore"
+    %sem = "ttnn.create_global_semaphore"() <{initial_value = 0 : ui32, core_range = #ttnn.core_range<(0,0), (7,7)>}> : () -> !ttnn.global_semaphore
+    // CHECK: emitpy.call_opaque "ttnn.reset_global_semaphore_value"
+    "ttnn.reset_global_semaphore"(%sem) <{value = 0 : ui32}> : (!ttnn.global_semaphore) -> ()
+    return
+  }
+}


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/8464

### Problem description
`ttnn.create_global_semaphore` and `ttnn.reset_global_semaphore` weren't converted to emitpy/emitc.

### What's changed
Now they're converted.

Additionally, `TTNN_Device` arg is made explicit in the op (aligned with all other ops). `TTNN_CoreRangeAttr` changed to `TTNN_CoreRangeSetAttr` to align with actual tt-metal signature.

### Checklist
- [x] New/Existing tests provide coverage for changes
