### PR TITLE
[TTNN] Zero-pad fill_cache / paged_fill_cache input tile-pad rows

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/FillCacheInputPadRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/FillCacheInputPadRewritePattern.h
@@ -45,6 +45,17 @@ public:
     }
     int64_t paddedSeqLen = llvm::divideCeil(seqLen, TILE_HEIGHT) * TILE_HEIGHT;
 
+    // `FillCacheOp` requires input.dim(-2) <= cache.dim(-2); skip when
+    // padding would exceed cache.dim(-2). `PagedFillCacheOp` is unconstrained
+    // here -- its cache.dim(-2) is page-block size, not seq_len.
+    if constexpr (std::is_same_v<CacheWriteOpT, ttnn::FillCacheOp>) {
+      auto cacheShape =
+          mlir::cast<RankedTensorType>(op.getCache().getType()).getShape();
+      if (paddedSeqLen > cacheShape[seqDim]) {
+        return failure();
+      }
+    }
+
     SmallVector<int64_t> paddedShape(shape);
     paddedShape[seqDim] = paddedSeqLen;
     SmallVector<int32_t> padding(2 * shape.size(), 0);

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/FillCacheInputPadRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/FillCacheInputPadRewritePattern.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_FILLCACHEINPUTPADREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_FILLCACHEINPUTPADREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// Workaround which zero-pads the cache-write input's seq_len (dim -2) to
+// the next tile multiple before `ttnn.fill_cache` / `ttnn.paged_fill_cache`.
+// Without this, the kernel iterates over the input's padded shape and
+// copies whatever (potentially +/-Inf / NaN) sits in the implicit tile-pad
+// rows verbatim into the KV cache, later leaking NaNs into SDPA via the
+// causal mask's `0 * Inf` path.
+// Metal issue reference: https://github.com/tenstorrent/tt-metal/issues/42779
+//
+// Templated on the cache-write op; instantiated for `FillCacheOp` and
+// `PagedFillCacheOp`, which share an `$input` operand with identical shape
+// semantics (4D, dim -2 = seq_len).
+template <typename CacheWriteOpT>
+class FillCacheInputPadRewritePattern : public OpRewritePattern<CacheWriteOpT> {
+public:
+  using OpRewritePattern<CacheWriteOpT>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(CacheWriteOpT op,
+                                PatternRewriter &rewriter) const override {
+    auto type = mlir::dyn_cast<RankedTensorType>(op.getInput().getType());
+    if (!type || type.getRank() < 2) {
+      return failure();
+    }
+    ArrayRef<int64_t> shape = type.getShape();
+    int64_t seqDim = static_cast<int64_t>(shape.size()) - 2;
+    int64_t seqLen = shape[seqDim];
+    if (seqLen % TILE_HEIGHT == 0) {
+      return failure();
+    }
+    int64_t paddedSeqLen = llvm::divideCeil(seqLen, TILE_HEIGHT) * TILE_HEIGHT;
+
+    SmallVector<int64_t> paddedShape(shape);
+    paddedShape[seqDim] = paddedSeqLen;
+    SmallVector<int32_t> padding(2 * shape.size(), 0);
+    padding[2 * seqDim + 1] = static_cast<int32_t>(paddedSeqLen - seqLen);
+
+    Value paddedInput = rewriter.create<ttnn::PadOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_scrub_input_pad"),
+        utils::RankedTensorTypeFactory::create(type, paddedShape),
+        op.getInput(), padding, /*pad_value=*/mlir::APFloat(0.0f),
+        /*use_multicore=*/true);
+
+    rewriter.modifyOpInPlace(
+        op, [&]() { op.getInputMutable().assign(paddedInput); });
+    return success();
+  }
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_FILLCACHEINPUTPADREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -18,6 +18,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/FillCacheInputPadRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormAffineReshapeRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.h"
@@ -650,6 +651,10 @@ public:
           workarounds::decomposition::ArgMaxOpDimRewritePattern,
           workarounds::decomposition::UpsampleOpBilinearPaddingRewritePattern,
           workarounds::decomposition::RotaryEmbeddingOpRewritePattern,
+          workarounds::decomposition::FillCacheInputPadRewritePattern<
+              ttnn::FillCacheOp>,
+          workarounds::decomposition::FillCacheInputPadRewritePattern<
+              ttnn::PagedFillCacheOp>,
           workarounds::decomposition::Conv2dRewritePattern<Conv2dOp>,
           workarounds::decomposition::Conv2dRewritePattern<ConvTranspose2dOp>,
           workarounds::decomposition::

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/fill_cache_input_pad_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/fill_cache_input_pad_workaround.mlir
@@ -1,0 +1,85 @@
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttnn-workaround -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Workaround under test:
+// `FillCacheOpInputPadRewritePattern` / `PagedFillCacheOpInputPadRewritePattern`
+// zero-pad the cache-write input's seq_len (dim -2) up to the next tile
+// multiple. This neutralizes any garbage (+/-Inf / NaN) sitting in the
+// implicit tile-pad rows of upstream producers, which the cache-write
+// kernel otherwise iterates over and copies verbatim into the KV cache
+// (tt-metal#42779, tt-xla#4785).
+
+#dram = #ttnn.buffer_type<dram>
+#input_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 576 + d1 * 18 + d2, d3), <1x1>, memref<18x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#cache_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<64x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// Case 1: fill_cache with non-tile-aligned input seq_len (18). The pattern
+// MUST insert a `ttnn.pad` that right-pads dim -2 from 18 up to 32 with
+// zeros, then rewrite fill_cache to consume the padded input.
+module @case1_fill_cache_unaligned attributes {} {
+  func.func public @fill_cache_unaligned_seq(
+      %cache: tensor<1x32x64x64xbf16, #cache_layout>,
+      %input: tensor<1x32x18x64xbf16, #input_layout>) {
+    // CHECK-LABEL: func.func public @fill_cache_unaligned_seq
+    // padding layout for 4D is
+    // [d0_lo, d0_hi, d1_lo, d1_hi, d2_lo, d2_hi, d3_lo, d3_hi],
+    // and we right-pad dim 2 by 14 (18 -> 32).
+    // CHECK: %[[PADDED:.*]] = "ttnn.pad"(%arg1)
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 14, 0, 0>
+    // CHECK-SAME: value = 0.000000e+00
+    // CHECK: "ttnn.fill_cache"(%arg0, %[[PADDED]])
+    // CHECK-SAME: batch_offset = 0
+    "ttnn.fill_cache"(%cache, %input) <{batch_offset = 0 : i32}> :
+        (tensor<1x32x64x64xbf16, #cache_layout>,
+         tensor<1x32x18x64xbf16, #input_layout>) -> ()
+    return
+  }
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#input_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#cache_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<64x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// Case 2: fill_cache whose input seq_len is already tile-aligned (32).
+// The pattern MUST NOT insert a pad — the original op survives unchanged.
+module @case2_fill_cache_aligned attributes {} {
+  func.func public @fill_cache_aligned_seq(
+      %cache: tensor<1x32x64x64xbf16, #cache_layout>,
+      %input: tensor<1x32x32x64xbf16, #input_layout>) {
+    // CHECK-LABEL: func.func public @fill_cache_aligned_seq
+    // CHECK-NOT: "ttnn.pad"
+    // CHECK: "ttnn.fill_cache"(%arg0, %arg1)
+    "ttnn.fill_cache"(%cache, %input) <{batch_offset = 0 : i32}> :
+        (tensor<1x32x64x64xbf16, #cache_layout>,
+         tensor<1x32x32x64xbf16, #input_layout>) -> ()
+    return
+  }
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#input_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 576 + d1 * 18 + d2, d3), <1x1>, memref<18x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#cache_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<64x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#page_table_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2xi32, #dram>, <interleaved>>
+
+// Case 3: paged_fill_cache with non-tile-aligned input seq_len. Same
+// hazard, same scrub.
+module @case3_paged_fill_cache_unaligned attributes {} {
+  func.func public @paged_fill_cache_unaligned_seq(
+      %cache: tensor<1x32x64x64xbf16, #cache_layout>,
+      %input: tensor<1x32x18x64xbf16, #input_layout>,
+      %page_table: tensor<1x2xi32, #page_table_layout>) {
+    // CHECK-LABEL: func.func public @paged_fill_cache_unaligned_seq
+    // CHECK: %[[PADDED:.*]] = "ttnn.pad"(%arg1)
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 14, 0, 0>
+    // CHECK: "ttnn.paged_fill_cache"(%arg0, %[[PADDED]], %arg2)
+    "ttnn.paged_fill_cache"(%cache, %input, %page_table) :
+        (tensor<1x32x64x64xbf16, #cache_layout>,
+         tensor<1x32x18x64xbf16, #input_layout>,
+         tensor<1x2xi32, #page_table_layout>) -> ()
+    return
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/fill_cache_input_pad_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/fill_cache_input_pad_workaround.mlir
@@ -1,29 +1,19 @@
 // RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttnn-workaround -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// Workaround under test:
-// `FillCacheOpInputPadRewritePattern` / `PagedFillCacheOpInputPadRewritePattern`
-// zero-pad the cache-write input's seq_len (dim -2) up to the next tile
-// multiple. This neutralizes any garbage (+/-Inf / NaN) sitting in the
-// implicit tile-pad rows of upstream producers, which the cache-write
-// kernel otherwise iterates over and copies verbatim into the KV cache
-// (tt-metal#42779, tt-xla#4785).
+// Tests for FillCacheInputPadRewritePattern (see header for rationale).
+// Refs: tt-metal#42779, tt-xla#4785.
 
 #dram = #ttnn.buffer_type<dram>
 #input_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 576 + d1 * 18 + d2, d3), <1x1>, memref<18x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #cache_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<64x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
-// Case 1: fill_cache with non-tile-aligned input seq_len (18). The pattern
-// MUST insert a `ttnn.pad` that right-pads dim -2 from 18 up to 32 with
-// zeros, then rewrite fill_cache to consume the padded input.
+// Case 1: unaligned input seq_len (18) -> pad to 32, then fill_cache.
 module @case1_fill_cache_unaligned attributes {} {
   func.func public @fill_cache_unaligned_seq(
       %cache: tensor<1x32x64x64xbf16, #cache_layout>,
       %input: tensor<1x32x18x64xbf16, #input_layout>) {
     // CHECK-LABEL: func.func public @fill_cache_unaligned_seq
-    // padding layout for 4D is
-    // [d0_lo, d0_hi, d1_lo, d1_hi, d2_lo, d2_hi, d3_lo, d3_hi],
-    // and we right-pad dim 2 by 14 (18 -> 32).
     // CHECK: %[[PADDED:.*]] = "ttnn.pad"(%arg1)
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 14, 0, 0>
     // CHECK-SAME: value = 0.000000e+00
@@ -42,8 +32,7 @@ module @case1_fill_cache_unaligned attributes {} {
 #input_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #cache_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<64x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
-// Case 2: fill_cache whose input seq_len is already tile-aligned (32).
-// The pattern MUST NOT insert a pad — the original op survives unchanged.
+// Case 2: input seq_len already tile-aligned (32) -> no pad inserted.
 module @case2_fill_cache_aligned attributes {} {
   func.func public @fill_cache_aligned_seq(
       %cache: tensor<1x32x64x64xbf16, #cache_layout>,
@@ -65,8 +54,7 @@ module @case2_fill_cache_aligned attributes {} {
 #cache_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<64x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #page_table_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2xi32, #dram>, <interleaved>>
 
-// Case 3: paged_fill_cache with non-tile-aligned input seq_len. Same
-// hazard, same scrub.
+// Case 3: paged_fill_cache with unaligned input -> same pad as Case 1.
 module @case3_paged_fill_cache_unaligned attributes {} {
   func.func public @paged_fill_cache_unaligned_seq(
       %cache: tensor<1x32x64x64xbf16, #cache_layout>,
@@ -80,6 +68,27 @@ module @case3_paged_fill_cache_unaligned attributes {} {
         (tensor<1x32x64x64xbf16, #cache_layout>,
          tensor<1x32x18x64xbf16, #input_layout>,
          tensor<1x2xi32, #page_table_layout>) -> ()
+    return
+  }
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#cache_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2016 + d1 * 63 + d2, d3), <1x1>, memref<63x16x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#input_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2016 + d1 * 63 + d2, d3), <1x1>, memref<63x16x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// Case 4: cache also non-tile-aligned (63) -> pattern bails (padding input
+// to 64 would violate input.dim(-2) <= cache.dim(-2)).
+module @case4_fill_cache_cache_also_unaligned attributes {} {
+  func.func public @fill_cache_cache_also_unaligned(
+      %cache: tensor<1x32x63x511xbf16, #cache_layout>,
+      %input: tensor<1x32x63x511xbf16, #input_layout>) {
+    // CHECK-LABEL: func.func public @fill_cache_cache_also_unaligned
+    // CHECK-NOT: "ttnn.pad"
+    // CHECK: "ttnn.fill_cache"(%arg0, %arg1)
+    "ttnn.fill_cache"(%cache, %input) <{batch_offset = 0 : i32}> :
+        (tensor<1x32x63x511xbf16, #cache_layout>,
+         tensor<1x32x63x511xbf16, #input_layout>) -> ()
     return
   }
 }


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4785 (LLM benchmark output quality)
- https://github.com/tenstorrent/tt-metal/issues/42779 (root cause)

### Problem description
`ttnn.fill_cache` / `ttnn.paged_fill_cache` iterate over the input's *padded* shape and copy tile-pad rows verbatim into the KV cache. When `seq_len` is not tile-aligned, those rows can hold `+/-Inf` / `NaN` from upstream producers, which then leak into SDPA via the causal mask's `0 * Inf` path and corrupt Llama prefill output.

### What's changed
`FillCacheInputPadRewritePattern<OpT>` (templated for `FillCacheOp` / `PagedFillCacheOp`): if the input's `seq_len` is not tile-aligned, right-pad dim -2 with zeros up to the next tile multiple before the cache write. Placed on the consumer so it covers every producer and needs no use-def walk.
### Checklist
- [x] Benchmark CI green (perf within tolerance + manual output-quality
      spot-check across all users, not just user 0):

  | Scope | Filter | runs-on | Run |
  |---|---|---|---|
  | All single-chip LLMs | `llama,qwen,phi,falcon,gemma,mistral,ministral` | `n150` | https://github.com/tenstorrent/tt-xla/actions/runs/26457197926 |
  | Llama 70b (llmbox + galaxy) | `llama_3_1_70b_tp` | All | https://github.com/tenstorrent/tt-xla/actions/runs/26457200474 |
  | Kimi galaxy | `kimi` | `galaxy-wh-6u` | https://github.com/tenstorrent/tt-xla/actions/runs/26457203043 |


  All three triggered with regression check enabled.
