### PR TITLE
[op-by-op-infra] Remove ttrt dependency, run flatbuffers via _ttmlir_runtime

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -196,6 +196,7 @@ declare_mlir_python_sources(TTMLIRPythonCommon.Main
     compile_and_run_utils.py
     compile_and_run.py
     _flatbuffer_worker.py
+    _system_desc_worker.py
 )
 
 ################################################################################

--- a/python/common/_flatbuffer_worker.py
+++ b/python/common/_flatbuffer_worker.py
@@ -119,13 +119,9 @@ def _run_flatbuffer(flatbuffer_path):
             if fbb.is_program_private(program_index):
                 continue
 
-            inputs, _keepalive = _build_inputs(
-                fbb, program_index, device, tt_runtime
-            )
+            inputs, _keepalive = _build_inputs(fbb, program_index, device, tt_runtime)
 
-            outputs = tt_runtime.runtime.submit(
-                device, fbb, program_index, inputs
-            )
+            outputs = tt_runtime.runtime.submit(device, fbb, program_index, inputs)
             tt_runtime.runtime.wait(outputs)
 
             for out in outputs:

--- a/python/common/_flatbuffer_worker.py
+++ b/python/common/_flatbuffer_worker.py
@@ -3,13 +3,141 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Subprocess worker for running flatbuffers on device.
+Subprocess worker for running flatbuffers on device using _ttmlir_runtime.
 
 Executed as subprocess (not multiprocessing) to ensure clean hardware shutdown.
 """
 
 import json
 import sys
+
+
+def _torch_dtype_to_runtime_dtype(dtype, tt_runtime):
+    import torch
+
+    if dtype == torch.float32:
+        return tt_runtime.runtime.DataType.Float32
+    if dtype == torch.float16:
+        return tt_runtime.runtime.DataType.Float16
+    if dtype == torch.bfloat16:
+        return tt_runtime.runtime.DataType.BFloat16
+    if dtype == torch.uint32:
+        return tt_runtime.runtime.DataType.UInt32
+    if dtype == torch.uint16:
+        return tt_runtime.runtime.DataType.UInt16
+    if dtype == torch.uint8:
+        return tt_runtime.runtime.DataType.UInt8
+    if dtype == torch.int32:
+        return tt_runtime.runtime.DataType.Int32
+    if dtype == torch.float64:
+        return tt_runtime.runtime.DataType.Float64
+    if dtype == torch.int64:
+        return tt_runtime.runtime.DataType.Int64
+    if dtype == torch.uint64:
+        return tt_runtime.runtime.DataType.UInt64
+    if dtype == torch.int16:
+        return tt_runtime.runtime.DataType.Int16
+    if dtype == torch.int8:
+        return tt_runtime.runtime.DataType.Int8
+    if dtype == torch.bool:
+        return tt_runtime.runtime.DataType.Bool
+    raise ValueError(f"Torch dtype: {dtype} has no runtime DataType equivalent")
+
+
+def _runtime_str_dtype_to_torch_dtype(dtype_str):
+    import torch
+
+    mapping = {
+        "Float32": torch.float32,
+        "Float16": torch.float16,
+        "BFloat16": torch.bfloat16,
+        "UInt32": torch.uint32,
+        "UInt16": torch.uint16,
+        "UInt8": torch.uint8,
+        "Int32": torch.int32,
+        "Float64": torch.float64,
+        "Int64": torch.int64,
+        "UInt64": torch.uint64,
+        "Int16": torch.int16,
+        "Int8": torch.int8,
+        "Bool": torch.bool,
+    }
+    if dtype_str not in mapping:
+        raise ValueError(f"Unsupported runtime dtype string: {dtype_str}")
+    return mapping[dtype_str]
+
+
+def _build_inputs(fbb, program_index, device, tt_runtime):
+    import torch
+
+    input_dict = json.loads(fbb.get_program_inputs_as_json(program_index))
+
+    inputs = []
+    # Keep host torch tensors alive for the duration of the submit so the
+    # owned-host-tensor pointers remain valid.
+    keepalive = []
+    for i, spec in enumerate(input_dict):
+        shape = spec["desc"]["shape"]
+        dtype_str = spec["desc"]["layout"]["memory_desc"]["data_type"]
+        torch_dtype = _runtime_str_dtype_to_torch_dtype(dtype_str)
+
+        if torch_dtype.is_floating_point:
+            host_tensor = torch.randn(shape, dtype=torch_dtype)
+        else:
+            host_tensor = torch.zeros(shape, dtype=torch_dtype)
+        keepalive.append(host_tensor)
+
+        rt_tensor = tt_runtime.runtime.create_owned_host_tensor(
+            host_tensor.data_ptr(),
+            list(host_tensor.shape),
+            list(host_tensor.stride()),
+            host_tensor.element_size(),
+            _torch_dtype_to_runtime_dtype(host_tensor.dtype, tt_runtime),
+        )
+
+        layout = tt_runtime.runtime.get_layout(fbb, program_index, i)
+        rt_tensor = tt_runtime.runtime.to_layout(rt_tensor, device, layout, True)
+        inputs.append(rt_tensor)
+
+    return inputs, keepalive
+
+
+def _run_flatbuffer(flatbuffer_path):
+    """Run flatbuffer on device. Returns (return_code, error_message)."""
+    import _ttmlir_runtime as tt_runtime
+
+    fbb = tt_runtime.binary.load_binary_from_path(flatbuffer_path)
+    tt_runtime.runtime.set_compatible_device_runtime(fbb)
+
+    options = tt_runtime.runtime.MeshDeviceOptions()
+    device = tt_runtime.runtime.open_mesh_device(options)
+
+    return_code = 0
+    error_message = None
+    try:
+        for program_index in range(fbb.get_num_programs()):
+            if fbb.is_program_private(program_index):
+                continue
+
+            inputs, _keepalive = _build_inputs(
+                fbb, program_index, device, tt_runtime
+            )
+
+            outputs = tt_runtime.runtime.submit(
+                device, fbb, program_index, inputs
+            )
+            tt_runtime.runtime.wait(outputs)
+
+            for out in outputs:
+                tt_runtime.runtime.to_host(out, untilize=True)
+                tt_runtime.runtime.deallocate_tensor(out, force=True)
+    except Exception as e:
+        return_code = 1
+        error_message = str(e)
+    finally:
+        tt_runtime.runtime.close_mesh_device(device)
+
+    return return_code, error_message
 
 
 def main():
@@ -24,15 +152,17 @@ def main():
     result_path = sys.argv[2]
 
     try:
-        from ttrt.common.api import API
-
-        API.initialize_apis()
-        run_instance = API.Run(args={"binary": flatbuffer_path})
-        return_code, _ = run_instance()
+        return_code, error_message = _run_flatbuffer(flatbuffer_path)
 
         if return_code != 0:
             with open(result_path, "w") as f:
-                json.dump({"status": "error", "error": f"{return_code}"}, f)
+                json.dump(
+                    {
+                        "status": "error",
+                        "error": error_message or f"{return_code}",
+                    },
+                    f,
+                )
         else:
             with open(result_path, "w") as f:
                 json.dump({"status": "success", "return_code": return_code}, f)

--- a/python/common/_flatbuffer_worker.py
+++ b/python/common/_flatbuffer_worker.py
@@ -73,9 +73,6 @@ def _build_inputs(fbb, program_index, device, tt_runtime):
     input_dict = json.loads(fbb.get_program_inputs_as_json(program_index))
 
     inputs = []
-    # Keep host torch tensors alive for the duration of the submit so the
-    # owned-host-tensor pointers remain valid.
-    keepalive = []
     for i, spec in enumerate(input_dict):
         shape = spec["desc"]["shape"]
         dtype_str = spec["desc"]["layout"]["memory_desc"]["data_type"]
@@ -85,7 +82,6 @@ def _build_inputs(fbb, program_index, device, tt_runtime):
             host_tensor = torch.randn(shape, dtype=torch_dtype)
         else:
             host_tensor = torch.zeros(shape, dtype=torch_dtype)
-        keepalive.append(host_tensor)
 
         rt_tensor = tt_runtime.runtime.create_owned_host_tensor(
             host_tensor.data_ptr(),
@@ -99,7 +95,7 @@ def _build_inputs(fbb, program_index, device, tt_runtime):
         rt_tensor = tt_runtime.runtime.to_layout(rt_tensor, device, layout, True)
         inputs.append(rt_tensor)
 
-    return inputs, keepalive
+    return inputs
 
 
 def _run_flatbuffer(flatbuffer_path):
@@ -119,7 +115,7 @@ def _run_flatbuffer(flatbuffer_path):
             if fbb.is_program_private(program_index):
                 continue
 
-            inputs, _keepalive = _build_inputs(fbb, program_index, device, tt_runtime)
+            inputs = _build_inputs(fbb, program_index, device, tt_runtime)
 
             outputs = tt_runtime.runtime.submit(device, fbb, program_index, inputs)
             tt_runtime.runtime.wait(outputs)

--- a/python/common/_system_desc_worker.py
+++ b/python/common/_system_desc_worker.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Subprocess worker for generating the system descriptor.
+
+Executed as subprocess (not multiprocessing) so that the device is released
+cleanly when the process exits, freeing the hardware for subsequent device
+opens in other subprocesses.
+"""
+
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python -m python.common._system_desc_worker <output_path>")
+        sys.exit(1)
+
+    output_path = sys.argv[1]
+
+    import _ttmlir_runtime as tt_runtime
+
+    system_desc = tt_runtime.runtime.get_current_system_desc()
+    system_desc.store(output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/common/compile_and_run.py
+++ b/python/common/compile_and_run.py
@@ -38,12 +38,15 @@ def stablehlo_to_ttir(module: Module | str) -> Module:
     return run_compilation_process(stablehlo_to_ttir_pipeline_worker, (m,))
 
 
+def _resolve_system_desc(system_desc: str | None) -> str:
+    if system_desc is not None:
+        return system_desc
+    return os.getenv("SYSTEM_DESC_PATH", "ttrt-artifacts/system_desc.ttsys")
+
+
 def ttir_to_ttnn(
     module: Module | str,
-    system_desc: str = os.getenv(
-        "SYSTEM_DESC_PATH",
-        "ttrt-artifacts/system_desc.ttsys",
-    ),
+    system_desc: str | None = None,
 ) -> Module:
     """
     Runs `ttir-to-ttnn-runtime-pipeline` compiler pass on `module` in a safe way.
@@ -62,16 +65,13 @@ def ttir_to_ttnn(
     """
     m = module if isinstance(module, str) else str(module)
     return run_compilation_process(
-        ttir_to_ttnn_runtime_pipeline_worker, (m, system_desc)
+        ttir_to_ttnn_runtime_pipeline_worker, (m, _resolve_system_desc(system_desc))
     )
 
 
 def ttir_to_ttmetal(
     module: Module | str,
-    system_desc: str = os.getenv(
-        "SYSTEM_DESC_PATH",
-        "ttrt-artifacts/system_desc.ttsys",
-    ),
+    system_desc: str | None = None,
 ) -> Module:
     """
     Runs `ttir-to-ttmetal-pipeline` compiler pass on `module` in a safe way.
@@ -90,13 +90,11 @@ def ttir_to_ttmetal(
     """
     m = module if isinstance(module, str) else str(module)
     return run_compilation_process(
-        ttir_to_ttmetal_backend_pipeline_worker, (m, system_desc)
+        ttir_to_ttmetal_backend_pipeline_worker, (m, _resolve_system_desc(system_desc))
     )
 
 
-def ttnn_to_flatbuffer(
-    module: Module, output_file_name: str = "ttnn_fb.ttnn"
-) -> str:
+def ttnn_to_flatbuffer(module: Module, output_file_name: str = "ttnn_fb.ttnn") -> str:
     """
     Converts TTNN module to flatbuffer in a safe way and saves to file.
 

--- a/python/common/compile_and_run.py
+++ b/python/common/compile_and_run.py
@@ -14,7 +14,6 @@ raising RuntimeError that can be handled with a try-except block in caller.
 import os
 
 from ttmlir.ir import Module
-from ttrt.common.util import Binary
 
 from .compile_and_run_internal import *
 
@@ -97,7 +96,7 @@ def ttir_to_ttmetal(
 
 def ttnn_to_flatbuffer(
     module: Module, output_file_name: str = "ttnn_fb.ttnn"
-) -> Binary:
+) -> str:
     """
     Converts TTNN module to flatbuffer in a safe way and saves to file.
 
@@ -107,7 +106,7 @@ def ttnn_to_flatbuffer(
 
     Returns
     -------
-    Flatbuffer `Binary` instance for convenience.
+    Path to the generated flatbuffer file.
 
     Raises
     ------
@@ -121,7 +120,7 @@ def ttnn_to_flatbuffer(
 
 def ttmetal_to_flatbuffer(
     module: Module, output_file_name: str = "ttmetal_fb.ttm"
-) -> Binary:
+) -> str:
     """
     Converts ttmetal module to flatbuffer in a safe way and saves to file.
 
@@ -131,7 +130,7 @@ def ttmetal_to_flatbuffer(
 
     Returns
     -------
-    Flatbuffer `Binary` instance for convenience.
+    Path to the generated flatbuffer file.
 
     Raises
     ------
@@ -143,20 +142,20 @@ def ttmetal_to_flatbuffer(
     )
 
 
-def run_flatbuffer(flatbuffer: Binary) -> int:
+def run_flatbuffer(flatbuffer_path: str) -> int:
     """
-    Runs `flatbuffer` on device in a safe way.
+    Runs flatbuffer at `flatbuffer_path` on device in a safe way.
 
-    This is a segfault resistant function. It runs the pybound translation pass in a
-    separate process, thus protecting the caller of this function from any unpredictable
-    (those that cannot be caught with a try-except) errors.
+    This is a segfault resistant function. It runs the device execution in a
+    separate subprocess, thus protecting the caller of this function from any
+    unpredictable (those that cannot be caught with a try-except) errors.
 
     Returns
     -------
-    Return code of `ttrt run flatbuffer.file_path` process.
+    Return code of the device run subprocess (0 on success).
 
     Raises
     ------
     RuntimeError if any errors happen.
     """
-    return run_flatbuffer_execution_process(flatbuffer.file_path)
+    return run_flatbuffer_execution_process(flatbuffer_path)

--- a/python/common/compile_and_run_internal.py
+++ b/python/common/compile_and_run_internal.py
@@ -15,7 +15,6 @@ from ttmlir.passes import (
     ttmetal_to_flatbuffer_file,
     ttnn_to_flatbuffer_file,
 )
-from ttrt.common.util import Binary, FileManager, Logger
 
 from .compile_and_run_utils import *
 
@@ -125,9 +124,6 @@ def ttmetal_to_flatbuffer_file_worker(
         result_queue.put(TranslationProcessResult.error(str(e)))
 
 
-# ---------- Utility wrappers around ttrt ----------
-
-
 # ---------- Public API ----------
 
 
@@ -149,23 +145,17 @@ def run_compilation_process(
 def run_translation_process(
     worker_fn: Callable,
     worker_args_without_queue: Tuple = (),
-) -> Binary:
+) -> str:
     """
     Runs `worker_fn` (function doing some translation pass) in a separate process,
-    returns produced flatbuffer `Binary` instance if no errors happened, otherwise
+    returns path to produced flatbuffer file if no errors happened, otherwise
     raises RuntimeError.
     """
-
-    def create_binary_from_fb_file(fb_file_path: str) -> Binary:
-        logger = Logger()
-        file_manager = FileManager(logger)
-        return Binary(logger, file_manager, fb_file_path)
-
     process_manager = get_process_manager()
     result: TranslationProcessResult = process_manager.run(
         worker_fn, worker_args_without_queue
     )
-    return create_binary_from_fb_file(result.fb_file_path)
+    return result.fb_file_path
 
 
 def run_flatbuffer_execution_process(

--- a/test/python/op_by_op/conftest.py
+++ b/test/python/op_by_op/conftest.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from op_by_op_infra.workflow import _ensure_system_desc
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _bootstrap_system_desc():
+    """Generate the system descriptor in-process before any op-by-op test runs."""
+    _ensure_system_desc()

--- a/test/python/op_by_op/op_by_op_read_ir_from_file.py
+++ b/test/python/op_by_op/op_by_op_read_ir_from_file.py
@@ -14,9 +14,6 @@ Requires:
     cmake -G Ninja -B build -DTTMLIR_ENABLE_RUNTIME=ON -DTTMLIR_ENABLE_STABLEHLO=ON
     cmake --build build
 
-    # Having system descriptor saved
-    ttrt query --save-artifacts
-
 Usage Examples:
     # Generate JSON report with pytest
     pytest -svv test/python/op_by_op/op_by_op_read_ir_from_file.py::test_op_by_op_inference_from_file --json-report --json-report-file=report.json

--- a/tools/op-by-op-infra/op_by_op_infra/execution_result.py
+++ b/tools/op-by-op-infra/op_by_op_infra/execution_result.py
@@ -9,8 +9,6 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from ttrt.common.util import Binary
-
 from .pydantic_models import OpTest, TensorDesc
 from .utils import ModuleWrapper
 
@@ -38,11 +36,11 @@ class ExecutionResult:
     execution_phase: ExecutionPhase
     # Last module generated during compilation.
     last_generated_module: ModuleWrapper
-    # Flatbuffer generated from TTNN module.
+    # Path to flatbuffer generated from TTNN module.
     # None if execution_phase < GENERATED_FLATBUFFER.
-    flatbuffer: Optional[Binary] = None
+    flatbuffer_path: Optional[str] = None
     # Flag indicating successful run on device.
-    # False if execution_phase < EXECUTED_FLATBUFFER or ttrt run returned code != 0.
+    # False if execution_phase < EXECUTED_FLATBUFFER or device run returned non-zero.
     device_run_passed: bool = False
     # Error message from the step that failed. None if all steps succeeded.
     error_message: Optional[str] = None
@@ -67,7 +65,7 @@ class ExecutionResult:
         """Returns True if flatbuffer was successfully produced from TTNN module."""
         return (
             self.execution_phase == ExecutionPhase.GENERATED_FLATBUFFER
-            and self.flatbuffer is not None
+            and self.flatbuffer_path is not None
         )
 
     @property

--- a/tools/op-by-op-infra/op_by_op_infra/mlir_module_executor.py
+++ b/tools/op-by-op-infra/op_by_op_infra/mlir_module_executor.py
@@ -13,7 +13,6 @@ from ttmlir.compile_and_run import (
     ttir_to_ttnn,
     ttnn_to_flatbuffer,
 )
-from ttrt.common.util import Binary
 
 from .execution_result import ExecutionPhase, ExecutionResult
 from .utils import (
@@ -113,15 +112,15 @@ class MLIRModuleExecutor:
         self,
         new_phase: ExecutionPhase,
         generated_module: Optional[ModuleWrapper] = None,
-        generated_flatbuffer: Optional[Binary] = None,
+        generated_flatbuffer_path: Optional[str] = None,
         run_passed: Optional[bool] = None,
     ) -> None:
         """Marks execution progress."""
         self._execution_result.execution_phase = new_phase
         if generated_module is not None:
             self._execution_result.last_generated_module = generated_module
-        if generated_flatbuffer is not None:
-            self._execution_result.flatbuffer = generated_flatbuffer
+        if generated_flatbuffer_path is not None:
+            self._execution_result.flatbuffer_path = generated_flatbuffer_path
         if run_passed is not None:
             self._execution_result.device_run_passed = run_passed
 
@@ -215,23 +214,24 @@ class MLIRModuleExecutor:
 
     def _generate_flatbuffer(
         self, flatbuffer_name: str = "ttnn_fb.ttnn"
-    ) -> Optional[Binary]:
+    ) -> Optional[str]:
         """
         Attempts generating flatbuffer from TTNN module.
 
-        Returns flatbuffer if successfully generated, None otherwise.
+        Returns flatbuffer file path if successfully generated, None otherwise.
         """
         assert self._execution_result.compilation_finished
 
         try:
-            flatbuffer = ttnn_to_flatbuffer(
+            flatbuffer_path = ttnn_to_flatbuffer(
                 self._execution_result.last_generated_module.module, flatbuffer_name
             )
             self._mark_execution_step(
-                ExecutionPhase.GENERATED_FLATBUFFER, generated_flatbuffer=flatbuffer
+                ExecutionPhase.GENERATED_FLATBUFFER,
+                generated_flatbuffer_path=flatbuffer_path,
             )
         finally:
-            return self._execution_result.flatbuffer
+            return self._execution_result.flatbuffer_path
 
     def _run(self) -> bool:
         """
@@ -243,7 +243,7 @@ class MLIRModuleExecutor:
         assert self._execution_result.flatbuffer_generated
 
         try:
-            return_code = run_flatbuffer(self._execution_result.flatbuffer)
+            return_code = run_flatbuffer(self._execution_result.flatbuffer_path)
             if return_code == 0:
                 self._mark_execution_step(
                     ExecutionPhase.EXECUTED_FLATBUFFER, run_passed=True

--- a/tools/op-by-op-infra/op_by_op_infra/workflow.py
+++ b/tools/op-by-op-infra/op_by_op_infra/workflow.py
@@ -66,9 +66,7 @@ def _ensure_system_desc() -> None:
             f"(subprocess exit {e.returncode}): {e.stderr}"
         ) from e
     except subprocess.TimeoutExpired as e:
-        raise RuntimeError(
-            f"System descriptor generation timed out: {e}"
-        ) from e
+        raise RuntimeError(f"System descriptor generation timed out: {e}") from e
 
     if not os.path.exists(path):
         raise RuntimeError(

--- a/tools/op-by-op-infra/op_by_op_infra/workflow.py
+++ b/tools/op-by-op-infra/op_by_op_infra/workflow.py
@@ -9,6 +9,9 @@ It is meant to simplify and abstract away all complexities of the infra.
 
 import os
 import re
+import subprocess
+import sys
+import tempfile
 from typing import List, Optional
 
 from ttmlir.ir import Module
@@ -17,6 +20,64 @@ from . import workflow_internal
 from .mlir_module_splitter import MLIRModuleSplitter
 from .pydantic_models import OpTest
 from .utils import OpWrapper
+
+_SYSTEM_DESC_PATH: Optional[str] = None
+
+
+def _ensure_system_desc() -> None:
+    """
+    Generates the system descriptor via `_ttmlir_runtime` in a subprocess and
+    points `SYSTEM_DESC_PATH` at it so the compiler pipeline can consume it.
+
+    The subprocess is used so that device resources opened during descriptor
+    generation are released cleanly when the subprocess exits, freeing the
+    hardware for per-op flatbuffer runs later in the session.
+
+    Generates once per Python process; subsequent calls are no-ops. Unconditionally
+    overrides any pre-existing `SYSTEM_DESC_PATH`.
+    """
+    global _SYSTEM_DESC_PATH
+
+    if _SYSTEM_DESC_PATH is not None and os.path.exists(_SYSTEM_DESC_PATH):
+        os.environ["SYSTEM_DESC_PATH"] = _SYSTEM_DESC_PATH
+        return
+
+    path = os.path.join(
+        tempfile.gettempdir(), f"op_by_op_system_desc_{os.getpid()}.ttsys"
+    )
+
+    from ttmlir import compile_and_run
+
+    worker_path = os.path.join(
+        os.path.dirname(compile_and_run.__file__), "_system_desc_worker.py"
+    )
+
+    try:
+        subprocess.run(
+            [sys.executable, worker_path, path],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"Could not obtain system descriptor from _ttmlir_runtime "
+            f"(subprocess exit {e.returncode}): {e.stderr}"
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"System descriptor generation timed out: {e}"
+        ) from e
+
+    if not os.path.exists(path):
+        raise RuntimeError(
+            f"System descriptor subprocess returned successfully but no file "
+            f"was written at {path}"
+        )
+
+    _SYSTEM_DESC_PATH = path
+    os.environ["SYSTEM_DESC_PATH"] = path
 
 
 def run_op_by_op_workflow(
@@ -57,6 +118,7 @@ def run_op_by_op_workflow(
     List[OpTest]
         List of `OpTest` pydantic models
     """
+    _ensure_system_desc()
 
     if compile_before_split:
         assert compile_each_submodule_after_split is not True, (
@@ -167,6 +229,8 @@ def execute_extracted_ops(
     List[OpTest]
         List of OpTest pydantic models with execution results
     """
+    _ensure_system_desc()
+
     executor = workflow_internal.MLIRModuleExecutor(
         compile_only, debug_print=debug_print
     )


### PR DESCRIPTION
### Problem description
The op-by-op infra depended on `ttrt.common` (the `ttrt` Python CLI layer) for running flatbuffers, generating the system descriptor, and wrapping flatbuffers in `Binary`. This pulls in `ttrt` and breaks when the infra is consumed outside the tt-mlir env.

### What's changed
- Run flatbuffers on device directly via `_ttmlir_runtime` in a subprocess worker; drop `ttrt.common.api.API.Run`
- Generate the system descriptor in a subprocess worker (`_system_desc_worker.py`) and point `SYSTEM_DESC_PATH` at it
- Pass flatbuffer **paths** (`str`) instead of `ttrt` `Binary` objects throughout the infra
- Resolve `SYSTEM_DESC_PATH` at call time instead of at import

### Checklist
- [ ] New/Existing tests provide coverage for changes
