### PR TITLE
[Optimizer] Give empty-beam sink ops a fallback candidate in MemoryLayoutPropagation

### DIFF
--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -604,11 +604,15 @@ MemoryLayoutPropagation::processOp(Operation *op) {
                  op->getName(), op->getLoc());
 
     TTNNLayoutAttr dramLayout = getDRAMInterleavedFallback(op);
-    if (dramLayout) {
+    bool isSink = optimizer_utils::isSinkOp(op);
+    if (dramLayout || isSink) {
       BeamCandidate fallback;
-      fallback.configHint = OpConfig(dramLayout);
-      fallback.score = LayoutScore(); // Lowest possible score.
-      fallback.outputLayouts.assign(op->getNumResults(), dramLayout);
+      fallback.configHint =
+          dramLayout ? OpConfig(dramLayout) : OpConfig(TTNNLayoutAttr());
+      fallback.score = LayoutScore();
+      if (dramLayout) {
+        fallback.outputLayouts.assign(op->getNumResults(), dramLayout);
+      }
       // When all tryHint calls fail (e.g. op model unavailable in NO_DISPATCH
       // mode) we fall through to this synthetic candidate. It carries no
       // producerCandidateIndices, so downstream phases implicitly assume the
@@ -1265,9 +1269,11 @@ MemoryLayoutPropagation::getDRAMInterleavedFallback(Operation *op) {
   }
   auto currentLayout =
       mlir::dyn_cast_or_null<TTNNLayoutAttr>(tensorType.getEncoding());
-  if (!currentLayout) {
-    return nullptr;
-  }
+  // A ranked tensor result always carries a TTNNLayoutAttr encoding by the
+  // time layout propagation runs (defaulted to DRAM-interleaved by the
+  // TTNNLayout pass), so a non-sink beam target always gets a fallback.
+  assert(currentLayout &&
+         "ranked tensor result must have a TTNNLayoutAttr encoding");
 
   // If the op already has an L1 layout it was pinned by an earlier pass
   // (workaround or lowering) that knows what the backend kernel requires.

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
@@ -127,10 +127,10 @@ public:
 
       func->walk([&](Operation *op) {
         if (!optimizer_utils::opHasTensorResult(op)) {
-          // Constraint sinks (FillCacheOp, PagedUpdateCacheOp) have no tensor
-          // result but still need input layout validation. Register a
-          // null-output OpConfig so processOp can validate their input
-          // combinations and drive upstream reshards.
+          // Constraint sinks (FillCacheOp, PagedUpdateCacheOp,
+          // PagedFillCacheOp) have no tensor result but still need input layout
+          // validation. Register a null-output OpConfig so processOp can
+          // validate their input combinations and drive upstream reshards.
           if (mlir::dyn_cast<OpModel>(op) && optimizer_utils::isSinkOp(op)) {
             legalConfigs[op] = {OpConfig{TTNNLayoutAttr()}};
           }

--- a/test/unittests/Optimizer/TestBeamSearch.cpp
+++ b/test/unittests/Optimizer/TestBeamSearch.cpp
@@ -478,3 +478,62 @@ TEST_F(BeamSearchTest, NoValidCandidateFallbackToDRAM) {
     }
   }
 }
+
+//===----------------------------------------------------------------------===//
+// Edge case: empty-beam sink op must still get a fallback candidate
+//===----------------------------------------------------------------------===//
+
+// Reproduced deterministically with a minimal DRAM-only candidate space (like
+// opt-level 1, where sharded/L1 layouts are cleared) plus an input whose
+// sequence length (128) exceeds the cache (64), so the single DRAM-interleaved
+// combo fails validation. The fix gives the sink op a fallback candidate, so
+// its beam is non-empty and consolidateBeam never indexes an empty vector.
+TEST_F(BeamSearchTest, SinkOpEmptyBeamGetsFallbackCandidate) {
+  llvm::SmallVector<int64_t> inputShape = {1, 32, 128, 512};
+  llvm::SmallVector<int64_t> cacheShape = {1, 32, 64, 512};
+  auto inputLayout = createDRAMInterleavedLayout(inputShape);
+  auto inputType = mlir::RankedTensorType::get(
+      inputShape, builder.getBF16Type(), inputLayout);
+  auto cacheLayout = createDRAMInterleavedLayout(cacheShape);
+  auto cacheType = mlir::RankedTensorType::get(
+      cacheShape, builder.getBF16Type(), cacheLayout);
+
+  // func(cache, in0, in1) -> cache.
+  // add(in0, in1)'s only consumer is a FillCacheOp sink (no tensor result).
+  createFuncOp({cacheType, inputType, inputType}, {cacheType});
+  mlir::Value cache = func.getBody().front().getArgument(0);
+  mlir::Value in0 = func.getBody().front().getArgument(1);
+  mlir::Value in1 = func.getBody().front().getArgument(2);
+
+  auto addOp =
+      builder.create<AddOp>(builder.getUnknownLoc(), inputType, in0, in1);
+  auto fillCache = builder.create<FillCacheOp>(builder.getUnknownLoc(), cache,
+                                               addOp.getResult(),
+                                               builder.getI32IntegerAttr(0));
+  builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(), cache);
+
+  // DRAM-only legal configs: a single interleaved combo, which the bad shape
+  // makes fail validation -> empty beam without a sink fallback.
+  std::vector<OpConfig> dramOnly;
+  dramOnly.emplace_back(createDRAMInterleavedLayout(inputShape));
+
+  llvm::DenseMap<mlir::Operation *, std::vector<OpConfig>> legalConfigs;
+  legalConfigs[addOp.getOperation()] = dramOnly;
+  legalConfigs[fillCache.getOperation()] = dramOnly;
+
+  MemoryLayoutPropagation propagation(func, legalConfigs,
+                                      /*tensorTypePossibleLayouts=*/nullptr,
+                                      /*beamWidth=*/8);
+
+  // Without the fix this aborts in consolidateBeam (empty-beam consumer).
+  EXPECT_NO_FATAL_FAILURE(propagation.run());
+
+  // With the fix the sink op gets a fallback candidate instead of an empty
+  // beam, so its input-reshard role is preserved and consolidateBeam is safe.
+  const auto &bs = propagation.getBeamState();
+  auto fcIt = bs.find(fillCache.getOperation());
+  ASSERT_NE(fcIt, bs.end());
+  EXPECT_FALSE(fcIt->second.empty())
+      << "sink op with no valid input combination must still get a fallback "
+         "candidate";
+}


### PR DESCRIPTION
## Problem

A cache-write sink op (`fill_cache` / `paged_update_cache` / `paged_fill_cache`) is a beam-search target via `isSinkOp` but has **no tensor result**. When the op-model constraint query rejects every input combination, its beam comes out **empty** — and unlike a normal op, `getDRAMInterleavedFallback` cannot synthesize a fallback for a result-less op.

That empty beam:
1. **Aborted `consolidateBeam`** (`SmallVector idx < size()`) when the sink was a producer's sole consumer — the crash reported in tenstorrent/tt-xla#4990 (opt-level 1, vLLM OPT/LLaMA/Qwen prefill).
2. Silently dropped the sink op's role of **driving its own input layout/reshard**.

Reachable at `optimization_level=1` because `enableGreedyOptimizer = (optLevel >= 1)` runs `MemoryLayoutPropagation` with the default `beamWidth=8`, so the backward pass (`consolidateBeam`) executes.

## Confirmed root cause of the empty beam (tt-xla #4990)

Traced on the failing OPT-125m model via the decision-trace JSON and an isolated `OpModel<PagedFillCacheOp>` test. For **all 768** `paged_fill_cache` ops the constraint query fails with:

```
TT_FATAL @ paged_fill_cache_device_operation.cpp:105: tensor.physical_volume() == 1
info: Batch idx tensor must have a single element
```

The `batch_idx` operand is `<1xi32>` — logically a single element. The chain:

- `batch_idx` is a **constant-marked arg** and is **not row-major-propagated before the optimizer**, so it reaches the greedy pass laid out **tiled**.
- A `<1xi32>` tensor laid out **tiled** pads to a 32×32 tile → `physical_volume()` = 1024 ≠ 1 → `TT_FATAL`. Laid out **row-major** → volume 1 → query passes. (Verified directly: `OpModelTest.PagedFillCacheBatchIdxLayout` — row-major OK, tiled FAILED, absent OK.)
- So every `paged_fill_cache` query fails → empty beam → (pre-fix) `consolidateBeam` OOB.
- The op itself is fine: the post-optimizer `ValidationFallback` pass converts the operand back to row-major (`[validation-fallback] ... ttnn.paged_fill_cache operand 3: layout tile -> row_major`), which is why opt-level 0 and the final IR are unaffected.

This makes the op-model query *correct* to reject a tiled `batch_idx`; the deeper issue is the optimizer offering a tiled layout for an index operand that must stay row-major (follow-up below).

## Fix

- Synthesize a **null-output fallback candidate** for sink ops in the `candidates.empty()` branch, carrying the input-filter reshards. Every beam target now yields ≥1 candidate, so the beam is never empty and `consolidateBeam` can never index an empty vector — the root cause of the crash, not just a bounds guard.
- Assert the `TTNNLayoutAttr` encoding invariant in `getDRAMInterleavedFallback` (a ranked-tensor result always has an encoding by the time layout propagation runs), guaranteeing non-sink targets always get a DRAM fallback.
- Stale-comment fix: include `PagedFillCacheOp` in the sink-op list.

Verified on the failing model: at opt-level 1 the compile now completes and all 768 `paged_fill_cache` ops survive (no abort).

## Test

`BeamSearchTest.SinkOpEmptyBeamGetsFallbackCandidate` — DRAM-only configs plus a rejecting shape force the empty-beam condition; asserts no crash and a non-empty sink beam. Aborts before the fix, passes after.

## Follow-up (not in this PR)

Keep the index operands (`batch_idx`, `page_table`) **row-major** before/through the optimizer so the `paged_fill_cache` query validates instead of always falling back — e.g. a per-operand row-major input filter in `PagedFillCacheRuleBook` / `PagedUpdateCacheRuleBook`, or RM-propagation for constant-marked index args. This fallback remains the correct safety net regardless: an op-model query that hard-errors must never abort the optimizer.

Closes: https://github.com/tenstorrent/tt-xla/issues/4990

🤖 Generated with [Claude Code](https://claude.com/claude-code)