### PR TITLE
Skip stablehlo tests when not built

### DIFF
--- a/test/ttmlir/Conversion/StableHLOToTTIR/round_nearest_afz.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/round_nearest_afz.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
 

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-complex-data-type-conversion -o %t %s
 // RUN: FileCheck %s --input-file=%t
 

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_concat.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_concat.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-complex-data-type-conversion -o %t %s
 // RUN: FileCheck %s --input-file=%t
 

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_slice.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_slice.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-complex-data-type-conversion -o %t %s
 // RUN: FileCheck %s --input-file=%t
 


### PR DESCRIPTION
### Problem description
the following stablehlo tests are still running even when `-DTTMLIR_ENABLE_STABLEHLO=OFF`

### What's changed
add the missing lit test `REQUIRE` guard

### Checklist
- [ ] New/Existing tests provide coverage for changes
