### PR TITLE
Enable dram optimization patterns by default

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -753,10 +753,10 @@ def TTNNMemoryManagement : Pass<"ttnn-memory-management", "::mlir::ModuleOp"> {
     This pass moves slice ops and reorganizes repeat ops to reduce memory usage.
   }];
   let options = [
-    Option<"enableAllPatterns",
-           "enable-all-patterns",
+    Option<"aggressiveMemorySaving",
+           "aggressive-memory-saving",
            "bool", /*default=*/"true",
-           "Opt-in: enable all patterns to reduce DRAM usage.">,
+           "Opt-out: disable aggressive memory saving patterns to reduce DRAM usage.">,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -752,6 +752,12 @@ def TTNNMemoryManagement : Pass<"ttnn-memory-management", "::mlir::ModuleOp"> {
   let description = [{
     This pass moves slice ops and reorganizes repeat ops to reduce memory usage.
   }];
+  let options = [
+    Option<"enableAllPatterns",
+           "enable-all-patterns",
+           "bool", /*default=*/"true",
+           "Opt-in: enable all patterns to reduce DRAM usage.">,
+  ];
 }
 
 def TTNNGreedyL1SpillManagement : Pass<"ttnn-greedy-l1-spill-management", "::mlir::ModuleOp"> {

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -359,7 +359,7 @@ void createTTIRToTTNNCommonPipeline(
     }
 
     TTNNMemoryManagementOptions memoryManagementOptions;
-    memoryManagementOptions.enableAllPatterns =
+    memoryManagementOptions.aggressiveMemorySaving =
         options.dramSpaceSavingOptimizationEnabled;
     devicePm.addPass(createTTNNMemoryManagement(memoryManagementOptions));
     createTTNNPipelineWorkaroundPass(devicePm, options);

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -358,9 +358,10 @@ void createTTIRToTTNNCommonPipeline(
       }
     }
 
-    if (options.dramSpaceSavingOptimizationEnabled) {
-      devicePm.addPass(createTTNNMemoryManagement());
-    }
+    TTNNMemoryManagementOptions memoryManagementOptions;
+    memoryManagementOptions.enableAllPatterns =
+        options.dramSpaceSavingOptimizationEnabled;
+    devicePm.addPass(createTTNNMemoryManagement(memoryManagementOptions));
     createTTNNPipelineWorkaroundPass(devicePm, options);
     // Add weight dtype conversion pass before analysis passes.
     // Analysis passes need to know data formats to decide on shardings.

--- a/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
@@ -1149,7 +1149,7 @@ public:
 
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
-    if (enableAllPatterns) {
+    if (aggressiveMemorySaving) {
       patterns.add<PropagateSliceThroughEltwise<ttnn::AddOp>,
                    PropagateSliceThroughEltwise<ttnn::MultiplyOp>,
                    PropagateSliceThroughEltwise<ttnn::SubtractOp>,

--- a/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
@@ -1149,18 +1149,21 @@ public:
 
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
-    patterns
-        .add<PropagateSliceThroughPermute, PropagateSliceThroughReshape,
-             HoistCommonReshapeAboveSlices, PropagateSliceThroughRepeat,
-             PropagateSliceThroughEltwise<ttnn::AddOp>,
-             PropagateSliceThroughEltwise<ttnn::MultiplyOp>,
-             PropagateSliceThroughEltwise<ttnn::SubtractOp>,
-             PropagateSliceThroughEltwise<ttnn::DivideOp>,
-             RepeatReshapeAdjusting, ReshapeElementwiseAdjusting<ttnn::AddOp>,
-             ReshapeElementwiseAdjusting<ttnn::MultiplyOp>,
-             ReshapeElementwiseAdjusting<ttnn::SubtractOp>,
-             ReshapeElementwiseAdjusting<ttnn::DivideOp>,
-             PermuteRowMajorAdjusting, ReshapeRowMajorAdjusting>(&getContext());
+    if (enableAllPatterns) {
+      patterns.add<PropagateSliceThroughEltwise<ttnn::AddOp>,
+                   PropagateSliceThroughEltwise<ttnn::MultiplyOp>,
+                   PropagateSliceThroughEltwise<ttnn::SubtractOp>,
+                   PropagateSliceThroughEltwise<ttnn::DivideOp>,
+                   ReshapeElementwiseAdjusting<ttnn::AddOp>,
+                   ReshapeElementwiseAdjusting<ttnn::MultiplyOp>,
+                   ReshapeElementwiseAdjusting<ttnn::SubtractOp>,
+                   ReshapeElementwiseAdjusting<ttnn::DivideOp>,
+                   PermuteRowMajorAdjusting, ReshapeRowMajorAdjusting>(
+          &getContext());
+    }
+    patterns.add<PropagateSliceThroughPermute, PropagateSliceThroughReshape,
+                 HoistCommonReshapeAboveSlices, PropagateSliceThroughRepeat,
+                 RepeatReshapeAdjusting>(&getContext());
 
     GreedyRewriteConfig config;
     config.setUseTopDownTraversal(true);


### PR DESCRIPTION
### Problem description
Dram optimization patterns are turned off by default because they can degrade execution time. However, some of the patterns are more general optimizations that are safe to be applied always.

### What's changed
Moved guard from pass level to pattern level. Now applies patterns if pipeline explicitly asked for them, and some are on by default.
 
### Checklist
- [x] New/Existing tests provide coverage for changes
