### PR TITLE
[TTNN] Swap bloated concat operands to row-major

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
@@ -1141,6 +1141,121 @@ public:
   }
 };
 
+// Layout-swap for `ttnn.concat`. When a concat's operands come from one-use
+// reshapes that produced tile-padded tensors with sub-tile inner dims, the
+// concat output is also bloated. Concat is a data-movement op that accepts
+// row-major, so we flip the operand reshapes' outputs and the concat output
+// to row-major, then restore tile via a single to_layout for downstream
+// consumers.
+class ConcatBloatedTileToRowMajor : public OpRewritePattern<ttnn::ConcatOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::ConcatOp op,
+                                PatternRewriter &rewriter) const override {
+    auto resultType = mlir::cast<RankedTensorType>(op.getResult().getType());
+    auto resultLayout =
+        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(resultType.getEncoding());
+    if (!resultLayout || !resultLayout.isTiled()) {
+      return failure();
+    }
+
+    ArrayRef<int64_t> resultShape = resultType.getShape();
+    if (!hasNonTileAlignedInnerDims(resultShape)) {
+      return failure();
+    }
+
+    auto paddedShape = ttnn::utils::getTilePaddedShape(resultShape);
+    int64_t tiledVolume = ttmlir::utils::volume(llvm::ArrayRef(paddedShape));
+    int64_t rmVolume = ttmlir::utils::volume(resultShape);
+
+    // If the difference is less than 1GB, nothing to do.
+    if (tiledVolume - rmVolume < 1LL * 1024LL * 1024LL * 1024LL) {
+      return failure();
+    }
+
+    // Every operand must be a one-use reshape so we can flip its output
+    // layout to row-major without affecting other consumers.
+    SmallVector<ttnn::ReshapeOp> operandReshapes;
+    for (Value v : op.getInputs()) {
+      auto r = v.getDefiningOp<ttnn::ReshapeOp>();
+      if (!r || !r->hasOneUse()) {
+        return failure();
+      }
+      operandReshapes.push_back(r);
+    }
+
+    auto rowMajorResultLayout =
+        TTNNLayoutAttr::Builder(resultLayout, resultShape)
+            .setLayout(ttnn::Layout::RowMajor)
+            .build();
+    if (rowMajorResultLayout == resultLayout) {
+      return failure();
+    }
+    RankedTensorType rowMajorResultType =
+        resultType.cloneWithEncoding(rowMajorResultLayout);
+
+    // For each upstream reshape, build a row-major variant whose input is
+    // also promoted to row-major (the reshape kernel preserves input layout;
+    // tile -> row-major in one reshape is invalid).
+    SmallVector<Value> newReshapeResults;
+    for (auto reshape : operandReshapes) {
+      auto reshapeResultType =
+          mlir::cast<RankedTensorType>(reshape.getResult().getType());
+      auto reshapeResultLayout =
+          mlir::dyn_cast<ttnn::TTNNLayoutAttr>(reshapeResultType.getEncoding());
+      if (!reshapeResultLayout || !reshapeResultLayout.isTiled()) {
+        return failure();
+      }
+
+      auto rowMajorReshapeLayout =
+          TTNNLayoutAttr::Builder(reshapeResultLayout,
+                                  reshapeResultType.getShape())
+              .setLayout(ttnn::Layout::RowMajor)
+              .build();
+      RankedTensorType rowMajorReshapeResultType =
+          reshapeResultType.cloneWithEncoding(rowMajorReshapeLayout);
+
+      Value reshapeInput = reshape.getInput();
+      if (!reshapeInput.getDefiningOp<ttnn::ToLayoutOp>()) {
+        auto inputType = mlir::cast<RankedTensorType>(reshapeInput.getType());
+        auto inputLayout =
+            mlir::dyn_cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+        if (inputLayout && inputLayout.isTiled()) {
+          auto rowMajorInput = utils::createToLayoutOp(
+              reshape,
+              mlir::cast<mlir::TypedValue<RankedTensorType>>(reshapeInput),
+              rewriter, Layout::RowMajor, inputLayout.getBufferType(),
+              inputLayout.getMemLayout(), inputLayout.getDataType(),
+              "_input_row_major");
+          reshapeInput = rowMajorInput.getResult();
+        }
+      }
+
+      auto newReshapeOp = rewriter.create<ttnn::ReshapeOp>(
+          reshape.getLoc(), rowMajorReshapeResultType, reshapeInput,
+          reshape.getShapeAttr());
+      newReshapeResults.push_back(newReshapeOp.getResult());
+    }
+
+    auto newConcatOp = rewriter.create<ttnn::ConcatOp>(
+        op.getLoc(), rowMajorResultType, newReshapeResults, op.getDimAttr());
+
+    auto restoredLayout = utils::createToLayoutOp(
+        op,
+        mlir::cast<mlir::TypedValue<RankedTensorType>>(newConcatOp.getResult()),
+        rewriter, resultLayout.getLayout(), resultLayout.getBufferType(),
+        resultLayout.getMemLayout(), resultLayout.getDataType(),
+        "_restore_layout");
+
+    rewriter.replaceOp(op, restoredLayout.getResult());
+    for (auto reshape : operandReshapes) {
+      rewriter.eraseOp(reshape);
+    }
+    return success();
+  }
+};
+
 class TTNNMemoryManagement
     : public impl::TTNNMemoryManagementBase<TTNNMemoryManagement> {
 public:
@@ -1158,8 +1273,8 @@ public:
                    ReshapeElementwiseAdjusting<ttnn::MultiplyOp>,
                    ReshapeElementwiseAdjusting<ttnn::SubtractOp>,
                    ReshapeElementwiseAdjusting<ttnn::DivideOp>,
-                   PermuteRowMajorAdjusting, ReshapeRowMajorAdjusting>(
-          &getContext());
+                   PermuteRowMajorAdjusting, ReshapeRowMajorAdjusting,
+                   ConcatBloatedTileToRowMajor>(&getContext());
     }
     patterns.add<PropagateSliceThroughPermute, PropagateSliceThroughReshape,
                  HoistCommonReshapeAboveSlices, PropagateSliceThroughRepeat,

--- a/test/ttmlir/Transforms/memory_management.mlir
+++ b/test/ttmlir/Transforms/memory_management.mlir
@@ -27,6 +27,11 @@
 #layout_8192x16384_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<256x512x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_4d_1x1x8192x8192_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 * 8192 + d2, d3), <1x1>, memref<256x256x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_4d_8192x8192x1x1_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 + d2, d3), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_concat_img    = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 4096 + d1, d2), <1x1>, memref<128x20x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_concat_txt    = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 384 + d1, d2), <1x1>, memref<12x20x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_concat_img_6d = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4, d5) -> (d0 * 41943040 + d1 * 10240 + d2 * 2048 + d3 * 32 + d4, d5), <1x1>, memref<1310720x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_concat_txt_6d = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4, d5) -> (d0 * 3932160 + d1 * 10240 + d2 * 2048 + d3 * 32 + d4, d5), <1x1>, memref<122880x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_concat_out    = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4, d5) -> (d0 * 45875200 + d1 * 10240 + d2 * 2048 + d3 * 32 + d4, d5), <1x1>, memref<1433600x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 
 module {
   // sliceReshape
@@ -163,5 +168,33 @@ module {
     %0 = "ttnn.reshape"(%arg0) <{shape = [8192 : i32, 8192 : i32, 1 : i32, 1 : i32]}> : (tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>) -> tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>
     %1 = "ttnn.permute"(%0) <{permutation = array<i64: 2, 3, 0, 1>}> : (tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>) -> tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>
     return %1 : tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>
+  }
+
+  // concat-bloated-tile-to-row-major adjust:
+  //   reshape (...) -> 6D tile with sub-tile inner dims (1, 2),
+  //   reshape (...) -> 6D tile with sub-tile inner dims (1, 2),
+  //   concat dim=1 -> 6D tile (bloat > 1 GB)
+  // After fix, both reshapes and the concat should be in row-major, with a
+  // single to_layout(tile) restoring tile layout at the boundary.
+  // CHECK-LABEL: func.func @concat_bloated_tile_to_row_major
+  // CHECK: %[[RM_IN0:.*]] = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>}>
+  // CHECK: %[[R0:.*]] = "ttnn.reshape"(%[[RM_IN0]]) <{shape = [1 : i32, 4096 : i32, 5 : i32, 64 : i32, 1 : i32, 2 : i32]}>
+  // CHECK: %[[RM_IN1:.*]] = "ttnn.to_layout"(%arg1) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>}>
+  // CHECK: %[[R1:.*]] = "ttnn.reshape"(%[[RM_IN1]]) <{shape = [1 : i32, 384 : i32, 5 : i32, 64 : i32, 1 : i32, 2 : i32]}>
+  // CHECK: %[[CAT:.*]] = "ttnn.concat"(%[[R0]], %[[R1]]) <{dim = 1 : si32}>
+  // CHECK: %[[OUT:.*]] = "ttnn.to_layout"(%[[CAT]]) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>}>
+  // CHECK: return %[[OUT]]
+  func.func @concat_bloated_tile_to_row_major(
+      %arg0: tensor<1x4096x640xf32, #layout_concat_img>,
+      %arg1: tensor<1x384x640xf32, #layout_concat_txt>)
+      -> tensor<1x4480x5x64x1x2xf32, #layout_concat_out> {
+    %0 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 4096 : i32, 5 : i32, 64 : i32, 1 : i32, 2 : i32]}>
+        : (tensor<1x4096x640xf32, #layout_concat_img>) -> tensor<1x4096x5x64x1x2xf32, #layout_concat_img_6d>
+    %1 = "ttnn.reshape"(%arg1) <{shape = [1 : i32, 384 : i32, 5 : i32, 64 : i32, 1 : i32, 2 : i32]}>
+        : (tensor<1x384x640xf32, #layout_concat_txt>) -> tensor<1x384x5x64x1x2xf32, #layout_concat_txt_6d>
+    %2 = "ttnn.concat"(%0, %1) <{dim = 1 : si32}>
+        : (tensor<1x4096x5x64x1x2xf32, #layout_concat_img_6d>, tensor<1x384x5x64x1x2xf32, #layout_concat_txt_6d>)
+        -> tensor<1x4480x5x64x1x2xf32, #layout_concat_out>
+    return %2 : tensor<1x4480x5x64x1x2xf32, #layout_concat_out>
   }
 }


### PR DESCRIPTION
### Ticket 

- https://github.com/tenstorrent/tt-xla/issues/4761#issuecomment-4602261133

### Problem

- Models using `reshape(...,-1,1,2)` pattern (RoPE, etc.) produce 6D tile-padded intermediates where inner dims `(1, 2)` each pad up to 32, causing 512x memory inflation. When such reshapes feed a `ttnn.concat`, multiple bloated tile buffers are live simultaneously, wasting DRAM.

### What's changed

- Inspired by [#8568](https://github.com/tenstorrent/tt-mlir/pull/8568), added `ConcatBloatedTileToRowMajor` pattern to `TTNNMemoryManagement`. Flips upstream reshapes' outputs and the concat output to row-major (no tile-padding waste), then restores tile via a single `to_layout` at the boundary for downstream consumers. Concat accepts row-major (data-movement op), so the workarounds pass does not undo the layout swap.
- **Sanity result** : pattern fires, all three previously-bloated tile buffers (image reshape 5 GB, text reshape 470 MB, concat output 5.47 GB) collapse into a row-major chain (~11 MB total) plus one boundary `to_layout(tile)`. Peak per-bank DRAM drops **937 MB → 471 MB**.
- **Model result (HiDream transformer):** pattern fires 6× across the transformer's reshape→concat sites (`concatenate.524` and siblings); zero remaining `1x4096x5x64x1x2 tile<32x32>` buffers in post-fix IR (was 1+ per site pre-fix). 


### Checklist

- [x] Verify the changes through local testing in WH

### Logs

- [jun2_hidream_transformer_before_fix.log](https://github.com/user-attachments/files/28507499/jun2_hidream_transformer.log)
- [jun2_concat_before_fix.log](https://github.com/user-attachments/files/28507496/jun2_concat_before_fix.log)
- [jun2_concat_after_fix.log](https://github.com/user-attachments/files/28507479/jun2_concat_after_fix.log)
- [jun2_hidream_transformer_after_fix.log](https://github.com/user-attachments/files/28507480/jun2_hidream_transformer_after_fix.log)

