### PR TITLE
[d2m] explicit bcast support

### DIFF
--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -1363,6 +1363,294 @@ private:
 };
 } // namespace
 
+namespace {
+class D2MBroadcastRewriter final
+    : public OpConversionPattern<ttir::BroadcastOp>,
+      D2MNamedRewriterCommon {
+public:
+  D2MBroadcastRewriter(const TypeConverter &typeConverter,
+                       mlir::MLIRContext *ctx,
+                       ttcore::MemorySpace defaultInputMemSpace,
+                       ttcore::MemorySpace defaultOutputMemSpace, bool ttnnMode,
+                       bool collapseTensors, bool enableMulticastInference)
+      : OpConversionPattern<ttir::BroadcastOp>(typeConverter, ctx),
+        D2MNamedRewriterCommon(defaultInputMemSpace, defaultOutputMemSpace,
+                               ttnnMode, collapseTensors,
+                               enableMulticastInference) {}
+
+private:
+  RankedTensorType getUnitGridLayoutType(RankedTensorType logicalType,
+                                         ttcore::MemorySpace memSpace,
+                                         bool tiled, OpBuilder &builder) const {
+    ArrayRef<int64_t> logicalShape = logicalType.getShape();
+
+    Type elementType = logicalType.getElementType();
+    llvm::SmallVector<int64_t> tileShape;
+    if (tiled) {
+      constexpr std::array<int64_t, 2> defaultShape =
+          ttcore::TileType::getDefaultShape();
+      tileShape.assign(defaultShape.begin(), defaultShape.end());
+      elementType = ttcore::TileType::get(elementType, tileShape);
+    }
+
+    auto emptyIntervalType = RankedTensorType::get(
+        {0, 2}, IntegerType::get(builder.getContext(), 64));
+    DenseIntElementsAttr emptyCollapseIntervals =
+        DenseIntElementsAttr::get(emptyIntervalType, ArrayRef<int64_t>{});
+    auto layout = ttcore::MetalLayoutAttr::get(
+        builder.getContext(), logicalShape, memSpace,
+        ttcore::TensorMemoryLayout::Sharded, emptyCollapseIntervals);
+
+    llvm::SmallVector<int64_t> unshardedShape =
+        layout.getPhysicalShape(tileShape);
+    llvm::SmallVector<int64_t> placeholderTensorGrid(unshardedShape.size(), 1);
+    llvm::SmallVector<int64_t> shardedShape =
+        layout.getDeviceShape(placeholderTensorGrid, tileShape);
+
+    return RankedTensorType::get(shardedShape, elementType, layout);
+  }
+
+  static bool isTileBroadcastDim(int64_t rank, int64_t dim) {
+    return rank == 1 ? dim == 0 : dim >= rank - 2;
+  }
+
+  static d2m::TileBcastType getTileBcastType(bool bcastRow, bool bcastCol) {
+    if (bcastRow && bcastCol) {
+      return d2m::TileBcastType::Scalar;
+    }
+    if (bcastCol) {
+      return d2m::TileBcastType::Col;
+    }
+    if (bcastRow) {
+      return d2m::TileBcastType::Row;
+    }
+    return d2m::TileBcastType::None;
+  }
+
+  static LogicalResult analyzeBroadcast(ttir::BroadcastOp op,
+                                        ConversionPatternRewriter &rewriter,
+                                        bool &hasOuterBroadcast,
+                                        d2m::TileBcastType &tileBcastType) {
+    auto inputType = mlir::cast<RankedTensorType>(op.getInput().getType());
+    auto outputType = mlir::cast<RankedTensorType>(op.getResult().getType());
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+    ArrayRef<int64_t> outputShape = outputType.getShape();
+    int64_t rank = inputType.getRank();
+    if (rank < 1) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M broadcast lowering expects ranked tensor with rank >= 1");
+    }
+
+    bool bcastRow = false;
+    bool bcastCol = false;
+    for (int64_t dim = 0; dim < rank; ++dim) {
+      int64_t inputDim = inputShape[dim];
+      int64_t outputDim = outputShape[dim];
+      if (inputDim == outputDim) {
+        continue;
+      }
+      if (ShapedType::isDynamic(inputDim) || ShapedType::isDynamic(outputDim)) {
+        return rewriter.notifyMatchFailure(
+            op, "D2M explicit broadcast lowering requires static shapes");
+      }
+      if (inputDim <= 0 || outputDim <= 0) {
+        return rewriter.notifyMatchFailure(
+            op, "D2M explicit broadcast lowering requires positive dims");
+      }
+
+      if (isTileBroadcastDim(rank, dim)) {
+        if (inputDim != 1) {
+          return rewriter.notifyMatchFailure(op, [&](Diagnostic &diag) {
+            diag << "tile-dim explicit broadcast dim " << dim
+                 << " requires input dim 1 (input=" << inputDim
+                 << ", output=" << outputDim << ")";
+          });
+        }
+        bcastRow |= rank > 1 && dim == rank - 2;
+        bcastCol |= dim == rank - 1;
+        continue;
+      }
+
+      if (outputDim % inputDim != 0) {
+        return rewriter.notifyMatchFailure(op, [&](Diagnostic &diag) {
+          diag << "outer-dim explicit broadcast dim " << dim
+               << " requires output dim (" << outputDim
+               << ") to be a positive multiple of input dim (" << inputDim
+               << ")";
+        });
+      }
+      hasOuterBroadcast = true;
+    }
+
+    tileBcastType = getTileBcastType(bcastRow, bcastCol);
+    return success();
+  }
+
+  static AffineMap buildOuterBcastViewMap(OpBuilder &builder,
+                                          RankedTensorType inputType,
+                                          RankedTensorType outputType) {
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+    ArrayRef<int64_t> outputShape = outputType.getShape();
+    TT_assert(inputShape.size() == outputShape.size());
+
+    SmallVector<AffineExpr> inputExprs;
+    inputExprs.reserve(outputShape.size());
+    for (auto [dim, shapeDims] :
+         llvm::enumerate(llvm::zip_equal(inputShape, outputShape))) {
+      auto [inputDim, outputDim] = shapeDims;
+      AffineExpr outputIndex = builder.getAffineDimExpr(dim);
+      if (inputDim == outputDim) {
+        inputExprs.push_back(outputIndex);
+        continue;
+      }
+
+      bool validOuterBroadcastDim =
+          inputDim > 0 && outputDim > 0 && outputDim % inputDim == 0;
+      TT_assertv(validOuterBroadcastDim,
+                 "explicit outer broadcast dim {} requires output dim ({}) "
+                 "to be a positive multiple of input dim ({})",
+                 dim, outputDim, inputDim);
+      inputExprs.push_back(inputDim == 1 ? builder.getAffineConstantExpr(0)
+                                         : outputIndex % inputDim);
+    }
+
+    return AffineMap::get(outputShape.size(), /*symbolCount=*/0, inputExprs,
+                          builder.getContext());
+  }
+
+  LogicalResult rewriteOuterBroadcastWithViewLayout(
+      ttir::BroadcastOp op, ttir::BroadcastOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const {
+    Location loc = op.getLoc();
+    auto outputType = mlir::cast<RankedTensorType>(op.getResult().getType());
+
+    Value input =
+        createOptimalLayoutOp(adaptor.getInput(), memorySpaces[0],
+                              /*tiled=*/true, /*noCollapse=*/true, rewriter);
+    auto viewType = getUnitGridLayoutType(outputType, memorySpaces[0],
+                                          /*tiled=*/true, rewriter);
+    auto remapping = buildOuterBcastViewMap(
+        rewriter, mlir::cast<RankedTensorType>(input.getType()), viewType);
+    auto view = rewriter.create<d2m::ViewLayoutOp>(
+        loc, viewType, input, remapping, /*reinterpretLayout=*/false);
+
+    rewriter.replaceOp(op,
+                       unLayoutResult(rewriter, view.getResult(), outputType));
+    return success();
+  }
+
+  static SmallVector<AffineMap>
+  buildPhysicalBcastIndexingMaps(OpBuilder &builder, Value input, Value output,
+                                 std::size_t physicalRank) {
+    auto getShardTiles = [](Value v) -> SmallVector<int64_t> {
+      auto tensorType = mlir::cast<RankedTensorType>(v.getType());
+      auto layout =
+          mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
+      return SmallVector<int64_t>(layout.getShardShape(tensorType));
+    };
+
+    SmallVector<int64_t> inputShard = getShardTiles(input);
+    SmallVector<int64_t> outputShard = getShardTiles(output);
+    TT_assertv(inputShard.size() == physicalRank,
+               "input shard rank ({}) must equal physicalRank ({})",
+               inputShard.size(), physicalRank);
+    TT_assertv(outputShard.size() == physicalRank,
+               "output shard rank ({}) must equal physicalRank ({})",
+               outputShard.size(), physicalRank);
+
+    SmallVector<AffineExpr> inputExprs;
+    inputExprs.reserve(physicalRank);
+    for (std::size_t d = 0; d < physicalRank; ++d) {
+      if (inputShard[d] == outputShard[d]) {
+        inputExprs.push_back(builder.getAffineDimExpr(d));
+        continue;
+      }
+      TT_assertv(inputShard[d] == 1,
+                 "incompatible explicit broadcast in physical dim {} "
+                 "(input={}, output={})",
+                 d, inputShard[d], outputShard[d]);
+      inputExprs.push_back(builder.getAffineConstantExpr(0));
+    }
+
+    return {
+        AffineMap::get(physicalRank, /*symbolCount=*/0, inputExprs,
+                       builder.getContext()),
+        builder.getMultiDimIdentityMap(physicalRank),
+    };
+  }
+
+  LogicalResult
+  matchAndRewrite(ttir::BroadcastOp op, ttir::BroadcastOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    bool hasOuterBroadcast = false;
+    d2m::TileBcastType tileBcastType = d2m::TileBcastType::None;
+    if (failed(
+            analyzeBroadcast(op, rewriter, hasOuterBroadcast, tileBcastType))) {
+      return failure();
+    }
+
+    if (hasOuterBroadcast && tileBcastType == d2m::TileBcastType::None) {
+      return rewriteOuterBroadcastWithViewLayout(op, adaptor, rewriter);
+    }
+
+    SmallVector<Value> origInputs = {adaptor.getInput()};
+    SmallVector<Value> origOutputs =
+        createDpsOutputs(loc, rewriter, {op.getResult().getType()});
+
+    auto [inputs, outputs] =
+        toLayoutOperandsAndResults(rewriter, {origInputs, origOutputs},
+                                   /*tiled=*/true, /*noCollapse=*/true);
+    assert(inputs.size() == 1);
+    assert(outputs.size() == 1);
+
+    std::size_t physicalRank =
+        ttcore::getDeviceLayout(outputs[0]).getRank() / 2;
+    SmallVector<AffineMap> indexingMaps = buildPhysicalBcastIndexingMaps(
+        rewriter, inputs[0], outputs[0], physicalRank);
+
+    auto parallel = ttcore::IteratorTypeAttr::get(
+        rewriter.getContext(), ttcore::IteratorType::Parallel);
+    SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
+
+    auto generic = rewriter.create<d2m::GenericOp>(
+        loc, inputs, outputs, /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
+
+    withD2MGenericRegion(
+        rewriter, loc, generic, inputs, outputs,
+        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+          SmallVector<mlir::utils::IteratorType> linalgIteratorTypes =
+              iteratorTypeTTIRToLinalg(rewriter, iteratorTypes);
+
+          auto linalgGeneric = rewriter.create<linalg::GenericOp>(
+              loc,
+              /*resultTensorTypes=*/
+              llvm::to_vector(ValueRange(blockArgs.take_back(1)).getTypes()),
+              /*inputs=*/blockArgs.take_front(1),
+              /*outputs=*/blockArgs.take_back(1), indexingMaps,
+              linalgIteratorTypes,
+              [&](OpBuilder &bbBuilder, Location bbLoc, ValueRange bbArgs) {
+                Value yield = bbArgs[0];
+                if (tileBcastType != d2m::TileBcastType::None) {
+                  yield = bbBuilder.create<d2m::TileBcastOp>(
+                      bbLoc, bbArgs[1].getType(), yield, tileBcastType);
+                }
+                bbBuilder.create<linalg::YieldOp>(bbLoc, yield);
+              });
+
+          return {linalgGeneric.getResult(0)};
+        });
+
+    rewriter.replaceOp(op, unLayoutResult(rewriter, generic->getResult(0),
+                                          op.getResult().getType()));
+    return success();
+  }
+};
+} // namespace
+
 // ----------------------------------------------------------------------------
 //
 // D2MNamedAccumReductionRewriter: outer logical-dim reductions
@@ -4376,6 +4664,7 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
     D2MNamedTileReduceRewriter<ttir::SumOp,  d2m::TileReduceSumOp, d2m::TileSFPUReduceSumOp>,
     // Data movement.
     D2MNamedElementwiseRewriter<ttir::TypecastOp,        d2m::TileTypecastOp>,
+    D2MBroadcastRewriter,
     // Tensor manipulation/View ops.
     D2MConcatRewriter,
     D2MTensorManipulationOpRewriter<ttir::RearrangeOp,        rearrangeLogicalInfo>,

--- a/test/python/golden/d2m/test_broadcast.py
+++ b/test/python/golden/d2m/test_broadcast.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from typing import List, Optional
+
+from builder.base.builder_apis import compile_and_execute_ttir
+from builder.base.builder_utils import Operand, Shape
+from builder.ttir.ttir_builder import TTIRBuilder
+from conftest import get_request_kwargs
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+EXPLICIT_BROADCAST_CASES = [
+    pytest.param(
+        (1,),
+        [128],
+        torch.float32,
+        id="f32-1d-1-to-128",
+    ),
+    pytest.param(
+        (1, 64),
+        [128, 1],
+        torch.float32,
+        id="f32-row-1x64-to-128x64",
+    ),
+    pytest.param(
+        (64, 1),
+        [1, 128],
+        torch.float32,
+        id="f32-col-64x1-to-64x128",
+    ),
+    pytest.param(
+        (1, 1),
+        [64, 128],
+        torch.bfloat16,
+        id="bf16-scalar-1x1-to-64x128",
+    ),
+    pytest.param(
+        (1, 1, 32, 1),
+        [1, 4, 1, 128],
+        torch.float32,
+        id="f32-nd-col-1x1x32x1-to-1x4x32x128",
+    ),
+    pytest.param(
+        (1, 1, 1, 128),
+        [1, 4, 32, 1],
+        torch.bfloat16,
+        id="bf16-nd-row-1x1x1x128-to-1x4x32x128",
+    ),
+    pytest.param(
+        (1, 1, 32, 128),
+        [1, 4, 1, 1],
+        torch.float32,
+        id="f32-outer-1x1x32x128-to-1x4x32x128",
+    ),
+    pytest.param(
+        (1, 32, 32),
+        [4, 1, 1],
+        torch.float32,
+        id="f32-outer-1x32x32-to-4x32x32",
+    ),
+    pytest.param(
+        (1, 1, 32, 128),
+        [2, 4, 1, 1],
+        torch.bfloat16,
+        id="bf16-multi-outer-1x1x32x128-to-2x4x32x128",
+    ),
+]
+
+
+def broadcast_output_shape(shape: Shape, broadcast_dimensions: List[int]) -> Shape:
+    return tuple(
+        broadcast_dim if broadcast_dim != 1 else input_dim
+        for input_dim, broadcast_dim in zip(shape, broadcast_dimensions)
+    )
+
+
+@pytest.mark.parametrize("shape,broadcast_dimensions,dtype", EXPLICIT_BROADCAST_CASES)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_explicit_broadcast(
+    shape: Shape,
+    broadcast_dimensions: List[int],
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [dtype])
+        def explicit_broadcast(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            if shape == (1,):
+                builder.set_goldens(inputs={in0: torch.ones(shape, dtype=dtype)})
+            return builder.broadcast(
+                in0,
+                broadcast_dimensions=broadcast_dimensions,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        print_ir=False,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_explicit_broadcast_consumed_by_binary(request, device, target: str):
+    input_shape = (1, 1, 32, 1)
+    broadcast_dimensions = [1, 4, 1, 128]
+    output_shape = broadcast_output_shape(input_shape, broadcast_dimensions)
+
+    def module(builder: TTIRBuilder):
+        @builder.func(
+            [input_shape, output_shape],
+            [torch.float32, torch.float32],
+        )
+        def broadcast_add(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            broadcasted = builder.broadcast(
+                in0,
+                broadcast_dimensions=broadcast_dimensions,
+                unit_attrs=unit_attrs,
+            )
+            return builder.add(broadcasted, in1, unit_attrs=unit_attrs)
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        print_ir=False,
+    )

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -96,6 +96,69 @@ DRAM_FUSION_CASES = [
     shape_dtype_param((128, 128), torch.bfloat16),
 ]
 
+DRAM_BROADCAST_CASES = [
+    pytest.param(
+        (1, 128, 1),
+        [1, 1, 2560],
+        torch.float32,
+        id="f32-1x128x1-to-1x128x2560",
+    ),
+    pytest.param(
+        (1, 1, 2560),
+        [1, 128, 1],
+        torch.bfloat16,
+        id="bf16-1x1x2560-to-1x128x2560",
+    ),
+    pytest.param(
+        (128, 1, 64),
+        [1, 32, 1],
+        torch.bfloat16,
+        id="bf16-128x1x64-to-128x32x64",
+    ),
+    pytest.param(
+        (128, 1, 64),
+        [1, 8, 1],
+        torch.bfloat16,
+        id="bf16-128x1x64-to-128x8x64",
+    ),
+    pytest.param(
+        (1, 128, 32, 1),
+        [1, 1, 1, 128],
+        torch.float32,
+        id="f32-1x128x32x1-to-1x128x32x128",
+    ),
+    pytest.param(
+        (1, 1, 1, 128),
+        [1, 128, 32, 1],
+        torch.bfloat16,
+        id="bf16-1x1x1x128-to-1x128x32x128",
+    ),
+    pytest.param(
+        (1, 64),
+        [128, 1],
+        torch.float32,
+        id="f32-1x64-to-128x64",
+    ),
+    pytest.param(
+        (1, 128, 8, 1),
+        [1, 1, 1, 128],
+        torch.float32,
+        id="f32-1x128x8x1-to-1x128x8x128",
+    ),
+    pytest.param(
+        (1, 1, 1, 128),
+        [1, 128, 8, 1],
+        torch.bfloat16,
+        id="bf16-1x1x1x128-to-1x128x8x128",
+    ),
+    pytest.param(
+        (128, 1),
+        [1, 64],
+        torch.float32,
+        id="f32-128x1-to-128x64",
+    ),
+]
+
 
 def get_add_scalar_value(dtype: torch.dtype):
     return 5 if dtype == torch.int32 else 5.0 if dtype == torch.bfloat16 else 2.5
@@ -232,6 +295,30 @@ def test_dram_fuse_converging_branches(
             return builder.multiply(lhs, rhs, unit_attrs=unit_attrs)
 
     compile_dram_fusion_test(module, request, device, target)
+
+
+@pytest.mark.parametrize("shape,broadcast_dimensions,dtype", DRAM_BROADCAST_CASES)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_dram_broadcast(
+    shape: Shape,
+    broadcast_dimensions: List[int],
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [dtype])
+        def broadcast(
+            in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+        ):
+            return builder.broadcast(
+                in0,
+                broadcast_dimensions=broadcast_dimensions,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_dram_test(module, request, device, target)
 
 
 @pytest.mark.parametrize("shape,dtype", DRAM_NUMERIC_CASES)

--- a/test/ttmlir/Conversion/TTIRToD2M/explicit_bcast.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/explicit_bcast.mlir
@@ -1,0 +1,124 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-grid-selection -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+!ttype = tensor<128x128xf32>
+!ttype1d = tensor<128xf32>
+!ttype1d_scalar = tensor<1xf32>
+!ttype_row = tensor<1x128xf32>
+!ttype_col = tensor<128x1xf32>
+!ttype_scalar = tensor<1x1xf32>
+
+!ttype4d = tensor<1x4x32x128xbf16>
+!ttype4d_row = tensor<1x1x1x128xbf16>
+!ttype4d_col = tensor<1x1x32x1xbf16>
+!ttype4d_outer = tensor<1x1x32x128xbf16>
+!ttype4d_multi_outer = tensor<2x4x32x128xbf16>
+!ttype3d_outer_in = tensor<1x32x32xbf16>
+!ttype3d_outer_out = tensor<4x32x32xbf16>
+
+module {
+  // CHECK-LABEL: func.func @explicit_1d_bcast
+  func.func @explicit_1d_bcast(%arg0: !ttype1d_scalar) -> !ttype1d {
+    // CHECK: d2m.generic
+    // CHECK: linalg.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type col>}>
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 128>}> : (!ttype1d_scalar) -> !ttype1d
+    return %0 : !ttype1d
+  }
+
+  // CHECK-LABEL: func.func @explicit_bcast_row
+  func.func @explicit_bcast_row(%arg0: !ttype_row) -> !ttype {
+    // CHECK: d2m.generic
+    // CHECK: linalg.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type row>}>
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 128, 1>}> : (!ttype_row) -> !ttype
+    return %0 : !ttype
+  }
+
+  // CHECK-LABEL: func.func @explicit_bcast_col
+  func.func @explicit_bcast_col(%arg0: !ttype_col) -> !ttype {
+    // CHECK: d2m.generic
+    // CHECK: linalg.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type col>}>
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 128>}> : (!ttype_col) -> !ttype
+    return %0 : !ttype
+  }
+
+  // CHECK-LABEL: func.func @explicit_bcast_scalar
+  func.func @explicit_bcast_scalar(%arg0: !ttype_scalar) -> !ttype {
+    // CHECK: d2m.generic
+    // CHECK: linalg.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type scalar>}>
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 128, 128>}> : (!ttype_scalar) -> !ttype
+    return %0 : !ttype
+  }
+
+  // CHECK-LABEL: func.func @explicit_nd_bcast_col
+  func.func @explicit_nd_bcast_col(%arg0: !ttype4d_col) -> !ttype4d {
+    // CHECK: d2m.generic
+    // CHECK: linalg.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type col>}>
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 4, 1, 128>}> : (!ttype4d_col) -> !ttype4d
+    return %0 : !ttype4d
+  }
+
+  // CHECK-LABEL: func.func @explicit_nd_bcast_row
+  func.func @explicit_nd_bcast_row(%arg0: !ttype4d_row) -> !ttype4d {
+    // CHECK: d2m.generic
+    // CHECK: linalg.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type row>}>
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 4, 32, 1>}> : (!ttype4d_row) -> !ttype4d
+    return %0 : !ttype4d
+  }
+
+  // CHECK-LABEL: func.func @explicit_outer_bcast
+  func.func @explicit_outer_bcast(%arg0: !ttype4d_outer) -> !ttype4d {
+    // CHECK-NOT: d2m.generic
+    // CHECK: d2m.view_layout
+    // CHECK-NOT: d2m.composite_view
+    // CHECK-NOT: "d2m.tile_bcast"
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 4, 1, 1>}> : (!ttype4d_outer) -> !ttype4d
+    return %0 : !ttype4d
+  }
+
+  // CHECK-LABEL: func.func @explicit_3d_outer_bcast
+  func.func @explicit_3d_outer_bcast(%arg0: !ttype3d_outer_in) -> !ttype3d_outer_out {
+    // CHECK-NOT: d2m.generic
+    // CHECK: d2m.view_layout
+    // CHECK-NOT: d2m.composite_view
+    // CHECK-NOT: "d2m.tile_bcast"
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 4, 1, 1>}> : (!ttype3d_outer_in) -> !ttype3d_outer_out
+    return %0 : !ttype3d_outer_out
+  }
+
+  // CHECK-LABEL: func.func @explicit_multi_outer_bcast
+  func.func @explicit_multi_outer_bcast(%arg0: !ttype4d_outer) -> !ttype4d_multi_outer {
+    // CHECK-NOT: d2m.generic
+    // CHECK: d2m.view_layout
+    // CHECK-NOT: d2m.composite_view
+    // CHECK-NOT: "d2m.tile_bcast"
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 2, 4, 1, 1>}> : (!ttype4d_outer) -> !ttype4d_multi_outer
+    return %0 : !ttype4d_multi_outer
+  }
+
+  // CHECK-LABEL: func.func @explicit_bcast_then_add
+  func.func @explicit_bcast_then_add(%arg0: !ttype_col, %arg1: !ttype) -> !ttype {
+    // CHECK: d2m.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type col>}>
+    // CHECK: d2m.generic
+    // CHECK: d2m.tile_add
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 128>}> : (!ttype_col) -> !ttype
+    %1 = "ttir.add"(%0, %arg1) : (!ttype, !ttype) -> !ttype
+    return %1 : !ttype
+  }
+}


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/6644

### Problem description
Need to support explicit bcast

### What's changed
- Added explicit bcast support in ttirtod2m
- Outer dim bcast rewritten as view layout with bcast affine map semantics
- Any bcast that operates on inner dim uses bcast tile api like how implicit bcast is done
- Added lit and builder tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
