### PR TITLE
Fix ND builder test segfault

### DIFF
--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -127,6 +127,7 @@ class Builder(metaclass=BuilderMeta):
         self._hoisted_cpu_functions: List[str] = []
         self._nested_funcs: List[str] = []
         self._func_name_to_op: Dict[str, func.FuncOp] = {}
+        self._parsed_root_module = None
 
     # ----- Class helper methods -----
 
@@ -1138,6 +1139,9 @@ class Builder(metaclass=BuilderMeta):
         parsed_root_module: Module,
         golden_inputs: Dict[str, [List[Dict[int, torch.tensor]]]],
     ):
+        # Keep parsed module alive; its FuncOps are stored as non-owning views.
+        self._parsed_root_module = parsed_root_module
+
         found_cpu_module = False
 
         for entry in parsed_root_module.body.operations:


### PR DESCRIPTION
### Problem description
see this [run](https://github.com/tenstorrent/tt-mlir/actions/runs/26601168132/attempts/1)

`test_parse_split_ops.py::test_stablehlo_parsing_splitting_ops[stablehlo_composite.mlir]` segfaults in CI:
```
  Fatal Python error: Segmentation fault
    File ".../stablehlo_builder.py", line 3715 in composite_split
    File ".../stablehlo_builder.py", line 10311 in split_op
    File ".../stablehlo_builder.py", line 10339 in split_module
    File ".../builder_apis.py", line 1469 in split_mlir_file
```

use-after-free bug that's ND because of GC timing (probably)

`_func_name_to_op` stores Python `FuncOp` handles that point at IR owned by `root_module`. Since `root_module` is freed on return, leaving those ptrs dangling, which `composite_split` later dereferences.

### What's changed
Retain the parsed module on the builder
