### PR TITLE
Fold broadcast into matmul

### DIFF
--- a/lib/Dialect/TTIR/Transforms/Broadcast.cpp
+++ b/lib/Dialect/TTIR/Transforms/Broadcast.cpp
@@ -96,70 +96,69 @@ public:
   }
 };
 
-// Drop a `ttir.broadcast` feeding a `ttir.matmul` operand when it only
-// expands batch (leading) dims and the other operand already supplies the
-// expanded size at those positions.
+// Drop a `ttir.broadcast` feeding the RHS of a `ttir.matmul` when it only
+// expands the second batch dim and the LHS already supplies the expanded size.
 class FoldBroadcastIntoMatmul : public OpRewritePattern<ttir::MatmulOp> {
 public:
   using OpRewritePattern<ttir::MatmulOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(ttir::MatmulOp op,
                                 PatternRewriter &rewriter) const override {
-    Value newA = op.getA();
-    Value newB = op.getB();
-    bool changed = false;
-    if (Value dropped = tryDropBroadcast(newA, newB)) {
-      newA = dropped;
-      changed = true;
-    }
-    if (Value dropped = tryDropBroadcast(newB, newA)) {
-      newB = dropped;
-      changed = true;
-    }
-    if (!changed) {
+    Value newB = tryDropBroadcast(op.getB(), op.getA());
+    if (!newB) {
       return failure();
     }
-    rewriter.modifyOpInPlace(op, [&]() {
-      op.setOperand(0, newA);
-      op.setOperand(1, newB);
-    });
+    rewriter.modifyOpInPlace(op, [&]() { op.setOperand(1, newB); });
     return success();
   }
 
 private:
-  // If `operand` is a ttir.broadcast that expanded only batch (leading-but-
-  // not-last-two) dims, and `other` already has the expanded size at every
-  // such position, return the broadcast's input. Otherwise return a null
-  // Value.
+  // TTNN's matmul documentation mentions that broadcasting is in general
+  // basically unsupported, albeit a few cases might work. This code only checks
+  // one case: With 4Dx4D operands, dim 1(second batch dimension) on the RHS can
+  // be broadcast to match the LHS. Other cases are explicitly out of scope for
+  // now. This *is* basically hardcoding the current details of metal behavior
+  // on the TTIR level, just like isImplicitBroadcastSupported does for
+  // elementwise ops.
+  //
+  // `operand` is the RHS (the potentially-broadcast input), `other` the LHS.
   static Value tryDropBroadcast(Value operand, Value other) {
     auto bcast = operand.getDefiningOp<ttir::BroadcastOp>();
-    if (!bcast || !ttir::utils::isImplicitBroadcastSupported(bcast)) {
+    if (!bcast) {
       return {};
     }
     auto inShape =
         mlir::cast<RankedTensorType>(bcast.getInput().getType()).getShape();
     auto outShape = mlir::cast<RankedTensorType>(operand.getType()).getShape();
     auto otherShape = mlir::cast<RankedTensorType>(other.getType()).getShape();
-    int64_t rank = outShape.size();
-    // Require ≥3D and equal ranks: matmul aligns batch dims by position when
-    // ranks match; differing ranks complicate the safety check.
-    if (rank < 3 || static_cast<int64_t>(otherShape.size()) != rank) {
+
+    constexpr int64_t kMatmulRank = 4;
+    constexpr int64_t kBroadcastableBatchDim = 1;
+    if (static_cast<int64_t>(inShape.size()) != kMatmulRank ||
+        static_cast<int64_t>(otherShape.size()) != kMatmulRank) {
       return {};
     }
-    // Inner two dims (M/K or K/N) are matmul-inner; broadcasting them would
-    // change semantics — in particular expanding K changes the contract size.
-    for (int64_t i = rank - 2; i < rank; ++i) {
-      if (inShape[i] != outShape[i]) {
+
+    // Validate the fold dim by dim:
+    //  - The broadcast must expand exactly dim 1 and leave every other dim
+    //    untouched -- the inner two dims (M/K, K/N) carry matmul semantics, and
+    //    the kernel cannot broadcast dim 0.
+    //  - On the batch dims, the LHS must already carry the matmul's batch size,
+    //    so dropping the broadcast leaves the result unchanged and the kernel
+    //    only has to implicitly broadcast a size-1 RHS dim 1 against a matching
+    //    dim 0.
+    constexpr int64_t kNumBatchDims = kMatmulRank - 2;
+    for (int64_t i = 0; i < kMatmulRank; ++i) {
+      bool expanded = inShape[i] != outShape[i];
+      if (expanded != (i == kBroadcastableBatchDim)) {
+        return {};
+      }
+      bool isBatchDim = i < kNumBatchDims;
+      if (isBatchDim && otherShape[i] != outShape[i]) {
         return {};
       }
     }
-    // For each expanded batch dim, the other operand must already supply the
-    // expanded size — otherwise dropping the broadcast shrinks the result.
-    for (int64_t i = 0; i < rank - 2; ++i) {
-      if (inShape[i] != outShape[i] && otherShape[i] != outShape[i]) {
-        return {};
-      }
-    }
+
     return bcast.getInput();
   }
 };

--- a/lib/Dialect/TTIR/Transforms/Broadcast.cpp
+++ b/lib/Dialect/TTIR/Transforms/Broadcast.cpp
@@ -3,15 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTIR/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
-#include "llvm/ADT/SmallSet.h"
 
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRIMPLICITBROADCASTFOLD
@@ -99,107 +96,76 @@ public:
   }
 };
 
-// Fold `dot_general(lhs, broadcast(rhs))` (and the symmetric lhs case) by
-// dropping batch dims that the broadcast expanded — the dim survives on the
-// other operand alone. Avoids materializing the expanded tensor.
-//
-// Only safe when every expanded dim is a batch dim of the dot_general:
-// expanding a contract dim would change semantics, and expanding a non-batch
-// non-contract dim would shrink the output. This is why it is done as a 
-// a separate pattern rather than using the Broadcastable trait.
-class FoldBroadcastIntoDotGeneral
-    : public OpRewritePattern<ttir::DotGeneralOp> {
+// Drop a `ttir.broadcast` feeding a `ttir.matmul` operand when it only
+// expands batch (leading) dims and the other operand already supplies the
+// expanded size at those positions. matmul's verifier broadcasts batch dims
+// natively (see MatmulOp::verify), so removing the explicit broadcast keeps
+// the result shape and computation. Avoids materializing the expanded
+// operand and prevents ConstEvalHoist from baking it into HBM (AOTAutograd
+// einsum tracing emits this on small constant matmul operands; the broadcast
+// lands on matmul after dot_general decomposition + canonicalization).
+class FoldBroadcastIntoMatmul : public OpRewritePattern<ttir::MatmulOp> {
 public:
-  using OpRewritePattern<ttir::DotGeneralOp>::OpRewritePattern;
+  using OpRewritePattern<ttir::MatmulOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(ttir::DotGeneralOp op,
+  LogicalResult matchAndRewrite(ttir::MatmulOp op,
                                 PatternRewriter &rewriter) const override {
-    if (succeeded(tryFoldOperand(op, /*isRhs=*/true, rewriter))) {
-      return success();
+    Value newA = op.getA();
+    Value newB = op.getB();
+    bool changed = false;
+    if (Value dropped = tryDropBroadcast(newA, newB)) {
+      newA = dropped;
+      changed = true;
     }
-    return tryFoldOperand(op, /*isRhs=*/false, rewriter);
+    if (Value dropped = tryDropBroadcast(newB, newA)) {
+      newB = dropped;
+      changed = true;
+    }
+    if (!changed) {
+      return failure();
+    }
+    rewriter.modifyOpInPlace(op, [&]() {
+      op.setOperand(0, newA);
+      op.setOperand(1, newB);
+    });
+    return success();
   }
 
 private:
-  static LogicalResult tryFoldOperand(ttir::DotGeneralOp op, bool isRhs,
-                                      PatternRewriter &rewriter) {
-    Value foldOperand = isRhs ? op.getRhs() : op.getLhs();
-    auto bcast = foldOperand.getDefiningOp<ttir::BroadcastOp>();
-    if (!bcast) {
-      return failure();
+  // If `operand` is a ttir.broadcast that expanded only batch (leading-but-
+  // not-last-two) dims, and `other` already has the expanded size at every
+  // such position, return the broadcast's input. Otherwise return a null
+  // Value.
+  static Value tryDropBroadcast(Value operand, Value other) {
+    auto bcast = operand.getDefiningOp<ttir::BroadcastOp>();
+    if (!bcast || !ttir::utils::isImplicitBroadcastSupported(bcast)) {
+      return {};
     }
-
-    auto outType = mlir::cast<RankedTensorType>(foldOperand.getType());
-    auto inType = mlir::cast<RankedTensorType>(bcast.getInput().getType());
-    if (!inType.hasStaticShape() || !outType.hasStaticShape()) {
-      return failure();
+    auto inShape =
+        mlir::cast<RankedTensorType>(bcast.getInput().getType()).getShape();
+    auto outShape = mlir::cast<RankedTensorType>(operand.getType()).getShape();
+    auto otherShape = mlir::cast<RankedTensorType>(other.getType()).getShape();
+    int64_t rank = outShape.size();
+    // Require ≥3D and equal ranks: matmul aligns batch dims by position when
+    // ranks match; differing ranks complicate the safety check.
+    if (rank < 3 || static_cast<int64_t>(otherShape.size()) != rank) {
+      return {};
     }
-
-    llvm::SmallSet<int64_t, 4> expanded;
-    for (int64_t i = 0; i < outType.getRank(); ++i) {
-      if (inType.getShape()[i] != outType.getShape()[i]) {
-        expanded.insert(i);
+    // Inner two dims (M/K or K/N) are matmul-inner; broadcasting them would
+    // change semantics — in particular expanding K changes the contract size.
+    for (int64_t i = rank - 2; i < rank; ++i) {
+      if (inShape[i] != outShape[i]) {
+        return {};
       }
     }
-    if (expanded.empty()) {
-      return failure();
-    }
-
-    auto foldBatch = isRhs ? op.getBatchDimsRhs() : op.getBatchDimsLhs();
-    auto otherBatch = isRhs ? op.getBatchDimsLhs() : op.getBatchDimsRhs();
-    auto foldContract =
-        isRhs ? op.getContractDimsRhs() : op.getContractDimsLhs();
-    auto otherContract =
-        isRhs ? op.getContractDimsLhs() : op.getContractDimsRhs();
-
-    if (!llvm::all_of(expanded, [&](int64_t d) {
-          return llvm::is_contained(foldBatch, d);
-        })) {
-      return failure();
-    }
-
-    // Drop expanded positions and build an old→new index remap.
-    llvm::SmallVector<int64_t> newShape;
-    llvm::SmallVector<int64_t> remap(outType.getRank(), -1);
-    for (int64_t i = 0, j = 0; i < outType.getRank(); ++i) {
-      if (!expanded.contains(i)) {
-        newShape.push_back(inType.getShape()[i]);
-        remap[i] = j++;
+    // For each expanded batch dim, the other operand must already supply the
+    // expanded size — otherwise dropping the broadcast shrinks the result.
+    for (int64_t i = 0; i < rank - 2; ++i) {
+      if (inShape[i] != outShape[i] && otherShape[i] != outShape[i]) {
+        return {};
       }
     }
-
-    llvm::SmallVector<int64_t> newFoldBatch, newOtherBatch;
-    for (auto [f, o] : llvm::zip_equal(foldBatch, otherBatch)) {
-      if (!expanded.contains(f)) {
-        newFoldBatch.push_back(remap[f]);
-        newOtherBatch.push_back(o);
-      }
-    }
-
-    llvm::SmallVector<int64_t> newFoldContract;
-    for (int64_t d : foldContract) {
-      newFoldContract.push_back(remap[d]);
-    }
-
-    Value newOperand = ttir::utils::createReshapeOp(
-        rewriter, op.getLoc(), bcast.getInput(), newShape);
-
-    Value newLhs = isRhs ? op.getLhs() : newOperand;
-    Value newRhs = isRhs ? newOperand : op.getRhs();
-    llvm::ArrayRef<int64_t> newBatchLhs = isRhs ? newOtherBatch : newFoldBatch;
-    llvm::ArrayRef<int64_t> newBatchRhs = isRhs ? newFoldBatch : newOtherBatch;
-    llvm::ArrayRef<int64_t> newContractLhs =
-        isRhs ? otherContract : llvm::ArrayRef<int64_t>(newFoldContract);
-    llvm::ArrayRef<int64_t> newContractRhs =
-        isRhs ? llvm::ArrayRef<int64_t>(newFoldContract) : otherContract;
-
-    rewriter.replaceOpWithNewOp<ttir::DotGeneralOp>(
-        op, op.getResult().getType(), newLhs, newRhs,
-        rewriter.getDenseI64ArrayAttr(newBatchLhs),
-        rewriter.getDenseI64ArrayAttr(newContractLhs),
-        rewriter.getDenseI64ArrayAttr(newBatchRhs),
-        rewriter.getDenseI64ArrayAttr(newContractRhs));
-    return success();
+    return bcast.getInput();
   }
 };
 
@@ -210,7 +176,7 @@ public:
       TTIRImplicitBroadcastFold>::TTIRImplicitBroadcastFoldBase;
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
-    patterns.add<TTIRImplicitBroadcastFoldRewriter, FoldBroadcastIntoDotGeneral>(
+    patterns.add<TTIRImplicitBroadcastFoldRewriter, FoldBroadcastIntoMatmul>(
         &getContext());
     FrozenRewritePatternSet patternSet(std::move(patterns));
 

--- a/lib/Dialect/TTIR/Transforms/Broadcast.cpp
+++ b/lib/Dialect/TTIR/Transforms/Broadcast.cpp
@@ -104,11 +104,11 @@ public:
 
   LogicalResult matchAndRewrite(ttir::MatmulOp op,
                                 PatternRewriter &rewriter) const override {
-    Value newB = tryDropBroadcast(op.getB(), op.getA());
-    if (!newB) {
+    Value newRhs = tryDropBroadcast(op.getB(), op.getA());
+    if (!newRhs) {
       return failure();
     }
-    rewriter.modifyOpInPlace(op, [&]() { op.setOperand(1, newB); });
+    rewriter.modifyOpInPlace(op, [&]() { op.setOperand(1, newRhs); });
     return success();
   }
 
@@ -120,43 +120,40 @@ private:
   // now. This *is* basically hardcoding the current details of metal behavior
   // on the TTIR level, just like isImplicitBroadcastSupported does for
   // elementwise ops.
-  //
-  // `operand` is the RHS (the potentially-broadcast input), `other` the LHS.
-  static Value tryDropBroadcast(Value operand, Value other) {
-    auto bcast = operand.getDefiningOp<ttir::BroadcastOp>();
+  static Value tryDropBroadcast(Value rhs, Value lhs) {
+    auto bcast = rhs.getDefiningOp<ttir::BroadcastOp>();
     if (!bcast) {
       return {};
     }
-    auto inShape =
+    // `foldedRhsShape` is what the RHS would become if we drop the broadcast.
+    auto foldedRhsShape =
         mlir::cast<RankedTensorType>(bcast.getInput().getType()).getShape();
-    auto outShape = mlir::cast<RankedTensorType>(operand.getType()).getShape();
-    auto otherShape = mlir::cast<RankedTensorType>(other.getType()).getShape();
+    auto rhsShape = mlir::cast<RankedTensorType>(rhs.getType()).getShape();
+    auto lhsShape = mlir::cast<RankedTensorType>(lhs.getType()).getShape();
 
     constexpr int64_t kMatmulRank = 4;
     constexpr int64_t kBroadcastableBatchDim = 1;
-    if (static_cast<int64_t>(inShape.size()) != kMatmulRank ||
-        static_cast<int64_t>(otherShape.size()) != kMatmulRank) {
+    if (static_cast<int64_t>(foldedRhsShape.size()) != kMatmulRank ||
+        static_cast<int64_t>(lhsShape.size()) != kMatmulRank) {
       return {};
     }
 
-    // Validate the fold dim by dim:
-    //  - The broadcast must expand exactly dim 1 and leave every other dim
-    //    untouched -- the inner two dims (M/K, K/N) carry matmul semantics, and
-    //    the kernel cannot broadcast dim 0.
-    //  - On the batch dims, the LHS must already carry the matmul's batch size,
-    //    so dropping the broadcast leaves the result unchanged and the kernel
-    //    only has to implicitly broadcast a size-1 RHS dim 1 against a matching
-    //    dim 0.
-    constexpr int64_t kNumBatchDims = kMatmulRank - 2;
+    // The broadcast must expand exactly dim 1 and leave every other dim
+    // untouched: the inner two dims (M/K, K/N) carry matmul semantics, and dim
+    // 0 is only sometimes broadcastable, so the safe default is to keep it
+    // untouched.
     for (int64_t i = 0; i < kMatmulRank; ++i) {
-      bool expanded = inShape[i] != outShape[i];
+      bool expanded = foldedRhsShape[i] != rhsShape[i];
       if (expanded != (i == kBroadcastableBatchDim)) {
         return {};
       }
-      bool isBatchDim = i < kNumBatchDims;
-      if (isBatchDim && otherShape[i] != outShape[i]) {
-        return {};
-      }
+    }
+
+    // The LHS must already supply the broadcast dim's full size, so dropping
+    // the broadcast leaves the result unchanged and the kernel only has to
+    // implicitly broadcast a size-1 RHS dim 1.
+    if (lhsShape[kBroadcastableBatchDim] != rhsShape[kBroadcastableBatchDim]) {
+      return {};
     }
 
     return bcast.getInput();

--- a/lib/Dialect/TTIR/Transforms/Broadcast.cpp
+++ b/lib/Dialect/TTIR/Transforms/Broadcast.cpp
@@ -3,12 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTIR/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallSet.h"
 
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRIMPLICITBROADCASTFOLD
@@ -96,6 +99,110 @@ public:
   }
 };
 
+// Fold `dot_general(lhs, broadcast(rhs))` (and the symmetric lhs case) by
+// dropping batch dims that the broadcast expanded — the dim survives on the
+// other operand alone. Avoids materializing the expanded tensor.
+//
+// Only safe when every expanded dim is a batch dim of the dot_general:
+// expanding a contract dim would change semantics, and expanding a non-batch
+// non-contract dim would shrink the output. This is why it is done as a 
+// a separate pattern rather than using the Broadcastable trait.
+class FoldBroadcastIntoDotGeneral
+    : public OpRewritePattern<ttir::DotGeneralOp> {
+public:
+  using OpRewritePattern<ttir::DotGeneralOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttir::DotGeneralOp op,
+                                PatternRewriter &rewriter) const override {
+    if (succeeded(tryFoldOperand(op, /*isRhs=*/true, rewriter))) {
+      return success();
+    }
+    return tryFoldOperand(op, /*isRhs=*/false, rewriter);
+  }
+
+private:
+  static LogicalResult tryFoldOperand(ttir::DotGeneralOp op, bool isRhs,
+                                      PatternRewriter &rewriter) {
+    Value foldOperand = isRhs ? op.getRhs() : op.getLhs();
+    auto bcast = foldOperand.getDefiningOp<ttir::BroadcastOp>();
+    if (!bcast) {
+      return failure();
+    }
+
+    auto outType = mlir::cast<RankedTensorType>(foldOperand.getType());
+    auto inType = mlir::cast<RankedTensorType>(bcast.getInput().getType());
+    if (!inType.hasStaticShape() || !outType.hasStaticShape()) {
+      return failure();
+    }
+
+    llvm::SmallSet<int64_t, 4> expanded;
+    for (int64_t i = 0; i < outType.getRank(); ++i) {
+      if (inType.getShape()[i] != outType.getShape()[i]) {
+        expanded.insert(i);
+      }
+    }
+    if (expanded.empty()) {
+      return failure();
+    }
+
+    auto foldBatch = isRhs ? op.getBatchDimsRhs() : op.getBatchDimsLhs();
+    auto otherBatch = isRhs ? op.getBatchDimsLhs() : op.getBatchDimsRhs();
+    auto foldContract =
+        isRhs ? op.getContractDimsRhs() : op.getContractDimsLhs();
+    auto otherContract =
+        isRhs ? op.getContractDimsLhs() : op.getContractDimsRhs();
+
+    if (!llvm::all_of(expanded, [&](int64_t d) {
+          return llvm::is_contained(foldBatch, d);
+        })) {
+      return failure();
+    }
+
+    // Drop expanded positions and build an old→new index remap.
+    llvm::SmallVector<int64_t> newShape;
+    llvm::SmallVector<int64_t> remap(outType.getRank(), -1);
+    for (int64_t i = 0, j = 0; i < outType.getRank(); ++i) {
+      if (!expanded.contains(i)) {
+        newShape.push_back(inType.getShape()[i]);
+        remap[i] = j++;
+      }
+    }
+
+    llvm::SmallVector<int64_t> newFoldBatch, newOtherBatch;
+    for (auto [f, o] : llvm::zip_equal(foldBatch, otherBatch)) {
+      if (!expanded.contains(f)) {
+        newFoldBatch.push_back(remap[f]);
+        newOtherBatch.push_back(o);
+      }
+    }
+
+    llvm::SmallVector<int64_t> newFoldContract;
+    for (int64_t d : foldContract) {
+      newFoldContract.push_back(remap[d]);
+    }
+
+    Value newOperand = ttir::utils::createReshapeOp(
+        rewriter, op.getLoc(), bcast.getInput(), newShape);
+
+    Value newLhs = isRhs ? op.getLhs() : newOperand;
+    Value newRhs = isRhs ? newOperand : op.getRhs();
+    llvm::ArrayRef<int64_t> newBatchLhs = isRhs ? newOtherBatch : newFoldBatch;
+    llvm::ArrayRef<int64_t> newBatchRhs = isRhs ? newFoldBatch : newOtherBatch;
+    llvm::ArrayRef<int64_t> newContractLhs =
+        isRhs ? otherContract : llvm::ArrayRef<int64_t>(newFoldContract);
+    llvm::ArrayRef<int64_t> newContractRhs =
+        isRhs ? llvm::ArrayRef<int64_t>(newFoldContract) : otherContract;
+
+    rewriter.replaceOpWithNewOp<ttir::DotGeneralOp>(
+        op, op.getResult().getType(), newLhs, newRhs,
+        rewriter.getDenseI64ArrayAttr(newBatchLhs),
+        rewriter.getDenseI64ArrayAttr(newContractLhs),
+        rewriter.getDenseI64ArrayAttr(newBatchRhs),
+        rewriter.getDenseI64ArrayAttr(newContractRhs));
+    return success();
+  }
+};
+
 class TTIRImplicitBroadcastFold
     : public impl::TTIRImplicitBroadcastFoldBase<TTIRImplicitBroadcastFold> {
 public:
@@ -103,7 +210,8 @@ public:
       TTIRImplicitBroadcastFold>::TTIRImplicitBroadcastFoldBase;
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
-    patterns.add<TTIRImplicitBroadcastFoldRewriter>(&getContext());
+    patterns.add<TTIRImplicitBroadcastFoldRewriter, FoldBroadcastIntoDotGeneral>(
+        &getContext());
     FrozenRewritePatternSet patternSet(std::move(patterns));
 
     if (failed(applyPatternsGreedily(getOperation(), patternSet))) {

--- a/lib/Dialect/TTIR/Transforms/Broadcast.cpp
+++ b/lib/Dialect/TTIR/Transforms/Broadcast.cpp
@@ -98,12 +98,7 @@ public:
 
 // Drop a `ttir.broadcast` feeding a `ttir.matmul` operand when it only
 // expands batch (leading) dims and the other operand already supplies the
-// expanded size at those positions. matmul's verifier broadcasts batch dims
-// natively (see MatmulOp::verify), so removing the explicit broadcast keeps
-// the result shape and computation. Avoids materializing the expanded
-// operand and prevents ConstEvalHoist from baking it into HBM (AOTAutograd
-// einsum tracing emits this on small constant matmul operands; the broadcast
-// lands on matmul after dot_general decomposition + canonicalization).
+// expanded size at those positions.
 class FoldBroadcastIntoMatmul : public OpRewritePattern<ttir::MatmulOp> {
 public:
   using OpRewritePattern<ttir::MatmulOp>::OpRewritePattern;

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -229,6 +229,34 @@ def test_broadcast(shape: List[int], broadcast_dimensions: List[int], request, d
 @pytest.mark.parametrize(
     "shapes",
     [
+        [(1, 4, 128, 128), (1, 4, 128, 128)] | SkipIf("sim"),
+        # Two shapes above exercise implicit broadcast, support for it can be spotty.
+        [(1, 4, 128, 128), (1, 1, 128, 128)] | SkipIf("sim"),
+        [(1, 8, 64, 128), (1, 1, 128, 256)] | SkipIf("sim"),
+    ],
+    ids=shapes_list_str,
+)
+def test_matmul(shapes: List[Shape], request, device):
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, [torch.float32] * len(shapes))
+        def matmul(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.matmul(in0, in1, unit_attrs=unit_attrs)
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+    )
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
         [
             (1, 32, 32, 64),
             (64, 32, 3, 3),

--- a/test/ttmlir/Dialect/TTIR/Transforms/ImplicitBroadcastFold/matmul_implicit_broadcast_fold.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/ImplicitBroadcastFold/matmul_implicit_broadcast_fold.mlir
@@ -1,0 +1,50 @@
+// RUN: ttmlir-opt --ttir-implicit-broadcast-fold -o %t %s
+// RUN: FileCheck --input-file=%t %s
+
+module {
+  // The supported case: a rank-4 RHS whose batch dim 1 is broadcast to match
+  // the LHS. TTNN's matmul broadcasts dim 1 implicitly, so the explicit
+  // ttir.broadcast is dropped and the matmul consumes the unbroadcast operand.
+  func.func @fold_rhs_batch_dim1(%arg0: tensor<1x256x128x128xf32>, %arg1: tensor<1x1x128x128xf32>) -> tensor<1x256x128x128xf32> {
+    %0 = "ttir.broadcast"(%arg1) <{broadcast_dimensions = array<i64: 1, 256, 1, 1>}> : (tensor<1x1x128x128xf32>) -> tensor<1x256x128x128xf32>
+    %1 = "ttir.matmul"(%arg0, %0) <{transpose_a = false, transpose_b = false}> : (tensor<1x256x128x128xf32>, tensor<1x256x128x128xf32>) -> tensor<1x256x128x128xf32>
+    // CHECK-LABEL: func.func @fold_rhs_batch_dim1
+    // CHECK-NOT: "ttir.broadcast"
+    // CHECK: "ttir.matmul"(%arg0, %arg1)
+    // CHECK-SAME: (tensor<1x256x128x128xf32>, tensor<1x1x128x128xf32>) -> tensor<1x256x128x128xf32>
+    return %1 : tensor<1x256x128x128xf32>
+  }
+
+  // Negative: a broadcast on the LHS is out of scope -- the fold only targets
+  // the RHS -- so it must be kept.
+  func.func @no_fold_lhs_batch_dim1(%arg0: tensor<1x1x128x128xf32>, %arg1: tensor<1x256x128x128xf32>) -> tensor<1x256x128x128xf32> {
+    %0 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 256, 1, 1>}> : (tensor<1x1x128x128xf32>) -> tensor<1x256x128x128xf32>
+    %1 = "ttir.matmul"(%0, %arg1) <{transpose_a = false, transpose_b = false}> : (tensor<1x256x128x128xf32>, tensor<1x256x128x128xf32>) -> tensor<1x256x128x128xf32>
+    // CHECK-LABEL: func.func @no_fold_lhs_batch_dim1
+    // CHECK: "ttir.broadcast"
+    // CHECK: "ttir.matmul"
+    return %1 : tensor<1x256x128x128xf32>
+  }
+
+  // Negative: rank-3 broadcast on dim 0. TTNN's matmul cannot broadcast dim 0,
+  // so the broadcast must be kept (this is the shape that previously faulted).
+  func.func @no_fold_rank3_batch_dim0(%arg0: tensor<1x544x2880xf32>, %arg1: tensor<1x2880x5760xf32>) -> tensor<4x544x5760xf32> {
+    %0 = "ttir.broadcast"(%arg1) <{broadcast_dimensions = array<i64: 4, 1, 1>}> : (tensor<1x2880x5760xf32>) -> tensor<4x2880x5760xf32>
+    %1 = "ttir.matmul"(%arg0, %0) <{transpose_a = false, transpose_b = false}> : (tensor<1x544x2880xf32>, tensor<4x2880x5760xf32>) -> tensor<4x544x5760xf32>
+    // CHECK-LABEL: func.func @no_fold_rank3_batch_dim0
+    // CHECK: "ttir.broadcast"
+    // CHECK: "ttir.matmul"
+    return %1 : tensor<4x544x5760xf32>
+  }
+
+  // Negative: rank-4 broadcast on dim 0. The kernel requires a_shape[0] ==
+  // b_shape[0], so dim-0 broadcasts cannot be folded either.
+  func.func @no_fold_rank4_batch_dim0(%arg0: tensor<4x256x128x128xf32>, %arg1: tensor<1x256x128x128xf32>) -> tensor<4x256x128x128xf32> {
+    %0 = "ttir.broadcast"(%arg1) <{broadcast_dimensions = array<i64: 4, 1, 1, 1>}> : (tensor<1x256x128x128xf32>) -> tensor<4x256x128x128xf32>
+    %1 = "ttir.matmul"(%arg0, %0) <{transpose_a = false, transpose_b = false}> : (tensor<4x256x128x128xf32>, tensor<4x256x128x128xf32>) -> tensor<4x256x128x128xf32>
+    // CHECK-LABEL: func.func @no_fold_rank4_batch_dim0
+    // CHECK: "ttir.broadcast"
+    // CHECK: "ttir.matmul"
+    return %1 : tensor<4x256x128x128xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/ImplicitBroadcastFold/matmul_implicit_broadcast_fold.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/ImplicitBroadcastFold/matmul_implicit_broadcast_fold.mlir
@@ -37,8 +37,8 @@ module {
     return %1 : tensor<4x544x5760xf32>
   }
 
-  // Negative: rank-4 broadcast on dim 0. The kernel requires a_shape[0] ==
-  // b_shape[0], so dim-0 broadcasts cannot be folded either.
+  // Negative: a rank-4 broadcast on dim 0. The fold only targets dim 1, so a
+  // broadcast that touches any other dim must be kept.
   func.func @no_fold_rank4_batch_dim0(%arg0: tensor<4x256x128x128xf32>, %arg1: tensor<1x256x128x128xf32>) -> tensor<4x256x128x128xf32> {
     %0 = "ttir.broadcast"(%arg1) <{broadcast_dimensions = array<i64: 4, 1, 1, 1>}> : (tensor<1x256x128x128xf32>) -> tensor<4x256x128x128xf32>
     %1 = "ttir.matmul"(%arg0, %0) <{transpose_a = false, transpose_b = false}> : (tensor<4x256x128x128xf32>, tensor<4x256x128x128xf32>) -> tensor<4x256x128x128xf32>
@@ -46,5 +46,18 @@ module {
     // CHECK: "ttir.broadcast"
     // CHECK: "ttir.matmul"
     return %1 : tensor<4x256x128x128xf32>
+  }
+
+  // Negative: the broadcast is on dim 1 of the RHS, but the LHS dim 1 is itself
+  // size 1 -- so the matmul's dim-1 output comes entirely from the RHS
+  // broadcast. Dropping it would shrink the result from 256 to 1, so it must be
+  // kept. This is why "broadcast on dim 1 of the RHS" alone is not sufficient.
+  func.func @no_fold_lhs_dim1_is_one(%arg0: tensor<1x1x128x128xf32>, %arg1: tensor<1x1x128x128xf32>) -> tensor<1x256x128x128xf32> {
+    %0 = "ttir.broadcast"(%arg1) <{broadcast_dimensions = array<i64: 1, 256, 1, 1>}> : (tensor<1x1x128x128xf32>) -> tensor<1x256x128x128xf32>
+    %1 = "ttir.matmul"(%arg0, %0) <{transpose_a = false, transpose_b = false}> : (tensor<1x1x128x128xf32>, tensor<1x256x128x128xf32>) -> tensor<1x256x128x128xf32>
+    // CHECK-LABEL: func.func @no_fold_lhs_dim1_is_one
+    // CHECK: "ttir.broadcast"
+    // CHECK: "ttir.matmul"
+    return %1 : tensor<1x256x128x128xf32>
   }
 }


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-xla/issues/3988 

### Problem description
Matmul wasn't eligible for broadcast folding, it wasn't marked as Broadcastable

### What's changed
Added a special rule to fold broadcasts into matmuls. The existing attribute was not used as matmul requires some special casing.

### Checklist
- [ ] New/Existing tests provide coverage for changes


Vibecoded