### PR TITLE
Uplift third_party/tt-metal to b2af0cd67b4e92dafeb2d0254e1c5b43c3ec5a25 2026-06-02

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=e4f47ae9b424a0bfe59cc4942f433255f54d3186
+ARG TT_METAL_DEPENDENCIES_COMMIT=b2af0cd67b4e92dafeb2d0254e1c5b43c3ec5a25
 
 # Install dependencies
 RUN <<EOT

--- a/runtime/include/tt/runtime/detail/ttnn/debug_apis.h
+++ b/runtime/include/tt/runtime/detail/ttnn/debug_apis.h
@@ -47,6 +47,8 @@ inline std::string toString(const ::ttnn::DataType &dtype) {
     return "UINT8";
   case ::ttnn::DataType::INT32:
     return "INT32";
+  case ::ttnn::DataType::FP8_E4M3:
+    return "FP8_E4M3";
   case ::ttnn::DataType::INVALID:
     return "INVALID";
   }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "e4f47ae9b424a0bfe59cc4942f433255f54d3186")
+set(TT_METAL_VERSION "b2af0cd67b4e92dafeb2d0254e1c5b43c3ec5a25")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the b2af0cd67b4e92dafeb2d0254e1c5b43c3ec5a25

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):