### PR TITLE
[ttkernel] Fix NOC barrier lowering

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3387,15 +3387,21 @@ def TTKernel_TransposeTileOp : TTKernel_Op<"transpose_wh_tile"> {
 def TTKernel_GetNocAddrOp : TTKernel_Op<"get_noc_addr"> {
     let summary = "GetNocAddr";
     let description = [{
-      GetNocAddr api including core coordinates
+      GetNocAddr api including core coordinates.
     }];
 
-    let arguments = (ins IndexLike:$x, IndexLike:$y, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_LocalSemaphore]>:$l1Address);
+    let arguments = (ins IndexLike:$x, IndexLike:$y, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_LocalSemaphore]>:$l1Address, Optional<I8>:$noc);
     let results = (outs TTKernel_NocAddr:$nocAddr);
 
     let assemblyFormat = [{
-      `(` $x `,` $y `,` $l1Address `)` attr-dict `:` functional-type(operands, results)
+      `(` $x `,` $y `,` $l1Address (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
     }];
+
+    let builders = [
+      OpBuilder<(ins "Value":$x, "Value":$y, "Value":$l1Address), [{
+        build($_builder, $_state, x, y, l1Address, /*noc=*/Value{});
+      }]>,
+    ];
 }
 
 def TTKernel_GetNocAddrFromBankIDOp: TTKernel_Op<"get_noc_addr_from_bank_id"> {
@@ -3515,12 +3521,20 @@ def TTKernel_NocAsyncReadOnePacketWithStateWithTridOp : TTKernel_Op<"noc_async_r
 def TTKernel_NocAsyncReadBarrierOp : TTKernel_Op<"noc_async_read_barrier", [TTKernel_DeviceZoneOpTrait]> {
     let summary = "NocAsyncReadBarrier";
     let description = [{
-      NocAsyncReadBarrier
+      Waits for all outstanding read transactions on the given NOC.
     }];
 
+    let arguments = (ins Optional<I8>:$noc);
+
     let assemblyFormat = [{
-      `(` `)` attr-dict `:` functional-type(operands, results)
+      `(` ($noc^)? `)` attr-dict `:` functional-type(operands, results)
     }];
+
+    let builders = [
+      OpBuilder<(ins), [{
+        build($_builder, $_state, /*noc=*/Value{});
+      }]>,
+    ];
 
     let hasCanonicalizer = 1;
 }
@@ -3620,12 +3634,20 @@ def TTKernel_NocAsyncWriteOnePacketWithTridOp : TTKernel_Op<"noc_async_write_one
 def TTKernel_NocAsyncWriteBarrierOp : TTKernel_Op<"noc_async_write_barrier", [TTKernel_DeviceZoneOpTrait]> {
     let summary = "NocAsyncWriteBarrier";
     let description = [{
-      NocAsyncWriteBarrier
+      Waits for all outstanding write transactions on the given NOC.
     }];
 
+    let arguments = (ins Optional<I8>:$noc);
+
     let assemblyFormat = [{
-      `(` `)` attr-dict `:` functional-type(operands, results)
+      `(` ($noc^)? `)` attr-dict `:` functional-type(operands, results)
     }];
+
+    let builders = [
+      OpBuilder<(ins), [{
+        build($_builder, $_state, /*noc=*/Value{});
+      }]>,
+    ];
 
     let hasCanonicalizer = 1;
 }

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1022,13 +1022,9 @@ public:
                   ttkernel::NocAsyncAtomicBarrierOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     SmallVector<Value, 1> operands;
-    std::string callStr = "noc_async_atomic_barrier(";
-    Value nocId = adaptor.getNocId();
-    if (nocId) {
-      callStr += "{}";
-      operands.push_back(nocId);
-    }
-    callStr += ");";
+    std::string nocName = ensureNocReference(op.getOperation(), rewriter,
+                                             operands, adaptor.getNocId());
+    std::string callStr = nocName + ".async_atomic_barrier();";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -326,6 +326,15 @@ static std::string ensureFunctionScopedDeclaration(
   return name.str();
 }
 
+static std::string getResultVariableName(Value result, llvm::StringRef prefix) {
+  std::string ssaName;
+  llvm::raw_string_ostream os(ssaName);
+  mlir::OpPrintingFlags flags;
+  result.printAsOperand(os, flags);
+  os.flush();
+  return (prefix + ssaName.substr(1)).str();
+}
+
 static std::string ensureNocDeclaration(Operation *useOp,
                                         ConversionPatternRewriter &rewriter) {
   constexpr llvm::StringLiteral nocName = "noc";
@@ -817,15 +826,7 @@ public:
     }
 
     // Float types: bit-cast via __builtin_memcpy (well-defined, avoids UB).
-    // Derive a unique variable name from the SSA result number.
-    std::string ssaName;
-    {
-      llvm::raw_string_ostream os(ssaName);
-      mlir::OpPrintingFlags flags;
-      op.getResult().printAsOperand(os, flags);
-      os.flush();
-    }
-    std::string varName = "_rc" + ssaName.substr(1);
+    std::string varName = getResultVariableName(op.getResult(), "_rc");
 
     // Emits: uint32_t <var>_src = <srcInit>; float <var>;
     //        __builtin_memcpy(&<var>, &<var>_src, sizeof(<var>));
@@ -1011,6 +1012,43 @@ private:
 } // namespace
 
 namespace {
+class TTKernelToEmitCGetNocAddrRewriter
+    : public OpConversionPattern<ttkernel::GetNocAddrOp> {
+public:
+  using OpConversionPattern<ttkernel::GetNocAddrOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttkernel::GetNocAddrOp op,
+                  ttkernel::GetNocAddrOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Type resultType =
+        this->getTypeConverter()->convertType(op->getResult(0).getType());
+    TT_assert(resultType);
+
+    SmallVector<Value, 1> nocOperands;
+    std::string nocName = ensureNocReference(op.getOperation(), rewriter,
+                                             nocOperands, adaptor.getNoc());
+    std::string endpoint = ensureEndpointDeclaration(
+        op.getOperation(), rewriter, "UnicastEndpoint", "unicast_ep");
+    SmallVector<Value, 4> operands = {adaptor.getX(), adaptor.getY(),
+                                      adaptor.getL1Address()};
+    operands.append(nocOperands);
+
+    std::string varName = getResultVariableName(op->getResult(0), "noc_addr_");
+    std::string callStr =
+        "uint64_t " + varName + " = " + endpoint +
+        ".get_noc_unicast_addr(static_cast<uint32_t>({}), "
+        "static_cast<uint32_t>({}), static_cast<uint32_t>({}), " +
+        nocName + ".get_noc_id());";
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    rewriter.replaceOp(
+        op, rewriter.create<emitc::LiteralOp>(op.getLoc(), resultType, varName)
+                .getResult());
+    return success();
+  }
+};
+
 class TTKernelToEmitCNocAtomicBarrierRewriter
     : public OpConversionPattern<ttkernel::NocAsyncAtomicBarrierOp> {
 public:
@@ -1524,14 +1562,8 @@ public:
       return success();
     }
 
-    // Generate unique variable name from SSA number (pattern from
-    // TTKernelClassMethodRewriter).
-    std::string ssaName;
-    llvm::raw_string_ostream os(ssaName);
-    mlir::OpPrintingFlags flags;
-    op->getResult(0).printAsOperand(os, flags);
-    os.flush();
-    std::string varName = "tensor_accessor_args_" + ssaName.substr(1);
+    std::string varName =
+        getResultVariableName(op->getResult(0), "tensor_accessor_args_");
 
     // Build CTA/CRTA expression with priority: expr attr > chaining > literal.
     auto buildArgExpr = [&](StringAttr exprAttr, Value baseValue,
@@ -1566,8 +1598,6 @@ public:
                        ", " + crtaArg + ">();";
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), code);
 
-    // Create literal to reference the variable (pattern from
-    // TTKernelClassMethodRewriter).
     auto resultType =
         this->getTypeConverter()->convertType(op->getResultTypes()[0]);
     auto literalOp =
@@ -1676,14 +1706,8 @@ public:
       resultTypes.push_back(convertedType);
     }
 
-    // Calling class/struct member function is difficult to do in EmitC..
-    // Create a unique variable name based on SSA number.
-    std::string ssaName;
-    llvm::raw_string_ostream os(ssaName);
-    mlir::OpPrintingFlags flags;
-    op->getResult(0).printAsOperand(os, flags);
-    os.flush();
-    std::string varName = "temp_" + ssaName.substr(1);
+    // Calling class/struct member function is difficult to do in EmitC.
+    std::string varName = getResultVariableName(op->getResult(0), "temp_");
 
     // Call the member function using verbatim with placeholders {} for args.
     TT_assert(resultTypes.size() == 1u);
@@ -2236,7 +2260,6 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::ClampScalarTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ClampScalarTileInt32Op>,
 
-        TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadTileOp>,
         TTKernelToEmitCOpaqueRewriter<
             ttkernel::NocAsyncReadOnePacketSetStateOp>,
@@ -2290,11 +2313,9 @@ public:
     patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::NocInlineDwWriteOp>>(
         typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(
-        typeConverter, funcOp.getContext(), "get_noc_addr");
-
     patterns
-        .add<TTKernelToEmitCNocAtomicBarrierRewriter,
+        .add<TTKernelToEmitCGetNocAddrRewriter,
+             TTKernelToEmitCNocAtomicBarrierRewriter,
              TTKernelToEmitCNocAsyncTransferRewriter<ttkernel::NocAsyncReadOp>,
              TTKernelToEmitCNocAsyncTransferRewriter<ttkernel::NocAsyncWriteOp>,
              TTKernelToEmitCNocAsyncWriteMulticastRewriter<

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -826,7 +826,15 @@ public:
     }
 
     // Float types: bit-cast via __builtin_memcpy (well-defined, avoids UB).
-    std::string varName = getResultVariableName(op.getResult(), "_rc");
+    // Derive a unique variable name from the SSA result number.
+    std::string ssaName;
+    {
+      llvm::raw_string_ostream os(ssaName);
+      mlir::OpPrintingFlags flags;
+      op.getResult().printAsOperand(os, flags);
+      os.flush();
+    }
+    std::string varName = "_rc" + ssaName.substr(1);
 
     // Emits: uint32_t <var>_src = <srcInit>; float <var>;
     //        __builtin_memcpy(&<var>, &<var>_src, sizeof(<var>));

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -327,37 +327,45 @@ static std::string ensureFunctionScopedDeclaration(
 }
 
 static std::string ensureNocDeclaration(Operation *useOp,
-                                        ConversionPatternRewriter &rewriter,
-                                        Value nocId = {}) {
+                                        ConversionPatternRewriter &rewriter) {
   constexpr llvm::StringLiteral nocName = "noc";
-  if (hasDominatingVerbatimWithPrefix(useOp, "Noc noc")) {
+  if (hasDominatingVerbatimWithPrefix(useOp, "Noc noc;") ||
+      hasDominatingVerbatimWithPrefix(useOp, "Noc noc(")) {
     return nocName.str();
   }
 
   OpBuilder::InsertionGuard guard(rewriter);
-  if (nocId) {
-    FailureOr<int64_t> nocIdx = getStaticNocIndex(useOp, nocId);
-    if (succeeded(nocIdx)) {
-      setInsertionPointToFunctionStart(useOp, rewriter);
-      rewriter.create<emitc::VerbatimOp>(
-          useOp->getLoc(), "Noc noc(" + std::to_string(*nocIdx) + ");");
-    } else {
-      setInsertionPointAfterDefOrBlockStart(nocId, rewriter);
-      rewriter.create<emitc::VerbatimOp>(useOp->getLoc(), "Noc noc({});",
-                                         ValueRange{nocId});
-    }
+  setInsertionPointToFunctionStart(useOp, rewriter);
+  FailureOr<int64_t> nocIdx = getStaticNocIndex(useOp);
+  if (succeeded(nocIdx)) {
+    rewriter.create<emitc::VerbatimOp>(
+        useOp->getLoc(), "Noc noc(" + std::to_string(*nocIdx) + ");");
   } else {
-    setInsertionPointToFunctionStart(useOp, rewriter);
-    FailureOr<int64_t> nocIdx = getStaticNocIndex(useOp);
-    if (succeeded(nocIdx)) {
-      rewriter.create<emitc::VerbatimOp>(
-          useOp->getLoc(), "Noc noc(" + std::to_string(*nocIdx) + ");");
-    } else {
-      rewriter.create<emitc::VerbatimOp>(useOp->getLoc(), "Noc noc;");
-    }
+    rewriter.create<emitc::VerbatimOp>(useOp->getLoc(), "Noc noc;");
   }
 
   return nocName.str();
+}
+
+static std::string ensureNocReference(Operation *useOp,
+                                      ConversionPatternRewriter &rewriter,
+                                      SmallVectorImpl<Value> &operands,
+                                      Value nocId = {}) {
+  if (!nocId) {
+    return ensureNocDeclaration(useOp, rewriter);
+  }
+
+  FailureOr<int64_t> nocIdx = getStaticNocIndex(useOp, nocId);
+  if (succeeded(nocIdx)) {
+    std::string nocName = "noc" + std::to_string(*nocIdx);
+    std::string declaration =
+        "Noc " + nocName + "(" + std::to_string(*nocIdx) + ");";
+    return ensureFunctionScopedDeclaration(useOp, rewriter, declaration,
+                                           nocName);
+  }
+
+  operands.push_back(nocId);
+  return "Noc({})";
 }
 
 static std::string
@@ -1003,58 +1011,86 @@ private:
 } // namespace
 
 namespace {
-template <typename SourceOp>
-class TTKernelToEmitCNocBarrierRewriter : public OpConversionPattern<SourceOp> {
+class TTKernelToEmitCNocAtomicBarrierRewriter
+    : public OpConversionPattern<ttkernel::NocAsyncAtomicBarrierOp> {
 public:
-  TTKernelToEmitCNocBarrierRewriter(TTKernelToEmitCTypeConverter &typeConverter,
-                                    MLIRContext *ctx)
-      : OpConversionPattern<SourceOp>(typeConverter, ctx) {}
+  using OpConversionPattern<
+      ttkernel::NocAsyncAtomicBarrierOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttkernel::NocAsyncAtomicBarrierOp op,
+                  ttkernel::NocAsyncAtomicBarrierOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    SmallVector<Value, 1> operands;
+    std::string callStr = "noc_async_atomic_barrier(";
+    Value nocId = adaptor.getNocId();
+    if (nocId) {
+      callStr += "{}";
+      operands.push_back(nocId);
+    }
+    callStr += ");";
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+template <typename SourceOp>
+class TTKernelToEmitCNocFullBarrierRewriter
+    : public OpConversionPattern<SourceOp> {
+public:
+  TTKernelToEmitCNocFullBarrierRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx,
+      std::string methodName)
+      : OpConversionPattern<SourceOp>(typeConverter, ctx),
+        methodName(std::move(methodName)) {}
 
   LogicalResult
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    Value nocId;
-    std::string barrierName;
-    std::string barrierMode = "<Noc::BarrierMode::FULL>";
-    SmallVector<Value, 1> trid;
+    SmallVector<Value, 1> operands;
+    std::string nocName = ensureNocReference(op.getOperation(), rewriter,
+                                             operands, adaptor.getNoc());
+    std::string callStr =
+        nocName + "." + methodName + "<Noc::BarrierMode::FULL>();";
 
-    if constexpr (std::is_same_v<SourceOp, ttkernel::NocAsyncReadBarrierOp>) {
-      barrierName = "async_read_barrier";
-    } else if constexpr (std::is_same_v<SourceOp,
-                                        ttkernel::NocAsyncWriteBarrierOp>) {
-      barrierName = "async_write_barrier";
-    } else if constexpr (std::is_same_v<SourceOp,
-                                        ttkernel::NocAsyncAtomicBarrierOp>) {
-      barrierName = "async_atomic_barrier";
-      nocId = adaptor.getNocId();
-    } else if constexpr (std::is_same_v<
-                             SourceOp,
-                             ttkernel::NocAsyncReadBarrierWithTridOp>) {
-      barrierName = "async_read_barrier";
-      barrierMode = "<Noc::BarrierMode::TXN_ID>";
-      nocId = adaptor.getNoc();
-      trid.push_back(adaptor.getTrid());
-    } else if constexpr (std::is_same_v<
-                             SourceOp,
-                             ttkernel::NocAsyncWriteBarrierWithTridOp>) {
-      barrierName = "async_write_barrier";
-      barrierMode = "<Noc::BarrierMode::TXN_ID>";
-      nocId = adaptor.getNoc();
-      trid.push_back(adaptor.getTrid());
-    }
-
-    std::string nocName =
-        ensureNocDeclaration(op.getOperation(), rewriter, nocId);
-    std::string callStr = nocName + "." + barrierName + barrierMode + "(";
-    if (!trid.empty()) {
-      callStr += "{}";
-    }
-    callStr += ");";
-
-    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, trid);
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);
     return success();
   }
+
+private:
+  std::string methodName;
+};
+
+template <typename SourceOp>
+class TTKernelToEmitCNocTridBarrierRewriter
+    : public OpConversionPattern<SourceOp> {
+public:
+  TTKernelToEmitCNocTridBarrierRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx,
+      std::string methodName)
+      : OpConversionPattern<SourceOp>(typeConverter, ctx),
+        methodName(std::move(methodName)) {}
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    SmallVector<Value, 2> operands;
+    std::string nocName = ensureNocReference(op.getOperation(), rewriter,
+                                             operands, adaptor.getNoc());
+    operands.push_back(adaptor.getTrid());
+    std::string callStr =
+        nocName + "." + methodName + "<Noc::BarrierMode::TXN_ID>({});";
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  std::string methodName;
 };
 
 template <typename SourceOp>
@@ -1149,8 +1185,9 @@ public:
   LogicalResult
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    std::string nocName =
-        ensureNocDeclaration(op.getOperation(), rewriter, adaptor.getNoc());
+    SmallVector<Value, 9> operands;
+    std::string nocName = ensureNocReference(op.getOperation(), rewriter,
+                                             operands, adaptor.getNoc());
     std::string endpoint = ensureEndpointDeclaration(
         op.getOperation(), rewriter, "MulticastEndpoint", "mcast_ep");
 
@@ -1160,11 +1197,10 @@ public:
             : "Noc::McastMode::INCLUDE_SRC";
     bool linked = op.getLinked().value_or(false);
 
-    SmallVector<Value, 8> operands{
-        adaptor.getSrcLocalL1Addr(), adaptor.getSize(),
-        adaptor.getNumDests(),       adaptor.getDstNocXStart(),
-        adaptor.getDstNocYStart(),   adaptor.getDstNocXEnd(),
-        adaptor.getDstNocYEnd(),     adaptor.getDstLocalL1Addr()};
+    operands.append({adaptor.getSrcLocalL1Addr(), adaptor.getSize(),
+                     adaptor.getNumDests(), adaptor.getDstNocXStart(),
+                     adaptor.getDstNocYStart(), adaptor.getDstNocXEnd(),
+                     adaptor.getDstNocYEnd(), adaptor.getDstLocalL1Addr()});
     std::string dstArgs =
         "noc_traits_t<MulticastEndpoint>::"
         "dst_args_mcast_type{{.noc_x_start = {}, .noc_y_start = {}, "
@@ -2261,21 +2297,27 @@ public:
     patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(
         typeConverter, funcOp.getContext(), "get_noc_addr");
 
+    patterns
+        .add<TTKernelToEmitCNocAtomicBarrierRewriter,
+             TTKernelToEmitCNocAsyncTransferRewriter<ttkernel::NocAsyncReadOp>,
+             TTKernelToEmitCNocAsyncTransferRewriter<ttkernel::NocAsyncWriteOp>,
+             TTKernelToEmitCNocAsyncWriteMulticastRewriter<
+                 ttkernel::NocAsyncWriteMulticastOp>,
+             TTKernelToEmitCNocAsyncWriteMulticastRewriter<
+                 ttkernel::NocAsyncWriteMulticastLoopbackSrcOp>>(
+            typeConverter, funcOp.getContext());
     patterns.add<
-        TTKernelToEmitCNocBarrierRewriter<ttkernel::NocAsyncReadBarrierOp>,
-        TTKernelToEmitCNocBarrierRewriter<ttkernel::NocAsyncWriteBarrierOp>,
-        TTKernelToEmitCNocBarrierRewriter<ttkernel::NocAsyncAtomicBarrierOp>,
-        TTKernelToEmitCNocBarrierRewriter<
-            ttkernel::NocAsyncReadBarrierWithTridOp>,
-        TTKernelToEmitCNocBarrierRewriter<
-            ttkernel::NocAsyncWriteBarrierWithTridOp>,
-        TTKernelToEmitCNocAsyncTransferRewriter<ttkernel::NocAsyncReadOp>,
-        TTKernelToEmitCNocAsyncTransferRewriter<ttkernel::NocAsyncWriteOp>,
-        TTKernelToEmitCNocAsyncWriteMulticastRewriter<
-            ttkernel::NocAsyncWriteMulticastOp>,
-        TTKernelToEmitCNocAsyncWriteMulticastRewriter<
-            ttkernel::NocAsyncWriteMulticastLoopbackSrcOp>>(
-        typeConverter, funcOp.getContext());
+        TTKernelToEmitCNocFullBarrierRewriter<ttkernel::NocAsyncReadBarrierOp>>(
+        typeConverter, funcOp.getContext(), "async_read_barrier");
+    patterns.add<TTKernelToEmitCNocFullBarrierRewriter<
+        ttkernel::NocAsyncWriteBarrierOp>>(typeConverter, funcOp.getContext(),
+                                           "async_write_barrier");
+    patterns.add<TTKernelToEmitCNocTridBarrierRewriter<
+        ttkernel::NocAsyncReadBarrierWithTridOp>>(
+        typeConverter, funcOp.getContext(), "async_read_barrier");
+    patterns.add<TTKernelToEmitCNocTridBarrierRewriter<
+        ttkernel::NocAsyncWriteBarrierWithTridOp>>(
+        typeConverter, funcOp.getContext(), "async_write_barrier");
 
     patterns.add<TTKernelInvokeSFPIOpRewriter>(typeConverter,
                                                funcOp.getContext());

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -528,8 +528,11 @@ void NocAsyncReadBarrierOp::getCanonicalizationPatterns(
     for (Operation *it = op->getPrevNode(); it != nullptr;
          it = it->getPrevNode()) {
       if (mlir::isa<NocAsyncReadBarrierOp>(it)) {
-        rewriter.eraseOp(op);
-        return success();
+        auto previousBarrier = mlir::cast<NocAsyncReadBarrierOp>(it);
+        if (previousBarrier.getNoc() == op.getNoc()) {
+          rewriter.eraseOp(op);
+          return success();
+        }
       }
       if (mlir::isa<NocAsyncReadOp, NocAsyncReadTileOp,
                     NocAsyncReadOnePacketSetStateOp,
@@ -550,8 +553,11 @@ void NocAsyncWriteBarrierOp::getCanonicalizationPatterns(
     for (Operation *it = op->getPrevNode(); it != nullptr;
          it = it->getPrevNode()) {
       if (mlir::isa<NocAsyncWriteBarrierOp>(it)) {
-        rewriter.eraseOp(op);
-        return success();
+        auto previousBarrier = mlir::cast<NocAsyncWriteBarrierOp>(it);
+        if (previousBarrier.getNoc() == op.getNoc()) {
+          rewriter.eraseOp(op);
+          return success();
+        }
       }
       if (mlir::isa<NocAsyncWriteOp, NocAsyncWriteTileOp,
                     NocAsyncWriteSetTridOp, NocAsyncWriteOnePacketWithTridOp,

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -175,7 +175,7 @@ public:
         headers.insert("api/dataflow/circular_buffer.h");
       }
 
-      if (value.starts_with("Noc ")) {
+      if (value.starts_with("Noc ") || value.starts_with("Noc(")) {
         headers.insert("api/core_local_mem.h");
         headers.insert("api/dataflow/endpoints.h");
         headers.insert("api/dataflow/noc.h");

--- a/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_false.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_false.mlir
@@ -12,9 +12,12 @@ module {
   func.func @test_block_matmul(%lhs: !lhs, %rhs: !rhs) -> (!matmul_result) {
     // CHECK-NOT: ttir.matmul
     // CHECK-NOT: matmul_tiles
-    // CHECK: emitc.verbatim "Noc noc(0);"
-    // CHECK: noc.async_write_multicast
-    // CHECK: emitc.verbatim "Noc noc(1);"
+    // CHECK-DAG: emitc.verbatim "Noc noc0(0);"
+    // CHECK-DAG: emitc.verbatim "Noc noc(0);"
+    // CHECK: noc0.async_write_multicast
+    // CHECK-DAG: emitc.verbatim "Noc noc1(1);"
+    // CHECK-DAG: emitc.verbatim "Noc noc(1);"
+    // CHECK: noc1.async_write_multicast
     // CHECK-NOT: noc_async_write_barrier
     // CHECK: mm_block_init
     // CHECK: mm_block_init_short

--- a/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_true.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_true.mlir
@@ -12,9 +12,12 @@ module {
   func.func @test_tile_matmul(%lhs: !lhs, %rhs: !rhs) -> (!matmul_result) {
     // CHECK-NOT: ttir.matmul
     // CHECK-NOT: matmul_block
-    // CHECK: emitc.verbatim "Noc noc(0);"
-    // CHECK: noc.async_write_multicast
-    // CHECK: emitc.verbatim "Noc noc(1);"
+    // CHECK-DAG: emitc.verbatim "Noc noc0(0);"
+    // CHECK-DAG: emitc.verbatim "Noc noc(0);"
+    // CHECK: noc0.async_write_multicast
+    // CHECK-DAG: emitc.verbatim "Noc noc1(1);"
+    // CHECK-DAG: emitc.verbatim "Noc noc(1);"
+    // CHECK: noc1.async_write_multicast
     // CHECK-NOT: noc_async_write_barrier
     // CHECK: mm_init
     // CHECK: mm_init_short

--- a/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
@@ -3,7 +3,7 @@
 // -----
 
 // CHECK-LABEL: func @trid_read_path
-// CHECK: emitc.verbatim "Noc noc(0);"
+// CHECK: emitc.verbatim "Noc noc0(0);"
 // CHECK-NEXT: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
 // CHECK-NEXT: %[[NOC_IDX:.*]] = "emitc.constant"() <{value = 0 : i8}> : () -> i8
 // CHECK-NEXT: %[[X:.*]] = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
@@ -14,7 +14,7 @@
 // CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"(%[[X]], %[[Y]], %[[DST_L1]]) : (!emitc.size_t, !emitc.size_t, i32) -> i64
 // CHECK-NEXT: emitc.call_opaque "noc_async_read_set_trid"(%[[TRID]], %[[NOC_IDX]]) : (i32, i8) -> ()
 // CHECK-NEXT: emitc.call_opaque "noc_async_read_one_packet_with_state_with_trid"(%[[SRC_BASE]], %[[SRC_ADDR]], %[[DST_L1]], %[[TRID]], %[[NOC_IDX]]) : (i32, i32, i32, i32, i8) -> ()
-// CHECK-NEXT: emitc.verbatim "noc.async_read_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32
+// CHECK-NEXT: emitc.verbatim "noc0.async_read_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32
 func.func @trid_read_path() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
   %noc_idx = arith.constant 0 : i8
@@ -33,7 +33,7 @@ func.func @trid_read_path() -> () attributes {ttkernel.thread = #ttkernel.thread
 // -----
 
 // CHECK-LABEL: func @trid_write_path
-// CHECK: emitc.verbatim "Noc noc(0);"
+// CHECK: emitc.verbatim "Noc noc0(0);"
 // CHECK-NEXT: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
 // CHECK-NEXT: %[[MASK:.*]] = "emitc.constant"() <{value = -1 : i32}> : () -> i32
 // CHECK-NEXT: %[[NOC_IDX:.*]] = "emitc.constant"() <{value = 0 : i8}> : () -> i8
@@ -44,7 +44,7 @@ func.func @trid_read_path() -> () attributes {ttkernel.thread = #ttkernel.thread
 // CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"(%[[X]], %[[Y]], %[[DST]]) : (!emitc.size_t, !emitc.size_t, i32) -> i64
 // CHECK-NEXT: emitc.call_opaque "noc_async_write_set_trid"(%[[TRID]], %[[NOC_IDX]]) : (i32, i8) -> ()
 // CHECK-NEXT: emitc.call_opaque "noc_async_write_one_packet_with_trid"(%[[DST]], %[[NOC_ADDR]], %[[SIZE]], %[[TRID]], %[[NOC_IDX]]) : (i32, i64, i32, i32, i8) -> ()
-// CHECK-NEXT: emitc.verbatim "noc.async_write_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32
+// CHECK-NEXT: emitc.verbatim "noc0.async_write_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32
 // CHECK-NEXT: emitc.call_opaque "reset_noc_trid_barrier_counter"(%[[MASK]], %[[NOC_IDX]]) : (i32, i8) -> ()
 func.func @trid_write_path() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32

--- a/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
@@ -67,3 +67,36 @@ func.func @trid_write_path() -> () attributes {ttkernel.thread = #ttkernel.threa
   "ttkernel.reset_noc_trid_barrier_counter"(%mask, %noc_idx) : (i32, i8) -> ()
   return
 }
+
+// -----
+
+// A TRID barrier with no NOC operand uses the default `noc` object. The trid is
+// the sole verbatim argument.
+// CHECK-LABEL: func @trid_barrier_default_noc
+// CHECK: emitc.verbatim "Noc noc;"
+// CHECK: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
+// CHECK: emitc.verbatim "noc.async_write_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32
+func.func @trid_barrier_default_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+  %trid = arith.constant 3 : i32
+  "ttkernel.noc_async_write_barrier_with_trid"(%trid) : (i32) -> ()
+  return
+}
+
+// -----
+
+// A TRID barrier with a dynamic (non-constant) NOC id emits a temporary
+// `Noc({})`. The NOC id fills the `Noc({})` placeholder and the trid fills the
+// barrier-call placeholder, so both must appear as verbatim args in that order.
+// CHECK-LABEL: func @trid_barrier_dynamic_noc
+// CHECK: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
+// CHECK: %[[NOC:.*]] = emitc.cast
+// CHECK: emitc.verbatim "Noc({}).async_read_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[NOC]], %[[TRID]] : i8, i32
+func.func @trid_barrier_dynamic_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+  %trid = arith.constant 3 : i32
+  %noc_arg = arith.constant 262400 : i32
+  %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+  %noc_offset = arith.constant 0 : i32
+  %noc = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
+  "ttkernel.noc_async_read_barrier_with_trid"(%trid, %noc) : (i32, i8) -> ()
+  return
+}

--- a/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
@@ -4,6 +4,8 @@
 
 // CHECK-LABEL: func @trid_read_path
 // CHECK: emitc.verbatim "Noc noc0(0);"
+// CHECK-NEXT: emitc.verbatim "UnicastEndpoint unicast_ep;"
+// CHECK-NEXT: emitc.verbatim "Noc noc;"
 // CHECK-NEXT: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
 // CHECK-NEXT: %[[NOC_IDX:.*]] = "emitc.constant"() <{value = 0 : i8}> : () -> i8
 // CHECK-NEXT: %[[X:.*]] = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
@@ -11,7 +13,8 @@
 // CHECK-NEXT: %[[DST_L1:.*]] = "emitc.constant"() <{value = 256 : i32}> : () -> i32
 // CHECK-NEXT: %[[SRC_BASE:.*]] = "emitc.constant"() <{value = 1024 : i32}> : () -> i32
 // CHECK-NEXT: %[[SRC_ADDR:.*]] = "emitc.constant"() <{value = 64 : i32}> : () -> i32
-// CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"(%[[X]], %[[Y]], %[[DST_L1]]) : (!emitc.size_t, !emitc.size_t, i32) -> i64
+// CHECK-NEXT: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %[[X]], %[[Y]], %[[DST_L1]] : !emitc.size_t, !emitc.size_t, i32
+// CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
 // CHECK-NEXT: emitc.call_opaque "noc_async_read_set_trid"(%[[TRID]], %[[NOC_IDX]]) : (i32, i8) -> ()
 // CHECK-NEXT: emitc.call_opaque "noc_async_read_one_packet_with_state_with_trid"(%[[SRC_BASE]], %[[SRC_ADDR]], %[[DST_L1]], %[[TRID]], %[[NOC_IDX]]) : (i32, i32, i32, i32, i8) -> ()
 // CHECK-NEXT: emitc.verbatim "noc0.async_read_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32
@@ -34,6 +37,8 @@ func.func @trid_read_path() -> () attributes {ttkernel.thread = #ttkernel.thread
 
 // CHECK-LABEL: func @trid_write_path
 // CHECK: emitc.verbatim "Noc noc0(0);"
+// CHECK-NEXT: emitc.verbatim "UnicastEndpoint unicast_ep;"
+// CHECK-NEXT: emitc.verbatim "Noc noc;"
 // CHECK-NEXT: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
 // CHECK-NEXT: %[[MASK:.*]] = "emitc.constant"() <{value = -1 : i32}> : () -> i32
 // CHECK-NEXT: %[[NOC_IDX:.*]] = "emitc.constant"() <{value = 0 : i8}> : () -> i8
@@ -41,7 +46,8 @@ func.func @trid_read_path() -> () attributes {ttkernel.thread = #ttkernel.thread
 // CHECK-NEXT: %[[Y:.*]] = "emitc.constant"() <{value = 1 : index}> : () -> !emitc.size_t
 // CHECK-NEXT: %[[DST:.*]] = "emitc.constant"() <{value = 512 : i32}> : () -> i32
 // CHECK-NEXT: %[[SIZE:.*]] = "emitc.constant"() <{value = 128 : i32}> : () -> i32
-// CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"(%[[X]], %[[Y]], %[[DST]]) : (!emitc.size_t, !emitc.size_t, i32) -> i64
+// CHECK-NEXT: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %[[X]], %[[Y]], %[[DST]] : !emitc.size_t, !emitc.size_t, i32
+// CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
 // CHECK-NEXT: emitc.call_opaque "noc_async_write_set_trid"(%[[TRID]], %[[NOC_IDX]]) : (i32, i8) -> ()
 // CHECK-NEXT: emitc.call_opaque "noc_async_write_one_packet_with_trid"(%[[DST]], %[[NOC_ADDR]], %[[SIZE]], %[[TRID]], %[[NOC_IDX]]) : (i32, i64, i32, i32, i8) -> ()
 // CHECK-NEXT: emitc.verbatim "noc0.async_write_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2254,19 +2254,35 @@ module {
 
     // CHECK-LABEL: func @noc_async_atomic_barrier
     func.func @noc_async_atomic_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK-NOT: emitc.verbatim "Noc noc{{.*}}"
-      // CHECK: emitc.verbatim "noc_async_atomic_barrier();"
+      // CHECK: emitc.verbatim "Noc noc;"
+      // CHECK: emitc.verbatim "noc.async_atomic_barrier();"
       ttkernel.noc_async_atomic_barrier() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @noc_async_atomic_barrier_with_noc_id
     func.func @noc_async_atomic_barrier_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK-NOT: emitc.verbatim "Noc noc{{.*}}"
+      // CHECK: emitc.verbatim "Noc noc1(1);"
       // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
       %noc_id = arith.constant 1 : i8
-      // CHECK-NOT: emitc.verbatim "Noc noc{{.*}}"
-      // CHECK: emitc.verbatim "noc_async_atomic_barrier({});" args %[[NOC_ID]] : i8
+      // CHECK: emitc.verbatim "noc1.async_atomic_barrier();"
+      ttkernel.noc_async_atomic_barrier(%noc_id) : (i8) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_async_atomic_barrier_with_dynamic_noc_id
+    func.func @noc_async_atomic_barrier_with_dynamic_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      %noc_arg = arith.constant 262400 : i32
+      %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+      %noc_offset = arith.constant 0 : i32
+      %noc_id = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
+      // CHECK: %[[NOC_ARG:.*]] = "emitc.constant"() <{value = 262400 : i32}>
+      // CHECK: %[[NOC_PTR:.*]] = emitc.call_opaque "reinterpret_cast<tt_l1_ptr uint8_t*>"(%[[NOC_ARG]])
+      // CHECK: %[[NOC_OFFSET:.*]] = "emitc.constant"() <{value = 0 : i32}>
+      // CHECK: %[[NOC_SLOT:.*]] = emitc.subscript %[[NOC_PTR]][%[[NOC_OFFSET]]
+      // CHECK: %[[LOADED_NOC:.*]] = emitc.load %[[NOC_SLOT]]
+      // CHECK: %[[DYNAMIC_NOC:.*]] = emitc.cast %[[LOADED_NOC]]
+      // CHECK: emitc.verbatim "Noc({}).async_atomic_barrier();" args %[[DYNAMIC_NOC]] : i8
       ttkernel.noc_async_atomic_barrier(%noc_id) : (i8) -> ()
       return
     }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1859,20 +1859,24 @@ module {
 
     // CHECK-LABEL: func @get_noc_addr
     func.func @get_noc_addr() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: emitc.verbatim "UnicastEndpoint unicast_ep;"
+      // CHECK: emitc.verbatim "Noc noc;"
       // CHECK: %[[X:.*]] = "emitc.constant"
       %x = arith.constant 1 : index
       // CHECK: %[[Y:.*]] = "emitc.constant"
       %y = arith.constant 2 : index
       // CHECK: %[[ADDR:.*]] = "emitc.constant"
       %addr = arith.constant 262400 : i32
-      // note: ttkernel.get_noc_addr() converts to one of metallium get_noc_addr() overloads
-      // CHECK: emitc.call_opaque "get_noc_addr"(%[[X]], %[[Y]], %[[ADDR]])
+      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %[[X]], %[[Y]], %[[ADDR]]
+      // CHECK: emitc.literal "noc_addr_{{[0-9]+}}" : i64
       "ttkernel.get_noc_addr"(%x, %y, %addr) : (index, index, i32) -> (!ttkernel.noc_addr)
       return
     }
 
     // CHECK-LABEL: func @get_noc_addr_with_noc_id
     func.func @get_noc_addr_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: emitc.verbatim "UnicastEndpoint unicast_ep;"
+      // CHECK: emitc.verbatim "Noc noc1(1);"
       // CHECK: %[[X:.*]] = "emitc.constant"
       %x = arith.constant 1 : index
       // CHECK: %[[Y:.*]] = "emitc.constant"
@@ -1881,7 +1885,33 @@ module {
       %addr = arith.constant 262400 : i32
       // CHECK: %[[NOC:.*]] = "emitc.constant"
       %noc = arith.constant 1 : i8
-      // CHECK: emitc.call_opaque "get_noc_addr"(%[[X]], %[[Y]], %[[ADDR]], %[[NOC]])
+      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc1.get_noc_id());" args %[[X]], %[[Y]], %[[ADDR]]
+      // CHECK: emitc.literal "noc_addr_{{[0-9]+}}" : i64
+      "ttkernel.get_noc_addr"(%x, %y, %addr, %noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
+      return
+    }
+
+    // CHECK-LABEL: func @get_noc_addr_with_dynamic_noc_id
+    func.func @get_noc_addr_with_dynamic_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: emitc.verbatim "UnicastEndpoint unicast_ep;"
+      %noc_arg = arith.constant 262400 : i32
+      %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+      %noc_offset = arith.constant 0 : i32
+      %noc = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
+      // CHECK: %[[NOC_ARG:.*]] = "emitc.constant"() <{value = 262400 : i32}>
+      // CHECK: %[[NOC_PTR:.*]] = emitc.call_opaque "reinterpret_cast<tt_l1_ptr uint8_t*>"(%[[NOC_ARG]])
+      // CHECK: %[[NOC_OFFSET:.*]] = "emitc.constant"() <{value = 0 : i32}>
+      // CHECK: %[[NOC_SLOT:.*]] = emitc.subscript %[[NOC_PTR]][%[[NOC_OFFSET]]
+      // CHECK: %[[LOADED_NOC:.*]] = emitc.load %[[NOC_SLOT]]
+      // CHECK: %[[DYNAMIC_NOC:.*]] = emitc.cast %[[LOADED_NOC]]
+      // CHECK: %[[X:.*]] = "emitc.constant"
+      %x = arith.constant 1 : index
+      // CHECK: %[[Y:.*]] = "emitc.constant"
+      %y = arith.constant 2 : index
+      // CHECK: %[[ADDR:.*]] = "emitc.constant"
+      %addr = arith.constant 262400 : i32
+      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), Noc({}).get_noc_id());" args %[[X]], %[[Y]], %[[ADDR]], %[[DYNAMIC_NOC]]
+      // CHECK: emitc.literal "noc_addr_{{[0-9]+}}" : i64
       "ttkernel.get_noc_addr"(%x, %y, %addr, %noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       return
     }
@@ -1932,11 +1962,11 @@ module {
 
     // CHECK-LABEL: func @noc_async_read_one_packet_set_state
     func.func @noc_async_read_one_packet_set_state() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
       %src_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: %[[SRC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       // CHECK: %[[SIZE:.*]] = "emitc.constant"
       %size = arith.constant 2048 : i32
       // CHECK: emitc.call_opaque "noc_async_read_one_packet_set_state"(%[[SRC_ADDR]], %[[SIZE]])
@@ -1946,11 +1976,11 @@ module {
 
     // CHECK-LABEL: func @noc_async_read_one_packet_with_state
     func.func @noc_async_read_one_packet_with_state() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
       %src_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: %[[SRC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       // CHECK: %[[DST_ADDR:.*]] = "emitc.constant"
       %dst_addr = arith.constant 327680 : i32
       // CHECK: emitc.call_opaque "noc_async_read_one_packet_with_state"(%[[SRC_ADDR]], %[[DST_ADDR]])
@@ -2122,7 +2152,7 @@ module {
 
     // CHECK-LABEL: func @noc_semaphore_inc
     func.func @noc_semaphore_inc() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2138,7 +2168,7 @@ module {
 
     // CHECK-LABEL: func @noc_semaphore_inc_posted
     func.func @noc_semaphore_inc_posted() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2152,7 +2182,7 @@ module {
 
     // CHECK-LABEL: func @noc_semaphore_inc_multicast
     func.func @noc_semaphore_inc_multicast() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2168,7 +2198,7 @@ module {
 
     // CHECK-LABEL: func @noc_semaphore_inc_multicast_with_noc_id
     func.func @noc_semaphore_inc_multicast_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2186,7 +2216,7 @@ module {
 
     // CHECK-LABEL: func @noc_semaphore_inc_multicast_posted
     func.func @noc_semaphore_inc_multicast_posted() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2204,7 +2234,7 @@ module {
     // Verify explicit `posted = false` round-trips and emits no template args
     // (must match the unset case byte-for-byte).
     func.func @noc_semaphore_inc_posted_false() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2219,7 +2249,7 @@ module {
 
     // CHECK-LABEL: func @noc_semaphore_inc_multicast_posted_false
     func.func @noc_semaphore_inc_multicast_posted_false() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2236,7 +2266,7 @@ module {
 
     // CHECK-LABEL: func @noc_semaphore_inc_multicast_with_noc_id_posted
     func.func @noc_semaphore_inc_multicast_with_noc_id_posted() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2303,7 +2333,7 @@ module {
     func.func @remote_sram_write_u32_sram_addr() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = buffer_address, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.literal "get_compile_time_arg_val(0)"
       %src_addr = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !ttkernel.l1_addr
-      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %noc_x = arith.constant 1 : index
       %noc_y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2346,7 +2376,8 @@ module {
       %remote_table_addr = arith.addi %table_base, %table_offset : i32
       %noc_x = arith.constant 1 : index
       %noc_y = arith.constant 2 : index
-      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"(%{{.*}}, %{{.*}}, %[[REMOTE_TABLE_ADDR]])
+      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %{{.*}}, %{{.*}}, %[[REMOTE_TABLE_ADDR]]
+      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %remote_table_addr) : (index, index, i32) -> !ttkernel.noc_addr
       // CHECK: emitc.call_opaque "noc_semaphore_set_remote"(%[[STAGING_ADDR]], %[[DST_NOC_ADDR]])
       "ttkernel.remote_sram_write_u32"(%staging_addr, %dst_noc_addr) : (i32, !ttkernel.noc_addr) -> ()
@@ -2362,7 +2393,8 @@ module {
       %noc_x = arith.constant 1 : index
       %noc_y = arith.constant 1 : index
       %dst_addr = arith.constant 262400 : i32
-      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"(%[[NOC_X]], %[[NOC_Y]], %[[DST_ADDR]])
+      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %[[NOC_X]], %[[NOC_Y]], %[[DST_ADDR]]
+      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %dst_addr) : (index, index, i32) -> !ttkernel.noc_addr
       // CHECK-DAG: %[[VAL:.*]] = "emitc.constant"() <{value = 7 : i32}> : () -> i32
       // CHECK-DAG: %[[BE:.*]] = "emitc.constant"() <{value = 15 : i8}> : () -> i8
@@ -2380,7 +2412,7 @@ module {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_semaphore"
       %sem_idx = arith.constant 2 : i32
       %src_addr = "ttkernel.get_semaphore"(%sem_idx) : (i32) -> (!ttkernel.local_semaphore)
-      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %noc_x = arith.constant 1 : index
       %noc_y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2421,7 +2453,7 @@ module {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_semaphore"
       %temp1 = arith.constant 2 : i32
       %src_addr = "ttkernel.get_semaphore"(%temp1) : (i32) -> (!ttkernel.local_semaphore) // a dummy l1 addr
-      // CHECK: %[[DST_MCAST_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[DST_MCAST_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp2 = arith.constant 262400 : i32
@@ -2440,7 +2472,7 @@ module {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_semaphore"
       %temp1 = arith.constant 2 : i32
       %src_addr = "ttkernel.get_semaphore"(%temp1) : (i32) -> (!ttkernel.local_semaphore) // a dummy l1 addr
-      // CHECK: %[[DST_MCAST_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      // CHECK: %[[DST_MCAST_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp2 = arith.constant 303104 : i32

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1871,6 +1871,21 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @get_noc_addr_with_noc_id
+    func.func @get_noc_addr_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[X:.*]] = "emitc.constant"
+      %x = arith.constant 1 : index
+      // CHECK: %[[Y:.*]] = "emitc.constant"
+      %y = arith.constant 2 : index
+      // CHECK: %[[ADDR:.*]] = "emitc.constant"
+      %addr = arith.constant 262400 : i32
+      // CHECK: %[[NOC:.*]] = "emitc.constant"
+      %noc = arith.constant 1 : i8
+      // CHECK: emitc.call_opaque "get_noc_addr"(%[[X]], %[[Y]], %[[ADDR]], %[[NOC]])
+      "ttkernel.get_noc_addr"(%x, %y, %addr, %noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
+      return
+    }
+
     // CHECK-LABEL: func @get_noc_addr_from_bank_id
     func.func @get_noc_addr_from_bank_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[BANK_ID:.*]] = "emitc.constant"
@@ -1952,6 +1967,16 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @noc_async_read_barrier_with_noc_id
+    func.func @noc_async_read_barrier_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: emitc.verbatim "Noc noc1(1);"
+      // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
+      %noc_id = arith.constant 1 : i8
+      // CHECK: emitc.verbatim "noc1.async_read_barrier<Noc::BarrierMode::FULL>();"
+      ttkernel.noc_async_read_barrier(%noc_id) : (i8) -> ()
+      return
+    }
+
     // CHECK-LABEL: func @noc_async_write
     func.func @noc_async_write() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.verbatim "UnicastEndpoint unicast_ep;"
@@ -1983,7 +2008,7 @@ module {
       // CHECK-NOT: get_noc_multicast_addr
       // CHECK-NOT: noc_async_write_multicast
       // CHECK: emitc.verbatim "MulticastEndpoint mcast_ep;"
-      // CHECK: emitc.verbatim "Noc noc(1);"
+      // CHECK: emitc.verbatim "Noc noc1(1);"
       // CHECK: %[[XS:.*]] = "emitc.constant"() <{value = 0 : index}>
       // CHECK: %[[YS:.*]] = "emitc.constant"() <{value = 1 : index}>
       // CHECK: %[[XE:.*]] = "emitc.constant"() <{value = 2 : index}>
@@ -1993,14 +2018,78 @@ module {
       // CHECK: %[[SIZE:.*]] = "emitc.constant"() <{value = 64 : i32}>
       // CHECK: %[[NUM_DESTS:.*]] = "emitc.constant"() <{value = 4 : i32}>
       // CHECK: %[[NOC:.*]] = "emitc.constant"() <{value = 1 : i8}>
-      // CHECK: emitc.verbatim "noc.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>
+      // CHECK: emitc.verbatim "noc1.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>
       // CHECK-SAME: noc_traits_t<MulticastEndpoint>::dst_args_mcast_type
       // CHECK-SAME: args %[[SRC]], %[[SIZE]], %[[NUM_DESTS]], %[[XE]], %[[YE]], %[[XS]], %[[YS]], %[[ADDR]]
       ttkernel.noc_async_write_multicast(%src, %size, %num_dests, start_xy[%xe, %ye], end_xy[%xs, %ys], %addr, %noc) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
-      // CHECK: emitc.verbatim "noc.async_write_multicast<Noc::McastMode::INCLUDE_SRC>
+      // CHECK: emitc.verbatim "noc1.async_write_multicast<Noc::McastMode::INCLUDE_SRC>
       // CHECK-SAME: noc_traits_t<MulticastEndpoint>::dst_args_mcast_type
       // CHECK-SAME: args %[[SRC]], %[[SIZE]], %[[NUM_DESTS]], %[[XE]], %[[YE]], %[[XS]], %[[YS]], %[[ADDR]]
       ttkernel.noc_async_write_multicast_loopback_src(%src, %size, %num_dests, start_xy[%xe, %ye], end_xy[%xs, %ys], %addr, %noc) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_async_multicast_after_default_noc_user
+    func.func @noc_async_multicast_after_default_noc_user() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      %xs = arith.constant 0 : index
+      %ys = arith.constant 1 : index
+      %xe = arith.constant 2 : index
+      %ye = arith.constant 3 : index
+      %addr = arith.constant 262144 : i32
+      %src = arith.constant 303104 : i32
+      %size = arith.constant 64 : i32
+      %num_dests = arith.constant 4 : i32
+      %noc = arith.constant 1 : i8
+      // CHECK-DAG: emitc.verbatim "Noc noc;"
+      // CHECK-DAG: emitc.verbatim "Noc noc1(1);"
+      // CHECK: %[[XS2:.*]] = "emitc.constant"() <{value = 0 : index}>
+      // CHECK: %[[YS2:.*]] = "emitc.constant"() <{value = 1 : index}>
+      // CHECK: %[[XE2:.*]] = "emitc.constant"() <{value = 2 : index}>
+      // CHECK: %[[YE2:.*]] = "emitc.constant"() <{value = 3 : index}>
+      // CHECK: %[[ADDR2:.*]] = "emitc.constant"() <{value = 262144 : i32}>
+      // CHECK: %[[SRC2:.*]] = "emitc.constant"() <{value = 303104 : i32}>
+      // CHECK: %[[SIZE2:.*]] = "emitc.constant"() <{value = 64 : i32}>
+      // CHECK: %[[NUM_DESTS2:.*]] = "emitc.constant"() <{value = 4 : i32}>
+      // CHECK: %[[NOC2:.*]] = "emitc.constant"() <{value = 1 : i8}>
+      // CHECK: emitc.verbatim "noc.async_write_barrier<Noc::BarrierMode::FULL>();"
+      "ttkernel.noc_async_write_barrier"() : () -> ()
+      // CHECK: emitc.verbatim "noc1.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>
+      // CHECK-SAME: args %[[SRC2]], %[[SIZE2]], %[[NUM_DESTS2]], %[[XE2]], %[[YE2]], %[[XS2]], %[[YS2]], %[[ADDR2]]
+      ttkernel.noc_async_write_multicast(%src, %size, %num_dests, start_xy[%xe, %ye], end_xy[%xs, %ys], %addr, %noc) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_async_multicast_dynamic_noc
+    func.func @noc_async_multicast_dynamic_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      %xs = arith.constant 0 : index
+      %ys = arith.constant 1 : index
+      %xe = arith.constant 2 : index
+      %ye = arith.constant 3 : index
+      %addr = arith.constant 262144 : i32
+      %src = arith.constant 303104 : i32
+      %size = arith.constant 64 : i32
+      %num_dests = arith.constant 4 : i32
+      %noc_arg = arith.constant 262400 : i32
+      %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+      %noc_offset = arith.constant 0 : i32
+      %noc = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
+      // CHECK: %[[XS3:.*]] = "emitc.constant"() <{value = 0 : index}>
+      // CHECK: %[[YS3:.*]] = "emitc.constant"() <{value = 1 : index}>
+      // CHECK: %[[XE3:.*]] = "emitc.constant"() <{value = 2 : index}>
+      // CHECK: %[[YE3:.*]] = "emitc.constant"() <{value = 3 : index}>
+      // CHECK: %[[ADDR3:.*]] = "emitc.constant"() <{value = 262144 : i32}>
+      // CHECK: %[[SRC3:.*]] = "emitc.constant"() <{value = 303104 : i32}>
+      // CHECK: %[[SIZE3:.*]] = "emitc.constant"() <{value = 64 : i32}>
+      // CHECK: %[[NUM_DESTS3:.*]] = "emitc.constant"() <{value = 4 : i32}>
+      // CHECK: %[[NOC_ARG:.*]] = "emitc.constant"() <{value = 262400 : i32}>
+      // CHECK: %[[NOC_PTR:.*]] = emitc.call_opaque "reinterpret_cast<tt_l1_ptr uint8_t*>"(%[[NOC_ARG]])
+      // CHECK: %[[NOC_OFFSET:.*]] = "emitc.constant"() <{value = 0 : i32}>
+      // CHECK: %[[NOC_SLOT:.*]] = emitc.subscript %[[NOC_PTR]][%[[NOC_OFFSET]]
+      // CHECK: %[[LOADED_NOC:.*]] = emitc.load %[[NOC_SLOT]]
+      // CHECK: %[[DYNAMIC_NOC:.*]] = emitc.cast %[[LOADED_NOC]]
+      // CHECK: emitc.verbatim "Noc({}).async_write_multicast<Noc::McastMode::EXCLUDE_SRC>
+      // CHECK-SAME: args %[[DYNAMIC_NOC]], %[[SRC3]], %[[SIZE3]], %[[NUM_DESTS3]], %[[XE3]], %[[YE3]], %[[XS3]], %[[YS3]], %[[ADDR3]]
+      ttkernel.noc_async_write_multicast(%src, %size, %num_dests, start_xy[%xe, %ye], end_xy[%xs, %ys], %addr, %noc) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
       return
     }
 
@@ -2009,6 +2098,16 @@ module {
       // CHECK: emitc.verbatim "Noc noc;"
       // CHECK: emitc.verbatim "noc.async_write_barrier<Noc::BarrierMode::FULL>();"
       "ttkernel.noc_async_write_barrier"() : () -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_async_write_barrier_with_noc_id
+    func.func @noc_async_write_barrier_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: emitc.verbatim "Noc noc1(1);"
+      // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
+      %noc_id = arith.constant 1 : i8
+      // CHECK: emitc.verbatim "noc1.async_write_barrier<Noc::BarrierMode::FULL>();"
+      ttkernel.noc_async_write_barrier(%noc_id) : (i8) -> ()
       return
     }
 
@@ -2155,18 +2254,19 @@ module {
 
     // CHECK-LABEL: func @noc_async_atomic_barrier
     func.func @noc_async_atomic_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: emitc.verbatim "Noc noc;"
-      // CHECK: emitc.verbatim "noc.async_atomic_barrier<Noc::BarrierMode::FULL>();"
+      // CHECK-NOT: emitc.verbatim "Noc noc{{.*}}"
+      // CHECK: emitc.verbatim "noc_async_atomic_barrier();"
       ttkernel.noc_async_atomic_barrier() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @noc_async_atomic_barrier_with_noc_id
     func.func @noc_async_atomic_barrier_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: emitc.verbatim "Noc noc(1);"
+      // CHECK-NOT: emitc.verbatim "Noc noc{{.*}}"
       // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
       %noc_id = arith.constant 1 : i8
-      // CHECK: emitc.verbatim "noc.async_atomic_barrier<Noc::BarrierMode::FULL>();"
+      // CHECK-NOT: emitc.verbatim "Noc noc{{.*}}"
+      // CHECK: emitc.verbatim "noc_async_atomic_barrier({});" args %[[NOC_ID]] : i8
       ttkernel.noc_async_atomic_barrier(%noc_id) : (i8) -> ()
       return
     }

--- a/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
+++ b/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
@@ -21,6 +21,46 @@ func.func @test_consecutive_write_barriers() {
   return
 }
 
+// CHECK-LABEL: func.func @test_consecutive_read_barriers_same_noc
+func.func @test_consecutive_read_barriers_same_noc(%noc: i8) {
+  // CHECK: ttkernel.noc_async_read_barrier(%{{.*}})
+  ttkernel.noc_async_read_barrier(%noc) : (i8) -> ()
+  // CHECK-NOT: ttkernel.noc_async_read_barrier
+  ttkernel.noc_async_read_barrier(%noc) : (i8) -> ()
+  // CHECK: return
+  return
+}
+
+// CHECK-LABEL: func.func @test_consecutive_read_barriers_different_noc
+func.func @test_consecutive_read_barriers_different_noc(%noc0: i8, %noc1: i8) {
+  // CHECK: ttkernel.noc_async_read_barrier(%{{.*}})
+  ttkernel.noc_async_read_barrier(%noc0) : (i8) -> ()
+  // CHECK: ttkernel.noc_async_read_barrier(%{{.*}})
+  ttkernel.noc_async_read_barrier(%noc1) : (i8) -> ()
+  // CHECK: return
+  return
+}
+
+// CHECK-LABEL: func.func @test_consecutive_write_barriers_same_noc
+func.func @test_consecutive_write_barriers_same_noc(%noc: i8) {
+  // CHECK: ttkernel.noc_async_write_barrier(%{{.*}})
+  ttkernel.noc_async_write_barrier(%noc) : (i8) -> ()
+  // CHECK-NOT: ttkernel.noc_async_write_barrier
+  ttkernel.noc_async_write_barrier(%noc) : (i8) -> ()
+  // CHECK: return
+  return
+}
+
+// CHECK-LABEL: func.func @test_consecutive_write_barriers_different_noc
+func.func @test_consecutive_write_barriers_different_noc(%noc0: i8, %noc1: i8) {
+  // CHECK: ttkernel.noc_async_write_barrier(%{{.*}})
+  ttkernel.noc_async_write_barrier(%noc0) : (i8) -> ()
+  // CHECK: ttkernel.noc_async_write_barrier(%{{.*}})
+  ttkernel.noc_async_write_barrier(%noc1) : (i8) -> ()
+  // CHECK: return
+  return
+}
+
 // CHECK-LABEL: func.func @test_consecutive_unpack_stall_on_pack
 func.func @test_consecutive_unpack_stall_on_pack() {
   // CHECK: ttkernel.experimental::unpack_stall_on_pack

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -67,9 +67,9 @@ func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<n
     %noc = arith.constant 1 : i8
     // CHECK: noc_inline_dw_write<InlineWriteDst::L1>([[NOCADDR1]], [[INLINE_VALUE]], [[BE]], [[NOC]])
     ttkernel.noc_inline_dw_write(%4, %inline_value, %be, %noc) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
-    // CHECK: noc_async_atomic_barrier()
+    // CHECK: [[NOC1]].async_atomic_barrier()
     ttkernel.noc_async_atomic_barrier() : () -> ()
-    // CHECK: noc_async_atomic_barrier([[NOC]])
+    // CHECK: noc1.async_atomic_barrier()
     ttkernel.noc_async_atomic_barrier(%noc) : (i8) -> ()
     // CHECK: [[NOC1]].async_read_barrier<Noc::BarrierMode::FULL>()
     ttkernel.noc_async_read_barrier() : () -> ()

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -51,7 +51,7 @@ func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<n
     %c262144_i32 = arith.constant 262144 : i32
     // CHECK: [[NOC1]].async_read([[EP1]], CoreLocalMem<uint32_t>([[C1]]), [[C0]]
     ttkernel.noc_async_read core[%c0_idx, %c0_idx], %c262144_i32, %c262400_i32, %c32_i32 : (index, index, i32, i32, i32) -> ()
-    // CHECK: int64_t [[NOCADDR1:.*]] = get_noc_addr([[A0]], [[A0]], [[B1]])
+    // CHECK: uint64_t [[NOCADDR1:.*]] = [[EP1]].get_noc_unicast_addr(static_cast<uint32_t>([[A0]]), static_cast<uint32_t>([[A0]]), static_cast<uint32_t>([[B1]]), [[NOC1]].get_noc_id())
     %4 = ttkernel.get_noc_addr(%c0_idx, %c0_idx, %c262208_i32) : (index, index, i32) -> !ttkernel.noc_addr
     // CHECK: [[NOC1]].async_read([[EP1]], CoreLocalMem<uint32_t>([[B0]]), [[C0]]
     ttkernel.noc_async_read core[%c0_idx, %c0_idx], %c262208_i32, %c262432_i32, %c32_i32 : (index, index, i32, i32, i32) -> ()
@@ -79,6 +79,7 @@ func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<n
 
 // CHECK: void kernel_main
 func.func @ttkernel_noc_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+    // CHECK-DAG: UnicastEndpoint [[EXPLICIT_EP:unicast_ep]]
     // CHECK-DAG: Noc [[EXPLICIT_NOC:noc1]](1)
     // CHECK-DAG: size_t [[EXPLICIT_X:.*]] = 1
     %x = arith.constant 1 : index
@@ -88,7 +89,7 @@ func.func @ttkernel_noc_with_noc_id() -> () attributes {ttkernel.thread = #ttker
     %addr = arith.constant 262400 : i32
     // CHECK-DAG: int8_t [[EXPLICIT_NOC_ID:.*]] = 1
     %noc_id = arith.constant 1 : i8
-    // CHECK: int64_t [[EXPLICIT_NOC_ADDR:.*]] = get_noc_addr([[EXPLICIT_X]], [[EXPLICIT_Y]], [[EXPLICIT_ADDR]], [[EXPLICIT_NOC_ID]])
+    // CHECK: uint64_t [[EXPLICIT_NOC_ADDR:.*]] = [[EXPLICIT_EP]].get_noc_unicast_addr(static_cast<uint32_t>([[EXPLICIT_X]]), static_cast<uint32_t>([[EXPLICIT_Y]]), static_cast<uint32_t>([[EXPLICIT_ADDR]]), [[EXPLICIT_NOC]].get_noc_id())
     %noc_addr = ttkernel.get_noc_addr(%x, %y, %addr, %noc_id) : (index, index, i32, i8) -> !ttkernel.noc_addr
     // CHECK: [[EXPLICIT_NOC]].async_read_barrier<Noc::BarrierMode::FULL>()
     ttkernel.noc_async_read_barrier(%noc_id) : (i8) -> ()

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -67,8 +67,33 @@ func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<n
     %noc = arith.constant 1 : i8
     // CHECK: noc_inline_dw_write<InlineWriteDst::L1>([[NOCADDR1]], [[INLINE_VALUE]], [[BE]], [[NOC]])
     ttkernel.noc_inline_dw_write(%4, %inline_value, %be, %noc) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
+    // CHECK: noc_async_atomic_barrier()
+    ttkernel.noc_async_atomic_barrier() : () -> ()
+    // CHECK: noc_async_atomic_barrier([[NOC]])
+    ttkernel.noc_async_atomic_barrier(%noc) : (i8) -> ()
     // CHECK: [[NOC1]].async_read_barrier<Noc::BarrierMode::FULL>()
     ttkernel.noc_async_read_barrier() : () -> ()
+    // CHECK: return
+    func.return
+}
+
+// CHECK: void kernel_main
+func.func @ttkernel_noc_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+    // CHECK-DAG: Noc [[EXPLICIT_NOC:noc1]](1)
+    // CHECK-DAG: size_t [[EXPLICIT_X:.*]] = 1
+    %x = arith.constant 1 : index
+    // CHECK-DAG: size_t [[EXPLICIT_Y:.*]] = 2
+    %y = arith.constant 2 : index
+    // CHECK-DAG: int32_t [[EXPLICIT_ADDR:.*]] = 262400
+    %addr = arith.constant 262400 : i32
+    // CHECK-DAG: int8_t [[EXPLICIT_NOC_ID:.*]] = 1
+    %noc_id = arith.constant 1 : i8
+    // CHECK: int64_t [[EXPLICIT_NOC_ADDR:.*]] = get_noc_addr([[EXPLICIT_X]], [[EXPLICIT_Y]], [[EXPLICIT_ADDR]], [[EXPLICIT_NOC_ID]])
+    %noc_addr = ttkernel.get_noc_addr(%x, %y, %addr, %noc_id) : (index, index, i32, i8) -> !ttkernel.noc_addr
+    // CHECK: [[EXPLICIT_NOC]].async_read_barrier<Noc::BarrierMode::FULL>()
+    ttkernel.noc_async_read_barrier(%noc_id) : (i8) -> ()
+    // CHECK: [[EXPLICIT_NOC]].async_write_barrier<Noc::BarrierMode::FULL>()
+    ttkernel.noc_async_write_barrier(%noc_id) : (i8) -> ()
     // CHECK: return
     func.return
 }

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc_dynamic_atomic.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc_dynamic_atomic.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt --convert-ttkernel-to-emitc -o %t %s
+// RUN: ttmlir-translate --ttkernel-to-cpp -o %t.cpp %t
+// RUN: FileCheck %s --input-file=%t.cpp
+
+// CHECK: #include "api/dataflow/dataflow_api.h"
+// CHECK: #include "api/dataflow/noc.h"
+// CHECK: void kernel_main
+func.func @ttkernel_dynamic_noc_atomic_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+  // CHECK: int32_t [[NOC_ARG:.*]] = 262400
+  %noc_arg = arith.constant 262400 : i32
+  %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+  %noc_offset = arith.constant 0 : i32
+  // CHECK: int8_t [[NOC:v[0-9]+]] = (int8_t)
+  %noc = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
+  // CHECK: Noc([[NOC]]).async_atomic_barrier()
+  ttkernel.noc_async_atomic_barrier(%noc) : (i8) -> ()
+  // CHECK: return
+  func.return
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`ttkernel.noc_async_atomic_barrier` lowered to `Noc::async_atomic_barrier<Noc::BarrierMode::FULL>`, but the tt-metal NOC object API exposes `async_atomic_barrier()` without a barrier-mode template. Generated C++ kernels therefore failed to compile with the current tt-metal NOC API.

Moreover, the optional NOC ID parameter was not handled correctly across NOC address and barrier ops: lowering used it only to construct a `Noc` object, then emitted barrier calls with no argument, dropping the actual NOC ID parameter in the ttkernel op.

Mixed default and explicit NOC use could also select the wrong object. For example, after emitting `Noc noc;`, an operation with `%noc = 1` could still emit `noc.async_write_multicast(...)` instead of `noc1.async_write_multicast(...)`.

`ttkernel.get_noc_addr` still lowered to the bare `get_noc_addr(...)` helper. That left generated kernels partially on the old C-style API even after the barrier and multicast lowering moved to the NOC object API.

Read/write barrier canonicalization also treated all consecutive barriers as duplicates, even when they targeted different NOC IDs.

### What's changed
Lower `ttkernel.noc_async_atomic_barrier` to `Noc::async_atomic_barrier()` object calls, preserving the optional NOC ID operand.

Separate default NOC declaration from explicit NOC-ID reference selection. Default-NOC operations still use `Noc noc`; static explicit IDs use function-scoped declarations like `Noc noc1(1)`; dynamic explicit IDs use a temporary `Noc({})` expression.

Route multicast writes and TRID barriers through the same explicit-NOC reference logic.

Allow `ttkernel.get_noc_addr`, `ttkernel.noc_async_read_barrier`, and `ttkernel.noc_async_write_barrier` to carry an optional NOC ID operand.

Lower `ttkernel.get_noc_addr` through `UnicastEndpoint::get_noc_unicast_addr(..., noc.get_noc_id())` instead of emitting the bare `get_noc_addr(...)` helper. Static NOC IDs reuse function-scoped `Noc nocN(N)` declarations; dynamic NOC IDs are passed in the correct EmitC placeholder order through `Noc({}).get_noc_id()`.

Only canonicalize duplicate read/write barriers when the previous barrier targets the same NOC ID.

Refactor repeated SSA-derived temporary-name generation into a local helper used by the new address lowering and existing EmitC temporary declarations.

Add TTKernel-to-EmitC, TTKernel-to-C++ translation, and canonicalizer coverage for atomic barriers, get-noc-addr with static and dynamic NOC IDs, read/write barriers with NOC ID, multicast writes, mixed default/explicit NOC usage, TRID barriers, and same/different-NOC barrier canonicalization.

### Checklist
- [x] New/Existing tests provide coverage for changes

Validated:
- `llvm-lit build/test/ttmlir/Conversion/TTKernelToEmitC build/test/ttmlir/Translate/TTKernel build/test/ttmlir/Dialect/TTKernel`
- End-to-end on Blackhole via [tt-lang #635](https://github.com/tenstorrent/tt-lang/pull/635): 432 device tests pass, 0 JIT-build errors, no PCC regressions. PCC passes confirm the default-NOC `get_noc_addr` path is correct (`Noc().get_noc_id()` resolves to the kernel's compile-time `noc_index`).
- The TXN_ID barrier and dynamic (runtime) NOC ID branches have no tt-lang caller yet, so they are covered by lit tests only here.