### PR TITLE
[chisel] Fix Goldens for Softmax, Matmul and Linear

### DIFF
--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -12990,7 +12990,7 @@ class TTIRBuilder(Builder):
         return self._op_proxy(
             ttir.SoftmaxOp,
             [in0],
-            golden_kwargs={"dim": dimension},
+            golden_kwargs={"dimension": dimension},
             ttir_kwargs={
                 "dimension": dimension,
                 "numericStable": numeric_stable,

--- a/tools/golden/__init__.py
+++ b/tools/golden/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "GoldenMapTensor",
     "unpack_mlir_attr",
     "get_golden_function",
+    "get_golden_function_for_activation",
     "GOLDEN_MAPPINGS",
     "CHISEL_GOLDEN_MAPPINGS",
     "get_chisel_golden_function",

--- a/tools/golden/__init__.py
+++ b/tools/golden/__init__.py
@@ -8,7 +8,6 @@ __all__ = [
     "GoldenMapTensor",
     "unpack_mlir_attr",
     "get_golden_function",
-    "get_golden_function_for_activation",
     "GOLDEN_MAPPINGS",
     "CHISEL_GOLDEN_MAPPINGS",
     "get_chisel_golden_function",

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -28,7 +28,6 @@ import re
 import einops
 import torch
 import torch.nn.functional
-from ttnn.operations.activations import get_golden_function_for_activation
 from ttmlir.dialects import ttir, stablehlo, d2m, ttnn, ttcore, sdy, debug, func
 from ttmlir.ir import *
 from ttmlir.passes import DataType
@@ -6735,6 +6734,38 @@ def ttnn_atan2_golden(
     return torch.atan2(input_tensor, other_tensor).to(output_dtype)
 
 
+# Torch goldens for fused matmul activations. Mirrors
+# ttnn.operations.activations._get_golden_map_for_unary_op (string keys are
+# lowercase op names; ``*_approx`` suffix is stripped before lookup).
+_FUSED_MATMUL_ACTIVATION_FNS: Dict[str, Callable] = {
+    "relu": torch.nn.functional.relu,
+    "relu6": torch.nn.functional.relu6,
+    "silu": torch.nn.functional.silu,
+    "mish": torch.nn.functional.mish,
+    "sigmoid": torch.nn.functional.sigmoid,
+    "hardsigmoid": torch.nn.functional.hardsigmoid,
+    "tanh": torch.nn.functional.tanh,
+    "log": torch.log,
+    "softplus": torch.nn.functional.softplus,
+    "gelu": torch.nn.functional.gelu,
+    "sqrt": torch.sqrt,
+}
+
+
+def _get_fused_matmul_activation_fn(
+    activation: Optional[Union[str, StringAttr]],
+) -> Optional[Callable]:
+    if activation is None:
+        return None
+    if not isinstance(activation, str):
+        activation = unpack_mlir_attr(activation)
+    name = activation[:-7] if activation.endswith("_approx") else activation
+    activation_fn = _FUSED_MATMUL_ACTIVATION_FNS.get(name)
+    if activation_fn is None:
+        raise ValueError(f"Unsupported fused matmul activation: {activation}")
+    return activation_fn
+
+
 def ttnn_matmul_golden(
     input_tensor: GoldenMapTensor,
     other_tensor: GoldenMapTensor,
@@ -6749,10 +6780,7 @@ def ttnn_matmul_golden(
     a = torch.transpose(input_tensor, -2, -1) if transpose_a else input_tensor
     b = torch.transpose(other_tensor, -2, -1) if transpose_b else other_tensor
     output = torch.matmul(a, b)
-    activation = activation_attr
-    if activation is not None and not isinstance(activation, str):
-        activation = unpack_mlir_attr(activation)
-    activation_fn = get_golden_function_for_activation(activation)
+    activation_fn = _get_fused_matmul_activation_fn(activation_attr)
     if activation_fn is not None:
         output = activation_fn(output)
     return output.to(output_dtype)

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3052,7 +3052,7 @@ def silu_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
 
 def softmax_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
     """
-    Golden function for silu operation with TTIR parameter names.
+    Golden function for softmax with TTIR/TTNN parameter names.
 
     Parameters
     ----------
@@ -3066,7 +3066,7 @@ def softmax_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
     GoldenMapTensor
         Softmax output
     """
-    dimension = kwargs.get("dim", 1)
+    dimension = kwargs.get("dimension",  1)
     return torch.nn.functional.softmax(input_tensor, dim=dimension)
 
 
@@ -6740,13 +6740,18 @@ def ttnn_matmul_golden(
     transpose_a_attr: BoolAttr,
     transpose_b_attr: BoolAttr,
     output_type_mlir: Type,
+    activation_attr: Optional[StringAttr] = None,
 ) -> GoldenMapTensor:
     transpose_a = unpack_mlir_attr(transpose_a_attr)
     transpose_b = unpack_mlir_attr(transpose_b_attr)
     output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
     a = torch.transpose(input_tensor, -2, -1) if transpose_a else input_tensor
     b = torch.transpose(other_tensor, -2, -1) if transpose_b else other_tensor
-    return torch.matmul(a, b).to(output_dtype)
+    output = torch.matmul(a, b)
+    activation_golden = get_golden_function_for_activation(activation_attr)
+    if activation_golden is not None:
+        return activation_golden(output, output_type_mlir)
+    return output.to(output_dtype)
 
 
 def ttnn_linear_golden(
@@ -7997,6 +8002,40 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
 }
 
 
+_FUSED_ACTIVATION_GOLDEN_OPS: Dict[str, type] = {
+    "relu": ttnn.ReluOp,
+    "sigmoid": ttnn.SigmoidOp,
+    "gelu": ttnn.GeluOp,
+    "silu": ttnn.SiluOp,
+}
+
+
+def get_golden_function_for_activation(
+    activation: Optional[Union[str, StringAttr]] = None,
+) -> Optional[Callable]:
+    """
+    Get the TTNN unary golden for a fused matmul/linear activation string.
+
+    Parameters
+    ----------
+    activation : Optional[Union[str, StringAttr]]
+        Activation name from TTNN matmul/linear (e.g. ``"relu"``, ``"sigmoid"``).
+
+    Returns
+    -------
+    Optional[Callable]
+        Unary golden taking ``(input_tensor, output_type_mlir)``, or None if absent.
+    """
+    if activation is None:
+        return None
+    if not isinstance(activation, str):
+        activation = unpack_mlir_attr(activation)
+    op_class = _FUSED_ACTIVATION_GOLDEN_OPS.get(activation)
+    if op_class is None:
+        raise ValueError(f"Unsupported fused activation: {activation}")
+    return get_golden_function(op_class)
+
+
 def get_golden_function(ttir_op_class: type, **kwargs) -> Optional[Callable]:
     """
     Get the golden function for a given TTIR operation class.
@@ -8127,6 +8166,7 @@ def chisel_ttnn_matmul(op, inputs):
         other_tensor=inputs["b"],
         transpose_a_attr=op.attributes["transpose_a"],
         transpose_b_attr=op.attributes["transpose_b"],
+        activation_attr=_attr_get(op.attributes, "activation"),
         output_type_mlir=op.results[0].type.element_type,
     )
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3066,7 +3066,7 @@ def softmax_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
     GoldenMapTensor
         Softmax output
     """
-    dimension = kwargs.get("dimension",  1)
+    dimension = kwargs.get("dimension", 1)
     return torch.nn.functional.softmax(input_tensor, dim=dimension)
 
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -6734,10 +6734,10 @@ def ttnn_atan2_golden(
     return torch.atan2(input_tensor, other_tensor).to(output_dtype)
 
 
-# Torch goldens for fused matmul activations. Mirrors
+# Torch goldens for fused matmul/linear activations. Mirrors
 # ttnn.operations.activations._get_golden_map_for_unary_op (string keys are
 # lowercase op names; ``*_approx`` suffix is stripped before lookup).
-_FUSED_MATMUL_ACTIVATION_FNS: Dict[str, Callable] = {
+_FUSED_ACTIVATION_FNS: Dict[str, Callable] = {
     "relu": torch.nn.functional.relu,
     "relu6": torch.nn.functional.relu6,
     "silu": torch.nn.functional.silu,
@@ -6752,7 +6752,7 @@ _FUSED_MATMUL_ACTIVATION_FNS: Dict[str, Callable] = {
 }
 
 
-def _get_fused_matmul_activation_fn(
+def _get_fused_activation_fn(
     activation: Optional[Union[str, StringAttr]],
 ) -> Optional[Callable]:
     if activation is None:
@@ -6760,9 +6760,9 @@ def _get_fused_matmul_activation_fn(
     if not isinstance(activation, str):
         activation = unpack_mlir_attr(activation)
     name = activation[:-7] if activation.endswith("_approx") else activation
-    activation_fn = _FUSED_MATMUL_ACTIVATION_FNS.get(name)
+    activation_fn = _FUSED_ACTIVATION_FNS.get(name)
     if activation_fn is None:
-        raise ValueError(f"Unsupported fused matmul activation: {activation}")
+        raise ValueError(f"Unsupported fused activation: {activation}")
     return activation_fn
 
 
@@ -6780,7 +6780,7 @@ def ttnn_matmul_golden(
     a = torch.transpose(input_tensor, -2, -1) if transpose_a else input_tensor
     b = torch.transpose(other_tensor, -2, -1) if transpose_b else other_tensor
     output = torch.matmul(a, b)
-    activation_fn = _get_fused_matmul_activation_fn(activation_attr)
+    activation_fn = _get_fused_activation_fn(activation_attr)
     if activation_fn is not None:
         output = activation_fn(output)
     return output.to(output_dtype)
@@ -6793,6 +6793,7 @@ def ttnn_linear_golden(
     transpose_a_attr: BoolAttr,
     transpose_b_attr: BoolAttr,
     output_type_mlir: Type,
+    activation_attr: Optional[StringAttr] = None,
 ) -> GoldenMapTensor:
     transpose_a = unpack_mlir_attr(transpose_a_attr)
     transpose_b = unpack_mlir_attr(transpose_b_attr)
@@ -6809,7 +6810,11 @@ def ttnn_linear_golden(
         if bias_tensor.shape != output.shape
         else bias_tensor
     )
-    return torch.add(output, bias_tensor).to(output_dtype)
+    output = torch.add(output, bias_tensor)
+    activation_fn = _get_fused_activation_fn(activation_attr)
+    if activation_fn is not None:
+        output = activation_fn(output)
+    return output.to(output_dtype)
 
 
 def ttnn_rms_norm_pre_all_gather_golden(
@@ -8224,6 +8229,7 @@ def chisel_ttnn_linear(op, inputs):
         bias_tensor=inputs["bias"],
         transpose_a_attr=op.attributes["transpose_a"],
         transpose_b_attr=op.attributes["transpose_b"],
+        activation_attr=_attr_get(op.attributes, "activation"),
         output_type_mlir=op.results[0].type.element_type,
     )
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -28,6 +28,7 @@ import re
 import einops
 import torch
 import torch.nn.functional
+from ttnn.operations.activations import get_golden_function_for_activation
 from ttmlir.dialects import ttir, stablehlo, d2m, ttnn, ttcore, sdy, debug, func
 from ttmlir.ir import *
 from ttmlir.passes import DataType
@@ -6748,9 +6749,12 @@ def ttnn_matmul_golden(
     a = torch.transpose(input_tensor, -2, -1) if transpose_a else input_tensor
     b = torch.transpose(other_tensor, -2, -1) if transpose_b else other_tensor
     output = torch.matmul(a, b)
-    activation_golden = get_golden_function_for_activation(activation_attr)
-    if activation_golden is not None:
-        return activation_golden(output, output_type_mlir)
+    activation = activation_attr
+    if activation is not None and not isinstance(activation, str):
+        activation = unpack_mlir_attr(activation)
+    activation_fn = get_golden_function_for_activation(activation)
+    if activation_fn is not None:
+        output = activation_fn(output)
     return output.to(output_dtype)
 
 
@@ -8000,40 +8004,6 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     debug.RegionStartOp: debug_region_start_golden,
     debug.RegionEndOp: debug_region_end_golden,
 }
-
-
-_FUSED_ACTIVATION_GOLDEN_OPS: Dict[str, type] = {
-    "relu": ttnn.ReluOp,
-    "sigmoid": ttnn.SigmoidOp,
-    "gelu": ttnn.GeluOp,
-    "silu": ttnn.SiluOp,
-}
-
-
-def get_golden_function_for_activation(
-    activation: Optional[Union[str, StringAttr]] = None,
-) -> Optional[Callable]:
-    """
-    Get the TTNN unary golden for a fused matmul/linear activation string.
-
-    Parameters
-    ----------
-    activation : Optional[Union[str, StringAttr]]
-        Activation name from TTNN matmul/linear (e.g. ``"relu"``, ``"sigmoid"``).
-
-    Returns
-    -------
-    Optional[Callable]
-        Unary golden taking ``(input_tensor, output_type_mlir)``, or None if absent.
-    """
-    if activation is None:
-        return None
-    if not isinstance(activation, str):
-        activation = unpack_mlir_attr(activation)
-    op_class = _FUSED_ACTIVATION_GOLDEN_OPS.get(activation)
-    if op_class is None:
-        raise ValueError(f"Unsupported fused activation: {activation}")
-    return get_golden_function(op_class)
 
 
 def get_golden_function(ttir_op_class: type, **kwargs) -> Optional[Callable]:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When using chisel, we have noticed that several golden functions did not return proper results.

### What's changed
Fix for softmax, matmul and linear implemented.

Fix for softmax:
- Rename `dim` to `dimension` to match what `ttnn` uses.

Fix for matmul and linear:
- Addition of fused `activation` parameter.
- Application of `activation` to the result of the op.

### Checklist
- [ ] New/Existing tests provide coverage for changes
