### PR TITLE
[OpModel] Remove redundant device worker-grid validation (#7726)

### DIFF
--- a/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
+++ b/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
@@ -11,8 +11,12 @@
 
 #include "Constants.h"
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -110,6 +114,15 @@ public:
     return m_device.get();
   }
 
+  // Returns the device's compute-with-storage grid as a {y, x} shape (the
+  // worker-grid convention used by GridAttr and the output-layout builders).
+  // The value is cached when the device is opened/reset/reshaped, so callers do
+  // not re-query the device on every use. Asserts that a device is active.
+  llvm::ArrayRef<int64_t> getComputeGridShape() const {
+    assert(m_device != nullptr && "Device is not initialized.");
+    return m_computeGridShape;
+  }
+
   // Returns true if the device is initialized.
   bool isDeviceInitialized() const { return m_device != nullptr; }
 
@@ -124,8 +137,25 @@ private:
   SingletonDeviceContext(const SingletonDeviceContext &) = delete;
   SingletonDeviceContext &operator=(const SingletonDeviceContext &) = delete;
 
+  // Caches the current device's compute-with-storage grid into
+  // m_computeGridShape (as {y, x}). Must be called whenever m_device is
+  // (re)assigned.
+  void refreshComputeGridShape();
+
+  // If a system descriptor is registered, verifies that the opened device's
+  // compute-with-storage grid matches the grid the system descriptor describes
+  // (the logical worker grid, i.e. the per-dimension min across chips). A
+  // mismatch means the device was configured from a system desc that does not
+  // describe it (e.g. a differently-harvested system desc used in mock mode),
+  // which would silently produce wrong output layouts; this is fatal.
+  void validateComputeGridAgainstSystemDesc() const;
+
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> m_device;
   ttcore::SystemDescAttr m_systemDesc;
+
+  // Device compute-with-storage grid as a {y, x} shape, refreshed on every
+  // device (re)assignment. Empty when no device is active.
+  llvm::SmallVector<int64_t, 2> m_computeGridShape;
 
   // This field is technically not needed, but is there to assert that
   // `resetInstance()` is legal. If we are using an external device, we cannot

--- a/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
+++ b/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
@@ -123,6 +123,11 @@ public:
     return m_computeGridShape;
   }
 
+  // Monotonic counter bumped whenever the device's compute grid changes. Lets
+  // device-dependent caches detect staleness without this class needing to know
+  // anything about them. Safe to call with no active device (returns 0).
+  uint64_t getDeviceGeneration() const { return m_deviceGeneration; }
+
   // Returns true if the device is initialized.
   bool isDeviceInitialized() const { return m_device != nullptr; }
 
@@ -143,19 +148,23 @@ private:
   void refreshComputeGridShape();
 
   // If a system descriptor is registered, verifies that the opened device's
-  // compute-with-storage grid matches the grid the system descriptor describes
-  // (the logical worker grid, i.e. the per-dimension min across chips). A
-  // mismatch means the device was configured from a system desc that does not
-  // describe it (e.g. a differently-harvested system desc used in mock mode),
-  // which would silently produce wrong output layouts; this is fatal.
+  // compute-with-storage grid matches the system desc's chip grid (the first
+  // chip's grid; all chips on a system are assumed identical). A mismatch means
+  // the device was configured from a system desc that does not describe it
+  // (e.g. a differently-harvested system desc used in mock mode), which would
+  // silently produce wrong output layouts; this is fatal.
   void validateComputeGridAgainstSystemDesc() const;
 
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> m_device;
   ttcore::SystemDescAttr m_systemDesc;
 
   // Device compute-with-storage grid as a {y, x} shape, refreshed on every
-  // device (re)assignment. Empty when no device is active.
+  // device (re)assignment. Empty until the first device is opened; retained
+  // across close so a reset to the same grid does not bump m_deviceGeneration.
   llvm::SmallVector<int64_t, 2> m_computeGridShape;
+
+  // Bumped whenever m_computeGridShape changes; see getDeviceGeneration().
+  uint64_t m_deviceGeneration = 0;
 
   // This field is technically not needed, but is there to assert that
   // `resetInstance()` is legal. If we are using an external device, we cannot

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -45,14 +45,6 @@ bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
                                  TTNNLayoutAttr layout,
                                  ttcore::GridAttr maxGrid);
 
-//===----------------------------------------------------------------------===//
-// Device
-//===----------------------------------------------------------------------===//
-
-namespace Device {
-llvm::Expected<bool> getDeviceConstraints(ttcore::GridAttr workerGrid);
-}; // namespace Device
-
 template <typename OpTy>
 struct OpModel;
 
@@ -63,8 +55,7 @@ struct OpModel;
 template <typename OpT>
 struct UnaryEltwiseOpModel {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
@@ -75,8 +66,7 @@ struct UnaryEltwiseOpModel {
 template <typename OpT>
 struct UnaryEltwiseWithFastApproxModeOpModel {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
@@ -186,8 +176,7 @@ struct OpModel<ErfcOp> : UnaryEltwiseOpModel<ErfcOp> {};
 template <>
 struct OpModel<SigmoidOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
@@ -202,8 +191,7 @@ struct OpModel<SigmoidOp> {
 template <>
 struct OpModel<LeakyReluOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::APFloat slope,
                    TTNNLayoutAttr outputLayout);
 
@@ -220,10 +208,9 @@ struct OpModel<LeakyReluOp> {
 template <typename OpT>
 struct BinaryEltwiseOpModel {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-      TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout,
-      ttcore::DataTypeAttr opDtypeAttr = nullptr);
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -234,10 +221,9 @@ struct BinaryEltwiseOpModel {
 template <typename OpT>
 struct BinaryCompositeOpModel {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-      TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout,
-      ttcore::DataTypeAttr opDtypeAttr = nullptr);
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -323,10 +309,9 @@ struct OpModel<Atan2Op> : BinaryCompositeOpModel<Atan2Op> {};
 template <>
 struct OpModel<GeluBackwardOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-      TTNNLayoutAttr inputLayoutB, std::string approximate,
-      TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      std::string approximate, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -341,10 +326,10 @@ struct OpModel<GeluBackwardOp> {
 template <typename OpT>
 struct TernaryEltwiseOpModel {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-      TTNNLayoutAttr inputLayoutB, llvm::ArrayRef<int64_t> inputShapeC,
-      TTNNLayoutAttr inputLayoutC, TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -362,10 +347,11 @@ struct OpModel<WhereOp> : TernaryEltwiseOpModel<WhereOp> {};
 
 template <typename OpT>
 struct ReductionOpModel {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, std::optional<llvm::ArrayRef<int64_t>> dimArg,
-      bool keepDim, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout,
+                   std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+                   TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -392,8 +378,7 @@ struct OpModel<MinOp> : ReductionOpModel<MinOp> {};
 template <>
 struct OpModel<ArgMaxOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, std::optional<int32_t> dim,
                    bool keepDim, bool multicore, TTNNLayoutAttr outputLayout);
 
@@ -411,8 +396,7 @@ struct OpModel<ArgMaxOp> {
 template <>
 struct OpModel<ProdOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, std::optional<int64_t> dim,
                    bool keepDim, TTNNLayoutAttr outputLayout);
 };
@@ -424,8 +408,7 @@ struct OpModel<ProdOp> {
 template <typename OpT>
 struct NamedFullOpModel {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   mlir::tt::ttnn::ShapeAttr shape,
+  getOpConstraints(mlir::tt::ttnn::ShapeAttr shape,
                    std::optional<mlir::tt::ttcore::DataType> dtype,
                    std::optional<mlir::tt::ttnn::Layout> layout,
                    mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -443,11 +426,11 @@ struct OpModel<OnesOp> : NamedFullOpModel<OnesOp> {};
 template <typename OpT>
 struct QuantizationOpModel {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> scaleShape,
-      TTNNLayoutAttr scaleLayout, llvm::ArrayRef<int64_t> zeroPointShape,
-      TTNNLayoutAttr zeroPointLayout, std::optional<int32_t> axis,
-      std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> scaleShape, TTNNLayoutAttr scaleLayout,
+      llvm::ArrayRef<int64_t> zeroPointShape, TTNNLayoutAttr zeroPointLayout,
+      std::optional<int32_t> axis, std::optional<ttcore::DataType> outputDtype,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -467,9 +450,9 @@ struct OpModel<DequantizeOp> : QuantizationOpModel<DequantizeOp> {};
 template <>
 struct OpModel<RequantizeOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> inScaleShape,
-      TTNNLayoutAttr inScaleLayout, llvm::ArrayRef<int64_t> inZeroPointShape,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
+      llvm::ArrayRef<int64_t> inZeroPointShape,
       TTNNLayoutAttr inZeroPointLayout, llvm::ArrayRef<int64_t> outScaleShape,
       TTNNLayoutAttr outScaleLayout, llvm::ArrayRef<int64_t> outZeroPointShape,
       TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
@@ -492,8 +475,7 @@ struct OpModel<RequantizeOp> {
 template <>
 struct OpModel<SoftmaxOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const int dimArg,
                    bool numericStable, TTNNLayoutAttr outputLayout);
 
@@ -511,11 +493,10 @@ struct OpModel<SoftmaxOp> {
 template <>
 struct OpModel<ScatterOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> indexShape,
-      TTNNLayoutAttr indexLayout, llvm::ArrayRef<int64_t> sourceShape,
-      TTNNLayoutAttr sourceLayout, int32_t dim,
-      std::optional<ttcore::ReduceTypeAttr> optReduction,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
+      llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
+      int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
       TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
@@ -533,9 +514,8 @@ struct OpModel<ScatterOp> {
 template <>
 struct OpModel<ReshapeOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> outputShape,
-      TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -550,8 +530,7 @@ struct OpModel<ReshapeOp> {
 template <>
 struct OpModel<SliceStaticOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
                    llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
                    TTNNLayoutAttr outputLayout);
@@ -569,10 +548,10 @@ struct OpModel<SliceStaticOp> {
 template <>
 struct OpModel<SliceDynamicOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> beginsShape,
-      TTNNLayoutAttr beginsLayout, llvm::ArrayRef<int64_t> endsShape,
-      TTNNLayoutAttr endsLayout, std::optional<llvm::SmallVector<int64_t>> step,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
+      llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
+      std::optional<llvm::SmallVector<int64_t>> step,
       TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
@@ -590,8 +569,7 @@ struct OpModel<SliceDynamicOp> {
 template <>
 struct OpModel<BitcastConvertOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
                    TTNNLayoutAttr outputLayout);
 
@@ -608,8 +586,7 @@ struct OpModel<BitcastConvertOp> {
 template <>
 struct OpModel<TypecastOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
                    TTNNLayoutAttr outputLayout);
 
@@ -626,9 +603,8 @@ struct OpModel<TypecastOp> {
 template <>
 struct OpModel<ToLayoutOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, std::optional<ttcore::DataType> outputDtype,
-      TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -643,8 +619,7 @@ struct OpModel<ToLayoutOp> {
 template <>
 struct OpModel<ToMemoryConfigOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
@@ -659,8 +634,7 @@ struct OpModel<ToMemoryConfigOp> {
 template <>
 struct OpModel<ConcatOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   std::vector<llvm::ArrayRef<int64_t>> inputShapes,
+  getOpConstraints(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
                    std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
                    TTNNLayoutAttr outputLayout);
 
@@ -677,8 +651,7 @@ struct OpModel<ConcatOp> {
 template <>
 struct OpModel<TransposeOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
                    TTNNLayoutAttr outputLayout);
 
@@ -694,10 +667,11 @@ struct OpModel<TransposeOp> {
 
 template <>
 struct OpModel<CumSumOp> {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, const int32_t dim,
-      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, const int32_t dim,
+                   std::optional<ttcore::DataType> dtype,
+                   TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -712,8 +686,7 @@ struct OpModel<CumSumOp> {
 template <>
 struct OpModel<ConcatenateHeadsOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
@@ -727,8 +700,7 @@ struct OpModel<ConcatenateHeadsOp> {
 template <>
 struct OpModel<ScaledDotProductAttentionDecodeOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> queryShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> queryShape,
                    TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
                    TTNNLayoutAttr keyLayout, llvm::ArrayRef<int64_t> valueShape,
                    TTNNLayoutAttr valueLayout, bool isCausal,
@@ -762,12 +734,11 @@ struct OpModel<ScaledDotProductAttentionDecodeOp> {
 template <>
 struct OpModel<PagedScaledDotProductAttentionDecodeOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> queryShape,
-      TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
-      TTNNLayoutAttr keyLayout, llvm::ArrayRef<int64_t> valueShape,
-      TTNNLayoutAttr valueLayout, llvm::ArrayRef<int64_t> pageTableShape,
-      TTNNLayoutAttr pageTableLayout, bool isCausal,
-      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
       std::optional<TTNNLayoutAttr> attentionMaskLayout,
       std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
       std::optional<TTNNLayoutAttr> curPosTensorLayout,
@@ -802,9 +773,8 @@ struct OpModel<PagedScaledDotProductAttentionDecodeOp> {
 template <>
 struct OpModel<PagedFlashMultiLatentAttentionDecodeOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> queryShape,
-      TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
-      TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
       std::optional<llvm::ArrayRef<int64_t>> valueShape,
       std::optional<TTNNLayoutAttr> valueLayout, uint32_t headDimV,
       llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
@@ -838,10 +808,9 @@ struct OpModel<PagedFlashMultiLatentAttentionDecodeOp> {
 template <>
 struct OpModel<ScaledDotProductAttentionOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> queryShape,
-      TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
-      TTNNLayoutAttr keyLayout, llvm::ArrayRef<int64_t> valueShape,
-      TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
       std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
       std::optional<TTNNLayoutAttr> attentionMaskLayout,
       std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
@@ -869,12 +838,11 @@ struct OpModel<ScaledDotProductAttentionOp> {
 template <>
 struct OpModel<RotaryEmbeddingLlamaOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> cosShape,
-      TTNNLayoutAttr cosLayout, llvm::ArrayRef<int64_t> sinShape,
-      TTNNLayoutAttr sinLayout, llvm::ArrayRef<int64_t> transMatShape,
-      TTNNLayoutAttr transMatLayout, bool isDecodeMode,
-      TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+      llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+      llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
+      bool isDecodeMode, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -892,8 +860,7 @@ struct OpModel<RotaryEmbeddingLlamaOp> {
 template <>
 struct OpModel<RotaryEmbeddingOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> cosShape,
                    TTNNLayoutAttr cosLayout, llvm::ArrayRef<int64_t> sinShape,
                    TTNNLayoutAttr sinLayout, std::optional<uint32_t> tokenIndex,
@@ -913,8 +880,7 @@ struct OpModel<RotaryEmbeddingOp> {
 template <>
 struct OpModel<NLPCreateQKVHeadsDecodeOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
       std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
       std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
@@ -935,8 +901,7 @@ struct OpModel<NLPCreateQKVHeadsDecodeOp> {
 template <>
 struct OpModel<SplitQueryKeyValueAndSplitHeadsOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
                    std::optional<TTNNLayoutAttr> inputKVLayout,
@@ -958,8 +923,7 @@ struct OpModel<SplitQueryKeyValueAndSplitHeadsOp> {
 template <>
 struct OpModel<NLPConcatHeadsOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
@@ -973,8 +937,7 @@ struct OpModel<NLPConcatHeadsOp> {
 template <>
 struct OpModel<NLPConcatHeadsDecodeOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, uint32_t headDim,
                    TTNNLayoutAttr outputLayout);
 
@@ -991,8 +954,7 @@ struct OpModel<NLPConcatHeadsDecodeOp> {
 template <>
 struct OpModel<RepeatInterleaveOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const unsigned int repeats,
                    const int dim, TTNNLayoutAttr outputLayout);
 
@@ -1010,8 +972,7 @@ struct OpModel<RepeatInterleaveOp> {
 template <>
 struct OpModel<RepeatOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> repeats,
                    TTNNLayoutAttr outputLayout);
 
@@ -1027,10 +988,11 @@ struct OpModel<RepeatOp> {
 
 template <>
 struct OpModel<PadOp> {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int32_t> padding,
-      llvm::APFloat padValue, bool multicore, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, llvm::ArrayRef<int32_t> padding,
+                   llvm::APFloat padValue, bool multicore,
+                   TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1045,8 +1007,7 @@ struct OpModel<PadOp> {
 template <>
 struct OpModel<SortOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, int dim, bool descending,
                    bool stable, TTNNLayoutAttr outputLayout);
 
@@ -1064,11 +1025,10 @@ struct OpModel<SortOp> {
 template <>
 struct OpModel<TopKRouterGptOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> biasShape,
-      TTNNLayoutAttr biasLayout, uint32_t k, uint32_t numExperts,
-      TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
+      uint32_t numExperts, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1084,9 +1044,8 @@ struct OpModel<TopKRouterGptOp> {
 template <>
 struct OpModel<LinearOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-      TTNNLayoutAttr inputLayoutB,
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
       bool transposeA, bool transposeB,
@@ -1110,10 +1069,10 @@ struct OpModel<LinearOp> {
 template <>
 struct OpModel<MatmulOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-      TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout, bool transposeA,
-      bool transposeB, std::optional<llvm::StringRef> activation = std::nullopt,
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
+      std::optional<llvm::StringRef> activation = std::nullopt,
       std::optional<mlir::Attribute> programConfigAttr = std::nullopt,
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
           std::nullopt);
@@ -1142,10 +1101,9 @@ struct OpModel<DeallocateOp> {
 template <>
 struct OpModel<FillCacheOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> cacheShape,
-      TTNNLayoutAttr cacheLayout, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, uint32_t batchOffset,
-      TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      uint32_t batchOffset, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
@@ -1160,9 +1118,9 @@ struct OpModel<FillCacheOp> {
 template <>
 struct OpModel<UpdateCacheOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> cacheShape,
-      TTNNLayoutAttr cacheLayout, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> updateIndexShape,
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> updateIndexShape,
       TTNNLayoutAttr updateIndexLayout, uint32_t batchOffset,
       TTNNLayoutAttr outputLayout);
 
@@ -1181,9 +1139,9 @@ struct OpModel<UpdateCacheOp> {
 template <>
 struct OpModel<PagedUpdateCacheOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> cacheShape,
-      TTNNLayoutAttr cacheLayout, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> updateIndexShape,
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> updateIndexShape,
       TTNNLayoutAttr updateIndexLayout,
       std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
       std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
@@ -1206,10 +1164,9 @@ struct OpModel<PagedUpdateCacheOp> {
 template <>
 struct OpModel<PagedFillCacheOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> cacheShape,
-      TTNNLayoutAttr cacheLayout, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> pageTableShape,
-      TTNNLayoutAttr pageTableLayout,
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
       std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
       std::optional<TTNNLayoutAttr> batchIdxLayout,
       TTNNLayoutAttr outputLayout);
@@ -1231,9 +1188,8 @@ struct OpModel<PagedFillCacheOp> {
 template <>
 struct OpModel<Conv2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-      TTNNLayoutAttr weightLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
       uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
@@ -1267,9 +1223,8 @@ struct OpModel<Conv2dOp> {
 template <>
 struct OpModel<Conv3dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-      TTNNLayoutAttr weightLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
       uint32_t out_channels, uint32_t batch_size, uint32_t input_depth,
@@ -1305,9 +1260,8 @@ struct OpModel<Conv3dOp> {
 template <>
 struct OpModel<ConvTranspose2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-      TTNNLayoutAttr weightLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
       uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
@@ -1339,8 +1293,8 @@ struct OpModel<ConvTranspose2dOp> {
 template <>
 struct OpModel<PrepareConv2dWeightsOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, TTNNLayoutAttr weightLayout,
-      llvm::ArrayRef<int64_t> weightShape, MemoryConfigAttr inputMemConfig,
+      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+      MemoryConfigAttr inputMemConfig,
       ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
       int32_t inChannels, int32_t outChannels, int32_t batchSize,
       int32_t inputHeight, int32_t inputWidth,
@@ -1361,8 +1315,8 @@ struct OpModel<PrepareConv2dWeightsOp> {
 template <>
 struct OpModel<PrepareConv2dBiasOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, TTNNLayoutAttr biasLayout,
-      llvm::ArrayRef<int64_t> biasShape, MemoryConfigAttr inputMemConfig,
+      TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+      MemoryConfigAttr inputMemConfig,
       ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
       int32_t outChannels, int32_t batchSize, int32_t inputHeight,
       int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
@@ -1381,8 +1335,8 @@ struct OpModel<PrepareConv2dBiasOp> {
 template <>
 struct OpModel<PrepareConvTranspose2dWeightsOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, TTNNLayoutAttr weightLayout,
-      llvm::ArrayRef<int64_t> weightShape, MemoryConfigAttr inputMemConfig,
+      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+      MemoryConfigAttr inputMemConfig,
       ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
       int32_t inChannels, int32_t outChannels, int32_t batchSize,
       int32_t inputHeight, int32_t inputWidth,
@@ -1403,8 +1357,8 @@ struct OpModel<PrepareConvTranspose2dWeightsOp> {
 template <>
 struct OpModel<PrepareConvTranspose2dBiasOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, TTNNLayoutAttr biasLayout,
-      llvm::ArrayRef<int64_t> biasShape, MemoryConfigAttr inputMemConfig,
+      TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+      MemoryConfigAttr inputMemConfig,
       ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
       int32_t outChannels, int32_t batchSize, int32_t inputHeight,
       int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
@@ -1424,13 +1378,13 @@ struct OpModel<PrepareConvTranspose2dBiasOp> {
 template <>
 struct OpModel<MaxPool2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, int32_t batchSize, int32_t inputHeight,
-      int32_t inputWidth, int32_t inputChannels,
-      llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-      bool ceilMode, bool reallocateHaloOutput,
-      std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+      bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1450,14 +1404,13 @@ struct OpModel<MaxPool2dOp> {
 template <>
 struct OpModel<MaxPool2dWithIndicesOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, int32_t batchSize, int32_t inputHeight,
-      int32_t inputWidth, int32_t inputChannels,
-      llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-      bool ceilMode, bool reallocateHaloOutput, bool deallocateInput,
-      bool returnIndices, std::optional<bool> configTensorsInDram,
-      TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+      bool reallocateHaloOutput, bool deallocateInput, bool returnIndices,
+      std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1477,13 +1430,13 @@ struct OpModel<MaxPool2dWithIndicesOp> {
 template <>
 struct OpModel<AvgPool2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, int32_t batchSize, int32_t inputHeight,
-      int32_t inputWidth, int32_t inputChannels,
-      llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-      bool ceilMode, bool reallocateHaloOutput,
-      std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+      bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1503,9 +1456,8 @@ struct OpModel<AvgPool2dOp> {
 template <>
 struct OpModel<GlobalAvgPool2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, std::optional<ttcore::DataType> dtype,
-      TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1520,8 +1472,7 @@ struct OpModel<GlobalAvgPool2dOp> {
 template <>
 struct OpModel<BatchNormInferenceOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
                    std::optional<TTNNLayoutAttr> runningMeanLayout,
@@ -1553,8 +1504,7 @@ struct OpModel<BatchNormInferenceOp> {
 template <>
 struct OpModel<BatchNormTrainingOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
       std::optional<TTNNLayoutAttr> runningMeanLayout,
       std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
@@ -1585,8 +1535,7 @@ struct OpModel<BatchNormTrainingOp> {
 template <>
 struct OpModel<RMSNormOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<llvm::ArrayRef<int64_t>> weightShape,
       std::optional<TTNNLayoutAttr> weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
@@ -1613,8 +1562,7 @@ struct OpModel<RMSNormOp> {
 template <>
 struct OpModel<RMSNormPreAllGatherOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
       std::optional<TTNNLayoutAttr> residualInputLayout,
       std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
@@ -1635,8 +1583,7 @@ struct OpModel<RMSNormPreAllGatherOp> {
 template <>
 struct OpModel<LayerNormOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    std::optional<llvm::ArrayRef<int64_t>> weightShape,
                    std::optional<TTNNLayoutAttr> weightLayout,
@@ -1660,8 +1607,7 @@ struct OpModel<LayerNormOp> {
 template <>
 struct OpModel<LayerNormPreAllGatherOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
       std::optional<TTNNLayoutAttr> residualInputLayout,
       std::optional<llvm::ArrayRef<int64_t>> recipShape,
@@ -1685,9 +1631,8 @@ struct OpModel<LayerNormPreAllGatherOp> {
 template <>
 struct OpModel<LayerNormPostAllGatherOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> statsShape,
-      TTNNLayoutAttr statsLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
       std::optional<llvm::ArrayRef<int64_t>> weightShape,
       std::optional<TTNNLayoutAttr> weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
@@ -1711,8 +1656,7 @@ struct OpModel<LayerNormPostAllGatherOp> {
 template <>
 struct OpModel<GroupNormOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
                    std::optional<TTNNLayoutAttr> inputMaskLayout,
@@ -1740,8 +1684,7 @@ struct OpModel<GroupNormOp> {
 template <>
 struct OpModel<ClampScalarOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, mlir::Attribute min,
                    mlir::Attribute max, TTNNLayoutAttr outputLayout);
 
@@ -1759,8 +1702,7 @@ struct OpModel<ClampScalarOp> {
 template <>
 struct OpModel<ClampTensorOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> minShape,
                    TTNNLayoutAttr minLayout, llvm::ArrayRef<int64_t> maxShape,
                    TTNNLayoutAttr maxLayout, TTNNLayoutAttr outputLayout);
@@ -1778,10 +1720,11 @@ struct OpModel<ClampTensorOp> {
 
 template <>
 struct OpModel<PermuteOp> {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> permutation,
-      llvm::APFloat padValue, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout,
+                   llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
+                   TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1796,8 +1739,7 @@ struct OpModel<PermuteOp> {
 template <>
 struct OpModel<PowScalarOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, mlir::Attribute exponent,
                    TTNNLayoutAttr outputLayout);
 
@@ -1814,8 +1756,7 @@ struct OpModel<PowScalarOp> {
 template <>
 struct OpModel<UpsampleOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
                    llvm::StringRef mode, TTNNLayoutAttr outputLayout);
 
@@ -1832,10 +1773,11 @@ struct OpModel<UpsampleOp> {
 
 template <>
 struct OpModel<EmbeddingOp> {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-      TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout,
+                   llvm::ArrayRef<int64_t> weightShape,
+                   TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1850,10 +1792,10 @@ struct OpModel<EmbeddingOp> {
 template <>
 struct OpModel<EmbeddingBackwardOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> inGradientShape,
-      TTNNLayoutAttr inGradientLayout, TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1869,9 +1811,9 @@ struct OpModel<EmbeddingBackwardOp> {
 template <>
 struct OpModel<GatherOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> indexShape,
-      TTNNLayoutAttr indexLayout, int32_t dim, TTNNLayoutAttr outputLayout);
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
+      int32_t dim, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1884,10 +1826,11 @@ struct OpModel<GatherOp> {
 //===----------------------------------------------------------------------===//
 template <>
 struct OpModel<mlir::tt::ttnn::EmptyOp> {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      mlir::tt::ttcore::DataTypeAttr dtype, mlir::tt::ttnn::Layout inputLayout,
-      mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   mlir::tt::ttcore::DataTypeAttr dtype,
+                   mlir::tt::ttnn::Layout inputLayout,
+                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1896,8 +1839,7 @@ struct OpModel<mlir::tt::ttnn::EmptyOp> {
 template <>
 struct OpModel<mlir::tt::ttnn::ArangeOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   ::mlir::IntegerAttr start, ::mlir::IntegerAttr end,
+  getOpConstraints(::mlir::IntegerAttr start, ::mlir::IntegerAttr end,
                    ::mlir::IntegerAttr step,
                    std::optional<mlir::tt::ttcore::DataType> dtype,
                    mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -1910,8 +1852,7 @@ struct OpModel<mlir::tt::ttnn::ArangeOp> {
 template <>
 struct OpModel<mlir::tt::ttnn::FullOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   mlir::tt::ttnn::ShapeAttr shape, mlir::Attribute fillValue,
+  getOpConstraints(mlir::tt::ttnn::ShapeAttr shape, mlir::Attribute fillValue,
                    std::optional<mlir::tt::ttcore::DataType> dtype,
                    std::optional<mlir::tt::ttnn::Layout> layout,
                    mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -1924,8 +1865,7 @@ struct OpModel<mlir::tt::ttnn::FullOp> {
 template <>
 struct OpModel<ConstantOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid, mlir::ElementsAttr value,
-                   TTNNLayoutAttr outputLayout);
+  getOpConstraints(mlir::ElementsAttr value, TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1935,10 +1875,9 @@ struct OpModel<ConstantOp> {
 template <>
 struct OpModel<mlir::tt::ttnn::RandOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      mlir::tt::ttcore::GridAttr deviceGrid, mlir::tt::ttnn::ShapeAttr size,
-      mlir::tt::ttcore::DataType dtype, mlir::tt::ttnn::Layout layout,
-      llvm::APFloat low, llvm::APFloat high, uint32_t seed,
-      mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+      mlir::tt::ttnn::ShapeAttr size, mlir::tt::ttcore::DataType dtype,
+      mlir::tt::ttnn::Layout layout, llvm::APFloat low, llvm::APFloat high,
+      uint32_t seed, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1947,10 +1886,11 @@ struct OpModel<mlir::tt::ttnn::RandOp> {
 
 template <>
 struct OpModel<mlir::tt::ttnn::DropoutOp> {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, llvm::APFloat prob, llvm::APFloat scale,
-      uint32_t seed, bool usePerDeviceSeed, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, llvm::APFloat prob,
+                   llvm::APFloat scale, uint32_t seed, bool usePerDeviceSeed,
+                   TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1965,8 +1905,7 @@ struct OpModel<mlir::tt::ttnn::DropoutOp> {
 template <>
 struct OpModel<mlir::tt::ttnn::AssignOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    std::optional<mlir::tt::ttcore::DataType> outputDtype);
 
@@ -1982,8 +1921,7 @@ struct OpModel<mlir::tt::ttnn::AssignOp> {
 template <>
 struct OpModel<TopKOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, int k, int dim, bool largest,
                    bool sorted, TTNNLayoutAttr outputLayout);
 
@@ -2000,8 +1938,7 @@ struct OpModel<TopKOp> {
 template <>
 struct OpModel<SamplingOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputValuesShape,
+  getOpConstraints(llvm::ArrayRef<int64_t> inputValuesShape,
                    TTNNLayoutAttr inputValuesLayout,
                    llvm::ArrayRef<int64_t> inputIndicesShape,
                    TTNNLayoutAttr inputIndicesLayout,
@@ -2027,10 +1964,11 @@ struct OpModel<SamplingOp> {
 
 template <>
 struct OpModel<MeshPartitionOp> {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      TTNNLayoutAttr inputLayout, int32_t dim,
-      std::optional<uint32_t> clusterAxis, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, int32_t dim,
+                   std::optional<uint32_t> clusterAxis,
+                   TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,

--- a/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
@@ -6,6 +6,9 @@
 #define TTMLIR_OPMODEL_TTNN_TTNNOPSMODELCACHE_H
 
 #include "ttmlir/OpModel/TTNN/TTNNOpConstraints.h"
+// Self-guards on TTMLIR_ENABLE_OPMODEL (expands to nothing when OpModel is
+// disabled); the device-generation lookup below is guarded separately.
+#include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
 
 #include "mlir/IR/Operation.h"
 #include "llvm/ADT/DenseMap.h"
@@ -91,6 +94,18 @@ public:
   llvm::Expected<ValueT> getOrCompute(Callable &&computeFunc, Operation *op,
                                       Args &&...args) {
     assert(op != nullptr);
+#ifdef TTMLIR_ENABLE_OPMODEL
+    // Cached entries are computed against the active device's grid. If the
+    // device session's grid changed, drop the now-stale entries. The device
+    // context owns the change signal (a generation counter) and knows nothing
+    // about this cache.
+    const uint64_t deviceGen =
+        op_model::SingletonDeviceContext::getInstance().getDeviceGeneration();
+    if (deviceGen != generation) {
+      clear();
+      generation = deviceGen;
+    }
+#endif
     // The following line attempts to combine the arguments into a single
     // hash_code. For user-defined types it attempts to call a hash_value
     // overload (via ADL) for the type (provided at the end of this file).
@@ -154,6 +169,8 @@ private:
 
   Cache cache;
   CacheStats stats;
+  // Device generation this cache was last filled under; see getOrCompute.
+  uint64_t generation = 0;
 };
 
 // Singleton accessor implementations

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -648,8 +648,8 @@ bool MemoryLayoutPropagation::validateReshard(
   }
 
   auto result = op_constraint_validation::validateOperation<ToMemoryConfigOp>(
-      consumerOp, /*additionalL1Usage=*/0, deviceAttr.getWorkerGrid(),
-      inputShape, producerOutputLayout, reshardLayout);
+      consumerOp, /*additionalL1Usage=*/0, inputShape, producerOutputLayout,
+      reshardLayout);
 
   bool valid = result.isSuccess();
 

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -79,20 +79,6 @@ issueErrorForGetOpConstraints(mlir::Operation *op,
 }
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-llvm::Expected<bool> checkDeviceWorkerGrid(mlir::Operation *op) {
-  auto deviceAttr = ttcore::lookupDevice(op);
-  assert(deviceAttr);
-  return op_model::Device::getDeviceConstraints(deviceAttr.getWorkerGrid());
-}
-
-llvm::Expected<ttcore::GridAttr> getValidatedDeviceGrid(mlir::Operation *op) {
-  auto check = checkDeviceWorkerGrid(op);
-  if (!check) {
-    return check.takeError();
-  }
-  return ttcore::lookupDevice(op).getWorkerGrid();
-}
-
 // Resolves the output dtype to pass to the op-model query.
 //
 // Preference order:
@@ -145,11 +131,9 @@ getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
-      inputs[0], opConfig.outputLayout);
+      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
+      opConfig.outputLayout);
 }
 
 template <typename OpT>
@@ -174,17 +158,14 @@ getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = op.getLhs().getType().getShape();
   const auto inputShapeB = op.getRhs().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
-
   ttcore::DataTypeAttr opDtypeAttr = nullptr;
   if (auto dtypeOp = mlir::dyn_cast<TTNNDtypeOpInterface>(op.getOperation())) {
     opDtypeAttr = dtypeOp.getDtypeAttr();
   }
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShapeA,
-      inputs[0], inputShapeB, inputs[1], opConfig.outputLayout, opDtypeAttr);
+      op_model::OpModel<OpT>::getOpConstraints, op, inputShapeA, inputs[0],
+      inputShapeB, inputs[1], opConfig.outputLayout, opDtypeAttr);
 }
 
 template <typename OpT>
@@ -211,13 +192,9 @@ getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeB = op.getSecond().getType().getShape();
   const auto inputShapeC = op.getThird().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShapeA,
-      inputs[0], inputShapeB, inputs[1], inputShapeC, inputs[2],
-      opConfig.outputLayout);
+      op_model::OpModel<OpT>::getOpConstraints, op, inputShapeA, inputs[0],
+      inputShapeB, inputs[1], inputShapeC, inputs[2], opConfig.outputLayout);
 }
 
 template <typename OpT>
@@ -241,11 +218,9 @@ getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   assert(inputs.size() == 1);
   const auto inputShape = op.getInput().getType().getShape();
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
-      inputs[0], detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
+      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
+      detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
       op.getKeepDim(), opConfig.outputLayout);
 }
 
@@ -269,12 +244,9 @@ getPoolingOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
-      inputs[0], op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
+      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
+      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
       op.getChannels(), op.getKernelSize(), op.getStride(), op.getPadding(),
       op.getDilation(), op.getCeilMode(), op.getReallocateHaloOutput(),
       op.getConfigTensorsInDram(), opConfig.outputLayout);
@@ -305,12 +277,9 @@ getMaxPool2dWithIndicesOpConstraints(OpT op,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
-      inputs[0], op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
+      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
+      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
       op.getChannels(), op.getKernelSize(), op.getStride(), op.getPadding(),
       op.getDilation(), op.getCeilMode(), op.getReallocateHaloOutput(),
       /*deallocate_input*/ false, /*return_indices*/ true,
@@ -341,17 +310,14 @@ getNamedFullOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   assert(inputs.size() == 0);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
-
   const mlir::tt::ttnn::ShapeAttr shape = op.getShape();
   const std::optional<mlir::tt::ttcore::DataType> dtype =
       dataTypeAttrToOptional(op.getDtypeAttr());
   const std::optional<mlir::tt::ttnn::Layout> layout = op.getLayout();
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, shape, dtype,
-      layout, opConfig.outputLayout);
+      op_model::OpModel<OpT>::getOpConstraints, op, shape, dtype, layout,
+      opConfig.outputLayout);
 }
 
 template <typename OpT>
@@ -363,12 +329,9 @@ getQuantizationOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto scaleShape = op.getScale().getType().getShape();
   const auto zeroPointShape = op.getZeroPoint().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
-      inputs[0], scaleShape, inputs[1], zeroPointShape, inputs[2], op.getAxis(),
+      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
+      scaleShape, inputs[1], zeroPointShape, inputs[2], op.getAxis(),
       op.getOutputDtype(), opConfig.outputLayout);
 }
 
@@ -927,12 +890,9 @@ LeakyReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LeakyReluOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getParameter(), opConfig.outputLayout);
+      op_model::OpModel<LeakyReluOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getParameter(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1120,9 +1080,6 @@ ScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto indexShape = getIndex().getType().getShape();
   const auto sourceShape = getSource().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   std::optional<ttcore::ReduceTypeAttr> reduceType =
       ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
   if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
@@ -1131,9 +1088,9 @@ ScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ScatterOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], indexShape, inputs[1], sourceShape, inputs[2],
-      getDim(), reduceType, opConfig.outputLayout);
+      op_model::OpModel<ScatterOp>::getOpConstraints, *this, inputShape,
+      inputs[0], indexShape, inputs[1], sourceShape, inputs[2], getDim(),
+      reduceType, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1167,16 +1124,13 @@ GatherOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == 2);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   const auto inputShape = getInput().getType().getShape();
   const auto indexShape = getIndex().getType().getShape();
   int32_t dim = getDim();
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GatherOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], indexShape, inputs[1], dim, opConfig.outputLayout);
+      op_model::OpModel<GatherOp>::getOpConstraints, *this, inputShape,
+      inputs[0], indexShape, inputs[1], dim, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1221,13 +1175,10 @@ GeluBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = getLhs().getType().getShape();
   const auto inputShapeB = getRhs().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<GeluBackwardOp>::getOpConstraints, getOperation(),
-      deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1],
-      getApproximate().str(), opConfig.outputLayout);
+      inputShapeA, inputs[0], inputShapeB, inputs[1], getApproximate().str(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1290,12 +1241,9 @@ PowScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getLhs().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PowScalarOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getRhs(), opConfig.outputLayout);
+      op_model::OpModel<PowScalarOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getRhs(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1561,12 +1509,9 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SoftmaxOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getDimension(), getNumericStable(),
-      opConfig.outputLayout);
+      op_model::OpModel<SoftmaxOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getDimension(), getNumericStable(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1594,12 +1539,9 @@ ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto outputShape = getResult().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ReshapeOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], outputShape, opConfig.outputLayout);
+      op_model::OpModel<ReshapeOp>::getOpConstraints, *this, inputShape,
+      inputs[0], outputShape, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1626,12 +1568,9 @@ SliceStaticOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SliceStaticOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
+      op_model::OpModel<SliceStaticOp>::getOpConstraints, *this, inputShape,
+      inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
       detail::convertArrayAttrToSmallVec(getEnds()),
       detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout);
 }
@@ -1663,12 +1602,9 @@ SliceDynamicOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto beginsShape = getBegins().getType().getShape();
   const auto endsShape = getEnds().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SliceDynamicOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], beginsShape, inputs[1], endsShape, inputs[2],
+      op_model::OpModel<SliceDynamicOp>::getOpConstraints, *this, inputShape,
+      inputs[0], beginsShape, inputs[1], endsShape, inputs[2],
       detail::convertOptionalArrayAttrToSmallVec(getStep()),
       opConfig.outputLayout);
 }
@@ -1699,16 +1635,13 @@ BitcastConvertOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   ttcore::DataTypeAttr dtype =
       detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
   assert(dtype && "BitcastConvertOp requires output dtype");
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<BitcastConvertOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], dtype, opConfig.outputLayout);
+      op_model::OpModel<BitcastConvertOp>::getOpConstraints, *this, inputShape,
+      inputs[0], dtype, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1743,16 +1676,13 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   ttcore::DataTypeAttr dtype =
       detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
   assert(dtype && "TypecastOp requires output dtype");
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<TypecastOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], dtype, opConfig.outputLayout);
+      op_model::OpModel<TypecastOp>::getOpConstraints, *this, inputShape,
+      inputs[0], dtype, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1789,9 +1719,6 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   // Only signal a dtype conversion to the op model when this to_layout is
   // genuinely changing dtype. Use the resolved (candidate or intrinsic)
   // output dtype, and compare it against the input dtype.
@@ -1804,8 +1731,8 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ToLayoutOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], outputDtype, opConfig.outputLayout);
+      op_model::OpModel<ToLayoutOp>::getOpConstraints, *this, inputShape,
+      inputs[0], outputDtype, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1841,17 +1768,14 @@ ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   TTNNLayoutAttr outputLayout =
       opConfig.outputLayout
           ? opConfig.outputLayout
           : mlir::cast<TTNNLayoutAttr>(getResult().getType().getEncoding());
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ToMemoryConfigOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], outputLayout);
+      op_model::OpModel<ToMemoryConfigOp>::getOpConstraints, *this, inputShape,
+      inputs[0], outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1887,12 +1811,9 @@ ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     inputShapes.push_back(inputType.getShape());
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConcatOp>::getOpConstraints, *this, deviceGrid,
-      inputShapes, inputs, getDim(), opConfig.outputLayout);
+      op_model::OpModel<ConcatOp>::getOpConstraints, *this, inputShapes, inputs,
+      getDim(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1923,12 +1844,9 @@ TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<TransposeOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
+      op_model::OpModel<TransposeOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1954,12 +1872,9 @@ CumSumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<CumSumOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
+      op_model::OpModel<CumSumOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
       opConfig.outputLayout);
 }
 
@@ -1984,14 +1899,11 @@ ConcatenateHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   const auto inputShape = getInput().getType().getShape();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ConcatenateHeadsOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], opConfig.outputLayout);
+      inputShape, inputs[0], opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2096,18 +2008,15 @@ ScaledDotProductAttentionDecodeOp::getOpConstraints(
          "ttnn::transformer::scaled_dot_product_attention_decode can have 3, "
          "4, 5, or 6 input tensors");
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   ScaledDotProductAttentionDecodeArgs sdpaArgs =
       unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
 
   auto scale = getScale();
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints,
-      *this, deviceGrid, sdpaArgs.queryShape, sdpaArgs.queryLayout,
-      sdpaArgs.keyShape, sdpaArgs.keyLayout, sdpaArgs.valueShape,
-      sdpaArgs.valueLayout, sdpaArgs.isCausal, sdpaArgs.attentionMaskShape,
+      *this, sdpaArgs.queryShape, sdpaArgs.queryLayout, sdpaArgs.keyShape,
+      sdpaArgs.keyLayout, sdpaArgs.valueShape, sdpaArgs.valueLayout,
+      sdpaArgs.isCausal, sdpaArgs.attentionMaskShape,
       sdpaArgs.attentionMaskLayout, sdpaArgs.curPosTensorShape,
       sdpaArgs.curPosTensorLayout, sdpaArgs.attentionSinkShape,
       sdpaArgs.attentionSinkLayout, sdpaArgs.scale, sdpaArgs.programConfig,
@@ -2228,16 +2137,13 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
          "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
          "7 input tensors");
 
-  ttcore::GridAttr deviceGrid;
-  ASSIGN_OR_RETURN(deviceGrid, detail::getValidatedDeviceGrid(getOperation()));
-
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<
           PagedScaledDotProductAttentionDecodeOp>::getOpConstraints,
-      *this, deviceGrid, pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
+      *this, pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
       pagedSdpaArgs.keyShape, pagedSdpaArgs.keyLayout, pagedSdpaArgs.valueShape,
       pagedSdpaArgs.valueLayout, pagedSdpaArgs.pageTableShape,
       pagedSdpaArgs.pageTableLayout, pagedSdpaArgs.isCausal,
@@ -2357,8 +2263,6 @@ llvm::Expected<op_model::OpConstraints>
 PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   PagedFlashMultiLatentAttentionDecodeArgs args =
       unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
@@ -2366,12 +2270,12 @@ PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<
           PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints,
-      *this, deviceGrid, args.queryShape, args.queryLayout, args.keyShape,
-      args.keyLayout, args.valueShape, args.valueLayout, args.headDimV,
-      args.pageTableShape, args.pageTableLayout, args.isCausal,
-      args.attentionMaskShape, args.attentionMaskLayout, args.curPosTensorShape,
-      args.curPosTensorLayout, args.attentionSinkShape,
-      args.attentionSinkLayout, args.scale, opConfig.outputLayout);
+      *this, args.queryShape, args.queryLayout, args.keyShape, args.keyLayout,
+      args.valueShape, args.valueLayout, args.headDimV, args.pageTableShape,
+      args.pageTableLayout, args.isCausal, args.attentionMaskShape,
+      args.attentionMaskLayout, args.curPosTensorShape, args.curPosTensorLayout,
+      args.attentionSinkShape, args.attentionSinkLayout, args.scale,
+      opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
@@ -2403,9 +2307,6 @@ ScaledDotProductAttentionOp::getOpConstraints(
          "ttnn::scaled_dot_product_attention can have 3 to 5 operands input "
          "tensors (q, k, v, optional mask, optional attention_sink)");
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   const auto queryShape = getQuery().getType().getShape();
   const auto keyShape = getKey().getType().getShape();
   const auto valueShape = getValue().getType().getShape();
@@ -2428,8 +2329,8 @@ ScaledDotProductAttentionOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ScaledDotProductAttentionOp>::getOpConstraints, *this,
-      deviceGrid, queryShape, inputs[0], keyShape, inputs[1], valueShape,
-      inputs[2], attentionMaskShape, attentionMaskLayout, attentionSinkShape,
+      queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
+      attentionMaskShape, attentionMaskLayout, attentionSinkShape,
       attentionSinkLayout, isCausal, getScale(), getSlidingWindowSize(),
       opConfig.outputLayout);
 }
@@ -2476,8 +2377,6 @@ RotaryEmbeddingLlamaOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 4);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
   auto inputShape = getInput().getType().getShape();
   auto cosShape = getCosCache().getType().getShape();
   auto sinShape = getSinCache().getType().getShape();
@@ -2486,8 +2385,8 @@ RotaryEmbeddingLlamaOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], cosShape, inputs[1], sinShape,
-      inputs[2], transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
+      inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
+      transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2516,18 +2415,15 @@ RotaryEmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                     const OpConfig &opConfig) {
   assert(inputs.size() == 3);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   auto inputShape = getInput().getType().getShape();
   auto cosShape = getCosCache().getType().getShape();
   auto sinShape = getSinCache().getType().getShape();
   auto tokenIndex = getTokenIndex();
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RotaryEmbeddingOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
-      tokenIndex, opConfig.outputLayout);
+      op_model::OpModel<RotaryEmbeddingOp>::getOpConstraints, *this, inputShape,
+      inputs[0], cosShape, inputs[1], sinShape, inputs[2], tokenIndex,
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2555,9 +2451,6 @@ NLPCreateQKVHeadsDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == (1 + (getBatchOffset() == nullptr ? 0 : 1)));
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   auto inputShape = getInput().getType().getShape();
 
   std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape;
@@ -2569,7 +2462,7 @@ NLPCreateQKVHeadsDecodeOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], batchOffsetShape, batchOffsetEncoding,
+      inputShape, inputs[0], batchOffsetShape, batchOffsetEncoding,
       getNumHeads(), getNumKvHeads(), getOverlapQkCoregrid(), getSliceSize(),
       opConfig.outputLayout);
 }
@@ -2603,13 +2496,11 @@ NLPConcatHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
   auto inputShape = getInput().getType().getShape();
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<NLPConcatHeadsOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], opConfig.outputLayout);
+      op_model::OpModel<NLPConcatHeadsOp>::getOpConstraints, *this, inputShape,
+      inputs[0], opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2632,15 +2523,12 @@ NLPConcatHeadsDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   const auto inputShape = getInput().getType().getShape();
   uint32_t numHeads = getNumHeads();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], numHeads, opConfig.outputLayout);
+      inputShape, inputs[0], numHeads, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2662,8 +2550,6 @@ llvm::Expected<op_model::OpConstraints>
 SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == (1 + (getKvInputTensor() ? 1 : 0)));
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto inputShape = getInputTensor().getType().getShape();
 
@@ -2678,8 +2564,8 @@ SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], kvInputShape, kvInputLayout,
-      getNumHeads(), getNumKvHeads(), getTransposeKey(), opConfig.outputLayout);
+      *this, inputShape, inputs[0], kvInputShape, kvInputLayout, getNumHeads(),
+      getNumKvHeads(), getTransposeKey(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> SplitQueryKeyValueAndSplitHeadsOp::getOpRuntime(
@@ -2710,13 +2596,9 @@ RepeatInterleaveOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RepeatInterleaveOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], getRepeats(), getDim(),
-      opConfig.outputLayout);
+      inputShape, inputs[0], getRepeats(), getDim(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2742,12 +2624,9 @@ RepeatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RepeatOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getRepeatDims().getShape(), opConfig.outputLayout);
+      op_model::OpModel<RepeatOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getRepeatDims().getShape(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2773,13 +2652,9 @@ PadOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PadOp>::getOpConstraints, *this, deviceGrid, inputShape,
-      inputs[0], getPadding(), getValue(), getUseMulticore(),
-      opConfig.outputLayout);
+      op_model::OpModel<PadOp>::getOpConstraints, *this, inputShape, inputs[0],
+      getPadding(), getValue(), getUseMulticore(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2805,13 +2680,9 @@ SortOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SortOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getDim(), getDescending(), getStable(),
-      opConfig.outputLayout);
+      op_model::OpModel<SortOp>::getOpConstraints, *this, inputShape, inputs[0],
+      getDim(), getDescending(), getStable(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2837,12 +2708,9 @@ ArgMaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ArgMaxOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getDim(), getKeepDim(), getUseMulticore(),
+      op_model::OpModel<ArgMaxOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getDim(), getKeepDim(), getUseMulticore(),
       opConfig.outputLayout);
 }
 
@@ -2869,12 +2737,9 @@ ProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ProdOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getDimArg(), getKeepDim(), opConfig.outputLayout);
+      op_model::OpModel<ProdOp>::getOpConstraints, *this, inputShape, inputs[0],
+      getDimArg(), getKeepDim(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2930,14 +2795,11 @@ RequantizeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outScaleShape = getOutScale().getType().getShape();
   const auto outZeroPointShape = getOutZeroPoint().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RequantizeOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], inScaleShape, inputs[1], inZeroPointShape,
-      inputs[2], outScaleShape, inputs[3], outZeroPointShape, inputs[4],
-      getAxis(), getOutputDtype(), opConfig.outputLayout);
+      op_model::OpModel<RequantizeOp>::getOpConstraints, *this, inputShape,
+      inputs[0], inScaleShape, inputs[1], inZeroPointShape, inputs[2],
+      outScaleShape, inputs[3], outZeroPointShape, inputs[4], getAxis(),
+      getOutputDtype(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3004,9 +2866,6 @@ LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
       getActivation() ? std::make_optional(getActivation().value())
@@ -3016,8 +2875,8 @@ LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LinearOp>::getOpConstraints, *this, deviceGrid,
-      inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
+      op_model::OpModel<LinearOp>::getOpConstraints, *this, inputShapeA,
+      inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
       opConfig.outputLayout, getTransposeA(), getTransposeB(), activation,
       attr.matmulProgramConfig, attr.computeKernelConfig);
 }
@@ -3056,9 +2915,6 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = getA().getType().getShape();
   const auto inputShapeB = getB().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
       getActivation() ? std::make_optional(getActivation().value())
@@ -3068,9 +2924,9 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<MatmulOp>::getOpConstraints, *this, deviceGrid,
-      inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout,
-      getTransposeA(), getTransposeB(), activation, attr.matmulProgramConfig,
+      op_model::OpModel<MatmulOp>::getOpConstraints, *this, inputShapeA,
+      inputs[0], inputShapeB, inputs[1], opConfig.outputLayout, getTransposeA(),
+      getTransposeB(), activation, attr.matmulProgramConfig,
       attr.computeKernelConfig);
 }
 
@@ -3097,16 +2953,13 @@ TopKRouterGptOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                   const OpConfig &opConfig) {
   assert(inputs.size() == 3);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
   const auto biasShape = getBias().getType().getShape();
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<TopKRouterGptOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], weightShape, inputs[1], biasShape, inputs[2],
+      op_model::OpModel<TopKRouterGptOp>::getOpConstraints, *this, inputShape,
+      inputs[0], weightShape, inputs[1], biasShape, inputs[2],
       static_cast<uint32_t>(getK()), static_cast<uint32_t>(getNumExperts()),
       opConfig.outputLayout);
 }
@@ -3156,15 +3009,13 @@ llvm::Expected<op_model::OpConstraints>
 FillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(inputs.size() == 2);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<FillCacheOp>::getOpConstraints, *this, deviceGrid,
-      cacheShape, inputs[0], inputShape, inputs[1], getBatchOffset(),
+      op_model::OpModel<FillCacheOp>::getOpConstraints, *this, cacheShape,
+      inputs[0], inputShape, inputs[1], getBatchOffset(),
       opConfig.outputLayout);
 }
 
@@ -3189,16 +3040,14 @@ llvm::Expected<op_model::OpConstraints>
 UpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
   assert(inputs.size() == 3);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
   auto updateIndexShape = getUpdateIndex().getType().getShape();
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<UpdateCacheOp>::getOpConstraints, *this, deviceGrid,
-      cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
+      op_model::OpModel<UpdateCacheOp>::getOpConstraints, *this, cacheShape,
+      inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
       getBatchOffset(), opConfig.outputLayout);
 }
 
@@ -3221,8 +3070,6 @@ PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedUpdateCacheOp must have 3 or 4 inputs");
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3236,9 +3083,8 @@ PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PagedUpdateCacheOp>::getOpConstraints, *this,
-      deviceGrid, cacheShape, inputs[0], inputShape, inputs[1],
-      updateIndexShape, inputs[2], pageTableShape, pageTableLayout,
-      getShareCache(), opConfig.outputLayout);
+      cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
+      pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3267,8 +3113,6 @@ PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedFillCacheOp must have 3 or 4 inputs");
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3281,8 +3125,8 @@ PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PagedFillCacheOp>::getOpConstraints, *this, deviceGrid,
-      cacheShape, inputs[0], inputShape, inputs[1], pageTableShape, inputs[2],
+      op_model::OpModel<PagedFillCacheOp>::getOpConstraints, *this, cacheShape,
+      inputs[0], inputShape, inputs[1], pageTableShape, inputs[2],
       batchIdxShape, batchIdxLayout, opConfig.outputLayout);
 }
 
@@ -3315,11 +3159,9 @@ llvm::Expected<op_model::OpConstraints>
 SamplingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 5);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::SamplingOp>::getOpConstraints, *this,
-      deviceGrid, getInputValues().getType().getShape(), inputs[0],
+      getInputValues().getType().getShape(), inputs[0],
       getInputIndices().getType().getShape(), inputs[1],
       getK().getType().getShape(), inputs[2], getP().getType().getShape(),
       inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
@@ -3378,18 +3220,15 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
   Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<Conv2dOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), attr.conv2dConfig,
-      attr.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
-      opConfig.outputLayout);
+      op_model::OpModel<Conv2dOp>::getOpConstraints, *this, inputShape,
+      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
+      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
+      getKernelSize(), getStride(), getPadding(), getDilation(), getGroups(),
+      attr.conv2dConfig, attr.deviceComputeKernelConfig,
+      getConv2dSliceConfigAttr(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3436,16 +3275,13 @@ Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<Conv3dOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputDepth(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getGroups(), getPaddingMode(), getDtypeAttr(),
-      getConv3dConfig(), getComputeConfig(), opConfig.outputLayout);
+      op_model::OpModel<Conv3dOp>::getOpConstraints, *this, inputShape,
+      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
+      getOutChannels(), getBatchSize(), getInputDepth(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(), getGroups(),
+      getPaddingMode(), getDtypeAttr(), getConv3dConfig(), getComputeConfig(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3512,18 +3348,15 @@ ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   // If a conv config has been specified, use that. If not, read the op property
   Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConvTranspose2dOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getOutputPadding(), getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
+      op_model::OpModel<ConvTranspose2dOp>::getOpConstraints, *this, inputShape,
+      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
+      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
+      getKernelSize(), getStride(), getPadding(), getOutputPadding(),
+      getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
       getConv2dSliceConfig(), opConfig.outputLayout);
 }
 
@@ -3562,8 +3395,6 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConv2dWeightsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const ::llvm::ArrayRef<int64_t> weightShape =
       getWeightTensor().getType().getShape();
@@ -3571,11 +3402,11 @@ PrepareConv2dWeightsOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PrepareConv2dWeightsOp>::getOpConstraints, *this,
-      deviceGrid, inputs[0], weightShape, getInputMemoryConfig(),
-      getInputTensorLayout(), getWeightsFormat(), getInChannels(),
-      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
-      getKernelSize(), getStride(), getPadding(), getDilation(), getHasBias(),
-      getGroups(), getInputDtype(), getOutputDtype(), conv2dAttrs.conv2dConfig,
+      inputs[0], weightShape, getInputMemoryConfig(), getInputTensorLayout(),
+      getWeightsFormat(), getInChannels(), getOutChannels(), getBatchSize(),
+      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
+      getPadding(), getDilation(), getHasBias(), getGroups(), getInputDtype(),
+      getOutputDtype(), conv2dAttrs.conv2dConfig,
       conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
       opConfig.outputLayout);
 }
@@ -3595,8 +3426,6 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                       const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const ::llvm::ArrayRef<int64_t> biasShape =
       getBiasTensor().getType().getShape();
@@ -3604,12 +3433,12 @@ PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PrepareConv2dBiasOp>::getOpConstraints, *this,
-      deviceGrid, inputs[0], biasShape, getInputMemoryConfig(),
-      getInputTensorLayout(), getInChannels(), getOutChannels(), getBatchSize(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getDilation(), getGroups(), getInputDtype(),
-      getOutputDtype(), conv2dAttrs.conv2dConfig,
-      conv2dAttrs.deviceComputeKernelConfig, opConfig.outputLayout);
+      inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
+      conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3646,8 +3475,6 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConvTranspose2dWeightsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const ::llvm::ArrayRef<int64_t> weightShape =
       getWeightTensor().getType().getShape();
@@ -3655,7 +3482,7 @@ PrepareConvTranspose2dWeightsOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints,
-      *this, deviceGrid, inputs[0], weightShape, getInputMemoryConfig(),
+      *this, inputs[0], weightShape, getInputMemoryConfig(),
       getInputTensorLayout(), getWeightsFormat(), getInChannels(),
       getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
       getKernelSize(), getStride(), getPadding(), getDilation(), getHasBias(),
@@ -3678,8 +3505,6 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConvTranspose2dBiasOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const ::llvm::ArrayRef<int64_t> biasShape =
       getBiasTensor().getType().getShape();
@@ -3687,13 +3512,12 @@ PrepareConvTranspose2dBiasOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints, *this,
-      deviceGrid, inputs[0], biasShape, getInputMemoryConfig(),
-      getInputTensorLayout(), getInChannels(), getOutChannels(), getBatchSize(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getDilation(), getGroups(), getInputDtype(),
-      getOutputDtype(), conv2dAttrs.conv2dConfig,
-      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfig(),
-      opConfig.outputLayout);
+      inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
+      conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
+      getConv2dSliceConfig(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> PrepareConvTranspose2dBiasOp::getOpRuntime(
@@ -3789,9 +3613,6 @@ llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
                                "(representing main input tensor, "
                                "running_mean, running_var, weight and bias).");
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   const auto inputShape = getInput().getType().getShape();
 
   BatchNormOptionalArgs optionalArgs =
@@ -3799,7 +3620,7 @@ llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<BatchNormInferenceOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], optionalArgs.runningMeanShape,
+      inputShape, inputs[0], optionalArgs.runningMeanShape,
       optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
@@ -3841,9 +3662,6 @@ BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
          "usage of this op with 2-4 input tensors is discouraged as it's "
          "ambiguous.");
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   const auto inputShape = getInput().getType().getShape();
 
   BatchNormOptionalArgs optionalArgs =
@@ -3851,7 +3669,7 @@ BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<BatchNormTrainingOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], optionalArgs.runningMeanShape,
+      inputShape, inputs[0], optionalArgs.runningMeanShape,
       optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
@@ -3918,8 +3736,6 @@ unpackRMSNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 RMSNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -3931,11 +3747,10 @@ RMSNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
           : std::nullopt;
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RMSNormOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
-      computeKernelConfig);
+      op_model::OpModel<RMSNormOp>::getOpConstraints, *this, inputShape,
+      inputs[0], optionalArgs.weightShape, optionalArgs.weightLayout,
+      optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
+      opConfig.outputLayout, computeKernelConfig);
 }
 
 llvm::Expected<size_t>
@@ -3984,8 +3799,6 @@ unpackRMSNormPreAllGatherOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -3994,7 +3807,7 @@ llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RMSNormPreAllGatherOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], optionalArgs.residualInputShape,
+      inputShape, inputs[0], optionalArgs.residualInputShape,
       optionalArgs.residualInputLayout, dataTypeAttrToOptional(getDtypeAttr()),
       getUse_2dCoreGrid(), opConfig.outputLayout);
 }
@@ -4049,8 +3862,6 @@ unpackLayerNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 LayerNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4058,10 +3869,10 @@ LayerNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       unpackLayerNormOptionalArgs(inputs, *this);
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LayerNormOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+      op_model::OpModel<LayerNormOp>::getOpConstraints, *this, inputShape,
+      inputs[0], optionalArgs.weightShape, optionalArgs.weightLayout,
+      optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4114,8 +3925,6 @@ unpackLayerNormPreAllGatherOptionalArgs(
 llvm::Expected<op_model::OpConstraints>
 LayerNormPreAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4124,7 +3933,7 @@ LayerNormPreAllGatherOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<LayerNormPreAllGatherOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], optionalArgs.residualInputShape,
+      inputShape, inputs[0], optionalArgs.residualInputShape,
       optionalArgs.residualInputLayout, optionalArgs.recipShape,
       optionalArgs.recipLayout, dataTypeAttrToOptional(getDtypeAttr()),
       opConfig.outputLayout);
@@ -4181,8 +3990,6 @@ unpackLayerNormPostAllGatherOptionalArgs(
 llvm::Expected<op_model::OpConstraints>
 LayerNormPostAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
   const auto statsShape = getStats().getType().getShape();
@@ -4192,10 +3999,9 @@ LayerNormPostAllGatherOp::getOpConstraints(
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], statsShape, inputs[1],
-      optionalArgs.weightShape, optionalArgs.weightLayout,
-      optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
-      opConfig.outputLayout);
+      inputShape, inputs[0], statsShape, inputs[1], optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> LayerNormPostAllGatherOp::getOpRuntime(
@@ -4257,8 +4063,6 @@ llvm::Expected<op_model::OpConstraints>
 GroupNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(!inputs.empty() && "GroupNormOp requires at least input layout");
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4266,12 +4070,11 @@ GroupNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       unpackGroupNormOptionalArgs(inputs, *this);
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GroupNormOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], optionalArgs.inputMaskShape,
-      optionalArgs.inputMaskLayout, optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getNumGroups(), getEpsilon(),
-      opConfig.outputLayout);
+      op_model::OpModel<GroupNormOp>::getOpConstraints, *this, inputShape,
+      inputs[0], optionalArgs.inputMaskShape, optionalArgs.inputMaskLayout,
+      optionalArgs.weightShape, optionalArgs.weightLayout,
+      optionalArgs.biasShape, optionalArgs.biasLayout, getNumGroups(),
+      getEpsilon(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4302,12 +4105,9 @@ ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ClampScalarOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getMinAttr(), getMaxAttr(), opConfig.outputLayout);
+      op_model::OpModel<ClampScalarOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getMinAttr(), getMaxAttr(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4333,12 +4133,9 @@ ClampTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ClampTensorOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getMin().getType().getShape(), inputs[1],
+      op_model::OpModel<ClampTensorOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getMin().getType().getShape(), inputs[1],
       getMax().getType().getShape(), inputs[2], opConfig.outputLayout);
 }
 
@@ -4366,13 +4163,9 @@ PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PermuteOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getPermutation(), getPadValue(),
-      opConfig.outputLayout);
+      op_model::OpModel<PermuteOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getPermutation(), getPadValue(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4398,13 +4191,9 @@ UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<UpsampleOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getScaleFactor(), getMode(),
-      opConfig.outputLayout);
+      op_model::OpModel<UpsampleOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getScaleFactor(), getMode(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4431,12 +4220,9 @@ EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<EmbeddingOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], weightShape, inputs[1], opConfig.outputLayout);
+      op_model::OpModel<EmbeddingOp>::getOpConstraints, *this, inputShape,
+      inputs[0], weightShape, inputs[1], opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4465,13 +4251,10 @@ EmbeddingBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto weightShape = getWeight().getType().getShape();
   const auto inGradientShape = getInGradient().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<EmbeddingBackwardOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], weightShape, inputs[1],
-      inGradientShape, inputs[2], opConfig.outputLayout);
+      inputShape, inputs[0], weightShape, inputs[1], inGradientShape, inputs[2],
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4504,12 +4287,9 @@ EmptyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   assert(dtype && "EmptyOp requires output dtype");
   const mlir::tt::ttnn::Layout layout = getLayoutAttr().getValue();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints, *this,
-      deviceGrid, shape, dtype, layout, opConfig.outputLayout);
+      shape, dtype, layout, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4534,12 +4314,9 @@ ArangeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   std::optional<mlir::tt::ttcore::DataType> dtype =
       dataTypeAttrToOptional(getDtypeAttr());
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::ArangeOp>::getOpConstraints, *this,
-      deviceGrid, startAttr, endAttr, stepAttr, dtype, opConfig.outputLayout);
+      startAttr, endAttr, stepAttr, dtype, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4592,8 +4369,6 @@ llvm::Expected<op_model::OpConstraints>
 FullOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 0);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const mlir::tt::ttnn::ShapeAttr shape = getShape();
   const mlir::Attribute fillValue = getFillValue();
@@ -4602,8 +4377,8 @@ FullOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const std::optional<mlir::tt::ttnn::Layout> layout = getLayout();
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<mlir::tt::ttnn::FullOp>::getOpConstraints, *this,
-      deviceGrid, shape, fillValue, dtype, layout, opConfig.outputLayout);
+      op_model::OpModel<mlir::tt::ttnn::FullOp>::getOpConstraints, *this, shape,
+      fillValue, dtype, layout, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4624,12 +4399,9 @@ MeshPartitionOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<MeshPartitionOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getDim(), getClusterAxis(), opConfig.outputLayout);
+      op_model::OpModel<MeshPartitionOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getDim(), getClusterAxis(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4653,12 +4425,9 @@ ConstantOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 0);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConstantOp>::getOpConstraints, *this, deviceGrid,
-      getValue(), opConfig.outputLayout);
+      op_model::OpModel<ConstantOp>::getOpConstraints, *this, getValue(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4677,17 +4446,14 @@ RandOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 0);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   ttcore::DataTypeAttr dtype =
       detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
   assert(dtype && "RandOp requires output dtype");
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::RandOp>::getOpConstraints, *this,
-      deviceGrid, getSize(), dtype.getValue(), getLayout(), getLow(), getHigh(),
-      getSeed(), opConfig.outputLayout);
+      getSize(), dtype.getValue(), getLayout(), getLow(), getHigh(), getSeed(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4708,13 +4474,10 @@ DropoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<DropoutOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], getProb(), getScale(), getSeed(),
-      getUsePerDeviceSeed(), opConfig.outputLayout);
+      op_model::OpModel<DropoutOp>::getOpConstraints, *this, inputShape,
+      inputs[0], getProb(), getScale(), getSeed(), getUsePerDeviceSeed(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4741,13 +4504,9 @@ GlobalAvgPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
-
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GlobalAvgPool2dOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout);
+      op_model::OpModel<GlobalAvgPool2dOp>::getOpConstraints, *this, inputShape,
+      inputs[0], dataTypeAttrToOptional(getDtypeAttr()), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4770,15 +4529,12 @@ llvm::Expected<op_model::OpConstraints>
 AssignOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::AssignOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0],
-      dataTypeAttrToOptional(getDtypeAttr()));
+      inputShape, inputs[0], dataTypeAttrToOptional(getDtypeAttr()));
 }
 
 llvm::Expected<size_t>
@@ -4985,13 +4741,11 @@ llvm::Expected<op_model::OpConstraints>
 TopKOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
   const auto inputShape = getInputTensor().getType().getShape();
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::TopKOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0], getK(), getDim(), getLargest(),
-      getSorted(), opConfig.outputLayout);
+      inputShape, inputs[0], getK(), getDim(), getLargest(), getSorted(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -9,6 +9,9 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/OpModel/TTNN/MetalHeaders.h"
 
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/ErrorHandling.h"
+
 #include <cstdlib>
 #include <string>
 
@@ -27,6 +30,43 @@ SingletonDeviceContext &SingletonDeviceContext::getInstance() {
   return instance;
 }
 
+void SingletonDeviceContext::refreshComputeGridShape() {
+  assert(m_device != nullptr && "Device must be initialized to query grid");
+  const ::tt::tt_metal::CoreCoord grid =
+      m_device->compute_with_storage_grid_size();
+  // CoreCoord holds (x, y); GridAttr/layout convention is {y, x}.
+  m_computeGridShape = {static_cast<int64_t>(grid.y),
+                        static_cast<int64_t>(grid.x)};
+  validateComputeGridAgainstSystemDesc();
+}
+
+void SingletonDeviceContext::validateComputeGridAgainstSystemDesc() const {
+  if (!m_systemDesc) {
+    return;
+  }
+  llvm::ArrayRef<ttcore::ChipDescAttr> chipDescs = m_systemDesc.getChipDescs();
+  if (chipDescs.empty()) {
+    return;
+  }
+
+  // All chips on a given (multi-chip) system are assumed identical, so the
+  // first chip's grid is representative. Both the chip grid and
+  // m_computeGridShape use the {y, x} convention.
+  llvm::ArrayRef<int64_t> expected = chipDescs.front().getGrid();
+  assert(expected.size() == 2 && "expected 2D chip grid");
+
+  if (expected != llvm::ArrayRef<int64_t>(m_computeGridShape)) {
+    llvm::report_fatal_error(
+        llvm::Twine(
+            "OpModel device worker grid does not match the registered system "
+            "descriptor: device compute-with-storage grid {y=") +
+        llvm::Twine(m_computeGridShape[0]) +
+        ", x=" + llvm::Twine(m_computeGridShape[1]) +
+        "}, system desc grid {y=" + llvm::Twine(expected[0]) +
+        ", x=" + llvm::Twine(expected[1]) + "}.");
+  }
+}
+
 void SingletonDeviceContext::resetInstance() {
   SingletonDeviceContext &instance = getInstance();
   assert(!instance.m_isExternalDevice &&
@@ -42,6 +82,7 @@ void SingletonDeviceContext::closeInstance() {
   bool wasExternalDevice = instance.m_isExternalDevice;
   bool wasMockDevice = instance.m_isMockDevice;
   instance.m_device.reset();
+  instance.m_computeGridShape.clear();
   instance.m_isMockDevice = false;
   if (!wasExternalDevice && wasMockDevice) {
     ::tt::tt_metal::experimental::disable_mock_mode();
@@ -56,6 +97,7 @@ void SingletonDeviceContext::setExternalDevice(
          "Device is already initialized. Cannot set external device.");
   instance.m_device = std::move(device);
   instance.m_isExternalDevice = true;
+  instance.refreshComputeGridShape();
 }
 
 void SingletonDeviceContext::setSystemDesc(ttcore::SystemDescAttr systemDesc) {
@@ -121,6 +163,8 @@ void SingletonDeviceContext::openDevice(
       /* num_hw_cqs = */ 1, dispatchCoreType);
 
   m_device->disable_and_clear_program_cache();
+
+  refreshComputeGridShape();
 }
 
 void SingletonDeviceContext::reshapeMeshDevice(
@@ -145,6 +189,8 @@ void SingletonDeviceContext::reshapeMeshDevice(
       /* num_hw_cqs = */ 1, dispatchCoreType);
 
   m_device->disable_and_clear_program_cache();
+
+  refreshComputeGridShape();
 }
 
 } // namespace mlir::tt::ttnn::op_model

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -35,8 +35,12 @@ void SingletonDeviceContext::refreshComputeGridShape() {
   const ::tt::tt_metal::CoreCoord grid =
       m_device->compute_with_storage_grid_size();
   // CoreCoord holds (x, y); GridAttr/layout convention is {y, x}.
-  m_computeGridShape = {static_cast<int64_t>(grid.y),
-                        static_cast<int64_t>(grid.x)};
+  llvm::SmallVector<int64_t, 2> newGrid = {static_cast<int64_t>(grid.y),
+                                           static_cast<int64_t>(grid.x)};
+  if (newGrid != m_computeGridShape) {
+    m_computeGridShape = std::move(newGrid);
+    ++m_deviceGeneration;
+  }
   validateComputeGridAgainstSystemDesc();
 }
 
@@ -53,7 +57,15 @@ void SingletonDeviceContext::validateComputeGridAgainstSystemDesc() const {
   // first chip's grid is representative. Both the chip grid and
   // m_computeGridShape use the {y, x} convention.
   llvm::ArrayRef<int64_t> expected = chipDescs.front().getGrid();
-  assert(expected.size() == 2 && "expected 2D chip grid");
+  // A non-2D chip grid is a malformed system descriptor (the rest of the stack
+  // assumes 2D worker grids); fail fast rather than index out of bounds below
+  // in release builds, where the equivalent assert is compiled out.
+  if (expected.size() != 2) {
+    llvm::report_fatal_error(
+        llvm::Twine("OpModel system descriptor has a malformed chip grid: "
+                    "expected a 2D grid, got rank ") +
+        llvm::Twine(expected.size()) + ".");
+  }
 
   if (expected != llvm::ArrayRef<int64_t>(m_computeGridShape)) {
     llvm::report_fatal_error(
@@ -82,7 +94,9 @@ void SingletonDeviceContext::closeInstance() {
   bool wasExternalDevice = instance.m_isExternalDevice;
   bool wasMockDevice = instance.m_isMockDevice;
   instance.m_device.reset();
-  instance.m_computeGridShape.clear();
+  // m_computeGridShape is intentionally retained across close so that a reset
+  // to the same grid does not bump m_deviceGeneration (and needlessly drop the
+  // still-valid op-model caches). It is only read while a device is active.
   instance.m_isMockDevice = false;
   if (!wasExternalDevice && wasMockDevice) {
     ::tt::tt_metal::experimental::disable_mock_mode();
@@ -103,6 +117,13 @@ void SingletonDeviceContext::setExternalDevice(
 void SingletonDeviceContext::setSystemDesc(ttcore::SystemDescAttr systemDesc) {
   SingletonDeviceContext &instance = getInstance();
   instance.m_systemDesc = systemDesc;
+  // If a device is already open, validate the new descriptor against it now:
+  // the grid check otherwise only runs on device open/reshape, so a desc set
+  // on an already-active device (e.g. via ScopedSingletonDeviceGuard reusing a
+  // device) would never be checked.
+  if (instance.m_device != nullptr) {
+    instance.validateComputeGridAgainstSystemDesc();
+  }
 }
 
 void SingletonDeviceContext::openMockDevice(

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -131,14 +131,11 @@ executeConstraintQuery(Callable &callable) {
  * @param name The name of the operation to query constraints for.
  * @param context The MLIRContext to use for creating the TTNNLayoutAttr for the
  * output tensor
- * @param deviceGrid The worker grid of the device the op is targeted for.
- * Required for creating the output tensor layout
  * @param callable A callable object that performs the query.
  * @return A tuple containing query results or a string error.
  */
 template <class Callable>
 llvm::Expected<OpConstraints> getOpConstraints(MLIRContext *context,
-                                               ttcore::GridAttr deviceGrid,
                                                Callable &callable) {
 
   llvm::Expected<::ttnn::graph::ConstraintQueryResponse> query =
@@ -149,10 +146,18 @@ llvm::Expected<OpConstraints> getOpConstraints(MLIRContext *context,
 
   ::ttnn::graph::ConstraintQueryResponse response = query.get();
 
+  // The worker grid used to build interleaved output layouts is sourced from
+  // the open device rather than threaded in from the IR: the two are equivalent
+  // (the system desc that produced the IR's DeviceAttr is itself derived from
+  // this grid), and this is the only place the value is consumed. The context
+  // caches it across device open/reset, so this is a cheap lookup.
+  const llvm::ArrayRef<int64_t> deviceGrid =
+      SingletonDeviceContext::getInstance().getComputeGridShape();
+
   llvm::SmallVector<TTNNLayoutAttr> layoutAttrs;
   for (const auto &outputTensorSpec : response.output_tensor_specs.value()) {
     layoutAttrs.push_back(conversion::getLayoutAttrFromTensorSpec(
-        context, outputTensorSpec, deviceGrid.getShape()));
+        context, outputTensorSpec, deviceGrid));
   }
 
   return OpConstraints(response.resource_usage.cb_peak_size_per_core,
@@ -189,34 +194,6 @@ llvm::Expected<size_t> getOpRuntime(Callable &callable) {
 } // namespace operation
 
 namespace detail {
-/**
- * @brief Checks the validity of the compute grid size.
- *
- * This function verifies the dimensions and properties of the provided compute
- * grid size.
- *
- * @param computeGridSize The size of the compute grid, represented as a
- * CoreCoord object.
- * @param workerGrid The worker grid attributes, represented as a GridAttr
- * object. The shape of the worker grid is expected to be in the format {y, x}.
- *
- * @throws std::runtime_error If the worker grid size does not match the compute
- * grid size.
- */
-void checkGrid(const ::tt::tt_metal::CoreCoord &computeGridSize,
-               ttcore::GridAttr workerGrid) {
-  // metal CoreCoord holds x,y
-  // GridAttr holds shape {y,x}
-  if ((static_cast<size_t>(workerGrid.getShape()[1]) != computeGridSize.x) ||
-      (static_cast<size_t>(workerGrid.getShape()[0]) != computeGridSize.y)) {
-    throw std::runtime_error("Selected worker grid is different than available "
-                             "grid size. Compute Grid Size: " +
-                             computeGridSize.str() + ", Worker Grid Size: (x=" +
-                             std::to_string(workerGrid.getShape()[1]) + ",y=" +
-                             std::to_string(workerGrid.getShape()[0]) + ")");
-  }
-}
-
 /**
  * @brief Convenience wrapper to create and validate a tensor spec
  *
@@ -834,32 +811,14 @@ getPrepareConv2dBiasOpOutputTensorSpec(
 #endif // TTMLIR_ENABLE_OPMODEL
 
 //===----------------------------------------------------------------------===//
-// Device
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<bool> Device::getDeviceConstraints(ttcore::GridAttr workerGrid) {
-#ifdef TTMLIR_ENABLE_OPMODEL
-  try {
-    detail::checkGrid(SingletonDeviceContext::getInstance()
-                          .getDevice()
-                          ->compute_with_storage_grid_size(),
-                      workerGrid);
-    return true;
-  } catch (const std::exception &e) {
-    return llvm::createStringError(e.what());
-  }
-#endif
-  return true;
-}
-
-//===----------------------------------------------------------------------===//
 // Unary Eltwise Ops
 //===----------------------------------------------------------------------===//
 
 template <typename OpTy>
-llvm::Expected<OpConstraints> UnaryEltwiseOpModel<OpTy>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints>
+UnaryEltwiseOpModel<OpTy>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                                            TTNNLayoutAttr inputLayout,
+                                            TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
 
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -876,8 +835,7 @@ llvm::Expected<OpConstraints> UnaryEltwiseOpModel<OpTy>::getOpConstraints(
         detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -912,8 +870,8 @@ UnaryEltwiseOpModel<OpTy>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 template <typename OpTy>
 llvm::Expected<OpConstraints>
 UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -931,8 +889,7 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
         detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1003,9 +960,10 @@ template struct UnaryEltwiseWithFastApproxModeOpModel<GeluOp>;
 //===----------------------------------------------------------------------===//
 // SigmoidOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<SigmoidOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints>
+OpModel<SigmoidOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                                     TTNNLayoutAttr inputLayout,
+                                     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1026,8 +984,7 @@ llvm::Expected<OpConstraints> OpModel<SigmoidOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1067,9 +1024,8 @@ OpModel<SigmoidOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // LeakyReluOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::APFloat slope,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::APFloat slope, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1085,7 +1041,7 @@ llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      leakyReluOpQuery);
 #else
   return OpConstraints{};
@@ -1122,10 +1078,9 @@ llvm::Expected<size_t> OpModel<LeakyReluOp>::getOpRuntime(
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-    TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout,
-    ttcore::DataTypeAttr opDtypeAttr) {
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1153,8 +1108,7 @@ llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
                                                outputDType, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1197,10 +1151,9 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-    TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout,
-    ttcore::DataTypeAttr /*opDtypeAttr*/) {
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr /*opDtypeAttr*/) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1223,8 +1176,7 @@ llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
                                                outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1294,10 +1246,9 @@ template struct BinaryCompositeOpModel<Atan2Op>;
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<GeluBackwardOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-    TTNNLayoutAttr inputLayoutB, std::string approximate,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    std::string approximate, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1320,8 +1271,7 @@ llvm::Expected<OpConstraints> OpModel<GeluBackwardOp>::getOpConstraints(
                                 outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1363,9 +1313,8 @@ llvm::Expected<size_t> OpModel<GeluBackwardOp>::getOpRuntime(
 // PowScalar
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, mlir::Attribute exponent,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute exponent, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1389,14 +1338,12 @@ llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
   if (auto value = mlir::dyn_cast<mlir::IntegerAttr>(exponent)) {
     int32_t convertedExponent = static_cast<int32_t>(value.getInt());
     auto query = powScalarQuery(convertedExponent);
-    return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                       query);
+    return operation::getOpConstraints(inputLayout.getContext(), query);
   }
   if (auto value = mlir::dyn_cast<mlir::FloatAttr>(exponent)) {
     float convertedExponent = value.getValue().convertToFloat();
     auto query = powScalarQuery(convertedExponent);
-    return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                       query);
+    return operation::getOpConstraints(inputLayout.getContext(), query);
   }
   return llvm::createStringError("Invalid exponent");
 #else
@@ -1449,10 +1396,10 @@ llvm::Expected<size_t> OpModel<PowScalarOp>::getOpRuntime(
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-    TTNNLayoutAttr inputLayoutB, llvm::ArrayRef<int64_t> inputShapeC,
-    TTNNLayoutAttr inputLayoutC, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1479,8 +1426,7 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
                                                inputSpecC, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1533,9 +1479,9 @@ template struct TernaryEltwiseOpModel<WhereOp>;
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, std::optional<llvm::ArrayRef<int64_t>> dimArg,
-    bool keepDim, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1562,8 +1508,7 @@ llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
         /*sub_core_grids=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1618,7 +1563,7 @@ template struct ReductionOpModel<MinOp>;
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> NamedFullOpModel<OpTy>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, mlir::tt::ttnn::ShapeAttr shape,
+    mlir::tt::ttnn::ShapeAttr shape,
     std::optional<mlir::tt::ttcore::DataType> dtype,
     std::optional<mlir::tt::ttnn::Layout> layout,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
@@ -1647,8 +1592,7 @@ llvm::Expected<OpConstraints> NamedFullOpModel<OpTy>::getOpConstraints(
         conversion::getShape(shape.getShape()), metalDtype, metalLayout,
         deviceRef, metalMemoryConfig);
   };
-  return operation::getOpConstraints(shape.getContext(), deviceGrid,
-                                     namedFullOpQuery);
+  return operation::getOpConstraints(shape.getContext(), namedFullOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1662,9 +1606,8 @@ template struct NamedFullOpModel<OnesOp>;
 // SoftmaxOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, const int dimArg, bool numericStable,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int dimArg, bool numericStable, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1681,8 +1624,7 @@ llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
                                 numericStable);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     softmaxOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), softmaxOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1717,11 +1659,10 @@ llvm::Expected<size_t> OpModel<SoftmaxOp>::getOpRuntime(
 // ScatterOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> indexShape,
-    TTNNLayoutAttr indexLayout, llvm::ArrayRef<int64_t> sourceShape,
-    TTNNLayoutAttr sourceLayout, int32_t dim,
-    std::optional<ttcore::ReduceTypeAttr> optReduction,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
+    llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
+    int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1750,8 +1691,7 @@ llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
         /* sub_core_grid */ std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     scatterOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), scatterOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1799,9 +1739,8 @@ llvm::Expected<size_t> OpModel<ScatterOp>::getOpRuntime(
 // ReshapeOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> outputShape,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1817,8 +1756,7 @@ llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     reshapeOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), reshapeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1852,10 +1790,9 @@ llvm::Expected<size_t> OpModel<ReshapeOp>::getOpRuntime(
 // SliceStaticOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
-    llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
+    llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1884,8 +1821,7 @@ llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
                                 std::nullopt, std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     sliceOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), sliceOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1934,10 +1870,10 @@ llvm::Expected<size_t> OpModel<SliceStaticOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<SliceDynamicOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> beginsShape,
-    TTNNLayoutAttr beginsLayout, llvm::ArrayRef<int64_t> endsShape,
-    TTNNLayoutAttr endsLayout, std::optional<llvm::SmallVector<int64_t>> step,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
+    llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
+    std::optional<llvm::SmallVector<int64_t>> step,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1970,8 +1906,7 @@ llvm::Expected<OpConstraints> OpModel<SliceDynamicOp>::getOpConstraints(
         ::ttnn::slice, device, inputSpec, beginsVec, endsVec, stepVec,
         detail::getNullableMemoryConfig(outputLayout), outputSpec, padValue);
   };
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     sliceOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), sliceOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2027,9 +1962,8 @@ llvm::Expected<size_t> OpModel<SliceDynamicOp>::getOpRuntime(
 // BitcastConvertOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2045,8 +1979,7 @@ llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     bitcastOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), bitcastOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2080,9 +2013,8 @@ llvm::Expected<size_t> OpModel<BitcastConvertOp>::getOpRuntime(
 // TypecastOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2098,8 +2030,7 @@ llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     typecastOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), typecastOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2133,9 +2064,8 @@ llvm::Expected<size_t> OpModel<TypecastOp>::getOpRuntime(
 // ToLayoutOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, std::optional<ttcore::DataType> outputDtype,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2158,8 +2088,7 @@ llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
         conversion::getPageLayout(outputLayout.getLayout()), dtype,
         detail::getNullableMemoryConfig(outputLayout));
   };
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     toLayoutOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), toLayoutOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2200,9 +2129,10 @@ llvm::Expected<size_t> OpModel<ToLayoutOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ToMemoryConfigOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<ToMemoryConfigOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints>
+OpModel<ToMemoryConfigOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                                            TTNNLayoutAttr inputLayout,
+                                            TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2218,7 +2148,7 @@ llvm::Expected<OpConstraints> OpModel<ToMemoryConfigOp>::getOpConstraints(
         conversion::getMemoryConfig(MemoryConfigAttr::get(outputLayout)));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      toMemoryConfigOpQuery);
 #else
   return OpConstraints{};
@@ -2253,7 +2183,6 @@ OpModel<ToMemoryConfigOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // ConcatOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid,
     std::vector<llvm::ArrayRef<int64_t>> inputShapes,
     std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
     TTNNLayoutAttr outputLayout) {
@@ -2278,7 +2207,7 @@ llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayouts[0].getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayouts[0].getContext(),
                                      concatOpQuery);
 #else
   return OpConstraints{};
@@ -2320,9 +2249,8 @@ llvm::Expected<size_t> OpModel<ConcatOp>::getOpRuntime(
 // TransposeOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int dim0, const int dim1, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2339,7 +2267,7 @@ llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      transposeOpQuery);
 #else
   return OpConstraints{};
@@ -2375,9 +2303,9 @@ llvm::Expected<size_t> OpModel<TransposeOp>::getOpRuntime(
 // CumSumOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, const int32_t dim,
-    std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int32_t dim, std::optional<ttcore::DataType> dtype,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2398,8 +2326,7 @@ llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     cumSumOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), cumSumOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2441,8 +2368,8 @@ OpModel<CumSumOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2458,7 +2385,7 @@ llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      concatenateHeadsOpQuery);
 #else
   return OpConstraints{};
@@ -2495,11 +2422,10 @@ OpModel<ConcatenateHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
 OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> queryShape,
-    TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
-    TTNNLayoutAttr keyLayout, llvm::ArrayRef<int64_t> valueShape,
-    TTNNLayoutAttr valueLayout, bool isCausal,
-    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
     std::optional<TTNNLayoutAttr> attentionMaskLayout,
     std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
     std::optional<TTNNLayoutAttr> curPosTensorLayout,
@@ -2554,7 +2480,7 @@ OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(queryLayout.getContext(),
                                      scaledDotProductAttentionDecodeOpQuery);
 #else
   return OpConstraints{};
@@ -2627,12 +2553,11 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionDecodeOp>::getOpRuntime(
 
 llvm::Expected<OpConstraints>
 OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> queryShape,
-    TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
-    TTNNLayoutAttr keyLayout, llvm::ArrayRef<int64_t> valueShape,
-    TTNNLayoutAttr valueLayout, llvm::ArrayRef<int64_t> pageTableShape,
-    TTNNLayoutAttr pageTableLayout, bool isCausal,
-    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
     std::optional<TTNNLayoutAttr> attentionMaskLayout,
     std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
     std::optional<TTNNLayoutAttr> curPosTensorLayout,
@@ -2685,8 +2610,7 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
   };
 
   return operation::getOpConstraints(
-      queryLayout.getContext(), deviceGrid,
-      pagedScaledDotProductAttentionDecodeOpQuery);
+      queryLayout.getContext(), pagedScaledDotProductAttentionDecodeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2764,9 +2688,9 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
 
 llvm::Expected<OpConstraints>
 OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> queryShape,
-    TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
-    TTNNLayoutAttr keyLayout, std::optional<llvm::ArrayRef<int64_t>> valueShape,
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    std::optional<llvm::ArrayRef<int64_t>> valueShape,
     std::optional<TTNNLayoutAttr> valueLayout, uint32_t headDimV,
     llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
     bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
@@ -2815,7 +2739,7 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(queryLayout.getContext(),
                                      pagedFlashMlaDecodeOpQuery);
 #else
   return OpConstraints{};
@@ -2887,10 +2811,9 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpRuntime(
 
 llvm::Expected<OpConstraints>
 OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> queryShape,
-    TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
-    TTNNLayoutAttr keyLayout, llvm::ArrayRef<int64_t> valueShape,
-    TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
     std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
     std::optional<TTNNLayoutAttr> attentionMaskLayout,
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
@@ -2929,7 +2852,7 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
         /*compute_kernel_config=*/std::nullopt, attentionSinkSpec);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(queryLayout.getContext(),
                                      scaledDotProductAttentionOpQuery);
 #else
   return OpConstraints{};
@@ -2989,12 +2912,11 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionOp>::getOpRuntime(
 // RotaryEmbeddingLlamaOp
 // ===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> cosShape,
-    TTNNLayoutAttr cosLayout, llvm::ArrayRef<int64_t> sinShape,
-    TTNNLayoutAttr sinLayout, llvm::ArrayRef<int64_t> transMatShape,
-    TTNNLayoutAttr transMatLayout, bool isDecodeMode,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+    llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+    llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
+    bool isDecodeMode, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3017,7 +2939,7 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      rotaryEmbeddingLlamaOpQuery);
 #else
   return OpConstraints{};
@@ -3064,11 +2986,10 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingLlamaOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> cosShape,
-    TTNNLayoutAttr cosLayout, llvm::ArrayRef<int64_t> sinShape,
-    TTNNLayoutAttr sinLayout, std::optional<uint32_t> tokenIndex,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+    llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+    std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3087,7 +3008,7 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      rotaryEmbeddingOpQuery);
 #else
   return OpConstraints{};
@@ -3129,8 +3050,7 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 llvm::Expected<op_model::OpConstraints>
 OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
     std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
     std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
@@ -3160,7 +3080,7 @@ OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
         sliceSize, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      nlpCreateQKVHeadsDecode);
 
 #else
@@ -3210,8 +3130,7 @@ llvm::Expected<size_t> OpModel<NLPCreateQKVHeadsDecodeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
 OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
     std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
     std::optional<uint32_t> numKVHeads, bool transposeKey,
@@ -3239,7 +3158,7 @@ OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
         detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      splitQueryKeyValueAndSplitHeadsOpQuery);
 #else
   return OpConstraints{};
@@ -3284,9 +3203,10 @@ llvm::Expected<size_t> OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // NLPConcatHeadsOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints>
+OpModel<NLPConcatHeadsOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                                            TTNNLayoutAttr inputLayout,
+                                            TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3302,7 +3222,7 @@ llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      nlpConcatHeadsOpQuery);
 #else
   return OpConstraints{};
@@ -3338,9 +3258,8 @@ OpModel<NLPConcatHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // NLPConcatHeadsDecodeOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, uint32_t numHeads,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    uint32_t numHeads, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3373,7 +3292,7 @@ llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
         std::optional<::tt::tt_metal::Tensor>(std::nullopt), subCoreGrids);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      nlpConcatHeadsDecodeOpQuery);
 #else
   return OpConstraints{};
@@ -3422,9 +3341,8 @@ llvm::Expected<size_t> OpModel<NLPConcatHeadsDecodeOp>::getOpRuntime(
 // RepeatInterleaveOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, const unsigned int repeats, const int dim,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3440,7 +3358,7 @@ llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      repeatInterleaveOpQuery);
 #else
   return OpConstraints{};
@@ -3475,9 +3393,8 @@ llvm::Expected<size_t> OpModel<RepeatInterleaveOp>::getOpRuntime(
 // RepeatOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> repeats,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3503,8 +3420,7 @@ llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
                                 outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     repeatOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), repeatOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3577,9 +3493,9 @@ convertPadding(llvm::ArrayRef<int32_t> padding) {
 #endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int32_t> padding,
-    llvm::APFloat padValue, bool multicore, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3598,8 +3514,7 @@ llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     padOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), padOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3637,9 +3552,8 @@ llvm::Expected<size_t> OpModel<PadOp>::getOpRuntime(
 // SortOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, int dim, bool descending, bool stable,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
+    bool descending, bool stable, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3655,8 +3569,7 @@ llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     sortOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), sortOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3691,11 +3604,10 @@ llvm::Expected<size_t> OpModel<SortOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> biasShape,
-    TTNNLayoutAttr biasLayout, uint32_t k, uint32_t numExperts,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
+    uint32_t numExperts, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3716,7 +3628,7 @@ llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
                                 inputSpec, weightSpec, biasSpec, k, numExperts);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      topKRouterGptQuery);
 #else
   return OpConstraints{};
@@ -3758,9 +3670,9 @@ llvm::Expected<size_t> OpModel<TopKRouterGptOp>::getOpRuntime(
 // ArgMaxOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, std::optional<int32_t> dim, bool keepDim,
-    bool multicore, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<int32_t> dim, bool keepDim, bool multicore,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3776,8 +3688,7 @@ llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
         multicore, detail::getNullableMemoryConfig(outputLayout), std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     argMaxOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), argMaxOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3813,9 +3724,8 @@ OpModel<ArgMaxOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // ProdOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, std::optional<int64_t> dim, bool keepDim,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3830,8 +3740,7 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     prodOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), prodOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3843,11 +3752,11 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> QuantizationOpModel<OpTy>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> scaleShape,
-    TTNNLayoutAttr scaleLayout, llvm::ArrayRef<int64_t> zeroPointShape,
-    TTNNLayoutAttr zeroPointLayout, std::optional<int32_t> axis,
-    std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> scaleShape, TTNNLayoutAttr scaleLayout,
+    llvm::ArrayRef<int64_t> zeroPointShape, TTNNLayoutAttr zeroPointLayout,
+    std::optional<int32_t> axis, std::optional<ttcore::DataType> outputDtype,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3882,7 +3791,7 @@ llvm::Expected<OpConstraints> QuantizationOpModel<OpTy>::getOpConstraints(
         zeroPointSpec, axis, outputDType, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      quantizationOpQuery);
 #else
   return OpConstraints{};
@@ -3946,11 +3855,11 @@ template struct QuantizationOpModel<DequantizeOp>;
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> inScaleShape,
-    TTNNLayoutAttr inScaleLayout, llvm::ArrayRef<int64_t> inZeroPointShape,
-    TTNNLayoutAttr inZeroPointLayout, llvm::ArrayRef<int64_t> outScaleShape,
-    TTNNLayoutAttr outScaleLayout, llvm::ArrayRef<int64_t> outZeroPointShape,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
+    llvm::ArrayRef<int64_t> inZeroPointShape, TTNNLayoutAttr inZeroPointLayout,
+    llvm::ArrayRef<int64_t> outScaleShape, TTNNLayoutAttr outScaleLayout,
+    llvm::ArrayRef<int64_t> outZeroPointShape,
     TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
     std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -3996,7 +3905,7 @@ llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
         outScaleSpec, outZeroPointSpec, axis, outputDType, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      requantizeOpQuery);
 #else
   return OpConstraints{};
@@ -4064,9 +3973,8 @@ llvm::Expected<size_t> OpModel<RequantizeOp>::getOpRuntime(
 // LinearOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-    TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
     bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
@@ -4121,8 +4029,7 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
         /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), deviceGrid,
-                                     linearOpQuery);
+  return operation::getOpConstraints(inputLayoutA.getContext(), linearOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4180,10 +4087,10 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
 // MatmulOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
-    TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout, bool transposeA,
-    bool transposeB, std::optional<llvm::StringRef> activation,
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
+    std::optional<llvm::StringRef> activation,
     std::optional<mlir::Attribute> programConfigAttr,
     std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -4227,8 +4134,7 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
         /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), deviceGrid,
-                                     matmulOpQuery);
+  return operation::getOpConstraints(inputLayoutA.getContext(), matmulOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4306,10 +4212,9 @@ OpModel<DeallocateOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> cacheShape,
-    TTNNLayoutAttr cacheLayout, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, uint32_t batchOffset,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    uint32_t batchOffset, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4326,7 +4231,7 @@ llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
                                 inputSpec, batchOffset);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(cacheLayout.getContext(),
                                      fillCacheOpQuery);
 
 #else
@@ -4365,11 +4270,10 @@ llvm::Expected<size_t> OpModel<FillCacheOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> cacheShape,
-    TTNNLayoutAttr cacheLayout, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> updateIndexShape,
-    TTNNLayoutAttr updateIndexLayout, uint32_t batchOffset,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
+    uint32_t batchOffset, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4402,7 +4306,7 @@ llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraints(
                                 /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(cacheLayout.getContext(),
                                      updateCacheOpQuery);
 
 #else
@@ -4448,10 +4352,9 @@ llvm::Expected<size_t> OpModel<UpdateCacheOp>::getOpRuntime(
 // PagedUpdateCacheOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> cacheShape,
-    TTNNLayoutAttr cacheLayout, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> updateIndexShape,
-    TTNNLayoutAttr updateIndexLayout,
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
     std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
     std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
     TTNNLayoutAttr outputLayout) {
@@ -4487,7 +4390,7 @@ llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
         /*compute_kernel_config=*/std::nullopt, /*mesh_coords=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(cacheLayout.getContext(),
                                      pagedUpdateCacheOpQuery);
 #else
   return llvm::createStringError("Not Implemented");
@@ -4543,10 +4446,9 @@ llvm::Expected<size_t> OpModel<PagedUpdateCacheOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> cacheShape,
-    TTNNLayoutAttr cacheLayout, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> pageTableShape,
-    TTNNLayoutAttr pageTableLayout,
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
     std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
     std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -4579,7 +4481,7 @@ llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
         /*compute_kernel_config=*/std::nullopt, /*mesh_coords=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(cacheLayout.getContext(),
                                      pagedFillCacheOpQuery);
 #else
   return llvm::createStringError("Not Implemented");
@@ -4632,9 +4534,8 @@ llvm::Expected<size_t> OpModel<PagedFillCacheOp>::getOpRuntime(
 // Conv2dOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-    TTNNLayoutAttr weightLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
     uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
@@ -4709,8 +4610,7 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
         /*return_weights_and_bias=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     conv2dOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), conv2dOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4908,9 +4808,8 @@ llvm::Expected<Conv3dSpecs> prepareConv3dSpecs(
 #endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-    TTNNLayoutAttr weightLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
     uint32_t out_channels, uint32_t batch_size, uint32_t input_depth,
@@ -4947,8 +4846,7 @@ llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
         specs.deviceComputeKernelConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     conv3dOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), conv3dOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5003,9 +4901,8 @@ llvm::Expected<size_t> OpModel<Conv3dOp>::getOpRuntime(
 // ConvTranspose2dOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-    TTNNLayoutAttr weightLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
     uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
@@ -5077,7 +4974,7 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
         /*return_weights_and_bias=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      convTranspose2dOpQuery);
 #else
   return OpConstraints{};
@@ -5170,14 +5067,14 @@ llvm::Expected<size_t> OpModel<ConvTranspose2dOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, TTNNLayoutAttr weightLayout,
-    llvm::ArrayRef<int64_t> weightShape, MemoryConfigAttr inputMemConfig,
-    ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
-    int32_t inChannels, int32_t outChannels, int32_t batchSize,
-    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
-    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    bool hasBias, int32_t groups, ttcore::DataType inputDtype,
+    std::optional<ttcore::DataType> outputDtype,
     std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
@@ -5218,7 +5115,7 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
         sliceConfigConverted);
   };
 
-  return operation::getOpConstraints(weightLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(weightLayout.getContext(),
                                      prepareConv2dWeightsQuery);
 #else
   return OpConstraints{};
@@ -5230,11 +5127,10 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, TTNNLayoutAttr biasLayout,
-    llvm::ArrayRef<int64_t> biasShape, MemoryConfigAttr inputMemConfig,
-    ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
-    int32_t outChannels, int32_t batchSize, int32_t inputHeight,
-    int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
     llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
     llvm::ArrayRef<int32_t> dilation, int32_t groups,
     ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
@@ -5276,7 +5172,7 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
         sliceConfig);
   };
 
-  return operation::getOpConstraints(biasLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(biasLayout.getContext(),
                                      prepareConv2dWeightsQuery);
 #else
   return OpConstraints{};
@@ -5289,14 +5185,14 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
 
 llvm::Expected<OpConstraints>
 OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, TTNNLayoutAttr weightLayout,
-    llvm::ArrayRef<int64_t> weightShape, MemoryConfigAttr inputMemConfig,
-    ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
-    int32_t inChannels, int32_t outChannels, int32_t batchSize,
-    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
-    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    bool hasBias, int32_t groups, ttcore::DataType inputDtype,
+    std::optional<ttcore::DataType> outputDtype,
     std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
@@ -5335,7 +5231,7 @@ OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
         conversion::getConv2dSliceConfig(conv2dSliceConfig), mirrorKernel);
   };
 
-  return operation::getOpConstraints(weightLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(weightLayout.getContext(),
                                      prepareConvTranspose2dWeightsQuery);
 #else
   return OpConstraints{};
@@ -5348,11 +5244,10 @@ OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
 
 llvm::Expected<OpConstraints>
 OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, TTNNLayoutAttr biasLayout,
-    llvm::ArrayRef<int64_t> biasShape, MemoryConfigAttr inputMemConfig,
-    ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
-    int32_t outChannels, int32_t batchSize, int32_t inputHeight,
-    int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
     llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
     llvm::ArrayRef<int32_t> dilation, int32_t groups,
     ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
@@ -5394,7 +5289,7 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
         conversion::getConv2dSliceConfig(conv2dSliceConfig));
   };
 
-  return operation::getOpConstraints(biasLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(biasLayout.getContext(),
                                      prepareConvTranspose2dBiasQuery);
 #else
   return OpConstraints{};
@@ -5405,12 +5300,11 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
 // MaxPool2D
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, int32_t batchSize, int32_t inputHeight,
-    int32_t inputWidth, int32_t inputChannels,
-    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-    bool ceilMode, bool reallocateHaloOutput,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
     std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -5446,8 +5340,7 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
         configTensorsInDram.value_or(false) /* config_tensors_in_dram */);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     maxPool2DQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), maxPool2DQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5503,14 +5396,13 @@ llvm::Expected<size_t> OpModel<MaxPool2dOp>::getOpRuntime(
 // MaxPool2DWithIndices
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, int32_t batchSize, int32_t inputHeight,
-    int32_t inputWidth, int32_t inputChannels,
-    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-    bool ceilMode, bool reallocateHaloOutput, bool deallocateInput,
-    bool returnIndices, std::optional<bool> configTensorsInDram,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
+    bool deallocateInput, bool returnIndices,
+    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -5545,7 +5437,7 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
         ::ttnn::Layout::ROW_MAJOR, configTensorsInDram.value_or(false));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      maxPool2DWithIndicesQuery);
 #else
   return OpConstraints{};
@@ -5603,12 +5495,11 @@ llvm::Expected<size_t> OpModel<MaxPool2dWithIndicesOp>::getOpRuntime(
 // AvgPool2D
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, int32_t batchSize, int32_t inputHeight,
-    int32_t inputWidth, int32_t inputChannels,
-    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-    bool ceilMode, bool reallocateHaloOutput,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
     std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -5650,8 +5541,7 @@ llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
         configTensorsInDram.value_or(false) /* config_tensors_in_dram */);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     avgPool2DQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), avgPool2DQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5713,8 +5603,8 @@ llvm::Expected<size_t> OpModel<AvgPool2dOp>::getOpRuntime(
 // GlobalAvgPool2dOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, std::optional<mlir::tt::ttcore::DataType> dtype,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<mlir::tt::ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -5760,7 +5650,7 @@ llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
         outputDType, outputPageLayout, false /* config_tensors_in_dram */);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      globalAvgPool2DQuery);
 #else
   return OpConstraints{};
@@ -5825,8 +5715,7 @@ llvm::Expected<size_t> OpModel<GlobalAvgPool2dOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
     std::optional<TTNNLayoutAttr> runningMeanLayout,
     std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
@@ -5872,8 +5761,7 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
         computeKernelConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     batchNormQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), batchNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5938,8 +5826,7 @@ llvm::Expected<size_t> OpModel<BatchNormInferenceOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
     std::optional<TTNNLayoutAttr> runningMeanLayout,
     std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
@@ -5984,8 +5871,7 @@ llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
         detail::getNullableMemoryConfig(outputLayout), computeKernelConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     batchNormQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), batchNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6049,8 +5935,7 @@ llvm::Expected<size_t> OpModel<BatchNormTrainingOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> weightShape,
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
@@ -6086,8 +5971,7 @@ llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
         /*program_config=*/std::nullopt, computeKernelConfigConverted);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     rmsNormQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), rmsNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6141,8 +6025,7 @@ llvm::Expected<size_t> OpModel<RMSNormOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
     std::optional<TTNNLayoutAttr> residualInputLayout,
     std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
@@ -6175,8 +6058,7 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
         /*use_2d_core_grid=*/use2DCoreGrid);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 
 #else
   return OpConstraints{};
@@ -6227,8 +6109,7 @@ llvm::Expected<size_t> OpModel<RMSNormPreAllGatherOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> weightShape,
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
@@ -6258,8 +6139,7 @@ llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
         /*compute_kernel_config=*/std::nullopt, /*recip_tensor=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     layerNormQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), layerNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6309,8 +6189,7 @@ llvm::Expected<size_t> OpModel<LayerNormOp>::getOpRuntime(
 
 llvm::Expected<OpConstraints>
 OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
     std::optional<TTNNLayoutAttr> residualInputLayout,
     std::optional<llvm::ArrayRef<int64_t>> recipShape,
@@ -6346,8 +6225,7 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
         /*recip_tensor=*/recipSpec);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6402,9 +6280,8 @@ llvm::Expected<size_t> OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
 
 llvm::Expected<OpConstraints>
 OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> statsShape,
-    TTNNLayoutAttr statsLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
     std::optional<llvm::ArrayRef<int64_t>> weightShape,
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
@@ -6437,8 +6314,7 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
                                 /*dtype=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     query);
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6490,8 +6366,7 @@ llvm::Expected<size_t> OpModel<LayerNormPostAllGatherOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
     std::optional<TTNNLayoutAttr> inputMaskLayout,
     std::optional<llvm::ArrayRef<int64_t>> weightShape,
@@ -6534,8 +6409,7 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
                                 /*use_welford=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     groupNormQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), groupNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6609,9 +6483,8 @@ clampAttrToVariant(mlir::Attribute attr) {
 #endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, mlir::Attribute min, mlir::Attribute max,
-    TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute min, mlir::Attribute max, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6630,7 +6503,7 @@ llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
                                 maxVariant, memConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      clampScalarQuery);
 #else
   return OpConstraints{};
@@ -6668,10 +6541,10 @@ llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
 // ClampTensor
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> minShape,
-    TTNNLayoutAttr minLayout, llvm::ArrayRef<int64_t> maxShape,
-    TTNNLayoutAttr maxLayout, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
+    llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
+    TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6694,7 +6567,7 @@ llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      clampTensorQuery);
 #else
   return OpConstraints{};
@@ -6737,9 +6610,9 @@ llvm::Expected<size_t> OpModel<ClampTensorOp>::getOpRuntime(
 // Permute
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> permutation,
-    llvm::APFloat padValue, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6761,8 +6634,7 @@ llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
                                 defaultedPadValue);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     permuteQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), permuteQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6804,9 +6676,9 @@ llvm::Expected<size_t> OpModel<PermuteOp>::getOpRuntime(
 // Upsample
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
-    llvm::StringRef mode, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute scaleFactor, llvm::StringRef mode,
+    TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6841,8 +6713,7 @@ llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
                                 /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     upsampleQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), upsampleQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6919,9 +6790,9 @@ llvm::Expected<EmbeddingOpArgs> getEmbeddingOpArgs(
 #endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-    TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6954,7 +6825,7 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraints(
         detail::getNullableMemoryConfig(outputLayout), std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      embeddingOpQuery);
 #else
   return OpConstraints{};
@@ -7008,10 +6879,10 @@ llvm::Expected<size_t> OpModel<EmbeddingOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
-    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> inGradientShape,
-    TTNNLayoutAttr inGradientLayout, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7035,7 +6906,7 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
         /*optional_output_tensor*/ std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      embeddingBackwardOpQuery);
 #else
   return OpConstraints{};
@@ -7082,9 +6953,9 @@ OpModel<mlir::tt::ttnn::EmbeddingBackwardOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> indexShape,
-    TTNNLayoutAttr indexLayout, int32_t dim, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout, int32_t dim,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7104,8 +6975,7 @@ llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
         /*sub_core_grids=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     gatherOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), gatherOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7145,8 +7015,8 @@ llvm::Expected<size_t> OpModel<GatherOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
 OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttcore::DataTypeAttr dtype, mlir::tt::ttnn::Layout inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, mlir::tt::ttcore::DataTypeAttr dtype,
+    mlir::tt::ttnn::Layout inputLayout,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7165,8 +7035,7 @@ OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints(
         conversion::getPageLayout(inputLayout), device, memConfig);
   };
 
-  return operation::getOpConstraints(dtype.getContext(), deviceGrid,
-                                     emptyOpQuery);
+  return operation::getOpConstraints(dtype.getContext(), emptyOpQuery);
 #else
   return OpConstraints{};
 #endif //
@@ -7182,9 +7051,8 @@ OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints(
 //      mlir idiomatic than static_cast<int64_t>(start).
 llvm::Expected<OpConstraints>
 OpModel<mlir::tt::ttnn::ArangeOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, ::mlir::IntegerAttr start,
-    ::mlir::IntegerAttr end, ::mlir::IntegerAttr step,
-    std::optional<mlir::tt::ttcore::DataType> dtype,
+    ::mlir::IntegerAttr start, ::mlir::IntegerAttr end,
+    ::mlir::IntegerAttr step, std::optional<mlir::tt::ttcore::DataType> dtype,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7220,8 +7088,7 @@ OpModel<mlir::tt::ttnn::ArangeOp>::getOpConstraints(
                                 deviceRef, memoryConfig, layout);
   };
 
-  return operation::getOpConstraints(start.getContext(), deviceGrid,
-                                     arangeOpQuery);
+  return operation::getOpConstraints(start.getContext(), arangeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7232,8 +7099,8 @@ OpModel<mlir::tt::ttnn::ArangeOp>::getOpConstraints(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::FullOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, mlir::tt::ttnn::ShapeAttr shape,
-    mlir::Attribute fillValue, std::optional<mlir::tt::ttcore::DataType> dtype,
+    mlir::tt::ttnn::ShapeAttr shape, mlir::Attribute fillValue,
+    std::optional<mlir::tt::ttcore::DataType> dtype,
     std::optional<mlir::tt::ttnn::Layout> layout,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -7274,14 +7141,12 @@ llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::FullOp>::getOpConstraints(
   if (auto value = mlir::dyn_cast<mlir::IntegerAttr>(fillValue)) {
     int convertedFillValue = static_cast<int>(value.getInt());
     auto query = createFullOpQuery(convertedFillValue);
-    return operation::getOpConstraints(fillValue.getContext(), deviceGrid,
-                                       query);
+    return operation::getOpConstraints(fillValue.getContext(), query);
   }
   if (auto value = mlir::dyn_cast<mlir::FloatAttr>(fillValue)) {
     float convertedFillValue = value.getValue().convertToFloat();
     auto query = createFullOpQuery(convertedFillValue);
-    return operation::getOpConstraints(fillValue.getContext(), deviceGrid,
-                                       query);
+    return operation::getOpConstraints(fillValue.getContext(), query);
   }
   return llvm::createStringError("Invalid fillValue");
 #else
@@ -7294,10 +7159,9 @@ llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::FullOp>::getOpConstraints(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::RandOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, mlir::tt::ttnn::ShapeAttr size,
-    mlir::tt::ttcore::DataType dtype, mlir::tt::ttnn::Layout layout,
-    llvm::APFloat low, llvm::APFloat high, uint32_t seed,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    mlir::tt::ttnn::ShapeAttr size, mlir::tt::ttcore::DataType dtype,
+    mlir::tt::ttnn::Layout layout, llvm::APFloat low, llvm::APFloat high,
+    uint32_t seed, mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7316,8 +7180,7 @@ llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::RandOp>::getOpConstraints(
         high.convertToFloat(), seed);
   };
 
-  return operation::getOpConstraints(size.getContext(), deviceGrid,
-                                     randOpQuery);
+  return operation::getOpConstraints(size.getContext(), randOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7329,9 +7192,9 @@ llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::RandOp>::getOpConstraints(
 
 llvm::Expected<OpConstraints>
 OpModel<mlir::tt::ttnn::DropoutOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::APFloat prob, llvm::APFloat scale,
-    uint32_t seed, bool usePerDeviceSeed, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::APFloat prob, llvm::APFloat scale, uint32_t seed,
+    bool usePerDeviceSeed, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7351,8 +7214,7 @@ OpModel<mlir::tt::ttnn::DropoutOp>::getOpConstraints(
         std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     dropoutOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), dropoutOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7472,8 +7334,7 @@ auto dispatchGetRawData(mlir::ElementsAttr value, Func &&func)
 #endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints>
-OpModel<ConstantOp>::getOpConstraints(ttcore::GridAttr deviceGrid,
-                                      mlir::ElementsAttr value,
+OpModel<ConstantOp>::getOpConstraints(mlir::ElementsAttr value,
                                       TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7490,8 +7351,7 @@ OpModel<ConstantOp>::getOpConstraints(ttcore::GridAttr deviceGrid,
           getDataType(value), device, metalLayout,
           detail::getNullableMemoryConfig(outputLayout));
     };
-    return operation::getOpConstraints(value.getContext(), deviceGrid,
-                                       constantOpQuery);
+    return operation::getOpConstraints(value.getContext(), constantOpQuery);
   };
   return dispatchGetRawData(value, func);
 #else
@@ -7505,8 +7365,7 @@ OpModel<ConstantOp>::getOpConstraints(ttcore::GridAttr deviceGrid,
 
 llvm::Expected<OpConstraints>
 OpModel<mlir::tt::ttnn::AssignOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<mlir::tt::ttcore::DataType> outputDtype) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7532,8 +7391,7 @@ OpModel<mlir::tt::ttnn::AssignOp>::getOpConstraints(
                                 std::nullopt /*optionalOutputTensor*/);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     assignOpQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), assignOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7578,9 +7436,8 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, int32_t k, int32_t dim, bool largest,
-    bool sorted, TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t k,
+    int32_t dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7599,8 +7456,7 @@ llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
                                 std::nullopt, std::nullopt, std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     topKQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), topKQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7638,8 +7494,8 @@ llvm::Expected<size_t> OpModel<TopKOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputValuesShape,
-    TTNNLayoutAttr inputValuesLayout, llvm::ArrayRef<int64_t> inputIndicesShape,
+    llvm::ArrayRef<int64_t> inputValuesShape, TTNNLayoutAttr inputValuesLayout,
+    llvm::ArrayRef<int64_t> inputIndicesShape,
     TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
     TTNNLayoutAttr kLayout, llvm::ArrayRef<int64_t> pShape,
     TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
@@ -7677,7 +7533,7 @@ llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
                                 std::nullopt, std::nullopt);
   };
 
-  return operation::getOpConstraints(inputValuesLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputValuesLayout.getContext(),
                                      samplingQuery);
 #else
   return OpConstraints{};
@@ -7732,8 +7588,7 @@ llvm::Expected<size_t> OpModel<SamplingOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, int32_t dim,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t dim,
     std::optional<uint32_t> clusterAxis, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7751,7 +7606,7 @@ llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
                                 detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(),
                                      meshPartitionOpQuery);
 #else
   return OpConstraints{};

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -82,8 +82,8 @@ protected:
     const TTNNLayoutAttr outputLayout = CreateTiledLayout(
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
-    auto constraintsExp = OpModel<OpTy>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputLayout, outputLayout);
+    auto constraintsExp =
+        OpModel<OpTy>::getOpConstraints(inputShape, inputLayout, outputLayout);
     // Manually cast to bool because EXPECT_TRUE requires a const bool operator
     // which llvm::Expected<T> does not have
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -124,8 +124,8 @@ protected:
     const TTNNLayoutAttr outputLayout = CreateTiledLayoutInt32(
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
-    auto constraintsExp = OpModel<OpTy>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputLayout, outputLayout);
+    auto constraintsExp =
+        OpModel<OpTy>::getOpConstraints(inputShape, inputLayout, outputLayout);
     // Manually cast to bool because EXPECT_TRUE requires a const bool operator
     // which llvm::Expected<T> does not have
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -384,8 +384,7 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<OpTy>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputLayout, dimArg, keepDim,
-        outputLayout);
+        inputShape, inputLayout, dimArg, keepDim, outputLayout);
     // Manually cast to bool because EXPECT_TRUE requires a const bool operator
     // which llvm::Expected<T> does not have
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -455,20 +454,14 @@ INSTANTIATE_TEST_SUITE_P(MinTests, OpModelMinParam, reductionParams);
 
 TEST_F(OpModelTest, ArgMax) {
   const llvm::SmallVector<int64_t> tensorShape = {64, 64};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-
   // ArgMax requires ROW_MAJOR layout for both input and output
   // Note: L1 + ROW_MAJOR doesn't work (see tt-mlir issue #2976), so we use DRAM
   const TTNNLayoutAttr layoutDRAMRowMajor = CreateRowMajorLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   // Test case 1: no keepDim
   auto constraintsExp = OpModel<ArgMaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAMRowMajor, 1, false, false,
-      layoutDRAMRowMajor);
+      tensorShape, layoutDRAMRowMajor, 1, false, false, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -482,8 +475,7 @@ TEST_F(OpModelTest, ArgMax) {
 
   // Test case 2: with keepDim
   constraintsExp = OpModel<ArgMaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAMRowMajor, 1, true, false,
-      layoutDRAMRowMajor);
+      tensorShape, layoutDRAMRowMajor, 1, true, false, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -501,8 +493,7 @@ TEST_F(OpModelTest, ArgMax) {
       tensorShape2, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
   constraintsExp = OpModel<ArgMaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape2, layoutDRAMRowMajor2, 1, false, false,
-      layoutDRAMRowMajor2);
+      tensorShape2, layoutDRAMRowMajor2, 1, false, false, layoutDRAMRowMajor2);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -518,7 +509,6 @@ TEST_F(OpModelTest, ArgMax) {
 TEST_F(OpModelTest, Prod) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300,
                                                   workerCoresN300};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
@@ -526,11 +516,8 @@ TEST_F(OpModelTest, Prod) {
   const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = op_model::OpModel<ProdOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, false, layoutDRAM);
+      tensorShape, layoutDRAM, 0, false, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -538,8 +525,7 @@ TEST_F(OpModelTest, Prod) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = op_model::OpModel<ProdOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, false,
-      layoutL1Interleaved);
+      tensorShape, layoutDRAM, 0, false, layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -547,26 +533,20 @@ TEST_F(OpModelTest, Prod) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = op_model::OpModel<ProdOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, 0, false,
-      layoutL1WSharded);
+      tensorShape, layoutL1Interleaved, 0, false, layoutL1WSharded);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 }
 
 TEST_F(OpModelTest, SoftmaxInterleaved) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr inputLayout_dram = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr inputLayout_l1 = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayout_dram, -1, false,
-      inputLayout_dram);
+      tensorShape, inputLayout_dram, -1, false, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
       constraintsExp.get();
@@ -575,8 +555,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   EXPECT_EQ(l1PeakSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayout_dram, -1, false,
-      inputLayout_l1);
+      tensorShape, inputLayout_dram, -1, false, inputLayout_l1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -584,8 +563,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayout_l1, -1, false,
-      inputLayout_dram);
+      tensorShape, inputLayout_l1, -1, false, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -593,8 +571,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayout_l1, -1, false,
-      inputLayout_l1);
+      tensorShape, inputLayout_l1, -1, false, inputLayout_l1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -602,8 +579,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayout_dram, -1, false,
-      inputLayout_dram);
+      tensorShape, inputLayout_dram, -1, false, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -629,8 +605,7 @@ TEST_F(OpModelTest, SoftmaxNumericStable) {
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
   auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayout_dram, -1, true,
-      inputLayout_dram);
+      tensorShape, inputLayout_dram, -1, true, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   auto runtimeExp = OpModel<SoftmaxOp>::getOpRuntime(
@@ -646,7 +621,6 @@ TEST_F(OpModelTest, Scatter) {
   const ttcore::ReduceTypeAttr reduceTypeAttr =
       ttcore::ReduceTypeAttr::get(&context, ttcore::ReduceType::Invalid);
 
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr inputLayoutDRAM = CreateTiledLayout(
       inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr inputLayoutL1 = CreateTiledLayout(
@@ -660,14 +634,10 @@ TEST_F(OpModelTest, Scatter) {
   const TTNNLayoutAttr sourceLayoutL1 = CreateTiledLayout(
       indexSourceShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   // DRAM layouts
   auto constraintsExp = OpModel<ScatterOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayoutDRAM, indexSourceShape,
-      indexLayoutDRAM, indexSourceShape, sourceLayoutDRAM, dim, reduceTypeAttr,
-      inputLayoutDRAM);
+      inputShape, inputLayoutDRAM, indexSourceShape, indexLayoutDRAM,
+      indexSourceShape, sourceLayoutDRAM, dim, reduceTypeAttr, inputLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -683,9 +653,8 @@ TEST_F(OpModelTest, Scatter) {
 
   // L1 layouts
   constraintsExp = OpModel<ScatterOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayoutL1, indexSourceShape,
-      indexLayoutL1, indexSourceShape, sourceLayoutL1, dim, reduceTypeAttr,
-      inputLayoutL1);
+      inputShape, inputLayoutL1, indexSourceShape, indexLayoutL1,
+      indexSourceShape, sourceLayoutL1, dim, reduceTypeAttr, inputLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -702,17 +671,12 @@ TEST_F(OpModelTest, Scatter) {
 
 TEST_F(OpModelTest, Reshape) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1 = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<ReshapeOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, {workerCoresN300 * 4, 256},
-      layoutDRAM);
+      tensorShape, layoutDRAM, {workerCoresN300 * 4, 256}, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -725,8 +689,7 @@ TEST_F(OpModelTest, Reshape) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = OpModel<ReshapeOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, {workerCoresN300 * 4, 256},
-      layoutL1);
+      tensorShape, layoutDRAM, {workerCoresN300 * 4, 256}, layoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -742,19 +705,14 @@ TEST_F(OpModelTest, Reshape) {
 TEST_F(OpModelTest, Slice) {
   const llvm::SmallVector<int64_t> inputTensorShape = {1, 56, 56, 96};
   const llvm::SmallVector<int64_t> outputTensorShape = {1, 28, 56, 95};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       inputTensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   llvm::SmallVector<int64_t> begins = {0, 0, 0, 0};
   llvm::SmallVector<int64_t> ends = {1, 56, 56, 95};
   llvm::SmallVector<int64_t> step = {1, 2, 1, 1};
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<SliceStaticOp>::getOpConstraints(
-      CreateWorkerGrid(), inputTensorShape, layoutDRAM, begins, ends, step,
-      layoutDRAM);
+      inputTensorShape, layoutDRAM, begins, ends, step, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -771,7 +729,6 @@ TEST_F(OpModelTest, SliceDynamic) {
   const llvm::SmallVector<int64_t> inputTensorShape = {4, 32, 32};
   const llvm::SmallVector<int64_t> beginsShape = {3};
   const llvm::SmallVector<int64_t> endsShape = {3};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr inputLayoutDRAM = CreateTiledLayout(
       inputTensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr beginsLayoutDRAM = CreateTiledLayout(
@@ -784,12 +741,9 @@ TEST_F(OpModelTest, SliceDynamic) {
   std::optional<llvm::SmallVector<int64_t>> step =
       llvm::SmallVector<int64_t>{1, 1, 1};
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<SliceDynamicOp>::getOpConstraints(
-      CreateWorkerGrid(), inputTensorShape, inputLayoutDRAM, beginsShape,
-      beginsLayoutDRAM, endsShape, endsLayoutDRAM, step, outputLayoutDRAM);
+      inputTensorShape, inputLayoutDRAM, beginsShape, beginsLayoutDRAM,
+      endsShape, endsLayoutDRAM, step, outputLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -805,19 +759,14 @@ TEST_F(OpModelTest, SliceDynamic) {
 
 TEST_F(OpModelTest, ToLayout) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAMTiled = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutDRAMRowMajor = CreateRowMajorLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1RowMajorHS = CreateRowMajorLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::HeightSharded);
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<ToLayoutOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
-      layoutDRAMRowMajor);
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -831,8 +780,7 @@ TEST_F(OpModelTest, ToLayout) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = OpModel<ToLayoutOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
-      layoutL1RowMajorHS);
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutL1RowMajorHS);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 
@@ -842,8 +790,7 @@ TEST_F(OpModelTest, ToLayout) {
   llvm::consumeError(runtimeExp.takeError());
 
   constraintsExp = OpModel<ToLayoutOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
-      layoutDRAMRowMajor);
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -859,17 +806,12 @@ TEST_F(OpModelTest, ToLayout) {
 
 TEST_F(OpModelTest, ToMemoryConfig) {
   const llvm::SmallVector<int64_t> tensorShape = {1, 8, 64, 128};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   const TTNNLayoutAttr inputLayoutL1Tiled = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr outputLayoutDRAMTiled = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   auto constraintsExp = OpModel<ToMemoryConfigOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayoutL1Tiled,
-      outputLayoutDRAMTiled);
+      tensorShape, inputLayoutL1Tiled, outputLayoutDRAMTiled);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -884,7 +826,7 @@ TEST_F(OpModelTest, ToMemoryConfig) {
   const TTNNLayoutAttr outputLayoutL1Tiled = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::HeightSharded);
   constraintsExp = OpModel<ToMemoryConfigOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayoutL1Tiled, outputLayoutL1Tiled);
+      tensorShape, inputLayoutL1Tiled, outputLayoutL1Tiled);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -905,7 +847,7 @@ TEST_F(OpModelTest, Concat) {
       inputTensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
   auto constraintsExp = OpModel<ConcatOp>::getOpConstraints(
-      CreateWorkerGrid(), {inputTensorShape, inputTensorShape},
+      {inputTensorShape, inputTensorShape},
       {layoutL1Interleaved, layoutL1Interleaved}, 0, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
@@ -922,7 +864,6 @@ TEST_F(OpModelTest, Concat) {
 
 TEST_F(OpModelTest, Transpose) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
@@ -930,11 +871,8 @@ TEST_F(OpModelTest, Transpose) {
   const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<TransposeOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, 1, layoutDRAM);
+      tensorShape, layoutDRAM, 0, 1, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -947,7 +885,7 @@ TEST_F(OpModelTest, Transpose) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = OpModel<TransposeOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, 1, layoutL1Interleaved);
+      tensorShape, layoutDRAM, 0, 1, layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -960,8 +898,7 @@ TEST_F(OpModelTest, Transpose) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = OpModel<TransposeOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, 0, 1,
-      layoutL1WSharded);
+      tensorShape, layoutL1Interleaved, 0, 1, layoutL1WSharded);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 
@@ -973,7 +910,6 @@ TEST_F(OpModelTest, Transpose) {
 
 TEST_F(OpModelTest, CumSum) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
@@ -981,11 +917,8 @@ TEST_F(OpModelTest, CumSum) {
   const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = op_model::OpModel<CumSumOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, std::nullopt, layoutDRAM);
+      tensorShape, layoutDRAM, 0, std::nullopt, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -998,8 +931,7 @@ TEST_F(OpModelTest, CumSum) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<CumSumOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, std::nullopt,
-      layoutL1Interleaved);
+      tensorShape, layoutDRAM, 0, std::nullopt, layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1012,8 +944,7 @@ TEST_F(OpModelTest, CumSum) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<CumSumOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, 0, std::nullopt,
-      layoutL1WSharded);
+      tensorShape, layoutL1Interleaved, 0, std::nullopt, layoutL1WSharded);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 
@@ -1046,7 +977,7 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<ConcatenateHeadsOp>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputLayout, outputLayout);
+        inputShape, inputLayout, outputLayout);
 
     // Check if the operation is expected to be legal
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -1126,7 +1057,6 @@ TEST_F(OpModelTest, NLPConcatHeadsDecodeOp) {
   const llvm::SmallVector<int64_t> virtualGridWidthSharded = {
       1, batchSizeUnpadded};
 
-  ttcore::GridAttr workerGrid = CreateWorkerGrid(gridShapeHwN300);
   TTNNLayoutAttr inputLayout = CreateTiledLayout(
       inputShape, BufferType::L1, TensorMemoryLayout::HeightSharded,
       virtualGridHeightSharded);
@@ -1134,13 +1064,9 @@ TEST_F(OpModelTest, NLPConcatHeadsDecodeOp) {
       outputShape, BufferType::L1, TensorMemoryLayout::WidthSharded,
       virtualGridWidthSharded);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp =
       op_model::OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, numHeadsUnpadded,
-          outputLayout);
+          inputShape, inputLayout, numHeadsUnpadded, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 0);
@@ -1185,7 +1111,7 @@ protected:
 
     auto constraintsExp =
         OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
-            CreateWorkerGrid(), inputShape, inputLayout,
+            inputShape, inputLayout,
             std::nullopt, // inputKVShape
             std::nullopt, // inputKVLayout
             numHeads,
@@ -1306,7 +1232,6 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(OpModelTest, RepeatInterleave) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
@@ -1314,11 +1239,8 @@ TEST_F(OpModelTest, RepeatInterleave) {
   const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = op_model::OpModel<RepeatInterleaveOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 2, 0, layoutDRAM);
+      tensorShape, layoutDRAM, 2, 0, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1331,7 +1253,7 @@ TEST_F(OpModelTest, RepeatInterleave) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<RepeatInterleaveOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 2, 0, layoutL1Interleaved);
+      tensorShape, layoutDRAM, 2, 0, layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1344,8 +1266,7 @@ TEST_F(OpModelTest, RepeatInterleave) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<RepeatInterleaveOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, 2, 0,
-      layoutL1WSharded);
+      tensorShape, layoutL1Interleaved, 2, 0, layoutL1WSharded);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1360,14 +1281,10 @@ TEST_F(OpModelTest, RepeatInterleave) {
 
 TEST_F(OpModelTest, Repeat) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
-
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
 
   std::vector<int64_t> repeatDimsVec = {2, 1};
   llvm::ArrayRef<int64_t> repeatDims(repeatDimsVec);
@@ -1378,7 +1295,7 @@ TEST_F(OpModelTest, Repeat) {
       outputShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
 
   auto constraintsExp = op_model::OpModel<RepeatOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, repeatDims, layoutDRAM);
+      tensorShape, layoutDRAM, repeatDims, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1391,8 +1308,7 @@ TEST_F(OpModelTest, Repeat) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<RepeatOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, repeatDims,
-      layoutL1Interleaved);
+      tensorShape, layoutDRAM, repeatDims, layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1406,8 +1322,7 @@ TEST_F(OpModelTest, Repeat) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<RepeatOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, repeatDims,
-      outputLayoutL1WSharded);
+      tensorShape, layoutL1Interleaved, repeatDims, outputLayoutL1WSharded);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1422,7 +1337,6 @@ TEST_F(OpModelTest, Repeat) {
 
 TEST_F(OpModelTest, Pad) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
@@ -1430,16 +1344,12 @@ TEST_F(OpModelTest, Pad) {
   const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   std::vector<int32_t> paddingVec = {0, 2, 0, 2};
   llvm::ArrayRef<int32_t> padding(paddingVec);
   llvm::APFloat padValue = llvm::APFloat(1.0f);
 
   auto constraintsExp = op_model::OpModel<PadOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, padding, padValue, false,
-      layoutDRAM);
+      tensorShape, layoutDRAM, padding, padValue, false, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1452,8 +1362,7 @@ TEST_F(OpModelTest, Pad) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<PadOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, padding, padValue, false,
-      layoutL1Interleaved);
+      tensorShape, layoutDRAM, padding, padValue, false, layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1466,8 +1375,8 @@ TEST_F(OpModelTest, Pad) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<PadOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, padding, padValue,
-      false, layoutL1WSharded);
+      tensorShape, layoutL1Interleaved, padding, padValue, false,
+      layoutL1WSharded);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 
@@ -1481,7 +1390,6 @@ TEST_F(OpModelTest, Pad) {
 TEST_F(OpModelTest, Sort) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300,
                                                   workerCoresN300};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
@@ -1489,11 +1397,8 @@ TEST_F(OpModelTest, Sort) {
   const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = op_model::OpModel<SortOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, false, false, layoutDRAM);
+      tensorShape, layoutDRAM, 0, false, false, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1508,8 +1413,7 @@ TEST_F(OpModelTest, Sort) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<SortOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, false, false,
-      layoutL1Interleaved);
+      tensorShape, layoutDRAM, 0, false, false, layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1524,8 +1428,7 @@ TEST_F(OpModelTest, Sort) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = op_model::OpModel<SortOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, 0, false, false,
-      layoutL1WSharded);
+      tensorShape, layoutL1Interleaved, 0, false, false, layoutL1WSharded);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 
@@ -1538,7 +1441,6 @@ TEST_F(OpModelTest, Sort) {
 TEST_F(OpModelTest, TopK) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300,
                                                   workerCoresN300};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
@@ -1546,12 +1448,8 @@ TEST_F(OpModelTest, TopK) {
   const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = op_model::OpModel<TopKOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 4, -1, true, true,
-      layoutDRAM);
+      tensorShape, layoutDRAM, 4, -1, true, true, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1559,8 +1457,7 @@ TEST_F(OpModelTest, TopK) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = op_model::OpModel<TopKOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutDRAM, 4, -1, true, true,
-      layoutL1Interleaved);
+      tensorShape, layoutDRAM, 4, -1, true, true, layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1568,8 +1465,7 @@ TEST_F(OpModelTest, TopK) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = op_model::OpModel<TopKOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, 4, -1, true, true,
-      layoutL1WSharded);
+      tensorShape, layoutL1Interleaved, 4, -1, true, true, layoutL1WSharded);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 }
@@ -1584,8 +1480,6 @@ TEST_F(OpModelTest, TopKRouterGpt) {
   const uint32_t k = 4;
   const uint32_t numExperts = 128;
 
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-
   const TTNNLayoutAttr inputLayoutDRAM = CreateTiledLayout(
       inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr weightLayoutDRAM = CreateTiledLayout(
@@ -1595,14 +1489,10 @@ TEST_F(OpModelTest, TopKRouterGpt) {
   const TTNNLayoutAttr outputLayoutDRAM = CreateTiledLayout(
       inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   // DRAM layouts
   auto constraintsExp = op_model::OpModel<TopKRouterGptOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayoutDRAM, weightShape,
-      weightLayoutDRAM, biasShape, biasLayoutDRAM, k, numExperts,
-      outputLayoutDRAM);
+      inputShape, inputLayoutDRAM, weightShape, weightLayoutDRAM, biasShape,
+      biasLayoutDRAM, k, numExperts, outputLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   if (constraintsExp) {
     OpConstraints &opCstr = constraintsExp.get();
@@ -1626,16 +1516,12 @@ TEST_F(OpModelTest, TopKRouterGpt) {
 
 TEST_F(OpModelTest, MaxPool2dWithIndices) {
   const llvm::SmallVector<int64_t> inputShape = {1, 1, 128 * 128, 32};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
       inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
       inputShape, BufferType::L1, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
       inputShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
-
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
 
   // MaxPool2dWithIndices parameters
   int32_t batchSize = 1;
@@ -1657,10 +1543,10 @@ TEST_F(OpModelTest, MaxPool2dWithIndices) {
 
   auto constraintsExp =
       op_model::OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, layoutDRAM, batchSize, inputHeight,
-          inputWidth, inputChannels, kernelSize, stride, padding, dilation,
-          ceilMode, reallocateHaloOutput, deallocateInput, returnIndices,
-          std::nullopt, layoutDRAM);
+          inputShape, layoutDRAM, batchSize, inputHeight, inputWidth,
+          inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+          reallocateHaloOutput, deallocateInput, returnIndices, std::nullopt,
+          layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1669,10 +1555,9 @@ TEST_F(OpModelTest, MaxPool2dWithIndices) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = op_model::OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, layoutDRAM, batchSize, inputHeight,
-      inputWidth, inputChannels, kernelSize, stride, padding, dilation,
-      ceilMode, reallocateHaloOutput, deallocateInput, returnIndices,
-      std::nullopt, layoutDRAM);
+      inputShape, layoutDRAM, batchSize, inputHeight, inputWidth, inputChannels,
+      kernelSize, stride, padding, dilation, ceilMode, reallocateHaloOutput,
+      deallocateInput, returnIndices, std::nullopt, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1681,10 +1566,10 @@ TEST_F(OpModelTest, MaxPool2dWithIndices) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = op_model::OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, layoutL1Interleaved, batchSize,
-      inputHeight, inputWidth, inputChannels, kernelSize, stride, padding,
-      dilation, ceilMode, reallocateHaloOutput, deallocateInput, returnIndices,
-      std::nullopt, layoutL1WSharded);
+      inputShape, layoutL1Interleaved, batchSize, inputHeight, inputWidth,
+      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+      reallocateHaloOutput, deallocateInput, returnIndices, std::nullopt,
+      layoutL1WSharded);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 }
@@ -1692,18 +1577,13 @@ TEST_F(OpModelTest, MaxPool2dWithIndices) {
 TEST_F(OpModelTest, SoftmaxSharded) {
   const llvm::SmallVector<int64_t> tensorShape = {16 * workerCoresN300 * 32,
                                                   32};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr inputLayout_l1_hs = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::HeightSharded);
   const TTNNLayoutAttr inputLayout_l1_i = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayout_l1_hs, -2, false,
-      inputLayout_l1_hs);
+      tensorShape, inputLayout_l1_hs, -2, false, inputLayout_l1_hs);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1711,8 +1591,7 @@ TEST_F(OpModelTest, SoftmaxSharded) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayout_l1_hs, -2, false,
-      inputLayout_l1_i);
+      tensorShape, inputLayout_l1_hs, -2, false, inputLayout_l1_i);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1720,8 +1599,7 @@ TEST_F(OpModelTest, SoftmaxSharded) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayout_l1_i, -2, false,
-      inputLayout_l1_hs);
+      tensorShape, inputLayout_l1_i, -2, false, inputLayout_l1_hs);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1737,7 +1615,6 @@ TEST_F(OpModelTest, SoftmaxSharded) {
 TEST_F(OpModelTest, Typecast) {
   const llvm::SmallVector<int64_t> tensorShape = {16 * workerCoresN300 * 32,
                                                   32};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr inputLayoutDRAMIBF16 = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr inputLayoutL1HSBF16 = CreateTiledLayout(
@@ -1745,11 +1622,8 @@ TEST_F(OpModelTest, Typecast) {
   const TTNNLayoutAttr inputLayoutDRAMIF32 = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
       std::nullopt, GetPhysicalGridSize(), builder.getF32Type());
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<TypecastOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayoutDRAMIBF16,
+      tensorShape, inputLayoutDRAMIBF16,
       ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
       inputLayoutDRAMIF32);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
@@ -1766,7 +1640,7 @@ TEST_F(OpModelTest, Typecast) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = OpModel<TypecastOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayoutDRAMIBF16,
+      tensorShape, inputLayoutDRAMIBF16,
       ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
       inputLayoutL1HSBF16);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
@@ -1782,7 +1656,6 @@ TEST_F(OpModelTest, Typecast) {
 TEST_F(OpModelTest, BitcastConvert) {
   const llvm::SmallVector<int64_t> tensorShape = {16 * workerCoresN300 * 32,
                                                   32};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr inputLayoutDRAMIF32 = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
       std::nullopt, GetPhysicalGridSize(), builder.getF32Type());
@@ -1791,11 +1664,8 @@ TEST_F(OpModelTest, BitcastConvert) {
       std::nullopt, GetPhysicalGridSize(), builder.getF32Type());
   const TTNNLayoutAttr outputLayoutDRAMIU32 = CreateTiledLayoutUInt32(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<BitcastConvertOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayoutDRAMIF32,
+      tensorShape, inputLayoutDRAMIF32,
       ttcore::DataTypeAttr::get(&context, ttcore::DataType::UInt32),
       outputLayoutDRAMIU32);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
@@ -1812,7 +1682,7 @@ TEST_F(OpModelTest, BitcastConvert) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = OpModel<BitcastConvertOp>::getOpConstraints(
-      CreateWorkerGrid(), tensorShape, inputLayoutDRAMIF32,
+      tensorShape, inputLayoutDRAMIF32,
       ttcore::DataTypeAttr::get(&context, ttcore::DataType::UInt32),
       inputLayoutL1HSF32);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
@@ -1854,8 +1724,7 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<OpTy>::getOpConstraints(
-        CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB,
-        inputLayoutB, outputLayout);
+        inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputLayout);
     // Manually cast to bool because EXPECT_TRUE requires a const bool operator
     // which llvm::Expected<T> does not have
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -1900,8 +1769,7 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<OpTy>::getOpConstraints(
-        CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB,
-        inputLayoutB, outputLayout);
+        inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputLayout);
     // Manually cast to bool because EXPECT_TRUE requires a const bool operator
     // which llvm::Expected<T> does not have
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -1959,8 +1827,8 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<GeluBackwardOp>::getOpConstraints(
-        CreateWorkerGrid(), gradShape, gradLayout, inputShape, inputLayout,
-        approximate, outputLayout);
+        gradShape, gradLayout, inputShape, inputLayout, approximate,
+        outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -2296,7 +2164,7 @@ TEST_P(OpModelPowScalarParam, PowScalarParam) {
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   auto constraintsExp = OpModel<PowScalarOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, exponent, outputLayout);
+      inputShape, inputLayout, exponent, outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -2379,8 +2247,8 @@ TEST_P(OpModelLinearParam, LinearParam) {
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   auto constraintsExp = OpModel<LinearOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
-      biasShape, biasLayout, outputLayout, false, false,
+      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, biasShape,
+      biasLayout, outputLayout, false, false,
       /*programConfig=*/std::nullopt);
 
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
@@ -2601,8 +2469,8 @@ TEST_P(OpModelMatmulParam, MatmulParam) {
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   auto constraintsExp = OpModel<MatmulOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
-      outputLayout, false, false, /*programConfig=*/std::nullopt);
+      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputLayout, false,
+      false, /*programConfig=*/std::nullopt);
 
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
@@ -2833,10 +2701,10 @@ TEST_P(OpModelConv2dParam, Conv2d) {
           /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
 
   auto constraintsExp = OpModel<Conv2dOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, weightShape, weightLayout,
-      std::nullopt, std::nullopt, in_channels, out_channels, batch_size,
-      input_height, input_width, kernel_size, stride, padding, dilation, groups,
-      std::nullopt, deviceConfig, std::nullopt, outputLayout);
+      inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
+      std::nullopt, in_channels, out_channels, batch_size, input_height,
+      input_width, kernel_size, stride, padding, dilation, groups, std::nullopt,
+      deviceConfig, std::nullopt, outputLayout);
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -2953,10 +2821,10 @@ TEST_P(OpModelConvTranspose2dParam, ConvTranspose2d) {
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   auto constraintsExp = OpModel<ConvTranspose2dOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, weightShape, weightLayout,
-      std::nullopt, std::nullopt, in_channels, out_channels, batch_size,
-      input_height, input_width, kernel_size, stride, padding, output_padding,
-      dilation, groups, std::nullopt, std::nullopt, outputLayout);
+      inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
+      std::nullopt, in_channels, out_channels, batch_size, input_height,
+      input_width, kernel_size, stride, padding, output_padding, dilation,
+      groups, std::nullopt, std::nullopt, outputLayout);
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -3064,11 +2932,10 @@ TEST_P(OpModelConv3dParam, Conv3d) {
           /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
 
   auto constraintsExp = OpModel<Conv3dOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, weightShape, weightLayout,
-      std::nullopt, std::nullopt, in_channels, out_channels, batch_size,
-      input_depth, input_height, input_width, kernel_size, stride, padding,
-      groups, padding_mode, std::nullopt, std::nullopt, deviceConfig,
-      outputLayout);
+      inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
+      std::nullopt, in_channels, out_channels, batch_size, input_depth,
+      input_height, input_width, kernel_size, stride, padding, groups,
+      padding_mode, std::nullopt, std::nullopt, deviceConfig, outputLayout);
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
@@ -3169,9 +3036,9 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<OpTy>::getOpConstraints(
-        this->CreateWorkerGrid(), inputShape, inputLayout, batchSize,
-        inputHeight, inputWidth, inputChannels, kernelSize, stride, padding,
-        dilation, ceilMode, reallocateHaloOutput, std::nullopt, outputLayout);
+        inputShape, inputLayout, batchSize, inputHeight, inputWidth,
+        inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+        reallocateHaloOutput, std::nullopt, outputLayout);
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
 
     if (constraintsExp) {
@@ -3275,8 +3142,7 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<GlobalAvgPool2dOp>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputLayout, std::nullopt,
-        outputLayout);
+        inputShape, inputLayout, std::nullopt, outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -3387,7 +3253,7 @@ TEST_P(OpModelLeakyReluParam, LeakyReluParam) {
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   auto constraintsExp = op_model::OpModel<LeakyReluOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, slope, outputLayout);
+      inputShape, inputLayout, slope, outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -3454,8 +3320,7 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   auto constraintsExp = OpModel<ClampScalarOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, minAttr, maxAttr,
-      outputLayout);
+      inputShape, inputLayout, minAttr, maxAttr, outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -3506,7 +3371,7 @@ TEST_F(OpModelTest, ClampScalarInt32DtypePreserved) {
   mlir::Attribute maxAttr = builder.getI32IntegerAttr(2);
 
   auto constraintsExp = OpModel<ClampScalarOp>::getOpConstraints(
-      CreateWorkerGrid(), shape, inputLayout, minAttr, maxAttr, outputLayout);
+      shape, inputLayout, minAttr, maxAttr, outputLayout);
   ASSERT_TRUE(static_cast<bool>(constraintsExp))
       << "Constraints failed: " << llvm::toString(constraintsExp.takeError());
 
@@ -3547,8 +3412,8 @@ TEST_P(OpModelClampTensorParam, ClampTensorParam) {
       maxShape, maxBufferType, maxTensorLayout, maxVirtualGrid);
 
   auto constraintsExp = OpModel<ClampTensorOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, minShape, minLayout,
-      maxShape, maxLayout, outputLayout);
+      inputShape, inputLayout, minShape, minLayout, maxShape, maxLayout,
+      outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -3619,8 +3484,7 @@ TEST_P(OpModelPermuteParam, PermuteParam) {
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   auto constraintsExp = OpModel<PermuteOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, permutation, padValue,
-      outputLayout);
+      inputShape, inputLayout, permutation, padValue, outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -3701,8 +3565,7 @@ TEST_P(OpModelUpsampleParam, UpsampleParam) {
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   auto constraintsExp = OpModel<UpsampleOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, scaleFactor, mode,
-      outputLayout);
+      inputShape, inputLayout, scaleFactor, mode, outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -3763,8 +3626,8 @@ protected:
         TensorMemoryLayout::Interleaved, std::nullopt);
 
     auto constraintsExp = OpModel<EmbeddingOp>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputTiledLayout, weightShape,
-        weightTiledLayout, outputTiledLayout);
+        inputShape, inputTiledLayout, weightShape, weightTiledLayout,
+        outputTiledLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -3831,8 +3694,8 @@ TEST_F(OpModelTest, EmbeddingBackwardOp) {
                                         TensorMemoryLayout::Interleaved);
 
   auto constraintsExp = OpModel<EmbeddingBackwardOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, weightShape, weightLayout,
-      inGradientShape, inGradientLayout, outputLayout);
+      inputShape, inputLayout, weightShape, weightLayout, inGradientShape,
+      inGradientLayout, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
       constraintsExp.get();
@@ -3856,8 +3719,8 @@ TEST_F(OpModelTest, Where) {
       inputTensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
   auto constraintsExp = OpModel<WhereOp>::getOpConstraints(
-      CreateWorkerGrid(), inputTensorShape, inputLayout, inputTensorShape,
-      inputLayout, inputTensorShape, inputLayout, outputLayout);
+      inputTensorShape, inputLayout, inputTensorShape, inputLayout,
+      inputTensorShape, inputLayout, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
       constraintsExp.get();
@@ -3882,7 +3745,7 @@ TEST_F(OpModelTest, EmptyOp) {
                         mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
   auto constraintsExp =
       ttnn::op_model::OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints(
-          CreateWorkerGrid(), inputTensorShape, dtype, layout, outputLayout);
+          inputTensorShape, dtype, layout, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
       constraintsExp.get();
@@ -3907,7 +3770,7 @@ TEST_F(OpModelTest, ArangeOp) {
 
   auto constraintsExp =
       ttnn::op_model::OpModel<mlir::tt::ttnn::ArangeOp>::getOpConstraints(
-          CreateWorkerGrid(), startAttr, endAttr, stepAttr, dtype, inputLayout);
+          startAttr, endAttr, stepAttr, dtype, inputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
       constraintsExp.get();
@@ -3936,8 +3799,7 @@ protected:
     auto shapeAttr = mlir::tt::ttnn::ShapeAttr::get(&context, tensorShape);
 
     auto constraintsExp = ttnn::op_model::OpModel<OpTy>::getOpConstraints(
-        CreateWorkerGrid(), shapeAttr, std::nullopt, std::nullopt,
-        outputLayout);
+        shapeAttr, std::nullopt, std::nullopt, outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -3973,8 +3835,8 @@ TEST_F(OpModelTest, FullOp) {
   auto shapeAttr = mlir::tt::ttnn::ShapeAttr::get(&context, shape);
   auto constraintsExp =
       ttnn::op_model::OpModel<mlir::tt::ttnn::FullOp>::getOpConstraints(
-          CreateWorkerGrid(), shapeAttr, builder.getI32IntegerAttr(0),
-          std::nullopt, std::nullopt, outputLayout);
+          shapeAttr, builder.getI32IntegerAttr(0), std::nullopt, std::nullopt,
+          outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
       constraintsExp.get();
@@ -4039,11 +3901,11 @@ TEST_P(OpModelPrepareConv2dWeightsParam, PrepareConv2dWeights) {
       std::nullopt /*shardSpec*/);
 
   auto constraintsExp = OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
-      CreateWorkerGrid(), weightLayout, weightShape, inputMemConfig,
-      inputTensorLayout, weightsFormat, in_channels, out_channels, batch_size,
-      input_height, input_width, kernel_size, stride, padding, dilation,
-      has_bias, groups, ttcore::DataType::Float32, std::nullopt, std::nullopt,
-      std::nullopt, std::nullopt, outputLayout);
+      weightLayout, weightShape, inputMemConfig, inputTensorLayout,
+      weightsFormat, in_channels, out_channels, batch_size, input_height,
+      input_width, kernel_size, stride, padding, dilation, has_bias, groups,
+      ttcore::DataType::Float32, std::nullopt, std::nullopt, std::nullopt,
+      std::nullopt, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
@@ -4131,11 +3993,10 @@ TEST_P(OpModelPrepareConv2dBiasParam, PrepareConv2dBias) {
   conv2dConfig = conv2dConfig.withWeightsDtype(ttcore::DataType::Float32);
 
   auto constraintsExp = OpModel<PrepareConv2dBiasOp>::getOpConstraints(
-      CreateWorkerGrid(), biasLayout, biasShape, inputMemConfig,
-      inputTensorLayout, in_channels, out_channels, batch_size, input_height,
-      input_width, kernel_size, stride, padding, dilation, groups,
-      ttcore::DataType::Float32, std::nullopt, conv2dConfig, std::nullopt,
-      outputLayout);
+      biasLayout, biasShape, inputMemConfig, inputTensorLayout, in_channels,
+      out_channels, batch_size, input_height, input_width, kernel_size, stride,
+      padding, dilation, groups, ttcore::DataType::Float32, std::nullopt,
+      conv2dConfig, std::nullopt, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
@@ -4269,16 +4130,15 @@ TEST_P(OpModelBatchNormParam, BatchNormParam) {
 
   // Test getOpConstraints
   llvm::Expected<OpConstraints> constraintsExp =
-      training ? op_model::OpModel<BatchNormTrainingOp>::getOpConstraints(
-                     CreateWorkerGrid(), inputShape, inputLayout,
-                     runningMeanShape, runningMeanLayout, runningVarShape,
-                     runningVarLayout, weightShape, weightLayout, biasShape,
-                     biasLayout, epsilon, momentum, outputLayout)
-               : op_model::OpModel<BatchNormInferenceOp>::getOpConstraints(
-                     CreateWorkerGrid(), inputShape, inputLayout,
-                     runningMeanShape, runningMeanLayout, runningVarShape,
-                     runningVarLayout, weightShape, weightLayout, biasShape,
-                     biasLayout, epsilon, outputLayout);
+      training
+          ? op_model::OpModel<BatchNormTrainingOp>::getOpConstraints(
+                inputShape, inputLayout, runningMeanShape, runningMeanLayout,
+                runningVarShape, runningVarLayout, weightShape, weightLayout,
+                biasShape, biasLayout, epsilon, momentum, outputLayout)
+          : op_model::OpModel<BatchNormInferenceOp>::getOpConstraints(
+                inputShape, inputLayout, runningMeanShape, runningMeanLayout,
+                runningVarShape, runningVarLayout, weightShape, weightLayout,
+                biasShape, biasLayout, epsilon, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -4447,8 +4307,8 @@ TEST_P(OpModelRMSNormParam, RMSNormParam) {
 
   // Test getOpConstraints
   auto constraintsExp = op_model::OpModel<RMSNormOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, weightShape, weightLayout,
-      biasShape, biasLayout, epsilon, outputLayout);
+      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
+      epsilon, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -4578,8 +4438,8 @@ TEST_P(OpModelRMSNormPreAllGatherParam, RMSNormPreAllGatherParam) {
   // Test Constraints
   auto constraintsExp =
       op_model::OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, residualInputShape,
-          residualInputLayout, dtype, use_2d_core_grid, outputLayout);
+          inputShape, inputLayout, residualInputShape, residualInputLayout,
+          dtype, use_2d_core_grid, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -4700,8 +4560,8 @@ TEST_P(OpModelLayerNormParam, LayerNormParam) {
 
   // Test getOpConstraints
   auto constraintsExp = op_model::OpModel<LayerNormOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, weightShape, weightLayout,
-      biasShape, biasLayout, epsilon, outputLayout);
+      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
+      epsilon, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -4838,8 +4698,8 @@ TEST_P(OpModelLayerNormPreAllGatherParam, LayerNormPreAllGatherParam) {
   // Test getOpConstraints
   auto constraintsExp =
       op_model::OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, residualInputShape,
-          residualInputLayout, recipShape, recipLayout, dtype, outputLayout);
+          inputShape, inputLayout, residualInputShape, residualInputLayout,
+          recipShape, recipLayout, dtype, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -4965,9 +4825,8 @@ TEST_P(OpModelLayerNormPostAllGatherParam, LayerNormPostAllGatherParam) {
 
   auto constraintsExp =
       op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, statsShape, statsLayout,
-          weightShape, weightLayout, biasShape, biasLayout, epsilon,
-          outputLayout);
+          inputShape, inputLayout, statsShape, statsLayout, weightShape,
+          weightLayout, biasShape, biasLayout, epsilon, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -5101,9 +4960,8 @@ TEST_P(OpModelGroupNormParam, GroupNormParam) {
 
   // Test getOpConstraints
   auto constraintsExp = op_model::OpModel<GroupNormOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, inputMaskShape,
-      inputMaskLayout, weightShape, weightLayout, biasShape, biasLayout,
-      numGroups, epsilon, outputLayout);
+      inputShape, inputLayout, inputMaskShape, inputMaskLayout, weightShape,
+      weightLayout, biasShape, biasLayout, numGroups, epsilon, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -5197,7 +5055,7 @@ protected:
     // Test getOpConstraints
     auto constraintsExp =
         ttnn::op_model::OpModel<mlir::tt::ttnn::ConstantOp>::getOpConstraints(
-            CreateWorkerGrid(), attr, outputLayout);
+            attr, outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -5281,20 +5139,16 @@ INSTANTIATE_TEST_SUITE_P(ConstantOpUInt8Tests, OpModelConstantUInt8Param,
 
 TEST_F(OpModelTest, RandOp) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr outputLayoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr outputLayoutL1 = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   // Test RandOp with DRAM output
   auto shapeAttr = ttnn::ShapeAttr::get(&context, tensorShape);
 
   auto constraintsExp = OpModel<RandOp>::getOpConstraints(
-      workerGrid, shapeAttr, ttcore::DataType::BFloat16, ttnn::Layout::Tile,
+      shapeAttr, ttcore::DataType::BFloat16, ttnn::Layout::Tile,
       llvm::APFloat(0.0f), llvm::APFloat(1.0f), 0, outputLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
@@ -5304,7 +5158,7 @@ TEST_F(OpModelTest, RandOp) {
 
   // Test RandOp with L1 output
   constraintsExp = OpModel<RandOp>::getOpConstraints(
-      workerGrid, shapeAttr, ttcore::DataType::BFloat16, ttnn::Layout::Tile,
+      shapeAttr, ttcore::DataType::BFloat16, ttnn::Layout::Tile,
       llvm::APFloat(0.0f), llvm::APFloat(1.0f), 0, outputLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
@@ -5314,7 +5168,7 @@ TEST_F(OpModelTest, RandOp) {
 
   // Test RandOp with custom range parameters
   constraintsExp = OpModel<RandOp>::getOpConstraints(
-      workerGrid, shapeAttr, ttcore::DataType::BFloat16, ttnn::Layout::Tile,
+      shapeAttr, ttcore::DataType::BFloat16, ttnn::Layout::Tile,
       llvm::APFloat(-2.5f), llvm::APFloat(5.0f), 42, outputLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
@@ -5324,7 +5178,7 @@ TEST_F(OpModelTest, RandOp) {
 
   // Test RandOp with Float32 data type
   constraintsExp = OpModel<RandOp>::getOpConstraints(
-      workerGrid, shapeAttr, ttcore::DataType::Float32, ttnn::Layout::Tile,
+      shapeAttr, ttcore::DataType::Float32, ttnn::Layout::Tile,
       llvm::APFloat(0.0f), llvm::APFloat(1.0f), 0, outputLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
@@ -5335,7 +5189,6 @@ TEST_F(OpModelTest, RandOp) {
 
 TEST_F(OpModelTest, DropoutOp) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr inputLayoutDRAM = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr inputLayoutL1 = CreateTiledLayout(
@@ -5345,26 +5198,23 @@ TEST_F(OpModelTest, DropoutOp) {
   const TTNNLayoutAttr outputLayoutL1 = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
-
   auto constraintsExp = OpModel<DropoutOp>::getOpConstraints(
-      workerGrid, tensorShape, inputLayoutDRAM, llvm::APFloat(0.0f),
-      llvm::APFloat(1.0f), 0, true, outputLayoutDRAM);
+      tensorShape, inputLayoutDRAM, llvm::APFloat(0.0f), llvm::APFloat(1.0f), 0,
+      true, outputLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GE(opCstr.cbL1PeakSize, 0);
 
   constraintsExp = OpModel<DropoutOp>::getOpConstraints(
-      workerGrid, tensorShape, inputLayoutL1, llvm::APFloat(0.2f),
-      llvm::APFloat(1.25f), 21, true, outputLayoutL1);
+      tensorShape, inputLayoutL1, llvm::APFloat(0.2f), llvm::APFloat(1.25f), 21,
+      true, outputLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GE(opCstr.cbL1PeakSize, 0);
 
   constraintsExp = OpModel<DropoutOp>::getOpConstraints(
-      workerGrid, tensorShape, inputLayoutDRAM, llvm::APFloat(0.5f),
-      llvm::APFloat(2.0f), 21, false, outputLayoutL1);
+      tensorShape, inputLayoutDRAM, llvm::APFloat(0.5f), llvm::APFloat(2.0f),
+      21, false, outputLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GE(opCstr.cbL1PeakSize, 0);
@@ -5380,7 +5230,6 @@ TEST_F(OpModelTest, FillCacheOp) {
   // Test basic FillCacheOp with DRAM cache and input tensors
   const llvm::SmallVector<int64_t> cacheShape = {1, 32, 64, 512};
   const llvm::SmallVector<int64_t> inputShape = {1, 32, 3, 512};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
 
   const TTNNLayoutAttr cacheLayoutDRAM = CreateTiledLayout(
       cacheShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
@@ -5394,8 +5243,8 @@ TEST_F(OpModelTest, FillCacheOp) {
   // Test FillCacheOp constraints with batch_offset = 0
   uint32_t batchOffset = 0;
   auto constraintsExp = OpModel<FillCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutDRAM, inputShape, inputLayoutDRAM,
-      batchOffset, cacheLayoutDRAM);
+      cacheShape, cacheLayoutDRAM, inputShape, inputLayoutDRAM, batchOffset,
+      cacheLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   if (constraintsExp) {
@@ -5409,26 +5258,26 @@ TEST_F(OpModelTest, FillCacheOp) {
 
   // Test with L1 output layout
   constraintsExp = OpModel<FillCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutDRAM, inputShape, inputLayoutDRAM,
-      batchOffset, cacheLayoutL1);
+      cacheShape, cacheLayoutDRAM, inputShape, inputLayoutDRAM, batchOffset,
+      cacheLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   // Test with L1 cache layout
   constraintsExp = OpModel<FillCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutL1, inputShape, inputLayoutDRAM,
-      batchOffset, cacheLayoutL1);
+      cacheShape, cacheLayoutL1, inputShape, inputLayoutDRAM, batchOffset,
+      cacheLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   // Test with L1 input layout
   constraintsExp = OpModel<FillCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutDRAM, inputShape, inputLayoutL1,
-      batchOffset, cacheLayoutDRAM);
+      cacheShape, cacheLayoutDRAM, inputShape, inputLayoutL1, batchOffset,
+      cacheLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   // Test with all L1 layouts
   constraintsExp = OpModel<FillCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutL1, inputShape, inputLayoutL1,
-      batchOffset, cacheLayoutL1);
+      cacheShape, cacheLayoutL1, inputShape, inputLayoutL1, batchOffset,
+      cacheLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -5451,7 +5300,6 @@ TEST_F(OpModelTest, UpdateCacheOp) {
   const llvm::SmallVector<int64_t> cacheShape = {1, 32, 64, 512};
   const llvm::SmallVector<int64_t> inputShape = {1, 32, 3, 512};
   const llvm::SmallVector<int64_t> updateIndexShape = {1};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
 
   const TTNNLayoutAttr cacheLayoutDRAM = CreateTiledLayout(
       cacheShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
@@ -5469,7 +5317,7 @@ TEST_F(OpModelTest, UpdateCacheOp) {
   // Test UpdateCacheOp constraints with batch_offset = 0
   uint32_t batchOffset = 0;
   auto constraintsExp = OpModel<UpdateCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutDRAM, inputShape, inputLayoutDRAM,
+      cacheShape, cacheLayoutDRAM, inputShape, inputLayoutDRAM,
       updateIndexShape, updateIndexLayoutDRAM, batchOffset, cacheLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
@@ -5484,26 +5332,26 @@ TEST_F(OpModelTest, UpdateCacheOp) {
 
   // Test with L1 output layout
   constraintsExp = OpModel<UpdateCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutDRAM, inputShape, inputLayoutDRAM,
+      cacheShape, cacheLayoutDRAM, inputShape, inputLayoutDRAM,
       updateIndexShape, updateIndexLayoutDRAM, batchOffset, cacheLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   // Test with L1 cache layout
   constraintsExp = OpModel<UpdateCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutL1, inputShape, inputLayoutDRAM,
-      updateIndexShape, updateIndexLayoutDRAM, batchOffset, cacheLayoutL1);
+      cacheShape, cacheLayoutL1, inputShape, inputLayoutDRAM, updateIndexShape,
+      updateIndexLayoutDRAM, batchOffset, cacheLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   // Test with L1 input layout
   constraintsExp = OpModel<UpdateCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutDRAM, inputShape, inputLayoutL1,
-      updateIndexShape, updateIndexLayoutDRAM, batchOffset, cacheLayoutDRAM);
+      cacheShape, cacheLayoutDRAM, inputShape, inputLayoutL1, updateIndexShape,
+      updateIndexLayoutDRAM, batchOffset, cacheLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   // Test with all L1 layouts
   constraintsExp = OpModel<UpdateCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayoutL1, inputShape, inputLayoutL1,
-      updateIndexShape, updateIndexLayoutL1, batchOffset, cacheLayoutL1);
+      cacheShape, cacheLayoutL1, inputShape, inputLayoutL1, updateIndexShape,
+      updateIndexLayoutL1, batchOffset, cacheLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -5528,7 +5376,6 @@ TEST_F(OpModelTest, PagedUpdateCacheOp) {
   const llvm::SmallVector<int64_t> inputShape = {1, 8, 12, 256};
   const llvm::SmallVector<int64_t> updateIndexShape = {8};
   const llvm::SmallVector<int64_t> pageTableShape = {8, 16};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
 
   const TTNNLayoutAttr cacheLayout = CreateTiledLayout(
       cacheShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
@@ -5540,9 +5387,8 @@ TEST_F(OpModelTest, PagedUpdateCacheOp) {
       pageTableShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
   auto constraintsExp = OpModel<PagedUpdateCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayout, inputShape, inputLayout,
-      updateIndexShape, updateIndexLayout, pageTableShape, pageTableLayout,
-      false, cacheLayout);
+      cacheShape, cacheLayout, inputShape, inputLayout, updateIndexShape,
+      updateIndexLayout, pageTableShape, pageTableLayout, false, cacheLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   if (constraintsExp) {
@@ -5564,7 +5410,6 @@ TEST_F(OpModelTest, PagedUpdateCacheOpWithoutPageTable) {
   const llvm::SmallVector<int64_t> cacheShape = {8, 4, 32, 256};
   const llvm::SmallVector<int64_t> inputShape = {1, 8, 12, 256};
   const llvm::SmallVector<int64_t> updateIndexShape = {8};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
 
   const TTNNLayoutAttr cacheLayout = CreateTiledLayout(
       cacheShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
@@ -5574,9 +5419,8 @@ TEST_F(OpModelTest, PagedUpdateCacheOpWithoutPageTable) {
       updateIndexShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
   auto constraintsExp = OpModel<PagedUpdateCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayout, inputShape, inputLayout,
-      updateIndexShape, updateIndexLayout, std::nullopt, std::nullopt, false,
-      cacheLayout);
+      cacheShape, cacheLayout, inputShape, inputLayout, updateIndexShape,
+      updateIndexLayout, std::nullopt, std::nullopt, false, cacheLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   if (constraintsExp) {
@@ -5614,7 +5458,6 @@ TEST_F(OpModelTest, PagedUpdateCacheOpWrongGridTripwire) {
   const llvm::SmallVector<int64_t> cacheShape = {8, 4, 32, 256};
   const llvm::SmallVector<int64_t> inputShape = {1, 8, 12, 256};
   const llvm::SmallVector<int64_t> updateIndexShape = {8};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
 
   // numUsers = inputShape[1] = 8.  Correct virtual grid is {8, 1}; we use
   // {4, 1} (evenly divides numUsers, but not equal to it).
@@ -5629,7 +5472,7 @@ TEST_F(OpModelTest, PagedUpdateCacheOpWrongGridTripwire) {
       updateIndexShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
   auto constraintsExp = OpModel<PagedUpdateCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayout, inputShape, inputLayoutWrongGrid,
+      cacheShape, cacheLayout, inputShape, inputLayoutWrongGrid,
       updateIndexShape, updateIndexLayout, std::nullopt, std::nullopt, false,
       cacheLayout);
   const bool ok = static_cast<bool>(constraintsExp);
@@ -5646,7 +5489,6 @@ TEST_F(OpModelTest, PagedFillCacheOp) {
   const llvm::SmallVector<int64_t> inputShape = {1, 12, 65, 256};
   const llvm::SmallVector<int64_t> batchOffsetShape = {1};
   const llvm::SmallVector<int64_t> pageTableShape = {8, 16};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
 
   const TTNNLayoutAttr cacheLayout = CreateTiledLayout(
       cacheShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
@@ -5658,9 +5500,8 @@ TEST_F(OpModelTest, PagedFillCacheOp) {
       pageTableShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
   auto constraintsExp = OpModel<PagedFillCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayout, inputShape, inputLayout,
-      pageTableShape, pageTableLayout, batchOffsetShape, batchOffsetLayout,
-      cacheLayout);
+      cacheShape, cacheLayout, inputShape, inputLayout, pageTableShape,
+      pageTableLayout, batchOffsetShape, batchOffsetLayout, cacheLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   if (constraintsExp) {
@@ -5723,9 +5564,9 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<QuantizeOp>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputLayout, scaleShape, scaleLayout,
-        zeroPointShape, zeroPointLayout, axis,
-        std::make_optional(ttcore::DataType::Int32), outputLayout);
+        inputShape, inputLayout, scaleShape, scaleLayout, zeroPointShape,
+        zeroPointLayout, axis, std::make_optional(ttcore::DataType::Int32),
+        outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -5876,10 +5717,10 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<RequantizeOp>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputLayout, inScaleShape,
-        inScaleLayout, inZeroPointShape, inZeroPointLayout, outScaleShape,
-        outScaleLayout, outZeroPointShape, outZeroPointLayout, axis,
-        std::make_optional(ttcore::DataType::Int32), outputLayout);
+        inputShape, inputLayout, inScaleShape, inScaleLayout, inZeroPointShape,
+        inZeroPointLayout, outScaleShape, outScaleLayout, outZeroPointShape,
+        outZeroPointLayout, axis, std::make_optional(ttcore::DataType::Int32),
+        outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -6033,9 +5874,9 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<DequantizeOp>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputLayout, scaleShape, scaleLayout,
-        zeroPointShape, zeroPointLayout, axis,
-        std::make_optional(ttcore::DataType::BFloat16), outputLayout);
+        inputShape, inputLayout, scaleShape, scaleLayout, zeroPointShape,
+        zeroPointLayout, axis, std::make_optional(ttcore::DataType::BFloat16),
+        outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -6256,10 +6097,10 @@ protected:
 
     auto constraintsExp =
         OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
-            CreateWorkerGrid(), queryShape, queryLayout, keyShape, keyLayout,
-            valueShape, valueLayout, isCausal, attentionMaskShape,
-            attentionMaskLayout, curPosTensorShape, curPosTensorLayout,
-            attentionSinkShape, attentionSinkLayout, scale,
+            queryShape, queryLayout, keyShape, keyLayout, valueShape,
+            valueLayout, isCausal, attentionMaskShape, attentionMaskLayout,
+            curPosTensorShape, curPosTensorLayout, attentionSinkShape,
+            attentionSinkLayout, scale,
             /*programConfig=*/std::nullopt, outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -6576,8 +6417,8 @@ protected:
 
     auto constraintsExp =
         OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
-            CreateWorkerGrid(), queryShape, queryLayout, keyShape, keyLayout,
-            valueShape, valueLayout, pageTableShape, pageTableLayout, isCausal,
+            queryShape, queryLayout, keyShape, keyLayout, valueShape,
+            valueLayout, pageTableShape, pageTableLayout, isCausal,
             attentionMaskShape, attentionMaskLayout, curPosTensorShape,
             curPosTensorLayout, attentionSinkShape, attentionSinkLayout, scale,
             slidingWindowSize, programConfig, outputLayout);
@@ -6699,8 +6540,8 @@ protected:
 
     auto constraintsExp =
         OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
-            CreateWorkerGrid(), queryShape, queryLayout, keyShape, keyLayout,
-            valueShape, valueLayout, attentionMaskShape, attentionMaskLayout,
+            queryShape, queryLayout, keyShape, keyLayout, valueShape,
+            valueLayout, attentionMaskShape, attentionMaskLayout,
             /*attentionSinkShape=*/std::nullopt,
             /*attentionSinkLayout=*/std::nullopt, isCausal, scale,
             slidingWindowSize, outputLayout);
@@ -6789,17 +6630,13 @@ INSTANTIATE_TEST_SUITE_P(ScaledDotProductAttentionTests,
 
 TEST_F(OpModelTest, AssignOp) {
   const llvm::SmallVector<int64_t> tensorShape = {64, 64};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
 
   const TTNNLayoutAttr tensorLayoutDRAM_F32 = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
       std::nullopt, GetPhysicalGridSize(), builder.getF32Type());
   // Test AssignOp with DRAM output
   auto constraintsExp = OpModel<AssignOp>::getOpConstraints(
-      workerGrid, tensorShape, tensorLayoutDRAM_F32, std::nullopt);
+      tensorShape, tensorLayoutDRAM_F32, std::nullopt);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -6816,7 +6653,7 @@ TEST_F(OpModelTest, AssignOp) {
       std::nullopt, GetPhysicalGridSize(), builder.getF32Type());
   // Test AssignOp with L1 output
   constraintsExp = OpModel<AssignOp>::getOpConstraints(
-      workerGrid, tensorShape, tensorLayoutL1_F32, std::nullopt);
+      tensorShape, tensorLayoutL1_F32, std::nullopt);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -6833,7 +6670,7 @@ TEST_F(OpModelTest, AssignOp) {
 
   // Test AssignOp with output dtype
   constraintsExp = OpModel<AssignOp>::getOpConstraints(
-      workerGrid, tensorShape, tensorLayoutL1_F32, outputDtype);
+      tensorShape, tensorLayoutL1_F32, outputDtype);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -6951,8 +6788,7 @@ protected:
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<GatherOp>::getOpConstraints(
-        CreateWorkerGrid(), inputShape, inputLayout, indexShape, indexLayout,
-        dim, outputLayout);
+        inputShape, inputLayout, indexShape, indexLayout, dim, outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -7076,9 +6912,8 @@ protected:
 
     auto constraintsExp =
         OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
-            CreateWorkerGrid(), queryShape, queryLayout, keyShape, keyLayout,
-            valueShape, valueLayout, headDimV, pageTableShape, pageTableLayout,
-            isCausal,
+            queryShape, queryLayout, keyShape, keyLayout, valueShape,
+            valueLayout, headDimV, pageTableShape, pageTableLayout, isCausal,
             /*attentionMaskShape=*/std::nullopt,
             /*attentionMaskLayout=*/std::nullopt, curPosTensorShape,
             curPosTensorLayout,

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice.cpp
@@ -91,16 +91,12 @@ TEST_P(MeshPartitionLibMockDeviceTest, MeshPartitionOp) {
   // tiling succeeds only if the split dimension stays a multiple of 32.
   // e.g. 128/2=64 ✓, 128/4=32 ✓, 128/8=16 ✗, 64/2=32 ✓, 64/4=16 ✗
   const llvm::SmallVector<int64_t> inputShape = {64, 128};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const TTNNLayoutAttr layoutDRAMRowMajor = CreateRowMajorLayout(
       inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutDRAMTiled = CreateTiledLayout(
       inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutL1Tiled = CreateTiledLayout(
       inputShape, BufferType::L1, TensorMemoryLayout::Interleaved);
-
-  auto legalExp = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(static_cast<bool>(legalExp));
 
   const int32_t dim = p.dim;
   const std::optional<uint32_t> clusterAxis = p.clusterAxis;
@@ -112,14 +108,12 @@ TEST_P(MeshPartitionLibMockDeviceTest, MeshPartitionOp) {
 
   // Row-major layouts should always succeed.
   auto constraintsExp = OpModel<MeshPartitionOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, layoutDRAMRowMajor, dim, clusterAxis,
-      layoutDRAMRowMajor);
+      inputShape, layoutDRAMRowMajor, dim, clusterAxis, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   // Tiled DRAM layout — succeeds only if post-split shape is tile-aligned.
   constraintsExp = OpModel<MeshPartitionOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, layoutDRAMTiled, dim, clusterAxis,
-      layoutDRAMTiled);
+      inputShape, layoutDRAMTiled, dim, clusterAxis, layoutDRAMTiled);
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectTilingSuccess);
   if (!constraintsExp) {
     llvm::consumeError(constraintsExp.takeError());
@@ -127,8 +121,7 @@ TEST_P(MeshPartitionLibMockDeviceTest, MeshPartitionOp) {
 
   // Tiled L1 layout — same condition.
   constraintsExp = OpModel<MeshPartitionOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, layoutL1Tiled, dim, clusterAxis,
-      layoutL1Tiled);
+      inputShape, layoutL1Tiled, dim, clusterAxis, layoutL1Tiled);
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectTilingSuccess);
   if (!constraintsExp) {
     llvm::consumeError(constraintsExp.takeError());

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp
@@ -40,7 +40,6 @@ TEST_F(OpModelTripwireTest, PagedUpdateCacheOpWrongGrid) {
   const llvm::SmallVector<int64_t> cacheShape = {8, 4, 32, 256};
   const llvm::SmallVector<int64_t> inputShape = {1, 8, 12, 256};
   const llvm::SmallVector<int64_t> updateIndexShape = {8};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
 
   // numUsers = inputShape[1] = 8; the only valid HS grid in tt-mlir IR is
   // {8, 1}.  We use {4, 1} (num_cores = 4) so the new TT_FATAL rejects it
@@ -56,7 +55,7 @@ TEST_F(OpModelTripwireTest, PagedUpdateCacheOpWrongGrid) {
       updateIndexShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
   auto constraintsExp = OpModel<PagedUpdateCacheOp>::getOpConstraints(
-      workerGrid, cacheShape, cacheLayout, inputShape, inputLayoutWrongGrid,
+      cacheShape, cacheLayout, inputShape, inputLayoutWrongGrid,
       updateIndexShape, updateIndexLayout, std::nullopt, std::nullopt, false,
       cacheLayout);
   const bool ok = static_cast<bool>(constraintsExp);

--- a/test/unittests/OpModel/TTNN/Op/TestRMSNormWidthSharded.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestRMSNormWidthSharded.cpp
@@ -49,14 +49,13 @@ TEST_F(OpModelTest, RMSNormWidthShardedInputCrashTest) {
       llvm::SmallVector<int64_t>{numCoresY, numCoresX},
       llvm::SmallVector<int64_t>{shardHeight, shardWidth});
 
-  auto deviceGrid = CreateWorkerGrid();
   llvm::APFloat epsilon(1e-5f);
 
   // This should crash without the workaround in RMSNormOp::getOpConstraints.
   EXPECT_DEATH(
       {
         auto constraintsExp = op_model::OpModel<RMSNormOp>::getOpConstraints(
-            deviceGrid, inputShape, inputLayout, weightShape, weightLayout,
+            inputShape, inputLayout, weightShape, weightLayout,
             /*biasShape=*/std::nullopt, /*biasLayout=*/std::nullopt, epsilon,
             outputLayout);
         if (constraintsExp) {


### PR DESCRIPTION
Fixes #7726.

### Problem
`checkDeviceWorkerGrid` ran at the top of every OpModel interface method (~74 call sites), comparing the IR's `DeviceAttr` worker grid against the opened device's `compute_with_storage_grid_size()`. The two always match in practice — the system descriptor that produces the IR grid is itself generated from that device grid — so the check was a tautology on real and mock devices alike, while producing an *unrecoverable* false failure when a differently-harvested system desc was used in mock mode. It also protected nothing downstream: `validateTensorSpec` already validates output shard bounds against the device grid.

### Change
- Remove `checkDeviceWorkerGrid` / `getValidatedDeviceGrid` / `Device::getDeviceConstraints` / `detail::checkGrid`.
- `deviceGrid` was threaded through the entire OpModel API (`getOpConstraints` on ~86 methods, header decls, ~81 interface call sites) purely to reach `getLayoutAttrFromTensorSpec` for interleaved output layouts. Drop it from every caller and source the grid **once**, where it's actually consumed, inside `operation::getOpConstraints`.
- `SingletonDeviceContext` now owns the grid: it caches `compute_with_storage_grid_size()` (as `{y, x}`) and refreshes it on every device open/reset/reshape, exposed via `getComputeGridShape()`. `getLayoutAttrFromTensorSpec` keeps its parameter, so the IR-only output-inference path is unchanged.
- Replace the per-query tautology with a **one-time boundary check**: when a system descriptor is registered, `SingletonDeviceContext` verifies on device open that the device grid matches the system desc's chip grid, and `report_fatal_error`s on mismatch. This catches a genuinely misconfigured (e.g. differently-harvested) system desc once, at the boundary, instead of failing every query unrecoverably.

### Testing
- `TestOpModelLib` (689), `TestOpModelLibMockDevice` (20), `TestOpModelLibTripwires` (1), `TestOpModelInterface` (214), `TestConversion` (53) — all pass, no regressions. The new validation does not false-trip across any mock/real device config in the suite.
- Validated end-to-end in tt-xla n150 perf benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)