### PR TITLE
[chisel] Update `update_tensor_in_pool` To Do Data-Only Copy

### DIFF
--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -270,9 +270,12 @@ std::optional<Tensor>
 retrieveTensorFromPool(CallbackContext programContextHandle,
                        TensorRef tensorRef, bool untilize);
 
-// Updates the tensor in the program's tensor pool that is referenced by the
-// given tensor reference. Performs necessary layout and device conversions to
-// match the existing tensor.
+// Overwrites only the payload data of the existing tensor pool entry referenced
+// by the given tensor reference.
+// Preserves the existing tensor wrapper metadata/state (for example mesh event,
+// retain flag, callbacks, and wrapper identity/version lineage), while
+// performing the necessary layout and device normalization on srcTensor to
+// match the existing destination tensor.
 void updateTensorInPool(CallbackContext programContextHandle,
                         TensorRef tensorRef, Tensor srcTensor);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -274,7 +274,7 @@ retrieveTensorFromPool(CallbackContext programContextHandle,
 // by the given tensor reference.
 // Preserves the existing tensor wrapper metadata/state (for example mesh event,
 // retain flag, callbacks, and wrapper identity/version lineage), while
-// performing the necessary layout and device normalization on srcTensor to
+// performing the necessary layout normalization on srcTensor to
 // match the existing destination tensor.
 void updateTensorInPool(CallbackContext programContextHandle,
                         TensorRef tensorRef, Tensor srcTensor);

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -2260,8 +2260,6 @@ void walkProgram(tt::runtime::Binary executableHandle, uint32_t programIndex,
   }
 }
 
-// TODO(mmilosevicTT): Rework updating tensor to ensure all required fields are
-// preserved.
 void updateTensorInPool(CallbackContext programContextHandle,
                         TensorRef tensorRef, Tensor tensor) {
   auto &programContext =
@@ -2283,11 +2281,32 @@ void updateTensorInPool(CallbackContext programContextHandle,
   ::ttnn::Tensor &srcTensor = utils::getTTNNTensorFromRuntimeTensor(tensor);
   ::ttnn::Tensor &dstTensor = tensorPool.getTTNNTensorAndValidate(tensorRefPtr);
   srcTensor = ::ttnn::to_layout(srcTensor, dstTensor.layout());
-  if (utils::isOnDevice(dstTensor.storage_type())) {
-    srcTensor = ::ttnn::to_device(srcTensor, dstTensor.device(),
-                                  dstTensor.memory_config());
+
+  LOG_ASSERT(srcTensor.logical_volume() == dstTensor.logical_volume(),
+             "Logical volume mismatch when updating tensor in tensor pool: ",
+             srcTensor.logical_volume(), " != ", dstTensor.logical_volume());
+  LOG_ASSERT(srcTensor.dtype() == dstTensor.dtype(),
+             "Dtype mismatch when updating tensor in tensor pool");
+
+  const std::size_t srcShardCount =
+      ::ttnn::distributed::get_device_tensors(srcTensor).size();
+  const std::size_t dstShardCount =
+      ::ttnn::distributed::get_device_tensors(dstTensor).size();
+  LOG_ASSERT(srcShardCount == dstShardCount,
+             "Shard count mismatch when updating tensor in tensor pool: ",
+             srcShardCount, " != ", dstShardCount);
+
+  const bool srcOnHost = utils::isOnHost(srcTensor.storage_type());
+  const bool dstOnHost = utils::isOnHost(dstTensor.storage_type());
+  if (!srcOnHost && !dstOnHost) {
+    ::ttnn::Tensor hostSrcTensor = ::ttnn::from_device(srcTensor);
+    ::tt::tt_metal::copy_to_device(hostSrcTensor, dstTensor);
+  } else {
+    ::tt::runtime::Tensor &dstRuntimeTensor =
+        tensorPool.getRuntimeTensorAndValidate(tensorRefPtr);
+    memcpy(dstRuntimeTensor, tensor);
   }
-  tensorPool.insertTTNNTensorAndValidate(tensorRefPtr, srcTensor);
+  tensorPool.getTTNNTensorWrapperAndValidate(tensorRefPtr).updateVersion();
 }
 
 size_t getProgramIndex(CallbackContext programContextHandle) {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -2281,10 +2281,6 @@ void updateTensorInPool(CallbackContext programContextHandle,
   ::ttnn::Tensor &srcTensor = utils::getTTNNTensorFromRuntimeTensor(tensor);
   ::ttnn::Tensor &dstTensor = tensorPool.getTTNNTensorAndValidate(tensorRefPtr);
   srcTensor = ::ttnn::to_layout(srcTensor, dstTensor.layout());
-  if (utils::isOnDevice(dstTensor.storage_type())) {
-    srcTensor = ::ttnn::to_device(srcTensor, dstTensor.device(),
-                                  dstTensor.memory_config());
-  }
 
   LOG_ASSERT(srcTensor.logical_volume() == dstTensor.logical_volume(),
              "Logical volume mismatch when updating tensor in tensor pool: ",

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -2281,6 +2281,10 @@ void updateTensorInPool(CallbackContext programContextHandle,
   ::ttnn::Tensor &srcTensor = utils::getTTNNTensorFromRuntimeTensor(tensor);
   ::ttnn::Tensor &dstTensor = tensorPool.getTTNNTensorAndValidate(tensorRefPtr);
   srcTensor = ::ttnn::to_layout(srcTensor, dstTensor.layout());
+  if (utils::isOnDevice(dstTensor.storage_type())) {
+    srcTensor = ::ttnn::to_device(srcTensor, dstTensor.device(),
+                                  dstTensor.memory_config());
+  }
 
   LOG_ASSERT(srcTensor.logical_volume() == dstTensor.logical_volume(),
              "Logical volume mismatch when updating tensor in tensor pool: ",

--- a/runtime/test/ttnn/python/n150/test_intermediate_tensor_manipulation.py
+++ b/runtime/test/ttnn/python/n150/test_intermediate_tensor_manipulation.py
@@ -75,6 +75,8 @@ def postop(binary, programContext, opContext):
     # Each element will be 10 (from matmul) + 1 (from bias) = 11
     assert torch.allclose(torch_tensor, torch.ones_like(torch_tensor) * 11)
 
+    # Update the same tensor ref twice. The second payload should win.
+    update_device_tensor(programContext, tensor_ref, tensor, torch.zeros_like(torch_tensor))
     update_device_tensor(
         programContext, tensor_ref, tensor, torch.ones_like(torch_tensor)
     )

--- a/runtime/test/ttnn/python/n150/test_intermediate_tensor_manipulation.py
+++ b/runtime/test/ttnn/python/n150/test_intermediate_tensor_manipulation.py
@@ -76,7 +76,9 @@ def postop(binary, programContext, opContext):
     assert torch.allclose(torch_tensor, torch.ones_like(torch_tensor) * 11)
 
     # Update the same tensor ref twice. The second payload should win.
-    update_device_tensor(programContext, tensor_ref, tensor, torch.zeros_like(torch_tensor))
+    update_device_tensor(
+        programContext, tensor_ref, tensor, torch.zeros_like(torch_tensor)
+    )
     update_device_tensor(
         programContext, tensor_ref, tensor, torch.ones_like(torch_tensor)
     )

--- a/runtime/test/ttnn/python/n300/test_intermediate_tensor_manipulation.py
+++ b/runtime/test/ttnn/python/n300/test_intermediate_tensor_manipulation.py
@@ -34,7 +34,7 @@ def get_torch_tensor(tensor: ttrt.runtime.Tensor):
 
 
 def update_multi_device_tensor(
-    program_context, tensor_ref, dst_tensor, per_shard_torch_tensors, alive_refs
+    program_context, tensor_ref, dst_shards, per_shard_torch_tensors, alive_refs
 ):
     """Replace a multi-device pool entry with per-shard torch data.
 
@@ -44,9 +44,10 @@ def update_multi_device_tensor(
     contiguous_shards = [t.contiguous() for t in per_shard_torch_tensors]
     alive_refs.extend(contiguous_shards)
 
-    shape = dst_tensor.get_shape()
-    stride = dst_tensor.get_stride()
-    dtype = dst_tensor.get_dtype()
+    template_shard = dst_shards[0]
+    shape = template_shard.get_shape()
+    stride = template_shard.get_stride()
+    dtype = template_shard.get_dtype()
     item_size = contiguous_shards[0].element_size()
 
     multi_device_tensor = ttrt.runtime.create_multi_device_host_tensor(
@@ -75,7 +76,7 @@ def make_linear_postop(expected_per_shard, replacement_per_shard, alive_refs):
 
     - retrieves the per-shard intermediate tensor from the pool;
     - asserts each shard equals ``expected_per_shard[i]`` (a scalar);
-    - replaces the pool entry with per-shard tensors filled with
+    - updates the same pool entry twice, where the second replacement uses
       ``replacement_per_shard[i]``.
     """
 
@@ -121,8 +122,16 @@ def make_linear_postop(expected_per_shard, replacement_per_shard, alive_refs):
             )
             for i in range(len(shards))
         ]
+        first_replacement_shards = [torch.zeros_like(t) for t in replacement_shards]
         update_multi_device_tensor(
-            program_context, tensor_ref, shards[0], replacement_shards, alive_refs
+            program_context,
+            tensor_ref,
+            shards,
+            first_replacement_shards,
+            alive_refs,
+        )
+        update_multi_device_tensor(
+            program_context, tensor_ref, shards, replacement_shards, alive_refs
         )
 
     return postop


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/8528

### Problem description
`update_tensor_in_pool` was overwriting the existing tensor in pool with a fresh copy, which consequently changed metadata of the ops. This is a bad practice for public API call, as we would rewrite version, retain and many other fields. For single-chip updates this was not a big problem, but as we move more to multi-chip, dropping metadata fields can be fatal.

### What's changed
This PR changes `update_tensor_in_pool` to do data-only copy of tensors.

### Checklist
- [x] New/Existing tests provide coverage for changes
