### PR TITLE
[L1SpillManagement] Don't evict source of a view-eligible reshape (#8625)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -377,6 +377,13 @@ private:
   uint64_t ensureFitsL1(Operation *op, int64_t pos, ScheduleData &data,
                         uint64_t cbPeakUsage, uint64_t l1Size);
 
+  /// True when `op` is a view-eligible reshape whose source operand is still
+  /// resident in L1. Its output will alias the source's existing slot
+  /// (addTensorAtAddress) instead of carving a fresh one, so it consumes no
+  /// additional L1 and the fit / CB-overlap checks must not treat it as a
+  /// new allocation.
+  bool willAliasSourceInL1(Operation *op) const;
+
   /// OOM recovery: evict farthest-last-use tensors or demote self to DRAM.
   void handleOOM(Operation *op, int64_t pos,
                  llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -579,11 +579,32 @@ void L1SpillManagement<MemoryTracker>::processDeadTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
+bool L1SpillManagement<MemoryTracker>::willAliasSourceInL1(
+    Operation *op) const {
+  // canReshapeBeView already guarantees op is a ReshapeOp with operand(0).
+  // Use hasTensorAddress (not hasTensor): aliasing calls allocateAddressAt,
+  // which requires the source to occupy a simulated address slot. A tensor
+  // can be size-tracked but not address-tracked (e.g. zero-size or no-fit),
+  // in which case it cannot be aliased. This matches the replay path.
+  return canReshapeBeView(op) &&
+         memoryTracker.hasTensorAddress(op->getOperand(0));
+}
+
+template <typename MemoryTracker>
 uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
                                                         int64_t pos,
                                                         ScheduleData &data,
                                                         uint64_t cbPeakUsage,
                                                         uint64_t l1Size) {
+  // A view-eligible reshape aliases its source's existing L1 slot
+  // (addResultsToLiveSet uses addTensorAtAddress), so it consumes no fresh
+  // L1. Skip the fit / CB-overlap checks that assume a new allocation —
+  // otherwise wouldAllocateAt(l1Size) can falsely report no-fit and evict
+  // the very source the reshape is about to alias.
+  if (willAliasSourceInL1(op)) {
+    return l1Size;
+  }
+
   auto speculativeAddr = memoryTracker.wouldAllocateAt(l1Size);
   if (!speculativeAddr) {
     l1Size = handleNoFit(op, pos, data, l1Size);
@@ -1329,10 +1350,10 @@ void L1SpillManagement<MemoryTracker>::run() {
             {L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
 
         // View-eligible reshape: alias src's buffer instead of carving a
-        // fresh slot. See `addTensorAtAddress`.
+        // fresh slot. See `addTensorAtAddress`. Must stay in sync with the
+        // willAliasSourceInL1 short-circuit in ensureFitsL1.
         Operation *defOp = val.getDefiningOp();
-        if (defOp && canReshapeBeView(defOp) &&
-            memoryTracker.hasTensor(defOp->getOperand(0))) {
+        if (defOp && willAliasSourceInL1(defOp)) {
           memoryTracker.addTensorAtAddress(val, perResultL1,
                                            defOp->getOperand(0));
         } else {

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -658,22 +658,14 @@ TEST_F(HandleNoFitTest, AllocFreeReallocCoalesces) {
 
 class ViewEligibleReshapeAliasTest : public L1SpillTestFixture {};
 
-// DISABLED — reproducer for
-// https://github.com/tenstorrent/tt-mlir/issues/8625
+// Regression test for https://github.com/tenstorrent/tt-mlir/issues/8625.
 //
-// The alias path (`addTensorAtAddress` at L1SpillManagement.cpp:1124-1133)
-// runs only AFTER `ensureFitsL1` queries `wouldAllocateAt(perResultL1)`
-// using the reshape's full output size — ignoring that a view-eligible
-// reshape would not consume a fresh slot. So in any scenario where the
-// would-be alias size would otherwise force eviction, the pass evicts
-// the input instead of recognising the alias.
-//
-// To meaningfully test the alias path, the pass needs to consult
-// canReshapeBeView (or an analogous predicate) before the fit/CB
-// checks. Until then, this test reproduces the limitation: opA is
-// spilled even though the reshape SHOULD alias it.
-TEST_F(ViewEligibleReshapeAliasTest,
-       DISABLED_ReshapeAliasesInputNoDoubleCount) {
+// A view-eligible reshape aliases its source's existing L1 slot, so it
+// consumes no fresh L1. Without the willAliasSourceInL1 short-circuit in
+// ensureFitsL1, the pass would query wouldAllocateAt() with the reshape's
+// full output size, find no contiguous block (the source already fills
+// most of L1), and evict the very source the reshape is about to alias.
+TEST_F(ViewEligibleReshapeAliasTest, ReshapeAliasesInputNoDoubleCount) {
   l1BudgetPerCore = 1300 * kKiB;
 
   // 1024 = 32 × 32 (tile-aligned). 256 = 32 × 8 (tile-aligned).
@@ -695,13 +687,14 @@ TEST_F(ViewEligibleReshapeAliasTest,
   finishFunc({opConsumer->getResult(0)});
 
   auto [obs] = run();
-  (void)obs;
 
   EXPECT_EQ(obs->evictions.size(), 0u)
       << "view-eligible reshape must alias opA's slot — no eviction expected";
   EXPECT_EQ(countSpills(), 0u);
   EXPECT_FALSE(wasSpilled(opA->getResult(0)))
       << "opA must stay in L1; reshape aliases its slot";
+  EXPECT_TRUE(resultIsL1(opReshape->getResult(0)))
+      << "reshape output stays L1 (aliased), not demoted";
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

Fixes #8625.

`ensureFitsL1` queried `wouldAllocateAt()` with a reshape's full output size **before** the alias path (`addTensorAtAddress`) was reached. For a view-eligible reshape whose source nearly fills L1, that reported no-fit and evicted the very source the reshape was about to alias — a spurious spill.

## Fix

- Add `willAliasSourceInL1(op)`: true when `op` is a view-eligible reshape (`canReshapeBeView`) whose source operand is still L1-resident.
- Short-circuit `ensureFitsL1` for such ops — the aliased output consumes no fresh L1, so the fit / CB-overlap checks (which assume a new allocation) must be skipped.
- The same predicate now drives the `addTensorAtAddress` decision in `addResultsToLiveSet`, keeping the fit check and the allocation in sync.

## Test

Enables the previously `DISABLED_` `ViewEligibleReshapeAliasTest` as a regression test: a 1 MiB L1 source + a view-eligible reshape under a 1.3 MiB budget now produces 0 evictions and the source stays in L1.

- [x] `L1SpillManagementTests` — 17 pass, 0 disabled
- [x] `check-ttmlir` — 1806 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)