### PR TITLE
[runtime/ttnn] Honor host-buffer strides when creating owned tensors

### DIFF
--- a/runtime/include/tt/runtime/detail/common/dylib.h
+++ b/runtime/include/tt/runtime/detail/common/dylib.h
@@ -63,7 +63,7 @@ std::vector<common::WrappedTensor> inline packTensors(
       sizes[j] = shape->Get(j);
     }
 
-    std::vector<uint32_t> strides = tt::runtime::utils::calculateStride(sizes);
+    std::vector<uint64_t> strides = tt::runtime::utils::calculateStride(sizes);
     allSizesAndStrides.emplace_back(2 * rank);
     std::copy(sizes.begin(), sizes.end(), allSizesAndStrides.back().begin());
     std::transform(strides.begin(), strides.end(),
@@ -98,7 +98,7 @@ inline void
 prepareSizesAndStrides(const std::vector<int64_t> &sizes,
                        std::vector<std::vector<int64_t>> &allSizesAndStrides) {
 
-  std::vector<uint32_t> strides = tt::runtime::utils::calculateStride(sizes);
+  std::vector<uint64_t> strides = tt::runtime::utils::calculateStride(sizes);
   const size_t rank = sizes.size();
 
   allSizesAndStrides.emplace_back(2 * rank);

--- a/runtime/include/tt/runtime/detail/common/dylib.h
+++ b/runtime/include/tt/runtime/detail/common/dylib.h
@@ -63,7 +63,7 @@ std::vector<common::WrappedTensor> inline packTensors(
       sizes[j] = shape->Get(j);
     }
 
-    std::vector<uint64_t> strides = tt::runtime::utils::calculateStride(sizes);
+    std::vector<int64_t> strides = tt::runtime::utils::calculateStride(sizes);
     allSizesAndStrides.emplace_back(2 * rank);
     std::copy(sizes.begin(), sizes.end(), allSizesAndStrides.back().begin());
     std::transform(strides.begin(), strides.end(),
@@ -98,7 +98,7 @@ inline void
 prepareSizesAndStrides(const std::vector<int64_t> &sizes,
                        std::vector<std::vector<int64_t>> &allSizesAndStrides) {
 
-  std::vector<uint64_t> strides = tt::runtime::utils::calculateStride(sizes);
+  std::vector<int64_t> strides = tt::runtime::utils::calculateStride(sizes);
   const size_t rank = sizes.size();
 
   allSizesAndStrides.emplace_back(2 * rank);

--- a/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
@@ -65,7 +65,7 @@ public:
   static uint64_t buildCreateHostTensorCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,
       const ::tt::runtime::Tensor &outputTensor, const void *data,
-      const std::vector<uint32_t> &shape, const std::vector<uint32_t> &stride,
+      const std::vector<uint32_t> &shape, const std::vector<uint64_t> &stride,
       uint32_t itemSize, ::tt::target::DataType dataType);
 
   static uint64_t buildCreateMultiDeviceHostTensorFromShardsCommand(

--- a/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
@@ -65,7 +65,7 @@ public:
   static uint64_t buildCreateHostTensorCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,
       const ::tt::runtime::Tensor &outputTensor, const void *data,
-      const std::vector<uint32_t> &shape, const std::vector<uint64_t> &stride,
+      const std::vector<uint32_t> &shape, const std::vector<int64_t> &stride,
       uint32_t itemSize, ::tt::target::DataType dataType);
 
   static uint64_t buildCreateMultiDeviceHostTensorFromShardsCommand(

--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -114,7 +114,7 @@ public:
 
   ::tt::runtime::Tensor createOwnedHostTensor(
       const void *data, const std::vector<std::uint32_t> &shape,
-      const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+      const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
       ::tt::target::DataType dataType);
 
   ::tt::runtime::Tensor createMultiDeviceHostTensor(

--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -114,7 +114,7 @@ public:
 
   ::tt::runtime::Tensor createOwnedHostTensor(
       const void *data, const std::vector<std::uint32_t> &shape,
-      const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+      const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
       ::tt::target::DataType dataType);
 
   ::tt::runtime::Tensor createMultiDeviceHostTensor(

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -39,7 +39,7 @@ std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &meshDevice);
 
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint64_t> &stride,
+                      const std::vector<std::int64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
 
 ::tt::runtime::Tensor createMultiDeviceHostTensor(

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -39,7 +39,7 @@ std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &meshDevice);
 
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint32_t> &stride,
+                      const std::vector<std::uint64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
 
 ::tt::runtime::Tensor createMultiDeviceHostTensor(

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
@@ -60,7 +60,7 @@ table CreateHostTensorCommand {
   output_global_id: uint64;
   data: [ubyte];
   shape: [uint32];
-  stride: [uint64];
+  stride: [int64];
   item_size: uint32;
   data_type: tt.target.DataType;
 }

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
@@ -60,7 +60,7 @@ table CreateHostTensorCommand {
   output_global_id: uint64;
   data: [ubyte];
   shape: [uint32];
-  stride: [uint32];
+  stride: [uint64];
   item_size: uint32;
   data_type: tt.target.DataType;
 }

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
@@ -99,7 +99,7 @@ table TensorDescFlat {
   shape: [uint32];
   data_type: tt.target.DataType;
   itemsize: uint32;
-  stride: [uint32];
+  stride: [uint64];
   physical_volume: uint64;
 }
 

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
@@ -99,7 +99,7 @@ table TensorDescFlat {
   shape: [uint32];
   data_type: tt.target.DataType;
   itemsize: uint32;
-  stride: [uint64];
+  stride: [int64];
   physical_volume: uint64;
 }
 

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -46,7 +46,7 @@ createMetalHostBuffer(const void *data, const std::vector<std::uint32_t> &shape,
 
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
-                             const std::vector<std::uint64_t> &stride,
+                             const std::vector<std::int64_t> &stride,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType);
 
@@ -58,14 +58,14 @@ Tensor createMultiDeviceHostTensor(
 Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
 
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
@@ -80,7 +80,7 @@ bool isTensorAllocated(Tensor tensor);
 tt::target::DataType getTensorDataType(Tensor tensor);
 std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor);
 std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor);
-std::vector<std::uint64_t> getTensorStride(::tt::runtime::Tensor tensor);
+std::vector<std::int64_t> getTensorStride(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor);
 TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -46,7 +46,7 @@ createMetalHostBuffer(const void *data, const std::vector<std::uint32_t> &shape,
 
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
-                             const std::vector<std::uint32_t> &stride,
+                             const std::vector<std::uint64_t> &stride,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType);
 
@@ -58,14 +58,14 @@ Tensor createMultiDeviceHostTensor(
 Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
 
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
@@ -80,7 +80,7 @@ bool isTensorAllocated(Tensor tensor);
 tt::target::DataType getTensorDataType(Tensor tensor);
 std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor);
 std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor);
-std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor);
+std::vector<std::uint64_t> getTensorStride(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor);
 TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -87,7 +87,7 @@ namespace tt::runtime::ttnn {
 // allocation/deallocation).
 ::tt::runtime::Tensor
 createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
-                         const std::vector<std::uint64_t> &stride,
+                         const std::vector<std::int64_t> &stride,
                          std::uint32_t itemsize,
                          ::tt::target::DataType dataType);
 
@@ -95,7 +95,7 @@ createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
 // host and its allocation/deallocation is owned by this tensor instance).
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint64_t> &stride,
+                      const std::vector<std::int64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
 
 // Creates a borrowed host tensor that aliases the buffer of `ownedHostTensor`.
@@ -109,7 +109,7 @@ createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor);
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
@@ -126,14 +126,14 @@ createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor);
 // responsible for its allocation/deallocation).
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
 
 ::tt::runtime::Tensor createEmptyTensor(
     Device device, Layout layout, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize);
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize);
 
 ::tt::runtime::Tensor createScalarTensor(::tt::runtime::Scalar scalar);
 
@@ -168,7 +168,7 @@ bool isTensorAllocated(::tt::runtime::Tensor tensor);
 tt::target::DataType getTensorDataType(::tt::runtime::Tensor tensor);
 std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor);
 std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor);
-std::vector<std::uint64_t> getTensorStride(::tt::runtime::Tensor tensor);
+std::vector<std::int64_t> getTensorStride(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorLogicalVolume(::tt::runtime::Tensor tensor);

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -87,7 +87,7 @@ namespace tt::runtime::ttnn {
 // allocation/deallocation).
 ::tt::runtime::Tensor
 createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
-                         const std::vector<std::uint32_t> &stride,
+                         const std::vector<std::uint64_t> &stride,
                          std::uint32_t itemsize,
                          ::tt::target::DataType dataType);
 
@@ -95,7 +95,7 @@ createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
 // host and its allocation/deallocation is owned by this tensor instance).
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint32_t> &stride,
+                      const std::vector<std::uint64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
 
 // Creates a borrowed host tensor that aliases the buffer of `ownedHostTensor`.
@@ -109,7 +109,7 @@ createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor);
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
@@ -126,14 +126,14 @@ createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor);
 // responsible for its allocation/deallocation).
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
 
 ::tt::runtime::Tensor createEmptyTensor(
     Device device, Layout layout, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize);
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize);
 
 ::tt::runtime::Tensor createScalarTensor(::tt::runtime::Scalar scalar);
 
@@ -168,7 +168,7 @@ bool isTensorAllocated(::tt::runtime::Tensor tensor);
 tt::target::DataType getTensorDataType(::tt::runtime::Tensor tensor);
 std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor);
 std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor);
-std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor);
+std::vector<std::uint64_t> getTensorStride(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorLogicalVolume(::tt::runtime::Tensor tensor);

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -131,9 +131,10 @@ Tensor createMultiDeviceBorrowedHostTensor(
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
 
-::tt::runtime::Tensor createEmptyTensor(
-    Device device, Layout layout, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::int64_t> &stride, std::uint32_t itemsize);
+::tt::runtime::Tensor createEmptyTensor(Device device, Layout layout,
+                                        const std::vector<std::uint32_t> &shape,
+                                        const std::vector<std::int64_t> &stride,
+                                        std::uint32_t itemsize);
 
 ::tt::runtime::Tensor createScalarTensor(::tt::runtime::Scalar scalar);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -54,7 +54,7 @@ void shutdownDistributedRuntime();
 // responsible for its allocation/deallocation).
 Tensor createBorrowedHostTensor(void *data,
                                 const std::vector<std::uint32_t> &shape,
-                                const std::vector<std::uint64_t> &stride,
+                                const std::vector<std::int64_t> &stride,
                                 std::uint32_t itemsize,
                                 ::tt::target::DataType dataType);
 
@@ -63,7 +63,7 @@ Tensor createBorrowedHostTensor(void *data,
 // instance).
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
-                             const std::vector<std::uint64_t> &stride,
+                             const std::vector<std::int64_t> &stride,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType);
 
@@ -80,7 +80,7 @@ Tensor createUnsafeBorrowedHostTensor(Tensor ownedHostTensor);
 Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
@@ -97,7 +97,7 @@ Tensor createMultiDeviceHostTensor(
 // responsible for its allocation/deallocation).
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
@@ -105,7 +105,7 @@ Tensor createMultiDeviceBorrowedHostTensor(
 // Creates empty tensor on host/device depending on the passed layout.
 Tensor createEmptyTensor(Device device, Layout layout,
                          const std::vector<std::uint32_t> &shape,
-                         const std::vector<std::uint64_t> &stride,
+                         const std::vector<std::int64_t> &stride,
                          std::uint32_t itemsize);
 
 Tensor createScalarTensor(Scalar scalar);
@@ -142,7 +142,7 @@ std::uint32_t getTensorElementSize(Tensor tensor);
 std::uint32_t getTensorVolume(Tensor tensor);
 std::uint32_t getTensorLogicalVolume(Tensor tensor);
 std::vector<std::uint32_t> getTensorShape(Tensor tensor);
-std::vector<std::uint64_t> getTensorStride(Tensor tensor);
+std::vector<std::int64_t> getTensorStride(Tensor tensor);
 TensorDesc getTensorDesc(Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -54,7 +54,7 @@ void shutdownDistributedRuntime();
 // responsible for its allocation/deallocation).
 Tensor createBorrowedHostTensor(void *data,
                                 const std::vector<std::uint32_t> &shape,
-                                const std::vector<std::uint32_t> &stride,
+                                const std::vector<std::uint64_t> &stride,
                                 std::uint32_t itemsize,
                                 ::tt::target::DataType dataType);
 
@@ -63,7 +63,7 @@ Tensor createBorrowedHostTensor(void *data,
 // instance).
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
-                             const std::vector<std::uint32_t> &stride,
+                             const std::vector<std::uint64_t> &stride,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType);
 
@@ -80,7 +80,7 @@ Tensor createUnsafeBorrowedHostTensor(Tensor ownedHostTensor);
 Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
@@ -97,7 +97,7 @@ Tensor createMultiDeviceHostTensor(
 // responsible for its allocation/deallocation).
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
@@ -105,7 +105,7 @@ Tensor createMultiDeviceBorrowedHostTensor(
 // Creates empty tensor on host/device depending on the passed layout.
 Tensor createEmptyTensor(Device device, Layout layout,
                          const std::vector<std::uint32_t> &shape,
-                         const std::vector<std::uint32_t> &stride,
+                         const std::vector<std::uint64_t> &stride,
                          std::uint32_t itemsize);
 
 Tensor createScalarTensor(Scalar scalar);
@@ -142,7 +142,7 @@ std::uint32_t getTensorElementSize(Tensor tensor);
 std::uint32_t getTensorVolume(Tensor tensor);
 std::uint32_t getTensorLogicalVolume(Tensor tensor);
 std::vector<std::uint32_t> getTensorShape(Tensor tensor);
-std::vector<std::uint32_t> getTensorStride(Tensor tensor);
+std::vector<std::uint64_t> getTensorStride(Tensor tensor);
 TensorDesc getTensorDesc(Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -173,14 +173,14 @@ struct RuntimeCheckedConstObjectImpl {
 struct TensorDesc {
   std::vector<uint32_t> shape = {}; // Logical.
   ::tt::target::DataType dataType = ::tt::target::DataType::MAX;
-  std::vector<uint64_t> stride = {}; // Potentially padded.
+  std::vector<int64_t> stride = {}; // Potentially padded.
   uint64_t physicalVolume = 0;       // Potentially padded.
 
   TensorDesc() = default;
 
   TensorDesc(const std::vector<uint32_t> &shape,
              const ::tt::target::DataType dataType,
-             const std::optional<std::vector<uint64_t>> &stride = {},
+             const std::optional<std::vector<int64_t>> &stride = {},
              const std::optional<uint64_t> physicalVolume = {});
 
   size_t volume() const;

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -173,14 +173,14 @@ struct RuntimeCheckedConstObjectImpl {
 struct TensorDesc {
   std::vector<uint32_t> shape = {}; // Logical.
   ::tt::target::DataType dataType = ::tt::target::DataType::MAX;
-  std::vector<uint32_t> stride = {}; // Potentially padded.
+  std::vector<uint64_t> stride = {}; // Potentially padded.
   uint64_t physicalVolume = 0;       // Potentially padded.
 
   TensorDesc() = default;
 
   TensorDesc(const std::vector<uint32_t> &shape,
              const ::tt::target::DataType dataType,
-             const std::optional<std::vector<uint32_t>> &stride = {},
+             const std::optional<std::vector<uint64_t>> &stride = {},
              const std::optional<uint64_t> physicalVolume = {});
 
   size_t volume() const;

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -174,7 +174,7 @@ struct TensorDesc {
   std::vector<uint32_t> shape = {}; // Logical.
   ::tt::target::DataType dataType = ::tt::target::DataType::MAX;
   std::vector<int64_t> stride = {}; // Potentially padded.
-  uint64_t physicalVolume = 0;       // Potentially padded.
+  uint64_t physicalVolume = 0;      // Potentially padded.
 
   TensorDesc() = default;
 

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -188,7 +188,7 @@ void logMemoryStateIfNeeded(
     std::string_view prefix = "");
 
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-inline std::vector<uint64_t> calculateStride(const std::vector<T> &shape) {
+inline std::vector<int64_t> calculateStride(const std::vector<T> &shape) {
   // Scalar case:
   // For empty shape, return empty stride
   if (shape.empty()) {
@@ -196,7 +196,7 @@ inline std::vector<uint64_t> calculateStride(const std::vector<T> &shape) {
   }
 
   // For non-empty shape, calculate stride
-  std::vector<uint64_t> stride(shape.size(), 1);
+  std::vector<int64_t> stride(shape.size(), 1);
   for (size_t i = shape.size() - 1; i > 0; i--) {
     stride[i - 1] = stride[i] * shape[i];
   }

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -188,7 +188,7 @@ void logMemoryStateIfNeeded(
     std::string_view prefix = "");
 
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-inline std::vector<uint32_t> calculateStride(const std::vector<T> &shape) {
+inline std::vector<uint64_t> calculateStride(const std::vector<T> &shape) {
   // Scalar case:
   // For empty shape, return empty stride
   if (shape.empty()) {
@@ -196,7 +196,7 @@ inline std::vector<uint32_t> calculateStride(const std::vector<T> &shape) {
   }
 
   // For non-empty shape, calculate stride
-  std::vector<uint32_t> stride(shape.size(), 1);
+  std::vector<uint64_t> stride(shape.size(), 1);
   for (size_t i = shape.size() - 1; i > 0; i--) {
     stride[i - 1] = stride[i] * shape[i];
   }

--- a/runtime/lib/common/types.cpp
+++ b/runtime/lib/common/types.cpp
@@ -15,7 +15,7 @@ namespace tt::runtime {
 
 TensorDesc::TensorDesc(const std::vector<uint32_t> &shape,
                        const ::tt::target::DataType dataType,
-                       const std::optional<std::vector<uint64_t>> &stride,
+                       const std::optional<std::vector<int64_t>> &stride,
                        const std::optional<uint64_t> physicalVolume)
     : shape(shape), dataType(dataType) {
   this->stride = stride.value_or(utils::calculateStride(shape));

--- a/runtime/lib/common/types.cpp
+++ b/runtime/lib/common/types.cpp
@@ -15,7 +15,7 @@ namespace tt::runtime {
 
 TensorDesc::TensorDesc(const std::vector<uint32_t> &shape,
                        const ::tt::target::DataType dataType,
-                       const std::optional<std::vector<uint32_t>> &stride,
+                       const std::optional<std::vector<uint64_t>> &stride,
                        const std::optional<uint64_t> physicalVolume)
     : shape(shape), dataType(dataType) {
   this->stride = stride.value_or(utils::calculateStride(shape));

--- a/runtime/lib/distributed/controller/command_factory.cpp
+++ b/runtime/lib/distributed/controller/command_factory.cpp
@@ -214,7 +214,7 @@ uint64_t CommandFactory::buildGetMeshShapeCommand(
 uint64_t CommandFactory::buildCreateHostTensorCommand(
     ::flatbuffers::FlatBufferBuilder &fbb,
     const ::tt::runtime::Tensor &outputTensor, const void *data,
-    const std::vector<uint32_t> &shape, const std::vector<uint32_t> &stride,
+    const std::vector<uint32_t> &shape, const std::vector<uint64_t> &stride,
     uint32_t itemSize, ::tt::target::DataType dataType) {
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
@@ -226,7 +226,7 @@ uint64_t CommandFactory::buildCreateHostTensorCommand(
   auto dataVec =
       fbb.CreateVector<uint8_t>(static_cast<const uint8_t *>(data), numBytes);
   auto shapeVec = fbb.CreateVector<uint32_t>(shape.data(), shape.size());
-  auto strideVec = fbb.CreateVector<uint32_t>(stride.data(), stride.size());
+  auto strideVec = fbb.CreateVector<uint64_t>(stride.data(), stride.size());
 
   uint64_t commandId =
       BUILD_COMMAND(CreateHostTensor, fbb, outputTensor.getGlobalId(), dataVec,

--- a/runtime/lib/distributed/controller/command_factory.cpp
+++ b/runtime/lib/distributed/controller/command_factory.cpp
@@ -214,7 +214,7 @@ uint64_t CommandFactory::buildGetMeshShapeCommand(
 uint64_t CommandFactory::buildCreateHostTensorCommand(
     ::flatbuffers::FlatBufferBuilder &fbb,
     const ::tt::runtime::Tensor &outputTensor, const void *data,
-    const std::vector<uint32_t> &shape, const std::vector<uint64_t> &stride,
+    const std::vector<uint32_t> &shape, const std::vector<int64_t> &stride,
     uint32_t itemSize, ::tt::target::DataType dataType) {
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
@@ -226,7 +226,7 @@ uint64_t CommandFactory::buildCreateHostTensorCommand(
   auto dataVec =
       fbb.CreateVector<uint8_t>(static_cast<const uint8_t *>(data), numBytes);
   auto shapeVec = fbb.CreateVector<uint32_t>(shape.data(), shape.size());
-  auto strideVec = fbb.CreateVector<uint64_t>(stride.data(), stride.size());
+  auto strideVec = fbb.CreateVector<int64_t>(stride.data(), stride.size());
 
   uint64_t commandId =
       BUILD_COMMAND(CreateHostTensor, fbb, outputTensor.getGlobalId(), dataVec,

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -393,7 +393,7 @@ Controller::getMeshShape(const ::tt::runtime::Device &deviceHandle) {
 
 ::tt::runtime::Tensor Controller::createOwnedHostTensor(
     const void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType) {
 
   auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -393,7 +393,7 @@ Controller::getMeshShape(const ::tt::runtime::Device &deviceHandle) {
 
 ::tt::runtime::Tensor Controller::createOwnedHostTensor(
     const void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType) {
 
   auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -114,7 +114,7 @@ std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &meshDevice) {
 
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint32_t> &stride,
+                      const std::vector<std::uint64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
   assertControllerLaunched();
   return ControllerSingleton::get().createOwnedHostTensor(data, shape, stride,

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -114,7 +114,7 @@ std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &meshDevice) {
 
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint64_t> &stride,
+                      const std::vector<std::int64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
   assertControllerLaunched();
   return ControllerSingleton::get().createOwnedHostTensor(data, shape, stride,

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -337,7 +337,7 @@ void CommandExecutor::execute(uint64_t commandId,
   std::vector<uint32_t> shape(command->shape()->begin(),
                               command->shape()->end());
   std::vector<int64_t> stride(command->stride()->begin(),
-                               command->stride()->end());
+                              command->stride()->end());
   uint32_t itemSize = command->item_size();
   ::tt::target::DataType dataType = command->data_type();
 

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -336,7 +336,7 @@ void CommandExecutor::execute(uint64_t commandId,
   const uint8_t *tensorData = command->data()->data();
   std::vector<uint32_t> shape(command->shape()->begin(),
                               command->shape()->end());
-  std::vector<uint32_t> stride(command->stride()->begin(),
+  std::vector<uint64_t> stride(command->stride()->begin(),
                                command->stride()->end());
   uint32_t itemSize = command->item_size();
   ::tt::target::DataType dataType = command->data_type();

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -336,7 +336,7 @@ void CommandExecutor::execute(uint64_t commandId,
   const uint8_t *tensorData = command->data()->data();
   std::vector<uint32_t> shape(command->shape()->begin(),
                               command->shape()->end());
-  std::vector<uint64_t> stride(command->stride()->begin(),
+  std::vector<int64_t> stride(command->stride()->begin(),
                                command->stride()->end());
   uint32_t itemSize = command->item_size();
   ::tt::target::DataType dataType = command->data_type();

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -281,7 +281,7 @@ void shutdownDistributedRuntime() {
 
 Tensor createBorrowedHostTensor(void *data,
                                 const std::vector<std::uint32_t> &shape,
-                                const std::vector<std::uint64_t> &stride,
+                                const std::vector<std::int64_t> &stride,
                                 std::uint32_t itemsize,
                                 ::tt::target::DataType dataType) {
   using RetType = Tensor;
@@ -304,7 +304,7 @@ Tensor createBorrowedHostTensor(void *data,
 
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
-                             const std::vector<std::uint64_t> &stride,
+                             const std::vector<std::int64_t> &stride,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType) {
   using RetType = Tensor;
@@ -346,7 +346,7 @@ Tensor createUnsafeBorrowedHostTensor(Tensor ownedHostTensor) {
 Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -394,7 +394,7 @@ Tensor createMultiDeviceHostTensor(
 
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -420,7 +420,7 @@ Tensor createMultiDeviceBorrowedHostTensor(
 
 Tensor createEmptyTensor(Device device, Layout layout,
                          const std::vector<std::uint32_t> &shape,
-                         const std::vector<std::uint64_t> &stride,
+                         const std::vector<std::int64_t> &stride,
                          std::uint32_t itemsize) {
   using RetType = Tensor;
   LOG_ASSERT(!shape.empty());
@@ -514,8 +514,8 @@ std::vector<std::uint32_t> getTensorShape(Tensor t) {
       });
 }
 
-std::vector<std::uint64_t> getTensorStride(Tensor t) {
-  using RetType = std::vector<std::uint64_t>;
+std::vector<std::int64_t> getTensorStride(Tensor t) {
+  using RetType = std::vector<std::int64_t>;
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,
       [&]() -> RetType { return ::tt::runtime::ttnn::getTensorStride(t); },

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -281,7 +281,7 @@ void shutdownDistributedRuntime() {
 
 Tensor createBorrowedHostTensor(void *data,
                                 const std::vector<std::uint32_t> &shape,
-                                const std::vector<std::uint32_t> &stride,
+                                const std::vector<std::uint64_t> &stride,
                                 std::uint32_t itemsize,
                                 ::tt::target::DataType dataType) {
   using RetType = Tensor;
@@ -304,7 +304,7 @@ Tensor createBorrowedHostTensor(void *data,
 
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
-                             const std::vector<std::uint32_t> &stride,
+                             const std::vector<std::uint64_t> &stride,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType) {
   using RetType = Tensor;
@@ -346,7 +346,7 @@ Tensor createUnsafeBorrowedHostTensor(Tensor ownedHostTensor) {
 Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -394,7 +394,7 @@ Tensor createMultiDeviceHostTensor(
 
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -420,7 +420,7 @@ Tensor createMultiDeviceBorrowedHostTensor(
 
 Tensor createEmptyTensor(Device device, Layout layout,
                          const std::vector<std::uint32_t> &shape,
-                         const std::vector<std::uint32_t> &stride,
+                         const std::vector<std::uint64_t> &stride,
                          std::uint32_t itemsize) {
   using RetType = Tensor;
   LOG_ASSERT(!shape.empty());
@@ -514,8 +514,8 @@ std::vector<std::uint32_t> getTensorShape(Tensor t) {
       });
 }
 
-std::vector<std::uint32_t> getTensorStride(Tensor t) {
-  using RetType = std::vector<std::uint32_t>;
+std::vector<std::uint64_t> getTensorStride(Tensor t) {
+  using RetType = std::vector<std::uint64_t>;
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,
       [&]() -> RetType { return ::tt::runtime::ttnn::getTensorStride(t); },

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -407,7 +407,7 @@ inline TensorDesc
 createTensorDescFromBufferDesc(const target::metal::BufferDesc *bufferDesc) {
   const std::vector<uint32_t> shape(bufferDesc->shape()->begin(),
                                     bufferDesc->shape()->end());
-  const std::vector<uint64_t> stride(bufferDesc->host_strides()->begin(),
+  const std::vector<int64_t> stride(bufferDesc->host_strides()->begin(),
                                      bufferDesc->host_strides()->end());
   const uint64_t physicalVolume = bufferDesc->host_volume();
   assert(shape.size() == stride.size());

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -407,7 +407,7 @@ inline TensorDesc
 createTensorDescFromBufferDesc(const target::metal::BufferDesc *bufferDesc) {
   const std::vector<uint32_t> shape(bufferDesc->shape()->begin(),
                                     bufferDesc->shape()->end());
-  const std::vector<uint32_t> stride(bufferDesc->host_strides()->begin(),
+  const std::vector<uint64_t> stride(bufferDesc->host_strides()->begin(),
                                      bufferDesc->host_strides()->end());
   const uint64_t physicalVolume = bufferDesc->host_volume();
   assert(shape.size() == stride.size());

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -408,7 +408,7 @@ createTensorDescFromBufferDesc(const target::metal::BufferDesc *bufferDesc) {
   const std::vector<uint32_t> shape(bufferDesc->shape()->begin(),
                                     bufferDesc->shape()->end());
   const std::vector<int64_t> stride(bufferDesc->host_strides()->begin(),
-                                     bufferDesc->host_strides()->end());
+                                    bufferDesc->host_strides()->end());
   const uint64_t physicalVolume = bufferDesc->host_volume();
   assert(shape.size() == stride.size());
   const auto dataType = bufferDesc->data_type();

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -615,8 +615,12 @@ static void stridedMemcpy(const TensorDesc &dst, const TensorDesc &src,
   LOG_ASSERT(dst.elementSize() == src.elementSize(),
              "Tensor item size mismatch");
 
-  const auto srcIndices = getStridedRowStartIndices(src.shape, std::vector<std::uint32_t>(src.stride.begin(), src.stride.end()));
-  const auto dstIndices = getStridedRowStartIndices(dst.shape, std::vector<std::uint32_t>(dst.stride.begin(), dst.stride.end()));
+  const auto srcIndices = getStridedRowStartIndices(
+      src.shape,
+      std::vector<std::uint32_t>(src.stride.begin(), src.stride.end()));
+  const auto dstIndices = getStridedRowStartIndices(
+      dst.shape,
+      std::vector<std::uint32_t>(dst.stride.begin(), dst.stride.end()));
   assert(srcIndices.size() == dstIndices.size());
   assert(srcIndices.size() ==
          utils::product(src.shape.cbegin(), src.shape.cend() - 1));

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -129,7 +129,7 @@ createMetalHostBuffer(const void *data, const std::vector<std::uint32_t> &shape,
 
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
-                             const std::vector<std::uint64_t> &stride,
+                             const std::vector<std::int64_t> &stride,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType) {
   LOG_ASSERT(utils::isSupportedDataType(dataType),
@@ -181,7 +181,7 @@ Tensor createMultiDeviceHostTensor(
 Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -198,7 +198,7 @@ Tensor createMultiDeviceHostTensor(
 
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -858,28 +858,28 @@ std::vector<std::uint32_t> getTensorShape(Tensor tensor) {
       tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
 }
 
-std::vector<std::uint64_t> getTensorStride(Tensor tensor) {
+std::vector<std::int64_t> getTensorStride(Tensor tensor) {
   return std::visit(
       utils::overloaded{
           [&](const std::uint32_t &) {
             LOG_FATAL("Unsupported variant type");
-            return std::vector<std::uint64_t>{};
+            return std::vector<std::int64_t>{};
           },
           [&](const TensorDesc &desc) {
             return ttmetal::getTensorDesc(tensor).stride;
           },
           [&](const HostBuffer &buffer) {
             LOG_FATAL("getTensorStride from HostBuffer not supported.");
-            return std::vector<std::uint64_t>{};
+            return std::vector<std::int64_t>{};
           },
           [&](const DistributedHostBuffer &buffer) {
             LOG_FATAL(
                 "getTensorStride from DistributedHostBuffer not supported.");
-            return std::vector<std::uint64_t>{};
+            return std::vector<std::int64_t>{};
           },
           [&](const MeshBuffer &buffer) {
             LOG_FATAL("getTensorStride from MeshBuffer not supported.");
-            return std::vector<std::uint64_t>{};
+            return std::vector<std::int64_t>{};
           },
       },
       tensor.as<MetalTensor>(DeviceRuntime::TTMetal));

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -615,12 +615,15 @@ static void stridedMemcpy(const TensorDesc &dst, const TensorDesc &src,
   LOG_ASSERT(dst.elementSize() == src.elementSize(),
              "Tensor item size mismatch");
 
+  // `getStridedRowStartIndices` requires `shape` and `stride` to share the same
+  // element type. `stride` is signed `int64`, so widen `shape` to `int64`
+  // (lossless) rather than narrowing the stride.
   const auto srcIndices = getStridedRowStartIndices(
-      src.shape,
-      std::vector<std::uint32_t>(src.stride.begin(), src.stride.end()));
+      std::vector<std::int64_t>(src.shape.begin(), src.shape.end()),
+      src.stride);
   const auto dstIndices = getStridedRowStartIndices(
-      dst.shape,
-      std::vector<std::uint32_t>(dst.stride.begin(), dst.stride.end()));
+      std::vector<std::int64_t>(dst.shape.begin(), dst.shape.end()),
+      dst.stride);
   assert(srcIndices.size() == dstIndices.size());
   assert(srcIndices.size() ==
          utils::product(src.shape.cbegin(), src.shape.cend() - 1));

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -129,7 +129,7 @@ createMetalHostBuffer(const void *data, const std::vector<std::uint32_t> &shape,
 
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
-                             const std::vector<std::uint32_t> &stride,
+                             const std::vector<std::uint64_t> &stride,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType) {
   LOG_ASSERT(utils::isSupportedDataType(dataType),
@@ -181,7 +181,7 @@ Tensor createMultiDeviceHostTensor(
 Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -198,7 +198,7 @@ Tensor createMultiDeviceHostTensor(
 
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -615,8 +615,8 @@ static void stridedMemcpy(const TensorDesc &dst, const TensorDesc &src,
   LOG_ASSERT(dst.elementSize() == src.elementSize(),
              "Tensor item size mismatch");
 
-  const auto srcIndices = getStridedRowStartIndices(src.shape, src.stride);
-  const auto dstIndices = getStridedRowStartIndices(dst.shape, dst.stride);
+  const auto srcIndices = getStridedRowStartIndices(src.shape, std::vector<std::uint32_t>(src.stride.begin(), src.stride.end()));
+  const auto dstIndices = getStridedRowStartIndices(dst.shape, std::vector<std::uint32_t>(dst.stride.begin(), dst.stride.end()));
   assert(srcIndices.size() == dstIndices.size());
   assert(srcIndices.size() ==
          utils::product(src.shape.cbegin(), src.shape.cend() - 1));
@@ -854,28 +854,28 @@ std::vector<std::uint32_t> getTensorShape(Tensor tensor) {
       tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
 }
 
-std::vector<std::uint32_t> getTensorStride(Tensor tensor) {
+std::vector<std::uint64_t> getTensorStride(Tensor tensor) {
   return std::visit(
       utils::overloaded{
           [&](const std::uint32_t &) {
             LOG_FATAL("Unsupported variant type");
-            return std::vector<std::uint32_t>{};
+            return std::vector<std::uint64_t>{};
           },
           [&](const TensorDesc &desc) {
             return ttmetal::getTensorDesc(tensor).stride;
           },
           [&](const HostBuffer &buffer) {
             LOG_FATAL("getTensorStride from HostBuffer not supported.");
-            return std::vector<std::uint32_t>{};
+            return std::vector<std::uint64_t>{};
           },
           [&](const DistributedHostBuffer &buffer) {
             LOG_FATAL(
                 "getTensorStride from DistributedHostBuffer not supported.");
-            return std::vector<std::uint32_t>{};
+            return std::vector<std::uint64_t>{};
           },
           [&](const MeshBuffer &buffer) {
             LOG_FATAL("getTensorStride from MeshBuffer not supported.");
-            return std::vector<std::uint32_t>{};
+            return std::vector<std::uint64_t>{};
           },
       },
       tensor.as<MetalTensor>(DeviceRuntime::TTMetal));

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -51,12 +51,12 @@ static std::uint64_t getNumElements(const std::vector<std::uint32_t> &shape) {
 // irrelevant). A stride vector that does not match the rank is treated as
 // contiguous (we cannot interpret it).
 static bool isNonContiguous(const std::vector<std::uint32_t> &shape,
-                            const std::vector<std::uint32_t> &stride) {
+                            const std::vector<std::uint64_t> &stride) {
   if (stride.size() != shape.size()) {
     // this can happen with complex tensors and we treat them as contiguous
     return false;
   }
-  std::uint32_t rowMajorStride = 1;
+  std::uint64_t rowMajorStride = 1;
   for (size_t d = shape.size(); d-- > 0;) {
     if (shape[d] > 1 && stride[d] != rowMajorStride) {
       return true;
@@ -69,7 +69,7 @@ static bool isNonContiguous(const std::vector<std::uint32_t> &shape,
 // Gathers a strided host buffer into a dense, contiguous byte buffer.
 static std::vector<std::byte>
 gatherContiguousBytes(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint32_t> &stride,
+                      const std::vector<std::uint64_t> &stride,
                       std::uint32_t itemsize) {
   std::uint64_t numElements = getNumElements(shape);
   std::vector<std::byte> out(numElements * itemsize);
@@ -103,7 +103,7 @@ gatherContiguousBytes(const void *data, const std::vector<std::uint32_t> &shape,
 
 static ::ttnn::Tensor
 createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint32_t> &stride,
+                      const std::vector<std::uint64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
   const void *src = data;
   ::tt::target::DataType dataTypeToUse = dataType;
@@ -235,7 +235,7 @@ toHostSingleTensor(const ::tt::runtime::ttnn::TTNNTensorWrapper &tensorWrapper,
 
 ::tt::runtime::Tensor
 createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
-                         const std::vector<std::uint32_t> &stride,
+                         const std::vector<std::uint64_t> &stride,
                          std::uint32_t itemsize,
                          ::tt::target::DataType dataType) {
   LOG_ASSERT(
@@ -297,7 +297,7 @@ createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor) {
 
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint32_t> &stride,
+                      const std::vector<std::uint64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
 
   ::tt::runtime::Tensor tensor = utils::createRuntimeTensorFromTTNN(
@@ -329,7 +329,7 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -345,7 +345,7 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
 
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -361,7 +361,7 @@ Tensor createMultiDeviceBorrowedHostTensor(
 
 ::tt::runtime::Tensor createEmptyTensor(
     Device device, Layout layout, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize) {
+    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize) {
   const LayoutDesc &layoutDesc = layout.as<LayoutDesc>(DeviceRuntime::TTNN);
   LOG_ASSERT(::tt::runtime::utils::isSupportedDataType(
                  utils::fromTTNNDataType(layoutDesc.dataType)),
@@ -515,10 +515,10 @@ std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor) {
   return shape;
 }
 
-std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor) {
+std::vector<std::uint64_t> getTensorStride(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       utils::getTTNNTensorFromRuntimeTensor(tensor);
-  std::vector<std::uint32_t> stride;
+  std::vector<std::uint64_t> stride;
   for (size_t i = 0; i < ttnnTensor.strides().size(); ++i) {
     stride.push_back(ttnnTensor.strides()[i]);
   }

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -246,6 +246,13 @@ createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
       "Cannot create borrowed tensor with null data unless the volume is 0.");
   LOG_ASSERT(::tt::runtime::utils::isSupportedDataType(dataType),
              "Cannot create borrowed tensor with unsupported data type");
+  // A borrowed tensor aliases the caller's buffer and reads it as dense
+  // row-major, so it cannot represent a non-contiguous (e.g. transposed or
+  // sliced) layout. Such input must go through an owned tensor, which gathers
+  // the data into a contiguous buffer.
+  LOG_ASSERT(isContiguous(shape, stride),
+             "Cannot create borrowed tensor from a non-contiguous host buffer; "
+             "non-contiguous input must use an owned host tensor.");
   ::ttnn::Shape ttnnShape(shape);
 
   switch (dataType) {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -369,9 +369,10 @@ Tensor createMultiDeviceBorrowedHostTensor(
   return createMultiDeviceHostTensor(tensorShards, strategy, meshShape);
 }
 
-::tt::runtime::Tensor createEmptyTensor(
-    Device device, Layout layout, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::int64_t> &stride, std::uint32_t itemsize) {
+::tt::runtime::Tensor createEmptyTensor(Device device, Layout layout,
+                                        const std::vector<std::uint32_t> &shape,
+                                        const std::vector<std::int64_t> &stride,
+                                        std::uint32_t itemsize) {
   const LayoutDesc &layoutDesc = layout.as<LayoutDesc>(DeviceRuntime::TTNN);
   LOG_ASSERT(::tt::runtime::utils::isSupportedDataType(
                  utils::fromTTNNDataType(layoutDesc.dataType)),

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -39,13 +39,78 @@ namespace tt::runtime::ttnn {
 
 using ::tt::runtime::DeviceRuntime;
 
+// Returns the number of elements described by `shape`.
+static std::uint64_t getNumElements(const std::vector<std::uint32_t> &shape) {
+  return std::accumulate(shape.begin(), shape.end(),
+                         static_cast<std::uint64_t>(1),
+                         std::multiplies<std::uint64_t>());
+}
+
+// Returns true if `stride` (element strides) describes a non-contiguous layout
+// for `shape`. Dimensions of size <= 1 are ignored (their stride is
+// irrelevant). A stride vector that does not match the rank is treated as
+// contiguous (we cannot interpret it).
+static bool isNonContiguous(const std::vector<std::uint32_t> &shape,
+                            const std::vector<std::uint32_t> &stride) {
+  if (stride.size() != shape.size()) {
+    // this can happen with complex tensors and we treat them as contiguous
+    return false;
+  }
+  std::uint32_t rowMajorStride = 1;
+  for (size_t d = shape.size(); d-- > 0;) {
+    if (shape[d] > 1 && stride[d] != rowMajorStride) {
+      return true;
+    }
+    rowMajorStride *= shape[d];
+  }
+  return false;
+}
+
+// Gathers a strided host buffer into a dense, contiguous byte buffer.
+static std::vector<std::byte>
+gatherContiguousBytes(const void *data, const std::vector<std::uint32_t> &shape,
+            const std::vector<std::uint32_t> &stride, std::uint32_t itemsize) {
+  std::uint64_t numElements = getNumElements(shape);
+  std::vector<std::byte> out(numElements * itemsize);
+  if (numElements == 0) return out;
+
+  const std::byte *src = static_cast<const std::byte *>(data);
+  const size_t numDims = shape.size();
+  std::vector<std::uint64_t> idx(numDims, 0);
+
+  for (std::uint64_t i = 0; i < numElements; ++i) {
+    std::uint64_t srcOffset = 0;
+    for (size_t d = 0; d < numDims; ++d) {
+      srcOffset += idx[d] * static_cast<std::uint64_t>(stride[d]);
+    }
+
+    std::memcpy(out.data() + i * itemsize,
+                src + srcOffset * itemsize, itemsize);
+
+    for (size_t d = numDims; d-- > 0;) {
+      if (++idx[d] < shape[d]) break;
+      idx[d] = 0;
+    }
+  }
+
+  return out;
+}
+
 static ::ttnn::Tensor
 createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
-  const void *dataToUse = data;
+  const void *src = data;
   ::tt::target::DataType dataTypeToUse = dataType;
   std::vector<std::byte> castedData;
+
+  // Non-contiguous input: gather into a contiguous byte buffer first.
+  std::vector<std::byte> gatheredData;
+  if (data != nullptr && isNonContiguous(shape, stride)) {
+    gatheredData = gatherContiguousBytes(data, shape, stride, itemsize);
+    src = gatheredData.data();
+  }
+
   if (!::tt::runtime::utils::isSupportedDataType(dataType)) {
     dataTypeToUse = ::tt::runtime::utils::getUnsupportedDataTypeAlias(dataType);
 
@@ -55,20 +120,18 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
               ::tt::target::EnumNameDataType(dataTypeToUse),
               ", this may impact throughput and the integrity of the data.");
 
-    uint64_t numElements = std::accumulate(shape.begin(), shape.end(),
-                                           static_cast<std::uint64_t>(1),
-                                           std::multiplies<std::uint64_t>());
+    std::uint64_t numElements = getNumElements(shape);
 
     std::uint32_t itemSizeToUse =
         ::tt::runtime::utils::dataTypeElementSize(dataTypeToUse);
 
     castedData.resize(itemSizeToUse * numElements);
 
-    if (data != nullptr) {
-      ::tt::runtime::utils::handleBufferCast(data, castedData.data(), dataType,
+    if (src != nullptr) {
+      ::tt::runtime::utils::handleBufferCast(src, castedData.data(), dataType,
                                              dataTypeToUse, numElements);
     }
-    dataToUse = castedData.data();
+    src = castedData.data();
   }
 
   ::ttnn::Shape ttnnShape(shape);
@@ -76,20 +139,20 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
 
   switch (ttnnDataType) {
   case ::ttnn::DataType::FLOAT32:
-    return utils::createTTNNTensor<float>(dataToUse, ttnnShape, ttnnDataType);
+    return utils::createTTNNTensor<float>(src, ttnnShape, ttnnDataType);
   case ::ttnn::DataType::BFLOAT16:
-    return utils::createTTNNTensor<bfloat16>(dataToUse, ttnnShape,
+    return utils::createTTNNTensor<bfloat16>(src, ttnnShape,
                                              ttnnDataType);
   case ::ttnn::DataType::UINT32:
-    return utils::createTTNNTensor<uint32_t>(dataToUse, ttnnShape,
+    return utils::createTTNNTensor<uint32_t>(src, ttnnShape,
                                              ttnnDataType);
   case ::ttnn::DataType::UINT16:
-    return utils::createTTNNTensor<uint16_t>(dataToUse, ttnnShape,
+    return utils::createTTNNTensor<uint16_t>(src, ttnnShape,
                                              ttnnDataType);
   case ::ttnn::DataType::UINT8:
-    return utils::createTTNNTensor<uint8_t>(dataToUse, ttnnShape, ttnnDataType);
+    return utils::createTTNNTensor<uint8_t>(src, ttnnShape, ttnnDataType);
   case ::ttnn::DataType::INT32:
-    return utils::createTTNNTensor<int32_t>(dataToUse, ttnnShape, ttnnDataType);
+    return utils::createTTNNTensor<int32_t>(src, ttnnShape, ttnnDataType);
   default:
     LOG_FATAL("Unsupported data type");
   }

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -51,12 +51,12 @@ static std::uint64_t getNumElements(const std::vector<std::uint32_t> &shape) {
 // irrelevant). A stride vector that does not match the rank is treated as
 // contiguous (we cannot interpret it).
 static bool isContiguous(const std::vector<std::uint32_t> &shape,
-                         const std::vector<std::uint64_t> &stride) {
+                         const std::vector<std::int64_t> &stride) {
   if (stride.size() != shape.size()) {
     // this can happen with complex tensors and we treat them as contiguous
     return true;
   }
-  std::uint64_t rowMajorStride = 1;
+  std::int64_t rowMajorStride = 1;
   for (size_t d = shape.size(); d-- > 0;) {
     if (shape[d] > 1 && stride[d] != rowMajorStride) {
       return false;
@@ -69,7 +69,7 @@ static bool isContiguous(const std::vector<std::uint32_t> &shape,
 // Gathers a strided host buffer into a dense, contiguous byte buffer.
 static std::vector<std::byte>
 gatherContiguousBytes(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint64_t> &stride,
+                      const std::vector<std::int64_t> &stride,
                       std::uint32_t itemsize) {
   std::uint64_t numElements = getNumElements(shape);
   std::vector<std::byte> out(numElements * itemsize);
@@ -79,15 +79,18 @@ gatherContiguousBytes(const void *data, const std::vector<std::uint32_t> &shape,
 
   const std::byte *src = static_cast<const std::byte *>(data);
   const size_t numDims = shape.size();
-  std::vector<std::uint64_t> idx(numDims, 0);
+  std::vector<std::int64_t> idx(numDims, 0);
 
+  // `stride` is signed: a negative stride (e.g. a reversed view) walks backward
+  // from `data`, which points at the first logical element.
   for (std::uint64_t i = 0; i < numElements; ++i) {
-    std::uint64_t srcOffset = 0;
+    std::int64_t srcOffset = 0;
     for (size_t d = 0; d < numDims; ++d) {
-      srcOffset += idx[d] * static_cast<std::uint64_t>(stride[d]);
+      srcOffset += idx[d] * stride[d];
     }
 
-    std::memcpy(out.data() + i * itemsize, src + srcOffset * itemsize,
+    std::memcpy(out.data() + i * itemsize,
+                src + srcOffset * static_cast<std::int64_t>(itemsize),
                 itemsize);
 
     for (size_t d = numDims; d-- > 0;) {
@@ -103,7 +106,7 @@ gatherContiguousBytes(const void *data, const std::vector<std::uint32_t> &shape,
 
 static ::ttnn::Tensor
 createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint64_t> &stride,
+                      const std::vector<std::int64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
   const void *src = data;
   ::tt::target::DataType dataTypeToUse = dataType;
@@ -235,7 +238,7 @@ toHostSingleTensor(const ::tt::runtime::ttnn::TTNNTensorWrapper &tensorWrapper,
 
 ::tt::runtime::Tensor
 createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
-                         const std::vector<std::uint64_t> &stride,
+                         const std::vector<std::int64_t> &stride,
                          std::uint32_t itemsize,
                          ::tt::target::DataType dataType) {
   LOG_ASSERT(
@@ -304,7 +307,7 @@ createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor) {
 
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
-                      const std::vector<std::uint64_t> &stride,
+                      const std::vector<std::int64_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
 
   ::tt::runtime::Tensor tensor = utils::createRuntimeTensorFromTTNN(
@@ -336,7 +339,7 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -352,7 +355,7 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
 
 Tensor createMultiDeviceBorrowedHostTensor(
     std::vector<void *> &data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape) {
@@ -368,7 +371,7 @@ Tensor createMultiDeviceBorrowedHostTensor(
 
 ::tt::runtime::Tensor createEmptyTensor(
     Device device, Layout layout, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint64_t> &stride, std::uint32_t itemsize) {
+    const std::vector<std::int64_t> &stride, std::uint32_t itemsize) {
   const LayoutDesc &layoutDesc = layout.as<LayoutDesc>(DeviceRuntime::TTNN);
   LOG_ASSERT(::tt::runtime::utils::isSupportedDataType(
                  utils::fromTTNNDataType(layoutDesc.dataType)),
@@ -522,10 +525,10 @@ std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor) {
   return shape;
 }
 
-std::vector<std::uint64_t> getTensorStride(::tt::runtime::Tensor tensor) {
+std::vector<std::int64_t> getTensorStride(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       utils::getTTNNTensorFromRuntimeTensor(tensor);
-  std::vector<std::uint64_t> stride;
+  std::vector<std::int64_t> stride;
   for (size_t i = 0; i < ttnnTensor.strides().size(); ++i) {
     stride.push_back(ttnnTensor.strides()[i]);
   }

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -69,10 +69,13 @@ static bool isNonContiguous(const std::vector<std::uint32_t> &shape,
 // Gathers a strided host buffer into a dense, contiguous byte buffer.
 static std::vector<std::byte>
 gatherContiguousBytes(const void *data, const std::vector<std::uint32_t> &shape,
-            const std::vector<std::uint32_t> &stride, std::uint32_t itemsize) {
+                      const std::vector<std::uint32_t> &stride,
+                      std::uint32_t itemsize) {
   std::uint64_t numElements = getNumElements(shape);
   std::vector<std::byte> out(numElements * itemsize);
-  if (numElements == 0) return out;
+  if (numElements == 0) {
+    return out;
+  }
 
   const std::byte *src = static_cast<const std::byte *>(data);
   const size_t numDims = shape.size();
@@ -84,11 +87,13 @@ gatherContiguousBytes(const void *data, const std::vector<std::uint32_t> &shape,
       srcOffset += idx[d] * static_cast<std::uint64_t>(stride[d]);
     }
 
-    std::memcpy(out.data() + i * itemsize,
-                src + srcOffset * itemsize, itemsize);
+    std::memcpy(out.data() + i * itemsize, src + srcOffset * itemsize,
+                itemsize);
 
     for (size_t d = numDims; d-- > 0;) {
-      if (++idx[d] < shape[d]) break;
+      if (++idx[d] < shape[d]) {
+        break;
+      }
       idx[d] = 0;
     }
   }
@@ -141,14 +146,11 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
   case ::ttnn::DataType::FLOAT32:
     return utils::createTTNNTensor<float>(src, ttnnShape, ttnnDataType);
   case ::ttnn::DataType::BFLOAT16:
-    return utils::createTTNNTensor<bfloat16>(src, ttnnShape,
-                                             ttnnDataType);
+    return utils::createTTNNTensor<bfloat16>(src, ttnnShape, ttnnDataType);
   case ::ttnn::DataType::UINT32:
-    return utils::createTTNNTensor<uint32_t>(src, ttnnShape,
-                                             ttnnDataType);
+    return utils::createTTNNTensor<uint32_t>(src, ttnnShape, ttnnDataType);
   case ::ttnn::DataType::UINT16:
-    return utils::createTTNNTensor<uint16_t>(src, ttnnShape,
-                                             ttnnDataType);
+    return utils::createTTNNTensor<uint16_t>(src, ttnnShape, ttnnDataType);
   case ::ttnn::DataType::UINT8:
     return utils::createTTNNTensor<uint8_t>(src, ttnnShape, ttnnDataType);
   case ::ttnn::DataType::INT32:

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -46,24 +46,24 @@ static std::uint64_t getNumElements(const std::vector<std::uint32_t> &shape) {
                          std::multiplies<std::uint64_t>());
 }
 
-// Returns true if `stride` (element strides) describes a non-contiguous layout
-// for `shape`. Dimensions of size <= 1 are ignored (their stride is
+// Returns true if `stride` (element strides) describes a contiguous, row-major
+// layout for `shape`. Dimensions of size <= 1 are ignored (their stride is
 // irrelevant). A stride vector that does not match the rank is treated as
 // contiguous (we cannot interpret it).
-static bool isNonContiguous(const std::vector<std::uint32_t> &shape,
-                            const std::vector<std::uint64_t> &stride) {
+static bool isContiguous(const std::vector<std::uint32_t> &shape,
+                         const std::vector<std::uint64_t> &stride) {
   if (stride.size() != shape.size()) {
     // this can happen with complex tensors and we treat them as contiguous
-    return false;
+    return true;
   }
   std::uint64_t rowMajorStride = 1;
   for (size_t d = shape.size(); d-- > 0;) {
     if (shape[d] > 1 && stride[d] != rowMajorStride) {
-      return true;
+      return false;
     }
     rowMajorStride *= shape[d];
   }
-  return false;
+  return true;
 }
 
 // Gathers a strided host buffer into a dense, contiguous byte buffer.
@@ -111,7 +111,7 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
 
   // Non-contiguous input: gather into a contiguous byte buffer first.
   std::vector<std::byte> gatheredData;
-  if (data != nullptr && isNonContiguous(shape, stride)) {
+  if (data != nullptr && !isContiguous(shape, stride)) {
     gatheredData = gatherContiguousBytes(data, shape, stride, itemsize);
     src = gatheredData.data();
   }

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -366,7 +366,7 @@ void registerRuntimeBindings(nb::module_ &m) {
   m.def(
       "create_borrowed_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType) {
         return tt::runtime::createBorrowedHostTensor(
             reinterpret_cast<void *>(ptr), shape, stride, itemsize, dataType);
@@ -375,7 +375,7 @@ void registerRuntimeBindings(nb::module_ &m) {
   m.def(
       "create_owned_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType) {
         return tt::runtime::createOwnedHostTensor(
             reinterpret_cast<const void *>(ptr), shape, stride, itemsize,
@@ -392,7 +392,7 @@ void registerRuntimeBindings(nb::module_ &m) {
       "create_empty_tensor",
       [](::tt::runtime::Device device, ::tt::runtime::Layout layout,
          const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint32_t> &stride, std::uint32_t itemsize) {
+         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize) {
         return tt::runtime::createEmptyTensor(device, layout, shape, stride,
                                               itemsize);
       },
@@ -403,7 +403,7 @@ void registerRuntimeBindings(nb::module_ &m) {
       "create_multi_device_host_tensor",
       [](std::vector<std::uintptr_t> &ptrs,
          const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType,
          const std::unordered_map<std::string, std::string> &strategy,
          const std::vector<uint32_t> &meshShape) {
@@ -430,7 +430,7 @@ void registerRuntimeBindings(nb::module_ &m) {
       "create_multi_device_borrowed_host_tensor",
       [](std::vector<std::uintptr_t> &ptrs,
          const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType,
          const std::unordered_map<std::string, std::string> &strategy,
          const std::vector<uint32_t> &meshShape) {

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -366,7 +366,7 @@ void registerRuntimeBindings(nb::module_ &m) {
   m.def(
       "create_borrowed_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+         const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType) {
         return tt::runtime::createBorrowedHostTensor(
             reinterpret_cast<void *>(ptr), shape, stride, itemsize, dataType);
@@ -375,7 +375,7 @@ void registerRuntimeBindings(nb::module_ &m) {
   m.def(
       "create_owned_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+         const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType) {
         return tt::runtime::createOwnedHostTensor(
             reinterpret_cast<const void *>(ptr), shape, stride, itemsize,
@@ -392,7 +392,7 @@ void registerRuntimeBindings(nb::module_ &m) {
       "create_empty_tensor",
       [](::tt::runtime::Device device, ::tt::runtime::Layout layout,
          const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize) {
+         const std::vector<std::int64_t> &stride, std::uint32_t itemsize) {
         return tt::runtime::createEmptyTensor(device, layout, shape, stride,
                                               itemsize);
       },
@@ -403,7 +403,7 @@ void registerRuntimeBindings(nb::module_ &m) {
       "create_multi_device_host_tensor",
       [](std::vector<std::uintptr_t> &ptrs,
          const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+         const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType,
          const std::unordered_map<std::string, std::string> &strategy,
          const std::vector<uint32_t> &meshShape) {
@@ -430,7 +430,7 @@ void registerRuntimeBindings(nb::module_ &m) {
       "create_multi_device_borrowed_host_tensor",
       [](std::vector<std::uintptr_t> &ptrs,
          const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint64_t> &stride, std::uint32_t itemsize,
+         const std::vector<std::int64_t> &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType,
          const std::unordered_map<std::string, std::string> &strategy,
          const std::vector<uint32_t> &meshShape) {

--- a/runtime/test/ttnn/gtest/CMakeLists.txt
+++ b/runtime/test/ttnn/gtest/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_runtime_gtest(test_tensor_serialization)
 add_runtime_gtest(test_tensor_cache_lifetime)
 add_runtime_gtest(test_unsafe_borrowed_host_tensor)
+add_runtime_gtest(test_owned_host_tensor_strided)

--- a/runtime/test/ttnn/gtest/test_owned_host_tensor_strided.cpp
+++ b/runtime/test/ttnn/gtest/test_owned_host_tensor_strided.cpp
@@ -29,7 +29,7 @@ protected:
 
   static tt::runtime::Tensor makeOwned(const std::vector<float> &data,
                                        const std::vector<uint32_t> &shape,
-                                       const std::vector<uint64_t> &stride) {
+                                       const std::vector<int64_t> &stride) {
     return tt::runtime::createOwnedHostTensor(data.data(), shape, stride,
                                               sizeof(float),
                                               tt::target::DataType::Float32);
@@ -42,7 +42,7 @@ protected:
 TEST_F(OwnedHostTensorStridedTest, ContiguousIsUnchanged) {
   std::vector<float> data = {0, 1, 2, 3, 4, 5}; // 2x3 row-major
   std::vector<uint32_t> shape = {2, 3};
-  std::vector<uint64_t> stride = {3, 1}; // dense row-major strides
+  std::vector<int64_t> stride = {3, 1}; // dense row-major strides
 
   tt::runtime::Tensor tensor = makeOwned(data, shape, stride);
 
@@ -54,7 +54,7 @@ TEST_F(OwnedHostTensorStridedTest, ContiguousIsUnchanged) {
 TEST_F(OwnedHostTensorStridedTest, GathersTransposedView) {
   std::vector<float> parent = {0, 1, 2, 3, 4, 5};
   std::vector<uint32_t> shape = {3, 2};
-  std::vector<uint64_t> stride = {1, 3};
+  std::vector<int64_t> stride = {1, 3};
 
   tt::runtime::Tensor tensor = makeOwned(parent, shape, stride);
 
@@ -68,10 +68,26 @@ TEST_F(OwnedHostTensorStridedTest, GathersTransposedView) {
 TEST_F(OwnedHostTensorStridedTest, GathersSlicedView) {
   std::vector<float> parent = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
   std::vector<uint32_t> shape = {3, 2};
-  std::vector<uint64_t> stride = {4, 1};
+  std::vector<int64_t> stride = {4, 1};
 
   tt::runtime::Tensor tensor = makeOwned(parent, shape, stride);
 
   std::vector<float> expected = {0, 1, 4, 5, 8, 9};
+  EXPECT_EQ(readFloats(tensor), expected);
+}
+
+// A reversed (negative-stride) view must walk backward from the data pointer,
+// which points at the first logical element. parent = [0,1,2,3];
+// view = parent[::-1] -> shape [4], stride [-1], data pointer at parent[3].
+TEST_F(OwnedHostTensorStridedTest, GathersReversedView) {
+  std::vector<float> parent = {0, 1, 2, 3};
+  std::vector<uint32_t> shape = {4};
+  std::vector<int64_t> stride = {-1};
+
+  tt::runtime::Tensor tensor = tt::runtime::createOwnedHostTensor(
+      parent.data() + 3, shape, stride, sizeof(float),
+      tt::target::DataType::Float32);
+
+  std::vector<float> expected = {3, 2, 1, 0};
   EXPECT_EQ(readFloats(tensor), expected);
 }

--- a/runtime/test/ttnn/gtest/test_owned_host_tensor_strided.cpp
+++ b/runtime/test/ttnn/gtest/test_owned_host_tensor_strided.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt/runtime/runtime.h"
+#include "tt/runtime/types.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+class OwnedHostTensorStridedTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    tt::runtime::setCurrentDeviceRuntime(tt::runtime::DeviceRuntime::TTNN);
+  }
+
+  // Reads back the dense, row-major float contents of a host tensor.
+  static std::vector<float> readFloats(tt::runtime::Tensor tensor) {
+    std::vector<std::byte> bytes = tt::runtime::getTensorDataBuffer(tensor);
+    std::vector<float> values(bytes.size() / sizeof(float));
+    std::memcpy(values.data(), bytes.data(), bytes.size());
+    return values;
+  }
+
+  static tt::runtime::Tensor makeOwned(const std::vector<float> &data,
+                                       const std::vector<uint32_t> &shape,
+                                       const std::vector<uint64_t> &stride) {
+    return tt::runtime::createOwnedHostTensor(data.data(), shape, stride,
+                                              sizeof(float),
+                                              tt::target::DataType::Float32);
+  }
+};
+
+} // namespace
+
+// A contiguous buffer must be copied through unchanged (no spurious gather).
+TEST_F(OwnedHostTensorStridedTest, ContiguousIsUnchanged) {
+  std::vector<float> data = {0, 1, 2, 3, 4, 5}; // 2x3 row-major
+  std::vector<uint32_t> shape = {2, 3};
+  std::vector<uint64_t> stride = {3, 1}; // dense row-major strides
+
+  tt::runtime::Tensor tensor = makeOwned(data, shape, stride);
+
+  EXPECT_EQ(readFloats(tensor), data);
+}
+
+// A transposed (non-contiguous) view must be gathered into dense row-major
+// order. parent 2x3 = [0..5]; view = parent.T -> shape [3,2], strides [1,3].
+TEST_F(OwnedHostTensorStridedTest, GathersTransposedView) {
+  std::vector<float> parent = {0, 1, 2, 3, 4, 5};
+  std::vector<uint32_t> shape = {3, 2};
+  std::vector<uint64_t> stride = {1, 3};
+
+  tt::runtime::Tensor tensor = makeOwned(parent, shape, stride);
+
+  std::vector<float> expected = {0, 3, 1, 4, 2, 5};
+  EXPECT_EQ(readFloats(tensor), expected);
+}
+
+// A sliced view with gaps must skip the unused elements. parent 3x4 = [0..11];
+// view = parent[:, 0:2] -> shape [3,2], strides [4,1] (the row stride spans the
+// full parent row of 4, so columns 2 and 3 are skipped).
+TEST_F(OwnedHostTensorStridedTest, GathersSlicedView) {
+  std::vector<float> parent = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  std::vector<uint32_t> shape = {3, 2};
+  std::vector<uint64_t> stride = {4, 1};
+
+  tt::runtime::Tensor tensor = makeOwned(parent, shape, stride);
+
+  std::vector<float> expected = {0, 1, 4, 5, 8, 9};
+  EXPECT_EQ(readFloats(tensor), expected);
+}

--- a/runtime/test/ttnn/gtest/test_tensor_cache_lifetime.cpp
+++ b/runtime/test/ttnn/gtest/test_tensor_cache_lifetime.cpp
@@ -28,7 +28,7 @@ protected:
 
   tt::runtime::Tensor createTestTensor() {
     std::vector<uint32_t> shape = {2, 2};
-    std::vector<uint32_t> stride = tt::runtime::utils::calculateStride(shape);
+    std::vector<uint64_t> stride = tt::runtime::utils::calculateStride(shape);
     tt::target::DataType dataType = tt::target::DataType::Float32;
     uint32_t itemSize = sizeof(float);
 

--- a/runtime/test/ttnn/gtest/test_tensor_cache_lifetime.cpp
+++ b/runtime/test/ttnn/gtest/test_tensor_cache_lifetime.cpp
@@ -28,7 +28,7 @@ protected:
 
   tt::runtime::Tensor createTestTensor() {
     std::vector<uint32_t> shape = {2, 2};
-    std::vector<uint64_t> stride = tt::runtime::utils::calculateStride(shape);
+    std::vector<int64_t> stride = tt::runtime::utils::calculateStride(shape);
     tt::target::DataType dataType = tt::target::DataType::Float32;
     uint32_t itemSize = sizeof(float);
 

--- a/runtime/test/ttnn/gtest/test_tensor_serialization.cpp
+++ b/runtime/test/ttnn/gtest/test_tensor_serialization.cpp
@@ -38,7 +38,7 @@ private:
 
 TEST_F(TensorSerializationTest, TestDumpAndLoadFloat32Tensor) {
   std::vector<uint32_t> shape = {3, 3};
-  std::vector<uint64_t> stride = tt::runtime::utils::calculateStride(shape);
+  std::vector<int64_t> stride = tt::runtime::utils::calculateStride(shape);
   tt::target::DataType dataType = tt::target::DataType::Float32;
   uint32_t itemSize = sizeof(float);
 
@@ -80,7 +80,7 @@ TEST_F(TensorSerializationTest, TestDumpAndLoadFloat32Tensor) {
 
 TEST_F(TensorSerializationTest, TestDumpAndLoadTensorWithDevice) {
   std::vector<uint32_t> shape = {32, 32};
-  std::vector<uint64_t> stride = tt::runtime::utils::calculateStride(shape);
+  std::vector<int64_t> stride = tt::runtime::utils::calculateStride(shape);
   tt::target::DataType dataType = tt::target::DataType::BFloat16;
   uint32_t itemSize = sizeof(uint16_t);
 

--- a/runtime/test/ttnn/gtest/test_tensor_serialization.cpp
+++ b/runtime/test/ttnn/gtest/test_tensor_serialization.cpp
@@ -38,7 +38,7 @@ private:
 
 TEST_F(TensorSerializationTest, TestDumpAndLoadFloat32Tensor) {
   std::vector<uint32_t> shape = {3, 3};
-  std::vector<uint32_t> stride = tt::runtime::utils::calculateStride(shape);
+  std::vector<uint64_t> stride = tt::runtime::utils::calculateStride(shape);
   tt::target::DataType dataType = tt::target::DataType::Float32;
   uint32_t itemSize = sizeof(float);
 
@@ -80,7 +80,7 @@ TEST_F(TensorSerializationTest, TestDumpAndLoadFloat32Tensor) {
 
 TEST_F(TensorSerializationTest, TestDumpAndLoadTensorWithDevice) {
   std::vector<uint32_t> shape = {32, 32};
-  std::vector<uint32_t> stride = tt::runtime::utils::calculateStride(shape);
+  std::vector<uint64_t> stride = tt::runtime::utils::calculateStride(shape);
   tt::target::DataType dataType = tt::target::DataType::BFloat16;
   uint32_t itemSize = sizeof(uint16_t);
 

--- a/runtime/test/ttnn/gtest/test_unsafe_borrowed_host_tensor.cpp
+++ b/runtime/test/ttnn/gtest/test_unsafe_borrowed_host_tensor.cpp
@@ -25,7 +25,7 @@ protected:
 
 TEST_F(UnsafeBorrowedHostTensorTest, AliasesOwnedBuffer) {
   std::vector<uint32_t> shape = {2, 2};
-  std::vector<uint64_t> stride = tt::runtime::utils::calculateStride(shape);
+  std::vector<int64_t> stride = tt::runtime::utils::calculateStride(shape);
   tt::target::DataType dataType = tt::target::DataType::Float32;
   uint32_t itemSize = sizeof(float);
 

--- a/runtime/test/ttnn/gtest/test_unsafe_borrowed_host_tensor.cpp
+++ b/runtime/test/ttnn/gtest/test_unsafe_borrowed_host_tensor.cpp
@@ -25,7 +25,7 @@ protected:
 
 TEST_F(UnsafeBorrowedHostTensorTest, AliasesOwnedBuffer) {
   std::vector<uint32_t> shape = {2, 2};
-  std::vector<uint32_t> stride = tt::runtime::utils::calculateStride(shape);
+  std::vector<uint64_t> stride = tt::runtime::utils::calculateStride(shape);
   tt::target::DataType dataType = tt::target::DataType::Float32;
   uint32_t itemSize = sizeof(float);
 


### PR DESCRIPTION
### Ticket
fixes: #8622

### Problem description
`createOwnedHostTensor` accepted a `stride` argument but ignored it, which meant that the host buffer was always read linearly as dense row-major. When a frontend hands us a non-contiguous host buffer (a transposed or sliced view), the data was interpreted as contiguous and silently corrupted (Note: this is currently only possible trough `jax` path, because we are forcing `pytorch` tensors to be contiguous in frontend).

### What's changed
`createOwnedTTNNTensor` now detects a non-contiguous layout from the element strides (`isNonContiguous`) and gathers the strided source into a dense, row-major contiguous buffer before constructing the tensor (`gatherContiguousBytes`), then builds the owned tensor as usual. Contiguous inputs are unchanged.
