### PR TITLE
[ttkernel] switching op to signless

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4725,11 +4725,11 @@ def TTKernel_GetDataFormatOp: TTKernel_Op<"get_dataformat"> {
 def TTKernel_Bfloat16GreaterOp : TTKernel_Op<"bfloat16_greater", [Pure]> {
     let summary = "Compare two bfloat16 values using integer arithmetic.";
     let description = [{
-      Returns true if bf16_a > bf16_b.  Operates on the raw uint16 bit
+      Returns true if bf16_a > bf16_b.  Operates on the raw int16 bit
       representation.  Maps to bfloat16_greater() in device code.
     }];
 
-    let arguments = (ins UI16:$bf16_a, UI16:$bf16_b);
+    let arguments = (ins I16:$bf16_a, I16:$bf16_b);
     let results = (outs I1:$result);
 
     let assemblyFormat = [{
@@ -4740,11 +4740,11 @@ def TTKernel_Bfloat16GreaterOp : TTKernel_Op<"bfloat16_greater", [Pure]> {
 def TTKernel_Float32GreaterOp : TTKernel_Op<"float32_greater", [Pure]> {
     let summary = "Compare two float32 values using integer arithmetic.";
     let description = [{
-      Returns true if f32_a > f32_b.  Operates on the raw uint32 bit
+      Returns true if f32_a > f32_b.  Operates on the raw int32 bit
       representation.  Maps to float32_greater() in device code.
     }];
 
-    let arguments = (ins UI32:$f32_a, UI32:$f32_b);
+    let arguments = (ins I32:$f32_a, I32:$f32_b);
     let results = (outs I1:$result);
 
     let assemblyFormat = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4725,7 +4725,7 @@ def TTKernel_GetDataFormatOp: TTKernel_Op<"get_dataformat"> {
 def TTKernel_Bfloat16GreaterOp : TTKernel_Op<"bfloat16_greater", [Pure]> {
     let summary = "Compare two bfloat16 values using integer arithmetic.";
     let description = [{
-      Returns true if bf16_a > bf16_b.  Operates on the raw int16 bit
+      Returns true if bf16_a > bf16_b.  Operates on raw bits in int16 format
       representation.  Maps to bfloat16_greater() in device code.
     }];
 
@@ -4740,8 +4740,7 @@ def TTKernel_Bfloat16GreaterOp : TTKernel_Op<"bfloat16_greater", [Pure]> {
 def TTKernel_Float32GreaterOp : TTKernel_Op<"float32_greater", [Pure]> {
     let summary = "Compare two float32 values using integer arithmetic.";
     let description = [{
-      Returns true if f32_a > f32_b.  Operates on the raw int32 bit
-      representation.  Maps to float32_greater() in device code.
+      Returns true if f32_a > f32_b.  Operates on raw bits in int32 format.  Maps to float32_greater() in device code.
     }];
 
     let arguments = (ins I32:$f32_a, I32:$f32_b);

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2886,21 +2886,21 @@ module {
 
     // CHECK-LABEL: func @bfloat16_greater
     func.func @bfloat16_greater() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-      %raw0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> ui32
-      %raw1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> ui32
-      %arg0 = ttkernel.bitcast %raw0 : ui32 to ui16
-      %arg1 = ttkernel.bitcast %raw1 : ui32 to ui16
-      // CHECK: emitc.call_opaque "bfloat16_greater"(%{{.*}}, %{{.*}}) : (ui16, ui16) -> i1
-      %0 = ttkernel.bfloat16_greater(%arg0, %arg1) : (ui16, ui16) -> i1
+      %raw0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> i32
+      %raw1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> i32
+      %arg0 = arith.trunci %raw0 : i32 to i16
+      %arg1 = arith.trunci %raw1 : i32 to i16
+      // CHECK: emitc.call_opaque "bfloat16_greater"(%{{.*}}, %{{.*}}) : (i16, i16) -> i1
+      %0 = ttkernel.bfloat16_greater(%arg0, %arg1) : (i16, i16) -> i1
       return
     }
 
     // CHECK-LABEL: func @float32_greater
     func.func @float32_greater() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-      %arg0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> ui32
-      %arg1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> ui32
-      // CHECK: emitc.call_opaque "float32_greater"(%{{.*}}, %{{.*}}) : (ui32, ui32) -> i1
-      %0 = ttkernel.float32_greater(%arg0, %arg1) : (ui32, ui32) -> i1
+      %arg0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> i32
+      %arg1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> i32
+      // CHECK: emitc.call_opaque "float32_greater"(%{{.*}}, %{{.*}}) : (i32, i32) -> i1
+      %0 = ttkernel.float32_greater(%arg0, %arg1) : (i32, i32) -> i1
       return
     }
 

--- a/test/ttmlir/Dialect/TTKernel/ops.mlir
+++ b/test/ttmlir/Dialect/TTKernel/ops.mlir
@@ -251,17 +251,17 @@ func.func @test_remote_mailbox_protocol_ops(%mailbox: !ttkernel.l1_addr) {
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: func.func @test_bfloat16_greater
-// CHECK-SAME: (%[[A:.*]]: ui16, %[[B:.*]]: ui16)
-func.func @test_bfloat16_greater(%arg0: ui16, %arg1: ui16) -> () {
-  %0 = ttkernel.bfloat16_greater(%arg0, %arg1) : (ui16, ui16) -> i1
-  // CHECK: ttkernel.bfloat16_greater(%[[A]], %[[B]]) : (ui16, ui16) -> i1
+// CHECK-SAME: (%[[A:.*]]: i16, %[[B:.*]]: i16)
+func.func @test_bfloat16_greater(%arg0: i16, %arg1: i16) -> () {
+  %0 = ttkernel.bfloat16_greater(%arg0, %arg1) : (i16, i16) -> i1
+  // CHECK: ttkernel.bfloat16_greater(%[[A]], %[[B]]) : (i16, i16) -> i1
   return
 }
 
 // CHECK-LABEL: func.func @test_float32_greater
-// CHECK-SAME: (%[[A:.*]]: ui32, %[[B:.*]]: ui32)
-func.func @test_float32_greater(%arg0: ui32, %arg1: ui32) -> () {
-  %0 = ttkernel.float32_greater(%arg0, %arg1) : (ui32, ui32) -> i1
-  // CHECK: ttkernel.float32_greater(%[[A]], %[[B]]) : (ui32, ui32) -> i1
+// CHECK-SAME: (%[[A:.*]]: i32, %[[B:.*]]: i32)
+func.func @test_float32_greater(%arg0: i32, %arg1: i32) -> () {
+  %0 = ttkernel.float32_greater(%arg0, %arg1) : (i32, i32) -> i1
+  // CHECK: ttkernel.float32_greater(%[[A]], %[[B]]) : (i32, i32) -> i1
   return
 }

--- a/test/ttmlir/Translate/TTKernel/ttkernel_numeric.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_numeric.mlir
@@ -5,21 +5,21 @@
 // CHECK: #include "api/numeric/bfloat16.h"
 // CHECK: void kernel_main()
 func.func @bfloat16_greater_test() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-    %raw0 = ttkernel.get_compile_time_arg_val(0) : () -> ui32
-    %raw1 = ttkernel.get_compile_time_arg_val(1) : () -> ui32
-    %a = ttkernel.bitcast %raw0 : ui32 to ui16
-    %b = ttkernel.bitcast %raw1 : ui32 to ui16
+    %raw0 = ttkernel.get_compile_time_arg_val(0) : () -> i32
+    %raw1 = ttkernel.get_compile_time_arg_val(1) : () -> i32
+    %a = arith.trunci %raw0 : i32 to i16
+    %b = arith.trunci %raw1 : i32 to i16
     // CHECK: bool [[V1:v[0-9]+]] = bfloat16_greater(
-    %0 = ttkernel.bfloat16_greater(%a, %b) : (ui16, ui16) -> i1
+    %0 = ttkernel.bfloat16_greater(%a, %b) : (i16, i16) -> i1
     func.return
 }
 
 // CHECK: #include "api/numeric/float32.h"
 // CHECK: void kernel_main()
 func.func @float32_greater_test() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-    %arg0 = ttkernel.get_compile_time_arg_val(0) : () -> ui32
-    %arg1 = ttkernel.get_compile_time_arg_val(1) : () -> ui32
+    %arg0 = ttkernel.get_compile_time_arg_val(0) : () -> i32
+    %arg1 = ttkernel.get_compile_time_arg_val(1) : () -> i32
     // CHECK: bool [[V2:v[0-9]+]] = float32_greater(
-    %0 = ttkernel.float32_greater(%arg0, %arg1) : (ui32, ui32) -> i1
+    %0 = ttkernel.float32_greater(%arg0, %arg1) : (i32, i32) -> i1
     func.return
 }


### PR DESCRIPTION
Bf16 and f32 greater than should've been signless to align with other ttkernel ops
