### PR TITLE
[d2m] adding relu6 element wise op

### DIFF
--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -1141,6 +1141,19 @@ private:
           loc, resultTypes, ValueRange{operands[0], operands[1]});
       yield = bbBuilder.create<d2m::TileMinimumOp>(
           loc, resultTypes, ValueRange{yield, operands[2]});
+    } else if constexpr (std::is_same_v<ConcreteOp, ttir::Relu6Op>) {
+      // Decompose into a scalar clamp
+      auto tileTy = mlir::cast<ttcore::TileType>(resultTypes[0]);
+      mlir::Attribute minAttr, maxAttr;
+      if (tileTy.getElementType().isInteger()) {
+        minAttr = bbBuilder.getI32IntegerAttr(0);
+        maxAttr = bbBuilder.getI32IntegerAttr(6);
+      } else {
+        minAttr = bbBuilder.getF32FloatAttr(0.0f);
+        maxAttr = bbBuilder.getF32FloatAttr(6.0f);
+      }
+      yield = bbBuilder.create<d2m::TileClampScalarOp>(
+          loc, resultTypes[0], operands[0], minAttr, maxAttr);
     } else if constexpr (std::is_same_v<ConcreteOp, ttir::ClampScalarOp> ||
                          std::is_same_v<ConcreteOp, ttir::SeluOp>) {
       // Unary ops with forwarded attributes (e.g. clamp min/max, selu
@@ -4342,6 +4355,7 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
     D2MNamedElementwiseRewriter<ttir::PowOp,             d2m::TilePowOp>,
     D2MNamedElementwiseRewriter<ttir::ReciprocalOp,      d2m::TileRecipOp>,
     D2MNamedElementwiseRewriter<ttir::ReluOp,            d2m::TileReluOp>,
+    D2MNamedElementwiseRewriter<ttir::Relu6Op,           d2m::TileClampScalarOp>,
     D2MNamedElementwiseRewriter<ttir::RsqrtOp,           d2m::TileRsqrtOp>,
     D2MNamedElementwiseRewriter<ttir::SigmoidOp,         d2m::TileSigmoidOp>,
     D2MNamedElementwiseRewriter<ttir::SignOp,            d2m::TileSignOp>,

--- a/test/python/golden/d2m/test_unary.py
+++ b/test/python/golden/d2m/test_unary.py
@@ -281,7 +281,7 @@ unary_ops = [
     neg,
     reciprocal,
     relu,
-    relu6 | Marks(pytest.mark.skip_config(["ttmetal"])),
+    relu6,
     rsqrt,
     sigmoid,
     sign,
@@ -327,6 +327,7 @@ def test_unary_ops(
         "logical_not",
         "neg",
         "relu",
+        "relu6",
         "sign",
     }:
         pytest.skip("int32 unary op is not in the allowlist for this test")

--- a/test/python/golden/mlir_snippets/ttir/ttir_relu6.mlir
+++ b/test/python/golden/mlir_snippets/ttir/ttir_relu6.mlir
@@ -1,0 +1,6 @@
+module {
+  func.func @relu6(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %1 = "ttir.relu6"(%arg0) : (tensor<128x128xf32>) -> tensor<128x128xf32>
+    return %1 : tensor<128x128xf32>
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToD2M/named_to_generic.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/named_to_generic.mlir
@@ -500,6 +500,16 @@ module {
     return %0 : !ttype
   }
 
+  // CHECK-LABEL: func @named_relu6
+  func.func @named_relu6(%arg: !ttype) -> (!ttype) {
+    // named relu6 op, unary lowered to clamp_scalar with [0, 6] bounds:
+    // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #parallel]
+    // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
+    // CHECK: d2m.tile_clamp_scalar
+    %0 = "ttir.relu6"(%arg) : (!ttype) -> !ttype
+    return %0 : !ttype
+  }
+
   // CHECK-LABEL: func @named_logical_and
   func.func @named_logical_and(%lhs: !ttype, %rhs: !ttype) -> (!ttype) {
     // logical_and is decomposed into: NEZ(a) * NEZ(b) - both must be non-zero

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -11993,39 +11993,117 @@ class TTIRBuilder(Builder):
         """
         return self._op_proxy(ttir.ReluOp, [in0], unit_attrs)
 
-    def relu6(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
-        """
-        Creates ``ttir.relu6``.
+    @tag(ttir.Relu6Op)
+    def relu6(
+        self,
+        in0: Operand,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        ttir_op = self.get_opview_from_method(TTIRBuilder.relu6)
 
-        *Elementwise ReLU6 activation operation.*
+        if output_type is None:
+            mlir_output_type = self.get_type(in0)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
 
-        Computes the ReLU6 function for each element in the input tensor.
-        ReLU6 is defined as: min(max(0, x), 6)
-        This activation function clips values between 0 and 6, making it useful
-        for quantized neural networks and mobile applications.
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(input0, mlir_output_type)
+        result = self._create_ranked_tensor_type(golden_output.shape, mlir_output_type)
 
-        .. code-block:: mlir
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
 
-            // Compute ReLU6 of all elements
-            %result = ttir.relu6(%input, %output) : tensor<4xf32>, tensor<4xf32> -> tensor<4xf32>
-            // Input tensor:
-            // [-2.0, 3.0, 8.0, 1.5]
-            // Output tensor:
-            // [0.0, 3.0, 6.0, 1.5]
+        op = ttir_op(
+            result,
+            in0,
+            loc=loc,
+        )
+        op_result = op.result
 
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor
-        unit_attrs : *Optional[List[str]]*, optional
-            Optional list of unit attributes
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
 
-        Returns
-        -------
-        (*OpView*)
-            Tensor with ReLU6 activation values
-        """
-        return self._op_proxy(ttir.Relu6Op, [in0], unit_attrs)
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(ttir.Relu6Op)
+    def relu6_parser(
+        self,
+        old_op: ttir.Relu6Op,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttir_op = self.get_opview_from_parser(TTIRBuilder.relu6_parser)
+        in0 = global_dict[old_op.input]
+        result = old_op.result.type
+
+        new_op = ttir_op(
+            result,
+            in0,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(input0, result.element_type)
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(ttir.Relu6Op)
+    def relu6_split(
+        self,
+        old_op: ttir.Relu6Op,
+    ) -> Tuple[Module, TTIRBuilder]:
+        ttir_op = self.get_opview_from_split(TTIRBuilder.relu6_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            relu6_module = Module.create()
+            relu6_builder = TTIRBuilder(
+                old_ctx, old_loc, mesh_name=self._mesh_name, mesh_dict=self._mesh_dict
+            )
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(relu6_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="relu6_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttir_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    relu6_builder._set_golden_tensor(new_op_result, old_op_result)
+                    relu6_builder._set_golden_tensor(in0, input0)
+                    relu6_builder._annotate_presharded_arg(in0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                relu6_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return relu6_module, relu6_builder
 
     def silu(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         """
@@ -12098,40 +12176,6 @@ class TTIRBuilder(Builder):
             A tensor containing the Mish activation values of each element in the input tensor
         """
         return self._op_proxy(ttir.MishOp, [in0], unit_attrs)
-
-    def relu6(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
-        """
-        Creates ``ttir.relu6``.
-
-        *Elementwise ReLU6 activation operation.*
-
-        Computes the ReLU6 function for each element in the input tensor.
-        ReLU6 is defined as: min(max(0, x), 6)
-        This activation function clips values between 0 and 6, making it useful
-        for quantized neural networks and mobile applications.
-
-        .. code-block:: mlir
-
-            // Compute ReLU6 of all elements
-            %result = ttir.relu6(%input, %output) : tensor<4xf32>, tensor<4xf32> -> tensor<4xf32>
-            // Input tensor:
-            // [-2.0, 3.0, 8.0, 1.5]
-            // Output tensor:
-            // [0.0, 3.0, 6.0, 1.5]
-
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor
-        unit_attrs : *Optional[List[str]]*, optional
-            Optional list of unit attributes
-
-        Returns
-        -------
-        (*OpView*)
-            Tensor with ReLU6 activation values
-        """
-        return self._op_proxy(ttir.Relu6Op, [in0], unit_attrs)
 
     def sign(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         """

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -4900,6 +4900,13 @@ def ttir_hardsigmoid_golden(
     return torch.nn.functional.hardsigmoid(input_tensor).to(output_dtype)
 
 
+def ttir_relu6_golden(
+    input_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    return torch.nn.functional.relu6(input_tensor).to(output_dtype)
+
+
 def ttir_subtract_golden(
     input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
 ) -> GoldenMapTensor:
@@ -8049,7 +8056,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.TanhOp: ttir_tanh_golden,
     ttir.ReciprocalOp: torch.reciprocal,
     ttir.ReluOp: torch.relu,
-    ttir.Relu6Op: torch.nn.functional.relu6,
+    ttir.Relu6Op: ttir_relu6_golden,
     ttir.RsqrtOp: ttir_rsqrt_golden,
     ttir.SigmoidOp: ttir_sigmoid_golden,
     ttir.HardsigmoidOp: ttir_hardsigmoid_golden,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Added relu6 op support via decomposition

### What's changed
- Lowering and testing for relu6
- Added golden reference in 'mapping.py'
- Extended testing to include relu6, with integer support
- Decomposition to d2m::TileClampScalarOp during TTIRToD2M pass

### Checklist
- [ ] New/Existing tests provide coverage for changes
