### PR TITLE
Add activation dtype lowering before CCLs (proj + MLP)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -410,6 +410,15 @@ struct TTIRToTTNNCommonPipelineOptions
           clEnumValN(BFPDtype::BFP_BFloat4, "bfp_bf4", "BFP BFloat4 format")),
       llvm::cl::init(BFPDtype::None)};
 
+  Option<bool> enableActivationDtypeLowering{
+      *this, "enable-activation-dtype-lowering",
+      llvm::cl::desc(
+          "Lower activation precision to bfp_bf8 across CCL "
+          "boundaries (matmul -> reduce_scatter/all_gather -> consumer). "
+          "Pattern-matches Llama-style sub-graphs (O-proj+residual,"
+          "MLP + residual)."),
+      llvm::cl::init(false)};
+
   // ComputeKernelConfig options
   // Note: computeCfgMathFidelity default value is HiFi4
   // And computeCfgFp32DestAccEn default value is true.

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -482,7 +482,7 @@ def TTNNWeightDtypeConversion: Pass<"ttnn-weight-dtype-conversion", "::mlir::Mod
   ];
 }
 
-def TTNNActivationDtypeLowering: Pass<"ttnn-activation-dtype-lowering", "::mlir::ModuleOp"> {
+def TTNNCCLActivationDtypeLowering: Pass<"ttnn-ccl-activation-dtype-lowering", "::mlir::ModuleOp"> {
   let summary = "Lower activation precision to bfp_bf8 around CCL ops.";
   let description = [{
     This pass is part of the Mixed Precision effort in compiler.
@@ -512,12 +512,6 @@ def TTNNActivationDtypeLowering: Pass<"ttnn-activation-dtype-lowering", "::mlir:
     to add new patterns as we get more multichip models running and fuse patterns
     to more general ones as we get more cases.
   }];
-
-  list<Option> options = [
-    Option<"enable", "enable", "bool",
-           /*default=*/"false",
-           "Enable activation dtype lowering.">,
-  ];
 }
 
 def TTNNKVCacheDtypeConversion: Pass<"ttnn-kv-cache-dtype-conversion", "::mlir::ModuleOp"> {

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -482,6 +482,44 @@ def TTNNWeightDtypeConversion: Pass<"ttnn-weight-dtype-conversion", "::mlir::Mod
   ];
 }
 
+def TTNNActivationDtypeLowering: Pass<"ttnn-activation-dtype-lowering", "::mlir::ModuleOp"> {
+  let summary = "Lower activation precision to bfp_bf8 around CCL ops.";
+  let description = [{
+    This pass is part of the Mixed Precision effort in compiler.
+    This pass reduces ethernet traffic for collective communication (CCL) ops
+    in large transformer models by lowering activation precision from bf16 to
+    bfp_bf8 across the CCL boundary. Producer matmul ops have their result
+    tensor's layout encoding rewritten to bfp_bf8 so no explicit ttnn.typecast is
+    required at the producer side. On the consumer side, some patterns allow for
+    implicit casting back to bf16 (e.g. residual add). Currently we added only patterns
+    that don't require explicit casts on both sides.
+
+    The pass implements two strict per-pattern matchers, each modeled after a
+    Llama-style sub-graph:
+      - Projection matmul (attention output / MLP down) -> [view / CCL]* ->
+        residual add. The residual add's result encoding stays bf16 (it was
+        constructed from the bf16 residual operand), so TTNN restores bf16
+        at the block output by combining the bfp_bf8 CCL output with the
+        bf16 residual — no exit-side cast needed.
+      - MLP up / gate matmuls -> [view / CCL]* -> silu / multiply. The
+        multiply's result encoding is rewritten to bfp_bf8 so the downstream
+        FF2 matmul receives bfp_bf8 input; the FF2 residual add then
+        restores bf16 via the projection-residual matcher when FF2 itself is
+        lowered.
+
+    A matmul only matches a pattern when the entire downstream chain shape
+    matches the template, so the pass under-triggers by design. The idea is
+    to add new patterns as we get more multichip models running and fuse patterns
+    to more general ones as we get more cases.
+  }];
+
+  list<Option> options = [
+    Option<"enable", "enable", "bool",
+           /*default=*/"false",
+           "Enable activation dtype lowering.">,
+  ];
+}
+
 def TTNNKVCacheDtypeConversion: Pass<"ttnn-kv-cache-dtype-conversion", "::mlir::ModuleOp"> {
   let summary = "Convert KV cache tensors to a lower precision dtype.";
   let description = [{

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -382,6 +382,15 @@ void createTTIRToTTNNCommonPipeline(
       devicePm.addPass(createTTNNKVCacheDtypeConversion(convOpts));
     }
 
+    // Activation dtype lowering runs after weight dtype conversion and KV
+    // cache dtype conversion. This is important because activation dtype can
+    // be influenced by weight and KV cache dtype.
+    if (options.enableActivationDtypeLowering) {
+      TTNNActivationDtypeLoweringOptions actOpts;
+      actOpts.enable = true;
+      devicePm.addPass(createTTNNActivationDtypeLowering(actOpts));
+    }
+
     // Apply ComputeKernelConfig settings before analysis passes.
     // Create options struct and forward pipeline options.
     TTNNSetComputeKernelConfigOptions setConfigOptions;

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -386,9 +386,7 @@ void createTTIRToTTNNCommonPipeline(
     // cache dtype conversion. This is important because activation dtype can
     // be influenced by weight and KV cache dtype.
     if (options.enableActivationDtypeLowering) {
-      TTNNActivationDtypeLoweringOptions actOpts;
-      actOpts.enable = true;
-      devicePm.addPass(createTTNNActivationDtypeLowering(actOpts));
+      devicePm.addPass(createTTNNCCLActivationDtypeLowering());
     }
 
     // Apply ComputeKernelConfig settings before analysis passes.

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -51,6 +51,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNUniqueLocs.cpp
         TTNNWeightDtypeConversion.cpp
         TTNNKVCacheDtypeConversion.cpp
+        TTNNActivationDtypeLowering.cpp
         Workarounds/Decomposition/AllGatherOpRewritePattern.cpp
         Workarounds/Decomposition/AllReduceReshapeOpRewritePattern.cpp
         Workarounds/Decomposition/AllToAllDispatchMetadataDrainCoreRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/TTNNActivationDtypeLowering.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNActivationDtypeLowering.cpp
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace mlir::tt::ttnn {
+#define GEN_PASS_DEF_TTNNACTIVATIONDTYPELOWERING
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+namespace {
+
+// View-like ops: data values pass through unchanged; dtype is preserved.
+static bool isViewLikeOp(Operation *op) {
+  return mlir::isa<ReshapeOp, SliceStaticOp, ToMemoryConfigOp, ToLayoutOp>(op);
+}
+
+// CCL ops: shape changes, dtype is preserved.
+static bool isCCLOp(Operation *op) {
+  return mlir::isa<AllGatherOp, ReduceScatterOp, AllReduceOp>(op);
+}
+
+// Dtype carried by a value's TTNN layout encoding, if it has one.
+static std::optional<ttcore::DataType> getValueDtype(Value v) {
+  auto rt = mlir::dyn_cast<RankedTensorType>(v.getType());
+  if (!rt) {
+    return std::nullopt;
+  }
+  auto layout = mlir::dyn_cast_if_present<TTNNLayoutAttr>(rt.getEncoding());
+  if (!layout) {
+    return std::nullopt;
+  }
+  return layout.getDataType();
+}
+
+// The float dtypes this pass is allowed to lower from. Activations entering a
+// CCL chain are bf16 (or f32); anything else is left alone.
+static bool isLowerableFloat(std::optional<ttcore::DataType> dtype) {
+  return dtype && (*dtype == ttcore::DataType::BFloat16 ||
+                   *dtype == ttcore::DataType::Float32);
+}
+
+// Rewrite an op's single result type so its encoding carries `targetDtype`.
+// No-op if the op already produces `targetDtype` or has no TTNN layout
+// encoding. Returns true when a rewrite occurred.
+//
+// TTNN reads an op's output dtype from its result layout encoding, so
+// rewriting the encoding is all that's needed to set the output dtype.
+static bool rewriteResultDtype(Operation *op, ttcore::DataType targetDtype) {
+  if (op->getNumResults() != 1) {
+    return false;
+  }
+  Value result = op->getResult(0);
+  auto rt = mlir::dyn_cast<RankedTensorType>(result.getType());
+  if (!rt || !isLowerableFloat(getValueDtype(result))) {
+    return false;
+  }
+  if (getValueDtype(result) == targetDtype) {
+    return false;
+  }
+  auto newType = ttnn::utils::RankedTensorTypeFactory::create(rt, targetDtype);
+  result.setType(newType);
+  return true;
+}
+
+// Walks the def-use chain downstream from `start`, treating ops for which
+// `isFlowThrough(op)` returns true as transparent (their results are also
+// followed). Collects the visited flow-through ops in `flowThroughOps` and
+// the first non-flow-through users in `exits` (paired with the operand index
+// at which `start`'s descendant feeds them).
+template <typename FlowThroughFn>
+static void
+collectChain(Value start, FlowThroughFn isFlowThrough,
+             llvm::SmallVectorImpl<Operation *> &flowThroughOps,
+             llvm::SmallVectorImpl<std::pair<Operation *, unsigned>> &exits) {
+  llvm::SmallPtrSet<Operation *, 16> seenFlow;
+  llvm::SmallVector<Value, 8> worklist;
+  worklist.push_back(start);
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    for (OpOperand &use : v.getUses()) {
+      Operation *user = use.getOwner();
+      if (isFlowThrough(user)) {
+        if (seenFlow.insert(user).second) {
+          flowThroughOps.push_back(user);
+          for (Value result : user->getResults()) {
+            worklist.push_back(result);
+          }
+        }
+      } else {
+        exits.emplace_back(user, use.getOperandNumber());
+      }
+    }
+  }
+}
+
+// Validate-only core of both matchers. A matmul matches when:
+//   - its result reaches one or more exits through a chain of `isFlow` ops,
+//   - at least one of those flow-through ops is a CCL (otherwise there is no
+//     ethernet traffic to save and nothing to lower),
+//   - every exit satisfies `isValidExit(exitOp, operandIdx)`, and
+//   - the matmul itself currently produces a lowerable float (bf16 / f32).
+//
+// On success the visited flow-through ops and exits are returned via the
+// out-params. Mutates nothing, so it doubles as a read-only predicate.
+template <typename FlowFn, typename ExitFn>
+static bool matchMatmulChain(
+    MatmulOp matmul, FlowFn isFlow, ExitFn isValidExit,
+    llvm::SmallVectorImpl<Operation *> &flowThroughOps,
+    llvm::SmallVectorImpl<std::pair<Operation *, unsigned>> &exits) {
+  collectChain(matmul.getResult(), isFlow, flowThroughOps, exits);
+
+  if (exits.empty() || !llvm::any_of(flowThroughOps, isCCLOp)) {
+    return false;
+  }
+  for (auto [exitOp, operandIdx] : exits) {
+    if (!isValidExit(exitOp, operandIdx)) {
+      return false;
+    }
+  }
+  return isLowerableFloat(getValueDtype(matmul.getResult()));
+}
+
+// Lowering driver: match, then (only on a full match) lower the matmul output
+// to bfp_bf8 and propagate bfp_bf8 through every flow-through op. When
+// `rewriteExits` is set, each exit's result encoding is also rewritten to
+// bfp_bf8 (used to hand bfp_bf8 to a downstream consumer; see the MLP matcher).
+template <typename FlowFn, typename ExitFn>
+static bool tryLowerMatmulChain(MatmulOp matmul, FlowFn isFlow,
+                                ExitFn isValidExit, bool rewriteExits) {
+  llvm::SmallVector<Operation *> flowThroughOps;
+  llvm::SmallVector<std::pair<Operation *, unsigned>> exits;
+  if (!matchMatmulChain(matmul, isFlow, isValidExit, flowThroughOps, exits)) {
+    return false;
+  }
+
+  rewriteResultDtype(matmul, ttcore::DataType::BFP_BFloat8);
+  for (Operation *flow : flowThroughOps) {
+    rewriteResultDtype(flow, ttcore::DataType::BFP_BFloat8);
+  }
+  if (rewriteExits) {
+    for (const auto &exit : exits) {
+      rewriteResultDtype(exit.first, ttcore::DataType::BFP_BFloat8);
+    }
+  }
+  return true;
+}
+
+// Projection-residual chain shape:
+//   matmul -> [view / CCL]* -> residual add, where the add's *other* operand is
+// the bf16/f32 residual stream. The residual add is where the block returns to
+// bf16: TTNN combines the bfp_bf8 CCL output with the bf16 residual operand to
+// produce a bf16 result, so no explicit cast is needed at the add.
+//
+// Shared by the projection matcher (which lowers it) and the MLP matcher (which
+// uses it read-only to confirm the gate's FF2 matmul ends at such an add).
+
+static bool isProjChainFlow(Operation *op) {
+  return isViewLikeOp(op) || isCCLOp(op);
+}
+
+static bool isProjChainExit(Operation *exitOp, unsigned operandIdx) {
+  auto add = mlir::dyn_cast<AddOp>(exitOp);
+  if (!add) {
+    return false;
+  }
+  return isLowerableFloat(getValueDtype(add->getOperand(1 - operandIdx)));
+}
+
+// Read-only: does `matmul` root a projection-residual chain?
+static bool isProjResidualMatmul(MatmulOp matmul) {
+  llvm::SmallVector<Operation *> flowThroughOps;
+  llvm::SmallVector<std::pair<Operation *, unsigned>> exits;
+  return matchMatmulChain(matmul, isProjChainFlow, isProjChainExit,
+                          flowThroughOps, exits);
+}
+
+// Projection matmul (attention output / MLP down) -> [view / CCL]* ->
+// residual add (see "Projection-residual chain shape" above). Lowers the
+// producer matmul output to bfp_bf8 and propagates it through every
+// flow-through op; the residual add's encoding is left as bf16.
+//
+// Also used for the FF2 -> add (residual) tail of the MLP pattern.
+static bool tryProjResidualAddMatcher(MatmulOp matmul) {
+  return tryLowerMatmulChain(matmul, isProjChainFlow, isProjChainExit,
+                             /*rewriteExits=*/false);
+}
+
+// MLP up / gate matmuls -> [view / CCL]* -> silu (FF1) or multiply (FF3).
+//
+// FF1 path:  matmul -> CCL -> silu -> multiply.
+// FF3 path:  matmul -> CCL -> multiply.
+// Both branches converge at the gate multiply whose two inputs are the two
+// CCL-rooted chains; the multiply feeds the FF2 (down) matmul, whose residual
+// add then restores bf16 (handled by the projection-residual matcher on FF2's
+// own invocation).
+//
+// Action: lower the producer matmul output to bfp_bf8, propagate bfp_bf8
+// through view / CCL / silu on the producer's branch, and rewrite the gate
+// multiply's result encoding to bfp_bf8 so the downstream FF2 matmul receives
+// bfp_bf8 input.
+//
+// The exit check enforces the real MLP shape: the single-use requirement
+// rejects gate multiplies that fan out to consumers we should not silently
+// downcast, and the FF2/proj-residual check guarantees the bf16 restore point
+// downstream actually exists.
+static bool tryMLPUpGateMatcher(MatmulOp matmul) {
+  auto isFlow = [](Operation *op) {
+    return isViewLikeOp(op) || isCCLOp(op) || mlir::isa<SiluOp>(op);
+  };
+  auto isValidExit = [](Operation *exitOp, unsigned /*operandIdx*/) {
+    auto mul = mlir::dyn_cast<MultiplyOp>(exitOp);
+    if (!mul || !mul.getResult().hasOneUse()) {
+      return false;
+    }
+    auto ff2 = mlir::dyn_cast<MatmulOp>(*mul.getResult().getUsers().begin());
+    return ff2 && isProjResidualMatmul(ff2);
+  };
+  return tryLowerMatmulChain(matmul, isFlow, isValidExit,
+                             /*rewriteExits=*/true);
+}
+
+class TTNNActivationDtypeLoweringPass
+    : public impl::TTNNActivationDtypeLoweringBase<
+          TTNNActivationDtypeLoweringPass> {
+public:
+  using impl::TTNNActivationDtypeLoweringBase<
+      TTNNActivationDtypeLoweringPass>::TTNNActivationDtypeLoweringBase;
+
+  void runOnOperation() final {
+    if (!enable) {
+      return;
+    }
+
+    ModuleOp moduleOp = getOperation();
+
+    // Collect matmuls in a stable order before mutating; rewrites change the
+    // IR and we don't want to revisit a transformed matmul.
+    llvm::SmallVector<MatmulOp> matmuls;
+    moduleOp.walk([&](MatmulOp op) { matmuls.push_back(op); });
+
+    for (MatmulOp matmul : matmuls) {
+      // Try matchers in order. Each matcher is independent — the first one
+      // that succeeds claims the matmul. Strict matching means the matchers
+      // do not overlap.
+      if (tryProjResidualAddMatcher(matmul)) {
+        continue;
+      }
+      if (tryMLPUpGateMatcher(matmul)) {
+        continue;
+      }
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/TTNNActivationDtypeLowering.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNActivationDtypeLowering.cpp
@@ -35,29 +35,26 @@ static bool isCCLOp(Operation *op) {
   return mlir::isa<AllGatherOp, ReduceScatterOp, AllReduceOp>(op);
 }
 
-// Dtype carried by a value's TTNN layout encoding, if it has one.
-static std::optional<ttcore::DataType> getValueDtype(Value v) {
-  auto rt = mlir::dyn_cast<RankedTensorType>(v.getType());
-  if (!rt) {
-    return std::nullopt;
-  }
-  auto layout = mlir::dyn_cast_if_present<TTNNLayoutAttr>(rt.getEncoding());
-  if (!layout) {
-    return std::nullopt;
-  }
+// Dtype carried by a value's TTNN layout encoding. Every tensor at this stage
+// of the pipeline carries a TTNNLayoutAttr, so the dtype is always present;
+// callers only pass TTNN op results / operands.
+static ttcore::DataType getValueDtype(Value v) {
+  auto rt = mlir::cast<RankedTensorType>(v.getType());
+  auto layout = mlir::cast<TTNNLayoutAttr>(rt.getEncoding());
   return layout.getDataType();
 }
 
 // The float dtypes this pass is allowed to lower from. Activations entering a
 // CCL chain are bf16 (or f32); anything else is left alone.
-static bool isLowerableFloat(std::optional<ttcore::DataType> dtype) {
-  return dtype && (*dtype == ttcore::DataType::BFloat16 ||
-                   *dtype == ttcore::DataType::Float32);
+static bool isLowerableFloat(ttcore::DataType dtype) {
+  return dtype == ttcore::DataType::BFloat16 ||
+         dtype == ttcore::DataType::Float32;
 }
 
 // Rewrite an op's single result type so its encoding carries `targetDtype`.
-// No-op if the op already produces `targetDtype`, has no TTNN layout encoding,
-// or does not currently produce a lowerable float. Returns true on rewrite.
+// No-op if the op doesn't have a single ranked-tensor result, already produces
+// `targetDtype`, or does not currently produce a lowerable float. Returns true
+// on rewrite.
 //
 // TTNN reads an op's output dtype from its result layout encoding, so rewriting
 // the encoding is all that's needed to set the output dtype.

--- a/lib/Dialect/TTNN/Transforms/TTNNActivationDtypeLowering.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNActivationDtypeLowering.cpp
@@ -8,22 +8,26 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir::tt::ttnn {
-#define GEN_PASS_DEF_TTNNACTIVATIONDTYPELOWERING
+#define GEN_PASS_DEF_TTNNCCLACTIVATIONDTYPELOWERING
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
 
 namespace {
 
-// View-like ops: data values pass through unchanged; dtype is preserved.
+// View-like ops: data values pass through unchanged and the dtype is preserved.
+//
+// ToLayoutOp is intentionally NOT here: at this stage of the pipeline it can
+// carry a dtype change, so it is not safe to treat as dtype-preserving. The
+// patterns this pass currently handles (projection-residual, MLP up/gate) do
+// not contain any ToLayoutOp on their chains. When the LM-head / QKV->RoPE
+// patterns are added (they do have a ToLayoutOp), it should be admitted here
+// only when its input and output dtypes match.
 static bool isViewLikeOp(Operation *op) {
-  return mlir::isa<ReshapeOp, SliceStaticOp, ToMemoryConfigOp, ToLayoutOp>(op);
+  return mlir::isa<ReshapeOp, SliceStaticOp, ToMemoryConfigOp>(op);
 }
 
 // CCL ops: shape changes, dtype is preserved.
@@ -52,11 +56,11 @@ static bool isLowerableFloat(std::optional<ttcore::DataType> dtype) {
 }
 
 // Rewrite an op's single result type so its encoding carries `targetDtype`.
-// No-op if the op already produces `targetDtype` or has no TTNN layout
-// encoding. Returns true when a rewrite occurred.
+// No-op if the op already produces `targetDtype`, has no TTNN layout encoding,
+// or does not currently produce a lowerable float. Returns true on rewrite.
 //
-// TTNN reads an op's output dtype from its result layout encoding, so
-// rewriting the encoding is all that's needed to set the output dtype.
+// TTNN reads an op's output dtype from its result layout encoding, so rewriting
+// the encoding is all that's needed to set the output dtype.
 static bool rewriteResultDtype(Operation *op, ttcore::DataType targetDtype) {
   if (op->getNumResults() != 1) {
     return false;
@@ -74,175 +78,162 @@ static bool rewriteResultDtype(Operation *op, ttcore::DataType targetDtype) {
   return true;
 }
 
-// Walks the def-use chain downstream from `start`, treating ops for which
-// `isFlowThrough(op)` returns true as transparent (their results are also
-// followed). Collects the visited flow-through ops in `flowThroughOps` and
-// the first non-flow-through users in `exits` (paired with the operand index
-// at which `start`'s descendant feeds them).
-template <typename FlowThroughFn>
-static void
-collectChain(Value start, FlowThroughFn isFlowThrough,
-             llvm::SmallVectorImpl<Operation *> &flowThroughOps,
-             llvm::SmallVectorImpl<std::pair<Operation *, unsigned>> &exits) {
-  llvm::SmallPtrSet<Operation *, 16> seenFlow;
-  llvm::SmallVector<Value, 8> worklist;
-  worklist.push_back(start);
-  while (!worklist.empty()) {
-    Value v = worklist.pop_back_val();
-    for (OpOperand &use : v.getUses()) {
-      Operation *user = use.getOwner();
-      if (isFlowThrough(user)) {
-        if (seenFlow.insert(user).second) {
-          flowThroughOps.push_back(user);
-          for (Value result : user->getResults()) {
-            worklist.push_back(result);
-          }
-        }
-      } else {
-        exits.emplace_back(user, use.getOperandNumber());
-      }
-    }
-  }
-}
-
-// Validate-only core of both matchers. A matmul matches when:
-//   - its result reaches one or more exits through a chain of `isFlow` ops,
-//   - at least one of those flow-through ops is a CCL (otherwise there is no
-//     ethernet traffic to save and nothing to lower),
-//   - every exit satisfies `isValidExit(exitOp, operandIdx)`, and
-//   - the matmul itself currently produces a lowerable float (bf16 / f32).
-//
-// On success the visited flow-through ops and exits are returned via the
-// out-params. Mutates nothing, so it doubles as a read-only predicate.
-template <typename FlowFn, typename ExitFn>
-static bool matchMatmulChain(
-    MatmulOp matmul, FlowFn isFlow, ExitFn isValidExit,
-    llvm::SmallVectorImpl<Operation *> &flowThroughOps,
-    llvm::SmallVectorImpl<std::pair<Operation *, unsigned>> &exits) {
-  collectChain(matmul.getResult(), isFlow, flowThroughOps, exits);
-
-  if (exits.empty() || !llvm::any_of(flowThroughOps, isCCLOp)) {
-    return false;
-  }
-  for (auto [exitOp, operandIdx] : exits) {
-    if (!isValidExit(exitOp, operandIdx)) {
-      return false;
-    }
-  }
-  return isLowerableFloat(getValueDtype(matmul.getResult()));
-}
-
-// Lowering driver: match, then (only on a full match) lower the matmul output
-// to bfp_bf8 and propagate bfp_bf8 through every flow-through op. When
-// `rewriteExits` is set, each exit's result encoding is also rewritten to
-// bfp_bf8 (used to hand bfp_bf8 to a downstream consumer; see the MLP matcher).
-template <typename FlowFn, typename ExitFn>
-static bool tryLowerMatmulChain(MatmulOp matmul, FlowFn isFlow,
-                                ExitFn isValidExit, bool rewriteExits) {
-  llvm::SmallVector<Operation *> flowThroughOps;
-  llvm::SmallVector<std::pair<Operation *, unsigned>> exits;
-  if (!matchMatmulChain(matmul, isFlow, isValidExit, flowThroughOps, exits)) {
-    return false;
-  }
-
+// Down-cast `matmul`'s output and every flow-through op on its chain to
+// bfp_bf8.
+static void downcastChain(MatmulOp matmul,
+                          llvm::ArrayRef<Operation *> flowOps) {
   rewriteResultDtype(matmul, ttcore::DataType::BFP_BFloat8);
-  for (Operation *flow : flowThroughOps) {
-    rewriteResultDtype(flow, ttcore::DataType::BFP_BFloat8);
+  for (Operation *op : flowOps) {
+    rewriteResultDtype(op, ttcore::DataType::BFP_BFloat8);
   }
-  if (rewriteExits) {
-    for (const auto &exit : exits) {
-      rewriteResultDtype(exit.first, ttcore::DataType::BFP_BFloat8);
-    }
-  }
-  return true;
 }
 
-// Projection-residual chain shape:
-//   matmul -> [view / CCL]* -> residual add, where the add's *other* operand is
-// the bf16/f32 residual stream. The residual add is where the block returns to
-// bf16: TTNN combines the bfp_bf8 CCL output with the bf16 residual operand to
-// produce a bf16 result, so no explicit cast is needed at the add.
+// Projection-residual shape (read-only check):
+//   matmul -> [view / CCL]* -> residual add
+// walked as a single-use linear chain. Returns the flow-through ops on the
+// chain when:
+//   - the matmul currently produces a lowerable float,
+//   - the chain is a single-use line of view / CCL ops with at least one CCL,
+//   - it terminates at an AddOp whose *other* operand is a bf16/f32 residual.
+// Otherwise returns nullopt.
 //
-// Shared by the projection matcher (which lowers it) and the MLP matcher (which
-// uses it read-only to confirm the gate's FF2 matmul ends at such an add).
-
-static bool isProjChainFlow(Operation *op) {
-  return isViewLikeOp(op) || isCCLOp(op);
-}
-
-static bool isProjChainExit(Operation *exitOp, unsigned operandIdx) {
-  auto add = mlir::dyn_cast<AddOp>(exitOp);
-  if (!add) {
-    return false;
+// The residual add is where the block returns to bf16: TTNN combines the
+// bfp_bf8 CCL output with the bf16 residual operand to produce a bf16 result,
+// so no explicit cast is needed at the add. Used by the projection matcher (to
+// lower it) and by the MLP matcher (to confirm the gate's FF2 matmul -- a
+// *different* matmul -- ends at such an add).
+static std::optional<llvm::SmallVector<Operation *>>
+matmulReachesResidualAdd(MatmulOp matmul) {
+  if (!isLowerableFloat(getValueDtype(matmul.getResult()))) {
+    return std::nullopt;
   }
-  return isLowerableFloat(getValueDtype(add->getOperand(1 - operandIdx)));
-}
 
-// Read-only: does `matmul` root a projection-residual chain?
-static bool isProjResidualMatmul(MatmulOp matmul) {
-  llvm::SmallVector<Operation *> flowThroughOps;
-  llvm::SmallVector<std::pair<Operation *, unsigned>> exits;
-  return matchMatmulChain(matmul, isProjChainFlow, isProjChainExit,
-                          flowThroughOps, exits);
+  llvm::SmallVector<Operation *> flowOps;
+  bool sawCCL = false;
+  Value cur = matmul.getResult();
+  while (true) {
+    // A clean chain is single-use; a branch means this isn't the shape we
+    // model, so don't match (under-trigger by design).
+    if (!cur.hasOneUse()) {
+      return std::nullopt;
+    }
+    OpOperand &use = *cur.getUses().begin();
+    Operation *user = use.getOwner();
+
+    if (isViewLikeOp(user) || isCCLOp(user)) {
+      if (user->getNumResults() != 1) {
+        return std::nullopt;
+      }
+      sawCCL |= isCCLOp(user);
+      flowOps.push_back(user);
+      cur = user->getResult(0);
+      continue;
+    }
+
+    // Exit: must be a residual add whose other operand is a bf16/f32 residual.
+    auto add = mlir::dyn_cast<AddOp>(user);
+    if (!sawCCL || !add) {
+      return std::nullopt;
+    }
+    unsigned otherIdx = 1 - use.getOperandNumber();
+    if (!isLowerableFloat(getValueDtype(add->getOperand(otherIdx)))) {
+      return std::nullopt;
+    }
+    return flowOps;
+  }
 }
 
 // Projection matmul (attention output / MLP down) -> [view / CCL]* ->
-// residual add (see "Projection-residual chain shape" above). Lowers the
-// producer matmul output to bfp_bf8 and propagates it through every
-// flow-through op; the residual add's encoding is left as bf16.
+// residual add. Lowers the producer matmul output to bfp_bf8 and propagates it
+// through every flow-through op; the residual add's encoding is left as bf16.
 //
-// Also used for the FF2 -> add (residual) tail of the MLP pattern.
+// Also matches the FF2 -> add (residual) tail of the MLP pattern.
 static bool tryProjResidualAddMatcher(MatmulOp matmul) {
-  return tryLowerMatmulChain(matmul, isProjChainFlow, isProjChainExit,
-                             /*rewriteExits=*/false);
+  auto flowOps = matmulReachesResidualAdd(matmul);
+  if (!flowOps) {
+    return false;
+  }
+  downcastChain(matmul, *flowOps);
+  return true;
 }
 
-// MLP up / gate matmuls -> [view / CCL]* -> silu (FF1) or multiply (FF3).
+// MLP up / gate matmuls -> [view / CCL / silu]* -> gate multiply.
 //
-// FF1 path:  matmul -> CCL -> silu -> multiply.
-// FF3 path:  matmul -> CCL -> multiply.
-// Both branches converge at the gate multiply whose two inputs are the two
-// CCL-rooted chains; the multiply feeds the FF2 (down) matmul, whose residual
-// add then restores bf16 (handled by the projection-residual matcher on FF2's
-// own invocation).
+//   FF1 (up)   matmul -> CCL -> silu --\
+//                                       multiply (gate) -> FF2 (down) matmul
+//   FF3 (gate) matmul -> CCL ----------/
 //
-// Action: lower the producer matmul output to bfp_bf8, propagate bfp_bf8
-// through view / CCL / silu on the producer's branch, and rewrite the gate
-// multiply's result encoding to bfp_bf8 so the downstream FF2 matmul receives
-// bfp_bf8 input.
+// Lowers the producer matmul output to bfp_bf8, propagates it through the
+// producer's view / CCL / silu chain, and rewrites the gate multiply's result
+// to bfp_bf8 so the downstream FF2 matmul receives bfp_bf8 input. bf16 is
+// restored later, at the FF2 residual add, when FF2 is matched by the
+// projection matcher on its own visit.
 //
-// The exit check enforces the real MLP shape: the single-use requirement
-// rejects gate multiplies that fan out to consumers we should not silently
-// downcast, and the FF2/proj-residual check guarantees the bf16 restore point
-// downstream actually exists.
+// The gate multiply is matched strictly: it must have a single use, that use
+// must be the FF2 matmul, and FF2 must itself reach a residual add (the bf16
+// restore point). This rejects multiplies that fan out or whose output is not
+// a real MLP down-projection.
 static bool tryMLPUpGateMatcher(MatmulOp matmul) {
-  auto isFlow = [](Operation *op) {
-    return isViewLikeOp(op) || isCCLOp(op) || mlir::isa<SiluOp>(op);
-  };
-  auto isValidExit = [](Operation *exitOp, unsigned /*operandIdx*/) {
-    auto mul = mlir::dyn_cast<MultiplyOp>(exitOp);
-    if (!mul || !mul.getResult().hasOneUse()) {
+  if (!isLowerableFloat(getValueDtype(matmul.getResult()))) {
+    return false;
+  }
+
+  // Walk the single-use chain from the matmul to its first non-flow user.
+  llvm::SmallVector<Operation *> flowOps;
+  bool sawCCL = false;
+  Value cur = matmul.getResult();
+  Operation *exit = nullptr;
+  while (true) {
+    if (!cur.hasOneUse()) {
       return false;
     }
-    auto ff2 = mlir::dyn_cast<MatmulOp>(*mul.getResult().getUsers().begin());
-    return ff2 && isProjResidualMatmul(ff2);
-  };
-  return tryLowerMatmulChain(matmul, isFlow, isValidExit,
-                             /*rewriteExits=*/true);
+    OpOperand &use = *cur.getUses().begin();
+    Operation *user = use.getOwner();
+
+    if (isViewLikeOp(user) || isCCLOp(user) || mlir::isa<SiluOp>(user)) {
+      if (user->getNumResults() != 1) {
+        return false;
+      }
+      sawCCL |= isCCLOp(user);
+      flowOps.push_back(user);
+      cur = user->getResult(0);
+      continue;
+    }
+    exit = user;
+    break;
+  }
+  if (!sawCCL) {
+    return false;
+  }
+
+  // Exit must be the gate multiply feeding the FF2 matmul, and FF2 must reach a
+  // residual add downstream (where bf16 is restored).
+  auto gate = mlir::dyn_cast<MultiplyOp>(exit);
+  if (!gate || !gate.getResult().hasOneUse()) {
+    return false;
+  }
+  auto ff2 = mlir::dyn_cast<MatmulOp>(*gate.getResult().getUsers().begin());
+  if (!ff2 || !matmulReachesResidualAdd(ff2)) {
+    return false;
+  }
+
+  downcastChain(matmul, flowOps);
+  // Down-cast the gate multiply output so FF2 receives bfp_bf8 input. This only
+  // changes what the multiply hands to its consumer (the FF2 matmul, which
+  // accepts any input dtype); the other gate branch is lowered by this same
+  // matcher on its own producer matmul.
+  rewriteResultDtype(gate, ttcore::DataType::BFP_BFloat8);
+  return true;
 }
 
-class TTNNActivationDtypeLoweringPass
-    : public impl::TTNNActivationDtypeLoweringBase<
-          TTNNActivationDtypeLoweringPass> {
+class TTNNCCLActivationDtypeLoweringPass
+    : public impl::TTNNCCLActivationDtypeLoweringBase<
+          TTNNCCLActivationDtypeLoweringPass> {
 public:
-  using impl::TTNNActivationDtypeLoweringBase<
-      TTNNActivationDtypeLoweringPass>::TTNNActivationDtypeLoweringBase;
+  using impl::TTNNCCLActivationDtypeLoweringBase<
+      TTNNCCLActivationDtypeLoweringPass>::TTNNCCLActivationDtypeLoweringBase;
 
   void runOnOperation() final {
-    if (!enable) {
-      return;
-    }
-
     ModuleOp moduleOp = getOperation();
 
     // Collect matmuls in a stable order before mutating; rewrites change the

--- a/test/python/golden/ttir_ops/ccl/test_ccl_activation_dtype_lowering.py
+++ b/test/python/golden/ttir_ops/ccl/test_ccl_activation_dtype_lowering.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import torch
+from collections import OrderedDict
+from typing import List, Optional, Tuple
+
+from conftest import get_request_kwargs
+from builder.base.builder_utils import Operand, Shape, get_artifact_dir
+from builder.base.builder_enums import MeshShardDirection, MeshShardType
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_ttir_to_flatbuffer
+from test_utils import shape_str
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+# Builds the projection + residual pattern the `ttnn-ccl-activation-dtype-lowering`
+# pass targets, after the TTIR -> TTNN pipeline lowers it to:
+#
+#   ttnn.matmul -> ttnn.all_gather -> ttnn.add
+#
+# The pass should down-cast the matmul output (and the all_gather it propagates
+# through) to bfp_bf8, while the residual add stays bf16. We assert the pass
+# fires by compiling the *same* module twice -- once with the pass enabled and
+# once without -- and checking that `bfp_bf8` only appears when it is enabled.
+# A pure compile/IR check is used (rather than execution) because the pass is a
+# precision-lowering transform: its observable effect is the rewritten tensor
+# encoding, and this avoids relying on multi-device golden/PCC matching for a
+# tensor-parallel matmul (cf. the skipped `test_llama_attention_1xn_tp`).
+
+
+def _full_to_shard_replicate(builder: TTIRBuilder, input: Operand) -> Operand:
+    return builder.mesh_shard(
+        input,
+        shard_direction=MeshShardDirection.FullToShard.value,
+        shard_type=MeshShardType.Replicate.value,
+        shard_shape=[1],
+        shard_dims=[-1],
+    )
+
+
+def _full_to_shard_device(builder: TTIRBuilder, input: Operand, dim: int) -> Operand:
+    rank = len(builder._get_golden_tensor(input).shape)
+    num_devices = builder.mesh_shape[1]
+    shard_shape = [1] * rank
+    shard_shape[dim] = num_devices
+    return builder.mesh_shard(
+        input,
+        shard_direction=MeshShardDirection.FullToShard.value,
+        shard_type=MeshShardType.Devices.value,
+        shard_shape=shard_shape,
+        shard_dims=[-1, dim],
+    )
+
+
+def _shard_to_full_replicate(builder: TTIRBuilder, input: Operand) -> Operand:
+    return builder.mesh_shard(
+        input,
+        shard_direction=MeshShardDirection.ShardToFull.value,
+        shard_type=MeshShardType.Replicate.value,
+        shard_shape=[1],
+        shard_dims=[-1],
+    )
+
+
+def _compile_proj_residual_ttnn(
+    shapes: List[Shape],
+    cluster_axis: int,
+    mesh_shape: Tuple[int, int],
+    request,
+    enable_pass: bool,
+) -> str:
+    """Compile the projection+residual module to TTNN MLIR and return its text.
+
+    A column-parallel projection (replicated activation x column-sharded weight)
+    followed by an all_gather and a replicated residual add. With the pass
+    enabled this lowers to a matmul -> all_gather -> add chain whose activation
+    is cast to bfp_bf8 across the CCL.
+    """
+    act_shape, weight_shape, residual_shape = shapes
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, [torch.bfloat16] * len(shapes))
+        def proj_residual(
+            act: Operand,
+            weight: Operand,
+            residual: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            act_replicated = _full_to_shard_replicate(builder, act)
+            weight_sharded = _full_to_shard_device(builder, weight, dim=1)
+
+            # Projection matmul: [M, K] x [K, N/d] -> [M, N/d] per device.
+            proj = builder.matmul(act_replicated, weight_sharded)
+
+            # Gather the partial columns back to the full [M, N] activation.
+            gathered = builder.all_gather(
+                proj,
+                all_gather_dim=1,
+                cluster_axis=cluster_axis,
+            )
+
+            # Residual add restores bf16 (its result encoding is left bf16).
+            residual_replicated = _full_to_shard_replicate(builder, residual)
+            out = builder.add(gathered, residual_replicated)
+
+            return _shard_to_full_replicate(builder, out)
+
+    kwargs = get_request_kwargs(request)
+    test_base = kwargs["test_base"] + ("__pass_on" if enable_pass else "__pass_off")
+    artifact_dir = get_artifact_dir(
+        kwargs["output_root"], "TTIRBuilder", test_base, make_dir=True
+    )
+
+    pipeline_options = [f"enable-activation-dtype-lowering={str(enable_pass).lower()}"]
+
+    compile_ttir_to_flatbuffer(
+        module,
+        system_desc_path=kwargs["system_desc_path"],
+        artifact_dir=artifact_dir,
+        target="ttnn",
+        mesh_name="mesh",
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        pipeline_options=pipeline_options,
+        save_artifacts=True,
+    )
+
+    with open(os.path.join(artifact_dir, "ttnn_compiled.mlir"), "r") as f:
+        return f.read()
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [[(32, 128), (128, 256), (32, 256)]],
+    ids=["m32_k128_n256"],
+)
+@pytest.mark.parametrize("cluster_axis", [1])
+@pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=shape_str)
+def test_ccl_activation_dtype_lowering(
+    shapes: List[Shape],
+    cluster_axis: int,
+    mesh_shape: Tuple[int, int],
+    request,
+):
+    ir_pass_on = _compile_proj_residual_ttnn(
+        shapes, cluster_axis, mesh_shape, request, enable_pass=True
+    )
+    ir_pass_off = _compile_proj_residual_ttnn(
+        shapes, cluster_axis, mesh_shape, request, enable_pass=False
+    )
+
+    # The pass down-casts the projection activation to bfp_bf8 across the CCL.
+    assert (
+        "bfp_bf8" in ir_pass_on
+    ), "ttnn-ccl-activation-dtype-lowering should emit a bfp_bf8 activation"
+
+    # Without the pass the same module stays bf16 -- proves the bfp_bf8 above is
+    # the pass's doing, not something else in the pipeline.
+    assert (
+        "bfp_bf8" not in ir_pass_off
+    ), "no bfp_bf8 should appear when the pass is disabled"
+
+    # The cast is done by rewriting tensor encodings, never an explicit typecast.
+    assert (
+        "ttnn.typecast" not in ir_pass_on
+    ), "the pass must not insert any ttnn.typecast op"

--- a/test/python/golden/ttir_ops/ccl/test_ccl_activation_dtype_lowering.py
+++ b/test/python/golden/ttir_ops/ccl/test_ccl_activation_dtype_lowering.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import re
 import pytest
 import torch
 from collections import OrderedDict
@@ -16,6 +17,17 @@ from builder.base.builder_apis import compile_ttir_to_flatbuffer
 from test_utils import shape_str
 
 pytestmark = pytest.mark.frontend("ttir")
+
+
+def _has_bfp8_encoding(ir: str) -> bool:
+    """True iff a tensor in `ir` actually carries a bfp_bf8 element type.
+
+    Matches bfp_bf8 only inside a `!ttcore.tile<...>` element type (a real
+    tensor encoding). This deliberately ignores the `supported_data_types`
+    list embedded in the `#system_desc`, which always advertises `<bfp_bf8>`
+    regardless of whether the pass ran.
+    """
+    return re.search(r"!ttcore\.tile<[^>]*bfp_bf8", ir) is not None
 
 
 # Builds the projection + residual pattern the `ttnn-ccl-activation-dtype-lowering`
@@ -155,15 +167,15 @@ def test_ccl_activation_dtype_lowering(
     )
 
     # The pass down-casts the projection activation to bfp_bf8 across the CCL.
-    assert (
-        "bfp_bf8" in ir_pass_on
-    ), "ttnn-ccl-activation-dtype-lowering should emit a bfp_bf8 activation"
+    assert _has_bfp8_encoding(
+        ir_pass_on
+    ), "ttnn-ccl-activation-dtype-lowering should emit a bfp_bf8 activation tensor"
 
     # Without the pass the same module stays bf16 -- proves the bfp_bf8 above is
     # the pass's doing, not something else in the pipeline.
-    assert (
-        "bfp_bf8" not in ir_pass_off
-    ), "no bfp_bf8 should appear when the pass is disabled"
+    assert not _has_bfp8_encoding(
+        ir_pass_off
+    ), "no bfp_bf8 tensor should appear when the pass is disabled"
 
     # The cast is done by rewriting tensor encodings, never an explicit typecast.
     assert (

--- a/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/mlp_123_residual.mlir
+++ b/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/mlp_123_residual.mlir
@@ -1,0 +1,109 @@
+// RUN: ttmlir-opt --ttnn-activation-dtype-lowering=enable=true %s | FileCheck %s
+
+// MLP FF1/FF2/FF3 + residual add: FF1 (up) and FF3 (gate) matmuls ->
+// [view / CCL]* -> silu / multiply. The multiply feeds FF2 (down), and
+// FF2's matmul -> [view / CCL]* -> residual add restores bf16 at the
+// block output.
+//
+// The pass should:
+//   - Rewrite FF1, FF3, FF2 matmul result encodings to bfp_bf8.
+//   - Propagate bfp_bf8 through their CCL chains.
+//   - Rewrite the gate multiply's result encoding to bfp_bf8.
+//   - Leave the final residual add's result encoding as bf16 (TTNN derives
+//     output dtype from the result encoding, restoring bf16 at the exit).
+
+#dram = #ttnn.buffer_type<dram>
+#bf16_a    = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_b    = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_b2   = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_act  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_scat = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_out  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_out_scat = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module attributes {} {
+  // CHECK-LABEL: func.func @mlp_123_residual
+  func.func @mlp_123_residual(
+      %x:        tensor<32x128xbf16, #bf16_a>,
+      %w_ff1:    tensor<128x256xbf16, #bf16_b>,
+      %w_ff3:    tensor<128x256xbf16, #bf16_b>,
+      %w_ff2:    tensor<256x128xbf16, #bf16_b2>,
+      %residual: tensor<32x128xbf16, #bf16_out>
+  ) -> tensor<32x128xbf16, #bf16_out> {
+
+    // FF1 (up) matmul -> CCL -> silu -> multiply (gate)
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: bfp_bf8
+    // CHECK-NOT: ttnn.typecast
+    %ff1 = "ttnn.matmul"(%x, %w_ff1) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x128xbf16, #bf16_a>, tensor<128x256xbf16, #bf16_b>)
+       -> tensor<32x256xbf16, #bf16_act>
+
+    %rs1 = "ttnn.reduce_scatter"(%ff1) <{
+        cluster_axis = 0 : ui32,
+        reduce_type = #ttcore.reduce_type<sum>,
+        scatter_dim = 1 : si32}>
+        : (tensor<32x256xbf16, #bf16_act>) -> tensor<32x64xbf16, #bf16_scat>
+
+    %ag1 = "ttnn.all_gather"(%rs1) <{
+        all_gather_dim = 1 : si32, cluster_axis = 0 : ui32}>
+        : (tensor<32x64xbf16, #bf16_scat>) -> tensor<32x256xbf16, #bf16_act>
+
+    // CHECK: "ttnn.silu"
+    // CHECK-SAME: bfp_bf8
+    // CHECK-NOT: ttnn.typecast
+    %silu = "ttnn.silu"(%ag1) : (tensor<32x256xbf16, #bf16_act>)
+                              -> tensor<32x256xbf16, #bf16_act>
+
+    // FF3 (gate) matmul -> CCL -> multiply
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: bfp_bf8
+    // CHECK-NOT: ttnn.typecast
+    %ff3 = "ttnn.matmul"(%x, %w_ff3) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x128xbf16, #bf16_a>, tensor<128x256xbf16, #bf16_b>)
+       -> tensor<32x256xbf16, #bf16_act>
+
+    %rs3 = "ttnn.reduce_scatter"(%ff3) <{
+        cluster_axis = 0 : ui32,
+        reduce_type = #ttcore.reduce_type<sum>,
+        scatter_dim = 1 : si32}>
+        : (tensor<32x256xbf16, #bf16_act>) -> tensor<32x64xbf16, #bf16_scat>
+
+    %ag3 = "ttnn.all_gather"(%rs3) <{
+        all_gather_dim = 1 : si32, cluster_axis = 0 : ui32}>
+        : (tensor<32x64xbf16, #bf16_scat>) -> tensor<32x256xbf16, #bf16_act>
+
+    // CHECK: "ttnn.multiply"
+    // CHECK-SAME: bfp_bf8
+    // CHECK-NOT: ttnn.typecast
+    %gate = "ttnn.multiply"(%silu, %ag3)
+        : (tensor<32x256xbf16, #bf16_act>, tensor<32x256xbf16, #bf16_act>)
+       -> tensor<32x256xbf16, #bf16_act>
+
+    // FF2 (down) matmul -> CCL -> add (residual). Last add must restore bf16.
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: bfp_bf8
+    // CHECK-NOT: ttnn.typecast
+    %ff2 = "ttnn.matmul"(%gate, %w_ff2) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x256xbf16, #bf16_act>, tensor<256x128xbf16, #bf16_b2>)
+       -> tensor<32x128xbf16, #bf16_out>
+
+    %rs2 = "ttnn.reduce_scatter"(%ff2) <{
+        cluster_axis = 1 : ui32,
+        reduce_type = #ttcore.reduce_type<sum>,
+        scatter_dim = 1 : si32}>
+        : (tensor<32x128xbf16, #bf16_out>) -> tensor<32x32xbf16, #bf16_out_scat>
+
+    %ag2 = "ttnn.all_gather"(%rs2) <{
+        all_gather_dim = 1 : si32, cluster_axis = 1 : ui32}>
+        : (tensor<32x32xbf16, #bf16_out_scat>) -> tensor<32x128xbf16, #bf16_out>
+
+    // CHECK: "ttnn.add"
+    // CHECK-NOT: ttnn.typecast
+    %out = "ttnn.add"(%residual, %ag2)
+        : (tensor<32x128xbf16, #bf16_out>, tensor<32x128xbf16, #bf16_out>)
+       -> tensor<32x128xbf16, #bf16_out>
+
+    return %out : tensor<32x128xbf16, #bf16_out>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/mlp_123_residual.mlir
+++ b/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/mlp_123_residual.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttnn-activation-dtype-lowering=enable=true %s | FileCheck %s
+// RUN: ttmlir-opt --ttnn-ccl-activation-dtype-lowering %s | FileCheck %s
 
 // MLP FF1/FF2/FF3 + residual add: FF1 (up) and FF3 (gate) matmuls ->
 // [view / CCL]* -> silu / multiply. The multiply feeds FF2 (down), and

--- a/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/mlp_gate_no_match.mlir
+++ b/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/mlp_gate_no_match.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttnn-activation-dtype-lowering=enable=true %s | FileCheck %s
+// RUN: ttmlir-opt --ttnn-ccl-activation-dtype-lowering %s | FileCheck %s
 
 // Negative tests for the MLP up/gate matcher's strictness. The matcher only
 // fires when the gate multiply feeds *exactly one* consumer and that consumer

--- a/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/mlp_gate_no_match.mlir
+++ b/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/mlp_gate_no_match.mlir
@@ -1,0 +1,119 @@
+// RUN: ttmlir-opt --ttnn-activation-dtype-lowering=enable=true %s | FileCheck %s
+
+// Negative tests for the MLP up/gate matcher's strictness. The matcher only
+// fires when the gate multiply feeds *exactly one* consumer and that consumer
+// is the FF2 (down) matmul rooting a projection-residual chain. The two cases
+// below each violate one of those conditions, so nothing should be lowered to
+// bfp_bf8.
+
+#dram = #ttnn.buffer_type<dram>
+#bf16_a    = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_b    = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_b2   = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_act  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_scat = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_out  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module attributes {} {
+  // Case 1: the gate multiply fans out to a second consumer (the FF2 matmul
+  // *and* an extra add), so it does not have a single use. The matcher must
+  // not lower anything.
+  // CHECK-LABEL: func.func @mlp_gate_multi_use
+  // CHECK-NOT: bfp_bf8
+  func.func @mlp_gate_multi_use(
+      %x:     tensor<32x128xbf16, #bf16_a>,
+      %w_ff1: tensor<128x256xbf16, #bf16_b>,
+      %w_ff3: tensor<128x256xbf16, #bf16_b>,
+      %w_ff2: tensor<256x128xbf16, #bf16_b2>
+  ) -> (tensor<32x128xbf16, #bf16_out>, tensor<32x256xbf16, #bf16_act>) {
+
+    %ff1 = "ttnn.matmul"(%x, %w_ff1) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x128xbf16, #bf16_a>, tensor<128x256xbf16, #bf16_b>)
+       -> tensor<32x256xbf16, #bf16_act>
+    %rs1 = "ttnn.reduce_scatter"(%ff1) <{
+        cluster_axis = 0 : ui32,
+        reduce_type = #ttcore.reduce_type<sum>,
+        scatter_dim = 1 : si32}>
+        : (tensor<32x256xbf16, #bf16_act>) -> tensor<32x64xbf16, #bf16_scat>
+    %ag1 = "ttnn.all_gather"(%rs1) <{
+        all_gather_dim = 1 : si32, cluster_axis = 0 : ui32}>
+        : (tensor<32x64xbf16, #bf16_scat>) -> tensor<32x256xbf16, #bf16_act>
+    %silu = "ttnn.silu"(%ag1) : (tensor<32x256xbf16, #bf16_act>)
+                              -> tensor<32x256xbf16, #bf16_act>
+
+    %ff3 = "ttnn.matmul"(%x, %w_ff3) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x128xbf16, #bf16_a>, tensor<128x256xbf16, #bf16_b>)
+       -> tensor<32x256xbf16, #bf16_act>
+    %rs3 = "ttnn.reduce_scatter"(%ff3) <{
+        cluster_axis = 0 : ui32,
+        reduce_type = #ttcore.reduce_type<sum>,
+        scatter_dim = 1 : si32}>
+        : (tensor<32x256xbf16, #bf16_act>) -> tensor<32x64xbf16, #bf16_scat>
+    %ag3 = "ttnn.all_gather"(%rs3) <{
+        all_gather_dim = 1 : si32, cluster_axis = 0 : ui32}>
+        : (tensor<32x64xbf16, #bf16_scat>) -> tensor<32x256xbf16, #bf16_act>
+
+    %gate = "ttnn.multiply"(%silu, %ag3)
+        : (tensor<32x256xbf16, #bf16_act>, tensor<32x256xbf16, #bf16_act>)
+       -> tensor<32x256xbf16, #bf16_act>
+
+    // First consumer: the FF2 (down) matmul.
+    %ff2 = "ttnn.matmul"(%gate, %w_ff2) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x256xbf16, #bf16_act>, tensor<256x128xbf16, #bf16_b2>)
+       -> tensor<32x128xbf16, #bf16_out>
+    // Second consumer: extra use of the gate -> multiply is not single-use.
+    %extra = "ttnn.add"(%gate, %gate)
+        : (tensor<32x256xbf16, #bf16_act>, tensor<32x256xbf16, #bf16_act>)
+       -> tensor<32x256xbf16, #bf16_act>
+
+    return %ff2, %extra : tensor<32x128xbf16, #bf16_out>, tensor<32x256xbf16, #bf16_act>
+  }
+
+  // Case 2: the gate multiply has a single use, but its consumer is not a
+  // matmul (it feeds another silu), so it is not the FF2 down-projection. The
+  // matcher must not lower anything.
+  // CHECK-LABEL: func.func @mlp_gate_consumer_not_matmul
+  // CHECK-NOT: bfp_bf8
+  func.func @mlp_gate_consumer_not_matmul(
+      %x:     tensor<32x128xbf16, #bf16_a>,
+      %w_ff1: tensor<128x256xbf16, #bf16_b>,
+      %w_ff3: tensor<128x256xbf16, #bf16_b>
+  ) -> tensor<32x256xbf16, #bf16_act> {
+
+    %ff1 = "ttnn.matmul"(%x, %w_ff1) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x128xbf16, #bf16_a>, tensor<128x256xbf16, #bf16_b>)
+       -> tensor<32x256xbf16, #bf16_act>
+    %rs1 = "ttnn.reduce_scatter"(%ff1) <{
+        cluster_axis = 0 : ui32,
+        reduce_type = #ttcore.reduce_type<sum>,
+        scatter_dim = 1 : si32}>
+        : (tensor<32x256xbf16, #bf16_act>) -> tensor<32x64xbf16, #bf16_scat>
+    %ag1 = "ttnn.all_gather"(%rs1) <{
+        all_gather_dim = 1 : si32, cluster_axis = 0 : ui32}>
+        : (tensor<32x64xbf16, #bf16_scat>) -> tensor<32x256xbf16, #bf16_act>
+    %silu = "ttnn.silu"(%ag1) : (tensor<32x256xbf16, #bf16_act>)
+                              -> tensor<32x256xbf16, #bf16_act>
+
+    %ff3 = "ttnn.matmul"(%x, %w_ff3) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x128xbf16, #bf16_a>, tensor<128x256xbf16, #bf16_b>)
+       -> tensor<32x256xbf16, #bf16_act>
+    %rs3 = "ttnn.reduce_scatter"(%ff3) <{
+        cluster_axis = 0 : ui32,
+        reduce_type = #ttcore.reduce_type<sum>,
+        scatter_dim = 1 : si32}>
+        : (tensor<32x256xbf16, #bf16_act>) -> tensor<32x64xbf16, #bf16_scat>
+    %ag3 = "ttnn.all_gather"(%rs3) <{
+        all_gather_dim = 1 : si32, cluster_axis = 0 : ui32}>
+        : (tensor<32x64xbf16, #bf16_scat>) -> tensor<32x256xbf16, #bf16_act>
+
+    %gate = "ttnn.multiply"(%silu, %ag3)
+        : (tensor<32x256xbf16, #bf16_act>, tensor<32x256xbf16, #bf16_act>)
+       -> tensor<32x256xbf16, #bf16_act>
+
+    // Single use, but the consumer is a silu, not the FF2 matmul.
+    %out = "ttnn.silu"(%gate) : (tensor<32x256xbf16, #bf16_act>)
+                              -> tensor<32x256xbf16, #bf16_act>
+
+    return %out : tensor<32x256xbf16, #bf16_act>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/no_match_isolated_matmul.mlir
+++ b/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/no_match_isolated_matmul.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt --ttnn-activation-dtype-lowering=enable=true %s | FileCheck %s
+
+// A matmul whose result does not flow into any CCL op must be left untouched.
+// The strict matchers should under-trigger by design.
+
+#dram = #ttnn.buffer_type<dram>
+#bf16_a = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_b = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_out = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module attributes {} {
+  // CHECK-LABEL: func.func @matmul_no_ccl_downstream
+  func.func @matmul_no_ccl_downstream(
+      %arg0: tensor<32x128xbf16, #bf16_a>,
+      %arg1: tensor<128x256xbf16, #bf16_b>
+  ) -> tensor<32x256xbf16, #bf16_out> {
+    // CHECK: "ttnn.matmul"
+    // CHECK-NOT: bfp_bf8
+    // CHECK-SAME: -> tensor<32x256xbf16
+    %0 = "ttnn.matmul"(%arg0, %arg1) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x128xbf16, #bf16_a>, tensor<128x256xbf16, #bf16_b>)
+       -> tensor<32x256xbf16, #bf16_out>
+    return %0 : tensor<32x256xbf16, #bf16_out>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/no_match_isolated_matmul.mlir
+++ b/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/no_match_isolated_matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttnn-activation-dtype-lowering=enable=true %s | FileCheck %s
+// RUN: ttmlir-opt --ttnn-ccl-activation-dtype-lowering %s | FileCheck %s
 
 // A matmul whose result does not flow into any CCL op must be left untouched.
 // The strict matchers should under-trigger by design.

--- a/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/o_proj_residual.mlir
+++ b/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/o_proj_residual.mlir
@@ -1,0 +1,55 @@
+// RUN: ttmlir-opt --ttnn-activation-dtype-lowering=enable=true %s | FileCheck %s
+
+// Projection + residual add: O-projection matmul ->
+// [view / reduce_scatter / all_gather]* -> residual add. The matmul's
+// result encoding is rewritten to bfp_bf8 (propagating through the CCL
+// chain), and the residual add's result encoding stays bf16, so the runtime
+// produces bf16 at the block output by combining the bfp_bf8 CCL output
+// with the bf16 residual. No explicit ttnn.typecast is emitted.
+
+#dram = #ttnn.buffer_type<dram>
+#bf16_2d_a = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_2d_b = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_2d_out = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#bf16_2d_scat = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module attributes {} {
+  // CHECK-LABEL: func.func @o_proj_residual
+  func.func @o_proj_residual(
+      %act:      tensor<32x128xbf16, #bf16_2d_a>,
+      %weight:   tensor<128x256xbf16, #bf16_2d_b>,
+      %residual: tensor<32x256xbf16, #bf16_2d_out>
+  ) -> tensor<32x256xbf16, #bf16_2d_out> {
+
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: bfp_bf8
+    // CHECK-NOT: ttnn.typecast
+    %m = "ttnn.matmul"(%act, %weight) <{transpose_a = false, transpose_b = false}>
+        : (tensor<32x128xbf16, #bf16_2d_a>, tensor<128x256xbf16, #bf16_2d_b>)
+       -> tensor<32x256xbf16, #bf16_2d_out>
+
+    // CHECK: "ttnn.reduce_scatter"
+    // CHECK-SAME: bfp_bf8
+    // CHECK-NOT: ttnn.typecast
+    %rs = "ttnn.reduce_scatter"(%m) <{
+        cluster_axis = 1 : ui32,
+        reduce_type = #ttcore.reduce_type<sum>,
+        scatter_dim = 1 : si32}>
+        : (tensor<32x256xbf16, #bf16_2d_out>) -> tensor<32x64xbf16, #bf16_2d_scat>
+
+    // CHECK: "ttnn.all_gather"
+    // CHECK-SAME: bfp_bf8
+    // CHECK-NOT: ttnn.typecast
+    %ag = "ttnn.all_gather"(%rs) <{
+        all_gather_dim = 1 : si32, cluster_axis = 1 : ui32}>
+        : (tensor<32x64xbf16, #bf16_2d_scat>) -> tensor<32x256xbf16, #bf16_2d_out>
+
+    // CHECK: "ttnn.add"
+    // CHECK-NOT: ttnn.typecast
+    %out = "ttnn.add"(%residual, %ag)
+        : (tensor<32x256xbf16, #bf16_2d_out>, tensor<32x256xbf16, #bf16_2d_out>)
+       -> tensor<32x256xbf16, #bf16_2d_out>
+
+    return %out : tensor<32x256xbf16, #bf16_2d_out>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/o_proj_residual.mlir
+++ b/test/ttmlir/Dialect/TTNN/activation_dtype_lowering/o_proj_residual.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttnn-activation-dtype-lowering=enable=true %s | FileCheck %s
+// RUN: ttmlir-opt --ttnn-ccl-activation-dtype-lowering %s | FileCheck %s
 
 // Projection + residual add: O-projection matmul ->
 // [view / reduce_scatter / all_gather]* -> residual add. The matmul's


### PR DESCRIPTION
### Ticket
Closes #8700

### Problem description
All CCLs are currently moving bf16 data across ethernet links. We could save a lot of time just by having activations on bfp8 before CCLs and returning back to bf16 after CCls.

Good news is that many target patterns in LLMs enable us to do implicit casting by setting return dtype of operation to bfp8 instead of having to add explicit cast.

Some general pattern we see is: matmul -> [view/CCLs]* -> residual add (Both in MLP layers and Output projection)
So matmul generates output at bfp8, activations go to CCLs -> and residual add generates bf16 output.

Goal: speed up CCLs , without regressing e2e accuracy

### What's changed
Added ttnn-activation-dtype-lowering pass that lowers activation precision to bfp_bf8 across CCL boundaries to reduce ethernet traffic, then restores bf16 afterwards. No explicit ttnn.typecast ops are inserted -- every cast is done by rewriting a result tensor's layout encoding.

The idea is to make sure CCLs in LLMs work on bfp8 activations instead of bf16.


How the two casts happen:
  - Down-cast (bf16 -> bfp_bf8): rewrite a matmul's result encoding to bfp_bf8. Matmul directly emits bfp_bf8 directly at the producer.
  - Up-cast (bfp_bf8 -> bf16): done implicitly by a residual add. The add has a bfp_bf8 operand (the CCL output) and a bf16 operand (the residual); its result encoding is left bf16, so TTNN produces a bf16 output -- no cast op needed.

Two strict per-pattern matchers landed here.

Pattern 1 -- projection + residual (attention output / MLP down):
    matmul -> [view / CCL]* -> residual add
  - down-cast bf16 -> bfp_bf8 at the projection matmul output; bfp_bf8 then propagates through the view / CCL chain.
  - up-cast bfp_bf8 -> bf16 at the residual add (its encoding is left bf16).

Pattern 2 -- MLP up / gate:
    FF1 (up)   matmul -> [view / CCL]* -> silu --\
                                                  multiply (gate) -> FF2 matmul
    FF3 (gate) matmul -> [view / CCL]* ----------/
  - down-cast bf16 -> bfp_bf8 at the FF1 and FF3 matmul outputs; bfp_bf8
    propagates through their view / CCL / silu chains.
  - the gate multiply's result encoding is also rewritten to bfp_bf8, so the
    downstream FF2 (down) matmul receives bfp_bf8 input.
  - no up-cast happens inside this pattern: bf16 is restored later, at the FF2
    residual add, when FF2 is matched by Pattern 1.
  - the gate multiply is matched strictly -- it must feed exactly one
    consumer, that consumer must be the FF2 matmul, and FF2 must itself root a
    Pattern 1 chain (guaranteeing the bf16 return point exists). This rejects
    multiplies that fan out or whose output is not a matmul followed by add.

A matmul only matches a pattern when the entire downstream chain matches the template, so the pass under-triggers by design. Pass is gated by --enable-activation-dtype-lowering.

Added lit tests covering both matchers, a no-match isolated-matmul case, and no-match MLP gate cases (multiply fan-out / non-matmul consumer).


Verified in tt-xla on LLama 70B. We get some small perf bump while not regressing the accuracy. Will follow up with exact numbers in tt-xla PR.

QKV-projection-to-RoPE / KV-cache and LM-head -> argmax matchers are parked on a follow-up PR. Reason - they require a kernel-side cast on the exit and are waiting on the related tt-metal changes to be uplifted to tt-mlir.
