### PR TITLE
[d2m-jit] bcast support

### DIFF
--- a/test/d2m-jit/lit/broadcasts.py
+++ b/test/d2m-jit/lit/broadcasts.py
@@ -16,22 +16,22 @@ from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise
 
 
 @d2m.kernel
-def k_bcast(in_t, out_t, m_blocks, n_blocks):
+def k_tile_bcast(in_t, out_t, m_blocks, n_blocks):
     m_off = core_index(0) * m_blocks
     n_off = core_index(1) * n_blocks
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            row = bcast(x, "row")
-            col = x.bcast_col()
-            scalar = bcast_scalar(x)
+            row = tile_bcast(x, "row")
+            col = x.tile_bcast_col()
+            scalar = tile_bcast_scalar(x)
             remote_store(out_t, [m_off + m, n_off + n], row + col + scalar)
 
 
 L = d2m.Layout(shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1])
 inp = d2m.empty(L)
 out = d2m.empty(L)
-k_bcast(inp, out, 1, 1, grid=(1, 1))
+k_tile_bcast(inp, out, 1, 1, grid=(1, 1))
 
 builder = _Builder.get()
 _emit_returns_and_finalise(builder, [out])

--- a/test/d2m-jit/lit/broadcasts.py
+++ b/test/d2m-jit/lit/broadcasts.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR-shape coverage for d2m-jit tile broadcasts.
+
+This builds a lazy d2m-jit module and prints it before pipeline execution, so
+the test validates the Python DSL lowering without requiring a device run.
+"""
+
+import d2m_jit as d2m
+from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise
+
+
+@d2m.kernel
+def k_bcast(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            row = bcast(x, "row")
+            col = x.bcast_col()
+            scalar = bcast_scalar(x)
+            remote_store(out_t, [m_off + m, n_off + n], row + col + scalar)
+
+
+L = d2m.Layout(shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1])
+inp = d2m.empty(L)
+out = d2m.empty(L)
+k_bcast(inp, out, 1, 1, grid=(1, 1))
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [out])
+builder.module.operation.verify()
+print(builder.module)
+_Builder.reset()
+
+
+# CHECK-LABEL: func.func @main
+# CHECK:       d2m.generic
+# CHECK:       "d2m.tile_bcast"({{.*}}) <{bcast_type = #d2m<tile_bcast_type row>}>
+# CHECK:       "d2m.tile_bcast"({{.*}}) <{bcast_type = #d2m<tile_bcast_type col>}>
+# CHECK:       "d2m.tile_bcast"({{.*}}) <{bcast_type = #d2m<tile_bcast_type scalar>}>
+# CHECK:       "d2m.tile_add"

--- a/test/d2m-jit/lit/broadcasts.py
+++ b/test/d2m-jit/lit/broadcasts.py
@@ -24,8 +24,8 @@ def k_tile_bcast(in_t, out_t, m_blocks, n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
             row = tile_bcast(x, "row")
             col = x.tile_bcast_col()
-            scalar = tile_bcast_scalar(x)
-            remote_store(out_t, [m_off + m, n_off + n], row + col + scalar)
+            bcast_2d = x.tile_bcast_2d()
+            remote_store(out_t, [m_off + m, n_off + n], row + col + bcast_2d)
 
 
 L = d2m.Layout(shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1])

--- a/test/d2m-jit/test_broadcasts.py
+++ b/test/d2m-jit/test_broadcasts.py
@@ -11,33 +11,33 @@ from d2m_jit.api import _parse_tile_bcast_type
 
 
 @d2m.kernel
-def k_bcast_row(in_t, out_t, m_blocks, n_blocks):
+def k_tile_bcast_row(in_t, out_t, m_blocks, n_blocks):
     m_off = core_index(0) * m_blocks
     n_off = core_index(1) * n_blocks
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, n_off + n], bcast(x, "row"))
+            remote_store(out_t, [m_off + m, n_off + n], tile_bcast(x, "row"))
 
 
 @d2m.kernel
-def k_bcast_col(in_t, out_t, m_blocks, n_blocks):
+def k_tile_bcast_col(in_t, out_t, m_blocks, n_blocks):
     m_off = core_index(0) * m_blocks
     n_off = core_index(1) * n_blocks
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, n_off + n], x.bcast_col())
+            remote_store(out_t, [m_off + m, n_off + n], x.tile_bcast_col())
 
 
 @d2m.kernel
-def k_bcast_scalar(in_t, out_t, m_blocks, n_blocks):
+def k_tile_bcast_scalar(in_t, out_t, m_blocks, n_blocks):
     m_off = core_index(0) * m_blocks
     n_off = core_index(1) * n_blocks
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, n_off + n], bcast_scalar(x))
+            remote_store(out_t, [m_off + m, n_off + n], tile_bcast_scalar(x))
 
 
 def make_layout():
@@ -103,9 +103,9 @@ def test_tile_broadcasts():
     out_col = d2m.empty(L)
     out_scalar = d2m.empty(L)
     in_d = d2m.to_layout(host, L)
-    k_bcast_row(in_d, out_row, 1, 1, grid=(2, 2))
-    k_bcast_col(in_d, out_col, 1, 1, grid=(2, 2))
-    k_bcast_scalar(in_d, out_scalar, 1, 1, grid=(2, 2))
+    k_tile_bcast_row(in_d, out_row, 1, 1, grid=(2, 2))
+    k_tile_bcast_col(in_d, out_col, 1, 1, grid=(2, 2))
+    k_tile_bcast_scalar(in_d, out_scalar, 1, 1, grid=(2, 2))
 
     row, col, scalar = d2m.to_host(out_row, out_col, out_scalar)
     assert torch.allclose(row, expected_tile_bcast(host, "row"))

--- a/test/d2m-jit/test_broadcasts.py
+++ b/test/d2m-jit/test_broadcasts.py
@@ -31,13 +31,13 @@ def k_tile_bcast_col(in_t, out_t, m_blocks, n_blocks):
 
 
 @d2m.kernel
-def k_tile_bcast_scalar(in_t, out_t, m_blocks, n_blocks):
+def k_tile_bcast_2d(in_t, out_t, m_blocks, n_blocks):
     m_off = core_index(0) * m_blocks
     n_off = core_index(1) * n_blocks
     for m in range(m_blocks):
         for n in range(n_blocks):
             x = remote_load(in_t, [m_off + m, n_off + n])
-            remote_store(out_t, [m_off + m, n_off + n], tile_bcast_scalar(x))
+            remote_store(out_t, [m_off + m, n_off + n], tile_bcast_2d(x))
 
 
 def make_layout():
@@ -58,7 +58,7 @@ def expected_tile_bcast(t, bcast_type):
                 bcast_tile = tile[:1, :].expand(32, 32)
             elif bcast_type == "col":
                 bcast_tile = tile[:, :1].expand(32, 32)
-            elif bcast_type == "scalar":
+            elif bcast_type == "2d":
                 bcast_tile = tile[:1, :1].expand(32, 32)
             else:
                 raise ValueError(f"unknown bcast type {bcast_type}")
@@ -72,7 +72,7 @@ def expected_tile_bcast(t, bcast_type):
         ("row", "row"),
         ("COL", "col"),
         ("column", "col"),
-        ("scalar", "scalar"),
+        ("2d", "scalar"),
         ("none", "none"),
         ("no_bcast", "none"),
         (d2m.TileBcastType.Row, "row"),
@@ -101,13 +101,13 @@ def test_tile_broadcasts():
 
     out_row = d2m.empty(L)
     out_col = d2m.empty(L)
-    out_scalar = d2m.empty(L)
+    out_2d = d2m.empty(L)
     in_d = d2m.to_layout(host, L)
     k_tile_bcast_row(in_d, out_row, 1, 1, grid=(2, 2))
     k_tile_bcast_col(in_d, out_col, 1, 1, grid=(2, 2))
-    k_tile_bcast_scalar(in_d, out_scalar, 1, 1, grid=(2, 2))
+    k_tile_bcast_2d(in_d, out_2d, 1, 1, grid=(2, 2))
 
-    row, col, scalar = d2m.to_host(out_row, out_col, out_scalar)
+    row, col, bcast_2d = d2m.to_host(out_row, out_col, out_2d)
     assert torch.allclose(row, expected_tile_bcast(host, "row"))
     assert torch.allclose(col, expected_tile_bcast(host, "col"))
-    assert torch.allclose(scalar, expected_tile_bcast(host, "scalar"))
+    assert torch.allclose(bcast_2d, expected_tile_bcast(host, "2d"))

--- a/test/d2m-jit/test_broadcasts.py
+++ b/test/d2m-jit/test_broadcasts.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from ttmlir.ir import Context
+
+import d2m_jit as d2m
+from d2m_jit.api import _parse_tile_bcast_type
+
+
+@d2m.kernel
+def k_bcast_row(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], bcast(x, "row"))
+
+
+@d2m.kernel
+def k_bcast_col(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], x.bcast_col())
+
+
+@d2m.kernel
+def k_bcast_scalar(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], bcast_scalar(x))
+
+
+def make_layout():
+    return d2m.Layout(
+        shape=(64, 64),
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=[2, 2],
+    )
+
+
+def expected_tile_bcast(t, bcast_type):
+    out = torch.empty_like(t)
+    for tile_y in range(0, t.shape[-2], 32):
+        for tile_x in range(0, t.shape[-1], 32):
+            tile = t[tile_y : tile_y + 32, tile_x : tile_x + 32]
+            if bcast_type == "row":
+                bcast_tile = tile[:1, :].expand(32, 32)
+            elif bcast_type == "col":
+                bcast_tile = tile[:, :1].expand(32, 32)
+            elif bcast_type == "scalar":
+                bcast_tile = tile[:1, :1].expand(32, 32)
+            else:
+                raise ValueError(f"unknown bcast type {bcast_type}")
+            out[tile_y : tile_y + 32, tile_x : tile_x + 32] = bcast_tile
+    return out
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("row", "row"),
+        ("COL", "col"),
+        ("column", "col"),
+        ("scalar", "scalar"),
+        ("none", "none"),
+        ("no_bcast", "none"),
+        (d2m.TileBcastType.Row, "row"),
+        (d2m.TileBcastType.Col, "col"),
+        (d2m.TileBcastType.Scalar, "scalar"),
+        (int(d2m.TileBcastType.Row), "row"),
+        (int(d2m.TileBcastType.Col), "col"),
+        (int(d2m.TileBcastType.Scalar), "scalar"),
+    ],
+)
+def test_parse_tile_bcast_type_forms(value, expected):
+    with Context():
+        attr = _parse_tile_bcast_type(value)
+    assert str(attr) == f"#d2m<tile_bcast_type {expected}>"
+
+
+@pytest.mark.parametrize("value", ["rows", True, object()])
+def test_parse_tile_bcast_type_rejects_invalid_values(value):
+    with pytest.raises(ValueError, match="tile broadcast type must be one of"):
+        _parse_tile_bcast_type(value)
+
+
+def test_tile_broadcasts():
+    host = torch.arange(64 * 64, dtype=torch.float32).remainder(127).reshape(64, 64)
+    L = make_layout()
+
+    out_row = d2m.empty(L)
+    out_col = d2m.empty(L)
+    out_scalar = d2m.empty(L)
+    in_d = d2m.to_layout(host, L)
+    k_bcast_row(in_d, out_row, 1, 1, grid=(2, 2))
+    k_bcast_col(in_d, out_col, 1, 1, grid=(2, 2))
+    k_bcast_scalar(in_d, out_scalar, 1, 1, grid=(2, 2))
+
+    row, col, scalar = d2m.to_host(out_row, out_col, out_scalar)
+    assert torch.allclose(row, expected_tile_bcast(host, "row"))
+    assert torch.allclose(col, expected_tile_bcast(host, "col"))
+    assert torch.allclose(scalar, expected_tile_bcast(host, "scalar"))

--- a/tools/d2m-jit/KERNEL_AUDIT.md
+++ b/tools/d2m-jit/KERNEL_AUDIT.md
@@ -25,7 +25,7 @@ Status legend matches [TODO.md](TODO.md): 🔴 blocker · 🟡 missing surface
 | `tilize` / `untilize` / `to_layout` | ✅ | Layout conversions |
 | `zeros`, `full`, `empty` | ✅ | Host-side fill + `to_layout` |
 | Reductions (`tile_reduce_*`) | 🔴 | Not exposed in `api.py` |
-| Broadcast (`tile_bcast`) | ✅ | `d2m.tile_bcast`, row/col/scalar shorthands, method forms; lit + pytest coverage |
+| Broadcast (`tile_bcast`) | ✅ | `d2m.tile_bcast`, row/col/2d shorthands, method forms; lit + pytest coverage |
 | In-kernel typecast (`tile_typecast`) | 🔴 | Host-side only via `tilize(dtype=...)` |
 | Per-tile transpose (`tile_transpose`) | 🔴 | Not exposed — but logical permute via views is free |
 | Row/col mask helpers | 🔴 | Causal-mask building block missing |
@@ -127,7 +127,7 @@ d2m.reduce_max(x, dim)
 d2m.reduce_mean(x, dim)
 
 # Broadcast a partial tile back to a full 32x32 tile. This is available today.
-d2m.tile_bcast(x, bcast_type)  # bcast_type in {"row", "col", "scalar"}
+d2m.tile_bcast(x, bcast_type)  # bcast_type in {"row", "col", "2d"}
 ```
 
 The reduction spelling is a placeholder; the tile_bcast spelling shown here is

--- a/tools/d2m-jit/KERNEL_AUDIT.md
+++ b/tools/d2m-jit/KERNEL_AUDIT.md
@@ -25,7 +25,7 @@ Status legend matches [TODO.md](TODO.md): 🔴 blocker · 🟡 missing surface
 | `tilize` / `untilize` / `to_layout` | ✅ | Layout conversions |
 | `zeros`, `full`, `empty` | ✅ | Host-side fill + `to_layout` |
 | Reductions (`tile_reduce_*`) | 🔴 | Not exposed in `api.py` |
-| Broadcast (`tile_bcast`) | 🔴 | Not exposed |
+| Broadcast (`tile_bcast`) | ✅ | `d2m.bcast`, row/col/scalar shorthands, method forms; lit + pytest coverage |
 | In-kernel typecast (`tile_typecast`) | 🔴 | Host-side only via `tilize(dtype=...)` |
 | Per-tile transpose (`tile_transpose`) | 🔴 | Not exposed — but logical permute via views is free |
 | Row/col mask helpers | 🔴 | Causal-mask building block missing |
@@ -88,7 +88,7 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 - **SDPA at 1-tile granularity** (S ≤ 32, single head): Q×Kᵀ via
   permute-view + zeros-prefilled matmul + softmax… stops at softmax
-  because reduce/bcast are missing.
+  because reductions are missing.
 - **Multi-head attention scaffolding:** per-head views are free; the
   *compute* hits the reduction wall.
 - **MoE expert MLP body** (linear + GELU + linear): chained via views,
@@ -98,9 +98,10 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ### 🔴 Blocked on missing pieces
 
-- **Softmax** — needs reduce + bcast. Blocks every attention,
-  MoE-gating, and cross-entropy-loss kernel.
-- **LayerNorm / RMSNorm / GroupNorm** — same: reductions + broadcast.
+- **Softmax** — needs reductions; broadcast is available. Blocks every
+  attention, MoE-gating, and cross-entropy-loss kernel.
+- **LayerNorm / RMSNorm / GroupNorm** — same: reductions are the
+  remaining blocker; broadcast is available.
 - **Flash Attention** — needs softmax + multi-K matmul accumulation
   ([TODO §1](TODO.md)) + multicast on real grids
   ([TODO §2](TODO.md)) + online-softmax state across blocks.
@@ -113,9 +114,9 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ---
 
-## 4. Concrete kernel sketches with a proposed reduce + bcast surface
+## 4. Concrete kernel sketches with available bcast + proposed reductions
 
-These sketches assume a small, named-keyword API along these lines:
+These sketches assume reductions with this shape, plus the existing bcast API:
 
 ```python
 # Per-tile reductions: reduce over the tile's row or col axis. The
@@ -125,12 +126,13 @@ d2m.reduce_sum(x, dim)     # dim in {"row", "col"}
 d2m.reduce_max(x, dim)
 d2m.reduce_mean(x, dim)
 
-# Broadcast a partial tile back to a full 32x32 tile.
-d2m.bcast(x, dim)          # dim in {"row", "col", "scalar"}
+# Broadcast a partial tile back to a full 32x32 tile. This is available today.
+d2m.bcast(x, bcast_type)   # bcast_type in {"row", "col", "scalar"}
 ```
 
-The exact spelling is a placeholder; the point of the sketches is the
-**kernel shape**, not the bikeshed.
+The reduction spelling is a placeholder; the bcast spelling shown here is
+available today. The point of the sketches is the **kernel shape**, not the
+bikeshed.
 
 ### 4.1 Row-wise softmax (within-tile)
 
@@ -148,10 +150,10 @@ def softmax_row(x, out, m_blocks, n_blocks):
 
             # Numerically-stable softmax: subtract row max, exp, divide.
             row_max = reduce_max(t, dim="row")           # 32x1
-            t_shift = t - bcast(row_max, dim="row")      # 32x32
+            t_shift = t - bcast(row_max, "row")          # 32x32
             t_exp   = exp(t_shift)
             row_sum = reduce_sum(t_exp, dim="row")       # 32x1
-            t_out   = t_exp * bcast(recip(row_sum), dim="row")
+            t_out   = t_exp * bcast(recip(row_sum), "row")
 
             remote_store(out, [m_off + m, n_off + n], t_out)
 ```
@@ -175,7 +177,7 @@ def softmax_row_wide(x, out, m_blocks, n_blocks):
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
             row_max = maximum(row_max, bcast(reduce_max(t, dim="row"),
-                                             dim="row"))
+                                             "row"))
 
         # Pass 2: row sum of shifted exp.
         row_sum = full_tile(value=0.0)
@@ -183,7 +185,7 @@ def softmax_row_wide(x, out, m_blocks, n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
             t_exp = exp(t - row_max)
             row_sum = row_sum + bcast(reduce_sum(t_exp, dim="row"),
-                                      dim="row")
+                                      "row")
         row_inv = recip(row_sum)
 
         # Pass 3: normalise and write back.
@@ -219,7 +221,7 @@ def rmsnorm(x, gamma, out, m_blocks, n_blocks, eps_tile):
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
             sum_sq = sum_sq + bcast(reduce_sum(t * t, dim="row"),
-                                    dim="row")
+                                    "row")
         inv_rms = rsqrt(sum_sq * INV_N + eps_tile)
 
         # Pass 2: scale and write.
@@ -229,9 +231,10 @@ def rmsnorm(x, gamma, out, m_blocks, n_blocks, eps_tile):
             remote_store(out, [m_off + m, n_off + n], t * g * inv_rms)
 ```
 
-This is the cleanest end-to-end demo of the reduce+bcast pair: one
-small kernel that exercises both, in a pattern that immediately
-generalises to LayerNorm (add a mean reduction) and GroupNorm.
+This is the cleanest end-to-end demo of reductions plus the available
+bcast primitive: one small kernel that exercises both, in a pattern
+that immediately generalises to LayerNorm (add a mean reduction) and
+GroupNorm.
 
 ### 4.4 Single-head SDPA, chained via views
 
@@ -294,7 +297,7 @@ def flash_attn_inner(Q, K, V, O, l_state, m_state, S_q, S_kv, D):
         # 2. running max
         m_prev = m_state
         m_cur  = maximum(m_prev, bcast(reduce_max(s, dim="row"),
-                                       dim="row"))
+                                       "row"))
 
         # 3. correction factor for previous accumulator
         alpha  = exp(m_prev - m_cur)
@@ -302,7 +305,7 @@ def flash_attn_inner(Q, K, V, O, l_state, m_state, S_q, S_kv, D):
         # 4. exp of shifted scores, partial sum
         p      = exp(s - m_cur)
         l_cur  = alpha * l_state + bcast(reduce_sum(p, dim="row"),
-                                         dim="row")
+                                         "row")
 
         # 5. update O: O = alpha * O + p @ V
         O      = alpha * O + (p @ V_blk)
@@ -314,8 +317,8 @@ def flash_attn_inner(Q, K, V, O, l_state, m_state, S_q, S_kv, D):
     remote_store(out, [block_q_idx, 0], O * recip(l_state))
 ```
 
-Blockers beyond reduce/bcast: per-tile `tile_transpose` (or
-pre-permuted K, which views already give us), multi-K matmul
+Blockers beyond reductions: per-tile `tile_transpose` (or pre-permuted
+K, which views already give us), multi-K matmul
 accumulation, multi-output kernels (we'd want `m_state` / `l_state` as
 state we can read back for debugging).
 
@@ -355,9 +358,9 @@ nothing else does:
 ## 5. Critical-path unlocks, ranked
 
 1. **Expose reductions (`tile_reduce_sum`, `tile_reduce_max`,
-   `tile_reduce_mean`) + `tile_bcast`.** Unlocks softmax → unlocks
-   LayerNorm, RMSNorm, attention, MoE gating. Single biggest fan-out
-   for the surface we're missing.
+   `tile_reduce_mean`).** `tile_bcast` is already exposed. Unlocks
+   softmax → unlocks LayerNorm, RMSNorm, attention, MoE gating. Single
+   biggest fan-out for the surface we're missing.
 2. **Fix matmul accumulator init** ([TODO §1](TODO.md) —
    `D2MToTTKernel` fill-pattern handling). Unlocks multi-K matmul →
    real GEMM, real attention Q×Kᵀ across K, FFN.

--- a/tools/d2m-jit/KERNEL_AUDIT.md
+++ b/tools/d2m-jit/KERNEL_AUDIT.md
@@ -25,7 +25,7 @@ Status legend matches [TODO.md](TODO.md): 🔴 blocker · 🟡 missing surface
 | `tilize` / `untilize` / `to_layout` | ✅ | Layout conversions |
 | `zeros`, `full`, `empty` | ✅ | Host-side fill + `to_layout` |
 | Reductions (`tile_reduce_*`) | 🔴 | Not exposed in `api.py` |
-| Broadcast (`tile_bcast`) | ✅ | `d2m.bcast`, row/col/scalar shorthands, method forms; lit + pytest coverage |
+| Broadcast (`tile_bcast`) | ✅ | `d2m.tile_bcast`, row/col/scalar shorthands, method forms; lit + pytest coverage |
 | In-kernel typecast (`tile_typecast`) | 🔴 | Host-side only via `tilize(dtype=...)` |
 | Per-tile transpose (`tile_transpose`) | 🔴 | Not exposed — but logical permute via views is free |
 | Row/col mask helpers | 🔴 | Causal-mask building block missing |
@@ -114,9 +114,9 @@ qk_matmul_kernel(Q, K_T, qk, ..., grid=g)   # Q @ K_T, no DMA between
 
 ---
 
-## 4. Concrete kernel sketches with available bcast + proposed reductions
+## 4. Concrete kernel sketches with available tile_bcast + proposed reductions
 
-These sketches assume reductions with this shape, plus the existing bcast API:
+These sketches assume reductions with this shape, plus the existing tile_bcast API:
 
 ```python
 # Per-tile reductions: reduce over the tile's row or col axis. The
@@ -127,10 +127,10 @@ d2m.reduce_max(x, dim)
 d2m.reduce_mean(x, dim)
 
 # Broadcast a partial tile back to a full 32x32 tile. This is available today.
-d2m.bcast(x, bcast_type)   # bcast_type in {"row", "col", "scalar"}
+d2m.tile_bcast(x, bcast_type)  # bcast_type in {"row", "col", "scalar"}
 ```
 
-The reduction spelling is a placeholder; the bcast spelling shown here is
+The reduction spelling is a placeholder; the tile_bcast spelling shown here is
 available today. The point of the sketches is the **kernel shape**, not the
 bikeshed.
 
@@ -150,10 +150,10 @@ def softmax_row(x, out, m_blocks, n_blocks):
 
             # Numerically-stable softmax: subtract row max, exp, divide.
             row_max = reduce_max(t, dim="row")           # 32x1
-            t_shift = t - bcast(row_max, "row")          # 32x32
+            t_shift = t - tile_bcast(row_max, "row")     # 32x32
             t_exp   = exp(t_shift)
             row_sum = reduce_sum(t_exp, dim="row")       # 32x1
-            t_out   = t_exp * bcast(recip(row_sum), "row")
+            t_out   = t_exp * tile_bcast(recip(row_sum), "row")
 
             remote_store(out, [m_off + m, n_off + n], t_out)
 ```
@@ -176,7 +176,7 @@ def softmax_row_wide(x, out, m_blocks, n_blocks):
         row_max = NEG_INF
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            row_max = maximum(row_max, bcast(reduce_max(t, dim="row"),
+            row_max = maximum(row_max, tile_bcast(reduce_max(t, dim="row"),
                                              "row"))
 
         # Pass 2: row sum of shifted exp.
@@ -184,7 +184,7 @@ def softmax_row_wide(x, out, m_blocks, n_blocks):
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
             t_exp = exp(t - row_max)
-            row_sum = row_sum + bcast(reduce_sum(t_exp, dim="row"),
+            row_sum = row_sum + tile_bcast(reduce_sum(t_exp, dim="row"),
                                       "row")
         row_inv = recip(row_sum)
 
@@ -220,7 +220,7 @@ def rmsnorm(x, gamma, out, m_blocks, n_blocks, eps_tile):
         sum_sq = full_tile(value=0.0)
         for n in range(n_blocks):
             t = remote_load(x, [m_off + m, n_off + n])
-            sum_sq = sum_sq + bcast(reduce_sum(t * t, dim="row"),
+            sum_sq = sum_sq + tile_bcast(reduce_sum(t * t, dim="row"),
                                     "row")
         inv_rms = rsqrt(sum_sq * INV_N + eps_tile)
 
@@ -232,7 +232,7 @@ def rmsnorm(x, gamma, out, m_blocks, n_blocks, eps_tile):
 ```
 
 This is the cleanest end-to-end demo of reductions plus the available
-bcast primitive: one small kernel that exercises both, in a pattern
+tile_bcast primitive: one small kernel that exercises both, in a pattern
 that immediately generalises to LayerNorm (add a mean reduction) and
 GroupNorm.
 
@@ -296,7 +296,7 @@ def flash_attn_inner(Q, K, V, O, l_state, m_state, S_q, S_kv, D):
 
         # 2. running max
         m_prev = m_state
-        m_cur  = maximum(m_prev, bcast(reduce_max(s, dim="row"),
+        m_cur  = maximum(m_prev, tile_bcast(reduce_max(s, dim="row"),
                                        "row"))
 
         # 3. correction factor for previous accumulator
@@ -304,7 +304,7 @@ def flash_attn_inner(Q, K, V, O, l_state, m_state, S_q, S_kv, D):
 
         # 4. exp of shifted scores, partial sum
         p      = exp(s - m_cur)
-        l_cur  = alpha * l_state + bcast(reduce_sum(p, dim="row"),
+        l_cur  = alpha * l_state + tile_bcast(reduce_sum(p, dim="row"),
                                          "row")
 
         # 5. update O: O = alpha * O + p @ V

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -238,6 +238,17 @@ Ternary:
 | --- | --- |
 | `d2m.where(cond, t, f)` | Elementwise select: `cond ? t : f`. All three blocks must have the same type. `cond` is interpreted elementwise (non-zero ⇒ `t`, zero ⇒ `f`). Also available as `cond.where(t, f)`. |
 
+Tile broadcast:
+
+| Symbol | What |
+| --- | --- |
+| `d2m.bcast(x, "row")` | Broadcast the tile's 0-row across each tile. |
+| `d2m.bcast(x, "col")` | Broadcast the tile's 0-column across each tile. |
+| `d2m.bcast(x, "scalar")` | Broadcast element (0, 0) across each tile. |
+| `d2m.bcast_row(x)` / `x.bcast_row()` | No-argument row-broadcast shorthand. |
+| `d2m.bcast_col(x)` / `x.bcast_col()` | No-argument column-broadcast shorthand. |
+| `d2m.bcast_scalar(x)` / `x.bcast_scalar()` | No-argument scalar-broadcast shorthand. |
+
 ### Python operators on `TensorBlock`
 
 `+` `-` `*` `/` `@` map to `add`, `sub`, `mul`, `div`, `matmul`. Unary `-`
@@ -369,5 +380,5 @@ have been dropped — the DSL emits the post-legalisation form directly.
 ## Known issues / TODO
 
 See [TODO.md](TODO.md) for active pipeline gaps (matmul accumulator init,
-host-scope `linalg.generic`), missing API surface (reductions, broadcast,
+host-scope `linalg.generic`), missing API surface (reductions,
 in-kernel typecast, DMA primitives, ...), and other follow-ups.

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -244,10 +244,10 @@ Tile broadcast:
 | --- | --- |
 | `d2m.tile_bcast(x, "row")` | Broadcast the tile's 0-row across each tile. |
 | `d2m.tile_bcast(x, "col")` | Broadcast the tile's 0-column across each tile. |
-| `d2m.tile_bcast(x, "scalar")` | Broadcast element (0, 0) across each tile. |
+| `d2m.tile_bcast(x, "2d")` | Broadcast element (0, 0) across each tile. |
 | `d2m.tile_bcast_row(x)` / `x.tile_bcast_row()` | No-argument row-broadcast shorthand. |
 | `d2m.tile_bcast_col(x)` / `x.tile_bcast_col()` | No-argument column-broadcast shorthand. |
-| `d2m.tile_bcast_scalar(x)` / `x.tile_bcast_scalar()` | No-argument scalar-broadcast shorthand. |
+| `d2m.tile_bcast_2d(x)` / `x.tile_bcast_2d()` | No-argument row-and-column broadcast shorthand. |
 
 ### Python operators on `TensorBlock`
 

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -242,12 +242,12 @@ Tile broadcast:
 
 | Symbol | What |
 | --- | --- |
-| `d2m.bcast(x, "row")` | Broadcast the tile's 0-row across each tile. |
-| `d2m.bcast(x, "col")` | Broadcast the tile's 0-column across each tile. |
-| `d2m.bcast(x, "scalar")` | Broadcast element (0, 0) across each tile. |
-| `d2m.bcast_row(x)` / `x.bcast_row()` | No-argument row-broadcast shorthand. |
-| `d2m.bcast_col(x)` / `x.bcast_col()` | No-argument column-broadcast shorthand. |
-| `d2m.bcast_scalar(x)` / `x.bcast_scalar()` | No-argument scalar-broadcast shorthand. |
+| `d2m.tile_bcast(x, "row")` | Broadcast the tile's 0-row across each tile. |
+| `d2m.tile_bcast(x, "col")` | Broadcast the tile's 0-column across each tile. |
+| `d2m.tile_bcast(x, "scalar")` | Broadcast element (0, 0) across each tile. |
+| `d2m.tile_bcast_row(x)` / `x.tile_bcast_row()` | No-argument row-broadcast shorthand. |
+| `d2m.tile_bcast_col(x)` / `x.tile_bcast_col()` | No-argument column-broadcast shorthand. |
+| `d2m.tile_bcast_scalar(x)` / `x.tile_bcast_scalar()` | No-argument scalar-broadcast shorthand. |
 
 ### Python operators on `TensorBlock`
 

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -80,18 +80,12 @@ in the same scope (or split them into separate synchronized scopes).
 
 ## Missing API surface
 
-`tile_bcast` is exposed today via `d2m.bcast(x, bcast_type)` for
-`"row"`, `"col"`, or `"scalar"`, the `bcast_row` / `bcast_col` /
-`bcast_scalar` shorthands, and matching `TensorBlock` methods. It has
-both lit IR-shape coverage and pytest end-to-end coverage, so it is no
-longer tracked as missing surface.
-
 These ops live in `D2MGenericRegionOps.td` but are not yet exposed in
 `api.py`. Each is a "wait for a use case" item — the DSL is a testbed,
 so we add ops when we have something to test against rather than
 speculatively.
 
-### 🟡 Remaining bespoke-signature ops (need design)
+### 🟡 Bespoke-signature ops (need design)
 
 | op | why it's interesting | what's blocking |
 | --- | --- | --- |

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -80,19 +80,24 @@ in the same scope (or split them into separate synchronized scopes).
 
 ## Missing API surface
 
+`tile_bcast` is exposed today via `d2m.bcast(x, bcast_type)` for
+`"row"`, `"col"`, or `"scalar"`, the `bcast_row` / `bcast_col` /
+`bcast_scalar` shorthands, and matching `TensorBlock` methods. It has
+both lit IR-shape coverage and pytest end-to-end coverage, so it is no
+longer tracked as missing surface.
+
 These ops live in `D2MGenericRegionOps.td` but are not yet exposed in
 `api.py`. Each is a "wait for a use case" item — the DSL is a testbed,
 so we add ops when we have something to test against rather than
 speculatively.
 
-### 🟡 Bespoke-signature ops (need design)
+### 🟡 Remaining bespoke-signature ops (need design)
 
 | op | why it's interesting | what's blocking |
 | --- | --- | --- |
 | `tile_clamp_scalar(x, min, max)` | clamp with attribute (not operand) bounds | needs `FloatAttr` / `IntegerAttr` threading through `_eltwise_block`, plus a wrapper that picks the attr type from the tile's underlying dtype |
 | `tile_typecast(x)` | in-kernel dtype conversion (host-side already covered by `tilize(dtype=...)`) | needs an `_eltwise_block` variant that takes a target element type different from the input |
 | `tile_transpose(x)` | per-tile (32×32) element transpose -- distinct from logical `permute` / `view` | naming question — collides with `permute` / `view` semantics if called `transpose` |
-| `tile_bcast(x, bcast_type)` | broadcast row / col / scalar tile to full tile | needs a `BcastTypeAttr` argument; small but bespoke |
 
 ### 🟡 Reductions (scoped — float blocked, int viable)
 
@@ -220,11 +225,11 @@ debugging kernel bodies; would need a thin wrapper that emits
 
 ### 🟢 Lit-side IR-shape FileCheck tests
 
-`test/d2m-jit/lit/` only has `captures.py` (AST inspection). Worth
-adding lit + FileCheck tests that dump pre-pipeline IR (the builder
-already supports `print_ir_before_pipeline`) and check the shape of
-what each DSL primitive emits — would lock down the IR contract
-without going to silicon.
+`test/d2m-jit/lit/` now has coverage for captures, error paths,
+pattern rewrites, and broadcast lowering. Worth expanding that into
+lit + FileCheck tests that dump pre-pipeline IR (the builder already
+supports `print_ir_before_pipeline`) and check the shape of more DSL
+primitives — this locks down the IR contract without going to silicon.
 
 Sketch:
 

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -51,7 +51,7 @@ def _parse_tile_bcast_type(value):
             return Attribute.parse("#d2m<tile_bcast_type col>")
         if key == "row":
             return Attribute.parse("#d2m<tile_bcast_type row>")
-        if key == "scalar":
+        if key == "2d":
             return Attribute.parse("#d2m<tile_bcast_type scalar>")
     if isinstance(value, int) and not isinstance(value, bool):
         if value == int(d2m.TileBcastType.None_):
@@ -63,7 +63,7 @@ def _parse_tile_bcast_type(value):
         if value == int(d2m.TileBcastType.Scalar):
             return Attribute.parse("#d2m<tile_bcast_type scalar>")
     raise ValueError(
-        "tile broadcast type must be one of 'row', 'col', 'scalar', 'none', "
+        "tile broadcast type must be one of 'row', 'col', '2d', 'none', "
         f"or a d2m.TileBcastType, got {value!r}"
     )
 
@@ -481,9 +481,9 @@ def tile_bcast_col(input):
     return tile_bcast(input, d2m.TileBcastType.Col)
 
 
-@syntax("tile_bcast_scalar")
-def tile_bcast_scalar(input):
-    """Block-level tile broadcast of element (0, 0)."""
+@syntax("tile_bcast_2d")
+def tile_bcast_2d(input):
+    """Block-level tile broadcast of element (0, 0) across rows and columns."""
     return tile_bcast(input, d2m.TileBcastType.Scalar)
 
 
@@ -771,9 +771,9 @@ class TensorBlock:
         """Same as `d2m.tile_bcast_col(self)`."""
         return tile_bcast_col(ast_self)
 
-    def tile_bcast_scalar(ast_self: TensorBlock) -> TensorBlock:
-        """Same as `d2m.tile_bcast_scalar(self)`."""
-        return tile_bcast_scalar(ast_self)
+    def tile_bcast_2d(ast_self: TensorBlock) -> TensorBlock:
+        """Same as `d2m.tile_bcast_2d(self)`."""
+        return tile_bcast_2d(ast_self)
 
     def where(ast_self: TensorBlock, true_value, false_value) -> TensorBlock:
         """Same as `d2m.where(self, true_value, false_value)` -- `self` is

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -456,34 +456,35 @@ def right_shift(lhs, rhs):
     return _eltwise_block(lambda l, r: d2m.tile_right_shift(l.type, l, r), lhs, rhs)
 
 
-@syntax("bcast", args_as_attr=[False, _tile_bcast_type_attr])
-def bcast(input, bcast_type):
+@syntax("tile_bcast", args_as_attr=[False, _tile_bcast_type_attr])
+def tile_bcast(input, bcast_type):
     """Block-level tile broadcast.
 
     `bcast_type` matches the D2M tile-broadcast enum: `row` broadcasts the
     tile's 0-row, `col` broadcasts the tile's 0-column, and `scalar`
-    broadcasts element (0, 0).
+    broadcasts element (0, 0). The result has the same block shape as the
+    input, with each tile expanded according to `bcast_type`.
     """
     tile_bcast_type = _parse_tile_bcast_type(bcast_type)
     return _eltwise_block(lambda t: d2m.tile_bcast(t.type, t, tile_bcast_type), input)
 
 
-@syntax("bcast_row")
-def bcast_row(input):
+@syntax("tile_bcast_row")
+def tile_bcast_row(input):
     """Block-level tile broadcast of the tile's 0-row."""
-    return bcast(input, d2m.TileBcastType.Row)
+    return tile_bcast(input, d2m.TileBcastType.Row)
 
 
-@syntax("bcast_col")
-def bcast_col(input):
+@syntax("tile_bcast_col")
+def tile_bcast_col(input):
     """Block-level tile broadcast of the tile's 0-column."""
-    return bcast(input, d2m.TileBcastType.Col)
+    return tile_bcast(input, d2m.TileBcastType.Col)
 
 
-@syntax("bcast_scalar")
-def bcast_scalar(input):
+@syntax("tile_bcast_scalar")
+def tile_bcast_scalar(input):
     """Block-level tile broadcast of element (0, 0)."""
-    return bcast(input, d2m.TileBcastType.Scalar)
+    return tile_bcast(input, d2m.TileBcastType.Scalar)
 
 
 @syntax("where")
@@ -762,17 +763,17 @@ class TensorBlock:
         """Same as `d2m.right_shift(self, rhs)`."""
         return right_shift(ast_self, rhs)
 
-    def bcast_row(ast_self: TensorBlock) -> TensorBlock:
-        """Same as `d2m.bcast_row(self)`."""
-        return bcast_row(ast_self)
+    def tile_bcast_row(ast_self: TensorBlock) -> TensorBlock:
+        """Same as `d2m.tile_bcast_row(self)`."""
+        return tile_bcast_row(ast_self)
 
-    def bcast_col(ast_self: TensorBlock) -> TensorBlock:
-        """Same as `d2m.bcast_col(self)`."""
-        return bcast_col(ast_self)
+    def tile_bcast_col(ast_self: TensorBlock) -> TensorBlock:
+        """Same as `d2m.tile_bcast_col(self)`."""
+        return tile_bcast_col(ast_self)
 
-    def bcast_scalar(ast_self: TensorBlock) -> TensorBlock:
-        """Same as `d2m.bcast_scalar(self)`."""
-        return bcast_scalar(ast_self)
+    def tile_bcast_scalar(ast_self: TensorBlock) -> TensorBlock:
+        """Same as `d2m.tile_bcast_scalar(self)`."""
+        return tile_bcast_scalar(ast_self)
 
     def where(ast_self: TensorBlock, true_value, false_value) -> TensorBlock:
         """Same as `d2m.where(self, true_value, false_value)` -- `self` is

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -35,6 +35,42 @@ from ._src.rewrite import (
     apply_patterns,
 )
 
+TileBcastType = d2m.TileBcastType
+
+
+def _parse_tile_bcast_type(value):
+    if isinstance(value, Attribute):
+        return value
+    if isinstance(value, d2m.TileBcastType):
+        value = int(value)
+    if isinstance(value, str):
+        key = value.lower()
+        if key in {"none", "no_bcast"}:
+            return Attribute.parse("#d2m<tile_bcast_type none>")
+        if key in {"col", "column"}:
+            return Attribute.parse("#d2m<tile_bcast_type col>")
+        if key == "row":
+            return Attribute.parse("#d2m<tile_bcast_type row>")
+        if key == "scalar":
+            return Attribute.parse("#d2m<tile_bcast_type scalar>")
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value == int(d2m.TileBcastType.None_):
+            return Attribute.parse("#d2m<tile_bcast_type none>")
+        if value == int(d2m.TileBcastType.Col):
+            return Attribute.parse("#d2m<tile_bcast_type col>")
+        if value == int(d2m.TileBcastType.Row):
+            return Attribute.parse("#d2m<tile_bcast_type row>")
+        if value == int(d2m.TileBcastType.Scalar):
+            return Attribute.parse("#d2m<tile_bcast_type scalar>")
+    raise ValueError(
+        "tile broadcast type must be one of 'row', 'col', 'scalar', 'none', "
+        f"or a d2m.TileBcastType, got {value!r}"
+    )
+
+
+def _tile_bcast_type_attr(node):
+    return _parse_tile_bcast_type(node.value)
+
 
 @syntax("remote_load")
 def remote_load(
@@ -420,6 +456,36 @@ def right_shift(lhs, rhs):
     return _eltwise_block(lambda l, r: d2m.tile_right_shift(l.type, l, r), lhs, rhs)
 
 
+@syntax("bcast", args_as_attr=[False, _tile_bcast_type_attr])
+def bcast(input, bcast_type):
+    """Block-level tile broadcast.
+
+    `bcast_type` matches the D2M tile-broadcast enum: `row` broadcasts the
+    tile's 0-row, `col` broadcasts the tile's 0-column, and `scalar`
+    broadcasts element (0, 0).
+    """
+    tile_bcast_type = _parse_tile_bcast_type(bcast_type)
+    return _eltwise_block(lambda t: d2m.tile_bcast(t.type, t, tile_bcast_type), input)
+
+
+@syntax("bcast_row")
+def bcast_row(input):
+    """Block-level tile broadcast of the tile's 0-row."""
+    return bcast(input, d2m.TileBcastType.Row)
+
+
+@syntax("bcast_col")
+def bcast_col(input):
+    """Block-level tile broadcast of the tile's 0-column."""
+    return bcast(input, d2m.TileBcastType.Col)
+
+
+@syntax("bcast_scalar")
+def bcast_scalar(input):
+    """Block-level tile broadcast of element (0, 0)."""
+    return bcast(input, d2m.TileBcastType.Scalar)
+
+
 @syntax("where")
 def where(cond, true_value, false_value):
     """Block-level elementwise select: `cond ? true_value : false_value`.
@@ -695,6 +761,18 @@ class TensorBlock:
     def right_shift(ast_self: TensorBlock, rhs: TensorBlock) -> TensorBlock:
         """Same as `d2m.right_shift(self, rhs)`."""
         return right_shift(ast_self, rhs)
+
+    def bcast_row(ast_self: TensorBlock) -> TensorBlock:
+        """Same as `d2m.bcast_row(self)`."""
+        return bcast_row(ast_self)
+
+    def bcast_col(ast_self: TensorBlock) -> TensorBlock:
+        """Same as `d2m.bcast_col(self)`."""
+        return bcast_col(ast_self)
+
+    def bcast_scalar(ast_self: TensorBlock) -> TensorBlock:
+        """Same as `d2m.bcast_scalar(self)`."""
+        return bcast_scalar(ast_self)
 
     def where(ast_self: TensorBlock, true_value, false_value) -> TensorBlock:
         """Same as `d2m.where(self, true_value, false_value)` -- `self` is


### PR DESCRIPTION
### Problem description
Need to be able to express tile_bcast in d2m-jit

### What's changed
- d2m-jit tile broadcast API: d2m.bcast(x, "row" | "col" | "scalar")
- Convenience wrappers: d2m.bcast_row(x), d2m.bcast_col(x), d2m.bcast_scalar(x)
- TensorBlock method forms: x.bcast_row(), x.bcast_col(), x.bcast_scalar()
- Broadcast type parsing for strings, aliases like "column", D2M enum values, ints, and existing MLIR attrs
- Lowering from the Python DSL to d2m.tile_bcast with the right #d2m<tile_bcast_type ...> attr
- Added e2e pytest and lit test
- Updated docs

### Checklist
- [ ] New/Existing tests provide coverage for changes
