### PR TITLE
[ttkernel] bf16 and f32 metal soft float scalar comparison

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4723,10 +4723,10 @@ def TTKernel_GetDataFormatOp: TTKernel_Op<"get_dataformat"> {
 //===----------------------------------------------------------------------===//
 
 def TTKernel_Bfloat16GreaterOp : TTKernel_Op<"bfloat16_greater", [Pure]> {
-    let summary = "Compare two bfloat16 values.";
+    let summary = "Compare two bfloat16 values using integer arithmetic.";
     let description = [{
-      Returns true if bf16_a > bf16_b using integer arithmetic.
-      Maps to bfloat16_greater() in device code.
+      Returns true if bf16_a > bf16_b.  Operates on the raw uint16 bit
+      representation.  Maps to bfloat16_greater() in device code.
     }];
 
     let arguments = (ins UI16:$bf16_a, UI16:$bf16_b);

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4718,6 +4718,40 @@ def TTKernel_GetDataFormatOp: TTKernel_Op<"get_dataformat"> {
     }];
 }
 
+//===----------------------------------------------------------------------===//
+// TTKernel Numeric operations
+//===----------------------------------------------------------------------===//
+
+def TTKernel_Bfloat16GreaterOp : TTKernel_Op<"bfloat16_greater", [Pure]> {
+    let summary = "Compare two bfloat16 values.";
+    let description = [{
+      Returns true if bf16_a > bf16_b using integer arithmetic.
+      Maps to bfloat16_greater() in device code.
+    }];
+
+    let arguments = (ins UI16:$bf16_a, UI16:$bf16_b);
+    let results = (outs I1:$result);
+
+    let assemblyFormat = [{
+      `(` $bf16_a `,` $bf16_b `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
+def TTKernel_Float32GreaterOp : TTKernel_Op<"float32_greater", [Pure]> {
+    let summary = "Compare two float32 values using integer arithmetic.";
+    let description = [{
+      Returns true if f32_a > f32_b.  Operates on the raw uint32 bit
+      representation.  Maps to float32_greater() in device code.
+    }];
+
+    let arguments = (ins UI32:$f32_a, UI32:$f32_b);
+    let results = (outs I1:$result);
+
+    let assemblyFormat = [{
+      `(` $f32_a `,` $f32_b `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
 def TTKernel_DPrintOp : TTKernel_Op<"dprint", [MemoryEffects<[MemRead, MemWrite]>]> {
     let summary = "Print to output stream from kernel.";
     let description = [{

--- a/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
@@ -265,6 +265,10 @@ inline const llvm::StringMap<HeaderRequirement> &getCalleeToHeadersMap() {
         {"experimental::untilize_block",                   {"api/compute/untilize.h", ""}},
         {"experimental::pack_untilize_block",              {"api/compute/pack_untilize.h", ""}},
 
+        // Numeric.
+        {"bfloat16_greater",                               {"api/numeric/bfloat16.h", "api/numeric/bfloat16.h"}},
+        {"float32_greater",                                {"api/numeric/float32.h", "api/numeric/float32.h"}},
+
         // System.
         // These size_t specializations are hard-coded in TTKernelToEmitC.
         {"std::max<size_t>",                               {"<algorithm>", "<algorithm>"}},

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -2045,6 +2045,10 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsWaitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsReleaseOp>,
 
+        // Numeric
+        TTKernelToEmitCOpaqueRewriter<ttkernel::Bfloat16GreaterOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::Float32GreaterOp>,
+
         // Compute kernel hardware startup
         TTKernelToEmitCOpaqueRewriter<ttkernel::ComputeKernelHWStartupOp>,
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2878,4 +2878,32 @@ module {
 
   } // module
 
+  //===----------------------------------------------------------------------===//
+  // TTKernel Numeric operations
+  //===----------------------------------------------------------------------===//
+
+  module @ttkernel_numeric_operations {
+
+    // CHECK-LABEL: func @bfloat16_greater
+    func.func @bfloat16_greater() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      %raw0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> ui32
+      %raw1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> ui32
+      %arg0 = ttkernel.bitcast %raw0 : ui32 to ui16
+      %arg1 = ttkernel.bitcast %raw1 : ui32 to ui16
+      // CHECK: emitc.call_opaque "bfloat16_greater"(%{{.*}}, %{{.*}}) : (ui16, ui16) -> i1
+      %0 = ttkernel.bfloat16_greater(%arg0, %arg1) : (ui16, ui16) -> i1
+      return
+    }
+
+    // CHECK-LABEL: func @float32_greater
+    func.func @float32_greater() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      %arg0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> ui32
+      %arg1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> ui32
+      // CHECK: emitc.call_opaque "float32_greater"(%{{.*}}, %{{.*}}) : (ui32, ui32) -> i1
+      %0 = ttkernel.float32_greater(%arg0, %arg1) : (ui32, ui32) -> i1
+      return
+    }
+
+  } // module
+
 } // module

--- a/test/ttmlir/Dialect/TTKernel/ops.mlir
+++ b/test/ttmlir/Dialect/TTKernel/ops.mlir
@@ -245,3 +245,23 @@ func.func @test_remote_mailbox_protocol_ops(%mailbox: !ttkernel.l1_addr) {
   %sink = arith.addi %loaded, %zero : i32
   return
 }
+
+//===----------------------------------------------------------------------===//
+// Numeric operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @test_bfloat16_greater
+// CHECK-SAME: (%[[A:.*]]: ui16, %[[B:.*]]: ui16)
+func.func @test_bfloat16_greater(%arg0: ui16, %arg1: ui16) -> () {
+  %0 = ttkernel.bfloat16_greater(%arg0, %arg1) : (ui16, ui16) -> i1
+  // CHECK: ttkernel.bfloat16_greater(%[[A]], %[[B]]) : (ui16, ui16) -> i1
+  return
+}
+
+// CHECK-LABEL: func.func @test_float32_greater
+// CHECK-SAME: (%[[A:.*]]: ui32, %[[B:.*]]: ui32)
+func.func @test_float32_greater(%arg0: ui32, %arg1: ui32) -> () {
+  %0 = ttkernel.float32_greater(%arg0, %arg1) : (ui32, ui32) -> i1
+  // CHECK: ttkernel.float32_greater(%[[A]], %[[B]]) : (ui32, ui32) -> i1
+  return
+}

--- a/test/ttmlir/Translate/TTKernel/ttkernel_numeric.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_numeric.mlir
@@ -5,8 +5,8 @@
 // CHECK: #include "api/numeric/bfloat16.h"
 // CHECK: void kernel_main()
 func.func @bfloat16_greater_test() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-    %raw0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> ui32
-    %raw1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> ui32
+    %raw0 = ttkernel.get_compile_time_arg_val(0) : () -> ui32
+    %raw1 = ttkernel.get_compile_time_arg_val(1) : () -> ui32
     %a = ttkernel.bitcast %raw0 : ui32 to ui16
     %b = ttkernel.bitcast %raw1 : ui32 to ui16
     // CHECK: bool [[V1:v[0-9]+]] = bfloat16_greater(
@@ -17,9 +17,9 @@ func.func @bfloat16_greater_test() -> () attributes {ttkernel.arg_spec = #ttkern
 // CHECK: #include "api/numeric/float32.h"
 // CHECK: void kernel_main()
 func.func @float32_greater_test() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-    %arg0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> ui32
-    %arg1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> ui32
-    // CHECK: bool [[V1:v[0-9]+]] = float32_greater(
+    %arg0 = ttkernel.get_compile_time_arg_val(0) : () -> ui32
+    %arg1 = ttkernel.get_compile_time_arg_val(1) : () -> ui32
+    // CHECK: bool [[V2:v[0-9]+]] = float32_greater(
     %0 = ttkernel.float32_greater(%arg0, %arg1) : (ui32, ui32) -> i1
     func.return
 }

--- a/test/ttmlir/Translate/TTKernel/ttkernel_numeric.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_numeric.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt --convert-ttkernel-to-emitc -o %t %s
+// RUN: ttmlir-translate --ttkernel-to-cpp -o %t.cpp %t
+// RUN: FileCheck %s --input-file=%t.cpp
+
+// CHECK: #include "api/numeric/bfloat16.h"
+// CHECK: void kernel_main()
+func.func @bfloat16_greater_test() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    %raw0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> ui32
+    %raw1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> ui32
+    %a = ttkernel.bitcast %raw0 : ui32 to ui16
+    %b = ttkernel.bitcast %raw1 : ui32 to ui16
+    // CHECK: bool [[V1:v[0-9]+]] = bfloat16_greater(
+    %0 = ttkernel.bfloat16_greater(%a, %b) : (ui16, ui16) -> i1
+    func.return
+}
+
+// CHECK: #include "api/numeric/float32.h"
+// CHECK: void kernel_main()
+func.func @float32_greater_test() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    %arg0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> ui32
+    %arg1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> ui32
+    // CHECK: bool [[V1:v[0-9]+]] = float32_greater(
+    %0 = ttkernel.float32_greater(%arg0, %arg1) : (ui32, ui32) -> i1
+    func.return
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The TTKernel dialect lacks ops for scalar numeric comparisons on bfloat16 and float32 values. These are needed to implement device-side conditional logic that operates on raw numeric bit patterns (e.g. comparing bfloat16 values stored as uint16, or float32 values stored as uint32).

### What's changed
Adds two new TTKernel ops that map to tt-metal's scalar numeric APIs:

- **`ttkernel.bfloat16_greater`** — wraps `bfloat16_greater()` from `api/numeric/bfloat16.h`. Compares two `ui16` bfloat16 values and returns `i1`.
- **`ttkernel.float32_greater`** — wraps `float32_greater()` from `api/numeric/float32.h`. Compares two `ui32` float32 bit patterns and returns `i1`.

Both ops use the existing `TTKernelToEmitCOpaqueRewriter` template for lowering to `emitc.call_opaque`, and the includes map is extended so `TTKernelToCpp` emits the correct `#include` directives.

Three layers of test coverage are added:
1. Dialect round-trip (`test/ttmlir/Dialect/TTKernel/ops.mlir`)
2. TTKernelToEmitC conversion (`test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir`)
3. End-to-end C++ translation (`test/ttmlir/Translate/TTKernel/ttkernel_numeric.mlir`)

### Checklist
- [x] New/Existing tests provide coverage for changes