### PR TITLE
[chisel] cache device tensors to avoid redundant host pulls

### DIFF
--- a/tools/chisel/chisel/callbacks.py
+++ b/tools/chisel/chisel/callbacks.py
@@ -39,7 +39,7 @@ from .report import (
     SkippedNumericsPayload,
 )
 from .safety import chisel_safe
-from .utils import get_op_asm, retrieve_tensor
+from .utils import cached_retrieve_tensor, get_op_asm, invalidate_device_cache
 from .validators import check_numerics, check_shape_dtype
 
 logger = logging.getLogger("chisel")
@@ -85,7 +85,8 @@ def _validate_and_retrieve_tensor(
 ) -> GoldenMapTensor:
     op = ctx.op
     check_shape_dtype(op, "mlir_vs_tensor_ref", mlir_value, rt_tensor_ref)
-    tensor = retrieve_tensor(ctx.rt_program_context, rt_tensor_ref, ctx.mesh_shape)
+    ssa = mlir_value.get_name(ctx.asm_state)
+    tensor = cached_retrieve_tensor(ctx, ssa, rt_tensor_ref, ctx.mesh_shape)
     check_shape_dtype(op, "mlir_vs_runtime_tensor", mlir_value, tensor)
     return tensor
 
@@ -110,7 +111,6 @@ def _default_pre_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
 
     mlir_op_inputs = get_op_inputs(op)
     for mlir_input, rt_tensor_ref in zip(mlir_op_inputs, ctx.input_refs, strict=True):
-        # TODO(ndrakulic): Right now we are pulling input device tensors to host potentially multiple times
         tensor = _validate_and_retrieve_tensor(ctx, mlir_input, rt_tensor_ref)
         ssa = mlir_input.get_name(asm_state)
         ctx.stashed_inputs[ssa] = tensor
@@ -171,13 +171,14 @@ def _get_inplace_input_refs(
 
 
 def _evict_inplace_no_golden(ctx: ChiselContext) -> None:
-    """For each mutated tensor operand on `ctx.op`, drop the golden and record."""
+    """For each mutated tensor operand on `ctx.op`, drop both pools and record."""
     op = ctx.op
     asm_state = ctx.asm_state
     golden_pool = ctx.golden_tensor_pool
     for val in get_inplace_vals(op):
         ssa = val.get_name(asm_state)
         golden_pool.pop(ssa, None)
+        invalidate_device_cache(ctx, ssa)
         ctx.write_record(
             ChiselRecord(
                 op=op.name,
@@ -220,6 +221,12 @@ def _default_post_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
     )
     entries.extend(inplace_refs)
 
+    # Invalidate the device cache for every entry, then pull each device tensor
+    # once: outputs are freshly produced and in-place operands were just mutated,
+    # so any cached host copy is stale. The mode loop below reuses these.
+    entry_ssas = [mlir_value.get_name(asm_state) for mlir_value, _ in entries]
+    for ssa in entry_ssas:
+        invalidate_device_cache(ctx, ssa)
     device_tensors = [
         _validate_and_retrieve_tensor(ctx, mlir_value, tensor_ref)
         for mlir_value, tensor_ref in entries
@@ -234,15 +241,16 @@ def _default_post_op(ctx: ChiselContext, config: ChiselOpConfig) -> None:
         all_outs = execute_golden_with_ssa_inputs(op, ssa_inputs, asm_state)
 
         for idx, (mlir_value, _tensor_ref) in enumerate(entries):
-            ssa = mlir_value.get_name(asm_state)
+            ssa = entry_ssas[idx]
             golden_out = all_outs[idx]
+            device_tensor = device_tensors[idx]
             _emit_pcc(
                 ctx,
                 op,
                 ssa,
                 mlir_value,
                 golden_out,
-                device_tensors[idx],
+                device_tensor,
                 mode=mode,
                 skip_pcc=config.skip_pcc,
             )

--- a/tools/chisel/chisel/context.py
+++ b/tools/chisel/chisel/context.py
@@ -137,6 +137,14 @@ class ChiselContext:
         return program._golden_tensor_pool
 
     @property
+    def device_tensor_pool(self) -> Dict[SSAName, GoldenMapTensor]:
+        """Program-scoped SSA -> device tensor cache; persists across ops."""
+        program = self._current_callback_program
+        if program is None:
+            raise UnexpectedStateError("device_tensor_pool")
+        return program._device_tensor_pool
+
+    @property
     def rt_program_context(self) -> Optional[CallbackContext]:
         program = self._current_callback_program
         return program._rt_program_context if program is not None else None
@@ -292,8 +300,9 @@ class ProgramState:
         self._current_output_refs: Optional[List[TensorRef]] = None
         self._stashed_inputs: Optional[Dict[SSAName, GoldenMapTensor]] = None
         self._pre_failed: bool = False
-        # Persists across ops within a program; not reset per op.
+        # Both pools persist across ops within a program; not reset per op.
         self._golden_tensor_pool: Dict[SSAName, GoldenMapTensor] = {}
+        self._device_tensor_pool: Dict[SSAName, GoldenMapTensor] = {}
 
     def begin_op(self) -> None:
         self._current_op = next(self._op_iter).opview

--- a/tools/chisel/chisel/op_handlers.py
+++ b/tools/chisel/chisel/op_handlers.py
@@ -4,17 +4,19 @@
 from .ops import get_op_inputs
 from .report import ChiselRecord, GoldenEvictedPayload
 from .safety import chisel_safe
+from .utils import invalidate_device_cache
 
 
 @chisel_safe
 def _deallocate_pre_op(ctx, config) -> None:
-    """Evict each input SSA from the golden pool; emit one record per eviction."""
-    pool = ctx.golden_tensor_pool
+    """Evict each input SSA from both pools; emit one record per eviction."""
+    golden_pool = ctx.golden_tensor_pool
     asm_state = ctx.asm_state
     op = ctx.op
     for inp in get_op_inputs(op):
         ssa = inp.get_name(asm_state)
-        if pool.pop(ssa, None) is None:
+        invalidate_device_cache(ctx, ssa)
+        if golden_pool.pop(ssa, None) is None:
             continue
 
         ctx.write_record(

--- a/tools/chisel/chisel/utils.py
+++ b/tools/chisel/chisel/utils.py
@@ -64,6 +64,28 @@ def retrieve_tensor(
     return GoldenMapTensor(shard_map, mesh_shape)
 
 
+def cached_retrieve_tensor(
+    ctx, ssa: str, rt_tensor_ref: TensorRef, mesh_shape: Tuple[int, ...]
+) -> GoldenMapTensor:
+    """Return a host copy of `rt_tensor_ref`, caching by `ssa` in the device pool.
+
+    On a cache miss the tensor is pulled from device and stored; subsequent
+    requests for the same SSA reuse the cached copy.
+    """
+    pool = ctx.device_tensor_pool
+    cached = pool.get(ssa)
+    if cached is not None:
+        return cached
+    tensor = retrieve_tensor(ctx.rt_program_context, rt_tensor_ref, mesh_shape)
+    pool[ssa] = tensor
+    return tensor
+
+
+def invalidate_device_cache(ctx, ssa: str) -> None:
+    """Drop any cached host copy for `ssa` so the next read re-pulls from device."""
+    ctx.device_tensor_pool.pop(ssa, None)
+
+
 def get_op_asm(op) -> str:
     # Mirror OpPrintingFlags from FuncOpToProgram so the asm string matches
     # the flatbuffer debug_info.


### PR DESCRIPTION
### Ticket


### Problem description

Chisel pulls device tensors to host (`to_host`) every time it reads one for a golden check.
The same SSA is read repeatedly — once as an op's input in `_default_pre_op`, again as a producer's output in `_default_post_op`.
Each pull is an expensive device->host copy, so this redundancy added real overhead to every traced op.

### What's changed

Adds a program-scoped device tensor pool so each device tensor is pulled to host at most once per SSA, with cached copies reused across reads and modes:

- **`utils.py`** — `cached_retrieve_tensor` (read-through cache keyed by SSA, backed by the device pool) and `invalidate_device_cache` (drop a stale SSA so the next read re-pulls).

- **`context.py`** — `_device_tensor_pool` dict on `ProgramState` plus a `device_tensor_pool` property on `ChiselContext`, mirroring `golden_tensor_pool`; persists across ops within a program.
- **`callbacks.py` / `op_handlers.py`** — reads go through the cache, and stale entries are invalidated when a tensor is mutated or deallocated.
  In-place ops and deallocation evict the SSA from both the golden and device pools.
  `_default_post_op` invalidates freshly-produced outputs and just-mutated in-place operands, then pulls each device tensor once before the numerics mode loop and reuses them across modes.


### Checklist
- [ ] New/Existing tests provide coverage for changes
