### PR TITLE
[TTCore] Implement TileType::getFloatSemantics for block float dtypes

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -723,9 +723,7 @@ def TTCore_Tile : TTCore_Type<"Tile", "tile", [MemRefElementTypeInterface, Float
       // Returns the scalar element type of the tile, if compressed it returns
       // the corresponding uncompressed element type, i.e. bfp_bf8 -> bf16
       Type getElementType() const;
-      const ::llvm::fltSemantics &getFloatSemantics() {
-        llvm_unreachable("TTCore_Tile::getFloatSemantics unimplemented #5124");
-      }
+      const ::llvm::fltSemantics &getFloatSemantics();
 
       // ShapedTypeInterface methods
       /// Clone this type with the given shape and element type. If the

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -21,6 +21,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LLVM.h"
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -1855,6 +1856,30 @@ uint64_t TileType::getSizeBytes() const {
 
 mlir::Type TileType::getElementType() const {
   return dataTypeToElementType(getContext(), getDataType());
+}
+
+const llvm::fltSemantics &TileType::getFloatSemantics() {
+  switch (getDataType()) {
+  case DataType::Float32:
+    return llvm::APFloat::IEEEsingle();
+  case DataType::Float16:
+  case DataType::BFP_Float8:
+  case DataType::BFP_Float4:
+  case DataType::BFP_Float2:
+    return llvm::APFloat::IEEEhalf();
+  case DataType::BFloat16:
+  case DataType::BFP_BFloat8:
+  case DataType::BFP_BFloat4:
+  case DataType::BFP_BFloat2:
+    return llvm::APFloat::BFloat();
+  case DataType::UInt32:
+  case DataType::UInt16:
+  case DataType::UInt8:
+  case DataType::Int32:
+  case DataType::Bool:
+    break;
+  }
+  llvm_unreachable("getFloatSemantics called on non-float TileType");
 }
 
 TileType TileType::cloneWith(::std::optional<::llvm::ArrayRef<int64_t>> shape,


### PR DESCRIPTION
### Ticket
Closes #5124

### Problem description
  
  `TileType::getFloatSemantics()` was a stub that aborted with `llvm_unreachable("...unimplemented #5124")`. The `FloatTypeInterface` trait was originally added to `TileType` purely so `!ttcore.tile` would be accepted as an element type by upstream `arith.*` / `math.*` op verifiers, and no pass we exercised ever
   called `getFloatSemantics()` — so the stub was harmless.

  That changed with the tt-xla activation-dtype-lowering work (branch `dgolubovic/lower-act-dtypes-before-ccls-test`). The LM-head / Pattern D path produces `bfp_bf8`-tiled tensors that flow into an MLIR pass which does `cast<FloatType>(elementType).getFloatSemantics()`. That dispatches into
  `TileType::getFloatSemantics()` and aborts the process during compile:

```
  TTCore_Tile::getFloatSemantics unimplemented #5124
  UNREACHABLE executed at .../TTCoreOpsTypes.h.inc:48!
  Fatal Python error: Aborted
```

  ### What's changed

  - Out-of-line the declaration of `TileType::getFloatSemantics()` in `TTCoreOpsTypes.td` and implement it in `TTCoreOpsTypes.cpp` as a switch on `DataType`:
    - `FP32`- `llvm::APFloat::IEEEsingle()`
    - `FP16`, `BFP_Float8`, `BFP_Float4`, `BFP_Float2`  - llvm::APFloat::IEEEhalf();
    -  `BF16`, `BFP_BFloat8`, `BFP_BFloat4`, `BFP_BFloat2` → `llvm::APFloat::BFloat()`
    - Integer / `Bool` dtypes fall through to `llvm_unreachable` (calling `getFloatSemantics` on a non-float tile remains a bug).
  - The mapping mirrors the existing `getElementType()` contract (e.g. `bfp_bf8 → bf16`): the tile reports the IEEE semantics of its *decompressed component*, since `llvm::fltSemantics` has no representation of block-floating-point layout. This is sufficient for the `arith` / `math` interface contract the trait
  exists to satisfy; code that needs to reason about the actual BFP precision must still inspect `DataType` directly.

