### PR TITLE
[TTNN] Remove workaround for untilziing DRAM-sharded tensors on host

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -168,18 +168,6 @@ private:
            dataType == ttcore::DataType::Int32;
   }
 
-  bool canUntilizeOnDevice(const LayoutInfo &input,
-                           const LayoutInfo &output) const {
-    if (!canUntilizeDataTypeOnDevice(output.dataType)) {
-      return false;
-    }
-
-    // ttnn.untilize cannot operate on DRAM-sharded tensors - tt-metal issue
-    // #43975.
-    //
-    return !input.isDramSharded() && !output.isDramSharded();
-  }
-
   std::pair<LayoutInfo, LayoutInfo>
   getInputOutputLayouts(ttnn::ToLayoutOp op) const {
     LayoutInfo input, output;
@@ -632,7 +620,7 @@ private:
 
     // If the output is on device and we can untilize on device, move to device
     // and untilize.
-    if (info.shouldUntilize() && canUntilizeOnDevice(input, output)) {
+    if (info.shouldUntilize() && canUntilizeDataTypeOnDevice(output.dataType)) {
       currentInput =
           this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
       currentInput =
@@ -645,7 +633,8 @@ private:
 
     // If the output is on device and we should untilize, we untilize on
     // host and then move the tensor to device.
-    if (info.shouldUntilize() && !canUntilizeOnDevice(input, output)) {
+    if (info.shouldUntilize() &&
+        !canUntilizeDataTypeOnDevice(output.dataType)) {
       currentInput =
           this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
       currentInput =
@@ -787,7 +776,7 @@ private:
 
     // If we can untilize on device, move to device if
     // needed, perform the typecast first and then untilize
-    if (info.shouldUntilize() && canUntilizeOnDevice(input, output)) {
+    if (info.shouldUntilize() && canUntilizeDataTypeOnDevice(output.dataType)) {
       currentInput =
           this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
       currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
@@ -801,7 +790,8 @@ private:
     }
 
     // If we cannot untilize on device, untilize and typecast on host
-    if (info.shouldUntilize() && !canUntilizeOnDevice(input, output)) {
+    if (info.shouldUntilize() &&
+        !canUntilizeDataTypeOnDevice(output.dataType)) {
       currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
                                                            currentInput, info);
       currentInput =
@@ -970,14 +960,14 @@ private:
     }
 
     // If we can untilize on device, untilize on device then move to host.
-    if (info.shouldUntilize() && canUntilizeOnDevice(input, output)) {
+    if (info.shouldUntilize() && canUntilizeDataTypeOnDevice(input.dataType)) {
       untilizeOnDeviceThenFromHost(op, rewriter, currentInput, info);
       return;
     }
 
     // If we want to untilize, but we cannot untilize on
     // device, move to host and then untilize
-    if (info.shouldUntilize() && !canUntilizeOnDevice(input, output) &&
+    if (info.shouldUntilize() && !canUntilizeDataTypeOnDevice(input.dataType) &&
         opsToCreate.createFromDeviceOp) {
       currentInput =
           this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
@@ -990,7 +980,7 @@ private:
     // This is a rare untilize case, where we want to untilize a device tensor
     // but keep it on device. To handle this we need to move the tensor to host,
     // untilize it, and then move it back to device
-    if (info.shouldUntilize() && !canUntilizeOnDevice(input, output) &&
+    if (info.shouldUntilize() && !canUntilizeDataTypeOnDevice(input.dataType) &&
         !opsToCreate.createFromDeviceOp) {
       // Force-create a FromDeviceOp
       currentInput = this->createFromDeviceOpIfNeeded(
@@ -1141,14 +1131,15 @@ private:
 
     // If we need to untilize and the output can be untilized on device,
     // typecast and untilize on device.
-    if (info.shouldUntilize() && canUntilizeOnDevice(input, output)) {
+    if (info.shouldUntilize() && canUntilizeDataTypeOnDevice(output.dataType)) {
       untilizeOnDeviceThenFromHost(op, rewriter, currentInput, info);
       return;
     }
 
     // If we need to untilize and the output cannot be untilized on
     // device typecast on device then untilize on host
-    if (info.shouldUntilize() && !canUntilizeOnDevice(input, output) &&
+    if (info.shouldUntilize() &&
+        !canUntilizeDataTypeOnDevice(output.dataType) &&
         opsToCreate.createFromDeviceOp) {
       currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
                                                            currentInput, info);
@@ -1163,7 +1154,8 @@ private:
     // In case of device to device untilize, where we cannot
     // untilize on device, typecast on device, untilize on host, then move
     // back to device
-    if (info.shouldUntilize() && !canUntilizeOnDevice(input, output) &&
+    if (info.shouldUntilize() &&
+        !canUntilizeDataTypeOnDevice(output.dataType) &&
         !opsToCreate.createFromDeviceOp) {
       currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
                                                            currentInput, info);

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_dram_sharded.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_dram_sharded.mlir
@@ -4,11 +4,6 @@
 
 // DRAM-sharded layout decompositions for ttnn.to_layout.
 //
-// ttnn.untilize cannot operate on DRAM-sharded tensors (tt-metal issue
-// #43975), so any untilize touching a DRAM-sharded side is routed through
-// host. ttnn.tilize accepts DRAM-sharded inputs and outputs via its default
-// multicore factory, so tilize tests here are sanity coverage only.
-//
 // Width-sharded variants use a 1x12 grid matching Wormhole's 12 DRAM banks.
 
 #system_memory = #ttnn.buffer_type<system_memory>
@@ -46,6 +41,7 @@
 // CHECK-DAG: #[[DRAM_WS_RM_BF16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<1x12>, memref<32x32xbf16, #dram>, <width_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (11,0)>]>>
 // CHECK-DAG: #[[DRAM_WS_RM_F32:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<1x12>, memref<32x32xf32, #dram>, <width_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (11,0)>]>>
 // CHECK-DAG: #[[DRAM_WS_TILE_BF16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<1x12>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <width_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (11,0)>]>>
+// CHECK-DAG: #[[DRAM_WS_TILE_F32:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<1x12>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <width_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (11,0)>]>>
 // CHECK-DAG: #[[DRAM_WS_TILE_BF16_GRID6:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<1x6>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <width_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (5,0)>]>>
 // CHECK-DAG: #[[DRAM_HS_RM_BF16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<8x1>, memref<32x32xbf16, #dram>, <height_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (7,0)>]>>
 // CHECK-DAG: #[[DRAM_IL_RM_BF16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<1x1>, memref<32x384xbf16, #dram>, <interleaved>>
@@ -57,71 +53,69 @@ module attributes {} {
     // Untilize, no typecast
     //===------------------------------------------------------------------===//
 
-    // Host TILE bf16 to DRAM width-sharded RM bf16. The untilize runs on
-    // host and a single to_device places the result directly into the
-    // DRAM-sharded memory config.
+    // Host TILE bf16 to DRAM width-sharded RM bf16. to_device lands the
+    // tile in DRAM-sharded and untilize runs there.
     func.func @host_tile_bf16_to_dram_ws_rm_bf16(%arg0: tensor<32x384xbf16, #host_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16> {
         // CHECK-LABEL: func.func @host_tile_bf16_to_dram_ws_rm_bf16
-        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%arg0)
+        // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%arg0
+        // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
+        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[TO_DEV]])
         // CHECK-SAME: layout = #ttnn.layout<row_major>
-        // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[UNTILIZE]]
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
-        // CHECK: return %[[TO_DEV]]
+        // CHECK: return %[[UNTILIZE]]
         %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xbf16, #host_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
-    // DRAM-sharded TILE input with a non-sharded output forces a host
-    // roundtrip even though the output isn't sharded itself.
+    // DRAM-sharded TILE to DRAM-interleaved RM: untilize in place, then
+    // reshard.
     func.func @dram_ws_tile_bf16_to_dram_il_rm_bf16(%arg0: tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_il_rm_bf16> {
         // CHECK-LABEL: func.func @dram_ws_tile_bf16_to_dram_il_rm_bf16
-        // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg0)
-        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[FROM_DEV]])
+        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-SAME: layout = #ttnn.layout<row_major>
-        // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[UNTILIZE]]
+        // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
+        // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[UNTILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_RM_BF16]]>
-        // CHECK: return %[[TO_DEV]]
+        // CHECK: return %[[RESHARD]]
         %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_il_rm_bf16>
     }
 
-    // Both sides DRAM-sharded: host roundtrip with the final to_device
-    // landing back in DRAM-sharded RM.
+    // Same DRAM-sharded config on both sides: in-place untilize, no reshard.
     func.func @dram_ws_tile_bf16_to_dram_ws_rm_bf16(%arg0: tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16> {
         // CHECK-LABEL: func.func @dram_ws_tile_bf16_to_dram_ws_rm_bf16
-        // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg0)
-        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[FROM_DEV]])
+        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-SAME: layout = #ttnn.layout<row_major>
-        // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[UNTILIZE]]
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
-        // CHECK: return %[[TO_DEV]]
+        // CHECK-NOT: ttnn.to_memory_config
+        // CHECK-NOT: ttnn.from_device
+        // CHECK: return %[[UNTILIZE]]
         %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
-    // DRAM-sharded TILE to host RM. No to_device is emitted after the host
-    // untilize; from_device terminates the chain.
+    // DRAM-sharded TILE to host RM: untilize on device, then read back.
     func.func @dram_ws_tile_bf16_to_host_rm_bf16(%arg0: tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #host_rm_bf16> {
         // CHECK-LABEL: func.func @dram_ws_tile_bf16_to_host_rm_bf16
-        // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg0)
-        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[FROM_DEV]])
+        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-SAME: layout = #ttnn.layout<row_major>
-        // CHECK: return %[[UNTILIZE]]
+        // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
+        // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%[[UNTILIZE]])
+        // CHECK: return %[[FROM_DEV]]
         %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #host_rm_bf16>
         return %0 : tensor<32x384xbf16, #host_rm_bf16>
     }
 
-    // Height-sharded variant of the same host roundtrip; verifies the
-    // DRAM-sharded predicate fires regardless of which sharding flavor is
-    // used.
+    // Height-sharded variant of the same in-place untilize: same shard
+    // config on both sides, so just to_layout.
     func.func @dram_hs_tile_bf16_to_dram_hs_rm_bf16(%arg0: tensor<256x32xbf16, #dram_hs_tile_bf16>) -> tensor<256x32xbf16, #dram_hs_rm_bf16> {
         // CHECK-LABEL: func.func @dram_hs_tile_bf16_to_dram_hs_rm_bf16
-        // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg0)
-        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[FROM_DEV]])
+        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-SAME: layout = #ttnn.layout<row_major>
-        // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[UNTILIZE]]
         // CHECK-SAME: -> tensor<256x32xbf16, #[[DRAM_HS_RM_BF16]]>
-        // CHECK: return %[[TO_DEV]]
+        // CHECK-NOT: ttnn.to_memory_config
+        // CHECK-NOT: ttnn.from_device
+        // CHECK: return %[[UNTILIZE]]
         %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <height_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (7, 0)>]>, <32x32>, <row_major>>>}> : (tensor<256x32xbf16, #dram_hs_tile_bf16>) -> tensor<256x32xbf16, #dram_hs_rm_bf16>
         return %0 : tensor<256x32xbf16, #dram_hs_rm_bf16>
     }
@@ -130,64 +124,62 @@ module attributes {} {
     // Untilize, with typecast
     //===------------------------------------------------------------------===//
 
-    // Host TILE f32 to DRAM-sharded RM bf16. Both typecast and untilize
-    // run on host before a single to_device into the DRAM-sharded output.
+    // Host TILE f32 to DRAM-sharded RM bf16. to_device places the tile in
+    // DRAM-sharded, then typecast and untilize run on device.
     func.func @host_tile_f32_to_dram_ws_rm_bf16(%arg0: tensor<32x384xf32, #host_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16> {
         // CHECK-LABEL: func.func @host_tile_f32_to_dram_ws_rm_bf16
-        // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
-        // CHECK-SAME: -> tensor<{{.*}}bf16
+        // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%arg0
+        // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_WS_TILE_F32]]>
+        // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%[[TO_DEV]])
+        // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[CAST]])
         // CHECK-SAME: layout = #ttnn.layout<row_major>
-        // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[UNTILIZE]]
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
-        // CHECK: return %[[TO_DEV]]
+        // CHECK: return %[[UNTILIZE]]
         %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xf32, #host_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
-    // DRAM-interleaved TILE f32 to DRAM-sharded RM bf16. The typecast
-    // runs on device while the tensor is still TILE, then a host roundtrip
-    // handles the untilize that DRAM sharding would otherwise FATAL on.
+    // DRAM-interleaved TILE f32 to DRAM-sharded RM bf16. Typecast and
+    // untilize run on the interleaved input, then a reshard lands the
+    // tensor in DRAM-sharded.
     func.func @dram_il_tile_f32_to_dram_ws_rm_bf16(%arg0: tensor<32x384xf32, #dram_il_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16> {
         // CHECK-LABEL: func.func @dram_il_tile_f32_to_dram_ws_rm_bf16
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
-        // CHECK-SAME: -> tensor<{{.*}}bf16
-        // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%[[CAST]])
-        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[FROM_DEV]])
+        // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_TILE_BF16]]>
+        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[CAST]])
         // CHECK-SAME: layout = #ttnn.layout<row_major>
-        // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[UNTILIZE]]
+        // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_RM_BF16]]>
+        // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[UNTILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
-        // CHECK-NOT: ttnn.to_memory_config
-        // CHECK: return %[[TO_DEV]]
+        // CHECK: return %[[RESHARD]]
         %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xf32, #dram_il_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
-    // DRAM-sharded TILE f32 to DRAM-interleaved RM bf16. Verifies the
-    // typecast can run on a DRAM-sharded TILE input on device, and that
-    // from_device produces a clean host TILE (the source-side sharded
-    // encoding does not leak through).
+    // DRAM-sharded TILE f32 to DRAM-interleaved RM bf16. Typecast and
+    // untilize run on the sharded input, then a reshard lands the tensor
+    // in DRAM-interleaved.
     func.func @dram_ws_tile_f32_to_dram_il_rm_bf16(%arg0: tensor<32x384xf32, #dram_ws_tile_f32>) -> tensor<32x384xbf16, #dram_il_rm_bf16> {
         // CHECK-LABEL: func.func @dram_ws_tile_f32_to_dram_il_rm_bf16
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
-        // CHECK-SAME: -> tensor<{{.*}}bf16
-        // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%[[CAST]])
-        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[FROM_DEV]])
+        // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
+        // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[CAST]])
         // CHECK-SAME: layout = #ttnn.layout<row_major>
-        // CHECK: "ttnn.to_device"(%[[UNTILIZE]]
+        // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
+        // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[UNTILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_RM_BF16]]>
-        // CHECK: return
+        // CHECK: return %[[RESHARD]]
         %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x384xf32, #dram_ws_tile_f32>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_il_rm_bf16>
     }
 
     //===------------------------------------------------------------------===//
-    // Tilize, no typecast (sanity, ttnn.tilize accepts DRAM-sharded)
+    // Tilize, no typecast
     //===------------------------------------------------------------------===//
 
-    // Host RM bf16 to DRAM-sharded TILE bf16. ttnn.tilize accepts a
-    // DRAM-sharded output directly, so to_device lands the tensor in the
-    // sharded config and tilize runs there without staging.
+    // Host RM bf16 to DRAM-sharded TILE bf16. to_device lands the tensor
+    // in the sharded config and tilize runs there.
     func.func @host_rm_bf16_to_dram_ws_tile_bf16(%arg0: tensor<32x384xbf16, #host_rm_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16> {
         // CHECK-LABEL: func.func @host_rm_bf16_to_dram_ws_tile_bf16
         // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/43975

### Problem description
tt-metal now supports untilizing DRAM-sharded tensors on device.

### Checklist
- [x] Wait for the [tt-metal PR](https://github.com/tenstorrent/tt-metal/pull/44906) to be uplifted
- [x] New/Existing tests provide coverage for changes
