### PR TITLE
[StableHLOToTTIR] Restore int gather coverage for embedding-shaped shapes

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -4734,13 +4734,186 @@ class StableHLOGatherToEmbeddingPattern
    */
   LogicalResult checkBasicLegality(mlir::stablehlo::GatherOp srcOp,
                                    PatternRewriter &rewriter) const {
-    auto dimensionNumbers = srcOp.getDimensionNumbers();
+    // Shape/slice constraints shared with the integer-gather lowering.
+    if (failed(checkGatherShapeLegality(srcOp, rewriter))) {
+      return failure();
+    }
 
-    // Get input and start indices tensor shape.
+    // ttir.embedding casts its weight to bf16, which represents integers
+    // exactly only in [-256, 256], so wide integers round. Handle single-index
+    // integer gathers to StableHLOGatherIntToGatherPattern (ttir.gather keeps
+    // their precision); every other case (multi-dim integer indexing,
+    // index-typed, and float operands) stays on the embedding path unchanged.
+    auto operandElemType = srcOp.getOperand().getType().getElementType();
+    if (mlir::isa<mlir::IntegerType>(operandElemType) &&
+        numFlattenedIndexingDims(srcOp) <= 1) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "single-index integer gather lowered via ttir.gather");
+    }
+
+    return success();
+  }
+
+public:
+  /**
+   * Lowers Gather Op into Embedding Op (and applies Reshape and Permute Ops, if
+   * necessary)
+   *
+   * There is no TTNN Gather support.
+   * Gather Op is lowered into Embedding Op.
+   * Torch embeddings are lowered into Gather Op.
+   * Most models use Gather Op to implement simple embeddings.
+   * If encountered more complicated Gather Op implementations, they can be
+   * lowered into slice/ concat/ etc.
+   *
+   * Embedding Op expects:
+   * - weights to be strictly 2D. We index the first dimension of weights, and
+   * take slices from the full second dimension.
+   * - input can be 1D or 2D
+   * - output shape is the shape of input with the last dimension of the
+   * weights appended
+   *
+   *  - Gather Op input becomes Embedding Op weights. Because it can have
+   * any number and order of dimensions, it is permuted and reshaped
+   * (flattened).
+   *  - Gather Op startIndices becomes Embedding Op input. Because it can
+   * have any number and order of dimensions, it is permuted and reshaped
+   * (flattened).
+   * - Embedding Op output needs to be reshaped to recover lost
+   * dimensions and permuted as Gather Op output dimensions can be in any
+   * order.
+   */
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::GatherOp srcOp,
+                  mlir::stablehlo::GatherOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // GatherOp can be used to implement embedding lookup, check for that case.
+    LogicalResult err = checkBasicLegality(srcOp, rewriter);
+    if (!err.succeeded()) {
+      return err;
+    }
+
+    // Normalize the gather into the shared 2D (weights, indices) operands and
+    // lower to ttir.embedding. Integer single-index gathers are rejected by
+    // checkBasicLegality and handled by StableHLOGatherIntToGatherPattern.
+    GatherOperands ops = buildGatherOperands(srcOp, adaptor, rewriter);
+
+    auto embeddingOutputType = mlir::RankedTensorType::get(
+        ops.newOutputShape, ops.reshapedInput.getType().getElementType(),
+        ops.reshapedInput.getType().getEncoding());
+    ttir::EmbeddingOp embeddingOp =
+        rewriter.create<ttir::EmbeddingOp>(srcOp.getLoc(), embeddingOutputType,
+                                           ops.startIndices, ops.reshapedInput);
+
+    auto expectedOutputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult().getType()));
+    rewriter.replaceOp(srcOp, reshapeAndPermuteOutput(rewriter, embeddingOp,
+                                                      ops.indexedDim, srcOp,
+                                                      expectedOutputType));
+    return success();
+  }
+
+public:
+  // Result of buildGatherOperands: the 2D operands the embedding and
+  // integer-gather lowerings share, plus the metadata needed to reshape the
+  // result back to the gather's output layout.
+  struct GatherOperands {
+    // Operand permuted so indexed dims lead, then flattened to 2D [V, D].
+    mlir::TypedValue<mlir::RankedTensorType> reshapedInput;
+    // Start indices flattened/sliced/expanded to 2D.
+    mlir::TypedValue<mlir::RankedTensorType> startIndices;
+    // startIndices shape with the trailing weight dim (D) appended -- the
+    // shape the terminal op (embedding/gather) produces before
+    // reshapeAndPermuteOutput.
+    llvm::SmallVector<int64_t> newOutputShape;
+    // First flattened indexing dim; the axis reshapeAndPermuteOutput permutes
+    // around.
+    int64_t indexedDim;
+  };
+
+  // Pure description (emits no IR) of which operand dims actually get indexed
+  // after dropping full-slice dims and handling singletons. Mirrors the
+  // filtering buildGatherOperands performs, so legality checks can reason
+  // about the flattened indexing dims without building any ops.
+  struct IndexedDimInfo {
+    llvm::SmallVector<int64_t> startIndexMap;
+    int64_t actualIndexedDim;
+    bool needsExpansion;
+  };
+
+  static IndexedDimInfo computeIndexedDimInfo(mlir::stablehlo::GatherOp srcOp) {
+    auto dimensionNumbers = srcOp.getDimensionNumbers();
+    auto inputShape = srcOp.getOperand().getType().getShape();
+    auto sliceSizes = srcOp.getSliceSizes();
+    auto originalStartIndexMap = dimensionNumbers.getStartIndexMap();
+
+    // If there are indexed dims that have full slice size, we need to ignore
+    // them and slice indices accordingly, which is why we note the
+    // actualIndexedDim.
+    int64_t actualIndexedDim = -1;
+
+    // If there is an indexed dim with slice size > 1, but not full, we need to
+    // expand start indices to contain the implied ones.
+    bool needsExpansion = false;
+
+    // Create startIndexMap without dims for which sliceSizes[dim] =
+    // inputShape[dim]. If there are dims for which sliceSizes[dim] =
+    // inputShape[dim] = 1, they are treated specially:
+    // - if there is a partially indexed dim, they are removed
+    // - if all other indexed dims are full, one of them is kept
+    size_t fullIndexedDims = 0;
+    bool partialIndexedDimExists = false;
+    for (size_t i = 0; i < originalStartIndexMap.size(); ++i) {
+      int64_t dim = originalStartIndexMap[i];
+      if (sliceSizes[dim] == inputShape[dim]) {
+        fullIndexedDims++;
+      } else if (sliceSizes[dim] != 1) {
+        partialIndexedDimExists = true;
+      }
+    }
+
+    llvm::SmallVector<int64_t> startIndexMap;
+    for (size_t i = 0; i < originalStartIndexMap.size(); ++i) {
+      int64_t dim = originalStartIndexMap[i];
+      if (inputShape[dim] == 1) {
+        if (fullIndexedDims == originalStartIndexMap.size()) {
+          startIndexMap.push_back(dim);
+          actualIndexedDim = i;
+          break;
+        }
+        if (partialIndexedDimExists || fullIndexedDims > 0) {
+          continue;
+        }
+      } else if (sliceSizes[dim] == inputShape[dim]) {
+        continue;
+      }
+
+      startIndexMap.push_back(dim);
+      actualIndexedDim = i;
+      if (sliceSizes[dim] != 1) {
+        needsExpansion = true;
+      }
+    }
+
+    return IndexedDimInfo{std::move(startIndexMap), actualIndexedDim,
+                          needsExpansion};
+  }
+
+  // Number of input dims flattened into the single embedding/gather index
+  // dimension. Used to distinguish single-index gathers (-> ttir.gather for
+  // integers) from multi-index gathers.
+  static size_t numFlattenedIndexingDims(mlir::stablehlo::GatherOp srcOp) {
+    return computeIndexedDimInfo(srcOp).startIndexMap.size();
+  }
+
+  // Shape/slice constraints required to normalize a gather into the 2D
+  // (weights, indices) form. Element-type agnostic, so it is shared by the
+  // embedding and integer-gather patterns.
+  static LogicalResult checkGatherShapeLegality(mlir::stablehlo::GatherOp srcOp,
+                                                PatternRewriter &rewriter) {
+    auto dimensionNumbers = srcOp.getDimensionNumbers();
     auto inputShape = srcOp.getOperand().getType().getShape();
     auto startIndicesShape = srcOp.getStartIndices().getType().getShape();
-
-    // Get attributes needed for embedding op pattern matching checks.
     auto sliceSizes = srcOp.getSliceSizes();
     auto startIndexMap = dimensionNumbers.getStartIndexMap();
 
@@ -4799,98 +4972,24 @@ class StableHLOGatherToEmbeddingPattern
     return success();
   }
 
-public:
-  /**
-   * Lowers Gather Op into Embedding Op (and applies Reshape and Permute Ops, if
-   * necessary)
-   *
-   * There is no TTNN Gather support.
-   * Gather Op is lowered into Embedding Op.
-   * Torch embeddings are lowered into Gather Op.
-   * Most models use Gather Op to implement simple embeddings.
-   * If encountered more complicated Gather Op implementations, they can be
-   * lowered into slice/ concat/ etc.
-   *
-   * Embedding Op expects:
-   * - weights to be strictly 2D. We index the first dimension of weights, and
-   * take slices from the full second dimension.
-   * - input can be 1D or 2D
-   * - output shape is the shape of input with the last dimension of the
-   * weights appended
-   *
-   *  - Gather Op input becomes Embedding Op weights. Because it can have
-   * any number and order of dimensions, it is permuted and reshaped
-   * (flattened).
-   *  - Gather Op startIndices becomes Embedding Op input. Because it can
-   * have any number and order of dimensions, it is permuted and reshaped
-   * (flattened).
-   * - Embedding Op output needs to be reshaped to recover lost
-   * dimensions and permuted as Gather Op output dimensions can be in any
-   * order.
-   */
-  LogicalResult
-  matchAndRewrite(mlir::stablehlo::GatherOp srcOp,
-                  mlir::stablehlo::GatherOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    // GatherOp can be used to implement embedding lookup, check for that case.
-    LogicalResult err = checkBasicLegality(srcOp, rewriter);
-    if (!err.succeeded()) {
-      return err;
-    }
-
+  // Normalizes a (shape-legal) StableHLO gather into the 2D weights/indices
+  // operands shared by the embedding and integer-gather lowerings. Requires
+  // checkGatherShapeLegality to have already succeeded.
+  static GatherOperands
+  buildGatherOperands(mlir::stablehlo::GatherOp srcOp,
+                      mlir::stablehlo::GatherOp::Adaptor adaptor,
+                      ConversionPatternRewriter &rewriter) {
     auto dimensionNumbers = srcOp.getDimensionNumbers();
-    auto inputShape = srcOp.getOperand().getType().getShape();
     auto sliceSizes = srcOp.getSliceSizes();
     auto originalStartIndexMap = dimensionNumbers.getStartIndexMap();
 
-    // If there are indexed dims that have full slice size, we need to ignore
-    // them and slice indices accordingly, which is why we note the
-    // actualIndexedDim.
-    int64_t actualIndexedDim = -1;
-
-    // If there is an indexed dim with slice size > 1, but not full, we need to
-    // expand start indices to contain the implied ones.
-    bool needsExpansion = false;
-
-    // Create startIndexMap without dims for which sliceSizes[dim] =
-    // inputShape[dim]. If there are dims for which sliceSizes[dim] =
-    // inputShape[dim] = 1, they are treated specially:
-    // - if there is a partially indexed dim, they are removed
-    // - if all other indexed dims are full, one of them is kept
-    size_t fullIndexedDims = 0;
-    bool partialIndexedDimExists = false;
-    for (size_t i = 0; i < originalStartIndexMap.size(); ++i) {
-      int64_t dim = originalStartIndexMap[i];
-      if (sliceSizes[dim] == inputShape[dim]) {
-        fullIndexedDims++;
-      } else if (sliceSizes[dim] != 1) {
-        partialIndexedDimExists = true;
-      }
-    }
-
-    llvm::SmallVector<int64_t> startIndexMap;
-    for (size_t i = 0; i < originalStartIndexMap.size(); ++i) {
-      int64_t dim = originalStartIndexMap[i];
-      if (inputShape[dim] == 1) {
-        if (fullIndexedDims == originalStartIndexMap.size()) {
-          startIndexMap.push_back(dim);
-          actualIndexedDim = i;
-          break;
-        }
-        if (partialIndexedDimExists || fullIndexedDims > 0) {
-          continue;
-        }
-      } else if (sliceSizes[dim] == inputShape[dim]) {
-        continue;
-      }
-
-      startIndexMap.push_back(dim);
-      actualIndexedDim = i;
-      if (sliceSizes[dim] != 1) {
-        needsExpansion = true;
-      }
-    }
+    IndexedDimInfo info = computeIndexedDimInfo(srcOp);
+    ArrayRef<int64_t> startIndexMap = info.startIndexMap;
+    int64_t actualIndexedDim = info.actualIndexedDim;
+    bool needsExpansion = info.needsExpansion;
     auto numIndexingDims = startIndexMap.size();
+    assert(numIndexingDims != 0 &&
+           "gather lowering requires at least one flattened indexing dim");
 
     // Use adapted operands for building new ops (type-converted values).
     auto input = adaptor.getOperands()[0];
@@ -4957,21 +5056,12 @@ public:
                                               startIndicesShape.end());
     newOutputShape.push_back(reshapedInput.getType().getShape()[1]);
 
-    auto embeddingOutputType = mlir::RankedTensorType::get(
-        newOutputShape, reshapedInput.getType().getElementType(),
-        reshapedInput.getType().getEncoding());
-    ttir::EmbeddingOp embeddingOp = rewriter.create<ttir::EmbeddingOp>(
-        srcOp.getLoc(), embeddingOutputType, startIndices, reshapedInput);
-
-    auto expectedOutputType = mlir::cast<RankedTensorType>(
-        getTypeConverter()->convertType(srcOp.getResult().getType()));
-    rewriter.replaceOp(srcOp, reshapeAndPermuteOutput(rewriter, embeddingOp,
-                                                      startIndexMap[0], srcOp,
-                                                      expectedOutputType));
-    return success();
+    return GatherOperands{mlir::cast<mlir::TypedValue<mlir::RankedTensorType>>(
+                              reshapedInput.getResult()),
+                          startIndices, std::move(newOutputShape),
+                          startIndexMap[0]};
   }
 
-public:
   // In StableHLO, startIndexMap attribute refers to which dims of input
   // we are indexing (with startIndices). We need these dims to be
   // flattened together to be the first dim of transformed input (that is
@@ -5331,6 +5421,104 @@ public:
     return rewriter.create<ttir::AddOp>(
         ttmlir::utils::appendLocationSuffix(loc, "_expandedStartIndices"),
         expandedType, broadcastedStartIndices, offsetConstant);
+  }
+};
+
+// Single-index integer gathers can't use ttir.embedding: it casts the weight
+// to bf16 and rounds wide integers. Lowering to ttir.gather keeps integer
+// precision. Reuses StableHLOGatherToEmbeddingPattern's geometric
+// normalization (buildGatherOperands), then broadcasts the indices to the
+// weight's trailing dim so ttir.gather sees equal-rank operands (torch.gather
+// semantics).
+class StableHLOGatherIntToGatherPattern
+    : public OpConversionPattern<mlir::stablehlo::GatherOp> {
+  using OpConversionPattern<mlir::stablehlo::GatherOp>::OpConversionPattern;
+
+  // Matches only the integer single-index gathers that
+  // StableHLOGatherToEmbeddingPattern deliberately turns away.
+  static LogicalResult checkLegality(mlir::stablehlo::GatherOp srcOp,
+                                     PatternRewriter &rewriter) {
+    if (!mlir::isa<mlir::IntegerType>(
+            srcOp.getOperand().getType().getElementType())) {
+      return rewriter.notifyMatchFailure(srcOp, "non-integer operand");
+    }
+    if (failed(StableHLOGatherToEmbeddingPattern::checkGatherShapeLegality(
+            srcOp, rewriter))) {
+      return failure();
+    }
+    if (StableHLOGatherToEmbeddingPattern::numFlattenedIndexingDims(srcOp) >
+        1) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "multi-dim integer indexing uses the embedding path");
+    }
+    return success();
+  }
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::GatherOp srcOp,
+                  mlir::stablehlo::GatherOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (failed(checkLegality(srcOp, rewriter))) {
+      return failure();
+    }
+
+    auto ops = StableHLOGatherToEmbeddingPattern::buildGatherOperands(
+        srcOp, adaptor, rewriter);
+    auto reshapedInput = ops.reshapedInput;
+    auto startIndices = ops.startIndices;
+    auto startIndicesType = startIndices.getType();
+    auto startIndicesElemType = startIndicesType.getElementType();
+    int64_t D = reshapedInput.getType().getShape()[1];
+    int64_t B = 1;
+    for (int64_t dim : startIndicesType.getShape()) {
+      B *= dim;
+    }
+
+    auto indicesFlatType = mlir::RankedTensorType::get(
+        {B, 1}, startIndicesElemType, startIndicesType.getEncoding());
+    auto indicesFlat = ttir::utils::createReshapeOp(
+        rewriter,
+        ttmlir::utils::appendLocationSuffix(srcOp->getLoc(),
+                                            "_intGatherIndicesFlat"),
+        startIndices, indicesFlatType.getShape());
+
+    Value indicesBcast = indicesFlat;
+    if (D != 1) {
+      auto indicesBcastType = mlir::RankedTensorType::get(
+          {B, D}, startIndicesElemType, startIndicesType.getEncoding());
+      indicesBcast = rewriter.create<ttir::BroadcastOp>(
+          ttmlir::utils::appendLocationSuffix(srcOp->getLoc(),
+                                              "_intGatherIndicesBcast"),
+          indicesBcastType, indicesFlat, rewriter.getDenseI64ArrayAttr({1, D}));
+    }
+
+    auto gatherOutType = mlir::RankedTensorType::get(
+        {B, D}, reshapedInput.getType().getElementType(),
+        reshapedInput.getType().getEncoding());
+    Value gather = rewriter.create<ttir::GatherOp>(
+        ttmlir::utils::appendLocationSuffix(srcOp->getLoc(), "_intGather"),
+        gatherOutType, reshapedInput, indicesBcast,
+        rewriter.getI32IntegerAttr(0));
+
+    // Reshape (B, D) -> startIndices.shape + (D,) so reshapeAndPermuteOutput
+    // sees the same intermediate shape it would have from ttir.embedding.
+    auto reshaped = ttir::utils::createReshapeOp(
+        rewriter,
+        ttmlir::utils::appendLocationSuffix(srcOp->getLoc(),
+                                            "_intGatherReshape"),
+        mlir::cast<mlir::TypedValue<mlir::RankedTensorType>>(gather),
+        ops.newOutputShape);
+
+    auto expectedOutputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult().getType()));
+    rewriter.replaceOp(
+        srcOp, StableHLOGatherToEmbeddingPattern::reshapeAndPermuteOutput(
+                   rewriter,
+                   mlir::cast<mlir::TypedValue<mlir::RankedTensorType>>(
+                       reshaped.getResult()),
+                   ops.indexedDim, srcOp, expectedOutputType));
+    return success();
   }
 };
 
@@ -8898,6 +9086,7 @@ static void addGatherOpConversionPattern(MLIRContext *ctx,
   patterns.add<StableHLOGatherToGatherDimPattern>(typeConverter, ctx);
   patterns.add<StableHLOGatherToSliceRepeatConcatPattern>(typeConverter, ctx);
   patterns.add<StableHLOGatherToEmbeddingPattern>(typeConverter, ctx);
+  patterns.add<StableHLOGatherIntToGatherPattern>(typeConverter, ctx);
   patterns.add<StableHLOGatherMultiPartialFlattenPattern>(typeConverter, ctx);
 }
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_gather_integer_operand.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_gather_integer_operand.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module attributes {} {
+  // 2D integer operand, single indexed dim with full trailing slice (D != 1),
+  // so indices are broadcast across the weight dim before the gather.
+  // CHECK-LABEL: func.func @gather_int_select_rows
+  func.func @gather_int_select_rows(%operand: tensor<6x4xi32>, %start_indices: tensor<3x1xi32>) -> tensor<3x4xi32> {
+    // CHECK-NOT: "ttir.embedding"
+    // CHECK: "ttir.gather"
+    %0 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<6x4xi32>, tensor<3x1xi32>) -> tensor<3x4xi32>
+    return %0 : tensor<3x4xi32>
+  }
+
+  // 1D i64 operand (the Qwen 2.5 VL cu_seqlens shape): gathering scalar
+  // elements (D == 1). Wide i64 values must not round through bf16.
+  // CHECK-LABEL: func.func @gather_int_scalar_lookup
+  func.func @gather_int_scalar_lookup(%operand: tensor<4xi64>, %start_indices: tensor<2x1xi64>) -> tensor<2xi64> {
+    // CHECK-NOT: "ttir.embedding"
+    // CHECK: "ttir.gather"
+    %0 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<4xi64>, tensor<2x1xi64>) -> tensor<2xi64>
+    return %0 : tensor<2xi64>
+  }
+
+  // Float operand with the same single-index shape still uses ttir.embedding
+  // (the fast vocab-lookup path is unchanged).
+  // CHECK-LABEL: func.func @gather_float_stays_embedding
+  func.func @gather_float_stays_embedding(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x4xbf16> {
+    // CHECK: "ttir.embedding"
+    // CHECK-NOT: "ttir.gather"
+    %0 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<6x4xbf16>, tensor<3x1xi32>) -> tensor<3x4xbf16>
+    return %0 : tensor<3x4xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4981)

### Problem description

`ttir.embedding` casts its weight (the gather operand) to bf16. bf16 represents integers exactly only in `[-256, 256]`, so integer-typed `stablehlo.gather` operands with wider values round silently (e.g. `2204 → 2208`). This corrupts downstream consumers — for example it broke `split_with_sizes` in Qwen2.5-VL (`split_sizes` summed to `2208` instead of `2204`).

An earlier attempt (#8499) closed the embedding path for integer operands entirely. That regressed several JAX `lax.gather` shapes — with the integer operands rejected and no fallback, the patterns failed to legalize
`stablehlo.gather` — and #8499 was reverted in `73e2c9a1f`.

This PR re-introduces correct integer-gather handling in a self-contained way that does **not** disturb the other gather patterns or the float path.

### What's changed

1. **New pattern `StableHLOGatherIntToGatherPattern`.** Lowers integer-operand gathers that index a single dimension to `ttir.gather` instead of `ttir.embedding`, preserving integer precision. It reuses the embedding pattern's geometric normalization and broadcasts the flattened indices to the weight's trailing dim so `ttir.gather` sees equal-rank operands (torch.gather semantics).

2. **Shared helpers extracted from `StableHLOGatherToEmbeddingPattern`** so both patterns use the same 2-D `(weights, indices)` normalization instead of duplicating the geometry:
   - `checkGatherShapeLegality` - element-type-agnostic shape/slice legality.
   - `computeIndexedDimInfo` - flattened `startIndexMap`, `actualIndexedDim`,
     `needsExpansion`.
   - `buildGatherOperands` - permute / reshape / index-flatten into the shared
     2-D operands.

3. **Minimal element-type gate in `StableHLOGatherToEmbeddingPattern::checkBasicLegality`:** only **integer operands that index a single dimension** are rejected here (handed to `StableHLOGatherIntToGatherPattern`). 

The two patterns are mutually exclusive by construction - the embedding pattern rejects exactly the single-index integer case the new pattern accepts. Float lowering and every other gather path are untouched; this PR only reroutes the single-index integer gather (the Qwen2.5-VL case).

### Testing
- **New lit test** `test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_gather_integer_operand.mlir`:
  integer single-index (`i32`) → `ttir.gather` (with index broadcast); 1-D `i64` scalar lookup (the Qwen2.5-VL `cu_seqlens` shape) → `ttir.gather` float operand, same shape → still `ttir.embedding`.

- **JAX op tests** - `tests/jax/single_chip/ops/test_gather.py` now pass (previously rounded through bf16):
  - `test_gather[shape=(2048, 1, 200)-shape=(1, 6, 1)-shape=(2, 3)-shape=(0,)-shape=(1, 1, 200)]`
  - `test_gather[shape=(8, 26, 26, 192)-shape=(1,)-shape=(0, 1, 2)-shape=(3,)-shape=(8, 26, 26, 1)]`
  - `test_gather[shape=(32000, 3200)-shape=(1, 6, 1)-shape=(2,)-shape=(0,)-shape=(1, 3200)]`
  - `test_gather[shape=(8, 54, 54, 64)-shape=(1,)-shape=(0, 1, 2)-shape=(3,)-shape=(8, 54, 54, 1)]`

- **PyTorch model graph** — now passes:
  - `tests/torch/graphs/test_attention.py::test_qwen2_5_attention_prefill_push[7B_Instruct-1024-single_device]`

- Resolves the Qwen2.5-VL and Qwen3.5 `split_with_sizes` mismatch.

### Checklist
- [ ] New/Existing tests provide coverage for changes
