### PR TITLE
[d2m-jit] bespoke wrappers

### DIFF
--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -239,6 +239,17 @@ void createD2MBackendPipeline(OpPassManager &pm,
 void createD2MToTTKernelPipeline(OpPassManager &pm,
                                  const D2MPipelineOptions &options);
 
+// Split halves of the D2M -> TTKernel + EmitC pipeline. Exposed so callers
+// that need to interleave dispatch-level conversion passes (e.g.
+// ConvertD2MToTTMetalPass) between the TTKernel and EmitC stages can compose
+// them directly. Composing pre-EmitC + dispatch + hoist-inits + EmitC matches
+// the canonical ordering in createTTIRToTTMetalPipeline.
+void createD2MToTTKernelPreEmitCPipeline(OpPassManager &pm,
+                                         const D2MPipelineOptions &options);
+
+void createD2MEmitCPipeline(OpPassManager &pm,
+                            const D2MPipelineOptions &options);
+
 void createD2MToTTMetalPipeline(OpPassManager &pm,
                                 const D2MPipelineOptions &options);
 

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -278,13 +278,13 @@ void createD2MToTTNNPipeline(OpPassManager &pm,
 // Adds the D2M→TTKernel conversion and TTKernel optimisation passes, but
 // intentionally stops short of EmitC lowering. Callers that need dispatch-level
 // D2M passes (e.g. ConvertD2MToTTMetalPass) to inspect TTKernel ops must run
-// those passes between here and addEmitCPasses(). TTKernelHoistInits and
-// TTKernelInsertDeviceZoneScopes are intentionally excluded: they must run
+// those passes between here and createD2MEmitCPipeline(). TTKernelHoistInits
+// and TTKernelInsertDeviceZoneScopes are intentionally excluded: they must run
 // AFTER dispatch-level conversion passes so those passes see the TTKernel op
 // structure intact (e.g. TypecastTileOp locality for BFP8 unpack-mode
 // selection). Callers are responsible for adding them at the right point.
-static void addD2MToTTKernelPreEmitCPasses(OpPassManager &pm,
-                                           const D2MPipelineOptions &options) {
+void createD2MToTTKernelPreEmitCPipeline(OpPassManager &pm,
+                                         const D2MPipelineOptions &options) {
   d2m::ConvertD2MToTTKernelOptions D2MToTTKernelOptions;
   { D2MToTTKernelOptions.ttnnMode = options.ttnnMode; }
   pm.addPass(tt::createConvertD2MToTTKernelPass(D2MToTTKernelOptions));
@@ -293,8 +293,8 @@ static void addD2MToTTKernelPreEmitCPasses(OpPassManager &pm,
   createOptimizationPasses(pm, options);
 }
 
-static void addEmitCPasses(OpPassManager &pm,
-                           const D2MPipelineOptions &options) {
+void createD2MEmitCPipeline(OpPassManager &pm,
+                            const D2MPipelineOptions &options) {
   pm.addPass(createConvertTTKernelToEmitC());
   pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(mlir::emitc::createFormExpressionsPass());
@@ -302,12 +302,12 @@ static void addEmitCPasses(OpPassManager &pm,
 
 void createD2MToTTKernelPipeline(OpPassManager &pm,
                                  const D2MPipelineOptions &options) {
-  addD2MToTTKernelPreEmitCPasses(pm, options);
+  createD2MToTTKernelPreEmitCPipeline(pm, options);
   pm.addPass(ttkernel::createTTKernelHoistInits());
   if (options.insertProfilerTraces) {
     pm.addPass(ttkernel::createTTKernelInsertDeviceZoneScopes());
   }
-  addEmitCPasses(pm, options);
+  createD2MEmitCPipeline(pm, options);
 }
 
 void createTTIRToTTMetalPipeline(OpPassManager &pm,
@@ -333,7 +333,7 @@ void createTTIRToTTMetalPipeline(OpPassManager &pm,
   // TypecastTileOp) to configure hardware unpack modes, so the dispatch-level
   // D2M→TTMetal/TTNN conversion must see the TTKernel ops before they are
   // lowered away by EmitC.
-  addD2MToTTKernelPreEmitCPasses(devicePm, options);
+  createD2MToTTKernelPreEmitCPipeline(devicePm, options);
   if (options.ttnnMode) {
     createD2MToTTNNPipeline(devicePm, options);
   } else {
@@ -347,7 +347,7 @@ void createTTIRToTTMetalPipeline(OpPassManager &pm,
   if (options.insertProfilerTraces) {
     devicePm.addPass(ttkernel::createTTKernelInsertDeviceZoneScopes());
   }
-  addEmitCPasses(devicePm, options);
+  createD2MEmitCPipeline(devicePm, options);
 
   // Run pipeline for lowering the CPU module to LLVM.
   OpPassManager &cpuPm = pm.nest<ttcore::CPUModuleOp>().nest<mlir::ModuleOp>();
@@ -373,6 +373,18 @@ void registerD2MPipelines() {
   mlir::PassPipelineRegistration<tt::ttmetal::D2MPipelineOptions>(
       "d2m-to-ttkernel-pipeline", "Convert D2M to TTKernel + EmitC.",
       tt::ttmetal::createD2MToTTKernelPipeline);
+  mlir::PassPipelineRegistration<tt::ttmetal::D2MPipelineOptions>(
+      "d2m-to-ttkernel-pre-emitc-pipeline",
+      "D2M -> TTKernel passes, stopping short of EmitC so dispatch-level "
+      "conversion passes (e.g. ConvertD2MToTTMetalPass) can still inspect "
+      "TTKernel ops (e.g. TypecastTileOp for fp32 unpack-mode selection).",
+      tt::ttmetal::createD2MToTTKernelPreEmitCPipeline);
+  mlir::PassPipelineRegistration<tt::ttmetal::D2MPipelineOptions>(
+      "d2m-emitc-pipeline",
+      "Lower TTKernel ops to EmitC. Pair with d2m-to-ttkernel-pre-emitc-"
+      "pipeline (plus dispatch-level conversion + ttkernel-hoist-inits "
+      "in between) to reproduce the full d2m-to-ttkernel-pipeline.",
+      tt::ttmetal::createD2MEmitCPipeline);
   mlir::PassPipelineRegistration<tt::ttmetal::D2MPipelineOptions>(
       "d2m-to-ttmetal-pipeline", "Convert D2M to TTMetal.",
       tt::ttmetal::createD2MToTTMetalPipeline);

--- a/test/d2m-jit/test_bespoke.py
+++ b/test/d2m-jit/test_bespoke.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bespoke-signature tile ops: clamp_scalar, typecast, tile_transpose.
+
+Each carries one or more Python-literal arguments that lower to MLIR
+attributes on the underlying `d2m.tile_*` op (rather than to a runtime
+operand). These tests exercise the silicon lowering with a minimal
+single-tile-per-shard layout."""
+
+import torch
+import d2m_jit as d2m
+
+
+def _make_layout(dtype=d2m.float32, shape=(64, 64)):
+    return d2m.Layout(shape=shape, dtype=dtype, block_shape=[1, 1], grid_shape=[2, 2])
+
+
+# ---------------------------------------------------------------------------
+# clamp_scalar
+# ---------------------------------------------------------------------------
+
+
+@d2m.kernel
+def k_clamp(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            r = clamp_scalar(x, -0.5, 0.5)
+            remote_store(out_t, [m_off + m, n_off + n], r)
+
+
+def test_clamp_scalar_float():
+    """clamp_scalar(x, -0.5, 0.5) clips a normal distribution to [-0.5, 0.5]."""
+    t = torch.randn(64, 64, dtype=torch.float32)
+    L = _make_layout()
+    out = d2m.empty(L)
+    k_clamp(d2m.to_layout(t, L), out, 1, 1, grid=(2, 2))
+    result = out.to_host()
+    expected = t.clamp(-0.5, 0.5)
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.01, f"clamp_scalar max diff {diff}"
+
+
+# Asymmetric bounds covered by the free-function form (method-style is
+# unavailable: see the note next to TensorBlock.tile_transpose in api.py).
+@d2m.kernel
+def k_clamp_asymmetric(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            r = clamp_scalar(x, 0.0, 2.0)
+            remote_store(out_t, [m_off + m, n_off + n], r)
+
+
+def test_clamp_scalar_asymmetric():
+    """Asymmetric bounds [0.0, 2.0]: covers the min!=−max code path."""
+    t = torch.randn(64, 64, dtype=torch.float32) * 2.0
+    L = _make_layout()
+    out = d2m.empty(L)
+    k_clamp_asymmetric(d2m.to_layout(t, L), out, 1, 1, grid=(2, 2))
+    result = out.to_host()
+    expected = t.clamp(0.0, 2.0)
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.01, f"clamp_scalar asymmetric max diff {diff}"
+
+
+# ---------------------------------------------------------------------------
+# typecast
+# ---------------------------------------------------------------------------
+
+
+@d2m.kernel
+def k_typecast(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            r = typecast(x, "bf16")
+            remote_store(out_t, [m_off + m, n_off + n], r)
+
+
+def test_typecast_f32_to_bf16():
+    """f32 -> bf16 mid-kernel via tile_typecast. Numerical correctness
+    relies on the pipeline running `convert-d2m-to-ttmetal` while
+    `ttkernel.typecast_tile` is still present (so the per-thread
+    UnpackToDestMode picks Fp32 rather than Default) -- see the comment
+    on `_PIPELINE` in tools/d2m-jit/_src/builder.py."""
+    t = torch.randn(64, 64, dtype=torch.float32)
+    L_in = _make_layout(dtype=d2m.float32)
+    L_out = _make_layout(dtype=d2m.bfloat16)
+    out = d2m.empty(L_out)
+    k_typecast(d2m.to_layout(t, L_in), out, 1, 1, grid=(2, 2))
+    result = out.to_host()
+    assert result.dtype == torch.bfloat16
+    expected = t.to(torch.bfloat16)
+    diff = (expected.float() - result.float()).abs().max().item()
+    # bf16 truncation rounding -- one ULP at this magnitude is ~0.016.
+    assert diff < 0.05, f"typecast f32->bf16 max diff {diff}"
+
+
+# ---------------------------------------------------------------------------
+# tile_transpose
+# ---------------------------------------------------------------------------
+
+
+@d2m.kernel
+def k_tile_transpose(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            r = tile_transpose(x)
+            remote_store(out_t, [m_off + m, n_off + n], r)
+
+
+def test_tile_transpose_per_tile():
+    """tile_transpose transposes each 32x32 tile in place. With one tile
+    per shard, the output's [cy*32:(cy+1)*32, cx*32:(cx+1)*32] block is
+    the transpose of the corresponding input block (NOT a logical
+    transpose of the full 64x64 tensor)."""
+    t = torch.randn(64, 64, dtype=torch.float32)
+    L = _make_layout()
+    out = d2m.empty(L)
+    k_tile_transpose(d2m.to_layout(t, L), out, 1, 1, grid=(2, 2))
+    result = out.to_host()
+
+    expected = torch.empty_like(t)
+    for cy in range(2):
+        for cx in range(2):
+            r0, r1 = cy * 32, (cy + 1) * 32
+            c0, c1 = cx * 32, (cx + 1) * 32
+            expected[r0:r1, c0:c1] = t[r0:r1, c0:c1].T
+
+    diff = (expected - result).abs().max().item()
+    assert diff < 0.01, f"tile_transpose max diff {diff}"

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -85,14 +85,6 @@ These ops live in `D2MGenericRegionOps.td` but are not yet exposed in
 so we add ops when we have something to test against rather than
 speculatively.
 
-### 🟡 Bespoke-signature ops (need design)
-
-| op | why it's interesting | what's blocking |
-| --- | --- | --- |
-| `tile_clamp_scalar(x, min, max)` | clamp with attribute (not operand) bounds | needs `FloatAttr` / `IntegerAttr` threading through `_eltwise_block`, plus a wrapper that picks the attr type from the tile's underlying dtype |
-| `tile_typecast(x)` | in-kernel dtype conversion (host-side already covered by `tilize(dtype=...)`) | needs an `_eltwise_block` variant that takes a target element type different from the input |
-| `tile_transpose(x)` | per-tile (32×32) element transpose -- distinct from logical `permute` / `view` | naming question — collides with `permute` / `view` semantics if called `transpose` |
-
 ### 🟡 Reductions (scoped — float blocked, int viable)
 
 `tile_reduce_sum`, `tile_reduce_max`, `tile_reduce_mean` (float) and

--- a/tools/d2m-jit/_src/ast.py
+++ b/tools/d2m-jit/_src/ast.py
@@ -417,6 +417,15 @@ class D2MCompiler(ast.NodeVisitor):
 
     def visit_Call(self, node):
         def _resolve(arg):
+            # If args_as_attr supplied a callable, call it on the whole AST
+            # node directly -- bypassing visit dispatch -- so attribute-typed
+            # args can be expressed as `UnaryOp(USub, Constant(0.5))` (i.e.
+            # `-0.5`) and similar non-bare-Constant forms. visit_Constant
+            # also honors this, but only for raw Constants; doing it here
+            # generalises to any AST shape the callable wants to handle.
+            as_attr = getattr(arg, "_ttkernel_as_attr", False)
+            if callable(as_attr):
+                return as_attr(arg)
             v = self.visit(arg)
             if v is None:
                 self._fail(

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -115,6 +115,18 @@ def _get_system_desc_path():
     return _g_system_desc_path
 
 
+# Pre-backend section is a deliberate lean subset (the d2m-jit bypass goal:
+# stay out of the TTIR->D2M frontend machinery since we build D2M IR
+# directly). Backend and TTKernel/EmitC tail use canonical pipelines so
+# they don't drift from createTTIRToTTMetalPipeline in D2MPipelines.cpp.
+#
+# Interleave note: convert-d2m-to-ttmetal MUST run while the kernel body is
+# still in TTKernel form — it walks for `ttkernel.typecast_tile` to choose
+# per-thread `UnpackToDestMode` (Fp32 vs Default). If the EmitC tail ran
+# first, the typecast would have become `emitc.call_opaque "typecast_tile"`
+# and the walk would silently fail to find it → wrong unpack mode → byte
+# scramble on f32→bf16 typecast. The pre-emitc / dispatch / hoist-inits /
+# emitc-tail split below mirrors what createTTIRToTTMetalPipeline does.
 _PIPELINE = ",".join(
     [
         "canonicalize",
@@ -130,8 +142,10 @@ _PIPELINE = ",".join(
         "d2m-generic-lower-to-explicit-form",
         "canonicalize",
         "d2m-be-pipeline{use-tile-matmul=0}",
-        "d2m-to-ttkernel-pipeline",
+        "d2m-to-ttkernel-pre-emitc-pipeline",
         "d2m-to-ttmetal-pipeline",
+        "ttkernel-hoist-inits",
+        "d2m-emitc-pipeline",
     ]
 )
 

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -4,14 +4,16 @@
 
 from __future__ import annotations
 
+import ast
+
 from ttmlir.ir import *
-from ttmlir.dialects import d2m, arith, linalg
+from ttmlir.dialects import d2m, ttcore, arith, linalg
 
 from ._src.utils import _asindex
 from ._src.ast import D2MCompiler, syntax
 from ._src.config import config
 from ._src.errors import D2mJitError
-from ._src.tensor_layout import Layout, float32, float16, bfloat16
+from ._src.tensor_layout import Layout, float32, float16, bfloat16, _to_data_type
 from ._src.builder import (
     CompiledKernel,
     LazyTensor,
@@ -374,6 +376,117 @@ def trunc(input):
     return _eltwise_block(lambda t: d2m.tile_trunc(t.type, t), input)
 
 
+# --- Bespoke-signature unary ops --------------------------------------------
+#
+# These take additional Python-literal arguments that lower to MLIR
+# attributes on the tile op (rather than runtime values). When called from
+# inside a `@d2m.kernel` body, the literal args are pulled out of the AST
+# via `_const_value`; from regular Python the wrapper accepts the same
+# literals directly.
+
+
+def _const_value(node):
+    """args_as_attr callback: pull a Python literal out of `node`.
+
+    Accepts a bare `ast.Constant`, or a `+literal`/`-literal` UnaryOp on
+    a numeric constant (Python parses `-0.5` as `UnaryOp(USub,
+    Constant(0.5))`). Raises a clear error otherwise so kernel users
+    get a useful message instead of an obscure compile-time crash."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.UnaryOp) and isinstance(node.operand, ast.Constant):
+        v = node.operand.value
+        if isinstance(v, (int, float)):
+            if isinstance(node.op, ast.USub):
+                return -v
+            if isinstance(node.op, ast.UAdd):
+                return v
+    raise D2mJitError(
+        f"expected a Python literal (number/string), got "
+        f"{type(node).__name__}; runtime values are not supported "
+        f"for attribute-typed kernel arguments"
+    )
+
+
+def _tile_elem_type(block):
+    """Return the !ttcore.tile element type of a tile-tensor block, or
+    raise a clear error if `block` isn't a tile tensor."""
+    elem_ty = ttcore.ir.TileType.maybe_downcast(block.type.element_type)
+    if elem_ty is None:
+        raise TypeError(
+            f"expected a tile-typed tensor block, got element type "
+            f"{block.type.element_type}"
+        )
+    return elem_ty
+
+
+# The ttcore.DataType returned by `TileType.data_type` comes from a
+# different python-binding module than `ttcore.DataType.Float32` (separate
+# nanobind modules each bind the same C++ enum), so `==` and `in` fail.
+# Compare via `.name` strings.
+_FLOAT_DATA_TYPE_NAMES = frozenset({"Float32", "Float16", "BFloat16"})
+
+
+def _is_float_tile_dtype(tile_elem_ty):
+    return tile_elem_ty.data_type.name in _FLOAT_DATA_TYPE_NAMES
+
+
+@syntax(
+    "clamp_scalar",
+    args_as_attr=[False, _const_value, _const_value],
+)
+def clamp_scalar(input, min, max):
+    """Block-level elementwise clamp to scalar bounds `[min, max]`.
+
+    `min` and `max` must be Python literals. The attribute type is picked
+    from the tile element type: float tiles use F32Attr; integer tiles use
+    I32Attr (the verifier requires both bounds to be the same attr type).
+    """
+    elem_ty = _tile_elem_type(input)
+    if _is_float_tile_dtype(elem_ty):
+        f32 = F32Type.get()
+        min_attr = FloatAttr.get(f32, float(min))
+        max_attr = FloatAttr.get(f32, float(max))
+    else:
+        i32 = IntegerType.get_signless(32)
+        min_attr = IntegerAttr.get(i32, int(min))
+        max_attr = IntegerAttr.get(i32, int(max))
+    return _eltwise_block(
+        lambda t: d2m.tile_clamp_scalar(t.type, t, min_attr, max_attr),
+        input,
+    )
+
+
+@syntax(
+    "typecast",
+    args_as_attr=[False, _const_value],
+)
+def typecast(input, dtype):
+    """Block-level elementwise per-tile typecast to `dtype`.
+
+    `dtype` is a d2m DataType (e.g. `d2m.bfloat16`) or one of the strings
+    accepted by `_to_data_type` (`"fp32"`, `"bf16"`, `"fp16"`, ...). The
+    output block has the same shape as the input but a different tile
+    element type.
+
+    Distinct from host-side `tilize(dtype=...)` / `untilize(dtype=...)`:
+    those convert a `LazyTensor`'s layout off-device; this one happens
+    inside the kernel body during compute.
+    """
+    return _typecast_block(input, dtype)
+
+
+@syntax("tile_transpose")
+def tile_transpose(input):
+    """Block-level elementwise per-tile (32x32) transpose.
+
+    Distinct from logical `d2m.permute` / `d2m.view` (host-side layout
+    transformations on a `LazyTensor`): this one transposes each tile
+    in-place inside a kernel body.
+    """
+    return _eltwise_block(lambda t: d2m.tile_transpose(t.type, t), input)
+
+
 @syntax("add")
 def add(lhs, rhs):
     """Block-level elementwise addition."""
@@ -710,6 +823,18 @@ class TensorBlock:
         """Same as `d2m.trunc(self)`."""
         return trunc(ast_self)
 
+    def tile_transpose(ast_self: TensorBlock) -> TensorBlock:
+        """Same as `d2m.tile_transpose(self)` -- per-tile (32x32) transpose."""
+        return tile_transpose(ast_self)
+
+    # NOTE: clamp_scalar / typecast / bcast intentionally have no
+    # method-style form. They carry Python-literal attribute arguments,
+    # and the AST visitor's `args_as_attr` mechanism only kicks in on
+    # free-function calls (visit_Call on a Name target). Method calls go
+    # through visit_Attribute and fully evaluate their args, which would
+    # fall over on float literals (visit_Constant doesn't handle floats).
+    # Use the free-function form: `clamp_scalar(x, -1.0, 1.0)` etc.
+
     # --- Binary block-level method forms ----
     def add(ast_self: TensorBlock, rhs: TensorBlock) -> TensorBlock:
         """Same as `d2m.add(self, rhs)`."""
@@ -861,6 +986,58 @@ def _eltwise_block(tile_op_fn, *blocks):
         if hasattr(result, "result"):
             result = result.result
         linalg.yield_([result])
+    return generic.result
+
+
+def _typecast_block(input, dtype):
+    """Tile-level typecast inside a linalg.generic. Output block has the
+    same shape as `input` but a different tile element type.
+
+    Separate from `_eltwise_block` because that helper assumes input and
+    output blocks share an element type; typecast deliberately changes it.
+    """
+    src_tile_dc = _tile_elem_type(input)
+    dst_data_type = _to_data_type(dtype)
+    if src_tile_dc.data_type.name == dst_data_type.name:
+        # No-op: avoid emitting a typecast for a same-dtype cast (the
+        # backend may not support the resulting init/run pair).
+        return input
+    src_shape = src_tile_dc.shape
+    # `dst_tile_ty` is a plain ir.Type; `block_ty.element_type` is also a
+    # plain ir.Type. We deliberately use those (not the downcast
+    # `tt_ir.TileType`) as Block arg types -- Block.create_at_start does
+    # not accept the downcast subclass.
+    dst_tile_ty = ttcore.ir.TileType.get(
+        input.context, src_shape[0], src_shape[1], dst_data_type
+    )
+    block_ty = input.type
+    src_tile_ty = block_ty.element_type
+    rank = block_ty.rank
+    out_block_ty = RankedTensorType.get(list(block_ty.shape), dst_tile_ty)
+
+    output = d2m.empty(out_block_ty)
+    identity = AffineMap.get_identity(rank)
+    indexing_maps = ArrayAttr.get([AffineMapAttr.get(identity)] * 2)
+    parallel = Attribute.parse("#linalg.iterator_type<parallel>")
+    iterator_types = ArrayAttr.get([parallel] * rank)
+
+    generic = linalg.GenericOp(
+        [out_block_ty],
+        [input],
+        [output],
+        indexing_maps,
+        iterator_types,
+    )
+    body = Block.create_at_start(
+        generic.regions[0],
+        [src_tile_ty, dst_tile_ty],
+        [Location.unknown()] * 2,
+    )
+    with InsertionPoint(body):
+        casted = d2m.tile_typecast(dst_tile_ty, body.arguments[0])
+        if hasattr(casted, "result"):
+            casted = casted.result
+        linalg.yield_([casted])
     return generic.result
 
 


### PR DESCRIPTION
### Problem description
d2m-jit is missing support for a few ops: tile_clamp_scalar, tile_bcast, tile_transpose, and tile_typecast
### What's changed
Add support for these ops in d2m-jit

### Checklist
- [ ] New/Existing tests provide coverage for changes
