### PR TITLE
[TTIRToTTIRDecomposition] Lower degenerate dot_general to broadcast multiply to preserve f32 precision

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -283,10 +283,25 @@ struct DotGeneralToMatmulConversionPattern
     matmulDestinationShape.push_back(
         computeProductOfDims(rhsType.getShape(), rhsResultDims));
 
-    // Perform matmul operation.
-    auto matmulOp = rewriter.create<ttir::MatmulOp>(
-        op.getLoc(), RankedTensorType::get(matmulDestinationShape, elementType),
-        lhsMatmulInput, rhsMatmulInput);
+    // Perform the contraction. When every contracting dimension has extent 1
+    // the dot_general is a pure outer product, which we lower to a broadcast
+    // elementwise multiply to keep full f32 precision. lhsMatmulInput is
+    // [..., M, 1] and rhsMatmulInput is [..., 1, N], so they broadcast-multiply
+    // to the matmul destination shape [..., M, N].
+    int64_t contractionSize =
+        computeProductOfDims(lhsType.getShape(), lhsContractDims);
+    Value contractionResult;
+    if (contractionSize == 1) {
+      contractionResult = rewriter.create<ttir::MultiplyOp>(
+          op.getLoc(),
+          RankedTensorType::get(matmulDestinationShape, elementType),
+          lhsMatmulInput, rhsMatmulInput);
+    } else {
+      contractionResult = rewriter.create<ttir::MatmulOp>(
+          op.getLoc(),
+          RankedTensorType::get(matmulDestinationShape, elementType),
+          lhsMatmulInput, rhsMatmulInput);
+    }
 
     // Reshape the result by unrolling the prod(lhsResultDims) to original
     // lhsResultDims and likewise for rhsResultDims.
@@ -306,7 +321,7 @@ struct DotGeneralToMatmulConversionPattern
                                              resultShape.end());
 
     auto reshapeOutput = rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
-        op, RankedTensorType::get(resultShape, elementType), matmulOp,
+        op, RankedTensorType::get(resultShape, elementType), contractionResult,
         rewriter.getI32ArrayAttr(finalShapeI32));
 
     reshapeOutput->setLoc(ttmlir::utils::appendLocationSuffix(

--- a/test/ttmlir/Dialect/TTIR/Decomposition/dot_general/dot_general_degenerate_outer_product.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/dot_general/dot_general_degenerate_outer_product.mlir
@@ -1,0 +1,16 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// A degenerate dot_general whose only contracting dimension has extent 1 is a
+// pure outer product. It must decompose to a broadcast ttir.multiply (which
+// keeps full f32 precision) rather than ttir.matmul (whose hifi4 path splits
+// f32 into bf16 hi/lo and loses precision on large products, e.g. RoPE freqs).
+module @jit_dot_general_degenerate {
+  func.func public @test_dot_general_degenerate(%arg0: tensor<32x1xf32>, %arg1: tensor<1x64xf32>) -> tensor<32x64xf32> {
+    %0 = "ttir.dot_general"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<32x1xf32>, tensor<1x64xf32>) -> tensor<32x64xf32>
+    // CHECK-LABEL: func.func public @test_dot_general_degenerate
+    // CHECK: "ttir.multiply"
+    // CHECK-NOT: "ttir.matmul"
+    return %0 : tensor<32x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b.mlir
+++ b/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b.mlir
@@ -23,8 +23,9 @@
 
 // Llama 3.1 8B single decoder layer on Wormhole B0. SDPA is fused at opt=1
 // so the 6 weight projections (q/k/v/o + gate/up/down) and the SDPA op
-// itself are all DRAM-bound; one small ephemeral RoPE-helper matmul is
-// correctly skipped.
+// itself are all DRAM-bound. The small ephemeral RoPE-helper, a degenerate
+// K=1 dot_general, now lowers to a broadcast multiply rather than a matmul,
+// so it is no longer counted as a skipped matmul (skipped_ops drops to 0).
 
 // CHECK: "perf_targets":
 // CHECK: "aiclk_hz": 1000000000
@@ -37,5 +38,5 @@
 // CHECK: "params_count": 751828992
 // CHECK: "params_memory_bytes": 798818304
 // CHECK: "roofline_ms": 2.773674
-// CHECK: "skipped_ops": 1
+// CHECK: "skipped_ops": 0
 // CHECK: "top_perf_estimate_ms": 3.962392

--- a/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b_blackhole.mlir
+++ b/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b_blackhole.mlir
@@ -27,7 +27,9 @@
 // constants than n150 (512 GB/s DRAM, 1.35 GHz, 130 Tensix cores) so the
 // roofline shrinks vs the Wormhole companion test even though the model
 // is the same. At default opt level SDPA is not fused, so 6 dram-bound
-// weight matmuls + 3 skipped activation@activation matmuls.
+// weight matmuls + 2 skipped activation@activation matmuls. (The third,
+// a degenerate K=1 dot_general, now lowers to a broadcast multiply rather
+// than a matmul, so it is no longer counted among the skipped matmuls.)
 
 // CHECK: "perf_targets":
 // CHECK: "aiclk_hz": 1350000000
@@ -40,5 +42,5 @@
 // CHECK: "params_count": 743440384
 // CHECK: "params_memory_bytes": 789905408
 // CHECK: "roofline_ms": 1.542784
-// CHECK: "skipped_ops": 3
+// CHECK: "skipped_ops": 2
 // CHECK: "top_perf_estimate_ms": 2.203977


### PR DESCRIPTION
### Ticket
[#4748](https://github.com/tenstorrent/tt-xla/issues/4748)

### Problem description
The OmniGen RoPE sanity failed with a PCC drop (pcc=0.8502, required 0.99) on the cos/sin outputs. The graph computes freqs = inv_freq_expanded @ position_ids_expanded, then cos(emb)/sin(emb) where emb reaches ~4157 radians (position ids run into the thousands, and inv_freq[0]==1.0). Two compounding precision losses corrupt the angle before it reaches the SFPU trig kernel:

The dot_general is a degenerate K=1 outer product, but DotGeneralToMatmulConversionPattern always lowers it to a ttir.matmul. tt-metal's hifi4 matmul splits the f32 operands into bf16 hi/lo pairs, leaving the large products with only ~6–8 bits of absolute precision — several radians of error at magnitude 4157.
ttnn.sin/cos read their input through a 16-bit DST, so even a full-f32 large angle is truncated to ~bf16 before the SFPU's internal range reduction runs.
Diagnostics confirmed the split: a graph returning emb alone passed at 0.99 (PCC on large-magnitude values is precision-insensitive and hides the absolute error), while cos(emb) dropped to 0.909, and a variant computing emb via a broadcast multiply instead of the matmul passed at 0.99. The SFPU trig kernel (ckernel_sfpu_trigonometry.h) is itself accurate given a full-f32 input (verified by exact simulation → PCC 1.0).

### What's changed
In TTIRToTTIRDecomposition.cpp, DotGeneralToMatmulConversionPattern now detects when the contraction is degenerate — the product of the contracting dims equals 1 — and lowers it to a broadcast ttir.multiply instead of ttir.matmul. The operands are already reshaped to […, M, 1] and […, 1, N] by the existing permute/reshape logic, so they broadcast-multiply directly to the destination shape […, M, N] (ttir.multiply carries the TTIR_Broadcastable trait), and binary_ng keeps full f32 precision instead of the matmul's bf16 hi/lo split. The non-degenerate (real-contraction) path, the permutes/reshapes, and the final output reshape are unchanged; only the contraction op differs.

Perf-target golden updates: This PR lowers the RoPE outer product from a ttir.matmul to a broadcast ttir.multiply. Since that op is no longer a matmul, it drops out of the perf model's matmul tally, reducing skipped_ops by one — 1 → 0 on Wormhole and 3 → 2 on Blackhole. The llama_3_1_8b.mlir and llama_3_1_8b_blackhole.mlir goldens are updated to match.

This is a low-blast-radius change: the broadcast-multiply path only fires on degenerate (extent-1) contractions, and all sin/cos lowering is left untouched. Post this fix, the OmniGen RoPE sanity recovers from 0.85 to >0.99 and the full model passes e2e.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs
[omnigen_before_fix.log](https://github.com/user-attachments/files/28498924/omnigen_before_fix.log)
[omnigen_after_fix.log](https://github.com/user-attachments/files/28498935/omnigen_after_fix.log)