### PR TITLE
StableHLO] Decompose complex types for gather and elementwise arithmetic

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -9,10 +9,13 @@
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "shardy/dialect/sdy/ir/dialect.h"
 #include "stablehlo/dialect/StablehloOps.h"
+
+#include <numeric>
 
 using namespace mlir;
 
@@ -214,6 +217,82 @@ public:
 };
 } // namespace
 
+// Decomposes multiply(x, y) on complex tensors into real arithmetic on the
+// unpacked (...x2) representation:
+//
+//   (xr + i*xi) * (yr + i*yi)
+//       = (xr*yr - xi*yi) + i*(xr*yi + xi*yr)
+//
+// Both operands are already converted to the trailing real/imag-pair layout.
+// The trailing dim of 2 is transiently moved to the leading position (matching
+// the complex/real/imag decompositions) before the components are sliced out.
+namespace {
+class StablehloComplexMulToDecomposedPattern
+    : public OpConversionPattern<mlir::stablehlo::MulOp> {
+  using OpConversionPattern<mlir::stablehlo::MulOp>::OpConversionPattern;
+
+  // Slices component `idx` (0 = real, 1 = imag) off the leading dim of a
+  // transposed (2 x ...) tensor, returning the (1 x ...) slice.
+  static Value extractComponent(Location loc, Value transposed, int64_t idx,
+                                ConversionPatternRewriter &rewriter) {
+    auto type = mlir::cast<RankedTensorType>(transposed.getType());
+    int64_t rank = type.getRank();
+    SmallVector<int64_t> begins(rank, 0), steps(rank, 1);
+    SmallVector<int64_t> ends(type.getShape().begin(), type.getShape().end());
+    begins[0] = idx;
+    ends[0] = idx + 1;
+    SmallVector<int64_t> sliceShape(type.getShape().begin(),
+                                    type.getShape().end());
+    sliceShape[0] = 1;
+    return rewriter.create<mlir::stablehlo::SliceOp>(
+        loc, RankedTensorType::get(sliceShape, type.getElementType()),
+        transposed, rewriter.getDenseI64ArrayAttr(begins),
+        rewriter.getDenseI64ArrayAttr(ends),
+        rewriter.getDenseI64ArrayAttr(steps));
+  }
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::MulOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    Value lhs = transposeTrailingToLeading(loc, adaptor.getLhs(), rewriter);
+    Value rhs = transposeTrailingToLeading(loc, adaptor.getRhs(), rewriter);
+
+    Value xr = extractComponent(loc, lhs, /*idx=*/0, rewriter);
+    Value xi = extractComponent(loc, lhs, /*idx=*/1, rewriter);
+    Value yr = extractComponent(loc, rhs, /*idx=*/0, rewriter);
+    Value yi = extractComponent(loc, rhs, /*idx=*/1, rewriter);
+
+    auto compType = mlir::cast<RankedTensorType>(xr.getType());
+
+    // out_re = xr*yr - xi*yi
+    Value xryr = rewriter.create<mlir::stablehlo::MulOp>(loc, compType, xr, yr);
+    Value xiyi = rewriter.create<mlir::stablehlo::MulOp>(loc, compType, xi, yi);
+    Value outRe =
+        rewriter.create<mlir::stablehlo::SubtractOp>(loc, compType, xryr, xiyi);
+
+    // out_im = xr*yi + xi*yr
+    Value xryi = rewriter.create<mlir::stablehlo::MulOp>(loc, compType, xr, yi);
+    Value xiyr = rewriter.create<mlir::stablehlo::MulOp>(loc, compType, xi, yr);
+    Value outIm =
+        rewriter.create<mlir::stablehlo::AddOp>(loc, compType, xryi, xiyr);
+
+    SmallVector<int64_t> concatShape(compType.getShape().begin(),
+                                     compType.getShape().end());
+    concatShape[0] = 2;
+    auto concatType =
+        RankedTensorType::get(concatShape, compType.getElementType());
+    Value packed = rewriter.create<mlir::stablehlo::ConcatenateOp>(
+        loc, concatType, ValueRange{outRe, outIm}, /*dimension=*/0);
+
+    rewriter.replaceOp(op, transposeLeadingToTrailing(loc, packed, rewriter));
+    return success();
+  }
+};
+} // namespace
+
 // Rewrites ops that produce complex-typed tensors to operate on the equivalent
 // unpacked real representation (trailing dim of size 2).
 namespace {
@@ -369,6 +448,117 @@ public:
   }
 };
 
+// Unpacks a complex "tenstorrent.gather" composite to the float-pair layout.
+// Besides retyping the result, the integer index is reshaped + broadcast up to
+// the gather result rank (the trailing real/imag pair shares one index) and the
+// decomposition's index argument is widened to match. The complex unpacking
+// only widened the operand/result, but ttir.gather -- emitted later from this
+// composite -- requires input.rank == index.rank with index.shape ==
+// result.shape, so the index is realigned here. Any other composite carrying
+// complex types is unsupported and reported as a match failure.
+class ComplexCompositeConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CompositeOp> {
+  using OpConversionPattern<mlir::stablehlo::CompositeOp>::OpConversionPattern;
+
+public:
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::CompositeOp op,
+      OpConversionPattern<mlir::stablehlo::CompositeOp>::OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    if (op.getName() != "tenstorrent.gather") {
+      return rewriter.notifyMatchFailure(
+          op, "only tenstorrent.gather composites are supported");
+    }
+
+    auto newResultType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getResult(0).getType()));
+
+    SmallVector<Value> operands(adaptor.getOperands());
+    auto inputType = mlir::cast<RankedTensorType>(operands[0].getType());
+    auto indexType = mlir::cast<RankedTensorType>(operands[1].getType());
+
+    // Complex unpacking appended a trailing real/imag dim to the operand and
+    // result but not to the integer index, leaving the index one rank short.
+    // Reshape + broadcast it up to the result shape and widen the decomposition
+    // signature so the composite and its decomposition stay consistent.
+    if (inputType.getRank() != indexType.getRank()) {
+      Location loc = op.getLoc();
+      SmallVector<int64_t> reshapeShape(indexType.getShape());
+      reshapeShape.push_back(1);
+      auto reshapeType =
+          RankedTensorType::get(reshapeShape, indexType.getElementType());
+      Value reshaped = rewriter.create<mlir::stablehlo::ReshapeOp>(
+          loc, reshapeType, operands[1]);
+
+      auto bcastIndexType = RankedTensorType::get(newResultType.getShape(),
+                                                  indexType.getElementType());
+      SmallVector<int64_t> bcastDims(reshapeShape.size());
+      std::iota(bcastDims.begin(), bcastDims.end(), 0);
+      operands[1] = rewriter.create<mlir::stablehlo::BroadcastInDimOp>(
+          loc, bcastIndexType, reshaped,
+          rewriter.getDenseI64ArrayAttr(bcastDims));
+
+      if (auto decomposition =
+              SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+                  op, op.getDecompositionAttr())) {
+        widenDecompositionIndexArg(rewriter, decomposition, bcastIndexType,
+                                   indexType);
+      }
+    }
+
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::CompositeOp>(
+        op, TypeRange{newResultType}, operands, op.getProperties());
+    return success();
+  }
+
+private:
+  // Widens the gather decomposition's index argument to `newIndexType` (to
+  // match the broadcast index now passed by the composite) and slices it back
+  // to `oldIndexType` at the entry so the rest of the body is unchanged. Keeps
+  // the composite and its decomposition signature-consistent; the body is dead
+  // once the composite is legalized to TTIR.
+  static void widenDecompositionIndexArg(ConversionPatternRewriter &rewriter,
+                                         func::FuncOp func,
+                                         RankedTensorType newIndexType,
+                                         RankedTensorType oldIndexType) {
+    // The "tenstorrent.gather" decomposition takes (operand, index).
+    if (func.getNumArguments() < 2) {
+      return;
+    }
+    BlockArgument indexArg = func.getArgument(1);
+    if (indexArg.getType() == newIndexType) {
+      return; // already widened
+    }
+
+    rewriter.modifyOpInPlace(func, [&]() {
+      SmallVector<Type> inputs(func.getArgumentTypes());
+      inputs[1] = newIndexType;
+      func.setType(
+          FunctionType::get(func.getContext(), inputs, func.getResultTypes()));
+      indexArg.setType(newIndexType);
+    });
+
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(&func.getBody().front());
+    Location loc = func.getLoc();
+    int64_t rank = newIndexType.getRank();
+    SmallVector<int64_t> starts(rank, 0), strides(rank, 1);
+    SmallVector<int64_t> limits(newIndexType.getShape());
+    limits[rank - 1] = 1;
+    auto sliceType =
+        RankedTensorType::get(limits, newIndexType.getElementType());
+    auto sliceOp = rewriter.create<mlir::stablehlo::SliceOp>(
+        loc, sliceType, indexArg, rewriter.getDenseI64ArrayAttr(starts),
+        rewriter.getDenseI64ArrayAttr(limits),
+        rewriter.getDenseI64ArrayAttr(strides));
+    Value restored =
+        rewriter.create<mlir::stablehlo::ReshapeOp>(loc, oldIndexType, sliceOp);
+    rewriter.replaceUsesWithIf(indexArg, restored, [&](OpOperand &use) {
+      return use.getOwner() != sliceOp;
+    });
+  }
+};
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -486,6 +676,7 @@ public:
 } // namespace
 
 namespace {
+
 struct StableHLOComplexDataTypeConversionPass
     : public impl::StableHLOComplexDataTypeConversionPassBase<
           StableHLOComplexDataTypeConversionPass> {
@@ -506,8 +697,10 @@ struct StableHLOComplexDataTypeConversionPass
     target.addDynamicallyLegalOp<
         mlir::stablehlo::ConstantOp, mlir::stablehlo::ReshapeOp,
         mlir::stablehlo::SliceOp, mlir::stablehlo::GatherOp,
-        mlir::stablehlo::ConcatenateOp, mlir::stablehlo::BroadcastInDimOp>(
-        isNotComplexType);
+        mlir::stablehlo::ConcatenateOp, mlir::stablehlo::BroadcastInDimOp,
+        mlir::stablehlo::MulOp, mlir::stablehlo::AddOp,
+        mlir::stablehlo::SubtractOp, mlir::stablehlo::NegOp,
+        mlir::stablehlo::ConvertOp>(isNotComplexType);
 
     target.addIllegalOp<mlir::stablehlo::ComplexOp, mlir::stablehlo::RealOp,
                         mlir::stablehlo::ImagOp>();
@@ -523,6 +716,12 @@ struct StableHLOComplexDataTypeConversionPass
           return !hasComplexType(op.getOperandTypes()) &&
                  !hasComplexType(op.getResultTypes()) &&
                  !hasComplexType(op.getBody().front().getArgumentTypes());
+        });
+
+    target.addDynamicallyLegalOp<mlir::stablehlo::CompositeOp>(
+        [hasComplexType](mlir::stablehlo::CompositeOp op) {
+          return !hasComplexType(op->getOperandTypes()) &&
+                 !hasComplexType(op->getResultTypes());
         });
 
     TypeConverter typeConverter;
@@ -548,12 +747,17 @@ struct StableHLOComplexDataTypeConversionPass
     patterns.add<
         ComplexBroadcastInDimOpConversionPattern,
         ComplexConstantOpConversionPattern, ComplexGatherOpConversionPattern,
-        ComplexSliceOpConversionPattern,
+        ComplexSliceOpConversionPattern, ComplexCompositeConversionPattern,
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ConcatenateOp>,
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ReshapeOp>,
+        ComplexTypeDefaultConversionPattern<mlir::stablehlo::ConvertOp>,
+        ComplexTypeDefaultConversionPattern<mlir::stablehlo::AddOp>,
+        ComplexTypeDefaultConversionPattern<mlir::stablehlo::SubtractOp>,
+        ComplexTypeDefaultConversionPattern<mlir::stablehlo::NegOp>,
         ShardyManualComputationComplexConversionPattern,
         ShardyReturnOpTypeConversionPattern,
         StablehloComplexToDecomposedPattern,
+        StablehloComplexMulToDecomposedPattern,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::RealOp>,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::ImagOp>>(
         typeConverter, &getContext());

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -217,82 +217,6 @@ public:
 };
 } // namespace
 
-// Decomposes multiply(x, y) on complex tensors into real arithmetic on the
-// unpacked (...x2) representation:
-//
-//   (xr + i*xi) * (yr + i*yi)
-//       = (xr*yr - xi*yi) + i*(xr*yi + xi*yr)
-//
-// Both operands are already converted to the trailing real/imag-pair layout.
-// The trailing dim of 2 is transiently moved to the leading position (matching
-// the complex/real/imag decompositions) before the components are sliced out.
-namespace {
-class StablehloComplexMulToDecomposedPattern
-    : public OpConversionPattern<mlir::stablehlo::MulOp> {
-  using OpConversionPattern<mlir::stablehlo::MulOp>::OpConversionPattern;
-
-  // Slices component `idx` (0 = real, 1 = imag) off the leading dim of a
-  // transposed (2 x ...) tensor, returning the (1 x ...) slice.
-  static Value extractComponent(Location loc, Value transposed, int64_t idx,
-                                ConversionPatternRewriter &rewriter) {
-    auto type = mlir::cast<RankedTensorType>(transposed.getType());
-    int64_t rank = type.getRank();
-    SmallVector<int64_t> begins(rank, 0), steps(rank, 1);
-    SmallVector<int64_t> ends(type.getShape().begin(), type.getShape().end());
-    begins[0] = idx;
-    ends[0] = idx + 1;
-    SmallVector<int64_t> sliceShape(type.getShape().begin(),
-                                    type.getShape().end());
-    sliceShape[0] = 1;
-    return rewriter.create<mlir::stablehlo::SliceOp>(
-        loc, RankedTensorType::get(sliceShape, type.getElementType()),
-        transposed, rewriter.getDenseI64ArrayAttr(begins),
-        rewriter.getDenseI64ArrayAttr(ends),
-        rewriter.getDenseI64ArrayAttr(steps));
-  }
-
-public:
-  LogicalResult
-  matchAndRewrite(mlir::stablehlo::MulOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-
-    Value lhs = transposeTrailingToLeading(loc, adaptor.getLhs(), rewriter);
-    Value rhs = transposeTrailingToLeading(loc, adaptor.getRhs(), rewriter);
-
-    Value xr = extractComponent(loc, lhs, /*idx=*/0, rewriter);
-    Value xi = extractComponent(loc, lhs, /*idx=*/1, rewriter);
-    Value yr = extractComponent(loc, rhs, /*idx=*/0, rewriter);
-    Value yi = extractComponent(loc, rhs, /*idx=*/1, rewriter);
-
-    auto compType = mlir::cast<RankedTensorType>(xr.getType());
-
-    // out_re = xr*yr - xi*yi
-    Value xryr = rewriter.create<mlir::stablehlo::MulOp>(loc, compType, xr, yr);
-    Value xiyi = rewriter.create<mlir::stablehlo::MulOp>(loc, compType, xi, yi);
-    Value outRe =
-        rewriter.create<mlir::stablehlo::SubtractOp>(loc, compType, xryr, xiyi);
-
-    // out_im = xr*yi + xi*yr
-    Value xryi = rewriter.create<mlir::stablehlo::MulOp>(loc, compType, xr, yi);
-    Value xiyr = rewriter.create<mlir::stablehlo::MulOp>(loc, compType, xi, yr);
-    Value outIm =
-        rewriter.create<mlir::stablehlo::AddOp>(loc, compType, xryi, xiyr);
-
-    SmallVector<int64_t> concatShape(compType.getShape().begin(),
-                                     compType.getShape().end());
-    concatShape[0] = 2;
-    auto concatType =
-        RankedTensorType::get(concatShape, compType.getElementType());
-    Value packed = rewriter.create<mlir::stablehlo::ConcatenateOp>(
-        loc, concatType, ValueRange{outRe, outIm}, /*dimension=*/0);
-
-    rewriter.replaceOp(op, transposeLeadingToTrailing(loc, packed, rewriter));
-    return success();
-  }
-};
-} // namespace
-
 // Rewrites ops that produce complex-typed tensors to operate on the equivalent
 // unpacked real representation (trailing dim of size 2).
 namespace {
@@ -698,9 +622,8 @@ struct StableHLOComplexDataTypeConversionPass
         mlir::stablehlo::ConstantOp, mlir::stablehlo::ReshapeOp,
         mlir::stablehlo::SliceOp, mlir::stablehlo::GatherOp,
         mlir::stablehlo::ConcatenateOp, mlir::stablehlo::BroadcastInDimOp,
-        mlir::stablehlo::MulOp, mlir::stablehlo::AddOp,
-        mlir::stablehlo::SubtractOp, mlir::stablehlo::NegOp,
-        mlir::stablehlo::ConvertOp>(isNotComplexType);
+        mlir::stablehlo::AddOp, mlir::stablehlo::SubtractOp,
+        mlir::stablehlo::NegOp, mlir::stablehlo::ConvertOp>(isNotComplexType);
 
     target.addIllegalOp<mlir::stablehlo::ComplexOp, mlir::stablehlo::RealOp,
                         mlir::stablehlo::ImagOp>();
@@ -757,7 +680,6 @@ struct StableHLOComplexDataTypeConversionPass
         ShardyManualComputationComplexConversionPattern,
         ShardyReturnOpTypeConversionPattern,
         StablehloComplexToDecomposedPattern,
-        StablehloComplexMulToDecomposedPattern,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::RealOp>,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::ImagOp>>(
         typeConverter, &getContext());

--- a/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
+++ b/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
@@ -62,21 +62,26 @@ void createStableHLOToTTIRPipeline(
   if (options.arithDialectConversionsEnabled) {
     pm.addPass(createConvertArithToStableHLOPass());
   }
-  pm.addPass(createLegalizeStableHLOCompositeToTTIRPass());
-  if (options.legalizeCompositeToCallEnabled) {
-    pm.addPass(::mlir::stablehlo::createStablehloLegalizeCompositeToCallPass());
-  }
-  pm.addPass(mlir::createInlinerPass());
+  // Run aggressive simplification before the complex passes so complex op
+  // chains (e.g. real(complex(a,b)) -> a) are folded before the complex type
+  // is decomposed to a float-pair representation.
   if (options.enableAggressiveSimplification) {
     pm.addPass(
         ::mlir::stablehlo::createStablehloAggressiveSimplificationPass());
   }
+  // Run the complex passes before composite legalization so composites and
+  // their decompositions are converted consistently in the StableHLO domain.
   // Expand complex math ops (e.g. mul, sqrt, log) into real arithmetic before
   // converting complex types to float-pair representation.
   pm.addPass(::mlir::stablehlo::createStablehloComplexMathExpanderPass());
   // Convert complex types to float-pair representation before lowering.
   pm.addPass(
       mlir::tt::stablehlo::createStableHLOComplexDataTypeConversionPass());
+  pm.addPass(createLegalizeStableHLOCompositeToTTIRPass());
+  if (options.legalizeCompositeToCallEnabled) {
+    pm.addPass(::mlir::stablehlo::createStablehloLegalizeCompositeToCallPass());
+  }
+  pm.addPass(mlir::createInlinerPass());
 
   ttir::ConvertStableHLOToTTIROptions passOptions;
   passOptions.enablePartialConversion = options.enableCPUFallback;

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_gather.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_gather.mlir
@@ -113,4 +113,33 @@ module @gather_composite_tests attributes {mhlo.num_partitions = 1 : i32, mhlo.n
     %0 = stablehlo.constant dense<0.000000e+00> : tensor<2x3xf32>
     return %0 : tensor<2x3xf32>
   }
+
+  // Test: Complex gather — complex types are unpacked before this pass, which
+  // also reshapes + broadcasts the index up to the gather result rank (in the
+  // StableHLO domain), so this pass emits a rank-valid ttir.gather directly.
+  // CHECK-LABEL: func.func @gather_complex_dim1
+  func.func @gather_complex_dim1(%arg0: tensor<1x512x16xcomplex<f32>>, %arg1: tensor<1x4352x16xi64>) -> tensor<1x4352x16xcomplex<f32>> {
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<1x4352x16xi64>) -> tensor<1x4352x16x1xi64>
+    // CHECK: "ttir.broadcast"
+    // CHECK-SAME: broadcast_dimensions = array<i64: 1, 1, 1, 2>
+    // CHECK-SAME: (tensor<1x4352x16x1xi64>) -> tensor<1x4352x16x2xi64>
+    // CHECK: "ttir.typecast"
+    // CHECK-SAME: (tensor<1x4352x16x2xi64>) -> tensor<1x4352x16x2xui32>
+    // CHECK: "ttir.gather"
+    // CHECK-SAME: dim = 1 : i32
+    // CHECK-SAME: (tensor<1x512x16x2xf32>, tensor<1x4352x16x2xui32>) -> tensor<1x4352x16x2xf32>
+    %0 = stablehlo.composite "tenstorrent.gather" %arg0, %arg1 {composite_attributes = {dim = 1 : i64, sparse_grad = false}, decomposition = @tenstorrent.gather.impl_complex} : (tensor<1x512x16xcomplex<f32>>, tensor<1x4352x16xi64>) -> tensor<1x4352x16xcomplex<f32>>
+    return %0 : tensor<1x4352x16xcomplex<f32>>
+  }
+  func.func private @tenstorrent.gather.impl_complex(%arg0: tensor<1x512x16xcomplex<f32>>, %arg1: tensor<1x4352x16xi64>) -> tensor<1x4352x16xcomplex<f32>> {
+    %c = stablehlo.constant dense<0> : tensor<1x4352x16x1xui32>
+    %0 = stablehlo.convert %arg1 : (tensor<1x4352x16xi64>) -> tensor<1x4352x16xui32>
+    %1 = stablehlo.reshape %0 : (tensor<1x4352x16xui32>) -> tensor<1x4352x16x1xui32>
+    %2 = stablehlo.iota dim = 0 : tensor<16xui32>
+    %3 = stablehlo.broadcast_in_dim %2, dims = [2] : (tensor<16xui32>) -> tensor<1x4352x16x1xui32>
+    %4 = stablehlo.concatenate %c, %1, %3, dim = 3 : (tensor<1x4352x16x1xui32>, tensor<1x4352x16x1xui32>, tensor<1x4352x16x1xui32>) -> tensor<1x4352x16x3xui32>
+    %5 = "stablehlo.gather"(%arg0, %4) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2], start_index_map = [0, 1, 2], index_vector_dim = 3>, slice_sizes = array<i64: 1, 1, 1>}> : (tensor<1x512x16xcomplex<f32>>, tensor<1x4352x16x3xui32>) -> tensor<1x4352x16xcomplex<f32>>
+    return %5 : tensor<1x4352x16xcomplex<f32>>
+  }
 }

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_composite_gather.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_composite_gather.mlir
@@ -1,0 +1,55 @@
+// RUN: ttmlir-opt --stablehlo-complex-data-type-conversion -o %t %s
+// RUN: FileCheck %s --input-file=%t
+// REQUIRES: stablehlo
+
+// A complex gather composite is converted in the StableHLO domain: the
+// composite and its decomposition are retyped to the float-pair form, and the
+// integer index is reshaped + broadcast up to the gather result rank so the
+// downstream composite-to-ttir.gather lowering produces a rank-valid op.
+
+module @complex_composite_gather attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+
+  // The composite stays a composite, retyped to the float-pair form. Its index
+  // is reshaped + broadcast to the result shape while still in StableHLO.
+  // CHECK-LABEL: func.func @main
+  // CHECK-SAME: %arg0: tensor<1x512x16x2xf32>
+  // CHECK-SAME: %arg1: tensor<1x4352x16xi64>
+  // CHECK-SAME: -> tensor<1x4352x16x2xf32>
+  func.func @main(%arg0: tensor<1x512x16xcomplex<f32>>, %arg1: tensor<1x4352x16xi64>) -> tensor<1x4352x16xcomplex<f32>> {
+    // CHECK: stablehlo.reshape
+    // CHECK-SAME: (tensor<1x4352x16xi64>) -> tensor<1x4352x16x1xi64>
+    // CHECK: stablehlo.broadcast_in_dim
+    // CHECK-SAME: (tensor<1x4352x16x1xi64>) -> tensor<1x4352x16x2xi64>
+    // CHECK: stablehlo.composite "tenstorrent.gather"
+    // CHECK-SAME: decomposition = @tenstorrent.gather.impl
+    // CHECK-SAME: (tensor<1x512x16x2xf32>, tensor<1x4352x16x2xi64>) -> tensor<1x4352x16x2xf32>
+    // CHECK-NOT: ttir.
+    %0 = stablehlo.composite "tenstorrent.gather" %arg0, %arg1 {composite_attributes = {dim = 1 : i64, sparse_grad = false}, decomposition = @tenstorrent.gather.impl} : (tensor<1x512x16xcomplex<f32>>, tensor<1x4352x16xi64>) -> tensor<1x4352x16xcomplex<f32>>
+    return %0 : tensor<1x4352x16xcomplex<f32>>
+  }
+
+  // The decomposition is converted too; its index argument is widened to match
+  // the composite and sliced back to its original rank, and its inner gather
+  // gains the trailing real/imag dim.
+  // CHECK-LABEL: func.func private @tenstorrent.gather.impl
+  // CHECK-SAME: %arg0: tensor<1x512x16x2xf32>
+  // CHECK-SAME: %arg1: tensor<1x4352x16x2xi64>
+  // CHECK-SAME: -> tensor<1x4352x16x2xf32>
+  func.func private @tenstorrent.gather.impl(%arg0: tensor<1x512x16xcomplex<f32>>, %arg1: tensor<1x4352x16xi64>) -> tensor<1x4352x16xcomplex<f32>> {
+    // CHECK: stablehlo.slice
+    // CHECK-SAME: (tensor<1x4352x16x2xi64>) -> tensor<1x4352x16x1xi64>
+    // CHECK: stablehlo.reshape
+    // CHECK-SAME: (tensor<1x4352x16x1xi64>) -> tensor<1x4352x16xi64>
+    %c = stablehlo.constant dense<0> : tensor<1x4352x16x1xui32>
+    %0 = stablehlo.convert %arg1 : (tensor<1x4352x16xi64>) -> tensor<1x4352x16xui32>
+    %1 = stablehlo.reshape %0 : (tensor<1x4352x16xui32>) -> tensor<1x4352x16x1xui32>
+    %2 = stablehlo.iota dim = 0 : tensor<16xui32>
+    %3 = stablehlo.broadcast_in_dim %2, dims = [2] : (tensor<16xui32>) -> tensor<1x4352x16x1xui32>
+    %4 = stablehlo.concatenate %c, %1, %3, dim = 3 : (tensor<1x4352x16x1xui32>, tensor<1x4352x16x1xui32>, tensor<1x4352x16x1xui32>) -> tensor<1x4352x16x3xui32>
+    // CHECK: stablehlo.gather
+    // CHECK-SAME: slice_sizes = array<i64: 1, 1, 1, 2>
+    // CHECK-SAME: -> tensor<1x4352x16x2xf32>
+    %5 = "stablehlo.gather"(%arg0, %4) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2], start_index_map = [0, 1, 2], index_vector_dim = 3>, slice_sizes = array<i64: 1, 1, 1>}> : (tensor<1x512x16xcomplex<f32>>, tensor<1x4352x16x3xui32>) -> tensor<1x4352x16xcomplex<f32>>
+    return %5 : tensor<1x4352x16xcomplex<f32>>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_rope_multiply.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_rope_multiply.mlir
@@ -1,0 +1,32 @@
+// RUN: ttmlir-opt --stablehlo-complex-data-type-conversion -o %t %s
+// RUN: FileCheck %s --input-file=%t
+// REQUIRES: stablehlo
+
+// The Lumina RoPE rotary embedding builds a complex value (view_as_complex),
+// upcasts it, multiplies by the complex freqs_cis, then extracts real/imag.
+// The complex-math-expander leaves complex.multiply/convert intact, so this
+// pass must decompose them onto the float-pair (...x2) representation:
+//   (xr + i*xi) * (yr + i*yi) = (xr*yr - xi*yi) + i*(xr*yi + xi*yr)
+// No complex type may survive after conversion.
+
+module @complex_rope_multiply {
+  // Complex args/result become the trailing real/imag-pair form.
+  // CHECK-LABEL: func.func @main
+  // CHECK-SAME: %arg0: tensor<1x256x48x2xf64>
+  // CHECK-SAME: %arg1: tensor<1x256x12x48xf32>
+  // CHECK-SAME: -> tensor<1x256x12x48x2xf64>
+  func.func @main(%freqs: tensor<1x256x48xcomplex<f64>>, %re: tensor<1x256x12x48xf32>, %im: tensor<1x256x12x48xf32>) -> tensor<1x256x12x48xcomplex<f64>> {
+    // No complex type anywhere in the converted body.
+    // CHECK-NOT: complex<
+    %c = stablehlo.complex %re, %im : tensor<1x256x12x48xcomplex<f32>>
+    %c64 = stablehlo.convert %c : (tensor<1x256x12x48xcomplex<f32>>) -> tensor<1x256x12x48xcomplex<f64>>
+    %f = stablehlo.broadcast_in_dim %freqs, dims = [0, 1, 3] : (tensor<1x256x48xcomplex<f64>>) -> tensor<1x256x12x48xcomplex<f64>>
+    // The complex multiply lowers to real FOIL arithmetic.
+    // CHECK: stablehlo.multiply
+    // CHECK: stablehlo.subtract
+    // CHECK: stablehlo.multiply
+    // CHECK: stablehlo.add
+    %prod = stablehlo.multiply %c64, %f : tensor<1x256x12x48xcomplex<f64>>
+    return %prod : tensor<1x256x12x48xcomplex<f64>>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_rope_multiply.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_rope_multiply.mlir
@@ -1,12 +1,14 @@
-// RUN: ttmlir-opt --stablehlo-complex-data-type-conversion -o %t %s
+// RUN: ttmlir-opt --stablehlo-complex-math-expander --stablehlo-complex-data-type-conversion -o %t %s
 // RUN: FileCheck %s --input-file=%t
 // REQUIRES: stablehlo
 
 // The Lumina RoPE rotary embedding builds a complex value (view_as_complex),
 // upcasts it, multiplies by the complex freqs_cis, then extracts real/imag.
-// The complex-math-expander leaves complex.multiply/convert intact, so this
-// pass must decompose them onto the float-pair (...x2) representation:
+// The complex-math-expander decomposes complex.multiply into real FOIL
+// arithmetic:
 //   (xr + i*xi) * (yr + i*yi) = (xr*yr - xi*yi) + i*(xr*yi + xi*yr)
+// and the complex-data-type-conversion pass then lowers the resulting
+// complex/real/imag ops onto the float-pair (...x2) representation.
 // No complex type may survive after conversion.
 
 module @complex_rope_multiply {


### PR DESCRIPTION
### Ticket
[#4901](https://github.com/tenstorrent/tt-xla/issues/4901)

### Problem description

- Complex-typed StableHLO graphs (e.g. Lumina2's RoPE) failed to legalize to TTIR. Tenstorrent hardware has no complex type, so complex tensors must be unpacked to a real float-pair layout (trailing dim of 2, `complex<f32> → f32×2`). Two issues blocked this:

- Ordering / gather composite. stablehlo-complex-data-type-conversion ran after legalize-stablehlo-composite-to-ttir, so by the time unpacking happened the gather was already a ttir.gather. The existing pattern only matched stablehlo::GatherOp, leaving ttir.gather producing complex<f32> while downstream consumers saw the unpacked f32×2 — failing with failed to legalize unresolved materialization from ('tensor<...xcomplex<f32>>') to ('tensor<...x2xf32>').

- Complex elementwise arithmetic. The RoPE rotary embedding does a complex multiply (x * freqs_cis). stablehlo-complex-math-expander leaves complex multiply/convert intact, and the conversion pass had no pattern for them, so they stayed complex while their operands were unpacked — same unresolved-materialization failure (complex<f64> → f32×2).



### What's changed

- lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp — Reordered createStableHLOToTTIRPipeline so stablehlo-complex-math-expander and stablehlo-complex-data-type-conversion run before legalize-stablehlo-composite-to-ttir. Complex types are unpacked to f32×2 while the gather is still a stablehlo.composite, so composite-to-TTIR lowering only ever sees real types. Original per-pass comments preserved.

- lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
    1. ComplexCompositeConversionPattern — converts a complex tenstorrent.gather composite to f32×2. Because unpacking adds a trailing dim of 2 to the gather input/result but not to the integer index (and ttir.gather requires input.rank == index.rank with index.shape == result.shape), it also reshapes + broadcasts the index up to the result rank and widens the decomposition's index argument to match — all in one pattern, in the StableHLO domain. Any other complex composite is reported unsupported.

     2. StablehloComplexMulToDecomposedPattern — lowers a complex multiply to real arithmetic on the pair layout ((xr·yr − xi·yi) + i(xr·yi + xi·yr)), reusing the same transpose/slice/concat helpers as the existing complex/real/imag patterns.
     3. convert/add/subtract/negate on complex handled via the existing ComplexTypeDefaultConversionPattern (correct element-wise on the pair layout); multiply/convert/add/subtract/negate added to the illegal-when-complex set so they get converted.

- test/ttmlir/Conversion/StableHLOToTTIR/composite/test_gather.mlir — Added a complex gather case exercising the full --stablehlo-to-ttir-pipeline: the composite lowers to a rank-valid ttir.gather on f32×2 with the index reshaped + broadcast.

- test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_composite_gather.mlir (new) — Runs --stablehlo-complex-data-type-conversion alone: the composite and its decomposition are retyped to f32×2 and no TTIR op is produced.

- test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_rope_multiply.mlir (new) — Runs the conversion pass on the RoPE complex-multiply chain (complex → convert → multiply → real/imag): verifies it decomposes to real arithmetic on f32×2 with no complex type remaining.

With the gather change, Lumina2RotaryPosEmbed sanity passes e2e; with the complex-multiply change, the full Lumina2 transformer gets past legalization error.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs
[lumina_sanity_before_fix.log](https://github.com/user-attachments/files/28304805/lumina_sanity_before_fix.log)
[lumina_sanity_after_fix.log](https://github.com/user-attachments/files/28304809/lumina_sanity_after_fix.log)