### PR TITLE
Remove layout attribute

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -55,7 +55,7 @@ def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config"> {
     let hasVerifier = 1;
 }
 
-def TTNN_ToLayoutOp : TTNN_Op<"to_layout"> {
+def TTNN_ToLayoutOp : TTNN_Op<"to_layout", [TTNN_LayoutOpInterface]> {
     let summary = "ToLayout op.";
     let description = [{
       This op wraps all layout information gathered from ttir.toLayout. It is used/updated by the optimizer
@@ -64,16 +64,17 @@ def TTNN_ToLayoutOp : TTNN_Op<"to_layout"> {
       Once ttnn::to_layout supports other attrs, we can remove the optional tag.
 
       The output data type is derived from the result tensor's TTNNLayoutAttr
-      encoding via the TTNN_DtypeOpInterface. Whether this op actually changes dtype can
-      be queried via `hasDtypeChange()`.
+      encoding via the TTNN_DtypeOpInterface. The target page layout (tile vs
+      row-major) is also derived from the encoding. Whether this op actually
+      changes dtype can be queried via `hasDtypeChange()`.
     }];
 
-    let arguments = (ins AnyRankedTensor:$input,
-                         TTNN_LayoutAttr:$layout);
+    let arguments = (ins AnyRankedTensor:$input);
     let results = (outs AnyRankedTensor:$result);
 
     let hasFolder = 1;
     let hasCanonicalizer = 1;
+    let hasVerifier = 1;
 
     let extraClassDeclaration = [{
       // Returns true iff the input and result element data types differ,
@@ -2875,7 +2876,7 @@ def TTNN_ClampTensorOp : TTNN_Op<"clamp_tensor"> {
 }
 
 class TTNN_CreationOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_Op<mnemonic, [TTCore_CreationOpTrait, TTNN_TensorSpecInterface, TTNN_DeviceOperandInterface] # traits>;
+    TTNN_Op<mnemonic, [TTCore_CreationOpTrait, TTNN_TensorSpecInterface, TTNN_DeviceOperandInterface, TTNN_LayoutOpInterface] # traits>;
 
 def TTNN_EmptyOp : TTNN_CreationOp<"empty", [TTCore_NonCacheableTrait]> {
     let summary = "Empty op.";
@@ -2884,8 +2885,7 @@ def TTNN_EmptyOp : TTNN_CreationOp<"empty", [TTCore_NonCacheableTrait]> {
     }];
 
     let arguments = (ins TTNN_Device:$device,
-                         TTNN_ShapeAttr:$shape,
-                         TTNN_LayoutAttr:$layout);
+                         TTNN_ShapeAttr:$shape);
 
     let results = (outs AnyRankedTensor:$result);
 
@@ -2910,8 +2910,7 @@ def TTNN_ArangeOp : TTNN_CreationOp<"arange", [CanExecuteOnHostTrait]> {
   let arguments = (ins Optional<TTNN_Device>:$device,
                        I64Attr:$start,
                        I64Attr:$end,
-                       I64Attr:$step,
-                       OptionalAttr<TTNN_LayoutAttr>:$layout);
+                       I64Attr:$step);
 
   let results = (outs AnyRankedTensor:$result);
   let hasVerifier = 1;
@@ -2929,7 +2928,6 @@ def TTNN_RandOp : TTNN_CreationOp<"rand", [TTCore_NonCacheableTrait]> {
     Attributes:
       - `size` (TTNN_ShapeAttr): The shape of the tensor to create.
       - `device` (TTNN_Device): The device where the trace was captured.
-      - `layout` (TTNN_LayoutAttr): The layout for the output tensor.
       - `low` (Float): The lower bound of the range (inclusive) [Default: 0.0].
       - `high` (Float): The upper bound of the range (exclusive) [Default: 1.0].
       - `seed` (Integer): Value to initialize the random number generator for reproducible results [Default: 0].
@@ -2942,8 +2940,7 @@ def TTNN_RandOp : TTNN_CreationOp<"rand", [TTCore_NonCacheableTrait]> {
                        TTNN_ShapeAttr:$size,
                        DefaultValuedAttr<F32Attr, "0.0">:$low,
                        DefaultValuedAttr<F32Attr, "1.0">:$high,
-                       DefaultValuedAttr<UI32Attr, "0">:$seed,
-                       DefaultValuedAttr<TTNN_LayoutAttr, "mlir::tt::ttnn::Layout::Tile">:$layout);
+                       DefaultValuedAttr<UI32Attr, "0">:$seed);
 
   let results = (outs AnyRankedTensor:$result);
 
@@ -2991,8 +2988,7 @@ def TTNN_DropoutOp : TTNN_Op<"dropout", [TTCore_NonCacheableTrait]> {
 class TTNN_NamedFullOp<string mnemonic, list<Trait> traits = []> :
   TTNN_CreationOp<mnemonic, [CanExecuteOnHostTrait] # traits> {
   let arguments = (ins Optional<TTNN_Device>:$device,
-                       TTNN_ShapeAttr:$shape,
-                       OptionalAttr<TTNN_LayoutAttr>:$layout);
+                       TTNN_ShapeAttr:$shape);
 
   let results = (outs AnyRankedTensor:$result);
 
@@ -3036,16 +3032,14 @@ def TTNN_FullOp : TTNN_CreationOp<"full", [CanExecuteOnHostTrait]> {
     Example:
       %0 = "ttnn.full"() <{
         fill_value = 7 : i32,
-        layout = #ttnn.layout<tile>,
         shape = #ttnn.shape<64x128>
-      }> : () -> tensor<64x128xui32>
+      }> : () -> tensor<64x128xui32, #ttnn_layout>
       // %0: [[[7, 7, 7, ..., 7], [7, 7, 7, ..., 7], ..., [7, 7, 7, ..., 7]]]
   }];
 
   let arguments = (ins Optional<TTNN_Device>:$device,
                        TTNN_ShapeAttr:$shape,
-                       AnyAttrOf<[F32Attr, I32Attr]>:$fill_value,
-                       OptionalAttr<TTNN_LayoutAttr>:$layout);
+                       AnyAttrOf<[F32Attr, I32Attr]>:$fill_value);
 
   let results = (outs AnyRankedTensor:$result);
 
@@ -3069,8 +3063,7 @@ def TTNN_ConstantOp : TTNN_CreationOp<"constant", [AllShapesMatch<["value", "res
     }];
 
     let arguments = (ins Optional<TTNN_Device>:$device,
-                         ElementsAttr:$value,
-                         OptionalAttr<TTNN_LayoutAttr>:$layout);
+                         ElementsAttr:$value);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.h
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.h
@@ -37,6 +37,30 @@ inline MemoryConfigAttr getMemoryConfigFromResult(mlir::Operation *op) {
       .Default([](mlir::Attribute) { return MemoryConfigAttr(); });
 }
 
+// Derives the target page layout from the targeted result's TTNN(ND)LayoutAttr
+// encoding. Returns a null LayoutAttr if the result is missing encoding.
+inline LayoutAttr getLayoutAttrFromResult(mlir::Operation *op,
+                                          unsigned int resultIndex = 0) {
+  if (resultIndex >= op->getNumResults()) {
+    return nullptr;
+  }
+
+  auto output =
+      mlir::dyn_cast<RankedTensorType>(op->getResult(resultIndex).getType());
+  if (!output || !output.getEncoding()) {
+    return nullptr;
+  }
+
+  return llvm::TypeSwitch<mlir::Attribute, LayoutAttr>(output.getEncoding())
+      .Case<TTNNLayoutAttr>([](TTNNLayoutAttr layoutAttr) {
+        return LayoutAttr::get(layoutAttr.getContext(), layoutAttr.getLayout());
+      })
+      .Case<TTNNNDLayoutAttr>([](TTNNNDLayoutAttr layoutAttr) {
+        return LayoutAttr::get(layoutAttr.getContext(), layoutAttr.getLayout());
+      })
+      .Default([](mlir::Attribute) { return LayoutAttr(); });
+}
+
 // Derives the data type carried by a tensor-typed Value. Prefers the
 // TTNN(ND)LayoutAttr encoding's dataType when present, and otherwise falls
 // back to the tensor's element type. Returns a null DataTypeAttr only if the
@@ -89,39 +113,26 @@ dataTypeAttrToOptional(ttcore::DataTypeAttr attr) {
   return attr.getValue();
 }
 
-// Verifies the TTNNLayoutInterface
+inline std::optional<Layout> layoutAttrToOptional(LayoutAttr attr) {
+  if (!attr) {
+    return std::nullopt;
+  }
+  return attr.getValue();
+}
+
+// Verifies that tensor results carry a TTNN(ND)LayoutAttr encoding.
 template <typename ConcreteType>
 mlir::LogicalResult verifyTTNNLayoutInterface(mlir::Operation *op) {
-  // Check if the operation defines output layout attribute.
-  auto outputLayoutAttr = mlir::cast<ConcreteType>(op).getLayoutAttr();
-
-  // Retrieve output layout.
   for (Value result : op->getResults()) {
-    RankedTensorType output = mlir::cast<RankedTensorType>(result.getType());
-    TTNNLayoutAttr outputTTNNLayoutAttr =
-        mlir::dyn_cast_if_present<TTNNLayoutAttr>(output.getEncoding());
-
-    // If output layout isn't present, skip the verification.
-    if (!outputTTNNLayoutAttr) {
-      return mlir::success();
+    auto output = mlir::dyn_cast<RankedTensorType>(result.getType());
+    if (!output) {
+      continue;
     }
-
-    // Retrieve output layout attribute.
-    if (!outputLayoutAttr) {
-      return op->emitOpError("output layout attribute is not defined for op "
-                             "that has output layout attribute.");
-    }
-
-    // Compare output layout attribute with output tensor layout.
-    if (outputLayoutAttr.getValue() != outputTTNNLayoutAttr.getLayout()) {
-      return op->emitOpError()
-             << "output tensor layout "
-             << stringifyLayout(outputTTNNLayoutAttr.getLayout())
-             << " must match output layout attribute "
-             << stringifyLayout(outputLayoutAttr.getValue());
+    if (!mlir::dyn_cast_if_present<TTNNLayoutAttr>(output.getEncoding()) &&
+        !mlir::dyn_cast_if_present<TTNNNDLayoutAttr>(output.getEncoding())) {
+      return op->emitOpError("Output tensor type missing layout attribute");
     }
   }
-
   return mlir::success();
 }
 

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.td
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.td
@@ -46,22 +46,15 @@ def TTNN_LayoutOpInterface : OpInterface<"TTNNLayoutOpInterface"> {
   let methods = [
     InterfaceMethod<
       /*desc=*/[{
+        Returns the target page layout as a LayoutAttr, derived from the first
+        result's TTNN(ND)LayoutAttr encoding.
         }],
       /*retTy=*/"LayoutAttr",
       /*methodName=*/"getLayoutAttr",
       /*args=*/(ins),
-      /*methodBody=*/[{
-        return $_op.getLayoutAttr();
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
-        }],
-      /*retTy=*/"void",
-      /*methodName=*/"setLayoutAttr",
-      /*args=*/(ins "LayoutAttr": $layoutAttr),
-      /*methodBody=*/[{
-        $_op.setLayoutAttr(layoutAttr);
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::mlir::tt::ttnn::getLayoutAttrFromResult($_op.getOperation());
       }]
     >,
   ];

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -300,7 +300,7 @@ def TTNNPrepareModuleForExport : Pass<"ttnn-prepare-module-for-export", "::mlir:
     // After:
     %0 = ttcore.get_tuple_element %arg0[0]
         : (tuple<tensor<32x32xbf16, #host>, ...>)   -> tensor<32x32xbf16, #host>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<tile>}>
+    %1 = "ttnn.to_layout"(%0)
         : (tensor<32x32xbf16, #host>) -> tensor<32x32xbf16, #host_staged>
     %2 = "ttnn.to_device"(%1, %arg1)
         : (tensor<32x32xbf16, #host_staged>, !ttnn.device)

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -484,16 +484,13 @@ materializeIntermediateTensor(memref::AllocOp op, IRRewriter &rewriter,
       emptyTensorType = castResultType;
     }
 
-    auto emptyLayoutAttr =
-        mlir::cast<ttnn::TTNNLayoutAttr>(emptyTensorType.getEncoding());
     auto device = ttnn::utils::getOrInsertDevice(rewriter, op);
 
     OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPointAfter(op);
     auto emptyOp = rewriter.create<ttnn::EmptyOp>(
         loc, emptyTensorType, device,
-        ttnn::ShapeAttr::get(ctx, emptyTensorType.getShape()),
-        ttnn::LayoutAttr::get(ctx, emptyLayoutAttr.getLayout()));
+        ttnn::ShapeAttr::get(ctx, emptyTensorType.getShape()));
 
     valueMapping[op.getResult()] = emptyOp.getResult();
     for (auto castOp : castsToMap) {
@@ -532,8 +529,8 @@ static LogicalResult convertD2MEmpty(d2m::EmptyOp op, IRRewriter &rewriter,
 
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointAfter(op);
-  auto emptyOp = rewriter.create<ttnn::EmptyOp>(op.getLoc(), tensorType, device,
-                                                shape, *layout);
+  auto emptyOp =
+      rewriter.create<ttnn::EmptyOp>(op.getLoc(), tensorType, device, shape);
   valueMapping[op.getResult()] = emptyOp.getResult();
   return success();
 }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -57,14 +57,6 @@ public:
         rewriter.getContext(),
         mlir::cast<RankedTensorType>(op->getResult(0).getType()).getShape());
 
-    ttnn::Layout ttnnLayoutEnum = ttnn::Layout::RowMajor;
-
-    if (layoutAttr.isTiled()) {
-      ttnnLayoutEnum = ttnn::Layout::Tile;
-    }
-    ttnn::LayoutAttr tensorLayoutAttr =
-        ttnn::LayoutAttr::get(op.getContext(), ttnnLayoutEnum);
-
     // Due to API constraints, we need to use a host_empty op if tensor is in
     // system_memory.
     if (mlir::tt::ttnn::isSystemBufferType(layoutAttr.getBufferType())) {
@@ -72,7 +64,7 @@ public:
       //
       rewriter.replaceOpWithNewOp<ttnn::ZerosOp>(
           op, this->getTypeConverter()->convertType(op.getType()),
-          /*device=*/nullptr, shapeAttr, tensorLayoutAttr);
+          /*device=*/nullptr, shapeAttr);
       // Otherwise, we use regular empty op, with device-specific fields.
     } else {
       // Device
@@ -83,7 +75,7 @@ public:
       //
       rewriter.replaceOpWithNewOp<ttnn::EmptyOp>(
           op, this->getTypeConverter()->convertType(op.getType()), device,
-          shapeAttr, tensorLayoutAttr);
+          shapeAttr);
     }
     return success();
   }
@@ -114,9 +106,6 @@ public:
         rewriter.getContext(), llvm::SmallVector<int64_t, 4>(
                                    op.getShape().begin(), op.getShape().end()));
 
-    // Get tensor layout, device and memory config
-    ttnn::LayoutAttr tensorLayoutAttr =
-        ttnn::LayoutAttr::get(op.getContext(), layoutAttr.getLayout());
     ttnn::TensorMemoryLayoutAttr memLayout = layoutAttr.getMemLayout();
 
     // Device only exists if memLayout is *not* null
@@ -127,7 +116,7 @@ public:
 
     rewriter.replaceOpWithNewOp<TTNNType>(
         op, this->getTypeConverter()->convertType(op.getType()), device,
-        shapeAttr, tensorLayoutAttr);
+        shapeAttr);
 
     return success();
   }
@@ -180,21 +169,10 @@ public:
     assert(mlir::isa<mlir::RankedTensorType>(adaptor.getInput().getType()) &&
            "Expected RankedTensorType for ToLayoutOp input");
 
-    auto outputLayoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
-        mlir::cast<mlir::RankedTensorType>(op.getResult(0).getType())
-            .getEncoding());
-
-    // Determine the output layout (tile or row major)
-    ttnn::Layout outputLayoutEnum = outputLayoutAttr.getLayout();
-
     RankedTensorType result = mlir::cast<RankedTensorType>(op.getType(0));
 
-    ttnn::LayoutAttr outputLayout =
-        ttnn::LayoutAttr::get(rewriter.getContext(), outputLayoutEnum);
-
     rewriter.replaceOpWithNewOp<ttnn::ToLayoutOp>(
-        op, this->getTypeConverter()->convertType(result), adaptor.getInput(),
-        outputLayout);
+        op, this->getTypeConverter()->convertType(result), adaptor.getInput());
 
     return success();
   }
@@ -1121,16 +1099,6 @@ public:
     ttnn::TTNNLayoutAttr layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
         op.getResult().getType().getEncoding());
 
-    // Get tensor layout
-    //
-    ttnn::Layout ttnnLayoutEnum = ttnn::Layout::RowMajor;
-
-    if (layoutAttr.isTiled()) {
-      ttnnLayoutEnum = ttnn::Layout::Tile;
-    }
-    ttnn::LayoutAttr tensorLayoutAttr =
-        ttnn::LayoutAttr::get(op.getContext(), ttnnLayoutEnum);
-
     mlir::Value device = nullptr;
 
     if (!mlir::tt::ttnn::isSystemBufferType(layoutAttr.getBufferType())) {
@@ -1139,7 +1107,7 @@ public:
 
     rewriter.replaceOpWithNewOp<ttnn::ConstantOp>(
         op, this->getTypeConverter()->convertType(op.getType()), device,
-        adaptor.getValue(), tensorLayoutAttr);
+        adaptor.getValue());
 
     return success();
   }
@@ -1488,26 +1456,22 @@ public:
           mlir::cast<ttnn::TTNNLayoutAttr>(affineType.getEncoding());
       auto affineShapeAttr =
           ttnn::ShapeAttr::get(rewriter.getContext(), affineType.getShape());
-      auto affineTensorLayoutAttr =
-          ttnn::LayoutAttr::get(op.getContext(), affineLayoutAttr.getLayout());
       Value affineDevice =
           affineLayoutAttr.isDeviceBufferType()
               ? mlir::Value(::ttnn::utils::getOrInsertDevice(rewriter, op))
               : nullptr;
 
       if (!weight) {
-        weight =
-            rewriter
-                .create<ttnn::OnesOp>(loc, affineType, affineDevice,
-                                      affineShapeAttr, affineTensorLayoutAttr)
-                .getResult();
+        weight = rewriter
+                     .create<ttnn::OnesOp>(loc, affineType, affineDevice,
+                                           affineShapeAttr)
+                     .getResult();
       }
       if (!bias) {
-        bias =
-            rewriter
-                .create<ttnn::ZerosOp>(loc, affineType, affineDevice,
-                                       affineShapeAttr, affineTensorLayoutAttr)
-                .getResult();
+        bias = rewriter
+                   .create<ttnn::ZerosOp>(loc, affineType, affineDevice,
+                                          affineShapeAttr)
+                   .getResult();
       }
     }
 
@@ -2919,17 +2883,9 @@ public:
             ? mlir::Value(::ttnn::utils::getOrInsertDevice(rewriter, op))
             : nullptr;
 
-    ttnn::Layout ttnnLayoutEnum = ttnn::Layout::RowMajor;
-
-    if (ttnnLayoutAttr.isTiled()) {
-      ttnnLayoutEnum = ttnn::Layout::Tile;
-    }
-    ttnn::LayoutAttr tensorLayoutAttr =
-        ttnn::LayoutAttr::get(op.getContext(), ttnnLayoutEnum);
-
     rewriter.replaceOpWithNewOp<ttnn::ArangeOp>(
         op, outputType, device, adaptor.getStart(), adaptor.getEnd(),
-        adaptor.getStep(), tensorLayoutAttr);
+        adaptor.getStep());
 
     return success();
   }
@@ -2947,14 +2903,6 @@ public:
 
     // Get ttnn::TTNNLayoutAttr of the result type.
     //
-    ttnn::TTNNLayoutAttr layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
-        op.getResult().getType().getEncoding());
-
-    ttnn::Layout ttnnLayoutEnum =
-        layoutAttr.isTiled() ? ttnn::Layout::Tile : ttnn::Layout::RowMajor;
-    ttnn::LayoutAttr tensorLayoutAttr =
-        ttnn::LayoutAttr::get(op.getContext(), ttnnLayoutEnum);
-
     auto device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
 
     ttnn::ShapeAttr sizeAttr = ttnn::ShapeAttr::get(
@@ -2963,7 +2911,7 @@ public:
     rewriter.replaceOpWithNewOp<ttnn::RandOp>(
         op, this->getTypeConverter()->convertType(op.getType()), device,
         sizeAttr, adaptor.getLowAttr(), adaptor.getHighAttr(),
-        adaptor.getSeedAttr(), tensorLayoutAttr);
+        adaptor.getSeedAttr());
     return success();
   }
 };

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2258,7 +2258,7 @@ public:
                                    : emitter.emit(std::nullopt);
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getLayout()),
+        emitter.emit(srcOp.getLayoutAttr()),
         dtypeArg,
         emitter.emit(srcOp.getMemoryConfigAttr()),
     };
@@ -2290,7 +2290,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getShape()),
         emitter.emit(srcOp.getDtypeAttr()),
-        emitter.emit(srcOp.getLayout()),
+        emitter.emit(srcOp.getLayoutAttr().getValue()),
         emitter.emit(srcOp.getDevice()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
     };
@@ -2323,7 +2323,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getShape()),
         emitter.emit(srcOp.getDtypeAttr()),
-        emitter.emit(srcOp.getLayout()),
+        emitter.emit(srcOp.getLayoutAttr().getValue()),
         emitter.template emit<
             ::ttnn::operations::creation::detail::OptionalMeshDevice>(
             srcOp.getDevice()),
@@ -2375,7 +2375,7 @@ private:
         emitter.emit(srcOp.getShape()),
         emitter.emit(fillValue),
         emitter.emit(srcOp.getDtypeAttr()),
-        emitter.emit(srcOp.getLayout()),
+        emitter.emit(srcOp.getLayoutAttr().getValue()),
         emitter.emit<::ttnn::operations::creation::detail::OptionalMeshDevice>(
             srcOp.getDevice()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
@@ -2408,7 +2408,7 @@ public:
         emitter.emit(srcOp.getSize()),
         emitter.emit<::ttnn::distributed::MeshDevice>(srcOp.getDevice()),
         emitter.emit(srcOp.getDtypeAttr()),
-        emitter.emit(srcOp.getLayout()),
+        emitter.emit(srcOp.getLayoutAttr().getValue()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
         emitter.emit(srcOp.getLow()),
         emitter.emit(srcOp.getHigh()),

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -511,7 +511,7 @@ public:
         emitter.emit(constantOp.getValue()),
         emitter.emit(constantOp.getResult().getType().getShape()),
         emitter.emit(constantOp.getDtypeAttr()),
-        emitter.emit(constantOp.getLayout()),
+        emitter.emit(constantOp.getLayoutAttr().getValue()),
     };
 
     if (constantOp.getDevice()) {
@@ -1279,7 +1279,7 @@ public:
                                    : emitter.emit(std::nullopt);
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(toLayoutOp.getInput()),
-        emitter.emit(toLayoutOp.getLayout()),
+        emitter.emit(toLayoutOp.getLayoutAttr()),
         dtypeArg,
         emitter.emit(toLayoutOp.getMemoryConfigAttr(), "memory_config"),
     };
@@ -1344,7 +1344,7 @@ public:
         emitter.emit(srcOp.getStep()),
         emitter.emit(srcOp.getDtypeAttr(), "dtype"),
         emitter.emit(srcOp.getDevice(), "device"),
-        emitter.emit(srcOp.getLayout(), "layout"),
+        emitter.emit(srcOp.getLayoutAttr().getValue(), "layout"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
 
@@ -1375,7 +1375,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getShape()),
         emitter.emit(srcOp.getDtypeAttr()),
-        emitter.emit(srcOp.getLayout()),
+        emitter.emit(srcOp.getLayoutAttr().getValue()),
         emitter.emit(srcOp.getDevice()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
     };
@@ -1427,7 +1427,7 @@ private:
         emitter.emit(fullOp.getShape(), "shape"),
         emitter.emit(fillValue, "fill_value"),
         emitter.emit(fullOp.getDtypeAttr(), "dtype"),
-        emitter.emit(fullOp.getLayout(), "layout"),
+        emitter.emit(fullOp.getLayoutAttr().getValue(), "layout"),
         emitter.emit(fullOp.getDevice(), "device"),
         emitter.emit(fullOp.getMemoryConfigAttr(), "memory_config"),
     };
@@ -1461,7 +1461,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(namedFullOp.getShape(), "shape"),
         emitter.emit(namedFullOp.getDtypeAttr(), "dtype"),
-        emitter.emit(namedFullOp.getLayout(), "layout"),
+        emitter.emit(namedFullOp.getLayoutAttr().getValue(), "layout"),
         emitter.emit(namedFullOp.getDevice(), "device"),
         emitter.emit(namedFullOp.getMemoryConfigAttr(), "memory_config"),
     };
@@ -1493,7 +1493,7 @@ public:
         emitter.emit(srcOp.getSize()),
         emitter.emit(srcOp.getDevice()),
         emitter.emit(srcOp.getDtypeAttr(), "dtype"),
-        emitter.emit(srcOp.getLayout(), "layout"),
+        emitter.emit(srcOp.getLayoutAttr().getValue(), "layout"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
         emitter.emit(srcOp.getLow(), "low"),
         emitter.emit(srcOp.getHigh(), "high"),

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -398,12 +398,6 @@ void L1SpillManagement<MemoryTracker>::applyOutputConfig(
         RankedTensorType::get(tensorShape, newElementType, resultLayout);
     opResult.setType(newTensorType);
   }
-
-  // Update layout attribute for ops that have layout interface (op-level).
-  if (auto opWithLayoutIF = mlir::dyn_cast<TTNNLayoutOpInterface>(op)) {
-    opWithLayoutIF.setLayoutAttr(
-        LayoutAttr::get(op->getContext(), chosenLayout.getLayout()));
-  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1407,14 +1407,6 @@ void MemoryLayoutPropagation::applyOpConfig(Operation *op,
     result.setType(newTensorType);
   }
 
-  // Op-level attribute updates use result 0's layout (chosenLayout).
-
-  // Update layout attribute for ops that have layout interface.
-  if (auto opWithLayoutIF = mlir::dyn_cast<TTNNLayoutOpInterface>(op)) {
-    opWithLayoutIF.setLayoutAttr(
-        LayoutAttr::get(op->getContext(), chosenLayout.getLayout()));
-  }
-
   applyOpSpecificAttrs(op, candidate);
 }
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1311,15 +1311,10 @@ void mlir::tt::ttnn::FullOp::build(mlir::OpBuilder &builder,
                                    mlir::Value device) {
   mlir::MLIRContext *ctx = builder.getContext();
   mlir::RankedTensorType tensorType = mlir::cast<RankedTensorType>(resultType);
-  ttnn::TTNNLayoutAttr layoutAttr =
-      mlir::cast<ttnn::TTNNLayoutAttr>(tensorType.getEncoding());
 
   ttnn::ShapeAttr shapeAttr = ttnn::ShapeAttr::get(ctx, tensorType.getShape());
-  ttnn::LayoutAttr tensorLayoutAttr =
-      ttnn::LayoutAttr::get(ctx, layoutAttr.getLayout());
 
-  build(builder, state, resultType, device, shapeAttr, fillValue,
-        tensorLayoutAttr);
+  build(builder, state, resultType, device, shapeAttr, fillValue);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1342,28 +1337,12 @@ void mlir::tt::ttnn::FullOp::build(mlir::OpBuilder &builder,
                          << output.getShape();
   }
 
-  // Helper lambda to verify layout attributes generically
-  auto verifyLayoutAttr = [&](auto layoutAttr) -> LogicalResult {
-    // Layout
-    //
-    if (getLayout() != layoutAttr.getLayout()) {
-      return emitOpError("Layout mismatch between op and layoutAttr.");
-    }
+  if (!mlir::dyn_cast_if_present<TTNNLayoutAttr>(encoding) &&
+      !mlir::dyn_cast_if_present<TTNNNDLayoutAttr>(encoding)) {
+    return emitOpError() << "Unsupported layout encoding type";
+  }
 
-    return success();
-  };
-
-  // Use TypeSwitch to handle both TTNNLayoutAttr and TTNNNDLayoutAttr
-  return llvm::TypeSwitch<mlir::Attribute, mlir::LogicalResult>(encoding)
-      .Case<TTNNLayoutAttr>([&](TTNNLayoutAttr layoutAttr) {
-        return verifyLayoutAttr(layoutAttr);
-      })
-      .template Case<TTNNNDLayoutAttr>([&](TTNNNDLayoutAttr layoutAttr) {
-        return verifyLayoutAttr(layoutAttr);
-      })
-      .Default([&](mlir::Attribute) {
-        return emitOpError() << "Unsupported layout encoding type";
-      });
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -2109,6 +2088,10 @@ static bool isValidDeviceLayout(TensorMemoryLayoutAttr memLayoutAttr) {
 // ToLayoutOp
 //===----------------------------------------------------------------------===//
 
+::mlir::LogicalResult ToLayoutOp::verify() {
+  return verifyTTNNLayoutInterface<ToLayoutOp>(*this);
+}
+
 namespace {
 // ToLayoutOp can be folded if its input has the same layout as the output of
 // ToLayoutOp.
@@ -2273,7 +2256,6 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
       return failure();
     }
 
-    LayoutAttr targetLayoutAttr = toLayoutOp.getLayoutAttr();
     MemoryConfigAttr targetMemoryConfigAttr =
         mlir::cast<mlir::tt::ttnn::TTNNMemoryConfigOpInterface>(
             toLayoutOp.getOperation())
@@ -2292,8 +2274,6 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
     auto tensorSpecOp = mlir::cast<TTNNTensorSpecInterface>(creationOp);
 
     rewriter.startOpModification(tensorSpecOp);
-
-    tensorSpecOp.setLayoutAttr(targetLayoutAttr);
 
     BufferTypeAttr newBufferType = targetMemoryConfigAttr
                                        ? targetMemoryConfigAttr.getBufferType()
@@ -2362,9 +2342,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
     // encoding via the TTNN_DtypeOpInterface and no longer needs to be passed
     // through the builder.
     auto zerosOp = rewriter.replaceOpWithNewOp<mlir::tt::ttnn::ZerosOp>(
-        emptyOp, toLayoutOp.getType(), /*device=*/nullptr, emptyOp.getShape(),
-        toLayoutOp.getLayoutAttr() ? toLayoutOp.getLayoutAttr()
-                                   : emptyOp.getLayoutAttr());
+        emptyOp, toLayoutOp.getType(), /*device=*/nullptr, emptyOp.getShape());
 
     rewriter.replaceAllOpUsesWith(toLayoutOp, zerosOp);
     rewriter.eraseOp(toLayoutOp);
@@ -3523,7 +3501,6 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
           .build();
 
   auto statsShapeAttr = ShapeAttr::get(ctx, statsShape);
-  auto statsLayoutAttr = LayoutAttr::get(ctx, Layout::Tile);
 
   RankedTensorType statsResultType =
       RankedTensorType::get(statsShape, statsElementType, statsLayout);
@@ -3537,8 +3514,8 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
   {
     OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPointAfter(device);
-    statsEmptyOp = rewriter.create<ttnn::EmptyOp>(
-        getLoc(), statsResultType, device, statsShapeAttr, statsLayoutAttr);
+    statsEmptyOp = rewriter.create<ttnn::EmptyOp>(getLoc(), statsResultType,
+                                                  device, statsShapeAttr);
   }
 
   rewriter.modifyOpInPlace(

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -314,7 +314,8 @@ getNamedFullOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const mlir::tt::ttnn::ShapeAttr shape = op.getShape();
   const std::optional<mlir::tt::ttcore::DataType> dtype =
       dataTypeAttrToOptional(op.getDtypeAttr());
-  const std::optional<mlir::tt::ttnn::Layout> layout = op.getLayout();
+  const std::optional<mlir::tt::ttnn::Layout> layout =
+      layoutAttrToOptional(op.getLayoutAttr());
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, shape, dtype, layout,
@@ -1716,7 +1717,7 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 1);
   assert(opConfig.outputLayout && "ToLayoutOp requires output layout");
-  assert(opConfig.outputLayout.getLayout() == getLayout());
+  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -1741,7 +1742,7 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 1);
   assert(opConfig.outputLayout && "ToLayoutOp requires output layout");
-  assert(opConfig.outputLayout.getLayout() == getLayout());
+  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4597,7 +4598,8 @@ FullOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const mlir::Attribute fillValue = getFillValue();
   const std::optional<mlir::tt::ttcore::DataType> dtype =
       dataTypeAttrToOptional(getDtypeAttr());
-  const std::optional<mlir::tt::ttnn::Layout> layout = getLayout();
+  const std::optional<mlir::tt::ttnn::Layout> layout =
+      layoutAttrToOptional(getLayoutAttr());
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::FullOp>::getOpConstraints, *this, shape,
@@ -4675,8 +4677,8 @@ RandOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::RandOp>::getOpConstraints, *this,
-      getSize(), dtype.getValue(), getLayout(), getLow(), getHigh(), getSeed(),
-      opConfig.outputLayout);
+      getSize(), dtype.getValue(), getLayoutAttr().getValue(), getLow(),
+      getHigh(), getSeed(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
@@ -148,13 +148,11 @@ LogicalResult SDPADecodeDecompositionPattern::matchAndRewrite(
     // requires rank-1 output), then reshape to [1, 1, 1, Sk] for broadcast.
     auto arange1dType = ttnn::utils::RankedTensorTypeFactory::create(
         qType, llvm::SmallVector<int64_t>{seqLenKV});
-    ttnn::LayoutAttr tileLayoutAttr =
-        ttnn::LayoutAttr::get(rewriter.getContext(), ttnn::Layout::Tile);
-    Value indices = rewriter
-                        .create<ttnn::ArangeOp>(
-                            loc, arange1dType, device, /*start=*/0,
-                            /*end=*/seqLenKV, /*step=*/1, tileLayoutAttr)
-                        .getResult();
+    Value indices =
+        rewriter
+            .create<ttnn::ArangeOp>(loc, arange1dType, device, /*start=*/0,
+                                    /*end=*/seqLenKV, /*step=*/1)
+            .getResult();
 
     auto arange4dType = ttnn::utils::RankedTensorTypeFactory::create(
         qType, llvm::SmallVector<int64_t>{1, 1, 1, seqLenKV});

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
@@ -44,17 +44,8 @@ static Value generateCausalMask(PatternRewriter &rewriter, Location loc,
   auto plainMaskType = RankedTensorType::get(maskShape, rewriter.getF32Type());
   auto denseAttr = DenseFPElementsAttr::get(plainMaskType, maskData);
 
-  // Create ConstantOp with TTNN-encoded result type.
-  // Extract layout from encoding for the verifier.
   auto maskType = createResultType(referenceType, maskShape);
-  LayoutAttr tensorLayoutAttr;
-  if (auto layoutAttr = mlir::dyn_cast_if_present<TTNNLayoutAttr>(
-          referenceType.getEncoding())) {
-    tensorLayoutAttr =
-        LayoutAttr::get(rewriter.getContext(), layoutAttr.getLayout());
-  }
-  return rewriter.create<ConstantOp>(loc, maskType, device, denseAttr,
-                                     tensorLayoutAttr);
+  return rewriter.create<ConstantOp>(loc, maskType, device, denseAttr);
 }
 
 /// Generate a sliding window mask [1, 1, Sq, Skv] as a compile-time constant.
@@ -90,14 +81,7 @@ static Value generateSlidingWindowMask(PatternRewriter &rewriter, Location loc,
   auto denseAttr = DenseFPElementsAttr::get(plainMaskType, maskData);
 
   auto maskType = createResultType(referenceType, maskShape);
-  LayoutAttr tensorLayoutAttr;
-  if (auto layoutAttr = mlir::dyn_cast_if_present<TTNNLayoutAttr>(
-          referenceType.getEncoding())) {
-    tensorLayoutAttr =
-        LayoutAttr::get(rewriter.getContext(), layoutAttr.getLayout());
-  }
-  return rewriter.create<ConstantOp>(loc, maskType, device, denseAttr,
-                                     tensorLayoutAttr);
+  return rewriter.create<ConstantOp>(loc, maskType, device, denseAttr);
 }
 
 LogicalResult

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -812,20 +812,6 @@ void applyFallbackTransformations(
   for (size_t i = 0; i < configs.size(); ++i) {
     applyOutputLayoutChange(operation, i, result, configs[i]);
   }
-
-  // Update the layout attribute for ops that have one (e.g., creation ops).
-  // The layout attribute must match the first result type's layout.
-  TTNNLayoutAttr firstActualOutputLayout =
-      result.checkAndGetFirstActualOutputLayout();
-
-  if (configs[0].outputLayout &&
-      firstActualOutputLayout != configs[0].outputLayout) {
-    if (TTNNLayoutOpInterface opWithLayoutIF =
-            mlir::dyn_cast<TTNNLayoutOpInterface>(operation)) {
-      opWithLayoutIF.setLayoutAttr(LayoutAttr::get(
-          operation->getContext(), firstActualOutputLayout.getLayout()));
-    }
-  }
 }
 
 // Apply a single input operand change by inserting ToLayoutOp
@@ -918,9 +904,7 @@ ToLayoutOp createToLayoutOp(OpBuilder &builder, Location loc,
   RankedTensorType resultType = RankedTensorType::get(
       currentResultType.getShape(), scalarElementType, targetLayout);
 
-  return builder.create<ToLayoutOp>(
-      loc, resultType, inputValue,
-      LayoutAttr::get(builder.getContext(), targetLayout.getLayout()));
+  return builder.create<ToLayoutOp>(loc, resultType, inputValue);
 }
 
 // Try config fallbacks for Conv2d-like operations

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
@@ -455,11 +455,6 @@ public:
           RankedTensorType newTensorType =
               RankedTensorType::get(tensorShape, newElementType, chosenLayout);
 
-          // Update the memory space and layout of the op.
-          //
-          TTNNLayoutAttr layoutAttr =
-              mlir::cast<TTNNLayoutAttr>(newTensorType.getEncoding());
-
           // D2MSubgraphOp: apply chosen layout to result(s), output buffer(s),
           // and D2M subgraph.
           if (auto dispatchOp = dyn_cast<D2MSubgraphOp>(op)) {
@@ -468,26 +463,15 @@ public:
             return;
           }
 
-          // Update layout attribute for ops that have layout attribute.
-          if (TTNNLayoutOpInterface opWithLayoutIF =
-                  mlir::dyn_cast<TTNNLayoutOpInterface>(op)) {
-            opWithLayoutIF.setLayoutAttr(
-                LayoutAttr::get(op->getContext(), layoutAttr.getLayout()));
-          }
-
           op->getResult(0).setType(newTensorType);
 
           // Update DPS operand layout as well.
           //
           if (isa<mlir::DestinationStyleOpInterface>(op)) {
             op->getOperands().back().setType(newTensorType);
-            EmptyOp emptyOp =
-                mlir::cast<EmptyOp>(op->getOperands().back().getDefiningOp());
-
-            if (layoutAttr.isTiled()) {
-              emptyOp.setLayout(ttnn::Layout::Tile);
-            } else {
-              emptyOp.setLayout(ttnn::Layout::RowMajor);
+            if (EmptyOp emptyOp = mlir::dyn_cast<EmptyOp>(
+                    op->getOperands().back().getDefiningOp())) {
+              emptyOp.getResult().setType(newTensorType);
             }
           }
 
@@ -783,7 +767,6 @@ private:
       //
       if (isa_and_nonnull<ToLayoutOp>(producerOp)) {
         ToLayoutOp toLayoutOp = llvm::cast<ToLayoutOp>(producerOp);
-        toLayoutOp.setLayout(reshardOpLayout.getLayout());
         toLayoutOp.getResult().setType(newTensorType);
       } else {
         OpBuilder builder(consumerOp);
@@ -791,10 +774,8 @@ private:
                                                            "_mem_reconfig");
         ToLayoutOp memoryReconfigOp = builder.create<ToLayoutOp>(
             loc,
-            newTensorType,                             // output type
-            consumerOp->getOperand(edge.operandIndex), // input value
-            LayoutAttr::get(consumerOp->getContext(),
-                            reshardOpLayout.getLayout()));
+            newTensorType,                              // output type
+            consumerOp->getOperand(edge.operandIndex)); // input value
 
         consumerOp->setOperand(edge.operandIndex,
                                memoryReconfigOp->getResult(0));
@@ -844,8 +825,6 @@ private:
 
       // Create a ToLayoutOp with the new DRAM layout.
       OpBuilder builder(spilledOp->getContext());
-      LayoutAttr newLayout =
-          LayoutAttr::get(spilledOp->getContext(), dramLayout.getLayout());
 
       builder.setInsertionPointAfter(spilledOp);
       Location loc =
@@ -859,7 +838,7 @@ private:
 
       // Step 2: Insert spilling to DRAM.
       Operation *spillToDRAMOp = builder.create<ToLayoutOp>(
-          loc, newTensorType, spilledOp->getResult(0), newLayout);
+          loc, newTensorType, spilledOp->getResult(0));
 
       // Step 3: Reconnect uses.
       for (auto &use : uses) {
@@ -952,8 +931,6 @@ private:
           l1InterleavedLayout);
 
       OpBuilder builder(spilledOp->getContext());
-      LayoutAttr newLayout = LayoutAttr::get(spilledOp->getContext(),
-                                             l1InterleavedLayout.getLayout());
       builder.setInsertionPointAfter(spilledOp);
       Location loc = ttmlir::utils::appendLocationSuffix(spilledOp->getLoc(),
                                                          "_to_l1_interleaved");
@@ -965,7 +942,7 @@ private:
       }
 
       Operation *toLayoutOp = builder.create<ToLayoutOp>(
-          loc, newTensorType, spilledOp->getResult(0), newLayout);
+          loc, newTensorType, spilledOp->getResult(0));
 
       for (auto &[useOp, operandIdx] : uses) {
         useOp->setOperand(operandIdx, toLayoutOp->getResult(0));

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -583,8 +583,6 @@ private:
     // Get the shape of the tensor, tensor layout, and data type.
     //
     ShapeAttr shapeAttr = ttnn::ShapeAttr::get(ctx, tensorType.getShape());
-    ttnn::LayoutAttr tensorLayoutAttr =
-        ttnn::LayoutAttr::get(ctx, layoutAttr.getLayout());
 
     mlir::Value device;
     if (layoutAttr.isDeviceBufferType()) {
@@ -593,8 +591,8 @@ private:
     }
     // Create a new tensor of ones.
     //
-    ttnn::OnesOp onesOp = rewriter.create<ttnn::OnesOp>(
-        loc, tensorType, device, shapeAttr, tensorLayoutAttr);
+    ttnn::OnesOp onesOp =
+        rewriter.create<ttnn::OnesOp>(loc, tensorType, device, shapeAttr);
 
     return onesOp;
   }
@@ -1262,8 +1260,7 @@ private:
       // identity conversion the folder collapses the op to its input.
       //
       auto toLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
-          getElemOp.getLoc(), hostStagedTensorType, oldTupleElemResult,
-          LayoutAttr::get(ctx, targetLayout.getLayout()));
+          getElemOp.getLoc(), hostStagedTensorType, oldTupleElemResult);
 
       // Host-to-device transfer. The target memory config is conveyed via the
       // result tensor type's `TTNNLayoutAttr` encoding.

--- a/lib/Dialect/TTNN/Transforms/TTNNConstEvalInputsToSystemMemory.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNConstEvalInputsToSystemMemory.cpp
@@ -172,13 +172,10 @@ static void convertArgumentOfConstEvalFunc(func::FuncOp constEvalFuncOp,
 
     auto deviceTensorType =
         mlir::cast<RankedTensorType>(blockArgument.getType());
-    auto deviceTensorLayout =
-        mlir::cast<TTNNLayoutAttr>(deviceTensorType.getEncoding());
 
     // Create to_layout op to convert the argument to the original layout.
     auto toLayoutOp = builder.create<ttnn::ToLayoutOp>(
-        blockArgument.getLoc(), deviceTensorType, blockArgument,
-        deviceTensorLayout.getLayout());
+        blockArgument.getLoc(), deviceTensorType, blockArgument);
 
     // Replace the argument usages with the to_layout op result.
     //

--- a/lib/Dialect/TTNN/Transforms/TTNNCreateD2MSubgraphs.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNCreateD2MSubgraphs.cpp
@@ -254,13 +254,10 @@ private:
       auto tensorType = mlir::cast<RankedTensorType>(v.getType());
       outputTypes.push_back(tensorType);
 
-      auto layoutAttr = mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
       auto shapeAttr =
           ShapeAttr::get(rewriter.getContext(), tensorType.getShape());
-      auto tensorLayoutAttr =
-          LayoutAttr::get(rewriter.getContext(), layoutAttr.getLayout());
-      auto emptyOp = rewriter.create<EmptyOp>(loc, tensorType, device,
-                                              shapeAttr, tensorLayoutAttr);
+      auto emptyOp =
+          rewriter.create<EmptyOp>(loc, tensorType, device, shapeAttr);
       outputBuffers.push_back(emptyOp.getResult());
       lastEmptyOp = emptyOp.getOperation();
     }

--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -352,14 +352,12 @@ private:
     if (!info.opsToCreate.createToLayoutOp) {
       return currentInput;
     }
-    ttnn::LayoutAttr layoutAttr =
-        ttnn::LayoutAttr::get(op.getContext(), info.output.layoutEnum);
     RankedTensorType newResultType = utils::RankedTensorTypeFactory::create(
         mlir::cast<RankedTensorType>(currentInput.getType()),
         info.output.layoutEnum);
 
     return this->createOp<ttnn::ToLayoutOp>(rewriter, op, newResultType,
-                                            currentInput, layoutAttr);
+                                            currentInput);
   }
 
   mlir::Value createDataTypeCastingOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
@@ -550,10 +548,8 @@ private:
     RankedTensorType paddedTiledType = utils::RankedTensorTypeFactory::create(
         mlir::cast<RankedTensorType>(currentInput.getType()),
         info.output.layoutEnum);
-    ttnn::LayoutAttr layoutAttr =
-        ttnn::LayoutAttr::get(op.getContext(), info.output.layoutEnum);
     currentInput = rewriter.create<ttnn::ToLayoutOp>(
-        op.getLoc(), paddedTiledType, currentInput, layoutAttr);
+        op.getLoc(), paddedTiledType, currentInput);
 
     // Step 4: Slice back to original shape.
     SmallVector<int32_t> begins(rank, 0);

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -493,12 +493,9 @@ private:
       RankedTensorType deviceTensorType =
           mlir::cast<RankedTensorType>(traceInputSlotType);
 
-      ttnn::TTNNLayoutAttr ttnnLayoutAttr =
-          mlir::cast<ttnn::TTNNLayoutAttr>(deviceTensorType.getEncoding());
       auto emptyOp = builder.create<ttnn::EmptyOp>(
           runAndCaptureTraceFunc.getLoc(), deviceTensorType, deviceOp,
-          ttnn::ShapeAttr::get(context, deviceTensorType.getShape()),
-          ttnn::LayoutAttr::get(context, ttnnLayoutAttr.getLayout()));
+          ttnn::ShapeAttr::get(context, deviceTensorType.getShape()));
 
       traceInputSlots.push_back(emptyOp.getResult());
       traceCallArgs.push_back(emptyOp.getResult());
@@ -799,8 +796,7 @@ private:
                 tensorType, ttnn::BufferType::SystemMemory);
 
         auto toLayoutOp = builder.create<ttnn::ToLayoutOp>(
-            funcOp.getLoc(), systemMemoryTileType, input,
-            /*layout=*/LayoutAttr::get(context, layout.getLayout()));
+            funcOp.getLoc(), systemMemoryTileType, input);
         tensorInputs.push_back(toLayoutOp.getResult());
       } else {
         // Already on system memory

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
@@ -104,9 +104,8 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
   // Apply ToLayoutOp to convert the input tensor to width-sharded L1.
   RankedTensorType memoryConfigedInputType =
       inputType.cloneWithEncoding(desiredInputLayout);
-  auto inputToLayoutOp =
-      rewriter.create<ttnn::ToLayoutOp>(op.getLoc(), memoryConfigedInputType,
-                                        op.getInput(), tt::ttnn::Layout::Tile);
+  auto inputToLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
+      op.getLoc(), memoryConfigedInputType, op.getInput());
 
   // The fused kernel requires the weight in ROW_MAJOR layout. The 1D->2D
   // shape reshape is handled by the decomposition pattern; here we only
@@ -131,7 +130,7 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
       RankedTensorType rowMajorWeightType =
           weightType.cloneWithEncoding(rowMajorLayout);
       auto weightToLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
-          op.getLoc(), rowMajorWeightType, weight, tt::ttnn::Layout::RowMajor);
+          op.getLoc(), rowMajorWeightType, weight);
       weight = weightToLayoutOp.getResult();
     }
   }
@@ -148,7 +147,7 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
       RankedTensorType shardedResidualType =
           residualType.cloneWithEncoding(desiredInputLayout);
       auto residualToLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
-          op.getLoc(), shardedResidualType, residual, tt::ttnn::Layout::Tile);
+          op.getLoc(), shardedResidualType, residual);
       residual = residualToLayoutOp.getResult();
     }
   }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeComputeRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeComputeRewritePattern.cpp
@@ -106,9 +106,7 @@ MoeComputeRewritePattern::reshardTilizeInputs(MoeComputeOp srcOp,
                            .build();
     auto newType =
         RankedTensorType::get(t.getShape(), t.getElementType(), newEncoding);
-    return rewriter.create<ttnn::ToLayoutOp>(
-        srcOp.getLoc(), newType, oldInput,
-        LayoutAttr::get(ctx, Layout::RowMajor));
+    return rewriter.create<ttnn::ToLayoutOp>(srcOp.getLoc(), newType, oldInput);
   };
 
   Value newIndices = reshardToTilize(srcOp.getTilizeExpertIndicesTensor());

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeGptLayoutRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeGptLayoutRewritePattern.cpp
@@ -93,8 +93,7 @@ Value buildPreparedWeight(PatternRewriter &rewriter, Operation *anchor,
   // Step 2: to_layout TILE on host (no dtype).
   auto hostTiledType =
       utils::RankedTensorTypeFactory::create(hostType, Layout::Tile);
-  Value hostTiled =
-      rewriter.create<ToLayoutOp>(loc, hostTiledType, hostWeight, Layout::Tile);
+  Value hostTiled = rewriter.create<ToLayoutOp>(loc, hostTiledType, hostWeight);
 
   // Step 3: typecast to bfp4 on host.
   auto hostBfp4Type = utils::RankedTensorTypeFactory::create(

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
@@ -56,9 +56,8 @@ LogicalResult PagedUpdateCacheOpRewritePattern::matchAndRewrite(
   // Apply ToLayoutOp to convert the input tensor to the desired layout.
   RankedTensorType memoryConfigedInputType =
       inputType.cloneWithEncoding(desiredInputLayout);
-  auto toLayoutOp =
-      rewriter.create<ttnn::ToLayoutOp>(op.getLoc(), memoryConfigedInputType,
-                                        op.getInput(), tt::ttnn::Layout::Tile);
+  auto toLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
+      op.getLoc(), memoryConfigedInputType, op.getInput());
 
   // Replace the original PagedUpdateCacheOp with one which takes our properly
   // configured input tensor.

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -212,18 +212,7 @@ workaroundOutputOperand(mlir::TypedValue<RankedTensorType> opResult,
   rewriter.modifyOpInPlace(op, [&]() {
     opResult.setType(newOutputResultType);
 
-    // Some ops defines attributes with tensor layout, buffer type and memory
-    // layout, hence we need to update the attributes as well. For example,
-    // the empty op defines layout and memory_config attributes.
-    TTNNLayoutOpInterface layoutOp =
-        mlir::dyn_cast<TTNNLayoutOpInterface>(op.getOperation());
-    if (outputWorkaroundResults.tensorLayoutResult.isModified() && layoutOp) {
-      LayoutAttr updatedLayoutAttr = rewriter.getAttr<LayoutAttr>(
-          outputWorkaroundResults.tensorLayoutResult.targetValue);
-      layoutOp.setLayoutAttr(updatedLayoutAttr);
-    }
-
-    // The buffer type / memory layout changes are already encoded in the
+    // The buffer type / memory layout / page layout changes are encoded in the
     // result tensor's TTNNLayoutAttr (set above).
     TTNNDeviceOperandInterface deviceOperandOp =
         mlir::dyn_cast<TTNNDeviceOperandInterface>(op.getOperation());

--- a/lib/Dialect/TTNN/Utils/D2MOptimizerUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/D2MOptimizerUtils.cpp
@@ -28,11 +28,6 @@ void applyChosenLayoutToD2MSubgraphOp(D2MSubgraphOp dispatchOp,
   for (Value output : dispatchOp.getOutputs()) {
     if (EmptyOp emptyOp = output.getDefiningOp<EmptyOp>()) {
       emptyOp.getResult().setType(newTensorType);
-      if (layoutAttr.isTiled()) {
-        emptyOp.setLayout(ttnn::Layout::Tile);
-      } else {
-        emptyOp.setLayout(ttnn::Layout::RowMajor);
-      }
     } else {
       dispatchOp.emitOpError(
           "Expected EmptyOp for D2MSubgraphOp output buffer");
@@ -62,11 +57,9 @@ void applyChosenLayoutToD2MSubgraphOp(D2MSubgraphOp dispatchOp,
         if (currentResultValue.getType() != newTensorType) {
           OpBuilder builder(dispatchOp.getContext());
           builder.setInsertionPoint(returnOp);
-          LayoutAttr newLayout =
-              LayoutAttr::get(dispatchOp.getContext(), layoutAttr.getLayout());
           Location loc = mainFunc.getLoc();
           ToLayoutOp toLayoutOp = builder.create<ToLayoutOp>(
-              loc, newTensorType, currentResultValue, newLayout);
+              loc, newTensorType, currentResultValue);
           returnOp.setOperand(0, toLayoutOp.getResult());
         }
       }

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -111,9 +111,8 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
   Location loc = ttmlir::utils::appendLocationSuffix(op->getLoc(), locSuffix);
   // Create a ToLayoutOp to convert the input operand to the desired
   // tensor layout, buffer type and memory layout.
-  return rewriter.create<ttnn::ToLayoutOp>(
-      loc, toLayoutOpResultType, inputValue,
-      LayoutAttr::get(rewriter.getContext(), targetTensorLayout));
+  return rewriter.create<ttnn::ToLayoutOp>(loc, toLayoutOpResultType,
+                                           inputValue);
 }
 
 } // namespace mlir::tt::ttnn::utils

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -224,7 +224,8 @@ createOp(FlatbufferObjectCache &cache, ToMemoryConfigOp op) {
 createOp(FlatbufferObjectCache &cache, ToLayoutOp op) {
   auto input = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getInput()));
-  ::tt::target::TensorLayout layout = toFlatbuffer(cache, op.getLayout());
+  ::tt::target::TensorLayout layout =
+      toFlatbuffer(cache, op.getLayoutAttr().getValue());
   auto output =
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
                                   /*local_shape*/ std::nullopt);
@@ -325,7 +326,8 @@ createCpuOp(FlatbufferObjectCache &cache, func::CallOp op, uint32_t dylib_id) {
 createOp(FlatbufferObjectCache &cache, EmptyOp op) {
   ::llvm::ArrayRef<int64_t> shape = op.getShape().getShape();
   ::tt::target::DataType dtype = toFlatbuffer(cache, op.getDtypeAttr());
-  ::tt::target::TensorLayout layout = toFlatbuffer(cache, op.getLayout());
+  ::tt::target::TensorLayout layout =
+      toFlatbuffer(cache, op.getLayoutAttr().getValue());
 
   auto output = getOperandThroughDPSOps(op.getResult());
   auto device = getOperandThroughDPSOps(op.getDevice());
@@ -379,7 +381,7 @@ createOp(FlatbufferObjectCache &cache, FullOp op) {
     llvm_unreachable("fill value must be float or integer");
   }
   auto dtype = toFlatbuffer(cache, op.getDtypeAttr());
-  auto layout = toFlatbuffer(cache, op.getLayout());
+  auto layout = toFlatbuffer(cache, op.getLayoutAttr().getValue());
   auto memoryConfig = toFlatbuffer(cache, op.getMemoryConfigAttr());
   auto output =
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
@@ -395,7 +397,7 @@ createOp(FlatbufferObjectCache &cache, FullOp op) {
 createOp(FlatbufferObjectCache &cache, ArangeOp op) {
   auto dtype = toFlatbuffer(cache, op.getDtypeAttr());
   flatbuffers::Optional<::tt::target::TensorLayout> layout =
-      toFlatbuffer(cache, op.getLayout());
+      toFlatbuffer(cache, op.getLayoutAttr().getValue());
   auto device =
       op.getDevice() ? cache.at<::tt::target::DeviceRef>(op.getDevice()) : 0;
 
@@ -432,7 +434,7 @@ createNamedFullOp(FlatbufferObjectCache &cache, OpTy op) {
   auto dtype = toFlatbuffer(cache, op.getDtypeAttr());
 
   ::flatbuffers::Optional<::tt::target::TensorLayout> layout =
-      toFlatbuffer(cache, op.getLayout());
+      toFlatbuffer(cache, op.getLayoutAttr().getValue());
 
   flatbuffers::Offset<::tt::target::DeviceRef> device =
       op.getDevice() ? cache.at<::tt::target::DeviceRef>(op.getDevice()) : 0;
@@ -1990,7 +1992,7 @@ createOp(FlatbufferObjectCache &cache, ttnn::ConstantOp op) {
       cache, ttcore::elementTypeToDataType(op.getValue().getElementType()));
   auto dtype = toFlatbuffer(cache, op.getDtypeAttr());
   flatbuffers::Optional<::tt::target::TensorLayout> layout =
-      toFlatbuffer(cache, op.getLayout());
+      toFlatbuffer(cache, op.getLayoutAttr().getValue());
   auto device =
       op.getDevice() ? cache.at<::tt::target::DeviceRef>(op.getDevice()) : 0;
 
@@ -2762,7 +2764,8 @@ createRandOp(FlatbufferObjectCache &cache, RandOp op) {
   auto size = cache.fbb->CreateVector<int64_t>(op.getSize().getShape());
   auto device = getOperandThroughDPSOps(op.getDevice());
   ::tt::target::DataType dtype = toFlatbuffer(cache, op.getDtypeAttr());
-  ::tt::target::TensorLayout layout = toFlatbuffer(cache, op.getLayout());
+  ::tt::target::TensorLayout layout =
+      toFlatbuffer(cache, op.getLayoutAttr().getValue());
   auto out =
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
 

--- a/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast.mlir
@@ -11,12 +11,12 @@ module attributes {} {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 2x4>}> : () -> !ttnn.device
 
     // distribute input tensor
-    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_row_major>) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
+    %1 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_row_major>) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
     %2 = "ttnn.distribute_tensor"(%1, %0) <{mapper_config = #ttnn.mesh_mapper_config<placements = [<shard, 0 : i64>, <shard, 1 : i64>]>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_host_tile_shard>
     %3 = "ttnn.to_device"(%2, %0) : (tensor<32x32xbf16, #ttnn_layout_host_tile_shard>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_device_tile_sharded>
 
     // preallocate and distribute output tensor
-    %out1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_row_major>) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
+    %out1 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_row_major>) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
     %out2 = "ttnn.distribute_tensor"(%out1, %0) <{mapper_config = #ttnn.mesh_mapper_config<placements = [<shard, 0 : i64>, <shard, 1 : i64>]>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_host_tile_shard>
     %out3 = "ttnn.to_device"(%out2, %0) : (tensor<32x32xbf16, #ttnn_layout_host_tile_shard>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_device_tile_sharded>
 
@@ -53,7 +53,7 @@ module attributes {} {
     %out4 = "ttnn.to_memory_config"(%out3) : (tensor<32x32xbf16, #ttnn_layout_device_tile_sharded>) -> tensor<32x32xbf16, #ttnn_layout_device_tile_interleaved>
     %4 = "ttnn.from_device"(%out4) : (tensor<32x32xbf16, #ttnn_layout_device_tile_interleaved>) -> tensor<32x32xbf16, #ttnn_layout_host_tile_shard>
     %5 = "ttnn.aggregate_tensor"(%4, %0) <{composer_config = #ttnn.mesh_composer_config<dims = [0 : i64, 1 : i64]>}> : (tensor<32x32xbf16, #ttnn_layout_host_tile_shard>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
-    %6 = "ttnn.to_layout"(%5) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_row_major>
+    %6 = "ttnn.to_layout"(%5)  : (tensor<64x128xbf16, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_row_major>
 
     return %6 : tensor<64x128xbf16, #ttnn_layout_host_row_major>
   }

--- a/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast_sem_inc.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast_sem_inc.mlir
@@ -11,12 +11,12 @@ module attributes {} {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 2x4>}> : () -> !ttnn.device
 
     // distribute input tensor
-    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_row_major>) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
+    %1 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_row_major>) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
     %2 = "ttnn.distribute_tensor"(%1, %0) <{mapper_config = #ttnn.mesh_mapper_config<placements = [<shard, 0 : i64>, <shard, 1 : i64>]>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_host_tile_shard>
     %3 = "ttnn.to_device"(%2, %0) : (tensor<32x32xbf16, #ttnn_layout_host_tile_shard>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_device_tile_sharded>
 
     // preallocate and distribute output tensor
-    %out1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_row_major>) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
+    %out1 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_row_major>) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
     %out2 = "ttnn.distribute_tensor"(%out1, %0) <{mapper_config = #ttnn.mesh_mapper_config<placements = [<shard, 0 : i64>, <shard, 1 : i64>]>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_host_tile_shard>
     %out3 = "ttnn.to_device"(%out2, %0) : (tensor<32x32xbf16, #ttnn_layout_host_tile_shard>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_device_tile_sharded>
 
@@ -56,7 +56,7 @@ module attributes {} {
     %out4 = "ttnn.to_memory_config"(%out3) : (tensor<32x32xbf16, #ttnn_layout_device_tile_sharded>) -> tensor<32x32xbf16, #ttnn_layout_device_tile_interleaved>
     %4 = "ttnn.from_device"(%out4) : (tensor<32x32xbf16, #ttnn_layout_device_tile_interleaved>) -> tensor<32x32xbf16, #ttnn_layout_host_tile_shard>
     %5 = "ttnn.aggregate_tensor"(%4, %0) <{composer_config = #ttnn.mesh_composer_config<dims = [0 : i64, 1 : i64]>}> : (tensor<32x32xbf16, #ttnn_layout_host_tile_shard>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_host_tile>
-    %6 = "ttnn.to_layout"(%5) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_row_major>
+    %6 = "ttnn.to_layout"(%5)  : (tensor<64x128xbf16, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_row_major>
 
     return %6 : tensor<64x128xbf16, #ttnn_layout_host_row_major>
   }

--- a/test/python/golden/mlir_snippets/ttnn/ttnn_constant.mlir
+++ b/test/python/golden/mlir_snippets/ttnn/ttnn_constant.mlir
@@ -5,13 +5,13 @@
 #ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
   func.func @constant_row_major() -> tensor<2x2xf32, #ttnn_layout2> {
-    %0 = "ttnn.constant"() <{layout = #ttnn.layout<row_major>, value = dense<"0x0000803F000000400000404000008040"> : tensor<2x2xf32>}> : () -> tensor<2x2xf32, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<tile>}> : (tensor<2x2xf32, #ttnn_layout1>) -> tensor<2x2xf32, #ttnn_layout2>
+    %0 = "ttnn.constant"() <{value = dense<"0x0000803F000000400000404000008040"> : tensor<2x2xf32>}> : () -> tensor<2x2xf32, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0)  : (tensor<2x2xf32, #ttnn_layout1>) -> tensor<2x2xf32, #ttnn_layout2>
     return %1 : tensor<2x2xf32, #ttnn_layout2>
   }
   func.func @constant_tile() -> tensor<2x2xf32, #ttnn_layout2> {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.constant"(%0) <{layout = #ttnn.layout<tile>, value = dense<"0x0000803F000000400000404000008040"> : tensor<2x2xf32>}> : (!ttnn.device) -> tensor<2x2xf32, #ttnn_layout2>
+    %1 = "ttnn.constant"(%0) <{value = dense<"0x0000803F000000400000404000008040"> : tensor<2x2xf32>}> : (!ttnn.device) -> tensor<2x2xf32, #ttnn_layout2>
     return %1 : tensor<2x2xf32, #ttnn_layout2>
   }
 }

--- a/test/python/golden/mlir_snippets/ttnn/ttnn_full.mlir
+++ b/test/python/golden/mlir_snippets/ttnn/ttnn_full.mlir
@@ -6,13 +6,13 @@
 module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
   func.func @full_row_major() -> tensor<32x32xbf16, #ttnn_layout> {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.full"(%0) <{fill_value = 1.000000e+00 : f32, layout = #ttnn.layout<row_major>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout>
+    %1 = "ttnn.full"(%0) <{fill_value = 1.000000e+00 : f32, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
+    %2 = "ttnn.to_layout"(%1)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout>
     return %2 : tensor<32x32xbf16, #ttnn_layout>
   }
   func.func @full_tile() -> tensor<32x32xf32, #ttnn_layout2> {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.full"(%0) <{fill_value = 1.000000e+00 : f32, layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout2>
+    %1 = "ttnn.full"(%0) <{fill_value = 1.000000e+00 : f32, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout2>
     return %1 : tensor<32x32xf32, #ttnn_layout2>
   }
 }

--- a/test/ttmlir/Conversion/TTNNToTTIR/to_layout_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/to_layout_op.mlir
@@ -18,7 +18,7 @@ module {
     // CHECK-SAME: ->
     // CHECK-SAME: #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (0,0)>]>>>
     // CHECK-NOT: "ttnn.to_layout"
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> {ttnn.hoist_generic_via_d2m} : (tensor<32x32xbf16, #dram_layout>) -> tensor<32x32xbf16, #l1_layout>
+    %0 = "ttnn.to_layout"(%arg0)  {ttnn.hoist_generic_via_d2m} : (tensor<32x32xbf16, #dram_layout>) -> tensor<32x32xbf16, #l1_layout>
     return %0 : tensor<32x32xbf16, #l1_layout>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/layout_to_creation_ops_canonicalizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/layout_to_creation_ops_canonicalizer.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --canonicalize --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 //
 // Test cases to verify that the to_layout op merges correctly with creation ops.
@@ -18,185 +18,185 @@ module attributes {} {
   // Verify that to_layout op merges into empty op.
   func.func @to_layout_merge_into_empty_on_device() -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile> {
     // CHECK: "ttnn.empty"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32, bf16>
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<row_major>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %1 = "ttnn.empty"(%0) <{ shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
   //Verify that to_layout op doesn't merge into empty op if to layout moves the tensor to host.
   func.func @to_layout_not_merge_into_empty_from_device_to_host() -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile> {
     // CHECK: "ttnn.zeros"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<row_major>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
+    %1 = "ttnn.empty"(%0) <{ shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
   }
 
   // Verify that to_layout op merges into empty op.
   func.func @to_layout_merge_into_rand_on_device() -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile> {
     // CHECK: "ttnn.rand"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.rand"(%0) <{size = #ttnn.shape<32x32>, layout = #ttnn.layout<row_major>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %1 = "ttnn.rand"(%0) <{size = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
   //Verify that to_layout op doesn't merge into empty op if to layout moves the tensor to host.
   func.func @to_layout_not_merge_into_rand_from_device_to_host() -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile> {
     // CHECK: "ttnn.rand"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32x32xf32,
+    // CHECK-SAME: memref<32x32x
     // CHECK-NOT: "ttnn.to_layout"
     // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.rand"(%0) <{size = #ttnn.shape<32x32>, layout = #ttnn.layout<row_major>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
+    %1 = "ttnn.rand"(%0) <{size = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
   }
 
   // Verify that to_layout op merges into arange op.
   func.func @to_layout_merge_into_arange_from_host_to_device() -> tensor<32xbf16, #ttnn_layout_1_device_bf16_tile> {
     // CHECK: "ttnn.arange"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.arange"() <{layout = #ttnn.layout<row_major>, start = 0 : i64, step = 1 : i64, end = 32 : i64}> : () -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32xf32, #ttnn_layout_1_host_f32_rm>) -> tensor<32xbf16, #ttnn_layout_1_device_bf16_tile>
+    %1 = "ttnn.arange"() <{ start = 0 : i64, step = 1 : i64, end = 32 : i64}> : () -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32xf32, #ttnn_layout_1_host_f32_rm>) -> tensor<32xbf16, #ttnn_layout_1_device_bf16_tile>
     return %2 : tensor<32xbf16, #ttnn_layout_1_device_bf16_tile>
   }
 
   // Verify that to_layout op merges into arange op.
   func.func @to_layout_merge_into_arange_from_device_to_host() -> tensor<32xf32, #ttnn_layout_1_host_f32_rm> {
     // CHECK: "ttnn.arange"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32xf32,
+    // CHECK-SAME: memref<32x
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.arange"() <{layout = #ttnn.layout<tile>, start = 0 : i64, step = 1 : i64, end = 32 : i64}> : () -> tensor<32xf32, #ttnn_layout_1_device_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32xf32, #ttnn_layout_1_device_bf16_tile>) -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
+    %1 = "ttnn.arange"() <{ start = 0 : i64, step = 1 : i64, end = 32 : i64}> : () -> tensor<32xf32, #ttnn_layout_1_device_bf16_tile>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32xf32, #ttnn_layout_1_device_bf16_tile>) -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
     return %2 : tensor<32xf32, #ttnn_layout_1_host_f32_rm>
   }
 
   // Verify that to_layout op merges into zeros op.
   func.func @to_layout_merge_into_zeros_from_host_to_device() -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile> {
     // CHECK: "ttnn.zeros"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.zeros"() <{layout = #ttnn.layout<row_major>, shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %1 = "ttnn.zeros"() <{ shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
   // Verify that to_layout op merges into zeros op.
   func.func @to_layout_merge_into_zeros_from_device_to_host() -> tensor<32x32xf32, #ttnn_layout_host_f32_rm> {
     // CHECK: "ttnn.zeros"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32x32xf32,
+    // CHECK-SAME: memref<32x32x
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.zeros"() <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %1 = "ttnn.zeros"() <{ shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
     return %2 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>
   }
 
   // Verify that to_layout op merges into ones op.
   func.func @to_layout_merge_into_ones_from_host_to_device() -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile> {
     // CHECK: "ttnn.ones"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.ones"() <{layout = #ttnn.layout<row_major>, shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %1 = "ttnn.ones"() <{ shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
   // Verify that to_layout op merges into ones op.
   func.func @to_layout_merge_into_ones_from_device_to_host() -> tensor<32x32xf32, #ttnn_layout_host_f32_rm> {
     // CHECK: "ttnn.ones"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32x32xf32,
+    // CHECK-SAME: memref<32x32x
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.ones"() <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %1 = "ttnn.ones"() <{ shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
     return %2 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>
   }
 
   // Verify that to_layout op merges into ones op.
   func.func @to_layout_merge_into_full_from_host_to_device() -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile> {
     // CHECK: "ttnn.full"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.full"() <{layout = #ttnn.layout<row_major>, shape = #ttnn.shape<32x32>, fill_value = 7.0 : f32}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %1 = "ttnn.full"() <{ shape = #ttnn.shape<32x32>, fill_value = 7.0 : f32}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
   // Verify that to_layout op merges into full op.
   func.func @to_layout_merge_into_full_from_device_to_host() -> tensor<32x32xf32, #ttnn_layout_host_f32_rm> {
     // CHECK: "ttnn.full"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32x32xf32,
+    // CHECK-SAME: memref<32x32x
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.full"() <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>, fill_value = 7.0 : f32}> : () -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %1 = "ttnn.full"() <{ shape = #ttnn.shape<32x32>, fill_value = 7.0 : f32}> : () -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
     return %2 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>
   }
 
   // Verify that to_layout op merges into constant op.
   func.func @to_layout_merge_into_constant_from_host_to_device() -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile> {
     // CHECK: "ttnn.constant"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.constant"() <{value = dense_resource<dense_attr_f32> : tensor<32x32xf32>, layout = #ttnn.layout<row_major>}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %1 = "ttnn.constant"() <{value = dense_resource<dense_attr_f32> : tensor<32x32xf32>}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
   // Verify that to_layout op merges into constant op.
   func.func @to_layout_merge_into_constant_from_device_to_host() -> tensor<32x32xf32, #ttnn_layout_host_f32_rm> {
     // CHECK: "ttnn.constant"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32x32xf32,
+    // CHECK-SAME: memref<32x32x
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.constant"(%0) <{value = dense_resource<dense_attr_bf16> : tensor<32x32xbf16>, layout = #ttnn.layout<tile>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %1 = "ttnn.constant"(%0) <{value = dense_resource<dense_attr_bf16> : tensor<32x32xbf16>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
     return %2 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>
   }
 
   // Verify that the canonicalization shouldn't happen if the creation op has more than one use.
   func.func @to_layout_not_merge_into_constant_with_more_than_one_use() -> (tensor<32x32xf32, #ttnn_layout_host_f32_rm>, tensor<32x32xf32, #ttnn_layout_dram_bf16_rm>) {
     // CHECK: "ttnn.constant"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK: "ttnn.to_layout"
     // CHECK: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.constant"(%0) <{value = dense_resource<dense_attr_bf16> : tensor<32x32xbf16>, layout = #ttnn.layout<tile>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
-    %3 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_dram_bf16_rm>
+    %1 = "ttnn.constant"(%0) <{value = dense_resource<dense_attr_bf16> : tensor<32x32xbf16>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %3 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_dram_bf16_rm>
     return %2, %3 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>, tensor<32x32xf32, #ttnn_layout_dram_bf16_rm>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/simple_to_layout_op_canonicalizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/simple_to_layout_op_canonicalizer.mlir
@@ -12,63 +12,58 @@ module attributes {} {
   func.func @merge_to_layout_op_layout(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout2> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
     // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout1>
     // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout2>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout2>
     return %1 : tensor<32x32xbf16, #ttnn_layout2>
   }
 
   func.func @merge_to_layout_op_data_type(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout3> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
     // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout2>
     // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<tile>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout3>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout3>
     return %1 : tensor<32x32xf32, #ttnn_layout3>
   }
 
   func.func @merge_to_layout_op_memory_config(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout4> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
     // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout3>
     // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<tile>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout4>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout4>
     return %1 : tensor<32x32xbf16, #ttnn_layout4>
   }
 
   func.func @merge_to_layout_op_all(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
     // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout4>
     // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
     return %1 : tensor<32x32xf32, #ttnn_layout5>
   }
 
   func.func @merge_to_layout_op_4x(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
     // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout4>
     // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>}> : (tensor<32x32xf32, #ttnn_layout5>) -> tensor<32x32xf32, #ttnn_layout3>
-    %3 = "ttnn.to_layout"(%2) <{layout = #ttnn.layout<row_major>}> : (tensor<32x32xf32, #ttnn_layout3>) -> tensor<32x32xf32, #ttnn_layout5>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
+    %2 = "ttnn.to_layout"(%1)  : (tensor<32x32xf32, #ttnn_layout5>) -> tensor<32x32xf32, #ttnn_layout3>
+    %3 = "ttnn.to_layout"(%2)  : (tensor<32x32xf32, #ttnn_layout3>) -> tensor<32x32xf32, #ttnn_layout5>
     return %3 : tensor<32x32xf32, #ttnn_layout5>
   }
 
   func.func @fold_to_layout_op(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {
     // Verify folding of to_layout_op.
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
     // CHECK-NOT: "ttnn.to_layout"
     return %0 : tensor<32x32xbf16, #ttnn_layout>
     // CHECK: return %arg0 : tensor<32x32xbf16

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decompose_layouts_affine_map_test.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decompose_layouts_affine_map_test.mlir
@@ -21,9 +21,8 @@
 #ttnn_layout_dram_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x64x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>
 module {
   func.func @forward(%arg0: tensor<1x1x8x2048xbf16, #ttnn_layout_dram_rm>) -> tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile> {
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<1x1x8x2048xbf16, #ttnn_layout_dram_rm>) -> tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<1x1x8x2048xbf16, #ttnn_layout_dram_rm>) -> tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile>
     // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     return %0 : tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_cpu_hoisted.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_cpu_hoisted.mlir
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-decompose-layouts -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-decompose-layouts --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // Verify that CPU-hoisted function outputs are tilized/typecast on host before
@@ -26,12 +26,12 @@ module attributes {} {
     // CHECK: %[[GET_DEVICE:.*]] = "ttnn.get_device"()
     // CHECK: %[[CALL:.*]] = call @cpu_hoisted_rm()
     // CHECK-NEXT: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[CALL]])
-    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NEXT: %[[TO_DEVICE:.*]] = "ttnn.to_device"(%[[TO_LAYOUT]], %[[GET_DEVICE]])
     // CHECK-NOT: "ttnn.to_layout"
     // CHECK: return %[[TO_DEVICE]]
     %0 = func.call @cpu_hoisted_rm() {ttir.cpu_hoist_call = unit} : () -> tensor<64x128xf32, #ttnn_layout_host_rm>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+    %1 = "ttnn.to_layout"(%0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
     return %1 : tensor<64x128xf32, #ttnn_layout_device_tile>
   }
 
@@ -46,7 +46,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.typecast"
     // CHECK: return %[[TO_DEVICE]]
     %0 = func.call @cpu_hoisted_rm() {ttir.cpu_hoist_call = unit} : () -> tensor<64x128xf32, #ttnn_layout_host_rm>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+    %1 = "ttnn.to_layout"(%0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     return %1 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
   }
 
@@ -58,11 +58,11 @@ module attributes {} {
     // CHECK-NEXT: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[CALL]])
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-NEXT: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[TYPECAST]])
-    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NEXT: %[[TO_DEVICE:.*]] = "ttnn.to_device"(%[[TO_LAYOUT]], %[[GET_DEVICE]])
     // CHECK: return %[[TO_DEVICE]]
     %0 = func.call @cpu_hoisted_rm() {ttir.cpu_hoist_call = unit} : () -> tensor<64x128xf32, #ttnn_layout_host_rm>
-    %1 = "ttnn.to_layout"(%0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+    %1 = "ttnn.to_layout"(%0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     return %1 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
   }
 
@@ -71,11 +71,11 @@ module attributes {} {
     // CHECK-LABEL: func.func @cpu_hoisted_input_layout_no_typecast_tile_to_rm
     // CHECK: %[[FROM_DEVICE:.*]] = "ttnn.from_device"(%arg0)
     // CHECK-NEXT: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[FROM_DEVICE]])
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
     // CHECK-NEXT: %[[CALL:.*]] = call @cpu_hoisted_input_rm(%[[TO_LAYOUT]])
     // CHECK-NOT: "ttnn.to_layout"
     // CHECK: return %[[CALL]]
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_device_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_device_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
     %1 = func.call @cpu_hoisted_input_rm(%0) {ttir.cpu_hoist_call = unit} : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
     return %1 : tensor<64x128xf32, #ttnn_layout_host_rm>
   }
@@ -87,10 +87,10 @@ module attributes {} {
     // CHECK-NEXT: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEVICE]])
     // CHECK-SAME: -> tensor<{{.*}}xf32,
     // CHECK-NEXT: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[TYPECAST]])
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
     // CHECK-NEXT: %[[CALL:.*]] = call @cpu_hoisted_input_rm(%[[TO_LAYOUT]])
     // CHECK: return %[[CALL]]
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
     %1 = func.call @cpu_hoisted_input_rm(%0) {ttir.cpu_hoist_call = unit} : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
     return %1 : tensor<64x128xf32, #ttnn_layout_host_rm>
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-decompose-layouts -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-decompose-layouts --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
@@ -25,7 +25,7 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -38,7 +38,7 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
     }
 
@@ -48,7 +48,7 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
     }
 
@@ -60,7 +60,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[CASTING_OP]], %[[GET_DEVICE_OP]])
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
@@ -72,7 +72,7 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -83,9 +83,8 @@ module attributes {} {
     func.func @from_host_to_host_dt_to_dt_from_tile_to_rm(%arg0: tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm> {
         // This test verifies that the `to_layout` operation is correctly inserted to change the layout from tile to row-major on the host.
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
@@ -93,9 +92,8 @@ module attributes {} {
     func.func @from_host_to_host_dt_to_dt_from_rm_to_tile(%arg0: tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile> {
         // This test verifies that the `to_layout` operation is correctly inserted to change the layout from row-major to tile on the host.
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
@@ -105,9 +103,9 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
@@ -118,9 +116,9 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -131,9 +129,9 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -144,9 +142,9 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
         return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 
@@ -159,9 +157,9 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
@@ -171,9 +169,9 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
@@ -186,9 +184,9 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -199,11 +197,11 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_tile>
     }
 
@@ -214,11 +212,11 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -229,11 +227,11 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}ui32
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
         return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-decompose-layouts -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-decompose-layouts --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // Tests for device-to-device layout transformations in TTNNDecomposeLayouts.
@@ -27,14 +27,13 @@ module attributes {} {
     func.func @device_l1_rm_ui16_to_dram_tile_ui16_inserts_typecast_workaround(%arg0: tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16> {
         // CHECK-LABEL: func.func @device_l1_rm_ui16_to_dram_tile_ui16_inserts_typecast_workaround
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: %[[TYPECAST_U32:.*]] = "ttnn.typecast"(%[[TO_LAYOUT]])
         // CHECK-SAME: -> tensor<{{.*}}ui32
         // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST_U32]])
         // CHECK-NEXT: %[[TYPECAST_U16:.*]] = "ttnn.typecast"(%[[TO_MEM_CONFIG]])
         // CHECK-SAME: -> tensor<{{.*}}ui16
         // CHECK-NEXT: return %[[TYPECAST_U16]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
         return %0 : tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
     }
 
@@ -47,11 +46,11 @@ module attributes {} {
         // CHECK: %[[UNSHARD:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK-NEXT: %[[PAD:.*]] = "ttnn.pad"(%[[UNSHARD]])
         // CHECK-NEXT: %[[TILIZE:.*]] = "ttnn.to_layout"(%[[PAD]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: %[[SLICE:.*]] = "ttnn.slice_static"(%[[TILIZE]])
         // CHECK-NEXT: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[SLICE]])
         // CHECK-NEXT: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<32x4xbf16, #ttnn_layout_l1_hs_rm_bf16_nontile>) -> tensor<32x4xbf16, #ttnn_layout_l1_hs_tile_bf16_nontile>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x4xbf16, #ttnn_layout_l1_hs_rm_bf16_nontile>) -> tensor<32x4xbf16, #ttnn_layout_l1_hs_tile_bf16_nontile>
         return %0 : tensor<32x4xbf16, #ttnn_layout_l1_hs_tile_bf16_nontile>
     }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv2d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv2d_workaround.mlir
@@ -7,15 +7,12 @@ module attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x1x1024x64xbf16>
     // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
     // CHECK: %[[CONV2D_BIAS:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
     // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0)
           <{
@@ -40,15 +37,12 @@ module attributes {} {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
     // CHECK: %[[CONV2D_BIAS:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
     // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %arg2, %0)
           <{
@@ -76,11 +70,9 @@ module attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x1x1024x64xbf16>
     // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
     // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     %2 = "ttnn.conv2d"(%1, %arg1, %0)
           <{
@@ -106,11 +98,9 @@ module attributes {} {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
     // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %0)
           <{

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #dram = #ttnn.buffer_type<dram>
@@ -9,12 +9,13 @@ module @test_distributed_rms_norm_workaround attributes {} {
   func.func public @test_workaround_layout_only(
       %arg0: tensor<1x1x32x128xbf16, #ttnn_layout_supported>,
       %arg1: tensor<4x32xbf16, #ttnn_layout_weight_2d>) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported> {
-    // CHECK: #[[INPUT_WS_LAYOUT:.+]] = #ttnn.ttnn_layout{{.*}}#l1{{.*}}<width_sharded>
     // CHECK-LABEL: func.func public @test_workaround_layout_only
     // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: tensor<{{.*}}, #[[INPUT_WS_LAYOUT]]>
+    // CHECK-SAME: #ttnn.buffer_type<l1>
+    // CHECK-SAME: <width_sharded>
     // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: row_major
+    // CHECK-SAME: -> tensor<4x32xbf16,
+    // CHECK-SAME: memref<4x32xbf16, #ttnn.buffer_type
     // CHECK: "ttnn.distributed_rms_norm"
     // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>
     // CHECK-NOT: "ttnn.empty"

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround --canonicalize --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
@@ -10,30 +10,32 @@
 #ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {} {
   func.func @backward(%arg0: tensor<1x1x1x32xf32, #ttnn_layout>, %arg1: tensor<512x128xf32, #ttnn_layout1>, %arg2: tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<512x128xf32, #ttnn_layout1> {
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<1x1x1x32xf32, #ttnn_layout>) -> tensor<1x1x1x32xf32, #ttnn_layout3>
-    %1 = "ttnn.to_layout"(%arg1) <{layout = #ttnn.layout<tile>}> : (tensor<512x128xf32, #ttnn_layout1>) -> tensor<512x128xf32, #ttnn_layout4>
-    %2 = "ttnn.to_layout"(%arg2) <{layout = #ttnn.layout<tile>}> : (tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<1x32x128xf32, #ttnn_layout5>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<1x1x1x32xf32, #ttnn_layout>) -> tensor<1x1x1x32xf32, #ttnn_layout3>
+    %1 = "ttnn.to_layout"(%arg1)  : (tensor<512x128xf32, #ttnn_layout1>) -> tensor<512x128xf32, #ttnn_layout4>
+    %2 = "ttnn.to_layout"(%arg2)  : (tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<1x32x128xf32, #ttnn_layout5>
+    // CHECK: "ttnn.to_layout"(%arg2)
     // CHECK: "ttnn.reshape"
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]}> : (tensor<1x32x128xf32, #ttnn_layout5>) -> tensor<1x1x32x128xf32, #ttnn_layout5>
     // Check that the input operand is transformed into the row major layout.
-    // CHECK-NEXT: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: -> tensor<1x1x1x32xui32
+    // CHECK-SAME: memref<1x32xui32, #ttnn.buffer_type
     // Check that the data type of the weight operand is transformed in bf16.
-    // CHECK-NEXT: %[[TO_LAYOUT_WEIGHTS:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK: %[[TO_LAYOUT_WEIGHTS:.*]] = "ttnn.to_layout"(%arg1)
     // CHECK-SAME: -> tensor<512x128xbf16
+    // CHECK-SAME: !ttcore.tile<32x32,
     // Check that the data type of the in gradient operand is transformed in bf16.
-    // CHECK-NEXT: %[[TO_LAYOUT_IN_GRADIENT:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK: %[[TO_LAYOUT_IN_GRADIENT:.*]] = "ttnn.to_layout"
     // CHECK-SAME: -> tensor<1x1x32x128xbf16
+    // CHECK-SAME: !ttcore.tile<32x32,
     // Check that the data type of the output operand is transformed in bf16.
     %4 = "ttnn.embedding_bw"(%0, %1, %3) : (tensor<1x1x1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<512x128xf32, #ttnn_layout4>
-    // CHECK-NEXT: %[[EMBEDDING_BW_OP:.*]] = "ttnn.embedding_bw"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]], %[[TO_LAYOUT_IN_GRADIENT]])
+    // CHECK: %[[EMBEDDING_BW_OP:.*]] = "ttnn.embedding_bw"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]], %[[TO_LAYOUT_IN_GRADIENT]])
     // Check that the output operand is transformed back into the f32 data type.
-    // CHECK-NEXT: "ttnn.to_layout"(%[[EMBEDDING_BW_OP]])
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
-    %5 = "ttnn.to_layout"(%4) <{layout = #ttnn.layout<row_major>}> : (tensor<512x128xf32, #ttnn_layout4>) -> tensor<512x128xf32, #ttnn_layout1>
+    // CHECK: "ttnn.to_layout"(%[[EMBEDDING_BW_OP]])
+    // CHECK-SAME: -> tensor<512x128xf32
+    // CHECK-SAME: memref<512x128xf32, #ttnn.buffer_type
+    %5 = "ttnn.to_layout"(%4)  : (tensor<512x128xf32, #ttnn_layout4>) -> tensor<512x128xf32, #ttnn_layout1>
     return %5 : tensor<512x128xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_workaround.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround --canonicalize --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
@@ -9,17 +9,18 @@ module attributes {} {
   func.func @forward(%arg0: tensor<32x32xf32, #ttnn_layout>, %arg1: tensor<512x128xf32, #ttnn_layout1>) -> tensor<32x32x128xf32, #ttnn_layout2> {
     // Check that the input operand is transformed into the row major layout.
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<32x32xui32
+    // CHECK-SAME: memref<32x32xui32, #ttnn.buffer_type
     // Check that the data type of the weight operand is transformed in bf16.
     // CHECK-NEXT: %[[TO_LAYOUT_WEIGHTS:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<512x128xbf16
+    // CHECK-SAME: memref<512x128xbf16, #ttnn.buffer_type
     %0 = "ttnn.embedding"(%arg0, %arg1) : (tensor<32x32xf32, #ttnn_layout>, tensor<512x128xf32, #ttnn_layout1>) -> tensor<32x32x128xf32, #ttnn_layout2>
     // CHECK-NEXT: %[[EMBEDDING_OP:.*]] = "ttnn.embedding"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]])
     // Check that the output operand is transformed back into the f32 data type.
     // CHECK-NEXT: "ttnn.to_layout"(%[[EMBEDDING_OP]])
-    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: -> tensor<32x32x128xf32
+    // CHECK-SAME: !ttcore.tile<32x32,
     return %0 : tensor<32x32x128xf32, #ttnn_layout2>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/gather_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/gather_workaround.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #dram = #ttnn.buffer_type<dram>
@@ -22,12 +22,12 @@ module attributes {} {
     // CHECK-LABEL: func.func @gather_row_major_inputs
     // Check that the input operand is converted to tiled layout.
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<5x3xf32,
+    // CHECK-SAME: !ttcore.tile<32x32,
     // Check that the index operand is converted to tiled layout.
     // CHECK-NEXT: %[[TO_LAYOUT_INDEX:.*]] = "ttnn.to_layout"(%arg1)
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<2x3xui32,
+    // CHECK-SAME: !ttcore.tile<32x32,
     %0 = "ttnn.gather"(%arg0, %arg1)
         <{dim = 0 : i32}>
         : (tensor<5x3xf32, #ttnn_layout_input_rm>,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround --canonicalize -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround --canonicalize --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
@@ -8,23 +8,22 @@
 #ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4096 + d1 * 64 + d2, d3), <1x1>, memref<128x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {} {
   func.func @forward(%arg0: tensor<1x128x128x32xf32, #ttnn_layout>) -> tensor<1x64x64x32xf32, #ttnn_layout1> {
-    %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<1x128x128x32xf32, #ttnn_layout>) -> tensor<1x128x128x32xf32, #ttnn_layout2>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<1x128x128x32xf32, #ttnn_layout>) -> tensor<1x128x128x32xf32, #ttnn_layout2>
     // CHECK: "ttnn.to_layout"
     %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 1 : i32, 16384 : i32, 32 : i32]}> : (tensor<1x128x128x32xf32, #ttnn_layout2>) -> tensor<1x1x16384x32xf32, #ttnn_layout2>
     // Check that the input operand is transformed into the row major layout.
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<1x1x16384x32xbf16,
-    // %3 = "ttnn.max_pool2d"(%2, %0) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, dilation_height = 1 : si32, dilation_width = 1 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_height = 2 : si32, kernel_width = 2 : si32, padding_height = 0 : si32, padding_width = 0 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>, !ttcore.device<#device>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
+    // CHECK-SAME: memref<16384x32xbf16, #ttnn.buffer_type
     %2 = "ttnn.max_pool2d"(%1) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_size = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0>, in_place_halo = false}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
     // CHECK-NEXT: %[[MAX_POOL_2D_OP:.*]] = "ttnn.max_pool2d"(%[[TO_LAYOUT_INPUT]])
     // Check that the output operand is transformed back into the tile and f32 data type.
     // CHECK-NEXT: %[[TO_LAYOUT_OUTPUT:.*]] = "ttnn.to_layout"(%[[MAX_POOL_2D_OP]])
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<1x1x4096x32xf32
+    // CHECK-SAME: !ttcore.tile<32x32,
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 64 : i32, 64 : i32, 32 : i32]}> : (tensor<1x1x4096x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout3>
     // CHECK-NEXT: ttnn.reshape
-    %4 = "ttnn.to_layout"(%3) <{layout = #ttnn.layout<row_major>}> : (tensor<1x64x64x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout1>
+    %4 = "ttnn.to_layout"(%3)  : (tensor<1x64x64x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout1>
     return %4 : tensor<1x64x64x32xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
@@ -8,7 +8,6 @@ module attributes {} {
   func.func @test_pad_workaround(%arg0: tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1> {
     // CHECK-LABEL: @test_pad_workaround
     // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: tensor<1x30x30xsi32,
     // CHECK-SAME: -> tensor<1x30x30xsi32,
     // CHECK: %[[PAD:[0-9]+]] = "ttnn.pad"(%[[ARG0]])
@@ -16,7 +15,6 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x32x32xsi32,
     %0 = "ttnn.pad"(%arg0) <{padding = array<i32: 0, 0, 1, 1, 1, 1>, use_multicore = false, value = 0.000000e+00 : f32}> : (tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1>
     // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[PAD]])
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: tensor<1x32x32xsi32,
     // CHECK-SAME: -> tensor<1x32x32xsi32,
     return %0 : tensor<1x32x32xsi32, #ttnn_layout1>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sampling_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sampling_workaround.mlir
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #dram = #ttnn.buffer_type<dram>
@@ -33,14 +33,10 @@ module attributes {} {
     // CHECK-LABEL: func.func @sampling_rank2_input_decomposes_to_rank4
     // CHECK-DAG: "ttnn.reshape"
     // CHECK-DAG-SAME: shape = [1 : i32, 1 : i32, 1 : i32, 32 : i32]
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK-DAG: "ttnn.to_layout"{{.*}}memref<{{[0-9x]+}}si32,
+    // CHECK-DAG: "ttnn.to_layout"{{.*}}memref<{{[0-9x]+}}ui32,
+    // CHECK-DAG: "ttnn.to_layout"{{.*}}memref<{{[0-9x]+}}bf16,
+    // CHECK-DAG: "ttnn.to_layout"{{.*}}memref<{{[0-9x]+}}bf16,
     // ttnn.sampling now operates on the kernel-true rank-4 shape and yields ui32.
     // CHECK: "ttnn.sampling"
     // CHECK-SAME: (tensor<1x1x1x32xbf16{{.*}}>, tensor<1x1x1x32xsi32{{.*}}>, tensor<1xui32{{.*}}>, tensor<1xbf16{{.*}}>, tensor<1xbf16{{.*}}>)

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sparse_matmul_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sparse_matmul_workaround.mlir
@@ -23,7 +23,6 @@ module {
       %s: tensor<1x4x1x4xf32>) -> tensor<1x4x1x4x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sparse_matmul_sparsity_f32_to_bf16
     // CHECK: %[[SPARSITY_BF16:.*]] = "ttnn.to_layout"(%arg2)
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: tensor<1x4x1x4xf32,
     // CHECK-SAME: -> tensor<1x4x1x4xbf16,
     // CHECK: "ttnn.sparse_matmul"(%{{.*}}, %{{.*}}, %[[SPARSITY_BF16]])
@@ -48,7 +47,6 @@ module {
       %s: tensor<1x4x1x4xui16>) -> tensor<1x4x1x4x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sparse_matmul_sparsity_ui16_to_bf16
     // CHECK: %[[SPARSITY_BF16:.*]] = "ttnn.to_layout"(%arg2)
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: tensor<1x4x1x4xui16,
     // CHECK-SAME: -> tensor<1x4x1x4xbf16,
     // CHECK: "ttnn.sparse_matmul"(%{{.*}}, %{{.*}}, %[[SPARSITY_BF16]])

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_bilinear_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_bilinear_workaround.mlir
@@ -12,12 +12,10 @@ module {
     // CHECK: %[[PADDED:.*]] = "ttnn.pad"(%arg0)
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 0, 0, 2>
     // CHECK: %[[TO_ROWMAJOR:.*]] = "ttnn.to_layout"(%[[PADDED]])
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK: %[[UPSAMPLE:.*]] = "ttnn.upsample"(%[[TO_ROWMAJOR]])
     // CHECK-SAME: mode = "bilinear"
     // CHECK: %[[TO_TILE:.*]] = "ttnn.to_layout"(%[[UPSAMPLE]])
-    // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: -> tensor<{{.*}}xf32,
     // CHECK: "ttnn.slice_static"(%[[TO_TILE]])
     // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32]

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_workaround.mlir
@@ -11,19 +11,18 @@
 module attributes {} {
   func.func @upsample2d_scale_unifrom(%arg0: tensor<4x32x64x3xf32, #ttnn_layout>) -> tensor<4x64x128x3xf32, #ttnn_layout1> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<4x32x64x3xf32, #ttnn_layout>) -> tensor<4x32x64x3xf32, #ttnn_layout2>
+    %1 = "ttnn.to_layout"(%arg0)  : (tensor<4x32x64x3xf32, #ttnn_layout>) -> tensor<4x32x64x3xf32, #ttnn_layout2>
     %2 = "ttnn.to_device"(%1, %0) : (tensor<4x32x64x3xf32, #ttnn_layout2>, !ttnn.device) -> tensor<4x32x64x3xf32, #ttnn_layout3>
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<4x32x64x3xf32, #ttnn_layout2>) -> ()
     // CHECK: "ttnn.to_layout"
     // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK: "ttnn.upsample"
     %3 = "ttnn.upsample"(%2) <{mode = "nearest", scale_factor = 2 : si32}> : (tensor<4x32x64x3xf32, #ttnn_layout3>) -> tensor<4x64x128x3xf32, #ttnn_layout4>
     "ttnn.deallocate"(%2) <{force = false}> : (tensor<4x32x64x3xf32, #ttnn_layout3>) -> ()
     %4 = "ttnn.from_device"(%3) : (tensor<4x64x128x3xf32, #ttnn_layout4>) -> tensor<4x64x128x3xf32, #ttnn_layout5>
     "ttnn.deallocate"(%3) <{force = false}> : (tensor<4x64x128x3xf32, #ttnn_layout4>) -> ()
-    %5 = "ttnn.to_layout"(%4) <{layout = #ttnn.layout<row_major>}> : (tensor<4x64x128x3xf32, #ttnn_layout5>) -> tensor<4x64x128x3xf32, #ttnn_layout1>
+    %5 = "ttnn.to_layout"(%4)  : (tensor<4x64x128x3xf32, #ttnn_layout5>) -> tensor<4x64x128x3xf32, #ttnn_layout1>
     "ttnn.deallocate"(%4) <{force = false}> : (tensor<4x64x128x3xf32, #ttnn_layout5>) -> ()
     return %5 : tensor<4x64x128x3xf32, #ttnn_layout1>
   }

--- a/test/ttmlir/Dialect/TTNN/ccl/mesh_partition.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/mesh_partition.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="mesh-shape=2,4" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="mesh-shape=2,4" --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
@@ -16,7 +16,7 @@ module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
 
 // CHECK-LABEL: @test_sdy_all_slice_composite_row_major
 // CHECK: "ttnn.to_layout"(%arg0)
-// CHECK-SAME: <{layout = #ttnn.layout<row_major>}>
+// CHECK-SAME: memref<4x32xbf16, #ttnn.buffer_type<dram>>
 // CHECK: "ttnn.mesh_partition"
 // CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}>
 // CHECK: "ttnn.mesh_partition"

--- a/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
+++ b/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-const-eval=true enable-cpu-hoisted-const-eval=false" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-const-eval=true enable-cpu-hoisted-const-eval=false" --mlir-print-local-scope -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 module {
@@ -156,7 +156,8 @@ module {
 
   // CHECK-LABEL: func.func private @non_splat_constant_const_eval_0
   // CHECK: = "ttnn.get_device"
-  // CHECK: = "ttnn.constant"(%0) <{layout = #ttnn.layout<tile>, value = dense<{{\[\[}}-1.000000e+00, -2.000000e+00], [-3.000000e+00, -4.000000e+00]]>
+  // CHECK: = "ttnn.constant"(%{{.*}}) <{value = dense<{{\[\[}}-1.000000e+00, -2.000000e+00], [-3.000000e+00, -4.000000e+00]]>
+  // CHECK-SAME: !ttcore.tile<32x32, bf16>
 
   // CHECK: func.func @non_splat_constant(
   func.func @non_splat_constant(%arg0: tensor<2x2xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<2x2xbf16> {

--- a/test/ttmlir/Dialect/TTNN/layout_encoding.mlir
+++ b/test/ttmlir/Dialect/TTNN/layout_encoding.mlir
@@ -8,7 +8,7 @@
 module {
   func.func @forward(%arg0: tensor<32x32xf32, #ttnn_layout>) -> tensor<32x96xf32, #ttnn_layout1> {
     // CHECK: error: Memory layout is not allowed for SystemMemory buffer type.
-    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}>  : (tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%arg0)   : (tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout1>
     return %1 : tensor<32x32xf32, #ttnn_layout1>
   }
 }
@@ -23,7 +23,7 @@ module {
 module {
   func.func @forward(%arg0: tensor<32x32xf32, #ttnn_layout>) -> tensor<32x96xf32, #ttnn_layout1> {
     // CHECK: error: sharded TTNN layout (width_sharded) must carry a core_range_set
-    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}>  : (tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%arg0)   : (tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout1>
     return %1 : tensor<32x32xf32, #ttnn_layout1>
   }
 }
@@ -37,7 +37,7 @@ module {
 module {
   func.func @forward(%arg0: tensor<32x32xf32, #ttnn_layout>) -> tensor<32x96xf32, #ttnn_layout1> {
     // CHECK: error: Memory layout is required for non-SystemMemory buffer type.
-    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}>  : (tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%arg0)   : (tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout1>
     return %1 : tensor<32x32xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_prepare_weights_layout.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_prepare_weights_layout.mlir
@@ -28,17 +28,18 @@ module {
     // The IR shape is:
     //   %1 = prepare_conv3d_weights(...) -> tensor<..., #row_major_layout>
     //   "ttnn.deallocate"(%argweight) ...     // optional dealloc
-    //   %2 = to_layout(%1) <{layout = tile}>
+    //   %2 = to_layout(%1) -> tensor<..., #tile_layout>
     //   %3 = conv3d(input, %2, ...)
     //
     // We assert structurally: a `to_layout` to tile must appear between
     // prepare and conv3d, and the prepare op's result memref must NOT be
     // tiled.
     //
-    // CHECK: %{{[0-9]+}} = "ttnn.prepare_conv3d_weights"
-    // CHECK-NOT: !ttcore.tile
-    // CHECK: layout = #ttnn.layout<tile>
-    // CHECK: ttnn.conv3d
+    // CHECK-DAG: #[[PREPARE_RM_LAYOUT:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<3456x32xbf16, #dram>
+    // CHECK-DAG: #[[WEIGHTS_TILE_LAYOUT:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<108x1x!ttcore.tile<32x32, bf16>, #dram>
+    // CHECK: %[[PREPARE_WEIGHTS:.*]] = "ttnn.prepare_conv3d_weights"{{.*}} -> tensor<3456x32xbf16, #[[PREPARE_RM_LAYOUT]]>
+    // CHECK: %[[TILED_WEIGHTS:.*]] = "ttnn.to_layout"(%[[PREPARE_WEIGHTS]]){{.*}} -> tensor<3456x32xbf16, #[[WEIGHTS_TILE_LAYOUT]]>
+    // CHECK: "ttnn.conv3d"({{.*}}, %[[TILED_WEIGHTS]],
     %0 = "ttir.conv3d"(%arg0, %arg1) <{
         stride = array<i32: 1, 1, 1>,
         padding = array<i32: 0, 0, 0>,

--- a/test/ttmlir/Dialect/TTNN/optimizer/input_layout_loc_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/input_layout_loc_override.mlir
@@ -11,7 +11,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {
     // CHECK-DAG: %{{.*}} = "ttnn.to_device"{{.*}} loc(#[[LOC_MATMUL_IN0]])
-    // CHECK-DAG: %{{.*}} = "ttnn.to_layout"{{.*}} <{layout = #ttnn.layout<tile>}> : {{.*}} -> tensor<128x96xbf16, #[[IN_1_LAYOUT]]> loc(#[[LOC_MATMUL_IN1]])
+    // CHECK-DAG: %{{.*}} = "ttnn.to_layout"{{.*}}  : {{.*}} -> tensor<128x96xbf16, #[[IN_1_LAYOUT]]> loc(#[[LOC_MATMUL_IN1]])
     // CHECK-DAG: %{{.*}} = "ttnn.matmul"{{.*}} loc(#[[LOC_MATMUL]])
     %1 = "ttir.matmul"(%arg0, %arg1) : (tensor<64x128xbf16>, tensor<128x96xbf16>) -> tensor<64x96xbf16> loc(#loc2)
     return %1 : tensor<64x96xbf16>

--- a/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_const_eval.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_const_eval.mlir
@@ -12,7 +12,7 @@ module attributes {} {
   // CHECK-LABEL: func.func @main(
   func.func @main(%arg0: tensor<1x32x32xf32, #ttnn_layout>, %arg1: tensor<1x32x32xf32, #ttnn_layout> {ttcore.argument_type = #ttcore.argument_type<constant>}) -> tensor<1x32x32xf32, #ttnn_layout1> {
     // CHECK: "ttnn.to_layout"
-    %0 = "ttnn.to_layout"(%arg1) <{layout = #ttnn.layout<tile>}> : (tensor<1x32x32xf32, #ttnn_layout>) -> tensor<1x32x32xf32, #ttnn_layout1>
+    %0 = "ttnn.to_layout"(%arg1)  : (tensor<1x32x32xf32, #ttnn_layout>) -> tensor<1x32x32xf32, #ttnn_layout1>
     %1 = "ttnn.add"(%arg0, %0) : (tensor<1x32x32xf32, #ttnn_layout>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc1)
     return %1 : tensor<1x32x32xf32, #ttnn_layout1>
   }

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/argmax_layout_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/argmax_layout_validation.mlir
@@ -22,7 +22,6 @@ module attributes {} {
     // 3. UInt32 data type for output
 
     // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<1x1x32x32xbf16,
     // CHECK-NEXT: "ttnn.argmax"
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/pool2d_layout_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/pool2d_layout_validation.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-operation-validation-and-fallback %s -o %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-operation-validation-and-fallback %s --mlir-print-local-scope -o %t.mlir
 // RUN: FileCheck %s --input-file %t.mlir
 
 // Test that the post-optimizer validation analysis automatically detects
@@ -23,7 +23,8 @@ module attributes {} {
     // CHECK-NEXT: "ttnn.max_pool2d"
     // CHECK-SAME: -> tensor<1x1x4096x32xbf16,
     // CHECK-NEXT: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: -> tensor<1x1x4096x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
 
     %1 = "ttnn.max_pool2d"(%arg0) <{
       batch_size = 1 : si32,

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/sum_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/sum_validation.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-operation-validation-and-fallback %s -o %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-operation-validation-and-fallback %s --mlir-print-local-scope -o %t.mlir
 // RUN: FileCheck %s --input-file %t.mlir
 
 #dram = #ttnn.buffer_type<dram>
@@ -16,8 +16,8 @@ module attributes {} {
     // CHECK: %[[SUM_RES:.*]] = "ttnn.sum"
     // CHECK: "ttnn.to_layout"
     // CHECK-SAME: (%[[SUM_RES]]
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: -> tensor<1x1x1x1xbf16,
+    // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
 
     %1 = "ttnn.sum"(%arg0) <{
       dim_list = [2 : i32, 3 : i32],

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/tanh_dtype_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/tanh_dtype_validation.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-operation-validation-and-fallback %s -o %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-operation-validation-and-fallback %s --mlir-print-local-scope -o %t.mlir
 // RUN: FileCheck %s --input-file %t.mlir
 
 #dram = #ttnn.buffer_type<dram>
@@ -14,10 +14,9 @@ module attributes {} {
     // but the output layout doesn't match the expected one, so it inserts a revert to tile layout with bf16.
 
     // CHECK: %[[TANH_RES:.*]] = "ttnn.tanh"
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: (%[[TANH_RES]]
-    // CHECK-SAME: layout = #ttnn.layout<tile>
-    // CHECK-SAME: -> tensor<{{.*}}bf16
+    // CHECK: "ttnn.to_layout"(%[[TANH_RES]])
+    // CHECK-SAME: -> tensor<1x1x32x32xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
 
     %1 = "ttnn.tanh"(%arg0) : (tensor<1x1x32x32xf32, #ttnn_layout_tile_f32>) -> tensor<1x1x32x32xbf16, #ttnn_layout_tile_bf16>
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/upsample_post_optimizer_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/upsample_post_optimizer_validation.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-operation-validation-and-fallback %s -o %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-operation-validation-and-fallback %s --mlir-print-local-scope -o %t.mlir
 // RUN: FileCheck %s --input-file %t.mlir
 
 #dram = #ttnn.buffer_type<dram>
@@ -16,10 +16,10 @@ module attributes {} {
     // Also, the output layout of upsample op will be the same as input layout, so revert it back to the expected layout.
 
     // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-NEXT: "ttnn.upsample"
     // CHECK-NEXT: "ttnn.to_layout"
-    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: -> tensor<4x64x128x3xbf16,
+    // CHECK-SAME: !ttcore.tile<32x32,
 
     %1 = "ttnn.upsample"(%arg0) <{mode = "nearest", scale_factor = 2 : si32}> : (tensor<4x32x64x3xbf16, #ttnn_layout_tile_input>) -> tensor<4x64x128x3xbf16, #ttnn_layout_tile_output>
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
@@ -14,15 +14,15 @@ module attributes {} {
     // CHECK: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, <width_sharded>, core_ranges = <[#ttnn.core_range<(0, 0), (0, 0)>]>>
     // CHECK: #[[LAYOUT_3:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0, %0) <{layout = #ttnn.layout<tile>}> : (tensor<1x32x32xf32, #ttnn_layout>, !ttnn.device) -> tensor<1x32x32xf32, #ttnn_layout1>
-    %2 = "ttnn.to_layout"(%arg1, %0) <{layout = #ttnn.layout<tile>}> : (tensor<1x32x32xf32, #ttnn_layout>, !ttnn.device) -> tensor<1x32x32xf32, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%arg0, %0)  : (tensor<1x32x32xf32, #ttnn_layout>, !ttnn.device) -> tensor<1x32x32xf32, #ttnn_layout1>
+    %2 = "ttnn.to_layout"(%arg1, %0)  : (tensor<1x32x32xf32, #ttnn_layout>, !ttnn.device) -> tensor<1x32x32xf32, #ttnn_layout1>
     // CHECK: %[[C:.*]] = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
     %3 = "ttnn.add"(%1, %2) : (tensor<1x32x32xf32, #ttnn_layout1>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc1)
-    %4 = "ttnn.to_layout"(%arg0, %0) <{layout = #ttnn.layout<tile>}> : (tensor<1x32x32xf32, #ttnn_layout>, !ttnn.device) -> tensor<1x32x32xf32, #ttnn_layout1>
+    %4 = "ttnn.to_layout"(%arg0, %0)  : (tensor<1x32x32xf32, #ttnn_layout>, !ttnn.device) -> tensor<1x32x32xf32, #ttnn_layout1>
     // CHECK: %{{.*}} = "ttnn.to_layout"(%[[C]], %0) {{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %5 = "ttnn.add"(%3, %3) : (tensor<1x32x32xf32, #ttnn_layout1>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc2)
     %6 = "ttnn.relu"(%5) : (tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc3)
-    %7 = "ttnn.to_layout"(%6) <{layout = #ttnn.layout<row_major>}> : (tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout>
+    %7 = "ttnn.to_layout"(%6)  : (tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout>
     return %7 : tensor<1x32x32xf32, #ttnn_layout>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/rand/rand_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/rand/rand_tests_negative.mlir
@@ -23,15 +23,3 @@ module {
     return %1 : tensor<32x32xbf16, #ttnn_layout>
   }
 }
-
-// -----
-#dram = #ttnn.buffer_type<dram>
-#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-module {
-  func.func @test_rand_layout() -> tensor<32x32xbf16, #ttnn_layout> {
-    // CHECK: error: 'ttnn.rand' op output tensor layout tile must match output layout attribute row_major
-    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.rand"(%0) <{high = 1.000000e+00 : f32, layout = #ttnn.layout<row_major>, low = 0.000000e+00 : f32, seed = 0 : ui32, size = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout>
-    return %1 : tensor<32x32xbf16, #ttnn_layout>
-  }
-}

--- a/test/ttmlir/Dialect/TTNN/rand/simple_rand.mlir
+++ b/test/ttmlir/Dialect/TTNN/rand/simple_rand.mlir
@@ -6,7 +6,6 @@ module attributes {} {
     // CHECK-LABEL: @test_rand
     // CHECK: "ttnn.rand"
     // CHECK-SAME: high = 1.000000e+00 : f32,
-    // CHECK-SAME: layout = #ttnn.layout<tile>,
     // CHECK-SAME: low = 0.000000e+00 : f32,
     // CHECK-SAME: seed = 0 : ui32,
     // CHECK-SAME: size = #ttnn.shape<32x32>

--- a/test/ttmlir/Dialect/TTNN/test_remove_dead_values_pass.mlir
+++ b/test/ttmlir/Dialect/TTNN/test_remove_dead_values_pass.mlir
@@ -8,50 +8,50 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32, #ttnn_layout>, %arg1: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %2 = "ttnn.to_device"(%1, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %3 = "ttnn.to_layout"(%arg1) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %3 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %4 = "ttnn.to_device"(%3, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%3) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK: "ttnn.multiply"
     %5 = "ttnn.multiply"(%2, %4) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%4) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%2) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %6 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %6 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %7 = "ttnn.to_device"(%6, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%6) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %8 = "ttnn.to_layout"(%arg1) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %8 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %9 = "ttnn.to_device"(%8, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%8) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.add"
     %10 = "ttnn.add"(%7, %9) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%9) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%7) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %11 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %11 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %12 = "ttnn.to_device"(%11, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%11) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %13 = "ttnn.to_layout"(%arg1) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %13 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %14 = "ttnn.to_device"(%13, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%13) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.subtract"
     %15 = "ttnn.subtract"(%12, %14) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%14) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%12) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %16 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %16 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %17 = "ttnn.to_device"(%16, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%16) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %18 = "ttnn.to_layout"(%arg1) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %18 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %19 = "ttnn.to_device"(%18, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%18) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.divide"
     %20 = "ttnn.divide"(%17, %19) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%19) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%17) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %21 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %21 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %22 = "ttnn.to_device"(%21, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%21) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %23 = "ttnn.to_layout"(%arg1) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %23 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %24 = "ttnn.to_device"(%23, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%23) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.eq"

--- a/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
@@ -1,13 +1,16 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+// CHECK-DAG: #[[PAGE_TABLE_RM_LAYOUT:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<1x4xsi32, #dram>
+// CHECK-DAG: #[[CHUNK_START_RM_LAYOUT:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<1x1xsi32, #dram>
 module attributes {} {
   // query: [num_users, num_heads, chunk_len, head_size]; key/value: paged cache
   // [num_blocks, num_kv_heads, block_size, head_size].
   func.func @chunked_sdpa(%arg0: tensor<1x12x64x64xf32>, %arg1: tensor<128x12x32x64xf32>, %arg2: tensor<128x12x32x64xf32>, %arg3: tensor<1x4xi32>, %arg4: tensor<1xi32>) -> tensor<1x12x64x64xf32> {
     // CHECK-LABEL: @chunked_sdpa
     // page_table and chunk_start_idx are forced to ROW_MAJOR for the ttnn kernel.
-    // CHECK-DAG: "ttnn.to_layout"(%arg3) <{layout = #ttnn.layout<row_major>}>
-    // CHECK-DAG: "ttnn.to_layout"(%arg4) <{layout = #ttnn.layout<row_major>}>
+    // CHECK-DAG: %[[PAGE_TABLE:.*]] = "ttnn.to_layout"(%arg3){{.*}} -> tensor<1x4xsi32, #[[PAGE_TABLE_RM_LAYOUT]]>
+    // CHECK-DAG: %[[CHUNK_START:.*]] = "ttnn.to_layout"(%arg4){{.*}} -> tensor<1xsi32, #[[CHUNK_START_RM_LAYOUT]]>
     // CHECK: "ttnn.chunked_scaled_dot_product_attention"
+    // CHECK-SAME: %[[PAGE_TABLE]], %[[CHUNK_START]]
     // CHECK-SAME: <{scale = 1.250000e-01 : f32}>
     %0 = ttir.empty() : tensor<1x12x64x64xf32>
     %1 = "ttir.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4, %0) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_hoist_call.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_hoist_call.mlir
@@ -15,9 +15,9 @@ module {
     %3 = "ttir.add"(%arg0, %1) {ttir.should_hoist} : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
     // CHECK: %{{.*}} = call @cpu_hoisted_ttir_add_{{.*}}(%{{.*}}, %{{.*}})
     %5 = "ttir.add"(%arg0, %3) {ttir.should_hoist} : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
-    // CHECK: %{{.*}} = "ttnn.to_layout"(%{{.*}}) <{layout = #ttnn.layout<{{.*}}>}> : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
+    // CHECK: %{{.*}} = "ttnn.to_layout"(%{{.*}}) : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
     // CHECK: %{{.*}} = "ttnn.to_device"(%{{.*}}, %{{.*}}) : (tensor<[[DIMS:.*]], #{{.*}}>, !ttnn.device) -> tensor<[[DIMS]], #{{.*}}>
-    // CHECK: %{{.*}} = "ttnn.to_layout"(%{{.*}}) <{layout = #ttnn.layout<{{.*}}>}> : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
+    // CHECK: %{{.*}} = "ttnn.to_layout"(%{{.*}}) : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
     // CHECK: %{{.*}} = "ttnn.to_device"(%{{.*}}, %{{.*}}) : (tensor<[[DIMS:.*]], #{{.*}}>, !ttnn.device) -> tensor<[[DIMS]], #{{.*}}>
     // CHECK: %{{.*}} = "ttnn.multiply"(%{{.*}}, %{{.*}})
     %7 = "ttir.multiply"(%3, %5) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
@@ -51,7 +51,7 @@ func.func @conv2d_conv2dconfig(%arg0: tensor<1x1x1024x64xbf16, #ttnn_layout>, %a
   "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> ()
   %3 = "ttnn.from_device"(%2) : (tensor<1x30x30x64xbf16, #ttnn_layout4>) -> tensor<1x30x30x64xbf16, #ttnn_layout5>
   "ttnn.deallocate"(%2) <{force = false}> : (tensor<1x30x30x64xbf16, #ttnn_layout4>) -> ()
-  %4 = "ttnn.to_layout"(%3) <{layout = #ttnn.layout<row_major>}> : (tensor<1x30x30x64xbf16, #ttnn_layout5>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
+  %4 = "ttnn.to_layout"(%3)  : (tensor<1x30x30x64xbf16, #ttnn_layout5>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
   "ttnn.deallocate"(%3) <{force = false}> : (tensor<1x30x30x64xbf16, #ttnn_layout5>) -> ()
   return %4 : tensor<1x30x30x64xbf16, #ttnn_layout3>
 }

--- a/test/ttmlir/EmitC/TTNN/conv/conv3d_with_config.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv3d_with_config.mlir
@@ -31,7 +31,7 @@ func.func @conv3d_with_config(%arg0: tensor<1x8x28x28x32xbf16, #ttnn_layout>, %a
   "ttnn.deallocate"(%arg1) <{force = false}> : (tensor<32x32x3x3x3xbf16, #ttnn_layout1>) -> ()
   %2 = "ttnn.reshape"(%arg2) <{shape = [1 : i32, 32 : i32]}> : (tensor<1x1x1x1x32xbf16, #ttnn_layout2>) -> tensor<1x32xbf16, #ttnn_layout5>
   "ttnn.deallocate"(%arg2) <{force = false}> : (tensor<1x1x1x1x32xbf16, #ttnn_layout2>) -> ()
-  %3 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<1x8x28x28x32xbf16, #ttnn_layout>) -> tensor<1x8x28x28x32xbf16, #ttnn_layout6>
+  %3 = "ttnn.to_layout"(%arg0)  : (tensor<1x8x28x28x32xbf16, #ttnn_layout>) -> tensor<1x8x28x28x32xbf16, #ttnn_layout6>
   "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<1x8x28x28x32xbf16, #ttnn_layout>) -> ()
   %4 = "ttnn.conv3d"(%3, %1, %2, %0) <{
     batch_size = 1 : i32,

--- a/test/ttmlir/Silicon/StableHLO/n150/rand/rand_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/rand/rand_op.mlir
@@ -17,7 +17,6 @@ module {
     // CHECK-LABEL: @test_rand
     // CHECK: "ttnn.rand"(%{{[0-9]+}})
     // CHECK-SAME: high = 1.000000e+00 : f32,
-    // CHECK-SAME: layout = #ttnn.layout<tile>,
     // CHECK-SAME: low = 0.000000e+00 : f32,
     // CHECK-SAME: seed = 0 : ui32,
     // CHECK-SAME: size = #ttnn.shape<8x4>

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_dram_sharded.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_dram_sharded.mlir
@@ -46,6 +46,7 @@
 // CHECK-DAG: #[[DRAM_HS_RM_BF16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<8x1>, memref<32x32xbf16, #dram>, <height_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (7,0)>]>>
 // CHECK-DAG: #[[DRAM_IL_RM_BF16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<1x1>, memref<32x384xbf16, #dram>, <interleaved>>
 // CHECK-DAG: #[[DRAM_IL_TILE_BF16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<1x1>, memref<1x12x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// CHECK-DAG: #[[DRAM_IL_TILE_F32:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}<1x1>, memref<1x12x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 
 module attributes {} {
 
@@ -60,10 +61,9 @@ module attributes {} {
         // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%arg0
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[TO_DEV]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: return %[[UNTILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xbf16, #host_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #host_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
@@ -72,12 +72,11 @@ module attributes {} {
     func.func @dram_ws_tile_bf16_to_dram_il_rm_bf16(%arg0: tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_il_rm_bf16> {
         // CHECK-LABEL: func.func @dram_ws_tile_bf16_to_dram_il_rm_bf16
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[UNTILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_RM_BF16]]>
         // CHECK: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_il_rm_bf16>
     }
 
@@ -85,12 +84,11 @@ module attributes {} {
     func.func @dram_ws_tile_bf16_to_dram_ws_rm_bf16(%arg0: tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16> {
         // CHECK-LABEL: func.func @dram_ws_tile_bf16_to_dram_ws_rm_bf16
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK-NOT: ttnn.to_memory_config
         // CHECK-NOT: ttnn.from_device
         // CHECK: return %[[UNTILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
@@ -98,11 +96,10 @@ module attributes {} {
     func.func @dram_ws_tile_bf16_to_host_rm_bf16(%arg0: tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #host_rm_bf16> {
         // CHECK-LABEL: func.func @dram_ws_tile_bf16_to_host_rm_bf16
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%[[UNTILIZE]])
         // CHECK: return %[[FROM_DEV]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #host_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #host_rm_bf16>
         return %0 : tensor<32x384xbf16, #host_rm_bf16>
     }
 
@@ -111,12 +108,11 @@ module attributes {} {
     func.func @dram_hs_tile_bf16_to_dram_hs_rm_bf16(%arg0: tensor<256x32xbf16, #dram_hs_tile_bf16>) -> tensor<256x32xbf16, #dram_hs_rm_bf16> {
         // CHECK-LABEL: func.func @dram_hs_tile_bf16_to_dram_hs_rm_bf16
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-SAME: -> tensor<256x32xbf16, #[[DRAM_HS_RM_BF16]]>
         // CHECK-NOT: ttnn.to_memory_config
         // CHECK-NOT: ttnn.from_device
         // CHECK: return %[[UNTILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <height_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (7, 0)>]>, <32x32>, <row_major>>>}> : (tensor<256x32xbf16, #dram_hs_tile_bf16>) -> tensor<256x32xbf16, #dram_hs_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<256x32xbf16, #dram_hs_tile_bf16>) -> tensor<256x32xbf16, #dram_hs_rm_bf16>
         return %0 : tensor<256x32xbf16, #dram_hs_rm_bf16>
     }
 
@@ -133,10 +129,9 @@ module attributes {} {
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%[[TO_DEV]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[CAST]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: return %[[UNTILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xf32, #host_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #host_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
@@ -148,12 +143,11 @@ module attributes {} {
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_TILE_BF16]]>
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[CAST]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_RM_BF16]]>
         // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[UNTILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xf32, #dram_il_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #dram_il_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
@@ -165,12 +159,11 @@ module attributes {} {
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[CAST]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[UNTILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_RM_BF16]]>
         // CHECK: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x384xf32, #dram_ws_tile_f32>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #dram_ws_tile_f32>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_il_rm_bf16>
     }
 
@@ -185,10 +178,9 @@ module attributes {} {
         // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: %[[TILIZE:.*]] = "ttnn.to_layout"(%[[TO_DEV]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: return %[[TILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xbf16, #host_rm_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #host_rm_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16>
     }
 
@@ -203,11 +195,11 @@ module attributes {} {
         // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"
         // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_WS_RM_F32]]>
         // CHECK: %[[TILIZE:.*]] = "ttnn.to_layout"(%[[TO_DEV]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_WS_TILE_F32]]>
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%[[TILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: return %[[CAST]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xf32, #host_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #host_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16>
     }
 
@@ -217,13 +209,13 @@ module attributes {} {
     func.func @dram_il_rm_f32_to_dram_ws_tile_bf16(%arg0: tensor<32x384xf32, #dram_il_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16> {
         // CHECK-LABEL: func.func @dram_il_rm_f32_to_dram_ws_tile_bf16
         // CHECK: %[[TILIZE:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_IL_TILE_F32]]>
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%[[TILIZE]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[CAST]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xf32, #dram_il_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #dram_il_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16>
     }
 
@@ -241,7 +233,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[TO_MEM_CONFIG]])
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NEXT: return %[[TYPECAST]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xf32, #dram_il_tile_f32>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xf32, #dram_il_tile_f32>
         return %0 : tensor<32x384xf32, #dram_il_tile_f32>
     }
 
@@ -254,7 +246,7 @@ module attributes {} {
         // CHECK-NOT: ttnn.to_layout
         // CHECK-NOT: ttnn.typecast
         // CHECK: return %[[TO_MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (5, 0)>]>, <32x64>, <row_major>>>}> : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16_grid6>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16_grid6>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16_grid6>
     }
 
@@ -267,7 +259,7 @@ module attributes {} {
         // CHECK-NOT: ttnn.to_layout
         // CHECK-NOT: ttnn.typecast
         // CHECK: return %[[TO_MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <width_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0, 0), (11, 0)>]>, <32x32>, <row_major>>>}> : (tensor<32x384xbf16, #l1_bs_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #l1_bs_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
@@ -1,6 +1,6 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttnn-decompose-layouts -o %t.mlir %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttnn-decompose-layouts --mlir-print-local-scope -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer --mlir-print-local-scope -o %t.ttnn %t.mlir
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
 #ttnn_layout_host_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
@@ -26,7 +26,7 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -39,7 +39,7 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
     }
 
@@ -49,7 +49,7 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
     }
 
@@ -61,7 +61,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[CASTING_OP]], %[[GET_DEVICE_OP]])
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
@@ -73,7 +73,7 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -84,9 +84,8 @@ module attributes {} {
     func.func @from_host_to_host_dt_to_dt_from_tile_to_rm(%arg0: tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm> {
         // This test verifies that the `to_layout` operation is correctly inserted to change the layout from tile to row-major on the host.
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
@@ -94,9 +93,8 @@ module attributes {} {
     func.func @from_host_to_host_dt_to_dt_from_rm_to_tile(%arg0: tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile> {
         // This test verifies that the `to_layout` operation is correctly inserted to change the layout from row-major to tile on the host.
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
@@ -106,9 +104,9 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
@@ -119,9 +117,9 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -132,9 +130,9 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -145,9 +143,9 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
         return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 
@@ -160,9 +158,9 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
@@ -172,9 +170,9 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
@@ -187,9 +185,9 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -200,11 +198,11 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_tile>
     }
 
@@ -215,11 +213,11 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -230,11 +228,11 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: layout = #ttnn.layout<tile>
+        // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}ui32
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
         return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 
@@ -245,7 +243,7 @@ module attributes {} {
         // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[MEM_CONFIG]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK: return %[[TYPECAST]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<1x1x784x512xf32, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <7x8>, memref<4x2x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,6)>]>>>) -> tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<1x1x784x512xf32, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <7x8>, memref<4x2x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,6)>]>>>) -> tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
         return %0 : tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
     }
 

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
@@ -23,14 +23,13 @@ module attributes {} {
     func.func @device_l1_rm_ui16_to_dram_tile_ui16_inserts_typecast_workaround(%arg0: tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16> {
         // CHECK-LABEL: func.func @device_l1_rm_ui16_to_dram_tile_ui16_inserts_typecast_workaround
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: %[[TYPECAST_U32:.*]] = "ttnn.typecast"(%[[TO_LAYOUT]])
         // CHECK-SAME: -> tensor<64x128xui32
         // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST_U32]])
         // CHECK-NEXT: %[[TYPECAST_U16:.*]] = "ttnn.typecast"(%[[TO_MEM_CONFIG]])
         // CHECK-SAME: -> tensor<64x128xui16
         // CHECK-NEXT: return %[[TYPECAST_U16]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
         return %0 : tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
@@ -26,7 +26,7 @@ module attributes {} {
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: return %[[CAST]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #dram_il_rm_f32>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #dram_il_rm_f32>
         return %0 : tensor<32x128xf32, #dram_il_rm_f32>
     }
 
@@ -37,7 +37,7 @@ module attributes {} {
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<32x128xbf16, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: return %[[CAST]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x128xf32, #dram_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xf32, #dram_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x128xbf16, #dram_il_rm_bf16>
     }
 
@@ -48,7 +48,7 @@ module attributes {} {
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<l1>
         // CHECK-NEXT: return %[[CAST]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x128xbf16, #l1_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xbf16, #l1_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
         return %0 : tensor<32x128xf32, #l1_il_rm_f32>
     }
 
@@ -63,7 +63,7 @@ module attributes {} {
         // CHECK-NEXT: %[[MEM:.*]] = "ttnn.to_memory_config"(%[[CAST]])
         // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<l1>
         // CHECK-NEXT: return %[[MEM]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
         return %0 : tensor<32x128xf32, #l1_il_rm_f32>
     }
 
@@ -78,7 +78,7 @@ module attributes {} {
         // CHECK-NEXT: %[[MEM:.*]] = "ttnn.to_memory_config"(%[[CAST]])
         // CHECK-SAME: -> tensor<32x128xbf16, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: return %[[MEM]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x128xf32, #l1_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xf32, #l1_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x128xbf16, #dram_il_rm_bf16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_untilize_on_device.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_untilize_on_device.mlir
@@ -1,6 +1,8 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttnn-decompose-layouts -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+// CHECK-DAG: #[[DRAM_RM_UI16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<32x2048xui16, #dram>
+// CHECK-DAG: #[[L1_RM_UI16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<1x1024xui16, #l1>
 #dram = #ttnn.buffer_type<dram>
 #l1 = #ttnn.buffer_type<l1>
 #ttnn_layout_device_l1_tile_bf16 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x8>, memref<1x2x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
@@ -25,9 +27,8 @@ module attributes {} {
         // CHECK-LABEL: func.func @from_l1_tile_to_dram_rm_bf16
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[MEM_CONFIG]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x2048xbf16, #ttnn_layout_device_l1_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x2048xbf16, #ttnn_layout_device_l1_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
         return %0 : tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
     }
 
@@ -37,9 +38,8 @@ module attributes {} {
         // CHECK-LABEL: func.func @from_l1_tile_to_dram_rm_f32
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[MEM_CONFIG]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x2048xf32, #ttnn_layout_device_l1_tile_f32>) -> tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x2048xf32, #ttnn_layout_device_l1_tile_f32>) -> tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32>
         return %0 : tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32>
     }
 
@@ -48,10 +48,9 @@ module attributes {} {
     func.func @from_dram_tile_to_l1_rm_bf16(%arg0: tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16> {
         // CHECK-LABEL: func.func @from_dram_tile_to_l1_rm_bf16
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TO_LAYOUT]])
         // CHECK: return %[[MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16>
         return %0 : tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16>
     }
 
@@ -59,9 +58,8 @@ module attributes {} {
     func.func @from_dram_tile_to_dram_rm_bf16(%arg0: tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16> {
         // CHECK-LABEL: func.func @from_dram_tile_to_dram_rm_bf16
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
         return %0 : tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
     }
 
@@ -71,9 +69,8 @@ module attributes {} {
         // CHECK-LABEL: func.func @from_l1_sharded_tile_to_dram_rm_bf16
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[MEM_CONFIG]])
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x256xbf16, #ttnn_layout_device_l1_block_sharded_tile_bf16>) -> tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small>
+        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x256xbf16, #ttnn_layout_device_l1_block_sharded_tile_bf16>) -> tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small>
         return %0 : tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small>
     }
 
@@ -84,10 +81,10 @@ module attributes {} {
         // CHECK-LABEL: func.func @from_dram_tile_to_dram_rm_ui16
         // CHECK-NOT: "ttnn.from_device"
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: -> tensor<32x2048xui16, #[[DRAM_RM_UI16]]>
         // CHECK-NOT: "ttnn.from_device"
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_dram_rm_ui16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_dram_rm_ui16>
         return %0 : tensor<32x2048xui16, #ttnn_layout_device_dram_rm_ui16>
     }
 
@@ -99,15 +96,15 @@ module attributes {} {
         // CHECK-LABEL: func.func @from_dram_tile_to_l1_rm_ui16
         // CHECK-NOT: "ttnn.from_device"
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: layout = #ttnn.layout<row_major>
+        // CHECK-SAME: -> tensor<32x2048xui16, #[[DRAM_RM_UI16]]>
         // CHECK: %[[TYPECAST_U32:.*]] = "ttnn.typecast"(%[[TO_LAYOUT]])
         // CHECK-SAME: -> tensor<{{.*}}ui32
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST_U32]])
         // CHECK: %[[TYPECAST_U16:.*]] = "ttnn.typecast"(%[[MEM_CONFIG]])
-        // CHECK-SAME: -> tensor<{{.*}}ui16
+        // CHECK-SAME: -> tensor<32x2048xui16, #[[L1_RM_UI16]]>
         // CHECK-NOT: "ttnn.from_device"
         // CHECK: return %[[TYPECAST_U16]]
-        %0 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_l1_rm_ui16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_l1_rm_ui16>
         return %0 : tensor<32x2048xui16, #ttnn_layout_device_l1_rm_ui16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/data_movement/scatter/scatter.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/data_movement/scatter/scatter.mlir
@@ -58,10 +58,10 @@ func.func @scatter_simple_3(%arg0: tensor<71x32xbf16>, %arg1: tensor<71x4x2xi64>
 // Scatter with f32. For f32, there is a layout conversion before and after scatter due to tt-metal f32 scatter limitations.
 func.func @scatter_simple_4(%arg0: tensor<1000x32xf32>, %arg1: tensor<10x32xi64>, %arg2: tensor<10x32xf32>) -> tensor<1000x32xf32> {
   // CHECK-LABEL: func.func @scatter_simple_4
-  // CHECK: "ttnn.to_layout"({{.*}}) <{layout = #ttnn.layout<row_major>}>
-  // CHECK: "ttnn.to_layout"({{.*}}) <{layout = #ttnn.layout<row_major>}>
+  // CHECK: "ttnn.to_layout"({{.*}})
+  // CHECK: "ttnn.to_layout"({{.*}})
   // CHECK: "ttnn.scatter"({{.*}}) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<1000x32xf32, {{.*}}>, tensor<10x32xsi32, {{.*}}>, tensor<10x32xf32, {{.*}}>) -> tensor<1000x32xf32, {{.*}}>
-  // CHECK: "ttnn.to_layout"({{.*}}) <{layout = #ttnn.layout<tile>}>
+  // CHECK: "ttnn.to_layout"({{.*}})
   %0 = "ttir.scatter"(%arg0, %arg1, %arg2) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<1000x32xf32>, tensor<10x32xi64>, tensor<10x32xf32>) -> tensor<1000x32xf32>
   return %0 : tensor<1000x32xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
@@ -48,7 +48,7 @@ module attributes {} {
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> ()
     %3 = "ttnn.from_device"(%2) : (tensor<1x30x30x64xbf16, #ttnn_layout4>) -> tensor<1x30x30x64xbf16, #ttnn_layout5>
     "ttnn.deallocate"(%2) <{force = false}> : (tensor<1x30x30x64xbf16, #ttnn_layout4>) -> ()
-    %4 = "ttnn.to_layout"(%3) <{layout = #ttnn.layout<row_major>}> : (tensor<1x30x30x64xbf16, #ttnn_layout5>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
+    %4 = "ttnn.to_layout"(%3)  : (tensor<1x30x30x64xbf16, #ttnn_layout5>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
     "ttnn.deallocate"(%3) <{force = false}> : (tensor<1x30x30x64xbf16, #ttnn_layout5>) -> ()
     return %4 : tensor<1x30x30x64xbf16, #ttnn_layout3>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_device_compute_kernel_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_device_compute_kernel_config.mlir
@@ -40,7 +40,7 @@ module attributes {} {
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> ()
     %3 = "ttnn.from_device"(%2) : (tensor<1x30x30x64xbf16, #ttnn_layout4>) -> tensor<1x30x30x64xbf16, #ttnn_layout5>
     "ttnn.deallocate"(%2) <{force = false}> : (tensor<1x30x30x64xbf16, #ttnn_layout4>) -> ()
-    %4 = "ttnn.to_layout"(%3) <{layout = #ttnn.layout<row_major>}> : (tensor<1x30x30x64xbf16, #ttnn_layout5>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
+    %4 = "ttnn.to_layout"(%3)  : (tensor<1x30x30x64xbf16, #ttnn_layout5>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
     "ttnn.deallocate"(%3) <{force = false}> : (tensor<1x30x30x64xbf16, #ttnn_layout5>) -> ()
     return %4 : tensor<1x30x30x64xbf16, #ttnn_layout3>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_device_compute_kernel_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_device_compute_kernel_config.mlir
@@ -36,7 +36,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<3x8x8x256xbf16, #ttnn_layout>, %arg1: tensor<256x256x3x3xbf16, #ttnn_layout1>, %arg2: tensor<1x1x1x256xbf16, #ttnn_layout2>) -> tensor<3x10x10x256xbf16, #ttnn_layout3> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<3x8x8x256xbf16, #ttnn_layout>) -> tensor<3x8x8x256xbf16, #ttnn_layout4>
+    %1 = "ttnn.to_layout"(%arg0)  : (tensor<3x8x8x256xbf16, #ttnn_layout>) -> tensor<3x8x8x256xbf16, #ttnn_layout4>
     "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<3x8x8x256xbf16, #ttnn_layout>) -> ()
     %2 = "ttnn.conv_transpose2d"(%1, %arg1, %arg2, %0)
             <{

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_with_conv2d_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_with_conv2d_config.mlir
@@ -28,7 +28,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<3x8x8x256xbf16, #ttnn_layout>, %arg1: tensor<256x256x3x3xbf16, #ttnn_layout1>, %arg2: tensor<1x1x1x256xbf16, #ttnn_layout2>) -> tensor<3x10x10x256xbf16, #ttnn_layout3> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<3x8x8x256xbf16, #ttnn_layout>) -> tensor<3x8x8x256xbf16, #ttnn_layout4>
+    %1 = "ttnn.to_layout"(%arg0)  : (tensor<3x8x8x256xbf16, #ttnn_layout>) -> tensor<3x8x8x256xbf16, #ttnn_layout4>
     "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<3x8x8x256xbf16, #ttnn_layout>) -> ()
     %2 = "ttnn.conv_transpose2d"(%1, %arg1, %arg2, %0)
             <{

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_rand.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_rand.mlir
@@ -10,7 +10,6 @@ module attributes {} {
     // CHECK: %[[DEVICE:[0-9]+]] = "ttnn.get_device"()
     // CHECK: %{{[0-9]+}} = "ttnn.rand"(%[[DEVICE]])
     // CHECK-SAME: high = 1.000000e+00 : f32,
-    // CHECK-SAME: layout = #ttnn.layout<tile>,
     // CHECK-SAME: low = 0.000000e+00 : f32,
     // CHECK-SAME: seed = 0 : ui32,
     // CHECK-SAME: size = #ttnn.shape<32x32>

--- a/test/ttmlir/Silicon/TTNN/n150/rand/simple_rand.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/rand/simple_rand.mlir
@@ -10,7 +10,6 @@ module attributes {} {
     // CHECK: %[[DEVICE:[0-9]+]] = "ttnn.get_device"()
     // CHECK: %{{[0-9]+}} = "ttnn.rand"(%[[DEVICE]])
     // CHECK-SAME: high = 1.000000e+00 : f32,
-    // CHECK-SAME: layout = #ttnn.layout<tile>,
     // CHECK-SAME: low = 0.000000e+00 : f32,
     // CHECK-SAME: seed = 0 : ui32,
     // CHECK-SAME: size = #ttnn.shape<32x32>

--- a/test/ttmlir/Transforms/memory_management.mlir
+++ b/test/ttmlir/Transforms/memory_management.mlir
@@ -116,13 +116,13 @@ module {
   }
   // permute-reshape row-major adjust:
   // CHECK-LABEL: func.func @permute_reshape_row_major_adjusting
-  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}>
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0)
   // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RM_IN]])
   // CHECK-SAME: permutation = array<i64: 1, 0>
   // CHECK-SAME: -> tensor<67108864x1xf32
   // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[PERM]]) <{shape = [8192 : i32, 8192 : i32]}>
   // CHECK-SAME: -> tensor<8192x8192xf32
-  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[RESHAPE]]) <{layout = #ttnn.layout<tile>}>
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[RESHAPE]])
   // CHECK: return %[[RESTORED]]
   func.func @permute_reshape_row_major_adjusting(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<8192x8192xf32, #layout_8192x8192_tile> {
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
@@ -132,7 +132,7 @@ module {
 
   // permute-repeat-reshape row-major adjust:
   // CHECK-LABEL: func.func @permute_repeat_reshape_row_major_adjusting
-  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}>
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0)
   // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RM_IN]])
   // CHECK-SAME: permutation = array<i64: 1, 0>
   // CHECK-SAME: -> tensor<67108864x1xf32
@@ -140,7 +140,7 @@ module {
   // CHECK-SAME: -> tensor<67108864x2xf32
   // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[REPEAT]]) <{shape = [8192 : i32, 16384 : i32]}>
   // CHECK-SAME: -> tensor<8192x16384xf32
-  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[RESHAPE]]) <{layout = #ttnn.layout<tile>}>
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[RESHAPE]])
   // CHECK: return %[[RESTORED]]
   func.func @permute_repeat_reshape_row_major_adjusting(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<8192x16384xf32, #layout_8192x16384_tile> {
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
@@ -151,13 +151,13 @@ module {
 
   // reshape-permute row-major adjust:
   // CHECK-LABEL: func.func @reshape_permute_row_major_adjusting
-  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}>
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0)
   // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[RM_IN]]) <{shape = [8192 : i32, 8192 : i32, 1 : i32, 1 : i32]}>
   // CHECK-SAME: -> tensor<8192x8192x1x1xf32
   // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RESHAPE]])
   // CHECK-SAME: permutation = array<i64: 2, 3, 0, 1>
   // CHECK-SAME: -> tensor<1x1x8192x8192xf32
-  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[PERM]]) <{layout = #ttnn.layout<tile>}>
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[PERM]])
   // CHECK: return %[[RESTORED]]
   func.func @reshape_permute_row_major_adjusting(%arg0: tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>) -> tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile> {
     %0 = "ttnn.reshape"(%arg0) <{shape = [8192 : i32, 8192 : i32, 1 : i32, 1 : i32]}> : (tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>) -> tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>

--- a/test/unittests/OpModel/TTNN/Op/TestD2MOpCostModel.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestD2MOpCostModel.cpp
@@ -39,9 +39,9 @@ public:
     }
     auto rankedTensorType =
         createRankedTensorType(tensorShape, elementType, layout);
-    return builder.create<OnesOp>(
-        builder.getUnknownLoc(), rankedTensorType, /*device=*/nullptr,
-        ShapeAttr::get(&context, tensorShape), /*layout=*/nullptr);
+    return builder.create<OnesOp>(builder.getUnknownLoc(), rankedTensorType,
+                                  /*device=*/nullptr,
+                                  ShapeAttr::get(&context, tensorShape));
   }
 
   std::vector<TTNNLayoutAttr> getInputLayoutsFromOperands(mlir::Operation *op) {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -98,9 +98,9 @@ public:
     }
     RankedTensorType rankedTensorType =
         createRankedTensorType(tensorShape, elementType, layout);
-    return builder.create<OnesOp>(
-        builder.getUnknownLoc(), rankedTensorType, /*device=*/nullptr,
-        ShapeAttr::get(&context, tensorShape), /*layout=*/nullptr);
+    return builder.create<OnesOp>(builder.getUnknownLoc(), rankedTensorType,
+                                  /*device=*/nullptr,
+                                  ShapeAttr::get(&context, tensorShape));
   }
 };
 struct ExpectedResult {
@@ -661,9 +661,9 @@ TEST_F(OpModelBase, BitwiseNotOpInterface) {
   auto outputType = createRankedTensorType(tensorShape, intType, int32Layout);
 
   // Create input tensor using OnesOp with Int32 layout
-  auto input = builder.create<OnesOp>(
-      builder.getUnknownLoc(), inputType, /*device=*/nullptr,
-      ShapeAttr::get(&context, tensorShape), /*layout=*/nullptr);
+  auto input = builder.create<OnesOp>(builder.getUnknownLoc(), inputType,
+                                      /*device=*/nullptr,
+                                      ShapeAttr::get(&context, tensorShape));
 
   auto bitwiseNot = builder.create<BitwiseNotOp>(
       builder.getUnknownLoc(), outputType, ::mlir::ValueRange{input});
@@ -717,12 +717,12 @@ TEST_F(OpModelBase, LogicalRightShiftOpInterface) {
   auto outputType = createRankedTensorType(tensorShape, intType, int32Layout);
 
   // Create input tensors using OnesOp with Int32 layout
-  auto input1 = builder.create<OnesOp>(
-      builder.getUnknownLoc(), input1Type, /*device=*/nullptr,
-      ShapeAttr::get(&context, tensorShape), /*layout=*/nullptr);
-  auto input2 = builder.create<OnesOp>(
-      builder.getUnknownLoc(), input2Type, /*device=*/nullptr,
-      ShapeAttr::get(&context, tensorShape), /*layout=*/nullptr);
+  auto input1 = builder.create<OnesOp>(builder.getUnknownLoc(), input1Type,
+                                       /*device=*/nullptr,
+                                       ShapeAttr::get(&context, tensorShape));
+  auto input2 = builder.create<OnesOp>(builder.getUnknownLoc(), input2Type,
+                                       /*device=*/nullptr,
+                                       ShapeAttr::get(&context, tensorShape));
 
   auto logicalRightShift = builder.create<LogicalRightShiftOp>(
       builder.getUnknownLoc(), outputType, ::mlir::ValueRange{input1, input2});
@@ -775,12 +775,12 @@ TEST_F(OpModelBase, LogicalLeftShiftOpInterface) {
   auto outputType = createRankedTensorType(tensorShape, intType, int32Layout);
 
   // Create input tensors using OnesOp with Int32 layout
-  auto input1 = builder.create<OnesOp>(
-      builder.getUnknownLoc(), input1Type, /*device=*/nullptr,
-      ShapeAttr::get(&context, tensorShape), /*layout=*/nullptr);
-  auto input2 = builder.create<OnesOp>(
-      builder.getUnknownLoc(), input2Type, /*device=*/nullptr,
-      ShapeAttr::get(&context, tensorShape), /*layout=*/nullptr);
+  auto input1 = builder.create<OnesOp>(builder.getUnknownLoc(), input1Type,
+                                       /*device=*/nullptr,
+                                       ShapeAttr::get(&context, tensorShape));
+  auto input2 = builder.create<OnesOp>(builder.getUnknownLoc(), input2Type,
+                                       /*device=*/nullptr,
+                                       ShapeAttr::get(&context, tensorShape));
 
   auto logicalLeftShift = builder.create<LogicalLeftShiftOp>(
       builder.getUnknownLoc(), outputType, ::mlir::ValueRange{input1, input2});
@@ -1468,11 +1468,7 @@ TEST_F(OpModelBase, toLayoutOp) {
   RankedTensorType rankedTensorType = createRankedTensorType(tensorShape);
   auto tensor = builder.create<OnesOp>(
       builder.getUnknownLoc(), rankedTensorType,
-      /*device=*/nullptr, ShapeAttr::get(&context, tensorShape),
-      LayoutAttr::get(&context, Layout::RowMajor));
-
-  ToLayoutOp toLayout = builder.create<ToLayoutOp>(
-      builder.getUnknownLoc(), tensor.getType(), tensor, Layout::Tile);
+      /*device=*/nullptr, ShapeAttr::get(&context, tensorShape));
 
   // Manually create the operand layouts for calling the backend to make sure
   // the layouts are propagated all the way
@@ -1480,6 +1476,11 @@ TEST_F(OpModelBase, toLayoutOp) {
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   const TTNNLayoutAttr layoutDRAMTiled = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  RankedTensorType outputTensorType = RankedTensorType::get(
+      tensorShape, rankedTensorType.getElementType(), layoutDRAMTiled);
+  ToLayoutOp toLayout = builder.create<ToLayoutOp>(builder.getUnknownLoc(),
+                                                   outputTensorType, tensor);
 
   OpModel backend = dyn_cast<OpModel>(toLayout.getOperation());
   if (!backend) {
@@ -2657,9 +2658,9 @@ TEST_F(OpModelBase, typecastOp) {
   RankedTensorType rankedTensorTypeBF16 =
       RankedTensorType::get(tensorShape, builder.getBF16Type());
 
-  auto input = builder.create<OnesOp>(
-      builder.getUnknownLoc(), rankedTensorTypeBF16, /*device=*/nullptr,
-      ShapeAttr::get(&context, tensorShape), /*layout=*/nullptr);
+  auto input = builder.create<OnesOp>(builder.getUnknownLoc(),
+                                      rankedTensorTypeBF16, /*device=*/nullptr,
+                                      ShapeAttr::get(&context, tensorShape));
   RankedTensorType rankedTensorTypeF32 =
       RankedTensorType::get(tensorShape, builder.getF32Type());
 
@@ -2694,9 +2695,9 @@ TEST_F(OpModelBase, bitcastConvertOp) {
   RankedTensorType rankedTensorTypeBF16 =
       RankedTensorType::get(tensorShape, builder.getBF16Type());
 
-  auto input = builder.create<OnesOp>(
-      builder.getUnknownLoc(), rankedTensorTypeBF16, /*device=*/nullptr,
-      ShapeAttr::get(&context, tensorShape), /*layout=*/nullptr);
+  auto input = builder.create<OnesOp>(builder.getUnknownLoc(),
+                                      rankedTensorTypeBF16, /*device=*/nullptr,
+                                      ShapeAttr::get(&context, tensorShape));
   RankedTensorType rankedTensorTypeU16 =
       RankedTensorType::get(tensorShape, builder.getIntegerType(16, false));
 
@@ -5179,8 +5180,6 @@ TEST_F(OpModelBase, EmptyOpInterface) {
 
   // Cast to get TTNN layout attributes
   RankedTensorType inputTensorType = mlir::cast<RankedTensorType>(inputType);
-  ttnn::TTNNLayoutAttr ttnnLayoutAttr =
-      mlir::cast<ttnn::TTNNLayoutAttr>(inputTensorType.getEncoding());
 
   // Create a device value (required for EmptyOp)
   auto device = builder.create<ttnn::GetDeviceOp>(
@@ -5191,8 +5190,7 @@ TEST_F(OpModelBase, EmptyOpInterface) {
   // Create the EmptyOp with all required parameters
   auto empty = builder.create<ttnn::EmptyOp>(
       builder.getUnknownLoc(), inputType, device,
-      ttnn::ShapeAttr::get(&context, inputTensorType.getShape()),
-      ttnn::LayoutAttr::get(&context, ttnnLayoutAttr.getLayout()));
+      ttnn::ShapeAttr::get(&context, inputTensorType.getShape()));
 
   // test EmptyOp interface
   auto constraintsExp = getOpConstraints(empty.getOperation());
@@ -5223,7 +5221,7 @@ TEST_F(OpModelBase, ArangeOpInterface) {
 
   auto arange = builder.create<ArangeOp>(builder.getUnknownLoc(), resultType,
                                          /*device=*/nullptr, startAttr, endAttr,
-                                         stepAttr, /*layout=*/nullptr);
+                                         stepAttr);
 
   // test ArangeOp interface
   auto backend = dyn_cast<OpModel>(arange.getOperation());
@@ -5289,17 +5287,11 @@ TEST_P(NamedFullOpModelTest, TestOpInterface) {
 
 const auto createZeros = [](OpBuilder &b, Location loc, Type type,
                             ttnn::ShapeAttr shape) {
-  return b
-      .create<ZerosOp>(loc, type, /*device=*/nullptr, shape,
-                       /*layout=*/nullptr)
-      .getOperation();
+  return b.create<ZerosOp>(loc, type, /*device=*/nullptr, shape).getOperation();
 };
 const auto createOnes = [](OpBuilder &b, Location loc, Type type,
                            ttnn::ShapeAttr shape) {
-  return b
-      .create<OnesOp>(loc, type, /*device=*/nullptr, shape,
-                      /*layout=*/nullptr)
-      .getOperation();
+  return b.create<OnesOp>(loc, type, /*device=*/nullptr, shape).getOperation();
 };
 
 const ExpectedResult namedFullExpected{true};
@@ -5324,7 +5316,7 @@ TEST_F(OpModelBase, FullOpInterface) {
   auto fullInt = builder.create<FullOp>(
       builder.getUnknownLoc(), outputType, /*device=*/nullptr,
       ttnn::ShapeAttr::get(&context, tensorShape),
-      builder.getI32IntegerAttr(42), nullptr);
+      builder.getI32IntegerAttr(42));
 
   // test FullOp interface with int fill value:
   auto backendI = dyn_cast<OpModel>(fullInt.getOperation());
@@ -5345,8 +5337,8 @@ TEST_F(OpModelBase, FullOpInterface) {
   // test FullOp interface with float fill value:
   auto fullF = builder.create<FullOp>(
       builder.getUnknownLoc(), outputType, /*device=*/nullptr,
-      ttnn::ShapeAttr::get(&context, tensorShape), builder.getF32FloatAttr(0.5),
-      nullptr);
+      ttnn::ShapeAttr::get(&context, tensorShape),
+      builder.getF32FloatAttr(0.5));
   auto backendF = dyn_cast<OpModel>(fullF.getOperation());
   auto constraintsExpF =
       backendF.getOpConstraints(getInputLayouts(fullF), OpConfig(nullptr));
@@ -5380,7 +5372,7 @@ TEST_F(OpModelBase, ConstantOpInterface) {
 
   auto constant =
       builder.create<ConstantOp>(builder.getUnknownLoc(), outputType,
-                                 /*device=*/nullptr, attr, nullptr);
+                                 /*device=*/nullptr, attr);
 
   auto backend = dyn_cast<OpModel>(constant.getOperation());
   auto constraintsExp = backend.getOpConstraints(getInputLayouts(constant),
@@ -5419,7 +5411,7 @@ TEST_F(OpModelBase, ConstantOpInterfaceBF16) {
 
   auto constant =
       builder.create<ConstantOp>(builder.getUnknownLoc(), outputType,
-                                 /*device=*/nullptr, attr, nullptr);
+                                 /*device=*/nullptr, attr);
 
   auto backend = dyn_cast<OpModel>(constant.getOperation());
   auto constraintsExp = backend.getOpConstraints(getInputLayouts(constant),
@@ -5455,7 +5447,7 @@ TEST_F(OpModelBase, ConstantOpInterfaceNullOutputLayout) {
 
   auto constant =
       builder.create<ConstantOp>(builder.getUnknownLoc(), outputType,
-                                 /*device=*/nullptr, attr, nullptr);
+                                 /*device=*/nullptr, attr);
 
   auto backend = dyn_cast<OpModel>(constant.getOperation());
   auto constraintsExp =
@@ -5491,8 +5483,7 @@ TEST_F(OpModelBase, RandOpInterface) {
   auto randOp = builder.create<RandOp>(
       builder.getUnknownLoc(), outputType, device,
       ttnn::ShapeAttr::get(&context, tensorShape),
-      /*low=*/nullptr, /*high=*/nullptr, /*seed=*/nullptr,
-      /*layout=*/nullptr);
+      /*low=*/nullptr, /*high=*/nullptr, /*seed=*/nullptr);
 
   // Test RandOp interface
   auto backend = dyn_cast<OpModel>(randOp.getOperation());
@@ -5514,10 +5505,9 @@ TEST_F(OpModelBase, RandOpInterface) {
   auto randOpCustom =
       builder.create<RandOp>(builder.getUnknownLoc(), outputType, device,
                              ttnn::ShapeAttr::get(&context, tensorShape),
-                             builder.getF32FloatAttr(-1.0),  // low
-                             builder.getF32FloatAttr(2.0),   // high
-                             builder.getUI32IntegerAttr(42), // seed
-                             /*layout=*/nullptr);
+                             builder.getF32FloatAttr(-1.0),   // low
+                             builder.getF32FloatAttr(2.0),    // high
+                             builder.getUI32IntegerAttr(42)); // seed
 
   // Test RandOp interface with custom parameters
   auto backendCustom = dyn_cast<OpModel>(randOpCustom.getOperation());

--- a/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
+++ b/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
@@ -63,7 +63,7 @@ public:
     ShapeAttr shapeAttr = ShapeAttr::get(&context, getTensorShape());
     return builder.create<OnesOp>(builder.getUnknownLoc(),
                                   getTensorRankedType(), /*device=*/nullptr,
-                                  shapeAttr, /*layout=*/nullptr);
+                                  shapeAttr);
   }
 
   mlir::func::FuncOp createFuncOp() {

--- a/test/unittests/Optimizer/TestLegalLayoutAnalysis.cpp
+++ b/test/unittests/Optimizer/TestLegalLayoutAnalysis.cpp
@@ -111,8 +111,7 @@ protected:
     // Create an empty tensor
     auto empty = builder.create<mlir::tt::ttnn::EmptyOp>(
         builder.getUnknownLoc(), tensorType, device,
-        mlir::tt::ttnn::ShapeAttr::get(&context, getTensorShape()),
-        mlir::tt::ttnn::LayoutAttr::get(&context, Layout::Tile));
+        mlir::tt::ttnn::ShapeAttr::get(&context, getTensorShape()));
 
     // Use that tensor in a ReluOp so we have a relevant op with a tensor result
     auto relu = builder.create<mlir::tt::ttnn::ReluOp>(builder.getUnknownLoc(),

--- a/test/unittests/Optimizer/TestLegalTensorLayoutAnalysis.cpp
+++ b/test/unittests/Optimizer/TestLegalTensorLayoutAnalysis.cpp
@@ -102,8 +102,7 @@ protected:
     // Create an empty op with all required parameters
     builder.create<mlir::tt::ttnn::EmptyOp>(
         builder.getUnknownLoc(), tensorType, device,
-        mlir::tt::ttnn::ShapeAttr::get(&context, getTensorShape()),
-        mlir::tt::ttnn::LayoutAttr::get(&context, Layout::Tile));
+        mlir::tt::ttnn::ShapeAttr::get(&context, getTensorShape()));
 
     // Add return op
     builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc());

--- a/test/unittests/Optimizer/TestOpModelStrategy.cpp
+++ b/test/unittests/Optimizer/TestOpModelStrategy.cpp
@@ -96,13 +96,11 @@ public:
 
     auto input1 = builder.create<OnesOp>(builder.getUnknownLoc(), tensorType,
                                          /*device=*/nullptr,
-                                         ShapeAttr::get(&context, inputShape),
-                                         /*layout=*/nullptr);
+                                         ShapeAttr::get(&context, inputShape));
 
     auto input2 = builder.create<OnesOp>(builder.getUnknownLoc(), tensorType,
                                          /*device=*/nullptr,
-                                         ShapeAttr::get(&context, inputShape),
-                                         /*layout=*/nullptr);
+                                         ShapeAttr::get(&context, inputShape));
 
     return builder.create<AddOp>(builder.getUnknownLoc(), tensorType,
                                  input1.getResult(), input2.getResult());
@@ -122,8 +120,7 @@ public:
 
     auto input = builder.create<OnesOp>(
         builder.getUnknownLoc(), inputTensorType,
-        /*device=*/nullptr, ShapeAttr::get(&context, inputShape),
-        /*layout=*/nullptr);
+        /*device=*/nullptr, ShapeAttr::get(&context, inputShape));
 
     llvm::SmallVector<int32_t> outputShapeI32(outputShape.begin(),
                                               outputShape.end());
@@ -152,13 +149,11 @@ public:
 
     auto lhs = builder.create<OnesOp>(builder.getUnknownLoc(), lhsTensorType,
                                       /*device=*/nullptr,
-                                      ShapeAttr::get(&context, lhsShape),
-                                      /*layout=*/nullptr);
+                                      ShapeAttr::get(&context, lhsShape));
 
     auto rhs = builder.create<OnesOp>(builder.getUnknownLoc(), rhsTensorType,
                                       /*device=*/nullptr,
-                                      ShapeAttr::get(&context, rhsShape),
-                                      /*layout=*/nullptr);
+                                      ShapeAttr::get(&context, rhsShape));
 
     return builder.create<MatmulOp>(builder.getUnknownLoc(), outputTensorType,
                                     lhs.getResult(), rhs.getResult(),

--- a/test/unittests/Optimizer/TestShardSolver.cpp
+++ b/test/unittests/Optimizer/TestShardSolver.cpp
@@ -63,7 +63,7 @@ public:
     ShapeAttr shapeAttr = ShapeAttr::get(&context, getTensorShape());
     return builder.create<OnesOp>(builder.getUnknownLoc(),
                                   getTensorRankedType(), /*device=*/nullptr,
-                                  shapeAttr, /*layout=*/nullptr);
+                                  shapeAttr);
   }
 
   mlir::func::FuncOp createFuncOp() {

--- a/test/unittests/Validation/TestOpConstraintValidation.cpp
+++ b/test/unittests/Validation/TestOpConstraintValidation.cpp
@@ -100,13 +100,11 @@ public:
     // Create two input tensors using OnesOp (simpler than EmptyOp)
     auto input1 = builder.create<OnesOp>(builder.getUnknownLoc(), tensorType,
                                          /*device=*/nullptr,
-                                         ShapeAttr::get(&context, inputShape),
-                                         /*layout=*/nullptr);
+                                         ShapeAttr::get(&context, inputShape));
 
     auto input2 = builder.create<OnesOp>(builder.getUnknownLoc(), tensorType,
                                          /*device=*/nullptr,
-                                         ShapeAttr::get(&context, inputShape),
-                                         /*layout=*/nullptr);
+                                         ShapeAttr::get(&context, inputShape));
 
     // Create AddOp
     return builder.create<AddOp>(builder.getUnknownLoc(), tensorType,
@@ -179,8 +177,7 @@ TEST_F(OpConstraintValidationTest, UpdateCacheOpWithInvalidUpdateIndexType) {
       cacheShape, builder.getBF16Type(), cacheLayout);
   auto cacheOp = builder.create<OnesOp>(
       builder.getUnknownLoc(), cacheTensorType,
-      /*device=*/nullptr, ShapeAttr::get(&context, cacheShape),
-      /*layout=*/nullptr);
+      /*device=*/nullptr, ShapeAttr::get(&context, cacheShape));
 
   // Create input tensor (4D tensor with dim 2 = 1)
   llvm::SmallVector<int64_t> inputShape = {1, 1, 1, 32};
@@ -190,8 +187,7 @@ TEST_F(OpConstraintValidationTest, UpdateCacheOpWithInvalidUpdateIndexType) {
       inputShape, builder.getBF16Type(), inputLayout);
   auto inputOp = builder.create<OnesOp>(
       builder.getUnknownLoc(), inputTensorType,
-      /*device=*/nullptr, ShapeAttr::get(&context, inputShape),
-      /*layout=*/nullptr);
+      /*device=*/nullptr, ShapeAttr::get(&context, inputShape));
 
   // Create update_index tensor with WRONG type (BF16 instead of uint32)
   // This should cause validation to fail
@@ -202,8 +198,7 @@ TEST_F(OpConstraintValidationTest, UpdateCacheOpWithInvalidUpdateIndexType) {
       updateIndexShape, builder.getBF16Type(), updateIndexLayout);
   auto updateIndexOp = builder.create<OnesOp>(
       builder.getUnknownLoc(), updateIndexTensorType,
-      /*device=*/nullptr, ShapeAttr::get(&context, updateIndexShape),
-      /*layout=*/nullptr);
+      /*device=*/nullptr, ShapeAttr::get(&context, updateIndexShape));
 
   // Create UpdateCacheOp (inplace operation, no result type)
   auto updateCacheOp = builder.create<ttnn::UpdateCacheOp>(
@@ -233,8 +228,7 @@ TEST_F(OpConstraintValidationTest, UpdateCacheOpWithInvalidUpdateIndexType) {
       updateIndexShape, uint32Type, uint32UpdateIndexLayout);
   auto uint32UpdateIndexOp = builder.create<OnesOp>(
       builder.getUnknownLoc(), uint32UpdateIndexTensorType,
-      /*device=*/nullptr, ShapeAttr::get(&context, updateIndexShape),
-      /*layout=*/nullptr);
+      /*device=*/nullptr, ShapeAttr::get(&context, updateIndexShape));
 
   // Create UpdateCacheOp with correct uint32 type
   auto validUpdateCacheOp = builder.create<ttnn::UpdateCacheOp>(
@@ -394,8 +388,7 @@ TEST_F(OpConstraintValidationTest, ValidationStatusMetalBackendError) {
 
   auto input = builder.create<OnesOp>(builder.getUnknownLoc(), inputTensorType,
                                       /*device=*/nullptr,
-                                      ShapeAttr::get(&context, tensorShape),
-                                      /*layout=*/nullptr);
+                                      ShapeAttr::get(&context, tensorShape));
 
   // Output: L1 RowMajor HeightSharded layout (incompatible with DRAM Tiled)
   auto outputLayout = createRowMajorHSLayout(tensorShape, BufferType::L1,
@@ -405,8 +398,7 @@ TEST_F(OpConstraintValidationTest, ValidationStatusMetalBackendError) {
 
   // Create ToLayoutOp with incompatible input/output layouts
   auto toLayoutOp = builder.create<ToLayoutOp>(
-      builder.getUnknownLoc(), outputTensorType, input.getResult(),
-      LayoutAttr::get(&context, Layout::RowMajor));
+      builder.getUnknownLoc(), outputTensorType, input.getResult());
 
   auto layouts = ttnn::utils::extractInputLayouts(toLayoutOp);
   OpConfig config(outputLayout, OpConfig::OpSpecificAttrs{});
@@ -439,13 +431,11 @@ TEST_F(OpConstraintValidationTest, ValidationStatusOutOfMemoryError) {
 
   auto input1 = builder.create<OnesOp>(builder.getUnknownLoc(), tensorType,
                                        /*device=*/nullptr,
-                                       ShapeAttr::get(&context, largeShape),
-                                       /*layout=*/nullptr);
+                                       ShapeAttr::get(&context, largeShape));
 
   auto input2 = builder.create<OnesOp>(builder.getUnknownLoc(), tensorType,
                                        /*device=*/nullptr,
-                                       ShapeAttr::get(&context, largeShape),
-                                       /*layout=*/nullptr);
+                                       ShapeAttr::get(&context, largeShape));
 
   auto addOp = builder.create<AddOp>(builder.getUnknownLoc(), tensorType,
                                      input1.getResult(), input2.getResult());

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -7653,7 +7653,6 @@ class TTNNBuilder(Builder):
         else:
             fill_value_attr = FloatAttr.get_f32(fill_value)
 
-        layout_attr = ttnn.ir.LayoutAttr.get(self._ctx, layout)
         result = self.create_ttnn_tensor(
             shape, mlir_output_type, layout=layout, buffer_type=buffer_type
         )
@@ -7674,7 +7673,6 @@ class TTNNBuilder(Builder):
             shape=shape_attr,
             fill_value=fill_value_attr,
             device=device,
-            layout=layout_attr,
             loc=loc,
         )
         op_result = op.result
@@ -7702,7 +7700,6 @@ class TTNNBuilder(Builder):
             shape=old_op.shape,
             fill_value=old_op.fill_value,
             device=device,
-            layout=old_op.layout,
             loc=old_op.location,
         )
         new_op_result = new_op.result
@@ -7763,7 +7760,6 @@ class TTNNBuilder(Builder):
                         shape=old_op.shape,
                         fill_value=old_op.fill_value,
                         device=device,
-                        layout=old_op.layout,
                         loc=old_op.location,
                     )
                     new_op_result = new_op.result
@@ -7811,7 +7807,6 @@ class TTNNBuilder(Builder):
         value_shape = list(value.shape)
         mlir_value_type = RankedTensorType.get(value_shape, mlir_output_type)
 
-        layout_attr = ttnn.ir.LayoutAttr.get(self._ctx, layout)
         result = self.create_ttnn_tensor(
             value_shape, mlir_output_type, layout=layout, buffer_type=buffer_type
         )
@@ -7837,7 +7832,6 @@ class TTNNBuilder(Builder):
             result,
             value=value_attr,
             device=device,
-            layout=layout_attr,
             loc=loc,
         )
         op_result = op.result
@@ -7864,7 +7858,6 @@ class TTNNBuilder(Builder):
             result,
             value=old_op.value,
             device=device,
-            layout=old_op.layout,
             loc=old_op.location,
         )
         new_op_result = new_op.result
@@ -7924,7 +7917,6 @@ class TTNNBuilder(Builder):
                         result,
                         value=old_op.value,
                         device=device,
-                        layout=old_op.layout,
                         loc=old_op.location,
                     )
                     new_op_result = new_op.result
@@ -8429,7 +8421,6 @@ class TTNNBuilder(Builder):
             output_to_dram = ttnn.ToLayoutOp(
                 final_output_type,
                 op.result,
-                layout=ttnn.ir.LayoutAttr.get(self._ctx, ttnn.Layout.Tile),
                 loc=loc,
             )
 
@@ -8605,7 +8596,6 @@ class TTNNBuilder(Builder):
         op = ttnn_op(
             result,
             input,
-            layout=layout_attr,
             loc=loc,
         )
         op_result = op.result
@@ -8623,18 +8613,24 @@ class TTNNBuilder(Builder):
         ttnn_op = self.get_opview_from_parser(TTNNBuilder.to_layout_parser)
         in0 = global_dict[old_op.input]
         result = old_op.result.type
-        layout_attr = old_op.layout
 
         new_op = ttnn_op(
             result,
             in0,
-            layout=layout_attr,
             loc=old_op.location,
         )
         new_op_result = new_op.result
 
         input0 = self._get_golden_tensor(in0)
         op_golden_function = get_golden_function(ttnn_op)
+        result_layout = ttnn.ir.TTNNLayoutAttr.maybe_downcast(result.encoding)
+        layout = (
+            ttnn.Layout.Tile
+            if result_layout is not None
+            and "ttcore.tile" in str(result_layout.memref.element_type)
+            else ttnn.Layout.RowMajor
+        )
+        layout_attr = ttnn.ir.LayoutAttr.get(self._ctx, layout)
         golden_output = op_golden_function(input0, layout_attr, result.element_type)
         self._set_golden_tensor(new_op_result, golden_output)
 
@@ -8665,12 +8661,10 @@ class TTNNBuilder(Builder):
                 def decorated_func(*inputs):
                     in0 = inputs[0]
                     result = old_op.result.type
-                    layout_attr = old_op.layout
 
                     new_op = ttnn_op(
                         result,
                         in0,
-                        layout=layout_attr,
                         loc=old_op.location,
                     )
                     new_op_result = new_op.result


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/8377

### Problem description
`layout` attribute was redundant as informations it contains can be found directly in tensor layout. This created a situation where updating one place needed to be aware of the other and introduced unnecessary complications.

### What's changed
Removed `layout` attribute from TTNN IR.
Updated all relevant call sites.
Created helper `getLayoutAttr` that create this attribute on demand from tensor layout encoding.
Tensor layout is now the single source of truth regarding page layout.

### Checklist
- [x] New/Existing tests provide coverage for changes
