### PR TITLE
Pass computeConfig for LinearOp in TTNNToFlatbuffer conversion

### DIFF
--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -497,9 +497,15 @@ createOp(FlatbufferObjectCache &cache, LinearOp op) {
   }
 
   auto activation = toFlatbuffer(cache, op.getActivation()).value_or(0);
+
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   return ::tt::target::ttnn::CreateLinearOp(
       *cache.fbb, a, b, bias, output, op.getTransposeA(), op.getTransposeB(),
-      matmulProgramConfigType, matmulProgramConfigDesc, activation);
+      matmulProgramConfigType, matmulProgramConfigDesc, activation,
+      computeConfig.value_or(0));
 }
 
 // ANCHOR: adding_an_op_matmul_serialize_to_binary


### PR DESCRIPTION
### Ticket
N/A
### Problem description
Previously, `computeConfig` attribute of `linearOp` was not passed in TTNNToFlatbuffer conversion, and the attribute was defaulted to null. This caused `swin/image_classification/pytorch-S-single_device-inference` to fail with a lower pcc due to a mismatch between the flatbuffer path and emitpy path, which is properly passing `computeConfig`.  
### What's changed
Now, `computeConfig` is passed properly.

### Checklist
- [ ] New/Existing tests provide coverage for changes
