### PR TITLE
Handle rank-0 cache position in KV cache fusing pattern

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -6123,8 +6123,21 @@ public:
     auto cacheUpdateInputType =
         mlir::cast<RankedTensorType>((*CachePositions).getType());
     auto cacheUpdateInputShape = cacheUpdateInputType.getShape();
-    if (cacheUpdateInputShape.size() != 1) {
-      return mlir::failure();
+    if (cacheUpdateInputShape.size() > 1) {
+      return rewriter.notifyMatchFailure(
+          scatterOp,
+          "cache position operand must be rank-0 or rank-1, got rank " +
+              std::to_string(cacheUpdateInputShape.size()));
+    }
+
+    // If the cache position is rank-0 (scalar), reshape it to rank-1 so that
+    // downstream ops (UpdateCacheOp, its canonicalization) can index shape[0].
+    if (cacheUpdateInputShape.empty()) {
+      auto rank1Type =
+          RankedTensorType::get({1}, cacheUpdateInputType.getElementType());
+      *CachePositions = rewriter.create<mlir::tt::ttir::ReshapeOp>(
+          scatterOp.getLoc(), rank1Type, *CachePositions,
+          rewriter.getI32ArrayAttr({1}));
     }
 
     Value cache = scatterOp.getInputs()[0];

--- a/test/ttmlir/Conversion/StableHLOToTTIR/kv_cache_fusing.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/kv_cache_fusing.mlir
@@ -151,6 +151,53 @@ module @scatter {
   }
 }
 
+// Test case with a UpdateCache scatter op pattern where the cache position
+// input is a rank-0 scalar (tensor<i64>). The pattern should accept it and
+// reshape it to rank-1 before creating ttir.update_cache.
+module @scatter_update_cache_rank0 {
+  func.func @update_cache_rank0(%arg0: tensor<1x8x64x128xbf16>, %arg1: tensor<i64>, %arg2: tensor<1x8x1x128xbf16>) -> tensor<1x8x64x128xbf16> {
+    // CHECK-NOT: ttir.scatter
+    // CHECK-NOT: ttir.fill_cache
+    // CHECK: %[[RESHAPED:.*]] = "ttir.reshape"(%arg1) <{shape = [1 : i32]}> : (tensor<i64>) -> tensor<1xi64>
+    // CHECK: %[[RET:[0-9]+]] = "ttir.update_cache"(%arg0, %arg2, %[[RESHAPED]]) <{batch_offset = 0 : i32}> : (tensor<1x8x64x128xbf16>, tensor<1x8x1x128xbf16>, tensor<1xi64>) -> tensor<1x8x64x128xbf16>
+    // CHECK: return %[[RET]] : tensor<1x8x64x128xbf16>
+
+    %0 = stablehlo.constant() <{value = dense<0> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %1 = stablehlo.constant() <{value = dense<1> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %2 = stablehlo.constant() <{value = dense<0> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %3 = stablehlo.constant() <{value = dense<1> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %4 = stablehlo.constant() <{value = dense<0> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %5 = stablehlo.constant() <{value = dense<1> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %6 = stablehlo.iota dim = 0 : tensor<128xi64>
+    %8 = stablehlo.multiply %6, %5 : tensor<128xi64>
+    %10 = stablehlo.add %8, %4 : tensor<128xi64>
+    %11 = stablehlo.iota dim = 0 : tensor<8xi64>
+    %13 = stablehlo.multiply %11, %3 : tensor<8xi64>
+    %15 = stablehlo.add %13, %2 : tensor<8xi64>
+    %16 = stablehlo.iota dim = 0 : tensor<1xi64>
+    %18 = stablehlo.multiply %16, %1 : tensor<1xi64>
+    %20 = stablehlo.add %18, %0 : tensor<1xi64>
+    %22 = stablehlo.reshape %20 : (tensor<1xi64>) -> tensor<1x1x1x1xi64>
+    %24 = stablehlo.broadcast_in_dim %22, dims = [0, 1, 2, 3] : (tensor<1x1x1x1xi64>) -> tensor<1x8x1x128xi64>
+    %26 = stablehlo.reshape %24 : (tensor<1x8x1x128xi64>) -> tensor<1x8x1x128x1xi64>
+    %28 = stablehlo.reshape %15 : (tensor<8xi64>) -> tensor<1x8x1x1xi64>
+    %30 = stablehlo.broadcast_in_dim %28, dims = [0, 1, 2, 3] : (tensor<1x8x1x1xi64>) -> tensor<1x8x1x128xi64>
+    %32 = stablehlo.reshape %30 : (tensor<1x8x1x128xi64>) -> tensor<1x8x1x128x1xi64>
+    %34 = stablehlo.reshape %arg1 : (tensor<i64>) -> tensor<1x1x1x1xi64>
+    %36 = stablehlo.broadcast_in_dim %34, dims = [0, 1, 2, 3] : (tensor<1x1x1x1xi64>) -> tensor<1x8x1x128xi64>
+    %38 = stablehlo.reshape %36 : (tensor<1x8x1x128xi64>) -> tensor<1x8x1x128x1xi64>
+    %40 = stablehlo.reshape %10 : (tensor<128xi64>) -> tensor<1x1x1x128xi64>
+    %42 = stablehlo.broadcast_in_dim %40, dims = [0, 1, 2, 3] : (tensor<1x1x1x128xi64>) -> tensor<1x8x1x128xi64>
+    %44 = stablehlo.reshape %42 : (tensor<1x8x1x128xi64>) -> tensor<1x8x1x128x1xi64>
+    %46 = stablehlo.concatenate %26, %32, %38, %44, dim = 4 : (tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x1xi64>) -> tensor<1x8x1x128x4xi64>
+    %48 = "stablehlo.scatter"(%arg0, %46, %arg2) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [], inserted_window_dims = [0, 1, 2, 3], scatter_dims_to_operand_dims = [0, 1, 2, 3], index_vector_dim = 4>, unique_indices = false}> ({
+    ^bb0(%arg3: tensor<bf16>, %arg4: tensor<bf16>):
+      stablehlo.return %arg4 : tensor<bf16>
+    }) : (tensor<1x8x64x128xbf16>, tensor<1x8x1x128x4xi64>, tensor<1x8x1x128xbf16>) -> tensor<1x8x64x128xbf16>
+    return %48 : tensor<1x8x64x128xbf16>
+  }
+}
+
 // Test case with a scatter op that has to track all the way up to a const arange with the wrong values. Should not fuse scatter into ttir.update_cache
 module {
   func.func @main(%arg0: tensor<1x8x64x128xbf16>, %arg1: tensor<14xi64>, %arg2: tensor<1x8x14x128xbf16>) -> tensor<1x8x64x128xbf16> {


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/8618

### Summary
- The KV cache scatter fusing pattern previously rejected rank-0 (scalar)
  cache position inputs, causing the pattern to silently fail to match.
- Now rank-0 cache positions are reshaped to rank-1 via `ttir.reshape`
  before creating `ttir.update_cache`, matching what downstream ops expect.
- Improved the rank>1 failure message to use `notifyMatchFailure` instead
  of a bare `mlir::failure()`.
- Added a lit test for the rank-0 scalar cache position case.

### Checklist
- [ ] New/Existing tests provide coverage for changes
