### PR TITLE
[tt-alchemist] Install libtt-alchemist-lib.so and templates for downstream users

### DIFF
--- a/tools/tt-alchemist/csrc/CMakeLists.txt
+++ b/tools/tt-alchemist/csrc/CMakeLists.txt
@@ -88,6 +88,27 @@ target_link_options(${TT_ALCHEMIST_LIBRARY_NAME}
 )
 
 ################################################################################
+# Install (downstream consumers)
+################################################################################
+
+# Note: the "Install headers and templates" section further down uses
+# add_custom_target() to copy files into the *build tree*. The two rules
+# below are standard CMake install() commands that populate the install
+# prefix so downstream consumers (e.g. the tt-xla wheel) pick the
+# artifacts up via the standard install tree.
+include(GNUInstallDirs)
+
+install(TARGETS ${TT_ALCHEMIST_LIBRARY_NAME}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  COMPONENT SharedLib
+)
+
+install(DIRECTORY ${TT_ALCHEMIST_ROOT_SOURCE_DIR}/templates/
+  DESTINATION templates
+  COMPONENT SharedLib
+)
+
+################################################################################
 # Python Model Runner Library (separate subdirectory due to RTTI requirements)
 ################################################################################
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8257

### Problem description
Downstream users (like tt-xla) cannot easily package tt-alchemist lib for distribution. In their current setup, the wheel they distribute doesn't support codegen (via tt-alchemist).

### What's changed
Adds two install() rules to the SharedLib component:
- libtt-alchemist-lib.so -> ${CMAKE_INSTALL_LIBDIR}
- templates/ -> ${CMAKE_INSTALL_PREFIX}/templates

This matches the existing install rule for libtt-alchemist-python-runner.so in csrc/python_runner/CMakeLists.txt and lets downstream consumers (e.g. the tt-xla wheel) bundle codegen without reaching into the build tree.

### Checklist
- [ ] New/Existing tests provide coverage for changes
