### PR TITLE
Typecasting row major tensor on device

### DIFF
--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/RowMajorLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/RowMajorLayoutPropagation.cpp
@@ -194,63 +194,49 @@ private:
     return rmArgs;
   }
 
-  // Handles dtype conversion when backend dtype differs from IR tensor element
-  // type. Inserts a toLayout op with TILE layout (required for on-device
-  // typecast) to perform the dtype conversion. Returns true if conversion was
-  // inserted, indicating RM propagation should stop at this point.
-  //
-  // TODO(bmalesevic, #6783): Once issue is addressed (on-device typecasting
-  // support for RM tensors), RM propagation should be allowed to continue after
-  // dtype conversion without forcing conversion to tile layout (which currently
-  // stops RM propagation).
-  bool handleDtypeConversionIfNeeded(Operation *user, IRRewriter &rewriter,
-                                     TTNNLayoutAttr rmOutputLayout,
-                                     Type backendDataType,
-                                     Type tensorElementType,
-                                     RankedTensorType userResultType) {
-    if (backendDataType == tensorElementType) {
-      return false; // No conversion needed
-    }
-
-    TTMLIR_DEBUG(ttmlir::LogComponent::RMPropagation,
-                 "Dtype mismatch detected at op {}: backend dtype {} != "
-                 "tensor element type {}. Inserting toLayout op.",
-                 ttmlir::opToString(user), backendDataType, tensorElementType);
-
-    // First, set the operation's result type to match what the backend
-    // actually produces (with backend's dtype in the layout)
+  // Sets `user`'s result type to what the backend actually produces (RowMajor
+  // layout with the backend's dtype). If that dtype differs from the IR's
+  // expected element type, inserts a RowMajor-preserving toLayout op after
+  // `user` so the on-device typecast happens without leaving RowMajor.
+  // TTNNDecomposeLayouts emits an on-device typecast for this no-layout-change
+  // case (see handleDeviceInputNoLayoutTypecast). Returns the value to keep
+  // propagating RM layout from.
+  Value setBackendResultAndMaybeTypecast(Operation *user, IRRewriter &rewriter,
+                                         TTNNLayoutAttr rmOutputLayout,
+                                         Type backendDataType,
+                                         Type tensorElementType,
+                                         RankedTensorType userResultType) {
     RankedTensorType backendResultType = RankedTensorType::get(
         userResultType.getShape(), backendDataType, rmOutputLayout);
     user->getResult(0).setType(backendResultType);
 
+    if (backendDataType == tensorElementType) {
+      return user->getResult(0);
+    }
+
+    TTMLIR_DEBUG(ttmlir::LogComponent::RMPropagation,
+                 "Dtype mismatch at op {}: backend dtype {} != tensor element "
+                 "type {}. Inserting RowMajor toLayout op for on-device "
+                 "typecast.",
+                 ttmlir::opToString(user), backendDataType, tensorElementType);
+
     rewriter.setInsertionPointAfter(user);
 
-    // Create layout with TILE (required for on-device typecast) and the
-    // original tensor element type. TTNNDecomposeLayouts requires TILE
-    // layout for on-device dtype conversion; ROW_MAJOR would force a
-    // host round-trip (from_device → typecast → to_device).
-    TTNNLayoutAttr tileLayout =
+    TTNNLayoutAttr rmLayoutWithTargetDtype =
         TTNNLayoutAttr::Builder(rmOutputLayout, userResultType.getShape())
-            .setElementType(tensorElementType)
-            .setLayout(Layout::Tile);
+            .setElementType(tensorElementType);
 
-    // Create toLayout op using TILE layout for dtype conversion
     auto toLayoutOp = utils::createToLayoutOp(
         user,
         mlir::cast<mlir::TypedValue<RankedTensorType>>(user->getResult(0)),
-        rewriter, tileLayout.getLayout(), tileLayout.getBufferType(),
-        tileLayout.getMemLayout(), tileLayout.getDataType(),
-        "_dtype_conversion");
+        rewriter, rmLayoutWithTargetDtype.getLayout(),
+        rmLayoutWithTargetDtype.getBufferType(),
+        rmLayoutWithTargetDtype.getMemLayout(),
+        rmLayoutWithTargetDtype.getDataType(), "_dtype_conversion");
 
-    // Replace all uses (except the toLayout itself)
     user->getResult(0).replaceAllUsesExcept(toLayoutOp.getResult(), toLayoutOp);
 
-    TTMLIR_DEBUG(ttmlir::LogComponent::RMPropagation,
-                 "Inserted toLayout op (TILE) after {} to convert {} -> "
-                 "{}. Stopping RM propagation.",
-                 ttmlir::opToString(user), backendDataType, tensorElementType);
-
-    return true; // Conversion inserted, stop RM propagation
+    return toLayoutOp.getResult();
   }
 
   // Propagates RowMajor layout through the function starting from the given
@@ -297,24 +283,20 @@ private:
         Type backendDataType = rmOutputLayout->getScalarElementType();
         Type tensorElementType = userResultType.getElementType();
 
-        // Handle dtype conversion if backend dtype differs from IR element type
-        if (handleDtypeConversionIfNeeded(user, rewriter, rmOutputLayout.get(),
-                                          backendDataType, tensorElementType,
-                                          userResultType)) {
-          continue; // Stop RM propagation (converted to TILE)
-        }
-
-        // No dtype mismatch, continue propagating with RM layout
-        RankedTensorType backendResultType = RankedTensorType::get(
-            userResultType.getShape(), backendDataType, rmOutputLayout.get());
-        user->getResult(0).setType(backendResultType);
+        // Set the user's result to the backend's RM layout, inserting an
+        // on-device typecast (also RM) if the backend dtype differs from the
+        // IR's expected element type. Propagation continues either from the
+        // user op directly or from the inserted typecast.
+        Value propagatedValue = setBackendResultAndMaybeTypecast(
+            user, rewriter, rmOutputLayout.get(), backendDataType,
+            tensorElementType, userResultType);
 
         TTMLIR_DEBUG(
             ttmlir::LogComponent::RMPropagation,
             "Set RowMajor layout on op {} at {}, \n\t output layout: {}",
             user->getName(), user->getLoc(), rmOutputLayout.get());
 
-        worklist.push(user->getResult(0));
+        worklist.push(propagatedValue);
       }
     }
   }

--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -394,16 +394,6 @@ private:
     if (!info.opsToCreate.createDataTypeCastOp) {
       return currentInput;
     }
-
-    RankedTensorType currentInputType =
-        mlir::cast<RankedTensorType>(currentInput.getType());
-
-    TTNNLayoutAttr inputLayout =
-        mlir::cast<TTNNLayoutAttr>(currentInputType.getEncoding());
-    if (!inputLayout.isSystemBufferType()) {
-      assert(inputLayout.getLayout() == Layout::Tile &&
-             "Only tilized tensors are supported for device typecast");
-    }
     return this->createDataTypeCastingOp(op, rewriter, currentInput, info);
   }
 
@@ -1081,28 +1071,8 @@ private:
       return;
     }
 
-    // If the output is tilized, typecast directly on device
-    if (output.isTilized()) {
-      // If the input is sharded, typecast should happen after converting to
-      // memory.
-      if (input.isSharded()) {
-        currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                            currentInput, info);
-        currentInput = this->createDataTypeCastingOpIfNeeded(
-            op, rewriter, currentInput, info);
-      } else {
-        currentInput = this->createDataTypeCastingOpIfNeeded(
-            op, rewriter, currentInput, info);
-        currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                            currentInput, info);
-      }
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If the output is not tilized, typecast on host
+    // If the output is not tilized and we're moving to host anyway, typecast
+    // on host to avoid a redundant on-device typecast.
     if (!output.isTilized() && opsToCreate.createFromDeviceOp) {
       currentInput =
           this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
@@ -1112,24 +1082,24 @@ private:
       return;
     }
 
-    // Device to device untilized typecast, need to move to host first
-    if (!output.isTilized() && !opsToCreate.createFromDeviceOp) {
-      // Force-create a FromDeviceOp
-      currentInput = this->createFromDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, /*forceCreate=*/true);
-      // typecast on host
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      // move back to device and convert memory config if needed
-      currentInput = this->createToDeviceOpIfNeeded(op, rewriter, currentInput,
-                                                    info, /*forceCreate=*/true);
+    // Otherwise typecast directly on device. This covers both the tilized case
+    // and the device-to-device untilized case.
+    // If the input is sharded, typecast should happen after converting to
+    // memory.
+    if (input.isSharded()) {
       currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
                                                           currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
+                                                           currentInput, info);
+    } else {
+      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
+                                                           currentInput, info);
+      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
+                                                          currentInput, info);
     }
-
-    llvm_unreachable("Unreachable code path");
+    currentInput =
+        this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
+    op.getResult().replaceAllUsesWith(currentInput);
   }
 
   void handleDeviceInputLayoutTypecast(ttnn::ToLayoutOp op,

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttnn-decompose-layouts -o %t.mlir %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttnn-decompose-layouts --mlir-print-local-scope -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
 
@@ -19,74 +19,70 @@
 module attributes {} {
 
     // DRAM interleaved RM bf16 -> DRAM interleaved RM f32. Same memory config,
-    // just a dtype change. Expected: a single on-device typecast, no host
-    // round-trip and no spurious to_memory_config.
+    // just a dtype change. The typecast consumes %arg0 directly and its result
+    // tensor stays in DRAM.
     func.func @dram_il_rm_bf16_to_dram_il_rm_f32(%arg0: tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #dram_il_rm_f32> {
         // CHECK-LABEL: func.func @dram_il_rm_bf16_to_dram_il_rm_f32
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+        // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: return %[[CAST]]
-        // CHECK-NOT: ttnn.from_device
-        // CHECK-NOT: ttnn.to_device
-        // CHECK-NOT: ttnn.to_memory_config
         %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #dram_il_rm_f32>
         return %0 : tensor<32x128xf32, #dram_il_rm_f32>
     }
 
     // DRAM interleaved RM f32 -> DRAM interleaved RM bf16. Opposite dtype
-    // direction; same single-typecast expectation.
+    // direction; same single-typecast expectation, result stays in DRAM.
     func.func @dram_il_rm_f32_to_dram_il_rm_bf16(%arg0: tensor<32x128xf32, #dram_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16> {
         // CHECK-LABEL: func.func @dram_il_rm_f32_to_dram_il_rm_bf16
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+        // CHECK-SAME: -> tensor<32x128xbf16, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: return %[[CAST]]
-        // CHECK-NOT: ttnn.from_device
-        // CHECK-NOT: ttnn.to_device
-        // CHECK-NOT: ttnn.to_memory_config
         %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x128xf32, #dram_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x128xbf16, #dram_il_rm_bf16>
     }
 
     // L1 interleaved RM bf16 -> L1 interleaved RM f32. Same memory config,
-    // just a dtype change. Same single-typecast expectation as the DRAM case.
+    // just a dtype change. Result stays in L1.
     func.func @l1_il_rm_bf16_to_l1_il_rm_f32(%arg0: tensor<32x128xbf16, #l1_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32> {
         // CHECK-LABEL: func.func @l1_il_rm_bf16_to_l1_il_rm_f32
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+        // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<l1>
         // CHECK-NEXT: return %[[CAST]]
-        // CHECK-NOT: ttnn.from_device
-        // CHECK-NOT: ttnn.to_device
-        // CHECK-NOT: ttnn.to_memory_config
         %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#l1, <interleaved>>}> : (tensor<32x128xbf16, #l1_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
         return %0 : tensor<32x128xf32, #l1_il_rm_f32>
     }
 
     // DRAM interleaved RM bf16 -> L1 interleaved RM f32. Dtype change plus a
-    // memory move. Expected on-device sequence: typecast (in DRAM) followed
-    // by a single to_memory_config to L1; no host round-trip.
+    // memory move. The typecast runs on the DRAM input, then a single
+    // to_memory_config moves the (already-typecast) result to L1; no host
+    // round-trip.
     func.func @dram_il_rm_bf16_to_l1_il_rm_f32(%arg0: tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32> {
         // CHECK-LABEL: func.func @dram_il_rm_bf16_to_l1_il_rm_f32
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+        // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: %[[MEM:.*]] = "ttnn.to_memory_config"(%[[CAST]])
+        // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<l1>
         // CHECK-NEXT: return %[[MEM]]
-        // CHECK-NOT: ttnn.from_device
-        // CHECK-NOT: ttnn.to_device
         %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#l1, <interleaved>>}> : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
         return %0 : tensor<32x128xf32, #l1_il_rm_f32>
     }
 
     // L1 interleaved RM f32 -> DRAM interleaved RM bf16. Opposite memory
-    // direction with the smaller dtype on the output side. Same expectation:
-    // typecast first, then a single to_memory_config; no host round-trip.
+    // direction with the smaller dtype on the output side. The typecast runs
+    // on the L1 input (so its result is in L1), then a single to_memory_config
+    // moves it to DRAM; no host round-trip.
     func.func @l1_il_rm_f32_to_dram_il_rm_bf16(%arg0: tensor<32x128xf32, #l1_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16> {
         // CHECK-LABEL: func.func @l1_il_rm_f32_to_dram_il_rm_bf16
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+        // CHECK-SAME: -> tensor<32x128xbf16, {{.*}}#ttnn.buffer_type<l1>
         // CHECK-NEXT: %[[MEM:.*]] = "ttnn.to_memory_config"(%[[CAST]])
+        // CHECK-SAME: -> tensor<32x128xbf16, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: return %[[MEM]]
-        // CHECK-NOT: ttnn.from_device
-        // CHECK-NOT: ttnn.to_device
         %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x128xf32, #l1_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x128xbf16, #dram_il_rm_bf16>
     }

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
@@ -1,0 +1,93 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttnn-decompose-layouts -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+// Tests for device-to-device row-major typecasts in TTNNDecomposeLayouts
+// (handleDeviceInputNoLayoutTypecast, RM-output path).
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+#dram_il_rm_bf16 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x128xbf16, #dram>, <interleaved>>
+#dram_il_rm_f32  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x128xf32,  #dram>, <interleaved>>
+
+// L1 interleaved row-major is stored in linearized (1 x N) form per shard, so
+// for grid <1x1> a 32x128 tensor becomes memref<1x4096, #l1>.
+#l1_il_rm_bf16   = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4096xbf16, #l1>,   <interleaved>>
+#l1_il_rm_f32    = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4096xf32,  #l1>,   <interleaved>>
+
+module attributes {} {
+
+    // DRAM interleaved RM bf16 -> DRAM interleaved RM f32. Same memory config,
+    // just a dtype change. Expected: a single on-device typecast, no host
+    // round-trip and no spurious to_memory_config.
+    func.func @dram_il_rm_bf16_to_dram_il_rm_f32(%arg0: tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #dram_il_rm_f32> {
+        // CHECK-LABEL: func.func @dram_il_rm_bf16_to_dram_il_rm_f32
+        // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
+        // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+        // CHECK-NEXT: return %[[CAST]]
+        // CHECK-NOT: ttnn.from_device
+        // CHECK-NOT: ttnn.to_device
+        // CHECK-NOT: ttnn.to_memory_config
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #dram_il_rm_f32>
+        return %0 : tensor<32x128xf32, #dram_il_rm_f32>
+    }
+
+    // DRAM interleaved RM f32 -> DRAM interleaved RM bf16. Opposite dtype
+    // direction; same single-typecast expectation.
+    func.func @dram_il_rm_f32_to_dram_il_rm_bf16(%arg0: tensor<32x128xf32, #dram_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16> {
+        // CHECK-LABEL: func.func @dram_il_rm_f32_to_dram_il_rm_bf16
+        // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
+        // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+        // CHECK-NEXT: return %[[CAST]]
+        // CHECK-NOT: ttnn.from_device
+        // CHECK-NOT: ttnn.to_device
+        // CHECK-NOT: ttnn.to_memory_config
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x128xf32, #dram_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
+        return %0 : tensor<32x128xbf16, #dram_il_rm_bf16>
+    }
+
+    // L1 interleaved RM bf16 -> L1 interleaved RM f32. Same memory config,
+    // just a dtype change. Same single-typecast expectation as the DRAM case.
+    func.func @l1_il_rm_bf16_to_l1_il_rm_f32(%arg0: tensor<32x128xbf16, #l1_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32> {
+        // CHECK-LABEL: func.func @l1_il_rm_bf16_to_l1_il_rm_f32
+        // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
+        // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+        // CHECK-NEXT: return %[[CAST]]
+        // CHECK-NOT: ttnn.from_device
+        // CHECK-NOT: ttnn.to_device
+        // CHECK-NOT: ttnn.to_memory_config
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#l1, <interleaved>>}> : (tensor<32x128xbf16, #l1_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
+        return %0 : tensor<32x128xf32, #l1_il_rm_f32>
+    }
+
+    // DRAM interleaved RM bf16 -> L1 interleaved RM f32. Dtype change plus a
+    // memory move. Expected on-device sequence: typecast (in DRAM) followed
+    // by a single to_memory_config to L1; no host round-trip.
+    func.func @dram_il_rm_bf16_to_l1_il_rm_f32(%arg0: tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32> {
+        // CHECK-LABEL: func.func @dram_il_rm_bf16_to_l1_il_rm_f32
+        // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
+        // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+        // CHECK-NEXT: %[[MEM:.*]] = "ttnn.to_memory_config"(%[[CAST]])
+        // CHECK-NEXT: return %[[MEM]]
+        // CHECK-NOT: ttnn.from_device
+        // CHECK-NOT: ttnn.to_device
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#l1, <interleaved>>}> : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
+        return %0 : tensor<32x128xf32, #l1_il_rm_f32>
+    }
+
+    // L1 interleaved RM f32 -> DRAM interleaved RM bf16. Opposite memory
+    // direction with the smaller dtype on the output side. Same expectation:
+    // typecast first, then a single to_memory_config; no host round-trip.
+    func.func @l1_il_rm_f32_to_dram_il_rm_bf16(%arg0: tensor<32x128xf32, #l1_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16> {
+        // CHECK-LABEL: func.func @l1_il_rm_f32_to_dram_il_rm_bf16
+        // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
+        // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+        // CHECK-NEXT: %[[MEM:.*]] = "ttnn.to_memory_config"(%[[CAST]])
+        // CHECK-NEXT: return %[[MEM]]
+        // CHECK-NOT: ttnn.from_device
+        // CHECK-NOT: ttnn.to_device
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x128xf32, #l1_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
+        return %0 : tensor<32x128xbf16, #dram_il_rm_bf16>
+    }
+}


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/6783
https://github.com/tenstorrent/tt-xla/issues/4859

### Problem description
Typecasting a tensor in RM layout was previously done on host. [Support for device row major typecast was introduced in tt-metal](https://github.com/tenstorrent/tt-metal/pull/34596) and this constraint is no longer mandatory.

### What's changed
Simplified logic for typecasting to now not move tensor to host if it is in row major layout.

