### PR TITLE
[d2m] add float reductions to d2m jit

### DIFF
--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -10,6 +10,7 @@
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
 
 #include <utility>
 #include <variant>
@@ -28,6 +29,11 @@ constexpr llvm::StringLiteral kVirtualGridInverseMappingAttr =
     "d2m.virtualGridInverseMapping";
 constexpr llvm::StringLiteral kVirtualGridForwardMappingAttr =
     "d2m.virtualGridForwardMapping";
+constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
+
+inline bool isReductionScalerBuffer(Operation *op) {
+  return op && op->hasAttr(kReductionScalerAttr);
+}
 
 // Return a new shaped type by reblocking its device shape to match a new grid
 // shape.

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -39,8 +39,6 @@
 
 namespace mlir::tt::d2m {
 
-constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
-
 // Extract grid/shard extents from a shaped type without requiring an SSA value.
 static std::pair<SmallVector<int64_t>, SmallVector<int64_t>>
 getGridAndShardFromShapedType(ShapedType shapedType) {
@@ -221,8 +219,9 @@ mlir::LogicalResult d2m::EmptyOp::bufferize(
   if (auto fwd = getVirtualGridForwardMappingAttr()) {
     allocOp->setAttr(d2m::utils::kVirtualGridForwardMappingAttr, fwd);
   }
-  if (auto reductionScaler = getOperation()->getAttr(kReductionScalerAttr)) {
-    allocOp->setAttr(kReductionScalerAttr, reductionScaler);
+  if (auto reductionScaler =
+          getOperation()->getAttr(utils::kReductionScalerAttr)) {
+    allocOp->setAttr(utils::kReductionScalerAttr, reductionScaler);
   }
 
   mlir::bufferization::replaceOpWithBufferizedValues(rewriter, *this,

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -39,6 +39,8 @@
 
 namespace mlir::tt::d2m {
 
+constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
+
 // Extract grid/shard extents from a shaped type without requiring an SSA value.
 static std::pair<SmallVector<int64_t>, SmallVector<int64_t>>
 getGridAndShardFromShapedType(ShapedType shapedType) {
@@ -218,6 +220,9 @@ mlir::LogicalResult d2m::EmptyOp::bufferize(
   }
   if (auto fwd = getVirtualGridForwardMappingAttr()) {
     allocOp->setAttr(d2m::utils::kVirtualGridForwardMappingAttr, fwd);
+  }
+  if (auto reductionScaler = getOperation()->getAttr(kReductionScalerAttr)) {
+    allocOp->setAttr(kReductionScalerAttr, reductionScaler);
   }
 
   mlir::bufferization::replaceOpWithBufferizedValues(rewriter, *this,

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -26,6 +26,8 @@ namespace mlir::tt::d2m {
 
 namespace {
 
+constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
+
 /// Information about one scratch_space_loop "region of compute".
 /// Records enough structural information to:
 ///   1. decide whether one loop nest produces a value used by another,
@@ -188,6 +190,10 @@ collectScratchSpaceLoops(GenericOp genericOp) {
 /// Inputs/outputs of the generic already have externally visible storage and
 /// should never be replaced by scratch slots.
 static bool isIntermediateAlloc(memref::AllocOp allocOp, GenericOp genericOp) {
+  if (allocOp->hasAttr(kReductionScalerAttr)) {
+    return false;
+  }
+
   // Check if alloc is inside the generic op's region
   if (!genericOp->isProperAncestor(allocOp)) {
     return false;

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Utils.h"
 
@@ -25,8 +26,6 @@ namespace mlir::tt::d2m {
 #include <algorithm>
 
 namespace {
-
-constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
 
 /// Information about one scratch_space_loop "region of compute".
 /// Records enough structural information to:
@@ -190,7 +189,7 @@ collectScratchSpaceLoops(GenericOp genericOp) {
 /// Inputs/outputs of the generic already have externally visible storage and
 /// should never be replaced by scratch slots.
 static bool isIntermediateAlloc(memref::AllocOp allocOp, GenericOp genericOp) {
-  if (allocOp->hasAttr(kReductionScalerAttr)) {
+  if (utils::isReductionScalerBuffer(allocOp.getOperation())) {
     return false;
   }
 

--- a/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -18,8 +19,6 @@ namespace mlir::tt::d2m {
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 namespace {
-
-constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
 
 static bool containsAccumulatingCompute(Operation *op) {
   if (isa<d2m::TileMatmulOp, d2m::TileMatmulBlockOp, d2m::TileReduceSumOp,
@@ -66,7 +65,8 @@ public:
       for (auto &[cb, usageInfo] : cbUsageInfo) {
         if (auto allocOp =
                 mlir::dyn_cast<memref::AllocOp>(cb.getDefiningOp())) {
-          bool forceHoistedCB = allocOp->hasAttr(kReductionScalerAttr);
+          bool forceHoistedCB =
+              utils::isReductionScalerBuffer(allocOp.getOperation());
           int32_t bufferCount = numStreamBuffers;
           if (forceHoistedCB) {
             bufferCount = 1;

--- a/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
@@ -19,6 +19,8 @@ namespace mlir::tt::d2m {
 
 namespace {
 
+constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
+
 static bool containsAccumulatingCompute(Operation *op) {
   if (isa<d2m::TileMatmulOp, d2m::TileMatmulBlockOp, d2m::TileReduceSumOp,
           d2m::TileReduceMaxOp, d2m::TileReduceMeanOp, d2m::TileSFPUReduceSumOp,
@@ -64,17 +66,22 @@ public:
       for (auto &[cb, usageInfo] : cbUsageInfo) {
         if (auto allocOp =
                 mlir::dyn_cast<memref::AllocOp>(cb.getDefiningOp())) {
+          bool forceHoistedCB = allocOp->hasAttr(kReductionScalerAttr);
           int32_t bufferCount = numStreamBuffers;
-          for (Operation *producer : usageInfo.producers) {
-            if (cachedContainsAccumulatingCompute(producer)) {
-              bufferCount = 1;
-              break;
+          if (forceHoistedCB) {
+            bufferCount = 1;
+          } else {
+            for (Operation *producer : usageInfo.producers) {
+              if (cachedContainsAccumulatingCompute(producer)) {
+                bufferCount = 1;
+                break;
+              }
             }
           }
           allocOp->setAttr("d2m.synchronized_buffer",
                            rewriter.getI32IntegerAttr(bufferCount));
 
-          if (usageInfo.consumers.size() == 1 &&
+          if (!forceHoistedCB && usageInfo.consumers.size() == 1 &&
               usageInfo.producers.size() == 1) {
             auto *consumer = usageInfo.consumers.front();
             auto *producer = usageInfo.producers.front();

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Dialect/D2M/Utils/CBUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/DMAUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -23,8 +24,6 @@ namespace mlir::tt::d2m {
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 namespace {
-
-constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -53,7 +52,7 @@ Value traceComputeMemrefToCB(Value value, GenericOp genericOp) {
         if (definingOp && definingOp->getAttr("d2m.scratch_buffer")) {
           return nullptr;
         }
-        if (definingOp && definingOp->hasAttr(kReductionScalerAttr)) {
+        if (utils::isReductionScalerBuffer(definingOp)) {
           return nullptr;
         }
         return value;

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -24,6 +24,8 @@ namespace mlir::tt::d2m {
 
 namespace {
 
+constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -49,6 +51,9 @@ Value traceComputeMemrefToCB(Value value, GenericOp genericOp) {
         // Skip scratch buffers.
         Operation *definingOp = value.getDefiningOp();
         if (definingOp && definingOp->getAttr("d2m.scratch_buffer")) {
+          return nullptr;
+        }
+        if (definingOp && definingOp->hasAttr(kReductionScalerAttr)) {
           return nullptr;
         }
         return value;

--- a/test/d2m-jit/lit/reductions.py
+++ b/test/d2m-jit/lit/reductions.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR-shape coverage for d2m-jit float reductions.
+
+This stays below `to_host()` so lit can validate the builder contract without
+requiring device execution.
+"""
+
+import torch
+import d2m_jit as d2m
+
+from d2m_jit._src.builder import _Builder
+
+_L = d2m.Layout(
+    shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
+)
+_L_WIDE_BLOCK = d2m.Layout(
+    shape=(32, 64), dtype=d2m.float32, block_shape=[1, 2], grid_shape=[1, 1]
+)
+_L_REDUCE_ROWS_256 = d2m.Layout(
+    shape=(256, 256), dtype=d2m.float32, block_shape=[8, 1], grid_shape=[1, 8]
+)
+_L_REDUCE_COLS_256 = d2m.Layout(
+    shape=(256, 256), dtype=d2m.float32, block_shape=[1, 8], grid_shape=[8, 1]
+)
+
+
+def test_basic_reduction_ir_shape():
+    @d2m.kernel
+    def k(in_t, out_t):
+        x = remote_load(in_t, [0, 0])
+        s = reduce_sum(x, 1)
+        m = x.reduce_max(0)
+        a = reduce_mean(x, -1)
+        y = s.add(m).add(a)
+        remote_store(out_t, [0, 0], y)
+
+    t = torch.arange(32 * 32, dtype=torch.float32).reshape(32, 32)
+    k(d2m.to_layout(t, _L), d2m.empty(_L), grid=(1, 1))
+    print("BASIC_REDUCTION_IR")
+    print(_Builder.get().module)
+    _Builder.reset()
+
+
+def test_collapsed_reduction_ir_shape():
+    @d2m.kernel
+    def k(in_t, out_t):
+        x = remote_load(in_t, [0, 0])
+        remote_store(out_t, [0, 0], reduce_sum_collapse(x, 1))
+
+    t = torch.arange(32 * 32, dtype=torch.float32).reshape(32, 32)
+    k(d2m.to_layout(t, _L), d2m.empty(d2m.reduction_layout(_L, 1)), grid=(1, 1))
+    print("COLLAPSED_REDUCTION_IR")
+    print(_Builder.get().module)
+    _Builder.reset()
+
+
+def test_multi_tile_single_core_collapsed_reduction_ir_shape():
+    @d2m.kernel
+    def k(in_t, out_t):
+        x = remote_load(in_t, [0, 0])
+        remote_store(out_t, [0, 0], x.reduce_mean_collapse(1))
+
+    t = torch.arange(32 * 64, dtype=torch.float32).reshape(32, 64)
+    k(
+        d2m.to_layout(t, _L_WIDE_BLOCK),
+        d2m.empty(d2m.reduction_layout(_L_WIDE_BLOCK, 1)),
+        grid=(1, 1),
+    )
+    print("MULTI_TILE_SINGLE_CORE_COLLAPSED_REDUCTION_IR")
+    print(_Builder.get().module)
+    _Builder.reset()
+
+
+def test_multi_core_dim0_collapsed_reduction_ir_shape():
+    @d2m.kernel
+    def k(in_t, out_t):
+        n = core_index(1)
+        x = remote_load(in_t, [0, n])
+        remote_store(out_t, [0, n], reduce_sum_collapse(x, 0))
+
+    t = torch.arange(256 * 256, dtype=torch.float32).reshape(256, 256)
+    k(
+        d2m.to_layout(t, _L_REDUCE_ROWS_256),
+        d2m.empty(d2m.reduction_layout(_L_REDUCE_ROWS_256, 0)),
+        grid=(1, 8),
+    )
+    print("MULTI_CORE_DIM0_COLLAPSED_REDUCTION_IR")
+    print(_Builder.get().module)
+    _Builder.reset()
+
+
+def test_multi_core_dim1_collapsed_reduction_ir_shape():
+    @d2m.kernel
+    def k(in_t, out_t):
+        m = core_index(0)
+        x = remote_load(in_t, [m, 0])
+        remote_store(out_t, [m, 0], reduce_sum_collapse(x, 1))
+
+    t = torch.arange(256 * 256, dtype=torch.float32).reshape(256, 256)
+    k(
+        d2m.to_layout(t, _L_REDUCE_COLS_256),
+        d2m.empty(d2m.reduction_layout(_L_REDUCE_COLS_256, 1)),
+        grid=(8, 1),
+    )
+    print("MULTI_CORE_DIM1_COLLAPSED_REDUCTION_IR")
+    print(_Builder.get().module)
+    _Builder.reset()
+
+
+test_basic_reduction_ir_shape()
+test_collapsed_reduction_ir_shape()
+test_multi_tile_single_core_collapsed_reduction_ir_shape()
+test_multi_core_dim0_collapsed_reduction_ir_shape()
+test_multi_core_dim1_collapsed_reduction_ir_shape()
+print("PASS reductions")
+
+
+# CHECK-LABEL: BASIC_REDUCTION_IR
+# CHECK: "func.func"
+# CHECK: d2m.to_layout
+# CHECK: "d2m.generic"
+# CHECK: d2m.remote_load
+# CHECK: d2m.tile_reduce_sum
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
+# CHECK: d2m.tile_reduce_max
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim C>
+# CHECK: d2m.tile_reduce_mean
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
+
+# CHECK-LABEL: COLLAPSED_REDUCTION_IR
+# CHECK: logical_shape = 32x1
+# CHECK: d2m.tile_reduce_sum
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
+
+# CHECK-LABEL: MULTI_TILE_SINGLE_CORE_COLLAPSED_REDUCTION_IR
+# CHECK: logical_shape = 32x64
+# CHECK: logical_shape = 32x1
+# CHECK: affine_map<(d0, d1) -> (d0, 0)>
+# CHECK: affine_map<(d0, d1) -> (d0, 1)>
+# CHECK: tensor<1x2x!ttcore.tile<32x32, f32>>
+# CHECK: tensor<1x1x!ttcore.tile<32x32, f32>>
+# CHECK: d2m.tile_reduce_mean
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
+# CHECK: d2m.tile_reduce_mean
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
+
+# CHECK-LABEL: MULTI_CORE_DIM0_COLLAPSED_REDUCTION_IR
+# CHECK: logical_shape = 256x256
+# CHECK: logical_shape = 1x256
+# CHECK: tensor<8x1x!ttcore.tile<32x32, f32>>
+# CHECK: tensor<1x1x!ttcore.tile<32x32, f32>>
+# CHECK: d2m.tile_reduce_sum
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim C>
+
+# CHECK-LABEL: MULTI_CORE_DIM1_COLLAPSED_REDUCTION_IR
+# CHECK: logical_shape = 256x256
+# CHECK: logical_shape = 256x1
+# CHECK: tensor<1x8x!ttcore.tile<32x32, f32>>
+# CHECK: tensor<1x1x!ttcore.tile<32x32, f32>>
+# CHECK: d2m.tile_reduce_sum
+# CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
+# CHECK: PASS reductions

--- a/test/d2m-jit/lit/reductions.py
+++ b/test/d2m-jit/lit/reductions.py
@@ -47,24 +47,24 @@ def test_basic_reduction_ir_shape():
     _Builder.reset()
 
 
-def test_collapsed_reduction_ir_shape():
+def test_reduced_output_ir_shape():
     @d2m.kernel
     def k(in_t, out_t):
         x = remote_load(in_t, [0, 0])
-        remote_store(out_t, [0, 0], reduce_sum_collapse(x, 1))
+        remote_store(out_t, [0, 0], reduce_sum(x, 1))
 
     t = torch.arange(32 * 32, dtype=torch.float32).reshape(32, 32)
     k(d2m.to_layout(t, _L), d2m.empty(d2m.reduction_layout(_L, 1)), grid=(1, 1))
-    print("COLLAPSED_REDUCTION_IR")
+    print("REDUCED_OUTPUT_IR")
     print(_Builder.get().module)
     _Builder.reset()
 
 
-def test_multi_tile_single_core_collapsed_reduction_ir_shape():
+def test_multi_tile_single_core_reduction_ir_shape():
     @d2m.kernel
     def k(in_t, out_t):
         x = remote_load(in_t, [0, 0])
-        remote_store(out_t, [0, 0], x.reduce_mean_collapse(1))
+        remote_store(out_t, [0, 0], x.reduce_mean(1))
 
     t = torch.arange(32 * 64, dtype=torch.float32).reshape(32, 64)
     k(
@@ -72,17 +72,17 @@ def test_multi_tile_single_core_collapsed_reduction_ir_shape():
         d2m.empty(d2m.reduction_layout(_L_WIDE_BLOCK, 1)),
         grid=(1, 1),
     )
-    print("MULTI_TILE_SINGLE_CORE_COLLAPSED_REDUCTION_IR")
+    print("MULTI_TILE_SINGLE_CORE_REDUCTION_IR")
     print(_Builder.get().module)
     _Builder.reset()
 
 
-def test_multi_core_dim0_collapsed_reduction_ir_shape():
+def test_multi_core_dim0_reduction_ir_shape():
     @d2m.kernel
     def k(in_t, out_t):
         n = core_index(1)
         x = remote_load(in_t, [0, n])
-        remote_store(out_t, [0, n], reduce_sum_collapse(x, 0))
+        remote_store(out_t, [0, n], reduce_sum(x, 0))
 
     t = torch.arange(256 * 256, dtype=torch.float32).reshape(256, 256)
     k(
@@ -90,17 +90,17 @@ def test_multi_core_dim0_collapsed_reduction_ir_shape():
         d2m.empty(d2m.reduction_layout(_L_REDUCE_ROWS_256, 0)),
         grid=(1, 8),
     )
-    print("MULTI_CORE_DIM0_COLLAPSED_REDUCTION_IR")
+    print("MULTI_CORE_DIM0_REDUCTION_IR")
     print(_Builder.get().module)
     _Builder.reset()
 
 
-def test_multi_core_dim1_collapsed_reduction_ir_shape():
+def test_multi_core_dim1_reduction_ir_shape():
     @d2m.kernel
     def k(in_t, out_t):
         m = core_index(0)
         x = remote_load(in_t, [m, 0])
-        remote_store(out_t, [m, 0], reduce_sum_collapse(x, 1))
+        remote_store(out_t, [m, 0], reduce_sum(x, 1))
 
     t = torch.arange(256 * 256, dtype=torch.float32).reshape(256, 256)
     k(
@@ -108,16 +108,16 @@ def test_multi_core_dim1_collapsed_reduction_ir_shape():
         d2m.empty(d2m.reduction_layout(_L_REDUCE_COLS_256, 1)),
         grid=(8, 1),
     )
-    print("MULTI_CORE_DIM1_COLLAPSED_REDUCTION_IR")
+    print("MULTI_CORE_DIM1_REDUCTION_IR")
     print(_Builder.get().module)
     _Builder.reset()
 
 
 test_basic_reduction_ir_shape()
-test_collapsed_reduction_ir_shape()
-test_multi_tile_single_core_collapsed_reduction_ir_shape()
-test_multi_core_dim0_collapsed_reduction_ir_shape()
-test_multi_core_dim1_collapsed_reduction_ir_shape()
+test_reduced_output_ir_shape()
+test_multi_tile_single_core_reduction_ir_shape()
+test_multi_core_dim0_reduction_ir_shape()
+test_multi_core_dim1_reduction_ir_shape()
 print("PASS reductions")
 
 
@@ -132,13 +132,14 @@ print("PASS reductions")
 # CHECK-SAME: reduce_dim = #d2m<reduce_dim C>
 # CHECK: d2m.tile_reduce_mean
 # CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
+# CHECK: d2m.tile_bcast
 
-# CHECK-LABEL: COLLAPSED_REDUCTION_IR
+# CHECK-LABEL: REDUCED_OUTPUT_IR
 # CHECK: logical_shape = 32x1
 # CHECK: d2m.tile_reduce_sum
 # CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
 
-# CHECK-LABEL: MULTI_TILE_SINGLE_CORE_COLLAPSED_REDUCTION_IR
+# CHECK-LABEL: MULTI_TILE_SINGLE_CORE_REDUCTION_IR
 # CHECK: logical_shape = 32x64
 # CHECK: logical_shape = 32x1
 # CHECK: affine_map<(d0, d1) -> (d0, 0)>
@@ -150,7 +151,7 @@ print("PASS reductions")
 # CHECK: d2m.tile_reduce_mean
 # CHECK-SAME: reduce_dim = #d2m<reduce_dim R>
 
-# CHECK-LABEL: MULTI_CORE_DIM0_COLLAPSED_REDUCTION_IR
+# CHECK-LABEL: MULTI_CORE_DIM0_REDUCTION_IR
 # CHECK: logical_shape = 256x256
 # CHECK: logical_shape = 1x256
 # CHECK: tensor<8x1x!ttcore.tile<32x32, f32>>
@@ -158,7 +159,7 @@ print("PASS reductions")
 # CHECK: d2m.tile_reduce_sum
 # CHECK-SAME: reduce_dim = #d2m<reduce_dim C>
 
-# CHECK-LABEL: MULTI_CORE_DIM1_COLLAPSED_REDUCTION_IR
+# CHECK-LABEL: MULTI_CORE_DIM1_REDUCTION_IR
 # CHECK: logical_shape = 256x256
 # CHECK: logical_shape = 256x1
 # CHECK: tensor<1x8x!ttcore.tile<32x32, f32>>

--- a/test/d2m-jit/test_reductions.py
+++ b/test/d2m-jit/test_reductions.py
@@ -10,7 +10,7 @@ expected to produce defined values without an explicit accumulator pre-fill:
 1. `test_reduce_sum_compiles_and_runs` -- baseline shape/dtype smoke test.
 2. Parameterized correctness over several layout shapes, block shapes, and
    execution grids for row and column reduction directions.
-3. Mixed-input dtype coverage for the synthetic reduction scaler selection.
+3. Mixed-input dtype coverage for reduction scaler type selection.
 4. Invalid dim rejection for the Python DSL surface.
 """
 
@@ -136,30 +136,6 @@ def k_reduce_max_rows_accumulate_tile(in_t, acc_t, out_t, m_tile, n_blocks):
         remote_store(out_t, [0, n_off + n], acc.maximum(x.reduce_max_collapse(0)))
 
 
-@d2m.kernel
-def k_reduce_sum_cols_cross_tile(in_t, out_t, m_blocks, n_tiles):
-    m_off = core_index(0) * m_blocks
-    for m in range(m_blocks):
-        first = remote_load(in_t, [m_off + m, 0])
-        acc = reduce_sum_collapse(first, 1)
-        for n in range(1, n_tiles):
-            x = remote_load(in_t, [m_off + m, n])
-            acc = acc + reduce_sum_collapse(x, 1)
-        remote_store(out_t, [m_off + m, 0], acc)
-
-
-@d2m.kernel
-def k_reduce_max_rows_cross_tile(in_t, out_t, m_tiles, n_blocks):
-    n_off = core_index(1) * n_blocks
-    for n in range(n_blocks):
-        first = remote_load(in_t, [0, n_off + n])
-        acc = first.reduce_max_collapse(0)
-        for m in range(1, m_tiles):
-            x = remote_load(in_t, [m, n_off + n])
-            acc = acc.maximum(x.reduce_max_collapse(0))
-        remote_store(out_t, [0, n_off + n], acc)
-
-
 _LAYOUT_CASES = [
     pytest.param((32, 32), (1, 1), (1, 1), id="single-tile-grid-1x1"),
     pytest.param((64, 64), (1, 1), (2, 2), id="one-tile-per-core-grid-2x2"),
@@ -206,12 +182,6 @@ def _run_collapsed(kernel, tensor, input_layout, output_layout, grid):
     out = d2m.empty(output_layout)
     m_blocks, n_blocks = _blocks_per_core(input_layout, grid)
     kernel(d2m.to_layout(tensor, input_layout), out, m_blocks, n_blocks, grid=grid)
-    return out.to_host()
-
-
-def _run_cross_tile(kernel, tensor, input_layout, output_layout, grid, *scalars):
-    out = d2m.empty(output_layout)
-    kernel(d2m.to_layout(tensor, input_layout), out, *scalars, grid=grid)
     return out.to_host()
 
 
@@ -454,33 +424,6 @@ def test_reduce_sum_cols_cross_tile_output_layout():
             grid=(2, 1),
         )
         result = out.to_host()
-
-    assert tuple(result.shape) == (64, 1)
-    expected = tensor.sum(dim=1, keepdim=True)
-    diff = (expected - result).abs().max().item()
-    assert diff < 0.1, f"cross-tile reduce_sum(dim=1): max diff {diff}"
-
-
-@pytest.mark.skip(
-    reason=(
-        "A single unified kernel with multiple synchronizable remote_loads in "
-        "different loop scopes trips SplitUnifiedThread's synchronized-scope "
-        "assertion; the multi-pass variant above is the supported path for now."
-    )
-)
-def test_reduce_sum_cols_cross_tile_single_kernel_blocked():
-    input_layout = _make_layout(shape=(64, 64), grid_shape=(2, 2))
-    output_layout = d2m.reduction_layout(input_layout, 1, allow_cross_tile=True)
-    tensor = _tile_sum_input((64, 64))
-    result = _run_cross_tile(
-        k_reduce_sum_cols_cross_tile,
-        tensor,
-        input_layout,
-        output_layout,
-        (2, 1),
-        input_layout.logical_shape[0] // 32 // 2,
-        input_layout.logical_shape[1] // 32,
-    )
 
     assert tuple(result.shape) == (64, 1)
     expected = tensor.sum(dim=1, keepdim=True)

--- a/test/d2m-jit/test_reductions.py
+++ b/test/d2m-jit/test_reductions.py
@@ -10,7 +10,7 @@ expected to produce defined values without an explicit accumulator pre-fill:
 1. `test_reduce_sum_compiles_and_runs` -- baseline shape/dtype smoke test.
 2. Parameterized correctness over several layout shapes, block shapes, and
    execution grids for row and column reduction directions.
-3. Mixed-input dtype coverage for reduction scaler type selection.
+3. bf16 coverage for reduction scaler type selection.
 4. Invalid dim rejection for the Python DSL surface.
 """
 
@@ -26,10 +26,8 @@ def k_reduce_sum_cols(in_t, out_t, m_blocks, n_blocks):
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            # Keep the reduction in a temporary so call-site reduction
-            # detection cannot rely on it being nested under remote_store.
             reduced = reduce_sum(x, 1)
-            remote_store(out_t, [m_off + m, n_off + n], reduced)
+            remote_store(out_t, [m_off + m, 0], reduced)
 
 
 @d2m.kernel
@@ -39,7 +37,7 @@ def k_reduce_max_rows(in_t, out_t, m_blocks, n_blocks):
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, n_off + n], x.reduce_max(0))
+            remote_store(out_t, [0, n_off + n], x.reduce_max(0))
 
 
 @d2m.kernel
@@ -49,7 +47,7 @@ def k_reduce_mean_cols_negative_dim(in_t, out_t, m_blocks, n_blocks):
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, n_off + n], reduce_mean(x, -1))
+            remote_store(out_t, [m_off + m, 0], reduce_mean(x, -1))
 
 
 @d2m.kernel
@@ -59,47 +57,47 @@ def k_reduce_sum_rows_negative_dim(in_t, out_t, m_blocks, n_blocks):
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, n_off + n], x.reduce_sum(-2))
+            remote_store(out_t, [0, n_off + n], x.reduce_sum(-2))
 
 
 @d2m.kernel
-def k_reduce_sum_second_input(first_in_t, reduced_in_t, out_t, m_blocks, n_blocks):
-    m_off = core_index(0) * m_blocks
-    n_off = core_index(1) * n_blocks
-    for m in range(m_blocks):
-        for n in range(n_blocks):
-            x = remote_load(reduced_in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, n_off + n], reduce_sum(x, 1))
-
-
-@d2m.kernel
-def k_reduce_sum_cols_collapsed(in_t, out_t, m_blocks, n_blocks):
+def k_center_cols_with_implicit_bcast(in_t, out_t, m_blocks, n_blocks):
     m_off = core_index(0) * m_blocks
     n_off = core_index(1) * n_blocks
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, 0], reduce_sum_collapse(x, 1))
+            remote_store(out_t, [m_off + m, n_off + n], x - reduce_mean(x, 1))
 
 
 @d2m.kernel
-def k_reduce_max_rows_collapsed(in_t, out_t, m_blocks, n_blocks):
+def k_reduce_sum_cols_out(in_t, out_t, m_blocks, n_blocks):
     m_off = core_index(0) * m_blocks
     n_off = core_index(1) * n_blocks
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [0, n_off + n], x.reduce_max_collapse(0))
+            remote_store(out_t, [m_off + m, 0], reduce_sum(x, 1))
 
 
 @d2m.kernel
-def k_reduce_mean_cols_collapsed(in_t, out_t, m_blocks, n_blocks):
+def k_reduce_max_rows_out(in_t, out_t, m_blocks, n_blocks):
     m_off = core_index(0) * m_blocks
     n_off = core_index(1) * n_blocks
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, 0], x.reduce_mean_collapse(1))
+            remote_store(out_t, [0, n_off + n], x.reduce_max(0))
+
+
+@d2m.kernel
+def k_reduce_mean_cols_out(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, 0], x.reduce_mean(1))
 
 
 @d2m.kernel
@@ -107,7 +105,7 @@ def k_reduce_sum_cols_tile(in_t, out_t, m_blocks, n_tile):
     m_off = core_index(0) * m_blocks
     for m in range(m_blocks):
         x = remote_load(in_t, [m_off + m, n_tile])
-        remote_store(out_t, [m_off + m, 0], reduce_sum_collapse(x, 1))
+        remote_store(out_t, [m_off + m, 0], reduce_sum(x, 1))
 
 
 @d2m.kernel
@@ -116,7 +114,7 @@ def k_reduce_sum_cols_accumulate_tile(in_t, acc_t, out_t, m_blocks, n_tile):
     for m in range(m_blocks):
         x = remote_load(in_t, [m_off + m, n_tile])
         acc = remote_load(acc_t, [m_off + m, 0])
-        remote_store(out_t, [m_off + m, 0], acc + reduce_sum_collapse(x, 1))
+        remote_store(out_t, [m_off + m, 0], acc + reduce_sum(x, 1))
 
 
 @d2m.kernel
@@ -124,7 +122,7 @@ def k_reduce_max_rows_tile(in_t, out_t, m_tile, n_blocks):
     n_off = core_index(1) * n_blocks
     for n in range(n_blocks):
         x = remote_load(in_t, [m_tile, n_off + n])
-        remote_store(out_t, [0, n_off + n], x.reduce_max_collapse(0))
+        remote_store(out_t, [0, n_off + n], x.reduce_max(0))
 
 
 @d2m.kernel
@@ -133,7 +131,7 @@ def k_reduce_max_rows_accumulate_tile(in_t, acc_t, out_t, m_tile, n_blocks):
     for n in range(n_blocks):
         x = remote_load(in_t, [m_tile, n_off + n])
         acc = remote_load(acc_t, [0, n_off + n])
-        remote_store(out_t, [0, n_off + n], acc.maximum(x.reduce_max_collapse(0)))
+        remote_store(out_t, [0, n_off + n], acc.maximum(x.reduce_max(0)))
 
 
 _LAYOUT_CASES = [
@@ -141,6 +139,25 @@ _LAYOUT_CASES = [
     pytest.param((64, 64), (1, 1), (2, 2), id="one-tile-per-core-grid-2x2"),
     pytest.param((64, 64), (2, 1), (1, 1), id="two-row-tiles-per-block"),
     pytest.param((64, 64), (1, 2), (1, 1), id="two-col-tiles-per-block"),
+    pytest.param((96, 64), (1, 1), (3, 2), id="rectangular-grid-3x2"),
+]
+
+_COL_REDUCTION_CASES = [
+    pytest.param((32, 32), (1, 1), (1, 1), id="single-tile-grid-1x1"),
+    pytest.param((64, 32), (1, 1), (2, 1), id="cols-fit-on-core-grid-2x1"),
+    pytest.param((64, 64), (1, 2), (1, 1), id="two-col-tiles-per-block"),
+]
+
+_ROW_REDUCTION_CASES = [
+    pytest.param((32, 32), (1, 1), (1, 1), id="single-tile-grid-1x1"),
+    pytest.param((32, 64), (1, 1), (1, 2), id="rows-fit-on-core-grid-1x2"),
+    pytest.param((64, 64), (2, 1), (1, 1), id="two-row-tiles-per-block"),
+]
+
+_IMPLICIT_BCAST_CASES = [
+    pytest.param((32, 32), (1, 1), (1, 1), id="single-tile-grid-1x1"),
+    pytest.param((64, 64), (1, 1), (2, 2), id="one-tile-per-core-grid-2x2"),
+    pytest.param((64, 64), (2, 1), (1, 1), id="two-row-tiles-per-block"),
     pytest.param((96, 64), (1, 1), (3, 2), id="rectangular-grid-3x2"),
 ]
 
@@ -178,7 +195,16 @@ def _run(kernel, tensor, layout=None, grid=(1, 1)):
     return out.to_host()
 
 
-def _run_collapsed(kernel, tensor, input_layout, output_layout, grid):
+def _run_reduced(kernel, tensor, dim, layout=None, grid=(1, 1)):
+    layout = layout or _make_layout()
+    output_layout = d2m.reduction_layout(layout, dim)
+    out = d2m.empty(output_layout)
+    m_blocks, n_blocks = _blocks_per_core(layout, grid)
+    kernel(d2m.to_layout(tensor, layout), out, m_blocks, n_blocks, grid=grid)
+    return out.to_host()
+
+
+def _run_with_output_layout(kernel, tensor, input_layout, output_layout, grid):
     out = d2m.empty(output_layout)
     m_blocks, n_blocks = _blocks_per_core(input_layout, grid)
     kernel(d2m.to_layout(tensor, input_layout), out, m_blocks, n_blocks, grid=grid)
@@ -202,115 +228,111 @@ def _tile_max_input(shape, dtype=torch.float32):
 
 
 def _assert_reduce_sum_cols(result, tensor, atol=0.05):
-    for col_start in range(0, tensor.shape[1], 32):
-        expected = tensor[:, col_start : col_start + 32].sum(dim=1)
-        actual = result[:, col_start]
-        diff = (
-            (expected.to(torch.float32) - actual.to(torch.float32)).abs().max().item()
-        )
-        assert diff < atol, f"reduce_sum cols at col {col_start}: max diff {diff}"
+    expected = tensor.sum(dim=1, keepdim=True)
+    diff = (expected.to(torch.float32) - result.to(torch.float32)).abs().max().item()
+    assert diff < atol, f"reduce_sum cols: max diff {diff}"
 
 
 def _assert_reduce_mean_cols(result, tensor, atol=0.05):
-    for col_start in range(0, tensor.shape[1], 32):
-        expected = tensor[:, col_start : col_start + 32].mean(dim=1)
-        actual = result[:, col_start]
-        diff = (
-            (expected.to(torch.float32) - actual.to(torch.float32)).abs().max().item()
-        )
-        assert diff < atol, f"reduce_mean cols at col {col_start}: max diff {diff}"
+    expected = tensor.mean(dim=1, keepdim=True)
+    diff = (expected.to(torch.float32) - result.to(torch.float32)).abs().max().item()
+    assert diff < atol, f"reduce_mean cols: max diff {diff}"
 
 
 def _assert_reduce_max_rows(result, tensor, atol=0.05):
-    for row_start in range(0, tensor.shape[0], 32):
-        expected = tensor[row_start : row_start + 32, :].max(dim=0).values
-        actual = result[row_start, :]
-        diff = (
-            (expected.to(torch.float32) - actual.to(torch.float32)).abs().max().item()
-        )
-        assert diff < atol, f"reduce_max rows at row {row_start}: max diff {diff}"
+    expected = tensor.max(dim=0, keepdim=True).values
+    diff = (expected.to(torch.float32) - result.to(torch.float32)).abs().max().item()
+    assert diff < atol, f"reduce_max rows: max diff {diff}"
 
 
 def test_reduce_sum_compiles_and_runs():
     tensor = _tile_sum_input((32, 32))
     layout = _make_layout()
-    result = _run(k_reduce_sum_cols, tensor, layout=layout)
+    result = _run_reduced(k_reduce_sum_cols, tensor, 1, layout=layout)
 
-    assert tuple(result.shape) == (32, 32)
+    assert tuple(result.shape) == (32, 1)
     assert result.dtype == torch.float32
 
 
-@pytest.mark.parametrize("shape,block_shape,grid", _LAYOUT_CASES)
+@pytest.mark.parametrize("shape,block_shape,grid", _COL_REDUCTION_CASES)
 def test_reduce_sum_cols_correctness(shape, block_shape, grid):
     """Free-function form: `reduce_sum(x, 1)` reduces each tile's columns."""
     layout = _make_layout(shape=shape, block_shape=block_shape, grid_shape=grid)
     tensor = _tile_sum_input(shape)
-    result = _run(k_reduce_sum_cols, tensor, layout=layout, grid=grid)
+    result = _run_reduced(k_reduce_sum_cols, tensor, 1, layout=layout, grid=grid)
 
-    _assert_reduce_sum_cols(result, tensor)
+    _assert_reduce_sum_cols(result, tensor, atol=0.1)
 
 
-@pytest.mark.parametrize("shape,block_shape,grid", _LAYOUT_CASES)
+@pytest.mark.parametrize("shape,block_shape,grid", _ROW_REDUCTION_CASES)
 def test_reduce_max_rows_method_form_correctness(shape, block_shape, grid):
     """Method form: `x.reduce_max(0)` reduces each tile's rows."""
     layout = _make_layout(shape=shape, block_shape=block_shape, grid_shape=grid)
     tensor = _tile_max_input(shape)
-    result = _run(k_reduce_max_rows, tensor, layout=layout, grid=grid)
+    result = _run_reduced(k_reduce_max_rows, tensor, 0, layout=layout, grid=grid)
 
     _assert_reduce_max_rows(result, tensor)
 
 
-@pytest.mark.parametrize("shape,block_shape,grid", _LAYOUT_CASES)
+@pytest.mark.parametrize("shape,block_shape,grid", _COL_REDUCTION_CASES)
 def test_reduce_mean_cols_negative_dim_correctness(shape, block_shape, grid):
     """Negative dim form: `reduce_mean(x, -1)` aliases column reduction."""
     layout = _make_layout(shape=shape, block_shape=block_shape, grid_shape=grid)
     tensor = _tile_sum_input(shape)
-    result = _run(k_reduce_mean_cols_negative_dim, tensor, layout=layout, grid=grid)
+    result = _run_reduced(
+        k_reduce_mean_cols_negative_dim, tensor, 1, layout=layout, grid=grid
+    )
 
     _assert_reduce_mean_cols(result, tensor)
 
 
-@pytest.mark.parametrize("shape,block_shape,grid", _LAYOUT_CASES)
+@pytest.mark.parametrize("shape,block_shape,grid", _ROW_REDUCTION_CASES)
 def test_reduce_sum_rows_negative_dim_correctness(shape, block_shape, grid):
     """Method + negative dim form: `x.reduce_sum(-2)` aliases row reduction."""
     layout = _make_layout(shape=shape, block_shape=block_shape, grid_shape=grid)
     tensor = _tile_max_input(shape)
-    result = _run(k_reduce_sum_rows_negative_dim, tensor, layout=layout, grid=grid)
-
-    for row_start in range(0, tensor.shape[0], 32):
-        expected = tensor[row_start : row_start + 32, :].sum(dim=0)
-        actual = result[row_start, :]
-        diff = (expected - actual).abs().max().item()
-        assert diff < 0.1, f"reduce_sum rows at row {row_start}: max diff {diff}"
-
-
-def test_reduce_sum_second_input_mixed_dtype():
-    f32_layout = _make_layout(shape=(32, 32), dtype=d2m.float32)
-    bf16_layout = _make_layout(shape=(32, 32), dtype=d2m.bfloat16)
-    first = torch.zeros(32, 32, dtype=torch.float32)
-    reduced = torch.arange(32, dtype=torch.bfloat16).reshape(32, 1).repeat(1, 32)
-    reduced = reduced / 100.0
-
-    out = d2m.empty(bf16_layout)
-    k_reduce_sum_second_input(
-        d2m.to_layout(first, f32_layout),
-        d2m.to_layout(reduced, bf16_layout),
-        out,
-        1,
-        1,
-        grid=(1, 1),
+    result = _run_reduced(
+        k_reduce_sum_rows_negative_dim, tensor, 0, layout=layout, grid=grid
     )
-    result = out.to_host()
 
-    _assert_reduce_sum_cols(result, reduced, atol=0.15)
+    expected = tensor.sum(dim=0, keepdim=True)
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.1, f"reduce_sum rows: max diff {diff}"
 
 
-def test_reduce_sum_cols_collapsed_output_layout():
+def test_reduce_sum_bf16_dtype():
+    bf16_layout = _make_layout(shape=(32, 32), dtype=d2m.bfloat16)
+    tensor = _tile_sum_input((32, 32), dtype=torch.bfloat16)
+
+    result = _run_reduced(k_reduce_sum_cols, tensor, 1, layout=bf16_layout)
+
+    assert result.dtype == torch.bfloat16
+    _assert_reduce_sum_cols(result, tensor, atol=0.15)
+
+
+@pytest.mark.parametrize("shape,block_shape,grid", _IMPLICIT_BCAST_CASES)
+def test_reduce_mean_cols_implicit_broadcast(shape, block_shape, grid):
+    layout = _make_layout(shape=shape, block_shape=block_shape, grid_shape=grid)
+    tensor = _tile_sum_input(shape)
+    result = _run(k_center_cols_with_implicit_bcast, tensor, layout=layout, grid=grid)
+
+    expected = torch.empty_like(tensor)
+    block_width = block_shape[1] * 32
+    for col_start in range(0, tensor.shape[1], block_width):
+        block = tensor[:, col_start : col_start + block_width]
+        expected[:, col_start : col_start + block_width] = block - block.mean(
+            dim=1, keepdim=True
+        )
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.05, f"implicit reduce broadcast: max diff {diff}"
+
+
+def test_reduce_sum_cols_output_layout():
     input_layout = _make_layout(shape=(64, 32), grid_shape=(2, 1))
     output_layout = d2m.reduction_layout(input_layout, 1)
     tensor = _tile_sum_input((64, 32))
-    result = _run_collapsed(
-        k_reduce_sum_cols_collapsed,
+    result = _run_with_output_layout(
+        k_reduce_sum_cols_out,
         tensor,
         input_layout,
         output_layout,
@@ -320,15 +342,15 @@ def test_reduce_sum_cols_collapsed_output_layout():
     assert tuple(result.shape) == (64, 1)
     expected = tensor.sum(dim=1, keepdim=True)
     diff = (expected - result).abs().max().item()
-    assert diff < 0.05, f"collapsed reduce_sum(dim=1): max diff {diff}"
+    assert diff < 0.05, f"reduce_sum(dim=1): max diff {diff}"
 
 
-def test_reduce_max_rows_collapsed_output_layout():
+def test_reduce_max_rows_output_layout():
     input_layout = _make_layout(shape=(32, 64), grid_shape=(1, 2))
     output_layout = d2m.reduction_layout(input_layout, 0)
     tensor = _tile_max_input((32, 64))
-    result = _run_collapsed(
-        k_reduce_max_rows_collapsed,
+    result = _run_with_output_layout(
+        k_reduce_max_rows_out,
         tensor,
         input_layout,
         output_layout,
@@ -338,15 +360,15 @@ def test_reduce_max_rows_collapsed_output_layout():
     assert tuple(result.shape) == (1, 64)
     expected = tensor.max(dim=0, keepdim=True).values
     diff = (expected - result).abs().max().item()
-    assert diff < 0.05, f"collapsed reduce_max(dim=0): max diff {diff}"
+    assert diff < 0.05, f"reduce_max(dim=0): max diff {diff}"
 
 
-def test_reduce_sum_cols_collapsed_multi_tile_single_core():
+def test_reduce_sum_cols_multi_tile_single_core():
     input_layout = _make_layout(shape=(32, 64), block_shape=(1, 2), grid_shape=(1, 1))
     output_layout = d2m.reduction_layout(input_layout, 1)
     tensor = _tile_sum_input((32, 64))
-    result = _run_collapsed(
-        k_reduce_sum_cols_collapsed,
+    result = _run_with_output_layout(
+        k_reduce_sum_cols_out,
         tensor,
         input_layout,
         output_layout,
@@ -359,12 +381,12 @@ def test_reduce_sum_cols_collapsed_multi_tile_single_core():
     assert diff < 0.1, f"single-core multi-tile reduce_sum(dim=1): max diff {diff}"
 
 
-def test_reduce_max_rows_collapsed_multi_tile_single_core():
+def test_reduce_max_rows_multi_tile_single_core():
     input_layout = _make_layout(shape=(64, 32), block_shape=(2, 1), grid_shape=(1, 1))
     output_layout = d2m.reduction_layout(input_layout, 0)
     tensor = _tile_max_input((64, 32))
-    result = _run_collapsed(
-        k_reduce_max_rows_collapsed,
+    result = _run_with_output_layout(
+        k_reduce_max_rows_out,
         tensor,
         input_layout,
         output_layout,
@@ -377,12 +399,12 @@ def test_reduce_max_rows_collapsed_multi_tile_single_core():
     assert diff < 0.05, f"single-core multi-tile reduce_max(dim=0): max diff {diff}"
 
 
-def test_reduce_mean_cols_collapsed_multi_tile_single_core():
+def test_reduce_mean_cols_multi_tile_single_core():
     input_layout = _make_layout(shape=(32, 64), block_shape=(1, 2), grid_shape=(1, 1))
     output_layout = d2m.reduction_layout(input_layout, 1)
     tensor = _tile_sum_input((32, 64))
-    result = _run_collapsed(
-        k_reduce_mean_cols_collapsed,
+    result = _run_with_output_layout(
+        k_reduce_mean_cols_out,
         tensor,
         input_layout,
         output_layout,
@@ -395,7 +417,7 @@ def test_reduce_mean_cols_collapsed_multi_tile_single_core():
     assert diff < 0.1, f"single-core multi-tile reduce_mean(dim=1): max diff {diff}"
 
 
-def test_reduction_layout_rejects_cross_tile_collapse():
+def test_reduction_layout_rejects_cross_core_reduction():
     layout = _make_layout(shape=(64, 64), grid_shape=(2, 2))
     with pytest.raises(ValueError, match="fits on one core"):
         d2m.reduction_layout(layout, 1)

--- a/test/d2m-jit/test_reductions.py
+++ b/test/d2m-jit/test_reductions.py
@@ -401,6 +401,15 @@ def test_reduction_layout_rejects_cross_tile_collapse():
         d2m.reduction_layout(layout, 1)
 
 
+def test_reduction_layout_allows_multiple_blocks_on_one_core():
+    layout = _make_layout(shape=(64, 64), block_shape=(1, 1), grid_shape=(1, 1))
+    output_layout = d2m.reduction_layout(layout, 1)
+
+    assert output_layout.logical_shape == [64, 1]
+    assert output_layout.block_shape == [1, 1]
+    assert output_layout.grid_shape == [1, 1]
+
+
 def test_reduce_sum_cols_cross_tile_output_layout():
     input_layout = _make_layout(shape=(64, 64), grid_shape=(2, 2))
     output_layout = d2m.reduction_layout(input_layout, 1, allow_cross_tile=True)
@@ -461,7 +470,7 @@ def test_reduce_max_rows_cross_tile_output_layout():
     assert diff < 0.05, f"cross-tile reduce_max(dim=0): max diff {diff}"
 
 
-@pytest.mark.parametrize("bad_dim", [2, -3])
+@pytest.mark.parametrize("bad_dim", [2, -3, True, False])
 def test_reduce_invalid_dim_rejected(bad_dim):
     @d2m.kernel
     def k_bad_dim(in_t, out_t):
@@ -474,4 +483,7 @@ def test_reduce_invalid_dim_rejected(bad_dim):
         k_bad_dim(d2m.to_layout(tensor, layout), d2m.empty(layout), grid=(1, 1))
 
     msg = str(exc_info.value)
-    assert "reduce dim must be 0/1 or -2/-1" in msg
+    if isinstance(bad_dim, bool):
+        assert "expected integer literal" in msg
+    else:
+        assert "reduce dim must be 0/1 or -2/-1" in msg

--- a/test/d2m-jit/test_reductions.py
+++ b/test/d2m-jit/test_reductions.py
@@ -397,7 +397,7 @@ def test_reduce_mean_cols_collapsed_multi_tile_single_core():
 
 def test_reduction_layout_rejects_cross_tile_collapse():
     layout = _make_layout(shape=(64, 64), grid_shape=(2, 2))
-    with pytest.raises(ValueError, match="fits in one per-core block"):
+    with pytest.raises(ValueError, match="fits on one core"):
         d2m.reduction_layout(layout, 1)
 
 

--- a/test/d2m-jit/test_reductions.py
+++ b/test/d2m-jit/test_reductions.py
@@ -1,0 +1,534 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Float tile reductions exposed through the d2m-jit block DSL.
+
+Coverage mirrors `test_matmul.py` but is broader because reductions are
+expected to produce defined values without an explicit accumulator pre-fill:
+
+1. `test_reduce_sum_compiles_and_runs` -- baseline shape/dtype smoke test.
+2. Parameterized correctness over several layout shapes, block shapes, and
+   execution grids for row and column reduction directions.
+3. Mixed-input dtype coverage for the synthetic reduction scaler selection.
+4. Invalid dim rejection for the Python DSL surface.
+"""
+
+import pytest
+import torch
+import d2m_jit as d2m
+
+
+@d2m.kernel
+def k_reduce_sum_cols(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            # Keep the reduction in a temporary so call-site reduction
+            # detection cannot rely on it being nested under remote_store.
+            reduced = reduce_sum(x, 1)
+            remote_store(out_t, [m_off + m, n_off + n], reduced)
+
+
+@d2m.kernel
+def k_reduce_max_rows(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], x.reduce_max(0))
+
+
+@d2m.kernel
+def k_reduce_mean_cols_negative_dim(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], reduce_mean(x, -1))
+
+
+@d2m.kernel
+def k_reduce_sum_rows_negative_dim(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], x.reduce_sum(-2))
+
+
+@d2m.kernel
+def k_reduce_sum_second_input(first_in_t, reduced_in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(reduced_in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], reduce_sum(x, 1))
+
+
+@d2m.kernel
+def k_reduce_sum_cols_collapsed(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, 0], reduce_sum_collapse(x, 1))
+
+
+@d2m.kernel
+def k_reduce_max_rows_collapsed(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [0, n_off + n], x.reduce_max_collapse(0))
+
+
+@d2m.kernel
+def k_reduce_mean_cols_collapsed(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, 0], x.reduce_mean_collapse(1))
+
+
+@d2m.kernel
+def k_reduce_sum_cols_tile(in_t, out_t, m_blocks, n_tile):
+    m_off = core_index(0) * m_blocks
+    for m in range(m_blocks):
+        x = remote_load(in_t, [m_off + m, n_tile])
+        remote_store(out_t, [m_off + m, 0], reduce_sum_collapse(x, 1))
+
+
+@d2m.kernel
+def k_reduce_sum_cols_accumulate_tile(in_t, acc_t, out_t, m_blocks, n_tile):
+    m_off = core_index(0) * m_blocks
+    for m in range(m_blocks):
+        x = remote_load(in_t, [m_off + m, n_tile])
+        acc = remote_load(acc_t, [m_off + m, 0])
+        remote_store(out_t, [m_off + m, 0], acc + reduce_sum_collapse(x, 1))
+
+
+@d2m.kernel
+def k_reduce_max_rows_tile(in_t, out_t, m_tile, n_blocks):
+    n_off = core_index(1) * n_blocks
+    for n in range(n_blocks):
+        x = remote_load(in_t, [m_tile, n_off + n])
+        remote_store(out_t, [0, n_off + n], x.reduce_max_collapse(0))
+
+
+@d2m.kernel
+def k_reduce_max_rows_accumulate_tile(in_t, acc_t, out_t, m_tile, n_blocks):
+    n_off = core_index(1) * n_blocks
+    for n in range(n_blocks):
+        x = remote_load(in_t, [m_tile, n_off + n])
+        acc = remote_load(acc_t, [0, n_off + n])
+        remote_store(out_t, [0, n_off + n], acc.maximum(x.reduce_max_collapse(0)))
+
+
+@d2m.kernel
+def k_reduce_sum_cols_cross_tile(in_t, out_t, m_blocks, n_tiles):
+    m_off = core_index(0) * m_blocks
+    for m in range(m_blocks):
+        first = remote_load(in_t, [m_off + m, 0])
+        acc = reduce_sum_collapse(first, 1)
+        for n in range(1, n_tiles):
+            x = remote_load(in_t, [m_off + m, n])
+            acc = acc + reduce_sum_collapse(x, 1)
+        remote_store(out_t, [m_off + m, 0], acc)
+
+
+@d2m.kernel
+def k_reduce_max_rows_cross_tile(in_t, out_t, m_tiles, n_blocks):
+    n_off = core_index(1) * n_blocks
+    for n in range(n_blocks):
+        first = remote_load(in_t, [0, n_off + n])
+        acc = first.reduce_max_collapse(0)
+        for m in range(1, m_tiles):
+            x = remote_load(in_t, [m, n_off + n])
+            acc = acc.maximum(x.reduce_max_collapse(0))
+        remote_store(out_t, [0, n_off + n], acc)
+
+
+_LAYOUT_CASES = [
+    pytest.param((32, 32), (1, 1), (1, 1), id="single-tile-grid-1x1"),
+    pytest.param((64, 64), (1, 1), (2, 2), id="one-tile-per-core-grid-2x2"),
+    pytest.param((64, 64), (2, 1), (1, 1), id="two-row-tiles-per-block"),
+    pytest.param((64, 64), (1, 2), (1, 1), id="two-col-tiles-per-block"),
+    pytest.param((96, 64), (1, 1), (3, 2), id="rectangular-grid-3x2"),
+]
+
+
+def _make_layout(
+    shape=(32, 32),
+    dtype=d2m.float32,
+    block_shape=(1, 1),
+    grid_shape=(1, 1),
+):
+    return d2m.Layout(
+        shape=shape,
+        dtype=dtype,
+        block_shape=list(block_shape),
+        grid_shape=list(grid_shape),
+    )
+
+
+def _blocks_per_core(layout, grid):
+    m_tiles = layout.logical_shape[0] // 32
+    n_tiles = layout.logical_shape[1] // 32
+    assert m_tiles % (layout.block_shape[0] * grid[0]) == 0
+    assert n_tiles % (layout.block_shape[1] * grid[1]) == 0
+    return (
+        m_tiles // layout.block_shape[0] // grid[0],
+        n_tiles // layout.block_shape[1] // grid[1],
+    )
+
+
+def _run(kernel, tensor, layout=None, grid=(1, 1)):
+    layout = layout or _make_layout()
+    out = d2m.empty(layout)
+    m_blocks, n_blocks = _blocks_per_core(layout, grid)
+    kernel(d2m.to_layout(tensor, layout), out, m_blocks, n_blocks, grid=grid)
+    return out.to_host()
+
+
+def _run_collapsed(kernel, tensor, input_layout, output_layout, grid):
+    out = d2m.empty(output_layout)
+    m_blocks, n_blocks = _blocks_per_core(input_layout, grid)
+    kernel(d2m.to_layout(tensor, input_layout), out, m_blocks, n_blocks, grid=grid)
+    return out.to_host()
+
+
+def _run_cross_tile(kernel, tensor, input_layout, output_layout, grid, *scalars):
+    out = d2m.empty(output_layout)
+    kernel(d2m.to_layout(tensor, input_layout), out, *scalars, grid=grid)
+    return out.to_host()
+
+
+def _tile_sum_input(shape, dtype=torch.float32):
+    row_values = torch.arange(shape[0], dtype=torch.float32).reshape(shape[0], 1)
+    tensor = row_values.repeat(1, shape[1]) / 100.0
+    return tensor.to(dtype)
+
+
+def _tile_max_input(shape, dtype=torch.float32):
+    row_bias = torch.linspace(-0.5, 0.5, shape[0], dtype=torch.float32).reshape(
+        shape[0], 1
+    )
+    col_values = torch.linspace(-1.0, 1.0, shape[1], dtype=torch.float32).reshape(
+        1, shape[1]
+    )
+    return (row_bias + col_values).to(dtype)
+
+
+def _assert_reduce_sum_cols(result, tensor, atol=0.05):
+    for col_start in range(0, tensor.shape[1], 32):
+        expected = tensor[:, col_start : col_start + 32].sum(dim=1)
+        actual = result[:, col_start]
+        diff = (
+            (expected.to(torch.float32) - actual.to(torch.float32)).abs().max().item()
+        )
+        assert diff < atol, f"reduce_sum cols at col {col_start}: max diff {diff}"
+
+
+def _assert_reduce_mean_cols(result, tensor, atol=0.05):
+    for col_start in range(0, tensor.shape[1], 32):
+        expected = tensor[:, col_start : col_start + 32].mean(dim=1)
+        actual = result[:, col_start]
+        diff = (
+            (expected.to(torch.float32) - actual.to(torch.float32)).abs().max().item()
+        )
+        assert diff < atol, f"reduce_mean cols at col {col_start}: max diff {diff}"
+
+
+def _assert_reduce_max_rows(result, tensor, atol=0.05):
+    for row_start in range(0, tensor.shape[0], 32):
+        expected = tensor[row_start : row_start + 32, :].max(dim=0).values
+        actual = result[row_start, :]
+        diff = (
+            (expected.to(torch.float32) - actual.to(torch.float32)).abs().max().item()
+        )
+        assert diff < atol, f"reduce_max rows at row {row_start}: max diff {diff}"
+
+
+def test_reduce_sum_compiles_and_runs():
+    tensor = _tile_sum_input((32, 32))
+    layout = _make_layout()
+    result = _run(k_reduce_sum_cols, tensor, layout=layout)
+
+    assert tuple(result.shape) == (32, 32)
+    assert result.dtype == torch.float32
+
+
+@pytest.mark.parametrize("shape,block_shape,grid", _LAYOUT_CASES)
+def test_reduce_sum_cols_correctness(shape, block_shape, grid):
+    """Free-function form: `reduce_sum(x, 1)` reduces each tile's columns."""
+    layout = _make_layout(shape=shape, block_shape=block_shape, grid_shape=grid)
+    tensor = _tile_sum_input(shape)
+    result = _run(k_reduce_sum_cols, tensor, layout=layout, grid=grid)
+
+    _assert_reduce_sum_cols(result, tensor)
+
+
+@pytest.mark.parametrize("shape,block_shape,grid", _LAYOUT_CASES)
+def test_reduce_max_rows_method_form_correctness(shape, block_shape, grid):
+    """Method form: `x.reduce_max(0)` reduces each tile's rows."""
+    layout = _make_layout(shape=shape, block_shape=block_shape, grid_shape=grid)
+    tensor = _tile_max_input(shape)
+    result = _run(k_reduce_max_rows, tensor, layout=layout, grid=grid)
+
+    _assert_reduce_max_rows(result, tensor)
+
+
+@pytest.mark.parametrize("shape,block_shape,grid", _LAYOUT_CASES)
+def test_reduce_mean_cols_negative_dim_correctness(shape, block_shape, grid):
+    """Negative dim form: `reduce_mean(x, -1)` aliases column reduction."""
+    layout = _make_layout(shape=shape, block_shape=block_shape, grid_shape=grid)
+    tensor = _tile_sum_input(shape)
+    result = _run(k_reduce_mean_cols_negative_dim, tensor, layout=layout, grid=grid)
+
+    _assert_reduce_mean_cols(result, tensor)
+
+
+@pytest.mark.parametrize("shape,block_shape,grid", _LAYOUT_CASES)
+def test_reduce_sum_rows_negative_dim_correctness(shape, block_shape, grid):
+    """Method + negative dim form: `x.reduce_sum(-2)` aliases row reduction."""
+    layout = _make_layout(shape=shape, block_shape=block_shape, grid_shape=grid)
+    tensor = _tile_max_input(shape)
+    result = _run(k_reduce_sum_rows_negative_dim, tensor, layout=layout, grid=grid)
+
+    for row_start in range(0, tensor.shape[0], 32):
+        expected = tensor[row_start : row_start + 32, :].sum(dim=0)
+        actual = result[row_start, :]
+        diff = (expected - actual).abs().max().item()
+        assert diff < 0.1, f"reduce_sum rows at row {row_start}: max diff {diff}"
+
+
+def test_reduce_sum_second_input_mixed_dtype():
+    f32_layout = _make_layout(shape=(32, 32), dtype=d2m.float32)
+    bf16_layout = _make_layout(shape=(32, 32), dtype=d2m.bfloat16)
+    first = torch.zeros(32, 32, dtype=torch.float32)
+    reduced = torch.arange(32, dtype=torch.bfloat16).reshape(32, 1).repeat(1, 32)
+    reduced = reduced / 100.0
+
+    out = d2m.empty(bf16_layout)
+    k_reduce_sum_second_input(
+        d2m.to_layout(first, f32_layout),
+        d2m.to_layout(reduced, bf16_layout),
+        out,
+        1,
+        1,
+        grid=(1, 1),
+    )
+    result = out.to_host()
+
+    _assert_reduce_sum_cols(result, reduced, atol=0.15)
+
+
+def test_reduce_sum_cols_collapsed_output_layout():
+    input_layout = _make_layout(shape=(64, 32), grid_shape=(2, 1))
+    output_layout = d2m.reduction_layout(input_layout, 1)
+    tensor = _tile_sum_input((64, 32))
+    result = _run_collapsed(
+        k_reduce_sum_cols_collapsed,
+        tensor,
+        input_layout,
+        output_layout,
+        grid=(2, 1),
+    )
+
+    assert tuple(result.shape) == (64, 1)
+    expected = tensor.sum(dim=1, keepdim=True)
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.05, f"collapsed reduce_sum(dim=1): max diff {diff}"
+
+
+def test_reduce_max_rows_collapsed_output_layout():
+    input_layout = _make_layout(shape=(32, 64), grid_shape=(1, 2))
+    output_layout = d2m.reduction_layout(input_layout, 0)
+    tensor = _tile_max_input((32, 64))
+    result = _run_collapsed(
+        k_reduce_max_rows_collapsed,
+        tensor,
+        input_layout,
+        output_layout,
+        grid=(1, 2),
+    )
+
+    assert tuple(result.shape) == (1, 64)
+    expected = tensor.max(dim=0, keepdim=True).values
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.05, f"collapsed reduce_max(dim=0): max diff {diff}"
+
+
+def test_reduce_sum_cols_collapsed_multi_tile_single_core():
+    input_layout = _make_layout(shape=(32, 64), block_shape=(1, 2), grid_shape=(1, 1))
+    output_layout = d2m.reduction_layout(input_layout, 1)
+    tensor = _tile_sum_input((32, 64))
+    result = _run_collapsed(
+        k_reduce_sum_cols_collapsed,
+        tensor,
+        input_layout,
+        output_layout,
+        grid=(1, 1),
+    )
+
+    assert tuple(result.shape) == (32, 1)
+    expected = tensor.sum(dim=1, keepdim=True)
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.1, f"single-core multi-tile reduce_sum(dim=1): max diff {diff}"
+
+
+def test_reduce_max_rows_collapsed_multi_tile_single_core():
+    input_layout = _make_layout(shape=(64, 32), block_shape=(2, 1), grid_shape=(1, 1))
+    output_layout = d2m.reduction_layout(input_layout, 0)
+    tensor = _tile_max_input((64, 32))
+    result = _run_collapsed(
+        k_reduce_max_rows_collapsed,
+        tensor,
+        input_layout,
+        output_layout,
+        grid=(1, 1),
+    )
+
+    assert tuple(result.shape) == (1, 32)
+    expected = tensor.max(dim=0, keepdim=True).values
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.05, f"single-core multi-tile reduce_max(dim=0): max diff {diff}"
+
+
+def test_reduce_mean_cols_collapsed_multi_tile_single_core():
+    input_layout = _make_layout(shape=(32, 64), block_shape=(1, 2), grid_shape=(1, 1))
+    output_layout = d2m.reduction_layout(input_layout, 1)
+    tensor = _tile_sum_input((32, 64))
+    result = _run_collapsed(
+        k_reduce_mean_cols_collapsed,
+        tensor,
+        input_layout,
+        output_layout,
+        grid=(1, 1),
+    )
+
+    assert tuple(result.shape) == (32, 1)
+    expected = tensor.mean(dim=1, keepdim=True)
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.1, f"single-core multi-tile reduce_mean(dim=1): max diff {diff}"
+
+
+def test_reduction_layout_rejects_cross_tile_collapse():
+    layout = _make_layout(shape=(64, 64), grid_shape=(2, 2))
+    with pytest.raises(ValueError, match="fits in one per-core block"):
+        d2m.reduction_layout(layout, 1)
+
+
+def test_reduce_sum_cols_cross_tile_output_layout():
+    input_layout = _make_layout(shape=(64, 64), grid_shape=(2, 2))
+    output_layout = d2m.reduction_layout(input_layout, 1, allow_cross_tile=True)
+    tensor = _tile_sum_input((64, 64))
+    m_blocks = input_layout.logical_shape[0] // 32 // 2
+    n_tiles = input_layout.logical_shape[1] // 32
+
+    out = d2m.empty(output_layout)
+    k_reduce_sum_cols_tile(
+        d2m.to_layout(tensor, input_layout), out, m_blocks, 0, grid=(2, 1)
+    )
+    result = out.to_host()
+    for n_tile in range(1, n_tiles):
+        out = d2m.empty(output_layout)
+        k_reduce_sum_cols_accumulate_tile(
+            d2m.to_layout(tensor, input_layout),
+            d2m.to_layout(result, output_layout),
+            out,
+            m_blocks,
+            n_tile,
+            grid=(2, 1),
+        )
+        result = out.to_host()
+
+    assert tuple(result.shape) == (64, 1)
+    expected = tensor.sum(dim=1, keepdim=True)
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.1, f"cross-tile reduce_sum(dim=1): max diff {diff}"
+
+
+@pytest.mark.skip(
+    reason=(
+        "A single unified kernel with multiple synchronizable remote_loads in "
+        "different loop scopes trips SplitUnifiedThread's synchronized-scope "
+        "assertion; the multi-pass variant above is the supported path for now."
+    )
+)
+def test_reduce_sum_cols_cross_tile_single_kernel_blocked():
+    input_layout = _make_layout(shape=(64, 64), grid_shape=(2, 2))
+    output_layout = d2m.reduction_layout(input_layout, 1, allow_cross_tile=True)
+    tensor = _tile_sum_input((64, 64))
+    result = _run_cross_tile(
+        k_reduce_sum_cols_cross_tile,
+        tensor,
+        input_layout,
+        output_layout,
+        (2, 1),
+        input_layout.logical_shape[0] // 32 // 2,
+        input_layout.logical_shape[1] // 32,
+    )
+
+    assert tuple(result.shape) == (64, 1)
+    expected = tensor.sum(dim=1, keepdim=True)
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.1, f"cross-tile reduce_sum(dim=1): max diff {diff}"
+
+
+def test_reduce_max_rows_cross_tile_output_layout():
+    input_layout = _make_layout(shape=(64, 64), grid_shape=(2, 2))
+    output_layout = d2m.reduction_layout(input_layout, 0, allow_cross_tile=True)
+    tensor = _tile_max_input((64, 64))
+    m_tiles = input_layout.logical_shape[0] // 32
+    n_blocks = input_layout.logical_shape[1] // 32 // 2
+
+    out = d2m.empty(output_layout)
+    k_reduce_max_rows_tile(
+        d2m.to_layout(tensor, input_layout), out, 0, n_blocks, grid=(1, 2)
+    )
+    result = out.to_host()
+    for m_tile in range(1, m_tiles):
+        out = d2m.empty(output_layout)
+        k_reduce_max_rows_accumulate_tile(
+            d2m.to_layout(tensor, input_layout),
+            d2m.to_layout(result, output_layout),
+            out,
+            m_tile,
+            n_blocks,
+            grid=(1, 2),
+        )
+        result = out.to_host()
+
+    assert tuple(result.shape) == (1, 64)
+    expected = tensor.max(dim=0, keepdim=True).values
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.05, f"cross-tile reduce_max(dim=0): max diff {diff}"
+
+
+@pytest.mark.parametrize("bad_dim", [2, -3])
+def test_reduce_invalid_dim_rejected(bad_dim):
+    @d2m.kernel
+    def k_bad_dim(in_t, out_t):
+        x = remote_load(in_t, [0, 0])
+        remote_store(out_t, [0, 0], reduce_sum(x, bad_dim))
+
+    layout = _make_layout()
+    tensor = torch.zeros(32, 32, dtype=torch.float32)
+    with pytest.raises(d2m.D2mJitError) as exc_info:
+        k_bad_dim(d2m.to_layout(tensor, layout), d2m.empty(layout), grid=(1, 1))
+
+    msg = str(exc_info.value)
+    assert "reduce dim must be 0/1 or -2/-1" in msg

--- a/tools/d2m-jit/KERNEL_AUDIT.md
+++ b/tools/d2m-jit/KERNEL_AUDIT.md
@@ -89,8 +89,8 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
   tile.
 - **Cross-tile collapsed reductions:** row/column `sum` and `max` can be built
   as multiple host-orchestrated kernel launches that accumulate one tile at a
-  time into a collapsed output layout. This is functional, but not a fused
-  single-kernel lowering yet.
+  time into a collapsed output layout. Reducing across multiple cores in one
+  fused kernel is not supported today.
 
 ### 🟡 Buildable with workarounds / scope cuts
 
@@ -367,8 +367,9 @@ nothing else does:
 ## 5. Critical-path unlocks, ranked
 
 1. **Fuse cross-tile reductions/accumulation.** Reductions and tile_bcast cover
-   the per-tile pieces, and host-orchestrated cross-tile sum/max work, but
-   softmax and normalization still need a single-kernel path for wide rows.
+   the per-tile pieces, and host-orchestrated cross-tile sum/max work, but the
+   DSL does not currently support reducing across multiple cores in one fused
+   kernel.
 2. **Fix matmul accumulator init** ([TODO §1](TODO.md) —
    `D2MToTTKernel` fill-pattern handling). Unlocks multi-K matmul →
    real GEMM, real attention Q×Kᵀ across K, FFN.

--- a/tools/d2m-jit/KERNEL_AUDIT.md
+++ b/tools/d2m-jit/KERNEL_AUDIT.md
@@ -24,7 +24,7 @@ Status legend matches [TODO.md](TODO.md): 🔴 blocker · 🟡 missing surface
 | **Views** (`view`, `view_layout`, `permute`) | ✅ | Metadata reinterpretation, no data movement |
 | `tilize` / `untilize` / `to_layout` | ✅ | Layout conversions |
 | `zeros`, `full`, `empty` | ✅ | Host-side fill + `to_layout` |
-| Reductions (`tile_reduce_*`) | 🔴 | Not exposed in `api.py` |
+| Float reductions (`reduce_sum`, `reduce_max`, `reduce_mean`) | ✅ | Keepdim row/col reductions using `tile_reduce_*`, reduction output layouts, implicit eltwise broadcast; cross-core reductions need a core gather/redistribute op |
 | Broadcast (`tile_bcast`) | ✅ | `d2m.tile_bcast`, row/col/2d shorthands, method forms; lit + pytest coverage |
 | In-kernel typecast (`tile_typecast`) | 🔴 | Host-side only via `tilize(dtype=...)` |
 | Per-tile transpose (`tile_transpose`) | 🔴 | Not exposed — but logical permute via views is free |
@@ -83,14 +83,20 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 - **Per-shard outer product / hadamard** patterns.
 - **KV-cache writeback** at a computed index via `remote_store`.
 - **Pointwise quant/dequant** (mul + add + `floor`).
+- **Single-tile reductions:** row/column `sum`, `max`, and `mean` within each
+  32x32 tile. Results use one-row/one-column output layouts; elementwise ops
+  implicitly broadcast them back when combined with unreduced blocks.
+- **Cross-core reductions:** row/column reductions that span cores need a core
+  gather/redistribute op so partials can be collected from multiple cores and
+  placed back onto the cores that own the reduced output layout.
 
 ### 🟡 Buildable with workarounds / scope cuts
 
 - **SDPA at 1-tile granularity** (S ≤ 32, single head): Q×Kᵀ via
-  permute-view + zeros-prefilled matmul + softmax… stops at softmax
-  because reductions are missing.
+  permute-view + zeros-prefilled matmul + manually composed row softmax from
+  reductions.
 - **Multi-head attention scaffolding:** per-head views are free; the
-  *compute* hits the reduction wall.
+  *compute* hits broadcast and matmul-accumulator limits.
 - **MoE expert MLP body** (linear + GELU + linear): chained via views,
   but only single-tile shards until the matmul accumulator bug lands.
 - **Embedding lookup:** doable via `remote_load` with computed indices
@@ -98,10 +104,11 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ### 🔴 Blocked on missing pieces
 
-- **Softmax** — needs reductions; broadcast is available. Blocks every
-  attention, MoE-gating, and cross-entropy-loss kernel.
-- **LayerNorm / RMSNorm / GroupNorm** — same: reductions are the
-  remaining blocker; broadcast is available.
+- **Softmax over wide rows** — within-tile pieces exist, but a single fused
+  cross-tile implementation still needs accumulator/state handling.
+- **LayerNorm / RMSNorm / GroupNorm over wide rows** — reduction tiles and
+  one-tile output layouts exist, but reductions spanning cores need a core
+  gather/redistribute op.
 - **Flash Attention** — needs softmax + multi-K matmul accumulation
   ([TODO §1](TODO.md)) + multicast on real grids
   ([TODO §2](TODO.md)) + online-softmax state across blocks.
@@ -114,25 +121,21 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ---
 
-## 4. Concrete kernel sketches with available tile_bcast + proposed reductions
+## 4. Concrete kernel sketches with reductions
 
-These sketches assume reductions with this shape, plus the existing tile_bcast API:
+These sketches use the landed reduction API:
 
 ```python
-# Per-tile reductions: reduce over the tile's row or col axis. The
-# result is a partial tile (32x1 for dim="col", 1x32 for dim="row"),
-# matching the d2m.tile_reduce_* op semantics.
-d2m.reduce_sum(x, dim)     # dim in {"row", "col"}
+# Per-tile reductions: reduce over one tile axis. `dim` follows torch/numpy
+# numbering (`0`/`-2`, `1`/`-1`) and keeps the reduced dimension as size 1.
+# Elementwise ops implicitly broadcast reduced operands when needed.
+d2m.reduce_sum(x, dim)
 d2m.reduce_max(x, dim)
 d2m.reduce_mean(x, dim)
-
-# Broadcast a partial tile back to a full 32x32 tile. This is available today.
-d2m.tile_bcast(x, bcast_type)  # bcast_type in {"row", "col", "2d"}
 ```
 
-The reduction spelling is a placeholder; the tile_bcast spelling shown here is
-available today. The point of the sketches is the **kernel shape**, not the
-bikeshed.
+The point of the sketches is the **kernel shape**; exact helper names may still
+be adjusted as the DSL evolves.
 
 ### 4.1 Row-wise softmax (within-tile)
 
@@ -149,11 +152,11 @@ def softmax_row(x, out, m_blocks, n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
 
             # Numerically-stable softmax: subtract row max, exp, divide.
-            row_max = reduce_max(t, dim="row")           # 32x1
-            t_shift = t - tile_bcast(row_max, "row")     # 32x32
+            row_max = reduce_max(t, dim=1)               # keepdim row max
+            t_shift = t - row_max
             t_exp   = exp(t_shift)
-            row_sum = reduce_sum(t_exp, dim="row")       # 32x1
-            t_out   = t_exp * tile_bcast(recip(row_sum), "row")
+            row_sum = reduce_sum(t_exp, dim=1)           # keepdim row sum
+            t_out   = t_exp * recip(row_sum)
 
             remote_store(out, [m_off + m, n_off + n], t_out)
 ```
@@ -176,16 +179,14 @@ def softmax_row_wide(x, out, m_blocks, n_blocks):
         row_max = NEG_INF
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            row_max = maximum(row_max, tile_bcast(reduce_max(t, dim="row"),
-                                             "row"))
+            row_max = maximum(row_max, reduce_max(t, dim=1))
 
         # Pass 2: row sum of shifted exp.
         row_sum = full_tile(value=0.0)
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
             t_exp = exp(t - row_max)
-            row_sum = row_sum + tile_bcast(reduce_sum(t_exp, dim="row"),
-                                      "row")
+            row_sum = row_sum + reduce_sum(t_exp, dim=1)
         row_inv = recip(row_sum)
 
         # Pass 3: normalise and write back.
@@ -205,8 +206,7 @@ Notes:
 
 ### 4.3 RMSNorm
 
-`y = x * gamma / sqrt(mean(x²) + eps)` — a single per-row reduction,
-then broadcast.
+`y = x * gamma / sqrt(mean(x²) + eps)` — a single per-row reduction.
 
 ```python
 @d2m.kernel
@@ -220,8 +220,7 @@ def rmsnorm(x, gamma, out, m_blocks, n_blocks, eps_tile):
         sum_sq = full_tile(value=0.0)
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            sum_sq = sum_sq + tile_bcast(reduce_sum(t * t, dim="row"),
-                                    "row")
+            sum_sq = sum_sq + reduce_sum(t * t, dim=1)
         inv_rms = rsqrt(sum_sq * INV_N + eps_tile)
 
         # Pass 2: scale and write.
@@ -231,10 +230,8 @@ def rmsnorm(x, gamma, out, m_blocks, n_blocks, eps_tile):
             remote_store(out, [m_off + m, n_off + n], t * g * inv_rms)
 ```
 
-This is the cleanest end-to-end demo of reductions plus the available
-tile_bcast primitive: one small kernel that exercises both, in a pattern
-that immediately generalises to LayerNorm (add a mean reduction) and
-GroupNorm.
+This is the cleanest end-to-end demo of reductions: one small kernel that
+immediately generalises to LayerNorm (add a mean reduction) and GroupNorm.
 
 ### 4.4 Single-head SDPA, chained via views
 
@@ -296,16 +293,14 @@ def flash_attn_inner(Q, K, V, O, l_state, m_state, S_q, S_kv, D):
 
         # 2. running max
         m_prev = m_state
-        m_cur  = maximum(m_prev, tile_bcast(reduce_max(s, dim="row"),
-                                       "row"))
+        m_cur  = maximum(m_prev, reduce_max(s, dim=1))
 
         # 3. correction factor for previous accumulator
         alpha  = exp(m_prev - m_cur)
 
         # 4. exp of shifted scores, partial sum
         p      = exp(s - m_cur)
-        l_cur  = alpha * l_state + tile_bcast(reduce_sum(p, dim="row"),
-                                         "row")
+        l_cur  = alpha * l_state + reduce_sum(p, dim=1)
 
         # 5. update O: O = alpha * O + p @ V
         O      = alpha * O + (p @ V_blk)
@@ -357,10 +352,10 @@ nothing else does:
 
 ## 5. Critical-path unlocks, ranked
 
-1. **Expose reductions (`tile_reduce_sum`, `tile_reduce_max`,
-   `tile_reduce_mean`).** `tile_bcast` is already exposed. Unlocks
-   softmax → unlocks LayerNorm, RMSNorm, attention, MoE gating. Single
-   biggest fan-out for the surface we're missing.
+1. **Add core gather/redistribute for cross-core reductions.** Reductions cover
+   the per-core pieces, but the DSL needs an op that gathers partial results
+   from multiple cores and redistributes the reduced values to the output-owning
+   cores.
 2. **Fix matmul accumulator init** ([TODO §1](TODO.md) —
    `D2MToTTKernel` fill-pattern handling). Unlocks multi-K matmul →
    real GEMM, real attention Q×Kᵀ across K, FFN.

--- a/tools/d2m-jit/KERNEL_AUDIT.md
+++ b/tools/d2m-jit/KERNEL_AUDIT.md
@@ -24,7 +24,7 @@ Status legend matches [TODO.md](TODO.md): 🔴 blocker · 🟡 missing surface
 | **Views** (`view`, `view_layout`, `permute`) | ✅ | Metadata reinterpretation, no data movement |
 | `tilize` / `untilize` / `to_layout` | ✅ | Layout conversions |
 | `zeros`, `full`, `empty` | ✅ | Host-side fill + `to_layout` |
-| Reductions (`tile_reduce_*`) | 🔴 | Not exposed in `api.py` |
+| Float reductions (`reduce_sum`, `reduce_max`, `reduce_mean`) | ✅ | Per-tile row/col reductions using `tile_reduce_*`; same-shape, single-tile collapsed outputs, and host-orchestrated cross-tile sum/max |
 | Broadcast (`tile_bcast`) | ✅ | `d2m.tile_bcast`, row/col/2d shorthands, method forms; lit + pytest coverage |
 | In-kernel typecast (`tile_typecast`) | 🔴 | Host-side only via `tilize(dtype=...)` |
 | Per-tile transpose (`tile_transpose`) | 🔴 | Not exposed — but logical permute via views is free |
@@ -83,14 +83,23 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 - **Per-shard outer product / hadamard** patterns.
 - **KV-cache writeback** at a computed index via `remote_store`.
 - **Pointwise quant/dequant** (mul + add + `floor`).
+- **Single-tile reductions:** row/column `sum`, `max`, and `mean` within each
+  32x32 tile. Same-shape result lanes and collapsed one-row/one-column output
+  layouts are supported, and `tile_bcast` expands a reduced lane back to a full
+  tile.
+- **Cross-tile collapsed reductions:** row/column `sum` and `max` can be built
+  as multiple host-orchestrated kernel launches that accumulate one tile at a
+  time into a collapsed output layout. This is functional, but not a fused
+  single-kernel lowering yet.
 
 ### 🟡 Buildable with workarounds / scope cuts
 
 - **SDPA at 1-tile granularity** (S ≤ 32, single head): Q×Kᵀ via
-  permute-view + zeros-prefilled matmul + softmax… stops at softmax
-  because reductions are missing.
+  permute-view + zeros-prefilled matmul + manually composed row softmax from
+  reductions and tile broadcast. Wider rows still need fused cross-tile
+  accumulation.
 - **Multi-head attention scaffolding:** per-head views are free; the
-  *compute* hits the reduction wall.
+  *compute* hits broadcast and matmul-accumulator limits.
 - **MoE expert MLP body** (linear + GELU + linear): chained via views,
   but only single-tile shards until the matmul accumulator bug lands.
 - **Embedding lookup:** doable via `remote_load` with computed indices
@@ -98,10 +107,11 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ### 🔴 Blocked on missing pieces
 
-- **Softmax** — needs reductions; broadcast is available. Blocks every
-  attention, MoE-gating, and cross-entropy-loss kernel.
-- **LayerNorm / RMSNorm / GroupNorm** — same: reductions are the
-  remaining blocker; broadcast is available.
+- **Softmax over wide rows** — within-tile pieces exist, but a single fused
+  cross-tile implementation still needs accumulator/state handling.
+- **LayerNorm / RMSNorm / GroupNorm over wide rows** — reduction lanes,
+  collapsed one-tile outputs, tile broadcast, and host-orchestrated cross-tile
+  sum/max exist, but fused cross-tile accumulation is still missing.
 - **Flash Attention** — needs softmax + multi-K matmul accumulation
   ([TODO §1](TODO.md)) + multicast on real grids
   ([TODO §2](TODO.md)) + online-softmax state across blocks.
@@ -114,15 +124,15 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ---
 
-## 4. Concrete kernel sketches with available tile_bcast + proposed reductions
+## 4. Concrete kernel sketches with reductions + tile_bcast
 
-These sketches assume reductions with this shape, plus the existing tile_bcast API:
+These sketches use the landed reduction API and the existing tile_bcast API:
 
 ```python
-# Per-tile reductions: reduce over the tile's row or col axis. The
-# result is a partial tile (32x1 for dim="col", 1x32 for dim="row"),
-# matching the d2m.tile_reduce_* op semantics.
-d2m.reduce_sum(x, dim)     # dim in {"row", "col"}
+# Per-tile reductions: reduce over one tile axis. `dim` follows torch/numpy
+# numbering (`0`/`-2`, `1`/`-1`) and keeps the same tile shape with reduce
+# lanes populated by the hardware op.
+d2m.reduce_sum(x, dim)
 d2m.reduce_max(x, dim)
 d2m.reduce_mean(x, dim)
 
@@ -130,9 +140,8 @@ d2m.reduce_mean(x, dim)
 d2m.tile_bcast(x, bcast_type)  # bcast_type in {"row", "col", "2d"}
 ```
 
-The reduction spelling is a placeholder; the tile_bcast spelling shown here is
-available today. The point of the sketches is the **kernel shape**, not the
-bikeshed.
+The point of the sketches is the **kernel shape**; exact helper names may still
+be adjusted as the DSL evolves.
 
 ### 4.1 Row-wise softmax (within-tile)
 
@@ -149,11 +158,11 @@ def softmax_row(x, out, m_blocks, n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
 
             # Numerically-stable softmax: subtract row max, exp, divide.
-            row_max = reduce_max(t, dim="row")           # 32x1
-            t_shift = t - tile_bcast(row_max, "row")     # 32x32
+            row_max = reduce_max(t, dim=1)               # 32x1
+            t_shift = t - tile_bcast(row_max, "col")     # 32x32
             t_exp   = exp(t_shift)
-            row_sum = reduce_sum(t_exp, dim="row")       # 32x1
-            t_out   = t_exp * tile_bcast(recip(row_sum), "row")
+            row_sum = reduce_sum(t_exp, dim=1)           # 32x1
+            t_out   = t_exp * tile_bcast(recip(row_sum), "col")
 
             remote_store(out, [m_off + m, n_off + n], t_out)
 ```
@@ -176,16 +185,16 @@ def softmax_row_wide(x, out, m_blocks, n_blocks):
         row_max = NEG_INF
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            row_max = maximum(row_max, tile_bcast(reduce_max(t, dim="row"),
-                                             "row"))
+            row_max = maximum(row_max, tile_bcast(reduce_max(t, dim=1),
+                                             "col"))
 
         # Pass 2: row sum of shifted exp.
         row_sum = full_tile(value=0.0)
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
             t_exp = exp(t - row_max)
-            row_sum = row_sum + tile_bcast(reduce_sum(t_exp, dim="row"),
-                                      "row")
+            row_sum = row_sum + tile_bcast(reduce_sum(t_exp, dim=1),
+                                      "col")
         row_inv = recip(row_sum)
 
         # Pass 3: normalise and write back.
@@ -220,8 +229,8 @@ def rmsnorm(x, gamma, out, m_blocks, n_blocks, eps_tile):
         sum_sq = full_tile(value=0.0)
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            sum_sq = sum_sq + tile_bcast(reduce_sum(t * t, dim="row"),
-                                    "row")
+            sum_sq = sum_sq + tile_bcast(reduce_sum(t * t, dim=1),
+                                    "col")
         inv_rms = rsqrt(sum_sq * INV_N + eps_tile)
 
         # Pass 2: scale and write.
@@ -296,16 +305,16 @@ def flash_attn_inner(Q, K, V, O, l_state, m_state, S_q, S_kv, D):
 
         # 2. running max
         m_prev = m_state
-        m_cur  = maximum(m_prev, tile_bcast(reduce_max(s, dim="row"),
-                                       "row"))
+        m_cur  = maximum(m_prev, tile_bcast(reduce_max(s, dim=1),
+                                       "col"))
 
         # 3. correction factor for previous accumulator
         alpha  = exp(m_prev - m_cur)
 
         # 4. exp of shifted scores, partial sum
         p      = exp(s - m_cur)
-        l_cur  = alpha * l_state + tile_bcast(reduce_sum(p, dim="row"),
-                                         "row")
+        l_cur  = alpha * l_state + tile_bcast(reduce_sum(p, dim=1),
+                                         "col")
 
         # 5. update O: O = alpha * O + p @ V
         O      = alpha * O + (p @ V_blk)
@@ -357,10 +366,9 @@ nothing else does:
 
 ## 5. Critical-path unlocks, ranked
 
-1. **Expose reductions (`tile_reduce_sum`, `tile_reduce_max`,
-   `tile_reduce_mean`).** `tile_bcast` is already exposed. Unlocks
-   softmax → unlocks LayerNorm, RMSNorm, attention, MoE gating. Single
-   biggest fan-out for the surface we're missing.
+1. **Fuse cross-tile reductions/accumulation.** Reductions and tile_bcast cover
+   the per-tile pieces, and host-orchestrated cross-tile sum/max work, but
+   softmax and normalization still need a single-kernel path for wide rows.
 2. **Fix matmul accumulator init** ([TODO §1](TODO.md) —
    `D2MToTTKernel` fill-pattern handling). Unlocks multi-K matmul →
    real GEMM, real attention Q×Kᵀ across K, FFN.

--- a/tools/d2m-jit/KERNEL_AUDIT.md
+++ b/tools/d2m-jit/KERNEL_AUDIT.md
@@ -24,7 +24,7 @@ Status legend matches [TODO.md](TODO.md): 🔴 blocker · 🟡 missing surface
 | **Views** (`view`, `view_layout`, `permute`) | ✅ | Metadata reinterpretation, no data movement |
 | `tilize` / `untilize` / `to_layout` | ✅ | Layout conversions |
 | `zeros`, `full`, `empty` | ✅ | Host-side fill + `to_layout` |
-| Float reductions (`reduce_sum`, `reduce_max`, `reduce_mean`) | ✅ | Per-tile row/col reductions using `tile_reduce_*`; same-shape, single-tile collapsed outputs, and host-orchestrated cross-tile sum/max |
+| Reductions (`tile_reduce_*`) | 🔴 | Not exposed in `api.py` |
 | Broadcast (`tile_bcast`) | ✅ | `d2m.tile_bcast`, row/col/2d shorthands, method forms; lit + pytest coverage |
 | In-kernel typecast (`tile_typecast`) | 🔴 | Host-side only via `tilize(dtype=...)` |
 | Per-tile transpose (`tile_transpose`) | 🔴 | Not exposed — but logical permute via views is free |
@@ -83,23 +83,14 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 - **Per-shard outer product / hadamard** patterns.
 - **KV-cache writeback** at a computed index via `remote_store`.
 - **Pointwise quant/dequant** (mul + add + `floor`).
-- **Single-tile reductions:** row/column `sum`, `max`, and `mean` within each
-  32x32 tile. Same-shape result lanes and collapsed one-row/one-column output
-  layouts are supported, and `tile_bcast` expands a reduced lane back to a full
-  tile.
-- **Cross-tile collapsed reductions:** row/column `sum` and `max` can be built
-  as multiple host-orchestrated kernel launches that accumulate one tile at a
-  time into a collapsed output layout. Reducing across multiple cores in one
-  fused kernel is not supported today.
 
 ### 🟡 Buildable with workarounds / scope cuts
 
 - **SDPA at 1-tile granularity** (S ≤ 32, single head): Q×Kᵀ via
-  permute-view + zeros-prefilled matmul + manually composed row softmax from
-  reductions and tile broadcast. Wider rows still need fused cross-tile
-  accumulation.
+  permute-view + zeros-prefilled matmul + softmax… stops at softmax
+  because reductions are missing.
 - **Multi-head attention scaffolding:** per-head views are free; the
-  *compute* hits broadcast and matmul-accumulator limits.
+  *compute* hits the reduction wall.
 - **MoE expert MLP body** (linear + GELU + linear): chained via views,
   but only single-tile shards until the matmul accumulator bug lands.
 - **Embedding lookup:** doable via `remote_load` with computed indices
@@ -107,11 +98,10 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ### 🔴 Blocked on missing pieces
 
-- **Softmax over wide rows** — within-tile pieces exist, but a single fused
-  cross-tile implementation still needs accumulator/state handling.
-- **LayerNorm / RMSNorm / GroupNorm over wide rows** — reduction lanes,
-  collapsed one-tile outputs, tile broadcast, and host-orchestrated cross-tile
-  sum/max exist, but fused cross-tile accumulation is still missing.
+- **Softmax** — needs reductions; broadcast is available. Blocks every
+  attention, MoE-gating, and cross-entropy-loss kernel.
+- **LayerNorm / RMSNorm / GroupNorm** — same: reductions are the
+  remaining blocker; broadcast is available.
 - **Flash Attention** — needs softmax + multi-K matmul accumulation
   ([TODO §1](TODO.md)) + multicast on real grids
   ([TODO §2](TODO.md)) + online-softmax state across blocks.
@@ -124,15 +114,15 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ---
 
-## 4. Concrete kernel sketches with reductions + tile_bcast
+## 4. Concrete kernel sketches with available tile_bcast + proposed reductions
 
-These sketches use the landed reduction API and the existing tile_bcast API:
+These sketches assume reductions with this shape, plus the existing tile_bcast API:
 
 ```python
-# Per-tile reductions: reduce over one tile axis. `dim` follows torch/numpy
-# numbering (`0`/`-2`, `1`/`-1`) and keeps the same tile shape with reduce
-# lanes populated by the hardware op.
-d2m.reduce_sum(x, dim)
+# Per-tile reductions: reduce over the tile's row or col axis. The
+# result is a partial tile (32x1 for dim="col", 1x32 for dim="row"),
+# matching the d2m.tile_reduce_* op semantics.
+d2m.reduce_sum(x, dim)     # dim in {"row", "col"}
 d2m.reduce_max(x, dim)
 d2m.reduce_mean(x, dim)
 
@@ -140,8 +130,9 @@ d2m.reduce_mean(x, dim)
 d2m.tile_bcast(x, bcast_type)  # bcast_type in {"row", "col", "2d"}
 ```
 
-The point of the sketches is the **kernel shape**; exact helper names may still
-be adjusted as the DSL evolves.
+The reduction spelling is a placeholder; the tile_bcast spelling shown here is
+available today. The point of the sketches is the **kernel shape**, not the
+bikeshed.
 
 ### 4.1 Row-wise softmax (within-tile)
 
@@ -158,11 +149,11 @@ def softmax_row(x, out, m_blocks, n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
 
             # Numerically-stable softmax: subtract row max, exp, divide.
-            row_max = reduce_max(t, dim=1)               # 32x1
-            t_shift = t - tile_bcast(row_max, "col")     # 32x32
+            row_max = reduce_max(t, dim="row")           # 32x1
+            t_shift = t - tile_bcast(row_max, "row")     # 32x32
             t_exp   = exp(t_shift)
-            row_sum = reduce_sum(t_exp, dim=1)           # 32x1
-            t_out   = t_exp * tile_bcast(recip(row_sum), "col")
+            row_sum = reduce_sum(t_exp, dim="row")       # 32x1
+            t_out   = t_exp * tile_bcast(recip(row_sum), "row")
 
             remote_store(out, [m_off + m, n_off + n], t_out)
 ```
@@ -185,16 +176,16 @@ def softmax_row_wide(x, out, m_blocks, n_blocks):
         row_max = NEG_INF
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            row_max = maximum(row_max, tile_bcast(reduce_max(t, dim=1),
-                                             "col"))
+            row_max = maximum(row_max, tile_bcast(reduce_max(t, dim="row"),
+                                             "row"))
 
         # Pass 2: row sum of shifted exp.
         row_sum = full_tile(value=0.0)
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
             t_exp = exp(t - row_max)
-            row_sum = row_sum + tile_bcast(reduce_sum(t_exp, dim=1),
-                                      "col")
+            row_sum = row_sum + tile_bcast(reduce_sum(t_exp, dim="row"),
+                                      "row")
         row_inv = recip(row_sum)
 
         # Pass 3: normalise and write back.
@@ -229,8 +220,8 @@ def rmsnorm(x, gamma, out, m_blocks, n_blocks, eps_tile):
         sum_sq = full_tile(value=0.0)
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            sum_sq = sum_sq + tile_bcast(reduce_sum(t * t, dim=1),
-                                    "col")
+            sum_sq = sum_sq + tile_bcast(reduce_sum(t * t, dim="row"),
+                                    "row")
         inv_rms = rsqrt(sum_sq * INV_N + eps_tile)
 
         # Pass 2: scale and write.
@@ -305,16 +296,16 @@ def flash_attn_inner(Q, K, V, O, l_state, m_state, S_q, S_kv, D):
 
         # 2. running max
         m_prev = m_state
-        m_cur  = maximum(m_prev, tile_bcast(reduce_max(s, dim=1),
-                                       "col"))
+        m_cur  = maximum(m_prev, tile_bcast(reduce_max(s, dim="row"),
+                                       "row"))
 
         # 3. correction factor for previous accumulator
         alpha  = exp(m_prev - m_cur)
 
         # 4. exp of shifted scores, partial sum
         p      = exp(s - m_cur)
-        l_cur  = alpha * l_state + tile_bcast(reduce_sum(p, dim=1),
-                                         "col")
+        l_cur  = alpha * l_state + tile_bcast(reduce_sum(p, dim="row"),
+                                         "row")
 
         # 5. update O: O = alpha * O + p @ V
         O      = alpha * O + (p @ V_blk)
@@ -366,10 +357,10 @@ nothing else does:
 
 ## 5. Critical-path unlocks, ranked
 
-1. **Fuse cross-tile reductions/accumulation.** Reductions and tile_bcast cover
-   the per-tile pieces, and host-orchestrated cross-tile sum/max work, but the
-   DSL does not currently support reducing across multiple cores in one fused
-   kernel.
+1. **Expose reductions (`tile_reduce_sum`, `tile_reduce_max`,
+   `tile_reduce_mean`).** `tile_bcast` is already exposed. Unlocks
+   softmax → unlocks LayerNorm, RMSNorm, attention, MoE gating. Single
+   biggest fan-out for the surface we're missing.
 2. **Fix matmul accumulator init** ([TODO §1](TODO.md) —
    `D2MToTTKernel` fill-pattern handling). Unlocks multi-K matmul →
    real GEMM, real attention Q×Kᵀ across K, FFN.

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -134,7 +134,7 @@ on single tile scalars, so elementwise ops in the DSL are wrapped in
 Matmul follows the same pattern but with parallel/parallel/reduction iterators
 over (M, N, K) and `d2m.tile_matmul` in the body (`_matmul_block`).
 Float reductions use `d2m.tile_reduce_*` with an automatically generated
-unit-scaler tensor input (`_reduce_block`).
+device-local scaler generic (`_reduce_block`).
 
 ### Views
 

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -133,6 +133,8 @@ on single tile scalars, so elementwise ops in the DSL are wrapped in
 `linalg.generic` over the tensor of tiles (`_eltwise_block` in `api.py`).
 Matmul follows the same pattern but with parallel/parallel/reduction iterators
 over (M, N, K) and `d2m.tile_matmul` in the body (`_matmul_block`).
+Float reductions use `d2m.tile_reduce_*` with an automatically generated
+unit-scaler tensor input (`_reduce_block`).
 
 ### Views
 
@@ -166,6 +168,7 @@ kernel body.
 | `d2m.empty(layout)` | Allocate an uninitialised device tensor. |
 | `d2m.zeros(layout)` | Allocate a zero-initialised device tensor (host-side `torch.zeros` + `to_layout`). |
 | `d2m.full(layout, value)` | Allocate a device tensor initialised to a scalar `value` (host-side `torch.full` + `to_layout`). |
+| `d2m.reduction_layout(layout, dim, allow_cross_tile=False)` | Build the output layout for a collapsed row/column reduction. Set `allow_cross_tile=True` when the kernel sequence explicitly accumulates across all tiles in the reduced dimension. |
 | `d2m.tilize(lt, dtype=None)` | Convert a `LazyTensor` to a tile-typed (`tiled=True`) layout; optional dtype override. |
 | `d2m.untilize(lt, dtype=None)` | Convert a `LazyTensor` to row-major (`tiled=False`); optional dtype override. |
 | `d2m.view(lt, lambda d0, d1: ...)` | Logical-rank permutation. The lambda's parameter count matches the source's logical rank. Result is a view (`is_view=True`). |
@@ -248,6 +251,58 @@ Tile broadcast:
 | `d2m.tile_bcast_row(x)` / `x.tile_bcast_row()` | No-argument row-broadcast shorthand. |
 | `d2m.tile_bcast_col(x)` / `x.tile_bcast_col()` | No-argument column-broadcast shorthand. |
 | `d2m.tile_bcast_2d(x)` / `x.tile_bcast_2d()` | No-argument row-and-column broadcast shorthand. |
+
+### Float reduction block-level ops
+
+`reduce_sum`, `reduce_max`, and `reduce_mean` are registered as free functions
+and `TensorBlock` methods. The default form keeps the input layout shape and
+places the reduced row/column in the hardware-defined result lanes:
+
+```python
+row_sum = d2m.reduce_sum(x, 1)  # or x.reduce_sum(1)
+col_max = x.reduce_max(0)
+row_avg = x.reduce_mean(-1)
+```
+
+`dim` follows torch/numpy axis numbering for a 2D tile block:
+
+| `dim` | D2M reduce dim | Result lane checked by tests |
+| --- | --- | --- |
+| `0` / `-2` | `#d2m<reduce_dim C>` | `result[0, :]` |
+| `1` / `-1` | `#d2m<reduce_dim R>` | `result[:, 0]` |
+
+The output block has the same tensor-of-tiles shape as the input. These ops are
+float-only (`f32`, `f16`, `bf16`) and use synthetic 1x1 scaler tensors,
+matching the D2M float tile-reduce signature `reduce(a * b, c)`. Sum/max use
+a unit scaler; mean uses a `1/32` scaler for one tile axis.
+
+Collapsed-output forms are also available. When the reduced logical dimension
+fits in a single 32-wide tile, this is a single kernel:
+
+```python
+L_in = d2m.Layout(shape=(64, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[2, 1])
+L_out = d2m.reduction_layout(L_in, 1)  # shape=(64, 1), grid_shape=[2, 1]
+
+@d2m.kernel
+def row_sum_kernel(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, 0], reduce_sum_collapse(x, 1))
+```
+
+The collapsed helpers are `reduce_sum_collapse`, `reduce_max_collapse`, and
+`reduce_mean_collapse`, with matching `TensorBlock` methods.
+
+For cross-tile reductions, use `d2m.reduction_layout(..., allow_cross_tile=True)`
+and accumulate the collapsed per-tile results across multiple kernel launches,
+materializing the accumulator between launches. This is slower than a single
+fused kernel, but it is the path that lowers through the current D2M pipeline.
+A single unified kernel with multiple synchronizing remote loads in different
+loop scopes currently trips `SplitUnifiedThread`, and in-place accumulator
+updates need the accumulator tensor to be passed as a separate input and output.
 
 ### Python operators on `TensorBlock`
 
@@ -363,6 +418,10 @@ have been dropped — the DSL emits the post-legalisation form directly.
   generation that was not passed to `to_host` raises on re-use. If you need
   multiple values out, pass them all to a single `to_host`.
 - **Matmul accumulator is currently undefined.** See the matmul note above.
+- **Float reductions are per tile.** Collapsed-output helpers support
+  single-tile reductions directly. Cross-tile reductions work as multiple
+  host-orchestrated kernel passes; a single fused cross-tile kernel is blocked
+  by current unified-thread lowering limits.
 - **Argument order in a `@kernel` call.** All `LazyTensor` arguments first,
   then any `int` scalar arguments. Mixing raises a `TypeError`. The last
   `num_outs` `LazyTensor`s (default 1) are treated as outputs.
@@ -380,5 +439,5 @@ have been dropped — the DSL emits the post-legalisation form directly.
 ## Known issues / TODO
 
 See [TODO.md](TODO.md) for active pipeline gaps (matmul accumulator init,
-host-scope `linalg.generic`), missing API surface (reductions,
-in-kernel typecast, DMA primitives, ...), and other follow-ups.
+host-scope `linalg.generic`), missing API surface (in-kernel typecast, DMA
+primitives, ...), and other follow-ups.

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -272,7 +272,7 @@ row_avg = x.reduce_mean(-1)
 | `1` / `-1` | `#d2m<reduce_dim R>` | `result[:, 0]` |
 
 The output block has the same tensor-of-tiles shape as the input. These ops are
-float-only (`f32`, `f16`, `bf16`) and use synthetic 1x1 scaler tensors,
+float-only (`f32`, `bf16`) and use a device-local scaler generic,
 matching the D2M float tile-reduce signature `reduce(a * b, c)`. Sum/max use
 a unit scaler; mean uses a `1/32` scaler for one tile axis.
 
@@ -300,9 +300,8 @@ For cross-tile reductions, use `d2m.reduction_layout(..., allow_cross_tile=True)
 and accumulate the collapsed per-tile results across multiple kernel launches,
 materializing the accumulator between launches. This is slower than a single
 fused kernel, but it is the path that lowers through the current D2M pipeline.
-A single unified kernel with multiple synchronizing remote loads in different
-loop scopes currently trips `SplitUnifiedThread`, and in-place accumulator
-updates need the accumulator tensor to be passed as a separate input and output.
+The DSL does not currently support a single fused kernel that accumulates a
+reduction across multiple cores in the reduced dimension.
 
 ### Python operators on `TensorBlock`
 
@@ -420,8 +419,8 @@ have been dropped — the DSL emits the post-legalisation form directly.
 - **Matmul accumulator is currently undefined.** See the matmul note above.
 - **Float reductions are per tile.** Collapsed-output helpers support
   single-tile reductions directly. Cross-tile reductions work as multiple
-  host-orchestrated kernel passes; a single fused cross-tile kernel is blocked
-  by current unified-thread lowering limits.
+  host-orchestrated kernel passes; reducing across multiple cores in one fused
+  kernel is not supported today.
 - **Argument order in a `@kernel` call.** All `LazyTensor` arguments first,
   then any `int` scalar arguments. Mixing raises a `TypeError`. The last
   `num_outs` `LazyTensor`s (default 1) are treated as outputs.

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -168,7 +168,7 @@ kernel body.
 | `d2m.empty(layout)` | Allocate an uninitialised device tensor. |
 | `d2m.zeros(layout)` | Allocate a zero-initialised device tensor (host-side `torch.zeros` + `to_layout`). |
 | `d2m.full(layout, value)` | Allocate a device tensor initialised to a scalar `value` (host-side `torch.full` + `to_layout`). |
-| `d2m.reduction_layout(layout, dim, allow_cross_tile=False)` | Build the output layout for a collapsed row/column reduction. Set `allow_cross_tile=True` when the kernel sequence explicitly accumulates across all tiles in the reduced dimension. |
+| `d2m.reduction_layout(layout, dim, allow_cross_tile=False)` | Build the keepdim output layout for a row/column reduction. Set `allow_cross_tile=True` only when the kernel has a cross-core gather/redistribute strategy for the reduced dimension. |
 | `d2m.tilize(lt, dtype=None)` | Convert a `LazyTensor` to a tile-typed (`tiled=True`) layout; optional dtype override. |
 | `d2m.untilize(lt, dtype=None)` | Convert a `LazyTensor` to row-major (`tiled=False`); optional dtype override. |
 | `d2m.view(lt, lambda d0, d1: ...)` | Logical-rank permutation. The lambda's parameter count matches the source's logical rank. Result is a view (`is_view=True`). |
@@ -255,8 +255,8 @@ Tile broadcast:
 ### Float reduction block-level ops
 
 `reduce_sum`, `reduce_max`, and `reduce_mean` are registered as free functions
-and `TensorBlock` methods. The default form keeps the input layout shape and
-places the reduced row/column in the hardware-defined result lanes:
+and `TensorBlock` methods. They are keepdim reductions: the reduced logical
+dimension becomes size 1 in the destination layout.
 
 ```python
 row_sum = d2m.reduce_sum(x, 1)  # or x.reduce_sum(1)
@@ -266,18 +266,16 @@ row_avg = x.reduce_mean(-1)
 
 `dim` follows torch/numpy axis numbering for a 2D tile block:
 
-| `dim` | D2M reduce dim | Result lane checked by tests |
+| `dim` | D2M reduce dim | Result layout |
 | --- | --- | --- |
-| `0` / `-2` | `#d2m<reduce_dim C>` | `result[0, :]` |
-| `1` / `-1` | `#d2m<reduce_dim R>` | `result[:, 0]` |
+| `0` / `-2` | `#d2m<reduce_dim C>` | `shape[0] == 1` |
+| `1` / `-1` | `#d2m<reduce_dim R>` | `shape[1] == 1` |
 
-The output block has the same tensor-of-tiles shape as the input. These ops are
-float-only (`f32`, `bf16`) and use a device-local scaler generic,
-matching the D2M float tile-reduce signature `reduce(a * b, c)`. Sum/max use
-a unit scaler; mean uses a `1/32` scaler for one tile axis.
+These ops are float-only (`f32`, `bf16`) and use a device-local scaler generic,
+matching the D2M float tile-reduce signature `reduce(a * b, c)`. Sum/max use a
+unit scaler; mean scales by the number of elements reduced in the local block.
 
-Collapsed-output forms are also available. When the reduced logical dimension
-fits in a single 32-wide tile, this is a single kernel:
+Use `d2m.reduction_layout(input_layout, dim)` for the output tensor:
 
 ```python
 L_in = d2m.Layout(shape=(64, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[2, 1])
@@ -290,18 +288,19 @@ def row_sum_kernel(in_t, out_t, m_blocks, n_blocks):
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, 0], reduce_sum_collapse(x, 1))
+            remote_store(out_t, [m_off + m, 0], reduce_sum(x, 1))
 ```
 
-The collapsed helpers are `reduce_sum_collapse`, `reduce_max_collapse`, and
-`reduce_mean_collapse`, with matching `TensorBlock` methods.
+Elementwise ops implicitly broadcast a reduced operand when it is combined with
+an unreduced block, so softmax/layernorm-style code can stay natural:
 
-For cross-tile reductions, use `d2m.reduction_layout(..., allow_cross_tile=True)`
-and accumulate the collapsed per-tile results across multiple kernel launches,
-materializing the accumulator between launches. This is slower than a single
-fused kernel, but it is the path that lowers through the current D2M pipeline.
-The DSL does not currently support a single fused kernel that accumulates a
-reduction across multiple cores in the reduced dimension.
+```python
+y = x - x.reduce_max(1)
+```
+
+Reductions that span multiple cores need a core gather/redistribute op: gather
+partials from the cores that own the reduced dimension, complete the reduction,
+then redistribute the reduced values to the cores that own the output layout.
 
 ### Python operators on `TensorBlock`
 
@@ -417,10 +416,9 @@ have been dropped — the DSL emits the post-legalisation form directly.
   generation that was not passed to `to_host` raises on re-use. If you need
   multiple values out, pass them all to a single `to_host`.
 - **Matmul accumulator is currently undefined.** See the matmul note above.
-- **Float reductions are per tile.** Collapsed-output helpers support
-  single-tile reductions directly. Cross-tile reductions work as multiple
-  host-orchestrated kernel passes; reducing across multiple cores in one fused
-  kernel is not supported today.
+- **Float reductions are per tile/per core.** Use `reduction_layout` for reduced
+  outputs. Reductions spanning multiple cores need a core gather/redistribute
+  op.
 - **Argument order in a `@kernel` call.** All `LazyTensor` arguments first,
   then any `int` scalar arguments. Mixing raises a `TypeError`. The last
   `num_outs` `LazyTensor`s (default 1) are treated as outputs.

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -85,82 +85,22 @@ These ops live in `D2MGenericRegionOps.td` but are not yet exposed in
 so we add ops when we have something to test against rather than
 speculatively.
 
-### 🟡 Reductions (scoped — float blocked, int viable)
+### 🟡 Bespoke-signature ops (need design)
 
-`tile_reduce_sum`, `tile_reduce_max`, `tile_reduce_mean` (float) and
-`tile_sfpu_reduce_sum`, `tile_sfpu_reduce_max` (int).
+| op | why it's interesting | what's blocking |
+| --- | --- | --- |
+| `tile_clamp_scalar(x, min, max)` | clamp with attribute (not operand) bounds | needs `FloatAttr` / `IntegerAttr` threading through `_eltwise_block`, plus a wrapper that picks the attr type from the tile's underlying dtype |
+| `tile_typecast(x)` | in-kernel dtype conversion (host-side already covered by `tilize(dtype=...)`) | needs an `_eltwise_block` variant that takes a target element type different from the input |
+| `tile_transpose(x)` | per-tile (32×32) element transpose -- distinct from logical `permute` / `view` | naming question — collides with `permute` / `view` semantics if called `transpose` |
 
-**Locked V1 design** (deferred behind blockers below):
+### 🟡 Reduction follow-ups
 
-- Free functions `reduce_sum / reduce_max / reduce_mean(block, dim)`
-  reducing along numpy-style axis (`dim=0 → R`, `dim=1 → C`).
-- Two flavours per op: same-shape broadcast-back (default, for
-  `x - x.max(dim, keepdims=True)`-style softmax/layernorm prefixes) and
-  `*_collapse` (output axis collapsed to a single tile).
-- Float vs int auto-dispatch via tile-element-type inspection.
-- Multi-dim (RC) reduction deferred — call twice if needed.
-- Anchor test: softmax-prefix `exp(x - max(x))` on a single shard.
-
-#### Blocker A: float reductions need a scaler `b` operand
-
-`tile_reduce_*` (float) signature is `(a, b, c, dim) -> reduce(a*b)+c`.
-TTIR-to-D2M lowering supplies `b` as a separate 1×1-tile **tensor input**
-to the outer `d2m.GenericOp`, built by a *separate* `d2m.GenericOp` whose
-body fills the tile with `1.0` via `tile_fill`. The scaler is loaded into
-the reduce kernel via `remote_load(scaler, [0, 0])`.
-
-#### Blocker B: inline `tile_fill` in the reduce body fails to lower
-
-Attempted shortcut: emit `tile_fill(1.0)` and `tile_reduce_sum` as
-sibling ops inside the same `linalg.generic` body, so no host-side
-scaler tensor is needed. Builds clean IR but `D2MToTTKernel` cannot fold
-the resulting conversion cast:
-
-```
-error: failed to legalize unresolved materialization from
-  ('memref<4x!ttcore.tile<32x32, f32>, #ttcore.memory_space<dst>>')
-  to ('index')
-  that remained live after conversion
-```
-
-Root cause: `D2MTileFillRewriter` replaces the tile_fill result with a
-DST-register index, but the reduce rewriter's `getCB(op.getB())` call
-expects `b` to be a CB-backed tile (not a DST tile). Same family as the
-matmul accumulator init bug above.
-
-#### What V1 would actually cost
-
-If we go with the host-allocated scaler (the only path that lowers
-today):
-
-1. Walk the kernel AST at call time and detect `reduce_*` calls.
-2. Auto-host-allocate a 1×1-grid scaler tensor via
-   `d2m.full((32, 32), 1.0)`.
-3. Append the scaler to the outer `d2m.GenericOp` inputs and to the
-   inner kernel func signature as a synthetic argument.
-4. Inside the reduce primitive, emit `remote_load(scaler, [0, 0])`
-   once at body entry and cache the resulting tile (re-used across
-   multiple reduce calls in the same kernel).
-5. Plumb compiler state (thread-local or `D2MCompiler.symbol_tables`
-   sentinel) so the primitive can find the scaler from inside
-   `visit_Call`.
-6. Handle dtype matching (scaler must match the input tile's float
-   dtype: f32 vs bf16 vs f16).
-
-Estimated cost: **2–3 days** of DSL plumbing. Plus risk: the
-`remote_load(scaler, [0, 0])` from a >1×1 grid is structurally a
-multicast read from shard (0,0), which exercises the same path that
-SplitUnifiedThread blows up on (see TODO above). So grid>1×1 float
-reductions are likely blocked behind the same compiler bug.
-
-#### Recommended near-term
-
-- Land int-only `reduce_sum / reduce_max` via `tile_sfpu_reduce_*` (no
-  scaler). ~30 min of work. Provides the API shape for users to mirror.
-- Defer float reductions until either (a) `D2MToTTKernel` accepts a
-  tile_fill-produced `b` operand directly (Blocker B fix), or (b) the
-  scaler plumbing in the DSL is worth the 2–3 day investment.
-- Defer softmax/layernorm anchor tests until float lands.
+- Integer reductions via `tile_sfpu_reduce_sum` / `tile_sfpu_reduce_max`.
+- Fused cross-tile or multi-dim (RC) reductions. Cross-tile sum/max are
+  expressible today as multiple host-orchestrated kernel launches using
+  `reduction_layout(..., allow_cross_tile=True)`, but a single unified kernel
+  with multiple reduction loads still trips `SplitUnifiedThread`, and in-place
+  accumulator updates must pass the accumulator as both an input and output.
 
 ### 🟡 Lower-level kernel primitives (advanced)
 
@@ -209,38 +149,19 @@ debugging kernel bodies; would need a thin wrapper that emits
 
 ## Documentation / DX
 
-### 🟢 Lit-side IR-shape FileCheck tests
+### 🟢 More lit-side IR-shape FileCheck tests
 
-`test/d2m-jit/lit/` now has coverage for captures, error paths,
-pattern rewrites, and broadcast lowering. Worth expanding that into
-lit + FileCheck tests that dump pre-pipeline IR (the builder already
-supports `print_ir_before_pipeline`) and check the shape of more DSL
-primitives — this locks down the IR contract without going to silicon.
-
-Sketch:
-
-```python
-# RUN: %python %s | FileCheck %s
-# REQUIRES: d2m-jit
-import d2m_jit as d2m
-import torch
-d2m.config.print_ir_before_pipeline = True
-t = torch.zeros(64, 64)
-L = d2m.Layout(shape=(64,64), dtype=d2m.float32, block_shape=[1,1], grid_shape=[2,2])
-try:
-    d2m.to_layout(t, L).to_host()
-except Exception:
-    pass  # don't actually run on device
-# CHECK: d2m.to_layout
-# CHECK: d2m.view_layout
-# CHECK: return
-```
+`test/d2m-jit/lit/` now has no-device coverage for captures, error formatting,
+broadcast lowering, and reduction IR shape. More FileCheck tests would still be
+useful for views, layout conversion, multi-output kernels, and representative
+elementwise chains so the emitted IR contract is locked down without going to
+silicon.
 
 ### 🟢 More worked examples
 
-The README's "At a glance" has eltwise add. Multi-output, reductions,
-and views-into-kernel examples would help newcomers. Defer until the
-reduction / multi-output paths exist.
+The README's "At a glance" has eltwise add and the reductions section now has
+collapsed-output snippets. Multi-output and views-into-kernel examples would
+still help newcomers.
 
 ### 🟢 `_eltwise_block` as a public helper
 
@@ -253,15 +174,5 @@ and document it.
 
 ## Internal cleanup
 
-### 🟢 `_BUILDER._instance` lifecycle
-
-The builder is a class-level singleton. Test files reset it manually
-(`_b._Builder.reset()`) in a few places to avoid contamination across
-test functions. The `conftest.py::_set_seed` fixture could also reset
-the builder per-test for hygiene.
-
-### 🟢 Stale `_fill_block_value` reference
-
-The `_matmul_block` TODO mentions a host-scope fill prototype that no
-longer exists in the code. Update the comment when the gap above is
-resolved, or rephrase to be implementation-agnostic.
+No active cleanup-only items. Keep this section for small hygiene tasks that
+do not fit the pipeline/API sections above.

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -88,11 +88,10 @@ speculatively.
 ### 🟡 Reduction follow-ups
 
 - Integer reductions via `tile_sfpu_reduce_sum` / `tile_sfpu_reduce_max`.
-- Fused cross-tile or multi-dim (RC) reductions. Cross-tile sum/max are
-  expressible today as multiple host-orchestrated kernel launches using
-  `reduction_layout(..., allow_cross_tile=True)`, but the DSL does not
-  currently support a single fused kernel that accumulates across multiple
-  cores in the reduced dimension.
+- Cross-core or multi-dim (RC) reductions. Reductions spanning multiple cores
+  need a core gather/redistribute op that can collect partials from the cores
+  that own the reduced dimension and place the reduced values on the
+  output-owning cores.
 
 ### 🟡 Lower-level kernel primitives (advanced)
 

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -85,14 +85,6 @@ These ops live in `D2MGenericRegionOps.td` but are not yet exposed in
 so we add ops when we have something to test against rather than
 speculatively.
 
-### 🟡 Bespoke-signature ops (need design)
-
-| op | why it's interesting | what's blocking |
-| --- | --- | --- |
-| `tile_clamp_scalar(x, min, max)` | clamp with attribute (not operand) bounds | needs `FloatAttr` / `IntegerAttr` threading through `_eltwise_block`, plus a wrapper that picks the attr type from the tile's underlying dtype |
-| `tile_typecast(x)` | in-kernel dtype conversion (host-side already covered by `tilize(dtype=...)`) | needs an `_eltwise_block` variant that takes a target element type different from the input |
-| `tile_transpose(x)` | per-tile (32×32) element transpose -- distinct from logical `permute` / `view` | naming question — collides with `permute` / `view` semantics if called `transpose` |
-
 ### 🟡 Reduction follow-ups
 
 - Integer reductions via `tile_sfpu_reduce_sum` / `tile_sfpu_reduce_max`.
@@ -149,19 +141,38 @@ debugging kernel bodies; would need a thin wrapper that emits
 
 ## Documentation / DX
 
-### 🟢 More lit-side IR-shape FileCheck tests
+### 🟢 Lit-side IR-shape FileCheck tests
 
-`test/d2m-jit/lit/` now has no-device coverage for captures, error formatting,
-broadcast lowering, and reduction IR shape. More FileCheck tests would still be
-useful for views, layout conversion, multi-output kernels, and representative
-elementwise chains so the emitted IR contract is locked down without going to
-silicon.
+`test/d2m-jit/lit/` now has coverage for captures, error paths,
+pattern rewrites, and broadcast lowering. Worth expanding that into
+lit + FileCheck tests that dump pre-pipeline IR (the builder already
+supports `print_ir_before_pipeline`) and check the shape of more DSL
+primitives — this locks down the IR contract without going to silicon.
+
+Sketch:
+
+```python
+# RUN: %python %s | FileCheck %s
+# REQUIRES: d2m-jit
+import d2m_jit as d2m
+import torch
+d2m.config.print_ir_before_pipeline = True
+t = torch.zeros(64, 64)
+L = d2m.Layout(shape=(64,64), dtype=d2m.float32, block_shape=[1,1], grid_shape=[2,2])
+try:
+    d2m.to_layout(t, L).to_host()
+except Exception:
+    pass  # don't actually run on device
+# CHECK: d2m.to_layout
+# CHECK: d2m.view_layout
+# CHECK: return
+```
 
 ### 🟢 More worked examples
 
-The README's "At a glance" has eltwise add and the reductions section now has
-collapsed-output snippets. Multi-output and views-into-kernel examples would
-still help newcomers.
+The README's "At a glance" has eltwise add. Multi-output, reductions,
+and views-into-kernel examples would help newcomers. Defer until the
+reduction / multi-output paths exist.
 
 ### 🟢 `_eltwise_block` as a public helper
 
@@ -174,5 +185,15 @@ and document it.
 
 ## Internal cleanup
 
-No active cleanup-only items. Keep this section for small hygiene tasks that
-do not fit the pipeline/API sections above.
+### 🟢 `_BUILDER._instance` lifecycle
+
+The builder is a class-level singleton. Test files reset it manually
+(`_b._Builder.reset()`) in a few places to avoid contamination across
+test functions. The `conftest.py::_set_seed` fixture could also reset
+the builder per-test for hygiene.
+
+### 🟢 Stale `_fill_block_value` reference
+
+The `_matmul_block` TODO mentions a host-scope fill prototype that no
+longer exists in the code. Update the comment when the gap above is
+resolved, or rephrase to be implementation-agnostic.

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -98,9 +98,9 @@ speculatively.
 - Integer reductions via `tile_sfpu_reduce_sum` / `tile_sfpu_reduce_max`.
 - Fused cross-tile or multi-dim (RC) reductions. Cross-tile sum/max are
   expressible today as multiple host-orchestrated kernel launches using
-  `reduction_layout(..., allow_cross_tile=True)`, but a single unified kernel
-  with multiple reduction loads still trips `SplitUnifiedThread`, and in-place
-  accumulator updates must pass the accumulator as both an input and output.
+  `reduction_layout(..., allow_cross_tile=True)`, but the DSL does not
+  currently support a single fused kernel that accumulates across multiple
+  cores in the reduced dimension.
 
 ### 🟡 Lower-level kernel primitives (advanced)
 

--- a/tools/d2m-jit/_src/ast.py
+++ b/tools/d2m-jit/_src/ast.py
@@ -516,45 +516,48 @@ class D2MCompiler(ast.NodeVisitor):
         if isinstance(rhs, OpView):
             rhs = rhs.result
 
-        if lhs.type != rhs.type:
-            rhs = _cast(rhs, lhs.type)
-        assert lhs.type == rhs.type, f"{lhs.type} != {rhs.type}"
         mlir_type = _get_type_str(lhs.type)
 
-        def qualified_or(attr, otherwise, *args, **kwargs):
-            fn = self._fn_map.get(f"{mlir_type}.{attr}", otherwise)
-            return fn(*args, **kwargs)
+        def qualified_or(attr, otherwise):
+            fn = self._fn_map.get(f"{mlir_type}.{attr}")
+            if fn is not None:
+                return fn(lhs, rhs)
+            cast_rhs = rhs
+            if lhs.type != cast_rhs.type:
+                cast_rhs = _cast(cast_rhs, lhs.type)
+            assert lhs.type == cast_rhs.type, f"{lhs.type} != {cast_rhs.type}"
+            return otherwise(lhs, cast_rhs)
 
         def unimplemented(*args, **kwargs):
             raise NotImplementedError(f"{node.op} not implemented")
 
         match (node.op):
             case ast.Add():
-                return qualified_or("__add__", arith.addi, lhs, rhs)
+                return qualified_or("__add__", arith.addi)
             case ast.Sub():
-                return qualified_or("__sub__", arith.subi, lhs, rhs)
+                return qualified_or("__sub__", arith.subi)
             case ast.Mult():
-                return qualified_or("__mul__", arith.muli, lhs, rhs)
+                return qualified_or("__mul__", arith.muli)
             case ast.Div():
-                return qualified_or("__truediv__", unimplemented, lhs, rhs)
+                return qualified_or("__truediv__", unimplemented)
             case ast.MatMult():
-                return qualified_or("__matmul__", unimplemented, lhs, rhs)
+                return qualified_or("__matmul__", unimplemented)
             case ast.FloorDiv():
-                return qualified_or("__floordiv__", arith.divsi, lhs, rhs)
+                return qualified_or("__floordiv__", arith.divsi)
             case ast.Mod():
-                return qualified_or("__mod__", arith.remsi, lhs, rhs)
+                return qualified_or("__mod__", arith.remsi)
             case ast.Pow():
-                return qualified_or("__pow__", unimplemented, lhs, rhs)
+                return qualified_or("__pow__", unimplemented)
             case ast.LShift():
-                return qualified_or("__lshift__", arith.shli, lhs, rhs)
+                return qualified_or("__lshift__", arith.shli)
             case ast.RShift():
-                return qualified_or("__rshift__", arith.shrsi, lhs, rhs)
+                return qualified_or("__rshift__", arith.shrsi)
             case ast.BitOr():
-                return qualified_or("__or__", arith.ori, lhs, rhs)
+                return qualified_or("__or__", arith.ori)
             case ast.BitAnd():
-                return qualified_or("__and__", arith.andi, lhs, rhs)
+                return qualified_or("__and__", arith.andi)
             case ast.BitXor():
-                return qualified_or("__xor__", arith.xori, lhs, rhs)
+                return qualified_or("__xor__", arith.xori)
             case _:
                 raise NotImplementedError(
                     f"Binary operator {type(node.op).__name__} not implemented"

--- a/tools/d2m-jit/_src/ast.py
+++ b/tools/d2m-jit/_src/ast.py
@@ -561,10 +561,6 @@ class D2MCompiler(ast.NodeVisitor):
                 )
 
     def visit_UnaryOp(self, node):
-        as_attr = getattr(node, "_ttkernel_as_attr", False)
-        if callable(as_attr):
-            return as_attr(node)
-
         if (
             isinstance(node.op, ast.USub)
             and isinstance(node.operand, ast.Constant)

--- a/tools/d2m-jit/_src/ast.py
+++ b/tools/d2m-jit/_src/ast.py
@@ -19,6 +19,7 @@ from .errors import D2mJitError, closest_match
 from .utils import _discover_dialect_ops, _cast, _get_type_str
 from .tensor_layout import Layout
 
+
 _D2M_KERNEL_TYPES = {None, "datamovement", "noc", "compute", "unified"}
 
 
@@ -33,7 +34,6 @@ class D2MCompiler(ast.NodeVisitor):
 
     # Populated at import time by the @syntax decorator.
     _syntax = {}
-    _current = None
 
     _SUPPORTED_NODES = (
         # Variables
@@ -106,9 +106,6 @@ class D2MCompiler(ast.NodeVisitor):
         source_file=None,
         source_firstlineno=None,
         source_lines=None,
-        synthetic_args=None,
-        synthetic_arg_insert_index=None,
-        synthetic_reduce_scalers=None,
         **kwargs,
     ):
         assert kernel_type in _D2M_KERNEL_TYPES, f"Invalid kernel type {kernel_type}"
@@ -117,11 +114,6 @@ class D2MCompiler(ast.NodeVisitor):
         self.kernel_type = kernel_type
         self.captures = captures if captures is not None else {}
         self.args = args
-        self.synthetic_args = list(synthetic_args or [])
-        self.synthetic_arg_insert_index = synthetic_arg_insert_index
-        self.synthetic_symbol_table = {}
-        self.synthetic_reduce_scalers = dict(synthetic_reduce_scalers or {})
-        self.reduce_scaler_cache = {}
 
         # Source metadata used to build D2mJitError messages and to pin each
         # emitted op to a file_line_col Location.
@@ -143,10 +135,6 @@ class D2MCompiler(ast.NodeVisitor):
         self.symbol_tables = []
         self.supported_nodes = list(self._SUPPORTED_NODES)
         self._fn_map = dict(self._syntax)
-
-    @classmethod
-    def current(cls):
-        return cls._current
 
     # --- Error / source-location helpers ----------------------------------
 
@@ -194,17 +182,6 @@ class D2MCompiler(ast.NodeVisitor):
             names.update(tbl.keys())
         return names
 
-    def get_synthetic_arg(self, name):
-        return self.synthetic_symbol_table.get(name)
-
-    def get_synthetic_reduce_scaler(self, base_name, tile_element_type):
-        actual_name = self.synthetic_reduce_scalers.get(
-            (base_name, str(tile_element_type))
-        )
-        if actual_name is None:
-            return None
-        return self.get_synthetic_arg(actual_name)
-
     def _hint_for_function(self, name):
         match = closest_match(name, self._fn_map.keys())
         return f"did you mean `{match}`?" if match else None
@@ -245,8 +222,6 @@ class D2MCompiler(ast.NodeVisitor):
         params = inspect.signature(visitor).parameters
         filtered_kwargs = {k: v for k, v in kwargs.items() if k in params}
         loc = self._mlir_loc(node)
-        prev_current = D2MCompiler._current
-        D2MCompiler._current = self
         try:
             with loc:
                 if filtered_kwargs:
@@ -257,8 +232,6 @@ class D2MCompiler(ast.NodeVisitor):
             raise
         except Exception as orig:
             raise self._format_error(node, orig) from orig
-        finally:
-            D2MCompiler._current = prev_current
 
     # --- Module / function entry ------------------------------------------
 
@@ -271,13 +244,8 @@ class D2MCompiler(ast.NodeVisitor):
         assert not self.func_entry, "Cannot declare function within a function"
 
         func_operand_types = []
-        func_arg_names = []
-        user_arg_idx = 0
-        synthetic_insert_idx = self.synthetic_arg_insert_index
-        if synthetic_insert_idx is None:
-            synthetic_insert_idx = len(node.args.args)
-
-        def append_arg(arg_name, rt_arg, synthetic=False):
+        for i, arg in enumerate(node.args.args):
+            rt_arg = self.args[i]
             if isinstance(rt_arg, Layout):
                 func_operand_types.append(
                     rt_arg.build_device_tensor_type(self.ctx, blocked=True)
@@ -286,24 +254,8 @@ class D2MCompiler(ast.NodeVisitor):
                 func_operand_types.append(IndexType.get(self.ctx))
             else:
                 raise TypeError(
-                    f"Unknown kernel argument type {type(rt_arg)} for argument "
-                    f"{arg_name}"
+                    f"Unknown kernel argument type {type(rt_arg)} for argument {arg.arg}"
                 )
-            func_arg_names.append((arg_name, synthetic))
-
-        for i, arg in enumerate(node.args.args):
-            if i == synthetic_insert_idx:
-                for synthetic_name, synthetic_layout in self.synthetic_args:
-                    append_arg(synthetic_name, synthetic_layout, synthetic=True)
-            rt_arg = self.args[user_arg_idx]
-            user_arg_idx += 1
-            append_arg(arg.arg, rt_arg)
-
-        if synthetic_insert_idx >= len(node.args.args):
-            for synthetic_name, synthetic_layout in self.synthetic_args:
-                append_arg(synthetic_name, synthetic_layout, synthetic=True)
-
-        assert user_arg_idx == len(self.args)
 
         self.func_entry = func.FuncOp(name=node.name, type=(func_operand_types, []))
         self.func_entry.attributes[d2m.ir.ThreadAttr.name] = d2m.ir.ThreadAttr.get(
@@ -312,11 +264,8 @@ class D2MCompiler(ast.NodeVisitor):
 
         self.symbol_tables.append({})
         func_bb = self.func_entry.add_entry_block()
-        for (arg_name, synthetic), bb_arg in zip(func_arg_names, func_bb.arguments):
-            if synthetic:
-                self.synthetic_symbol_table[arg_name] = bb_arg
-            else:
-                self.symbol_tables[-1][arg_name] = bb_arg
+        for i, bb_arg in enumerate(func_bb.arguments):
+            self.symbol_tables[-1][node.args.args[i].arg] = bb_arg
         self.module_symbol_table = SymbolTable(self.module.operation)
 
         with InsertionPoint(func_bb):

--- a/tools/d2m-jit/_src/ast.py
+++ b/tools/d2m-jit/_src/ast.py
@@ -19,7 +19,6 @@ from .errors import D2mJitError, closest_match
 from .utils import _discover_dialect_ops, _cast, _get_type_str
 from .tensor_layout import Layout
 
-
 _D2M_KERNEL_TYPES = {None, "datamovement", "noc", "compute", "unified"}
 
 
@@ -34,6 +33,7 @@ class D2MCompiler(ast.NodeVisitor):
 
     # Populated at import time by the @syntax decorator.
     _syntax = {}
+    _current = None
 
     _SUPPORTED_NODES = (
         # Variables
@@ -106,6 +106,9 @@ class D2MCompiler(ast.NodeVisitor):
         source_file=None,
         source_firstlineno=None,
         source_lines=None,
+        synthetic_args=None,
+        synthetic_arg_insert_index=None,
+        synthetic_reduce_scalers=None,
         **kwargs,
     ):
         assert kernel_type in _D2M_KERNEL_TYPES, f"Invalid kernel type {kernel_type}"
@@ -114,6 +117,11 @@ class D2MCompiler(ast.NodeVisitor):
         self.kernel_type = kernel_type
         self.captures = captures if captures is not None else {}
         self.args = args
+        self.synthetic_args = list(synthetic_args or [])
+        self.synthetic_arg_insert_index = synthetic_arg_insert_index
+        self.synthetic_symbol_table = {}
+        self.synthetic_reduce_scalers = dict(synthetic_reduce_scalers or {})
+        self.reduce_scaler_cache = {}
 
         # Source metadata used to build D2mJitError messages and to pin each
         # emitted op to a file_line_col Location.
@@ -135,6 +143,10 @@ class D2MCompiler(ast.NodeVisitor):
         self.symbol_tables = []
         self.supported_nodes = list(self._SUPPORTED_NODES)
         self._fn_map = dict(self._syntax)
+
+    @classmethod
+    def current(cls):
+        return cls._current
 
     # --- Error / source-location helpers ----------------------------------
 
@@ -182,6 +194,17 @@ class D2MCompiler(ast.NodeVisitor):
             names.update(tbl.keys())
         return names
 
+    def get_synthetic_arg(self, name):
+        return self.synthetic_symbol_table.get(name)
+
+    def get_synthetic_reduce_scaler(self, base_name, tile_element_type):
+        actual_name = self.synthetic_reduce_scalers.get(
+            (base_name, str(tile_element_type))
+        )
+        if actual_name is None:
+            return None
+        return self.get_synthetic_arg(actual_name)
+
     def _hint_for_function(self, name):
         match = closest_match(name, self._fn_map.keys())
         return f"did you mean `{match}`?" if match else None
@@ -222,6 +245,8 @@ class D2MCompiler(ast.NodeVisitor):
         params = inspect.signature(visitor).parameters
         filtered_kwargs = {k: v for k, v in kwargs.items() if k in params}
         loc = self._mlir_loc(node)
+        prev_current = D2MCompiler._current
+        D2MCompiler._current = self
         try:
             with loc:
                 if filtered_kwargs:
@@ -232,6 +257,8 @@ class D2MCompiler(ast.NodeVisitor):
             raise
         except Exception as orig:
             raise self._format_error(node, orig) from orig
+        finally:
+            D2MCompiler._current = prev_current
 
     # --- Module / function entry ------------------------------------------
 
@@ -244,8 +271,13 @@ class D2MCompiler(ast.NodeVisitor):
         assert not self.func_entry, "Cannot declare function within a function"
 
         func_operand_types = []
-        for i, arg in enumerate(node.args.args):
-            rt_arg = self.args[i]
+        func_arg_names = []
+        user_arg_idx = 0
+        synthetic_insert_idx = self.synthetic_arg_insert_index
+        if synthetic_insert_idx is None:
+            synthetic_insert_idx = len(node.args.args)
+
+        def append_arg(arg_name, rt_arg, synthetic=False):
             if isinstance(rt_arg, Layout):
                 func_operand_types.append(
                     rt_arg.build_device_tensor_type(self.ctx, blocked=True)
@@ -254,8 +286,24 @@ class D2MCompiler(ast.NodeVisitor):
                 func_operand_types.append(IndexType.get(self.ctx))
             else:
                 raise TypeError(
-                    f"Unknown kernel argument type {type(rt_arg)} for argument {arg.arg}"
+                    f"Unknown kernel argument type {type(rt_arg)} for argument "
+                    f"{arg_name}"
                 )
+            func_arg_names.append((arg_name, synthetic))
+
+        for i, arg in enumerate(node.args.args):
+            if i == synthetic_insert_idx:
+                for synthetic_name, synthetic_layout in self.synthetic_args:
+                    append_arg(synthetic_name, synthetic_layout, synthetic=True)
+            rt_arg = self.args[user_arg_idx]
+            user_arg_idx += 1
+            append_arg(arg.arg, rt_arg)
+
+        if synthetic_insert_idx >= len(node.args.args):
+            for synthetic_name, synthetic_layout in self.synthetic_args:
+                append_arg(synthetic_name, synthetic_layout, synthetic=True)
+
+        assert user_arg_idx == len(self.args)
 
         self.func_entry = func.FuncOp(name=node.name, type=(func_operand_types, []))
         self.func_entry.attributes[d2m.ir.ThreadAttr.name] = d2m.ir.ThreadAttr.get(
@@ -264,8 +312,11 @@ class D2MCompiler(ast.NodeVisitor):
 
         self.symbol_tables.append({})
         func_bb = self.func_entry.add_entry_block()
-        for i, bb_arg in enumerate(func_bb.arguments):
-            self.symbol_tables[-1][node.args.args[i].arg] = bb_arg
+        for (arg_name, synthetic), bb_arg in zip(func_arg_names, func_bb.arguments):
+            if synthetic:
+                self.synthetic_symbol_table[arg_name] = bb_arg
+            else:
+                self.symbol_tables[-1][arg_name] = bb_arg
         self.module_symbol_table = SymbolTable(self.module.operation)
 
         with InsertionPoint(func_bb):
@@ -425,6 +476,9 @@ class D2MCompiler(ast.NodeVisitor):
             # generalises to any AST shape the callable wants to handle.
             as_attr = getattr(arg, "_ttkernel_as_attr", False)
             if callable(as_attr):
+                signature = inspect.signature(as_attr)
+                if len(signature.parameters) == 2:
+                    return as_attr(arg, self)
                 return as_attr(arg)
             v = self.visit(arg)
             if v is None:
@@ -558,6 +612,18 @@ class D2MCompiler(ast.NodeVisitor):
                 )
 
     def visit_UnaryOp(self, node):
+        as_attr = getattr(node, "_ttkernel_as_attr", False)
+        if callable(as_attr):
+            return as_attr(node)
+
+        if (
+            isinstance(node.op, ast.USub)
+            and isinstance(node.operand, ast.Constant)
+            and isinstance(node.operand.value, int)
+            and not isinstance(node.operand.value, bool)
+        ):
+            return arith.ConstantOp(IndexType.get(self.ctx), -node.operand.value)
+
         operand = self.visit(node.operand)
         if not operand:
             raise ValueError("Unary operand not found")

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -44,6 +44,7 @@ from .errors import D2mJitError
 from .tensor_layout import Layout
 from .utils import _cleanup_source_code
 
+
 # Reverse of ttcore.DataType for picking output torch dtypes.
 _TTCORE_TO_TORCH = None  # lazy-init since torch may be missing
 
@@ -147,29 +148,6 @@ _PIPELINE = ",".join(
         "d2m-emitc-pipeline",
     ]
 )
-
-_REDUCE_UNIT_SCALER_ARG = "__d2m_reduce_unit_scaler"
-_REDUCE_MEAN_SCALER_ARG = "__d2m_reduce_mean_scaler"
-_REDUCE_MEAN_COLLAPSE_SCALER_ARG = "__d2m_reduce_mean_collapse_scaler"
-_FLOAT_REDUCTION_NAMES = {
-    "reduce_sum",
-    "reduce_max",
-    "reduce_mean",
-    "reduce_sum_collapse",
-    "reduce_max_collapse",
-    "reduce_mean_collapse",
-}
-_FLOAT_SUM_MAX_REDUCTION_NAMES = {
-    "reduce_sum",
-    "reduce_max",
-    "reduce_sum_collapse",
-    "reduce_max_collapse",
-}
-_FLOAT_MEAN_REDUCTION_NAMES = {"reduce_mean"}
-
-
-def reduce_mean_collapse_scaler_arg_name(dim: int, tile_count: int) -> str:
-    return f"{_REDUCE_MEAN_COLLAPSE_SCALER_ARG}_{dim}_{tile_count}"
 
 
 # --- Scope abstraction ------------------------------------------------------
@@ -988,28 +966,6 @@ def _affine_map_from_lambda(fn):
     return AffineMap.get(len(dims), 0, exprs), spec
 
 
-def _kernel_float_reductions(kernel_ast):
-    class _ReductionUseVisitor(_ast.NodeVisitor):
-        def __init__(self):
-            self.names = set()
-
-        def visit_Call(self, node):
-            if isinstance(node.func, _ast.Name):
-                name = node.func.id
-            elif isinstance(node.func, _ast.Attribute):
-                name = node.func.attr
-            else:
-                name = None
-
-            if name in _FLOAT_REDUCTION_NAMES:
-                self.names.add(name)
-            self.generic_visit(node)
-
-    visitor = _ReductionUseVisitor()
-    visitor.visit(kernel_ast)
-    return visitor.names
-
-
 def _emit_kernel_generic(
     kernel: "CompiledKernel",
     args,
@@ -1080,55 +1036,6 @@ def _emit_kernel_generic(
     input_lts = lazy_args[: len(lazy_args) - num_outs]
     output_lts = lazy_args[len(lazy_args) - num_outs :]
 
-    synthetic_lts = []
-    synthetic_args = []
-    synthetic_reduce_scalers = {}
-    reduction_names = _kernel_float_reductions(kernel._ast)
-    if reduction_names:
-        if not input_lts:
-            raise _call_error(
-                "float reductions require at least one input tensor argument",
-                cause=ValueError(),
-            )
-
-        def add_scaler(base_name, value, input_layout):
-            scaler_layout = Layout(
-                shape=(32, 32),
-                dtype=input_layout.dtype,
-                block_shape=[1, 1],
-                grid_shape=[1, 1],
-                tiled=True,
-                collapse=input_layout.collapse,
-                mem_space=input_layout.mem_space,
-            )
-            with b.ctx, b.loc:
-                tile_element_type = scaler_layout.build_device_tensor_type(
-                    b.ctx, blocked=True
-                ).element_type
-            key = (base_name, str(tile_element_type))
-            if key in synthetic_reduce_scalers:
-                return
-            name = f"{base_name}_{len(synthetic_reduce_scalers)}"
-            # For tiled layouts, full() emits a device-side tile_fill generic.
-            # The scaler then enters the reduction kernel as a normal tensor
-            # input, which lowers to the CB-backed operand reduce_tile expects.
-            synthetic_lts.append(full(scaler_layout, value)._resolve())
-            synthetic_args.append((name, scaler_layout))
-            synthetic_reduce_scalers[key] = name
-
-        for input_lt in input_lts:
-            if reduction_names & _FLOAT_SUM_MAX_REDUCTION_NAMES:
-                add_scaler(_REDUCE_UNIT_SCALER_ARG, 1.0, input_lt.layout)
-            if reduction_names & _FLOAT_MEAN_REDUCTION_NAMES:
-                add_scaler(_REDUCE_MEAN_SCALER_ARG, 1.0 / 32.0, input_lt.layout)
-            if "reduce_mean_collapse" in reduction_names:
-                for dim, tile_count in enumerate(input_lt.layout.block_shape):
-                    add_scaler(
-                        reduce_mean_collapse_scaler_arg_name(dim, tile_count),
-                        1.0 / (32.0 * tile_count),
-                        input_lt.layout,
-                    )
-
     # Compile the kernel body in the current builder's context. D2MCompiler
     # picks up b.ctx via get_default_loc_context.
     with b.ctx, b.loc:
@@ -1141,9 +1048,6 @@ def _emit_kernel_generic(
             source_file=kernel._source_file,
             source_firstlineno=kernel._source_firstlineno,
             source_lines=kernel._source_lines,
-            synthetic_args=synthetic_args,
-            synthetic_arg_insert_index=len(input_lts),
-            synthetic_reduce_scalers=synthetic_reduce_scalers,
         )
         compiler.visit(kernel._ast)
         compiler.module.operation.verify()
@@ -1153,7 +1057,7 @@ def _emit_kernel_generic(
         # Scalars are sourced from func args (not host-scope constants) so the
         # GenericOp's region stays isolated-from-above.
         additional = [b.add_scalar_input(s) for s in scalar_args]
-        inputs = [lt.value for lt in input_lts] + [lt.value for lt in synthetic_lts]
+        inputs = [lt.value for lt in input_lts]
         outputs = [lt.value for lt in output_lts]
         output_types = [v.type for v in outputs]
 

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -587,8 +587,8 @@ def reduction_layout(layout: Layout, dim, allow_cross_tile: bool = False) -> Lay
     """Return the output layout for a collapsed per-tile reduction.
 
     The DSL's collapsed float reductions can reduce across all tiles contained
-    in one per-core block. Reductions spanning multiple blocks in the reduced
-    dimension still require explicit cross-block accumulation.
+    on one core. Reductions spanning multiple cores in the reduced dimension
+    still require explicit cross-core accumulation.
     """
     rank = len(layout.logical_shape)
     if dim < 0:
@@ -600,10 +600,10 @@ def reduction_layout(layout: Layout, dim, allow_cross_tile: bool = False) -> Lay
     if layout.blocked_grid_shape[dim] > 1 and not allow_cross_tile:
         raise ValueError(
             "collapsed reductions only support a reduced logical dimension "
-            "that fits in one per-core block; got "
-            f"{layout.blocked_grid_shape[dim]} blocks along dimension {dim}. "
+            "that fits on one core; got "
+            f"{layout.blocked_grid_shape[dim]} cores along dimension {dim}. "
             "Pass allow_cross_tile=True when the kernel explicitly accumulates "
-            "across all blocks in the reduced dimension."
+            "across all cores in the reduced dimension."
         )
 
     shape = list(layout.logical_shape)

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -583,11 +583,12 @@ def zeros(layout: Layout) -> LazyTensor:
 
 
 def reduction_layout(layout: Layout, dim, allow_cross_tile: bool = False) -> Layout:
-    """Return the output layout for a collapsed per-tile reduction.
+    """Return the output layout for a keepdim per-tile reduction.
 
-    The DSL's collapsed float reductions can reduce across all tiles contained
-    on one core. Reductions spanning multiple cores in the reduced dimension
-    still require explicit cross-core accumulation.
+    The DSL's float reductions can reduce across all tiles contained on one
+    core. Reductions spanning multiple cores in the reduced dimension need a
+    core gather/redistribute op to collect partials and place reduced values on
+    the output-owning cores.
     """
     rank = len(layout.logical_shape)
     if dim < 0:
@@ -601,8 +602,8 @@ def reduction_layout(layout: Layout, dim, allow_cross_tile: bool = False) -> Lay
             "collapsed reductions only support a reduced logical dimension "
             "that fits on one core; got "
             f"{layout.grid_shape[dim]} cores along dimension {dim}. "
-            "Pass allow_cross_tile=True when the kernel explicitly accumulates "
-            "across all cores in the reduced dimension."
+            "Pass allow_cross_tile=True only when the kernel has an explicit "
+            "cross-core gather/redistribute strategy for the reduced dimension."
         )
 
     shape = list(layout.logical_shape)

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -44,7 +44,6 @@ from .errors import D2mJitError
 from .tensor_layout import Layout
 from .utils import _cleanup_source_code
 
-
 # Reverse of ttcore.DataType for picking output torch dtypes.
 _TTCORE_TO_TORCH = None  # lazy-init since torch may be missing
 
@@ -597,11 +596,11 @@ def reduction_layout(layout: Layout, dim, allow_cross_tile: bool = False) -> Lay
         raise ValueError(
             f"reduce dim must be in range [-{rank}, {rank - 1}], got {dim}"
         )
-    if layout.blocked_grid_shape[dim] > 1 and not allow_cross_tile:
+    if layout.grid_shape[dim] > 1 and not allow_cross_tile:
         raise ValueError(
             "collapsed reductions only support a reduced logical dimension "
             "that fits on one core; got "
-            f"{layout.blocked_grid_shape[dim]} cores along dimension {dim}. "
+            f"{layout.grid_shape[dim]} cores along dimension {dim}. "
             "Pass allow_cross_tile=True when the kernel explicitly accumulates "
             "across all cores in the reduced dimension."
         )

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -44,7 +44,6 @@ from .errors import D2mJitError
 from .tensor_layout import Layout
 from .utils import _cleanup_source_code
 
-
 # Reverse of ttcore.DataType for picking output torch dtypes.
 _TTCORE_TO_TORCH = None  # lazy-init since torch may be missing
 
@@ -148,6 +147,29 @@ _PIPELINE = ",".join(
         "d2m-emitc-pipeline",
     ]
 )
+
+_REDUCE_UNIT_SCALER_ARG = "__d2m_reduce_unit_scaler"
+_REDUCE_MEAN_SCALER_ARG = "__d2m_reduce_mean_scaler"
+_REDUCE_MEAN_COLLAPSE_SCALER_ARG = "__d2m_reduce_mean_collapse_scaler"
+_FLOAT_REDUCTION_NAMES = {
+    "reduce_sum",
+    "reduce_max",
+    "reduce_mean",
+    "reduce_sum_collapse",
+    "reduce_max_collapse",
+    "reduce_mean_collapse",
+}
+_FLOAT_SUM_MAX_REDUCTION_NAMES = {
+    "reduce_sum",
+    "reduce_max",
+    "reduce_sum_collapse",
+    "reduce_max_collapse",
+}
+_FLOAT_MEAN_REDUCTION_NAMES = {"reduce_mean"}
+
+
+def reduce_mean_collapse_scaler_arg_name(dim: int, tile_count: int) -> str:
+    return f"{_REDUCE_MEAN_COLLAPSE_SCALER_ARG}_{dim}_{tile_count}"
 
 
 # --- Scope abstraction ------------------------------------------------------
@@ -583,6 +605,38 @@ def zeros(layout: Layout) -> LazyTensor:
     return full(layout, 0)
 
 
+def reduction_layout(layout: Layout, dim, allow_cross_tile: bool = False) -> Layout:
+    """Return the output layout for a collapsed per-tile reduction.
+
+    The DSL's collapsed float reductions can reduce across all tiles contained
+    in one per-core block. Reductions spanning multiple blocks in the reduced
+    dimension still require explicit cross-block accumulation.
+    """
+    rank = len(layout.logical_shape)
+    if dim < 0:
+        dim += rank
+    if dim < 0 or dim >= rank:
+        raise ValueError(
+            f"reduce dim must be in range [-{rank}, {rank - 1}], got {dim}"
+        )
+    if layout.blocked_grid_shape[dim] > 1 and not allow_cross_tile:
+        raise ValueError(
+            "collapsed reductions only support a reduced logical dimension "
+            "that fits in one per-core block; got "
+            f"{layout.blocked_grid_shape[dim]} blocks along dimension {dim}. "
+            "Pass allow_cross_tile=True when the kernel explicitly accumulates "
+            "across all blocks in the reduced dimension."
+        )
+
+    shape = list(layout.logical_shape)
+    block_shape = list(layout.block_shape)
+    grid_shape = list(layout.grid_shape)
+    shape[dim] = 1
+    block_shape[dim] = 1
+    grid_shape[dim] = 1
+    return layout.replace(shape=shape, block_shape=block_shape, grid_shape=grid_shape)
+
+
 def _derive_perm_layout(src_layout: Layout, spec):
     """If `spec` (from _affine_map_from_lambda) describes a clean permutation
     of paired (grid, tile) dims, return a Layout with logical_shape/
@@ -934,6 +988,28 @@ def _affine_map_from_lambda(fn):
     return AffineMap.get(len(dims), 0, exprs), spec
 
 
+def _kernel_float_reductions(kernel_ast):
+    class _ReductionUseVisitor(_ast.NodeVisitor):
+        def __init__(self):
+            self.names = set()
+
+        def visit_Call(self, node):
+            if isinstance(node.func, _ast.Name):
+                name = node.func.id
+            elif isinstance(node.func, _ast.Attribute):
+                name = node.func.attr
+            else:
+                name = None
+
+            if name in _FLOAT_REDUCTION_NAMES:
+                self.names.add(name)
+            self.generic_visit(node)
+
+    visitor = _ReductionUseVisitor()
+    visitor.visit(kernel_ast)
+    return visitor.names
+
+
 def _emit_kernel_generic(
     kernel: "CompiledKernel",
     args,
@@ -1004,6 +1080,55 @@ def _emit_kernel_generic(
     input_lts = lazy_args[: len(lazy_args) - num_outs]
     output_lts = lazy_args[len(lazy_args) - num_outs :]
 
+    synthetic_lts = []
+    synthetic_args = []
+    synthetic_reduce_scalers = {}
+    reduction_names = _kernel_float_reductions(kernel._ast)
+    if reduction_names:
+        if not input_lts:
+            raise _call_error(
+                "float reductions require at least one input tensor argument",
+                cause=ValueError(),
+            )
+
+        def add_scaler(base_name, value, input_layout):
+            scaler_layout = Layout(
+                shape=(32, 32),
+                dtype=input_layout.dtype,
+                block_shape=[1, 1],
+                grid_shape=[1, 1],
+                tiled=True,
+                collapse=input_layout.collapse,
+                mem_space=input_layout.mem_space,
+            )
+            with b.ctx, b.loc:
+                tile_element_type = scaler_layout.build_device_tensor_type(
+                    b.ctx, blocked=True
+                ).element_type
+            key = (base_name, str(tile_element_type))
+            if key in synthetic_reduce_scalers:
+                return
+            name = f"{base_name}_{len(synthetic_reduce_scalers)}"
+            # For tiled layouts, full() emits a device-side tile_fill generic.
+            # The scaler then enters the reduction kernel as a normal tensor
+            # input, which lowers to the CB-backed operand reduce_tile expects.
+            synthetic_lts.append(full(scaler_layout, value)._resolve())
+            synthetic_args.append((name, scaler_layout))
+            synthetic_reduce_scalers[key] = name
+
+        for input_lt in input_lts:
+            if reduction_names & _FLOAT_SUM_MAX_REDUCTION_NAMES:
+                add_scaler(_REDUCE_UNIT_SCALER_ARG, 1.0, input_lt.layout)
+            if reduction_names & _FLOAT_MEAN_REDUCTION_NAMES:
+                add_scaler(_REDUCE_MEAN_SCALER_ARG, 1.0 / 32.0, input_lt.layout)
+            if "reduce_mean_collapse" in reduction_names:
+                for dim, tile_count in enumerate(input_lt.layout.block_shape):
+                    add_scaler(
+                        reduce_mean_collapse_scaler_arg_name(dim, tile_count),
+                        1.0 / (32.0 * tile_count),
+                        input_lt.layout,
+                    )
+
     # Compile the kernel body in the current builder's context. D2MCompiler
     # picks up b.ctx via get_default_loc_context.
     with b.ctx, b.loc:
@@ -1016,6 +1141,9 @@ def _emit_kernel_generic(
             source_file=kernel._source_file,
             source_firstlineno=kernel._source_firstlineno,
             source_lines=kernel._source_lines,
+            synthetic_args=synthetic_args,
+            synthetic_arg_insert_index=len(input_lts),
+            synthetic_reduce_scalers=synthetic_reduce_scalers,
         )
         compiler.visit(kernel._ast)
         compiler.module.operation.verify()
@@ -1025,7 +1153,7 @@ def _emit_kernel_generic(
         # Scalars are sourced from func args (not host-scope constants) so the
         # GenericOp's region stays isolated-from-above.
         additional = [b.add_scalar_input(s) for s in scalar_args]
-        inputs = [lt.value for lt in input_lts]
+        inputs = [lt.value for lt in input_lts] + [lt.value for lt in synthetic_lts]
         outputs = [lt.value for lt in output_lts]
         output_types = [v.type for v in outputs]
 

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -1229,7 +1229,7 @@ def _float_scalar_type_for_tile(tile_type):
     if data_type == int(ttcore.DataType.BFloat16):
         return BF16Type.get(ctx)
     raise TypeError(
-        "float reductions require f32 or bf16 tile element types; " f"got {tile_type}"
+        f"float reductions require f32 or bf16 tile element types; got {tile_type}"
     )
 
 

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -40,6 +40,7 @@ from ._src.rewrite import (
 
 TileBcastType = d2m.TileBcastType
 _REDUCTION_SCALER_ATTR = "d2m.reduction_scaler"
+_REDUCED_AXES_ATTR = "d2m.reduced_axes"
 
 
 def _parse_tile_bcast_type(value):
@@ -581,7 +582,11 @@ def tile_bcast(input, bcast_type):
     input, with each tile expanded according to `bcast_type`.
     """
     tile_bcast_type = _parse_tile_bcast_type(bcast_type)
-    return _eltwise_block(lambda t: d2m.tile_bcast(t.type, t, tile_bcast_type), input)
+    return _eltwise_block(
+        lambda t: d2m.tile_bcast(t.type, t, tile_bcast_type),
+        input,
+        preserve_reduced_axes=False,
+    )
 
 
 @syntax("tile_bcast_row")
@@ -655,7 +660,9 @@ def reduce_sum(input, dim):
     """Block-level float sum reduction over one tile axis.
 
     `dim` follows torch/numpy axis numbering for a 2D tile block:
-    `0` reduces rows and `1` reduces columns.
+    `0` reduces rows and `1` reduces columns. The output keeps the reduced
+    dimension logically reduced; elementwise ops broadcast it back when it is
+    combined with an unreduced block.
     """
     return _reduce_block(
         lambda a, b, c, reduce_dim: d2m.tile_reduce_sum(a.type, a, b, c, reduce_dim),
@@ -663,6 +670,7 @@ def reduce_sum(input, dim):
         dim,
         1.0,
         0.0,
+        reduce_block_axis=True,
     )
 
 
@@ -671,7 +679,9 @@ def reduce_max(input, dim):
     """Block-level float max reduction over one tile axis.
 
     `dim` follows torch/numpy axis numbering for a 2D tile block:
-    `0` reduces rows and `1` reduces columns.
+    `0` reduces rows and `1` reduces columns. The output keeps the reduced
+    dimension logically reduced; elementwise ops broadcast it back when it is
+    combined with an unreduced block.
     """
     return _reduce_block(
         lambda a, b, c, reduce_dim: d2m.tile_reduce_max(a.type, a, b, c, reduce_dim),
@@ -679,6 +689,7 @@ def reduce_max(input, dim):
         dim,
         1.0,
         float("-inf"),
+        reduce_block_axis=True,
     )
 
 
@@ -687,51 +698,10 @@ def reduce_mean(input, dim):
     """Block-level float mean reduction over one tile axis.
 
     `dim` follows torch/numpy axis numbering for a 2D tile block:
-    `0` reduces rows and `1` reduces columns.
+    `0` reduces rows and `1` reduces columns. The output keeps the reduced
+    dimension logically reduced; elementwise ops broadcast it back when it is
+    combined with an unreduced block.
     """
-    return _reduce_block(
-        lambda a, b, c, reduce_dim: d2m.tile_reduce_mean(a.type, a, b, c, reduce_dim),
-        input,
-        dim,
-        1.0 / 32.0,
-        0.0,
-    )
-
-
-@syntax("reduce_sum_collapse", args_as_attr=[False, _int_attr_from_ast])
-def reduce_sum_collapse(input, dim):
-    """Block-level sum reduction for collapsed output layouts.
-
-    This reduces within each tile and across the reduced tile axis of the
-    local block. Pair it with a destination layout from
-    `d2m.reduction_layout(input_layout, dim)`.
-    """
-    return _reduce_block(
-        lambda a, b, c, reduce_dim: d2m.tile_reduce_sum(a.type, a, b, c, reduce_dim),
-        input,
-        dim,
-        1.0,
-        0.0,
-        collapse=True,
-    )
-
-
-@syntax("reduce_max_collapse", args_as_attr=[False, _int_attr_from_ast])
-def reduce_max_collapse(input, dim):
-    """Block-level max reduction for collapsed output layouts."""
-    return _reduce_block(
-        lambda a, b, c, reduce_dim: d2m.tile_reduce_max(a.type, a, b, c, reduce_dim),
-        input,
-        dim,
-        1.0,
-        float("-inf"),
-        collapse=True,
-    )
-
-
-@syntax("reduce_mean_collapse", args_as_attr=[False, _int_attr_from_ast])
-def reduce_mean_collapse(input, dim):
-    """Block-level mean reduction for collapsed output layouts."""
     rank = input.type.rank
     reduce_axis = _normalize_reduce_axis(dim, rank)
     tile_count = input.type.shape[reduce_axis]
@@ -741,7 +711,7 @@ def reduce_mean_collapse(input, dim):
         dim,
         1.0 / (32.0 * tile_count),
         0.0,
-        collapse=True,
+        reduce_block_axis=True,
     )
 
 
@@ -1045,18 +1015,6 @@ class TensorBlock:
         """Same as `d2m.reduce_mean(self, dim)`."""
         return reduce_mean(ast_self, dim)
 
-    def reduce_sum_collapse(ast_self: TensorBlock, dim) -> TensorBlock:
-        """Same as `d2m.reduce_sum_collapse(self, dim)`."""
-        return reduce_sum_collapse(ast_self, dim)
-
-    def reduce_max_collapse(ast_self: TensorBlock, dim) -> TensorBlock:
-        """Same as `d2m.reduce_max_collapse(self, dim)`."""
-        return reduce_max_collapse(ast_self, dim)
-
-    def reduce_mean_collapse(ast_self: TensorBlock, dim) -> TensorBlock:
-        """Same as `d2m.reduce_mean_collapse(self, dim)`."""
-        return reduce_mean_collapse(ast_self, dim)
-
     def store(ast_self: TensorBlock, rhs: TensorBlock) -> TensorBlock:
         return d2m.store(ast_self, rhs)
 
@@ -1082,11 +1040,62 @@ class Semaphore:
 # --- Block-level eltwise helper -------------------------------------------
 
 
-def _eltwise_block(tile_op_fn, *blocks):
+def _get_reduced_axes(value):
+    owner = getattr(value, "owner", None)
+    if owner is None:
+        return frozenset()
+    try:
+        attr = owner.attributes[_REDUCED_AXES_ATTR]
+    except Exception:
+        return frozenset()
+    return frozenset(IntegerAttr(axis).value for axis in ArrayAttr(attr))
+
+
+def _set_reduced_axes(value, axes):
+    if axes:
+        value.owner.attributes[_REDUCED_AXES_ATTR] = ArrayAttr.get(
+            [IntegerAttr.get(IntegerType.get_signless(64), axis) for axis in axes]
+        )
+
+
+def _broadcast_indexing_map(rank, input_shape, output_shape):
+    exprs = []
+    for axis, (input_dim, output_dim) in enumerate(zip(input_shape, output_shape)):
+        if input_dim == output_dim:
+            exprs.append(AffineDimExpr.get(axis))
+        elif input_dim == 1:
+            exprs.append(AffineConstantExpr.get(0))
+        else:
+            raise ValueError(
+                f"cannot broadcast dimension {axis}: {input_dim} to {output_dim}"
+            )
+    return AffineMap.get(rank, 0, exprs)
+
+
+def _broadcast_block_shape(blocks):
+    rank = blocks[0].type.rank
+    output_shape = []
+    for axis in range(rank):
+        dims = [block.type.shape[axis] for block in blocks]
+        dim = max(dims)
+        if any(input_dim not in (1, dim) for input_dim in dims):
+            raise ValueError(f"input block shapes are not broadcast-compatible: {dims}")
+        output_shape.append(dim)
+    return output_shape
+
+
+def _common_reduced_axes(blocks):
+    axes = [_get_reduced_axes(block) for block in blocks]
+    if axes and all(axis_set == axes[0] for axis_set in axes):
+        return axes[0]
+    return frozenset()
+
+
+def _eltwise_block(tile_op_fn, *blocks, preserve_reduced_axes=True):
     """Wrap an N-ary per-tile op inside a `linalg.generic` over tensors of
     tiles.
 
-    All `blocks` must have the same tensor type. `tile_op_fn` is called
+    All `blocks` must have broadcast-compatible tensor types. `tile_op_fn` is called
     with the scalar (tile-typed) values for each input and must return
     the scalar output value (or an OpView whose .result is the value).
 
@@ -1104,23 +1113,33 @@ def _eltwise_block(tile_op_fn, *blocks):
     if not blocks:
         raise ValueError("_eltwise_block requires at least one input block")
     block_ty = blocks[0].type
+    rank = block_ty.rank
+    elem_ty = block_ty.element_type
     for b in blocks[1:]:
-        if b.type != block_ty:
+        if b.type.rank != rank or b.type.element_type != elem_ty:
             raise ValueError(
                 f"_eltwise_block: input block type mismatch: {b.type} vs {block_ty}"
             )
-    rank = block_ty.rank
-    elem_ty = block_ty.element_type
+    output_shape = _broadcast_block_shape(blocks)
+    output_ty = RankedTensorType.get(output_shape, elem_ty)
 
-    output = d2m.empty(block_ty)
+    output = d2m.empty(output_ty)
     identity = AffineMap.get_identity(rank)
     n_args = len(blocks) + 1  # one input map per block + one output map
-    indexing_maps = ArrayAttr.get([AffineMapAttr.get(identity)] * n_args)
+    indexing_maps = ArrayAttr.get(
+        [
+            AffineMapAttr.get(
+                _broadcast_indexing_map(rank, block.type.shape, output_shape)
+            )
+            for block in blocks
+        ]
+        + [AffineMapAttr.get(identity)]
+    )
     parallel = Attribute.parse("#linalg.iterator_type<parallel>")
     iterator_types = ArrayAttr.get([parallel] * rank)
 
     generic = linalg.GenericOp(
-        [block_ty],
+        [output_ty],
         list(blocks),
         [output],
         indexing_maps,
@@ -1130,10 +1149,19 @@ def _eltwise_block(tile_op_fn, *blocks):
     body_arg_locs = [Location.unknown()] * n_args
     body = Block.create_at_start(generic.regions[0], body_arg_tys, body_arg_locs)
     with InsertionPoint(body):
-        result = tile_op_fn(*body.arguments[: len(blocks)])
+        args = []
+        common_reduced_axes = _common_reduced_axes(blocks)
+        for block, arg in zip(blocks, body.arguments[: len(blocks)]):
+            for axis in sorted(_get_reduced_axes(block) - common_reduced_axes):
+                bcast = d2m.tile_bcast(arg.type, arg, _reduce_axis_to_bcast_type(axis))
+                arg = bcast.result if hasattr(bcast, "result") else bcast
+            args.append(arg)
+        result = tile_op_fn(*args)
         if hasattr(result, "result"):
             result = result.result
         linalg.yield_([result])
+    if preserve_reduced_axes:
+        _set_reduced_axes(generic.result, common_reduced_axes)
     return generic.result
 
 
@@ -1247,7 +1275,7 @@ def _tile_fill_float(tile_type, value):
     return d2m.tile_fill(tile_type, scalar)
 
 
-def _collapse_input_map(rank, reduce_axis, reduce_index):
+def _reduction_input_map(rank, reduce_axis, reduce_index):
     exprs = []
     for axis in range(rank):
         if axis == reduce_axis:
@@ -1255,6 +1283,14 @@ def _collapse_input_map(rank, reduce_axis, reduce_index):
         else:
             exprs.append(AffineDimExpr.get(axis))
     return AffineMap.get(rank, 0, exprs)
+
+
+def _reduce_axis_to_bcast_type(reduce_axis):
+    if reduce_axis == 0:
+        return Attribute.parse("#d2m<tile_bcast_type row>")
+    if reduce_axis == 1:
+        return Attribute.parse("#d2m<tile_bcast_type col>")
+    raise ValueError(f"reduce axis must be 0 or 1, got {reduce_axis}")
 
 
 def _reduction_scaler_block(output_ty, scaler_value):
@@ -1285,7 +1321,7 @@ def _reduction_scaler_block(output_ty, scaler_value):
     return generic.result
 
 
-def _reduce_block_collapse_explicit(
+def _reduce_block_axis_explicit(
     tile_op_fn,
     input,
     scaler_value,
@@ -1304,7 +1340,7 @@ def _reduce_block_collapse_explicit(
 
     tile_count = block_ty.shape[reduce_axis]
     indexing_maps = [
-        AffineMapAttr.get(_collapse_input_map(rank, reduce_axis, reduce_index))
+        AffineMapAttr.get(_reduction_input_map(rank, reduce_axis, reduce_index))
         for reduce_index in range(tile_count)
     ]
     indexing_maps.append(AffineMapAttr.get(AffineMap.get_identity(rank)))
@@ -1331,16 +1367,20 @@ def _reduce_block_collapse_explicit(
             if hasattr(accumulator, "result"):
                 accumulator = accumulator.result
         linalg.yield_([accumulator])
+    _set_reduced_axes(generic.result, {reduce_axis})
 
     return generic.result
 
 
-def _reduce_block(tile_op_fn, input, dim, scaler_value, identity_value, collapse=False):
+def _reduce_block(
+    tile_op_fn, input, dim, scaler_value, identity_value, reduce_block_axis=False
+):
     """Wrap a float d2m.tile_reduce_* op in a per-block linalg.generic.
 
-    Non-collapsed reductions keep the same block shape as `input` and reduce
-    within each tile. Collapsed reductions shrink the reduced block dimension
-    to 1 and accumulate across all tiles in that local block dimension.
+    Reductions shrink the reduced block dimension to 1 and accumulate across all
+    tiles in that local block dimension. When the reduced axis is inside a
+    single tile, the tensor shape may be unchanged, so the result is also marked
+    with `_REDUCED_AXES_ATTR` for later implicit elementwise broadcasting.
     """
     block_ty = input.type
     if not isinstance(block_ty, RankedTensorType):
@@ -1351,8 +1391,8 @@ def _reduce_block(tile_op_fn, input, dim, scaler_value, identity_value, collapse
     reduce_axis = _normalize_reduce_axis(dim, rank)
     reduce_dim = _dim_to_reduce_dim_attr(dim)
 
-    if collapse and block_ty.shape[reduce_axis] > 1:
-        return _reduce_block_collapse_explicit(
+    if reduce_block_axis and block_ty.shape[reduce_axis] > 1:
+        return _reduce_block_axis_explicit(
             tile_op_fn,
             input,
             scaler_value,
@@ -1394,6 +1434,7 @@ def _reduce_block(tile_op_fn, input, dim, scaler_value, identity_value, collapse
         if hasattr(result, "result"):
             result = result.result
         linalg.yield_([result])
+    _set_reduced_axes(generic.result, {reduce_axis})
     return generic.result
 
 

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -10,7 +10,7 @@ from ttmlir.ir import *
 from ttmlir.dialects import d2m, ttcore, arith, linalg
 
 from ._src.utils import _asindex
-from ._src.ast import D2MCompiler, syntax
+from ._src.ast import syntax
 from ._src.config import config
 from ._src.errors import D2mJitError
 from ._src.tensor_layout import Layout, float32, float16, bfloat16, _to_data_type
@@ -29,9 +29,6 @@ from ._src.builder import (
     view,
     permute,
     to_host,
-    _REDUCE_MEAN_SCALER_ARG,
-    _REDUCE_UNIT_SCALER_ARG,
-    reduce_mean_collapse_scaler_arg_name,
 )
 from ._src.rewrite import (
     pattern,
@@ -42,6 +39,7 @@ from ._src.rewrite import (
 )
 
 TileBcastType = d2m.TileBcastType
+_REDUCTION_SCALER_ATTR = "d2m.reduction_scaler"
 
 
 def _parse_tile_bcast_type(value):
@@ -657,7 +655,7 @@ def reduce_sum(input, dim):
         lambda a, b, c, reduce_dim: d2m.tile_reduce_sum(a.type, a, b, c, reduce_dim),
         input,
         dim,
-        _REDUCE_UNIT_SCALER_ARG,
+        1.0,
         0.0,
     )
 
@@ -673,7 +671,7 @@ def reduce_max(input, dim):
         lambda a, b, c, reduce_dim: d2m.tile_reduce_max(a.type, a, b, c, reduce_dim),
         input,
         dim,
-        _REDUCE_UNIT_SCALER_ARG,
+        1.0,
         float("-inf"),
     )
 
@@ -689,7 +687,7 @@ def reduce_mean(input, dim):
         lambda a, b, c, reduce_dim: d2m.tile_reduce_mean(a.type, a, b, c, reduce_dim),
         input,
         dim,
-        _REDUCE_MEAN_SCALER_ARG,
+        1.0 / 32.0,
         0.0,
     )
 
@@ -706,7 +704,7 @@ def reduce_sum_collapse(input, dim):
         lambda a, b, c, reduce_dim: d2m.tile_reduce_sum(a.type, a, b, c, reduce_dim),
         input,
         dim,
-        _REDUCE_UNIT_SCALER_ARG,
+        1.0,
         0.0,
         collapse=True,
     )
@@ -719,7 +717,7 @@ def reduce_max_collapse(input, dim):
         lambda a, b, c, reduce_dim: d2m.tile_reduce_max(a.type, a, b, c, reduce_dim),
         input,
         dim,
-        _REDUCE_UNIT_SCALER_ARG,
+        1.0,
         float("-inf"),
         collapse=True,
     )
@@ -735,7 +733,7 @@ def reduce_mean_collapse(input, dim):
         lambda a, b, c, reduce_dim: d2m.tile_reduce_mean(a.type, a, b, c, reduce_dim),
         input,
         dim,
-        reduce_mean_collapse_scaler_arg_name(reduce_axis, tile_count),
+        1.0 / (32.0 * tile_count),
         0.0,
         collapse=True,
     )
@@ -1162,7 +1160,6 @@ def _typecast_block(input, dtype):
     output = d2m.empty(out_block_ty)
     identity = AffineMap.get_identity(rank)
     indexing_maps = ArrayAttr.get([AffineMapAttr.get(identity)] * 2)
-
     parallel = Attribute.parse("#linalg.iterator_type<parallel>")
     iterator_types = ArrayAttr.get([parallel] * rank)
 
@@ -1229,13 +1226,10 @@ def _float_scalar_type_for_tile(tile_type):
     data_type = tile_type.data_type_as_int
     if data_type == int(ttcore.DataType.Float32):
         return F32Type.get(ctx)
-    if data_type == int(ttcore.DataType.Float16):
-        return F16Type.get(ctx)
     if data_type == int(ttcore.DataType.BFloat16):
         return BF16Type.get(ctx)
     raise TypeError(
-        "float reductions require f32, f16, or bf16 tile element types; "
-        f"got {tile_type}"
+        "float reductions require f32 or bf16 tile element types; " f"got {tile_type}"
     )
 
 
@@ -1244,39 +1238,6 @@ def _tile_fill_float(tile_type, value):
     scalar_attr = FloatAttr.get(scalar_type, value)
     scalar = arith.ConstantOp(scalar_type, scalar_attr).result
     return d2m.tile_fill(tile_type, scalar)
-
-
-def _get_reduce_scaler_block(input_block, scaler_arg_name):
-    compiler = D2MCompiler.current()
-    if compiler is None:
-        raise RuntimeError(
-            "reduce_sum/reduce_max/reduce_mean can only be used inside @kernel"
-        )
-
-    key = (
-        scaler_arg_name,
-        str(input_block.type.element_type),
-        id(InsertionPoint.current.block),
-    )
-    cached = compiler.reduce_scaler_cache.get(key)
-    if cached is not None:
-        return cached
-
-    scaler = compiler.get_synthetic_reduce_scaler(
-        scaler_arg_name, input_block.type.element_type
-    )
-    if scaler is None:
-        raise RuntimeError("internal error: missing synthetic reduction scaler")
-
-    zero = arith.ConstantOp(IndexType.get(scaler.context), 0).result
-    scaler_block = remote_load(scaler, [zero, zero])
-    if scaler_block.type.element_type != input_block.type.element_type:
-        raise TypeError(
-            "reduction scaler tile type mismatch: "
-            f"{scaler_block.type.element_type} vs {input_block.type.element_type}"
-        )
-    compiler.reduce_scaler_cache[key] = scaler_block
-    return scaler_block
 
 
 def _collapse_input_map(rank, reduce_axis, reduce_index):
@@ -1289,10 +1250,38 @@ def _collapse_input_map(rank, reduce_axis, reduce_index):
     return AffineMap.get(rank, 0, exprs)
 
 
+def _reduction_scaler_block(output_ty, scaler_value):
+    rank = output_ty.rank
+    elem_ty = output_ty.element_type
+    output = d2m.empty(output_ty)
+    output.owner.attributes[_REDUCTION_SCALER_ATTR] = UnitAttr.get(output.context)
+    identity = AffineMap.get_identity(rank)
+    parallel = Attribute.parse("#linalg.iterator_type<parallel>")
+    iterator_types = ArrayAttr.get([parallel] * rank)
+
+    generic = linalg.GenericOp(
+        [output_ty],
+        [],
+        [output],
+        ArrayAttr.get([AffineMapAttr.get(identity)]),
+        iterator_types,
+    )
+    body = Block.create_at_start(
+        generic.regions[0],
+        [elem_ty],
+        [Location.unknown()],
+    )
+    with InsertionPoint(body):
+        scaler_tile = _tile_fill_float(elem_ty, scaler_value)
+        linalg.yield_([scaler_tile])
+
+    return generic.result
+
+
 def _reduce_block_collapse_explicit(
     tile_op_fn,
     input,
-    scaler,
+    scaler_value,
     reduce_axis,
     reduce_dim,
     identity_value,
@@ -1304,17 +1293,14 @@ def _reduce_block_collapse_explicit(
     output_shape[reduce_axis] = 1
     output_ty = RankedTensorType.get(output_shape, elem_ty)
     output = d2m.empty(output_ty)
+    scaler = _reduction_scaler_block(output_ty, scaler_value)
 
     tile_count = block_ty.shape[reduce_axis]
-    zero = AffineConstantExpr.get(0)
-    scaler_rank = scaler.type.rank
     indexing_maps = [
         AffineMapAttr.get(_collapse_input_map(rank, reduce_axis, reduce_index))
         for reduce_index in range(tile_count)
     ]
-    indexing_maps.append(
-        AffineMapAttr.get(AffineMap.get(rank, 0, [zero] * scaler_rank))
-    )
+    indexing_maps.append(AffineMapAttr.get(AffineMap.get_identity(rank)))
     indexing_maps.append(AffineMapAttr.get(AffineMap.get_identity(rank)))
 
     parallel = Attribute.parse("#linalg.iterator_type<parallel>")
@@ -1342,9 +1328,7 @@ def _reduce_block_collapse_explicit(
     return generic.result
 
 
-def _reduce_block(
-    tile_op_fn, input, dim, scaler_arg_name, identity_value, collapse=False
-):
+def _reduce_block(tile_op_fn, input, dim, scaler_value, identity_value, collapse=False):
     """Wrap a float d2m.tile_reduce_* op in a per-block linalg.generic.
 
     Non-collapsed reductions keep the same block shape as `input` and reduce
@@ -1359,13 +1343,12 @@ def _reduce_block(
     elem_ty = block_ty.element_type
     reduce_axis = _normalize_reduce_axis(dim, rank)
     reduce_dim = _dim_to_reduce_dim_attr(dim)
-    scaler = _get_reduce_scaler_block(input, scaler_arg_name)
 
     if collapse and block_ty.shape[reduce_axis] > 1:
         return _reduce_block_collapse_explicit(
             tile_op_fn,
             input,
-            scaler,
+            scaler_value,
             reduce_axis,
             reduce_dim,
             identity_value,
@@ -1373,13 +1356,12 @@ def _reduce_block(
 
     output_ty = block_ty
     output = d2m.empty(output_ty)
+    scaler = _reduction_scaler_block(output_ty, scaler_value)
     identity = AffineMap.get_identity(rank)
-    zero = AffineConstantExpr.get(0)
-    scaler_map = AffineMap.get(rank, 0, [zero, zero])
     indexing_maps = ArrayAttr.get(
         [
             AffineMapAttr.get(identity),
-            AffineMapAttr.get(scaler_map),
+            AffineMapAttr.get(identity),
             AffineMapAttr.get(identity),
         ]
     )

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -24,10 +24,14 @@ from ._src.builder import (
     empty,
     zeros,
     full,
+    reduction_layout,
     view_layout,
     view,
     permute,
     to_host,
+    _REDUCE_MEAN_SCALER_ARG,
+    _REDUCE_UNIT_SCALER_ARG,
+    reduce_mean_collapse_scaler_arg_name,
 )
 from ._src.rewrite import (
     pattern,
@@ -621,6 +625,122 @@ def matmul(lhs, rhs):
     return _matmul_block(lhs, rhs)
 
 
+def _int_attr_from_ast(node, compiler=None):
+    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+        value = node.value
+    elif (
+        isinstance(node, ast.UnaryOp)
+        and isinstance(node.op, ast.USub)
+        and isinstance(node.operand, ast.Constant)
+        and isinstance(node.operand.value, int)
+    ):
+        value = -node.operand.value
+    elif (
+        compiler is not None
+        and isinstance(node, ast.Name)
+        and isinstance(compiler.captures.get(node.id), int)
+    ):
+        value = compiler.captures[node.id]
+    else:
+        raise TypeError("expected integer literal")
+    return IntegerAttr.get(IntegerType.get_signless(64), value)
+
+
+@syntax("reduce_sum", args_as_attr=[False, _int_attr_from_ast])
+def reduce_sum(input, dim):
+    """Block-level float sum reduction over one tile axis.
+
+    `dim` follows torch/numpy axis numbering for a 2D tile block:
+    `0` reduces rows and `1` reduces columns.
+    """
+    return _reduce_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_sum(a.type, a, b, c, reduce_dim),
+        input,
+        dim,
+        _REDUCE_UNIT_SCALER_ARG,
+        0.0,
+    )
+
+
+@syntax("reduce_max", args_as_attr=[False, _int_attr_from_ast])
+def reduce_max(input, dim):
+    """Block-level float max reduction over one tile axis.
+
+    `dim` follows torch/numpy axis numbering for a 2D tile block:
+    `0` reduces rows and `1` reduces columns.
+    """
+    return _reduce_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_max(a.type, a, b, c, reduce_dim),
+        input,
+        dim,
+        _REDUCE_UNIT_SCALER_ARG,
+        float("-inf"),
+    )
+
+
+@syntax("reduce_mean", args_as_attr=[False, _int_attr_from_ast])
+def reduce_mean(input, dim):
+    """Block-level float mean reduction over one tile axis.
+
+    `dim` follows torch/numpy axis numbering for a 2D tile block:
+    `0` reduces rows and `1` reduces columns.
+    """
+    return _reduce_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_mean(a.type, a, b, c, reduce_dim),
+        input,
+        dim,
+        _REDUCE_MEAN_SCALER_ARG,
+        0.0,
+    )
+
+
+@syntax("reduce_sum_collapse", args_as_attr=[False, _int_attr_from_ast])
+def reduce_sum_collapse(input, dim):
+    """Block-level sum reduction for collapsed output layouts.
+
+    This reduces within each tile and across the reduced tile axis of the
+    local block. Pair it with a destination layout from
+    `d2m.reduction_layout(input_layout, dim)`.
+    """
+    return _reduce_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_sum(a.type, a, b, c, reduce_dim),
+        input,
+        dim,
+        _REDUCE_UNIT_SCALER_ARG,
+        0.0,
+        collapse=True,
+    )
+
+
+@syntax("reduce_max_collapse", args_as_attr=[False, _int_attr_from_ast])
+def reduce_max_collapse(input, dim):
+    """Block-level max reduction for collapsed output layouts."""
+    return _reduce_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_max(a.type, a, b, c, reduce_dim),
+        input,
+        dim,
+        _REDUCE_UNIT_SCALER_ARG,
+        float("-inf"),
+        collapse=True,
+    )
+
+
+@syntax("reduce_mean_collapse", args_as_attr=[False, _int_attr_from_ast])
+def reduce_mean_collapse(input, dim):
+    """Block-level mean reduction for collapsed output layouts."""
+    rank = input.type.rank
+    reduce_axis = _normalize_reduce_axis(dim, rank)
+    tile_count = input.type.shape[reduce_axis]
+    return _reduce_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_mean(a.type, a, b, c, reduce_dim),
+        input,
+        dim,
+        reduce_mean_collapse_scaler_arg_name(reduce_axis, tile_count),
+        0.0,
+        collapse=True,
+    )
+
+
 @syntax("!tensor")
 class TensorBlock:
     """The DSL-side host class for a tile-typed tensor block.
@@ -909,6 +1029,30 @@ class TensorBlock:
         """Same as `d2m.matmul(self, rhs)`."""
         return matmul(ast_self, rhs)
 
+    def reduce_sum(ast_self: TensorBlock, dim) -> TensorBlock:
+        """Same as `d2m.reduce_sum(self, dim)`."""
+        return reduce_sum(ast_self, dim)
+
+    def reduce_max(ast_self: TensorBlock, dim) -> TensorBlock:
+        """Same as `d2m.reduce_max(self, dim)`."""
+        return reduce_max(ast_self, dim)
+
+    def reduce_mean(ast_self: TensorBlock, dim) -> TensorBlock:
+        """Same as `d2m.reduce_mean(self, dim)`."""
+        return reduce_mean(ast_self, dim)
+
+    def reduce_sum_collapse(ast_self: TensorBlock, dim) -> TensorBlock:
+        """Same as `d2m.reduce_sum_collapse(self, dim)`."""
+        return reduce_sum_collapse(ast_self, dim)
+
+    def reduce_max_collapse(ast_self: TensorBlock, dim) -> TensorBlock:
+        """Same as `d2m.reduce_max_collapse(self, dim)`."""
+        return reduce_max_collapse(ast_self, dim)
+
+    def reduce_mean_collapse(ast_self: TensorBlock, dim) -> TensorBlock:
+        """Same as `d2m.reduce_mean_collapse(self, dim)`."""
+        return reduce_mean_collapse(ast_self, dim)
+
     def store(ast_self: TensorBlock, rhs: TensorBlock) -> TensorBlock:
         return d2m.store(ast_self, rhs)
 
@@ -1018,6 +1162,7 @@ def _typecast_block(input, dtype):
     output = d2m.empty(out_block_ty)
     identity = AffineMap.get_identity(rank)
     indexing_maps = ArrayAttr.get([AffineMapAttr.get(identity)] * 2)
+
     parallel = Attribute.parse("#linalg.iterator_type<parallel>")
     iterator_types = ArrayAttr.get([parallel] * rank)
 
@@ -1038,6 +1183,228 @@ def _typecast_block(input, dtype):
         if hasattr(casted, "result"):
             casted = casted.result
         linalg.yield_([casted])
+    return generic.result
+
+
+def _dim_to_reduce_dim_attr(dim):
+    if isinstance(dim, Attribute) and not isinstance(dim, IntegerAttr):
+        return dim
+    dim = _dim_to_int(dim)
+
+    if dim in (0, -2):
+        return Attribute.parse("#d2m<reduce_dim C>")
+    if dim in (1, -1):
+        return Attribute.parse("#d2m<reduce_dim R>")
+    raise ValueError(f"reduce dim must be 0/1 or -2/-1, got {dim}")
+
+
+def _dim_to_int(dim):
+    if isinstance(dim, arith.ConstantOp):
+        return IntegerAttr(dim.value).value
+    if isinstance(dim, IntegerAttr):
+        return dim.value
+    if isinstance(dim, int) and not isinstance(dim, bool):
+        return dim
+    raise TypeError(f"reduce dim must be an integer literal, got {dim!r}")
+
+
+def _normalize_reduce_axis(dim, rank):
+    dim = _dim_to_int(dim)
+    if dim not in (0, 1, -2, -1):
+        raise ValueError(f"reduce dim must be 0/1 or -2/-1, got {dim}")
+    if dim < 0:
+        dim += rank
+    if dim < 0 or dim >= rank:
+        raise ValueError(
+            f"reduce dim must be in range [-{rank}, {rank - 1}], got {dim}"
+        )
+    return dim
+
+
+def _float_scalar_type_for_tile(tile_type):
+    ctx = tile_type.context
+    tile_type = ttcore.ir.TileType.maybe_downcast(tile_type)
+    if tile_type is None:
+        raise TypeError(f"expected a ttcore.tile element type, got {tile_type}")
+    data_type = tile_type.data_type_as_int
+    if data_type == int(ttcore.DataType.Float32):
+        return F32Type.get(ctx)
+    if data_type == int(ttcore.DataType.Float16):
+        return F16Type.get(ctx)
+    if data_type == int(ttcore.DataType.BFloat16):
+        return BF16Type.get(ctx)
+    raise TypeError(
+        "float reductions require f32, f16, or bf16 tile element types; "
+        f"got {tile_type}"
+    )
+
+
+def _tile_fill_float(tile_type, value):
+    scalar_type = _float_scalar_type_for_tile(tile_type)
+    scalar_attr = FloatAttr.get(scalar_type, value)
+    scalar = arith.ConstantOp(scalar_type, scalar_attr).result
+    return d2m.tile_fill(tile_type, scalar)
+
+
+def _get_reduce_scaler_block(input_block, scaler_arg_name):
+    compiler = D2MCompiler.current()
+    if compiler is None:
+        raise RuntimeError(
+            "reduce_sum/reduce_max/reduce_mean can only be used inside @kernel"
+        )
+
+    key = (
+        scaler_arg_name,
+        str(input_block.type.element_type),
+        id(InsertionPoint.current.block),
+    )
+    cached = compiler.reduce_scaler_cache.get(key)
+    if cached is not None:
+        return cached
+
+    scaler = compiler.get_synthetic_reduce_scaler(
+        scaler_arg_name, input_block.type.element_type
+    )
+    if scaler is None:
+        raise RuntimeError("internal error: missing synthetic reduction scaler")
+
+    zero = arith.ConstantOp(IndexType.get(scaler.context), 0).result
+    scaler_block = remote_load(scaler, [zero, zero])
+    if scaler_block.type.element_type != input_block.type.element_type:
+        raise TypeError(
+            "reduction scaler tile type mismatch: "
+            f"{scaler_block.type.element_type} vs {input_block.type.element_type}"
+        )
+    compiler.reduce_scaler_cache[key] = scaler_block
+    return scaler_block
+
+
+def _collapse_input_map(rank, reduce_axis, reduce_index):
+    exprs = []
+    for axis in range(rank):
+        if axis == reduce_axis:
+            exprs.append(AffineConstantExpr.get(reduce_index))
+        else:
+            exprs.append(AffineDimExpr.get(axis))
+    return AffineMap.get(rank, 0, exprs)
+
+
+def _reduce_block_collapse_explicit(
+    tile_op_fn,
+    input,
+    scaler,
+    reduce_axis,
+    reduce_dim,
+    identity_value,
+):
+    block_ty = input.type
+    rank = block_ty.rank
+    elem_ty = block_ty.element_type
+    output_shape = list(block_ty.shape)
+    output_shape[reduce_axis] = 1
+    output_ty = RankedTensorType.get(output_shape, elem_ty)
+    output = d2m.empty(output_ty)
+
+    tile_count = block_ty.shape[reduce_axis]
+    zero = AffineConstantExpr.get(0)
+    scaler_rank = scaler.type.rank
+    indexing_maps = [
+        AffineMapAttr.get(_collapse_input_map(rank, reduce_axis, reduce_index))
+        for reduce_index in range(tile_count)
+    ]
+    indexing_maps.append(
+        AffineMapAttr.get(AffineMap.get(rank, 0, [zero] * scaler_rank))
+    )
+    indexing_maps.append(AffineMapAttr.get(AffineMap.get_identity(rank)))
+
+    parallel = Attribute.parse("#linalg.iterator_type<parallel>")
+    generic = linalg.GenericOp(
+        [output_ty],
+        [input] * tile_count + [scaler],
+        [output],
+        ArrayAttr.get(indexing_maps),
+        ArrayAttr.get([parallel] * rank),
+    )
+    body = Block.create_at_start(
+        generic.regions[0],
+        [elem_ty] * (tile_count + 2),
+        [Location.unknown()] * (tile_count + 2),
+    )
+    with InsertionPoint(body):
+        *input_tiles, scaler_tile, _ = body.arguments
+        accumulator = _tile_fill_float(elem_ty, identity_value)
+        for input_tile in input_tiles:
+            accumulator = tile_op_fn(input_tile, scaler_tile, accumulator, reduce_dim)
+            if hasattr(accumulator, "result"):
+                accumulator = accumulator.result
+        linalg.yield_([accumulator])
+
+    return generic.result
+
+
+def _reduce_block(
+    tile_op_fn, input, dim, scaler_arg_name, identity_value, collapse=False
+):
+    """Wrap a float d2m.tile_reduce_* op in a per-block linalg.generic.
+
+    Non-collapsed reductions keep the same block shape as `input` and reduce
+    within each tile. Collapsed reductions shrink the reduced block dimension
+    to 1 and accumulate across all tiles in that local block dimension.
+    """
+    block_ty = input.type
+    if not isinstance(block_ty, RankedTensorType):
+        raise TypeError(f"reduce input must be a ranked tensor, got {block_ty}")
+
+    rank = block_ty.rank
+    elem_ty = block_ty.element_type
+    reduce_axis = _normalize_reduce_axis(dim, rank)
+    reduce_dim = _dim_to_reduce_dim_attr(dim)
+    scaler = _get_reduce_scaler_block(input, scaler_arg_name)
+
+    if collapse and block_ty.shape[reduce_axis] > 1:
+        return _reduce_block_collapse_explicit(
+            tile_op_fn,
+            input,
+            scaler,
+            reduce_axis,
+            reduce_dim,
+            identity_value,
+        )
+
+    output_ty = block_ty
+    output = d2m.empty(output_ty)
+    identity = AffineMap.get_identity(rank)
+    zero = AffineConstantExpr.get(0)
+    scaler_map = AffineMap.get(rank, 0, [zero, zero])
+    indexing_maps = ArrayAttr.get(
+        [
+            AffineMapAttr.get(identity),
+            AffineMapAttr.get(scaler_map),
+            AffineMapAttr.get(identity),
+        ]
+    )
+    parallel = Attribute.parse("#linalg.iterator_type<parallel>")
+    iterator_types = ArrayAttr.get([parallel] * rank)
+
+    generic = linalg.GenericOp(
+        [output_ty],
+        [input, scaler],
+        [output],
+        indexing_maps,
+        iterator_types,
+    )
+    body = Block.create_at_start(
+        generic.regions[0],
+        [elem_ty, elem_ty, elem_ty],
+        [Location.unknown()] * 3,
+    )
+    with InsertionPoint(body):
+        input_tile, scaler_tile, _ = body.arguments
+        accumulator = _tile_fill_float(elem_ty, identity_value)
+        result = tile_op_fn(input_tile, scaler_tile, accumulator, reduce_dim)
+        if hasattr(result, "result"):
+            result = result.result
+        linalg.yield_([result])
     return generic.result
 
 

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -624,19 +624,25 @@ def matmul(lhs, rhs):
 
 
 def _int_attr_from_ast(node, compiler=None):
-    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+    if (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, int)
+        and not isinstance(node.value, bool)
+    ):
         value = node.value
     elif (
         isinstance(node, ast.UnaryOp)
         and isinstance(node.op, ast.USub)
         and isinstance(node.operand, ast.Constant)
         and isinstance(node.operand.value, int)
+        and not isinstance(node.operand.value, bool)
     ):
         value = -node.operand.value
     elif (
         compiler is not None
         and isinstance(node, ast.Name)
         and isinstance(compiler.captures.get(node.id), int)
+        and not isinstance(compiler.captures.get(node.id), bool)
     ):
         value = compiler.captures[node.id]
     else:
@@ -1184,8 +1190,6 @@ def _typecast_block(input, dtype):
 
 
 def _dim_to_reduce_dim_attr(dim):
-    if isinstance(dim, Attribute) and not isinstance(dim, IntegerAttr):
-        return dim
     dim = _dim_to_int(dim)
 
     if dim in (0, -2):
@@ -1219,10 +1223,13 @@ def _normalize_reduce_axis(dim, rank):
 
 
 def _float_scalar_type_for_tile(tile_type):
-    ctx = tile_type.context
-    tile_type = ttcore.ir.TileType.maybe_downcast(tile_type)
+    original_tile_type = tile_type
+    ctx = original_tile_type.context
+    tile_type = ttcore.ir.TileType.maybe_downcast(original_tile_type)
     if tile_type is None:
-        raise TypeError(f"expected a ttcore.tile element type, got {tile_type}")
+        raise TypeError(
+            f"expected a ttcore.tile element type, got {original_tile_type}"
+        )
     data_type = tile_type.data_type_as_int
     if data_type == int(ttcore.DataType.Float32):
         return F32Type.get(ctx)


### PR DESCRIPTION
### Problem description
Need to be able to write reductions in d2m jit

### What's changed
- Added D2M JIT float reductions: reduce_sum, reduce_max, and reduce_mean as free functions and TensorBlock methods
- Made reductions use keepdim semantics: reducing dim=1 writes to a shape[..., 1] output layout, and reducing dim=0 writes to a shape[1, ...] output layout
- Added d2m.reduction_layout(layout, dim, allow_cross_tile=False) to derive keepdim output layouts for reductions
- Added implicit elementwise broadcast for reduced operands, so local patterns like x - x.reduce_max(1) and numerator / numerator.reduce_sum(1) work naturally
- Added reduced-axis metadata internally (d2m.reduced_axes) because tile types alone cannot distinguish logical 32x1 from a physical 32x32 tile
- Updated binary operator dispatch in the AST compiler so tensor dunder methods get first chance to handle broadcast-compatible tensor shapes before scalar casting runs
- Emit reduction scaler tiles on device with a generated scaler linalg.generic
- Update D2M backend passes to preserve and handle reduction scaler buffers correctly. They can't be treated as scratch since device apis require a cb for the scaler
- Add pytests and lit tests
- Update docs

### Status
-  Support reductions across multiple tiles when the reduced dimension is local to one core
- Need core gather for sharding on the reduce dim
- Can write a single core single tile softmax kernel
- Multi tile single core softmax kernel results in a compiler error in `DstRegisterAnalysis.cpp` hitting `expected all linalg.generic outputs in a region to have shard size 1` for the bcast for division

### Checklist
- [ ] New/Existing tests provide coverage for changes
