### PR TITLE
[EmitPy] Fix argument emission in TTNNEmitter

### DIFF
--- a/.claude/skills/add-op/SKILL.md
+++ b/.claude/skills/add-op/SKILL.md
@@ -321,9 +321,7 @@ public:
         emitter.emit(srcOp.getEpsilon(), "epsilon"),
         emitter.emit(srcOp.getWeight(), "weight"),
         emitter.emit(srcOp.getBias(), "bias"),
-        emitter.emit(srcOp.getMemoryConfig() |
-                         emitter.getMemoryConfig(srcOp.getResult()),
-                     "memory_config"),
+        emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
 
     emitter.replaceOp(*this, args);

--- a/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
@@ -2372,12 +2372,12 @@ private:
     using DecayedConvertedTy = std::decay_t<ConvertedTy>;
     if constexpr (std::is_same_v<DecayedConvertedTy, std::string>) {
       addKeywordArgument(attrName);
-      return rewriter.getType<emitpy::OpaqueAttr>(convertedValue);
+      return rewriter.getAttr<emitpy::OpaqueAttr>(convertedValue);
     } else if constexpr (std::is_same_v<DecayedConvertedTy,
                                         std::optional<std::string>>) {
       if (convertedValue) {
         addKeywordArgument(attrName);
-        return rewriter.getType<emitpy::OpaqueAttr>(*convertedValue);
+        return rewriter.getAttr<emitpy::OpaqueAttr>(*convertedValue);
       }
       return emit(std::nullopt, attrName);
     } else {

--- a/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
@@ -2305,18 +2305,8 @@ public:
       typename =
           std::enable_if_t<std::is_convertible_v<MLIRAttrTy, mlir::Attribute>>>
   mlir::Attribute emit(MLIRAttrTy attr, std::string attrName = "") {
-    auto convertedValue =
-        EmitPyTypeConverter<TTNNTargetT<MLIRAttrTy>>::convert(attr);
-
-    addKeywordArgument(attrName);
-    if constexpr (std::is_same_v<decltype(convertedValue), std::string>) {
-      return rewriter.getType<emitpy::OpaqueAttr>(convertedValue);
-    } else if (convertedValue) {
-      return rewriter.getType<emitpy::OpaqueAttr>(*convertedValue);
-    }
-    // It's assumed that the conversion might fail, in which case the result
-    // will be `emitpy::OpaqueAttr("::std::nullopt")`.
-    return emit(std::nullopt, attrName);
+    return emitConvertedAttr(
+        EmitPyTypeConverter<TTNNTargetT<MLIRAttrTy>>::convert(attr), attrName);
   }
 
   // This is a special handling for cases when there is a many-to-many
@@ -2325,17 +2315,8 @@ public:
   // ttnn::SmallVector<int32_t>}).
   template <typename TargetTy>
   mlir::Attribute emit(mlir::Attribute attr, std::string attrName = "") {
-    auto convertedValue = EmitPyTypeConverter<TargetTy>::convert(attr);
-
-    addKeywordArgument(attrName);
-    if constexpr (std::is_same_v<decltype(convertedValue), std::string>) {
-      return rewriter.getType<emitpy::OpaqueAttr>(convertedValue);
-    } else if (convertedValue) {
-      return rewriter.getType<emitpy::OpaqueAttr>(*convertedValue);
-    }
-    // It's assumed that the conversion might fail, in which case the result
-    // will be `emitpy::OpaqueAttr("::std::nullopt")`.
-    return emit(std::nullopt, attrName);
+    return emitConvertedAttr(EmitPyTypeConverter<TargetTy>::convert(attr),
+                             attrName);
   }
 
   // Handles the case when a source type is not convertible to
@@ -2344,16 +2325,8 @@ public:
   std::enable_if_t<!IsMLIRTypeV<SourceTy>, mlir::Attribute>
   emit(SourceTy attr, std::string attrName = "") {
     using TargetTy = TTNNTargetT<llvm::remove_cvref_t<SourceTy>>;
-    auto result = EmitPyTypeConverter<TargetTy>::convert(attr);
-    // It's assumed that the conversion will always succeed, if the result is
-    // `std::optional<std::string>` we assume that it contains the converted
-    // value.
-    addKeywordArgument(attrName);
-    if constexpr (std::is_same_v<decltype(result),
-                                 std::optional<std::string>>) {
-      return rewriter.getType<emitpy::OpaqueAttr>(*result);
-    }
-    return rewriter.getType<emitpy::OpaqueAttr>(result);
+    return emitConvertedAttr(EmitPyTypeConverter<TargetTy>::convert(attr),
+                             attrName);
   }
 
   ttcore::DataTypeAttr getOutputDtype(mlir::Value val) {
@@ -2385,6 +2358,35 @@ public:
   }
 
 private:
+  // Records one keyword argument for the eventual call_opaque. Every
+  // argument must have a matching keyword name (at least an empty string if the
+  // keyword argument is missing).
+  //
+  // EmitPyTypeConverter::convert must return either:
+  // - std::string: always emitted (may be the None token for absent values).
+  // - std::optional<std::string>: empty optional emits Python None once;
+  //   engaged optional emits the converted expression.
+  template <typename ConvertedTy>
+  mlir::Attribute emitConvertedAttr(ConvertedTy &&convertedValue,
+                                    std::string attrName) {
+    using DecayedConvertedTy = std::decay_t<ConvertedTy>;
+    if constexpr (std::is_same_v<DecayedConvertedTy, std::string>) {
+      addKeywordArgument(attrName);
+      return rewriter.getType<emitpy::OpaqueAttr>(convertedValue);
+    } else if constexpr (std::is_same_v<DecayedConvertedTy,
+                                        std::optional<std::string>>) {
+      if (convertedValue) {
+        addKeywordArgument(attrName);
+        return rewriter.getType<emitpy::OpaqueAttr>(*convertedValue);
+      }
+      return emit(std::nullopt, attrName);
+    } else {
+      static_assert(sizeof(DecayedConvertedTy) == 0,
+                    "EmitPyTypeConverter::convert must return std::string or "
+                    "std::optional<std::string>");
+    }
+  }
+
   void addKeywordArgument(std::string attrName) {
     StringAttr keywordArg = rewriter.getStringAttr(attrName);
     keywordArgs.push_back(keywordArg);
@@ -2414,19 +2416,6 @@ private:
   llvm::SmallVector<mlir::Value> operands;
   llvm::SmallVector<mlir::Attribute> keywordArgs;
 };
-
-// Helper function that serves as an alternative to the
-// `emit<std::variant<...>>` member function of the `EmitPyTTNNEmitter` class.
-// For example, instead of calling `emit<std::variant<int32_t, float>>(attr)`,
-// one can call `emit<int32_t>(attr) | emit<float>(attr)`.
-inline mlir::Attribute operator|(mlir::Attribute lhs, mlir::Attribute rhs) {
-  const mlir::Attribute nulloptAttr = emitpy::OpaqueAttr::get(
-      lhs.getContext(), tt::ttnn_to_emitpy::TypeNameV<std::nullopt_t>);
-  if (!lhs || lhs == nulloptAttr) {
-    return rhs;
-  }
-  return lhs;
-}
 
 } // namespace ttnn_to_emitpy
 } // namespace tt

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -21,7 +21,6 @@
 
 using namespace mlir;
 using namespace mlir::tt;
-using ttnn_to_emitpy::operator|;
 
 // Base class for TTNN to EmitPy OpConversionPattern.
 //

--- a/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
+++ b/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
@@ -352,8 +352,11 @@ LogicalResult CallOpaqueOp::verify() {
   }
   if (getArgs() && getKeywordArgs() &&
       getArgs()->size() != getKeywordArgs()->size()) {
-    return emitOpError("there must be a specified keyword argument string for "
-                       "every argument; empty strings are allowed");
+    return emitOpError("args and keyword_args must have the same size (empty "
+                       "strings are allowed), but got "
+                       "args size = ")
+           << getArgs()->size()
+           << " and keyword_args size = " << getKeywordArgs()->size();
   }
   return success();
 }

--- a/test/ttmlir/EmitPy/emitpy_ttnn_emitter.mlir
+++ b/test/ttmlir/EmitPy/emitpy_ttnn_emitter.mlir
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Verifies that EmitPyTTNNEmitter's argument emission logic.
+//
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline -o %t.mlir %s
+// RUN: ttmlir-opt %t.mlir --verify-each -o /dev/null
+// RUN: ttmlir-translate --mlir-to-python %t.mlir | FileCheck %s
+
+// Optional attribute conversion (MatmulProgramConfig, activation).
+func.func @matmul(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {
+  %0 = "ttir.matmul"(%arg0, %arg1) : (tensor<64x128xbf16>, tensor<128x96xbf16>) -> tensor<64x96xbf16>
+  return %0 : tensor<64x96xbf16>
+}
+
+// Absent optional operand (kv_input_tensor) and absent optional attribute
+// (num_kv_heads).
+func.func @split_qkv(%arg0: tensor<2x32x3072xf32>) -> (tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>) {
+  %0, %1, %2 = "ttir.split_query_key_value_and_split_heads"(%arg0) <{num_heads = 16 : ui32, transpose_key = false}> : (tensor<2x32x3072xf32>) -> (tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>)
+  return %0, %1, %2 : tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>
+}
+
+// Positional tensor operands plus converted dtype/memory_config kwargs.
+func.func @add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  return %0 : tensor<32x32xbf16>
+}
+
+// Non-MLIR attribute (approximate StringRef) and default vs explicit value.
+func.func @gelu_bw_default(%arg0: tensor<4x4xbf16>, %arg1: tensor<4x4xbf16>) -> tensor<4x4xbf16> {
+  %0 = "ttir.gelu_bw"(%arg0, %arg1) : (tensor<4x4xbf16>, tensor<4x4xbf16>) -> tensor<4x4xbf16>
+  return %0 : tensor<4x4xbf16>
+}
+
+func.func @gelu_bw(%arg0: tensor<4x4xbf16>, %arg1: tensor<4x4xbf16>) -> tensor<4x4xbf16> {
+  %0 = "ttir.gelu_bw"(%arg0, %arg1) <{approximate = "tanh"}> : (tensor<4x4xbf16>, tensor<4x4xbf16>) -> tensor<4x4xbf16>
+  return %0 : tensor<4x4xbf16>
+}
+
+// Explicit emit(std::nullopt, "dtype") for a keyword with no MLIR attribute.
+func.func @remainder(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = "ttir.remainder"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  return %0 : tensor<32x32xbf16>
+}
+
+// CHECK-LABEL: def matmul(
+// CHECK: program_config=None
+// CHECK: activation=None
+
+// CHECK-LABEL: def split_qkv(
+// CHECK: ttnn.transformer.split_query_key_value_and_split_heads({{.*}}, None, num_heads=16, num_kv_heads=None, transpose_key=False
+
+// CHECK-LABEL: def add(
+// CHECK: ttnn.add({{.*}}, dtype=ttnn.DataType.BFLOAT16, memory_config=ttnn.MemoryConfig
+
+// CHECK-LABEL: def gelu_bw_default(
+// CHECK: approximate="none"
+
+// CHECK-LABEL: def gelu_bw(
+// CHECK: approximate="tanh"
+
+// CHECK-LABEL: def remainder(
+// CHECK: dtype=None


### PR DESCRIPTION
### Ticket
N/A
### Problem description
Previously, there was a bug in the Emitter's logic for attribute emission. Namely, there were scenarios when more than one keyword argument could be emitted per attribute. This violated `callOpaqueOp` expectation that there must be exactly one keyword argument per attribute. 
### What's changed
Fixed and refactored methods for attribute emission.

### Checklist
- [ ] New/Existing tests provide coverage for changes
