### PR TITLE
[EmitPy] Fix ScaledDotProductAttentionOp conversion

### DIFF
--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -4321,6 +4321,9 @@ public:
         emitter.emit<float>(srcOp.getScaleAttr(), "scale"),
         emitter.emit(srcOp.getSlidingWindowSize(), "sliding_window_size"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
+        emitter.emit(std::nullopt, "program_config"),
+        emitter.emit(std::nullopt, "compute_kernel_config"),
+        emitter.emit(srcOp.getAttentionSink(), "attention_sink"),
     };
 
     emitter.replaceOp(*this, args);


### PR DESCRIPTION
### Ticket
N/A

### What's changed
Added `ScaledDotProductAttentionOp` missing args in TTNNToEmitPy conversion.

### Checklist
- [ ] New/Existing tests provide coverage for changes
