### PR TITLE
Skip flaky test

### DIFF
--- a/test/python/golden/d2m/test_bfp8_typecast.py
+++ b/test/python/golden/d2m/test_bfp8_typecast.py
@@ -139,6 +139,7 @@ def test_cos_bf16(shape: Shape, target: str, request, device):
     )
 
 
+@pytest.mark.skip(reason="Flaky: times out on device causing entire CI workflow to be cancelled. See https://github.com/tenstorrent/tt-mlir/issues/7656")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/test/python/golden/d2m/test_bfp8_typecast.py
+++ b/test/python/golden/d2m/test_bfp8_typecast.py
@@ -139,7 +139,9 @@ def test_cos_bf16(shape: Shape, target: str, request, device):
     )
 
 
-@pytest.mark.skip(reason="Flaky: times out on device causing entire CI workflow to be cancelled. See https://github.com/tenstorrent/tt-mlir/issues/7656")
+@pytest.mark.skip(
+    reason="Flaky: times out on device causing entire CI workflow to be cancelled. See https://github.com/tenstorrent/tt-mlir/issues/7656"
+)
 @pytest.mark.parametrize(
     "shape",
     [


### PR DESCRIPTION
### Ticket
N/A

### Problem description

Skip flaky test_matmul_f32 in test_bfp8_typecast.py
Marking the test with @pytest.mark.skip until the underlying issue is resolved.                                                                        
                                                                                                                                                                          
  Example failure from CI 
  https://github.com/tenstorrent/tt-mlir/actions/runs/26468899805/job/77941585048
  
  ```
  test/python/golden/d2m/test_binary.py::test_1d[ttmetal-f32-128] PASSED   [ 66%]
test/python/golden/d2m/test_bfp8_typecast.py::test_triple_exp_f32[ttmetal-shape0] PASSED [ 66%]
test/python/golden/d2m/test_bfp8_typecast.py::test_matmul_f32[ttmetal-True-512x512x512] PASSED [ 66%]
test/python/golden/d2m/test_bfp8_typecast.py::test_matmul_f32[ttmetal-True-512x1024x2048] 2026-05-26 20:06:18.290 | critical |          Always | TT_THROW: Device 0: Timeout (300000 ms) waiting for physical cores to finish: 14-3, 14-2. (assert.hpp:104)
FAILED [ 67%]
test/python/golden/d2m/test_bfp8_typecast.py::test_matmul_f32[ttmetal-True-512x1024x1024] 2026-05-26 20:16:20.010 | critical |          Always | TT_THROW: Device 0: Timeout (300000 ms) waiting for physical cores to finish: 14-3, 14-2. (assert.hpp:104)
FAILED [ 67%]
test/python/golden/d2m/test_bfp8_typecast.py::test_matmul_f32[ttmetal-False-512x512x512] 2026-05-26 20:26:22.247 | critical |          Always | TT_THROW: Device 0: Timeout (300000 ms) waiting for physical cores to finish: 14-3, 14-2. (assert.hpp:104)
FAILED [ 67%]
test/python/golden/d2m/test_bfp8_typecast.py::test_matmul_f32[ttmetal-False-1024x1024x1024] 2026-05-26 20:36:24.099 | critical |          Always | TT_THROW: Device 0: Timeout (300000 ms) waiting for physical cores to finish: 14-3, 14-2. (assert.hpp:104)
FAILED [ 67%]
```
https://github.com/tenstorrent/tt-mlir/actions/runs/26488629959
https://github.com/tenstorrent/tt-mlir/actions/runs/26481709936
https://github.com/tenstorrent/tt-mlir/actions/runs/26469404496