### PR TITLE
[D2M] Prepare D2M Subgraphs for Trace

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -349,6 +349,29 @@ def TTNNCreateD2MSubgraphs: Pass<"ttnn-create-d2m-subgraphs", "::mlir::ModuleOp"
   }];
 }
 
+def TTNNPrepareD2MSubgraphsForTrace : Pass<"ttnn-prepare-d2m-subgraphs-for-trace", "::mlir::ModuleOp"> {
+  let summary = "Prepare D2M subgraphs so they can be hoisted into traces.";
+  let description = [{
+    D2M subgraph lowering (TTNNCollaspeD2M) emits each subgraph as a
+    `ttnn.get_device` -> `ttnn.empty` -> `ttnn.generic` triple. The `get_device`
+    and `empty` ops are not hoistable, and they land interleaved between the
+    surrounding hoistable ops. `TTNNTraceHoistTransform` requires a contiguous
+    run of hoistable ops and fails with "Non-hoistable op found in the middle of
+    hoistable ops" when it encounters them.
+
+    This pass runs before trace hoisting and normalizes each forward-device
+    function so the trace boundary is clean:
+    - All `ttnn.get_device` ops are merged into a single op at the top of the
+      function (device handles are interchangeable).
+    - All `ttnn.empty` scratch buffers are moved into the function prelude, ahead
+      of the first hoistable op.
+
+    The scratch buffers then enter the trace as device-resident pass-through
+    inputs, the same way prelude-allocated scratch is already handled by the
+    trace hoist transform.
+  }];
+}
+
 def TTNNTraceHoistTransform : Pass<"ttnn-trace-hoist-transform", "::mlir::ModuleOp"> {
   let summary = "TTNN Trace hoist transform";
   let description = [{

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -424,6 +424,10 @@ void createTTIRToTTNNCommonPipeline(
       createTTNNPipelineD2MPass(devicePm, d2mOptions);
       devicePm.addPass(createTTNNCollaspeD2M());
       devicePm.addPass(createCanonicalizerPass());
+
+      if (options.enableTrace) {
+        devicePm.addPass(tt::ttnn::createTTNNPrepareD2MSubgraphsForTrace());
+      }
     }
 
     // We need to re-run const-eval to pick up const prepare conv2d weight ops

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNResolveComposites.cpp
         TTNNCollectPerfMetrics.cpp
         TTNNCreateD2MSubgraphs.cpp
+        TTNNPrepareD2MSubgraphsForTrace.cpp
         TTNNFileSplit.cpp
         TTNNPrepareConstEvalCaching.cpp
         TTNNDecomposeLayouts.cpp

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareD2MSubgraphsForTrace.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareD2MSubgraphsForTrace.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/FunctionTypes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttnn {
+
+#define GEN_PASS_DEF_TTNNPREPARED2MSUBGRAPHSFORTRACE
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+namespace {
+
+// D2M subgraph lowering emits each subgraph as a get_device -> empty -> generic
+// triple, leaving the (non-hoistable) get_device and empty ops interleaved
+// between hoistable ops. This pass pulls those non-hoistable ops out of the way
+// so TTNNTraceHoistTransform sees a contiguous run of hoistable ops:
+//   - all get_device ops are merged into one at the top of the function, and
+//   - all ttnn.empty scratch buffers are moved into the prelude, ahead of the
+//     first hoistable op.
+class TTNNPrepareD2MSubgraphsForTrace
+    : public impl::TTNNPrepareD2MSubgraphsForTraceBase<
+          TTNNPrepareD2MSubgraphsForTrace> {
+public:
+  using impl::TTNNPrepareD2MSubgraphsForTraceBase<
+      TTNNPrepareD2MSubgraphsForTrace>::TTNNPrepareD2MSubgraphsForTraceBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    IRRewriter rewriter(&getContext());
+
+    moduleOp.walk([&](func::FuncOp funcOp) {
+      if (!ttmlir::utils::isForwardDeviceFunc(funcOp)) {
+        return;
+      }
+      if (funcOp.getBlocks().size() != 1) {
+        return;
+      }
+      prepareFuncOp(rewriter, funcOp);
+    });
+  }
+
+private:
+  // Merge every ttnn.get_device in `block` into a single op placed at the top
+  // of the block and return it. Device handles are interchangeable, so all uses
+  // are redirected to the one canonical device.
+  GetDeviceOp mergeGetDeviceOps(IRRewriter &rewriter, Block &block) {
+    // getOrInsertDevice returns the first existing get_device, or inserts one
+    // at the top of the block if none exist.
+    GetDeviceOp canonicalDevice = utils::getOrInsertDevice(rewriter, &block);
+
+    // The existing device op may sit mid-block (D2M emits it next to each
+    // subgraph); move the canonical one into the prelude so it dominates the
+    // sunk creation ops.
+    if (&block.front() != canonicalDevice.getOperation()) {
+      canonicalDevice->moveBefore(&block.front());
+    }
+
+    // Redirect and erase the remaining (duplicate) device ops.
+    llvm::SmallVector<GetDeviceOp> duplicateDevices;
+    for (GetDeviceOp deviceOp : block.getOps<GetDeviceOp>()) {
+      if (deviceOp != canonicalDevice) {
+        duplicateDevices.push_back(deviceOp);
+      }
+    }
+    for (GetDeviceOp duplicateDevice : duplicateDevices) {
+      rewriter.replaceOp(duplicateDevice, canonicalDevice.getResult());
+    }
+
+    return canonicalDevice;
+  }
+
+  // Move all ttnn.empty scratch buffers into the prelude, immediately after
+  // `deviceOp`, preserving their relative order. Their only operand is the
+  // device, which now dominates the insertion point. Only empty ops are handled
+  // for now; other creation ops can be added here if a need arises.
+  void moveEmptyOpsToPrelude(GetDeviceOp deviceOp, Block &block) {
+    llvm::SmallVector<EmptyOp> emptyOps(block.getOps<EmptyOp>());
+
+    Operation *insertAfter = deviceOp;
+    for (EmptyOp emptyOp : emptyOps) {
+      emptyOp->moveAfter(insertAfter);
+      insertAfter = emptyOp;
+    }
+  }
+
+  void prepareFuncOp(IRRewriter &rewriter, func::FuncOp funcOp) {
+    Block &block = funcOp.getBlocks().front();
+
+    // Nothing to prepare unless the function has a device (and therefore the
+    // D2M subgraph prelude ops we care about).
+    if (block.getOps<GetDeviceOp>().empty()) {
+      return;
+    }
+
+    GetDeviceOp deviceOp = mergeGetDeviceOps(rewriter, block);
+    moveEmptyOpsToPrelude(deviceOp, block);
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::ttnn

--- a/test/python/golden/d2m/test_fusion_with_optimizer.py
+++ b/test/python/golden/d2m/test_fusion_with_optimizer.py
@@ -5,6 +5,7 @@
 import os
 
 import pytest
+import torch
 
 import _ttmlir_runtime as tt_runtime
 from builder.base.builder_apis import (
@@ -38,15 +39,65 @@ SNIPPETS = [
     "ttir/d2m_optimizer_two_d2m_subgraphs/eltwise_matmul_eltwise",
 ]
 
+# Snippets that additionally exercise TTNNTraceHoistTransform (enable-trace=true).
+# The D2M lowering of these subgraphs materializes scratch ttnn.empty buffers
+# that land interleaved between hoistable ops; trace hoist rejects the
+# non-hoistable op sitting between hoistable ops (issue #8402).
+TRACE_SNIPPETS = [
+    "models/gpt_oss_120b/rope_cos_sin_concat_prefill",
+]
 
-@pytest.mark.parametrize("target", ["ttnn"])
-@pytest.mark.parametrize("snippet", SNIPPETS)
-def test_d2m_fusion_with_optimizer(request, target, snippet):
-    """E2E: TTIR with D2M fusion (optimization-level=1, enable-create-d2m-subgraphs) -> flatbuffer -> run.
 
-    Compilation runs with no device open so the pipeline can use mock/simulator
-    context for opmodel; device is opened only after compile for execute_fb.
+def _rope_cos_sin_concat_golden_inputs():
+    """Realistic RoPE inputs for rope_cos_sin_concat_prefill.
+
+    The snippet derives the rotary frequencies from position_ids via
+    typecast -> reshape -> matmul. With the default random goldens,
+    position_ids are large integers (randint up to 255) and inv_freq is
+    standard-normal, so the matmul produces huge angles and the device
+    cos/sin diverge from the f32 golden (PCC ~0.89). Seeding the inputs the
+    way a real prefill does -- positions 0..seqlen-1 and the standard
+    decaying inverse frequencies -- keeps the angles small and matches the
+    >0.99 PCC observed in the full model.
     """
+    seqlen = 17
+    head_dim = 64  # concat of 32 cos + 32 sin freqs
+    n_freq = 32
+
+    position_ids = torch.arange(seqlen, dtype=torch.int32)
+    inv_freq = (
+        1.0
+        / (10000.0 ** (torch.arange(0, n_freq, dtype=torch.float32) * 2.0 / head_dim))
+    ).reshape(1, n_freq, 1)
+    scale_cos = torch.ones(1, 1, 1, dtype=torch.float32)
+    scale_sin = torch.ones(1, 1, 1, dtype=torch.float32)
+
+    return {
+        "rope_cos_sin_concat_prefill": [
+            {0: position_ids},
+            {0: inv_freq},
+            {0: scale_cos},
+            {0: scale_sin},
+        ]
+    }
+
+
+# Snippets whose default random goldens produce numerically unstable values.
+# Maps snippet path -> callable returning the golden_inputs dict for
+# load_mlir_file (keyed by the MLIR func name).
+GOLDEN_INPUTS_BUILDERS = {
+    "models/gpt_oss_120b/rope_cos_sin_concat_prefill": _rope_cos_sin_concat_golden_inputs,
+}
+
+
+def _run_d2m_fusion_with_optimizer_test(
+    request,
+    target,
+    snippet,
+    *,
+    enable_trace,
+    artifact_subdir,
+):
     mlir_path = os.path.join(SNIPPETS_BASE_DIR, f"{snippet}.mlir")
     if not os.path.exists(mlir_path):
         pytest.skip(f"MLIR not found: {mlir_path}")
@@ -58,13 +109,27 @@ def test_d2m_fusion_with_optimizer(request, target, snippet):
     output_root = kwargs.get("output_root", ".")
     save_artifacts = kwargs.get("save_artifacts", False)
     artifact_dir = get_artifact_dir(
-        output_root, f"d2m_fusion/{snippet.replace('/', '_')}", target, save_artifacts
+        output_root,
+        f"{artifact_subdir}/{snippet.replace('/', '_')}",
+        target,
+        save_artifacts,
     )
 
     with open(mlir_path, "r") as f:
         mlir_content = f.read().strip()
 
-    module, builder = load_mlir_file(mlir_content, target="ttir")
+    golden_inputs_builder = GOLDEN_INPUTS_BUILDERS.get(snippet)
+    golden_inputs = golden_inputs_builder() if golden_inputs_builder else None
+    module, builder = load_mlir_file(
+        mlir_content, golden_inputs=golden_inputs, target="ttir"
+    )
+    pipeline_options = [
+        "optimization-level=1",
+        "enable-create-d2m-subgraphs=true",
+    ]
+    if enable_trace:
+        pipeline_options.append("enable-trace=true")
+
     (
         compiled_bin,
         input_output_goldens,
@@ -76,10 +141,7 @@ def test_d2m_fusion_with_optimizer(request, target, snippet):
         artifact_dir=artifact_dir,
         target=target,
         save_artifacts=save_artifacts,
-        pipeline_options=[
-            "optimization-level=1",
-            "enable-create-d2m-subgraphs=true",
-        ],
+        pipeline_options=pipeline_options,
     )
     # Open device only after compile so the pipeline can use mock context for opmodel.
     # If this is not done, we'll get this error: "Cannot switch to real hardware while 1 device(s) are active."
@@ -100,3 +162,37 @@ def test_d2m_fusion_with_optimizer(request, target, snippet):
         tt_runtime.runtime.close_mesh_device(device)
         tt_runtime.runtime.set_fabric_config(tt_runtime.runtime.FabricConfig.DISABLED)
         clear_device_cache()
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.parametrize("snippet", SNIPPETS)
+def test_d2m_fusion_with_optimizer(request, target, snippet):
+    """E2E: TTIR with D2M fusion (optimization-level=1, enable-create-d2m-subgraphs) -> flatbuffer -> run.
+
+    Compilation runs with no device open so the pipeline can use mock/simulator
+    context for opmodel; device is opened only after compile for execute_fb.
+    """
+    _run_d2m_fusion_with_optimizer_test(
+        request,
+        target,
+        snippet,
+        enable_trace=False,
+        artifact_subdir="d2m_fusion",
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.parametrize("snippet", TRACE_SNIPPETS)
+def test_d2m_fusion_with_optimizer_and_trace(request, target, snippet):
+    """E2E with enable-trace=true, exercising TTNNTraceHoistTransform.
+
+    D2M subgraphs whose lowering materializes scratch ttnn.empty buffers fail
+    trace hoist when a non-hoistable op lands between hoistable ops (issue #8402).
+    """
+    _run_d2m_fusion_with_optimizer_test(
+        request,
+        target,
+        snippet,
+        enable_trace=True,
+        artifact_subdir="d2m_fusion_trace",
+    )

--- a/test/python/golden/mlir_snippets/models/gpt_oss_120b/rope_cos_sin_concat_prefill.mlir
+++ b/test/python/golden/mlir_snippets/models/gpt_oss_120b/rope_cos_sin_concat_prefill.mlir
@@ -1,0 +1,28 @@
+// RoPE cos+sin+concat subgraph (prefill shape: 1x17x32 -> 1x17x64).
+// Builds freqs via typecast(i32->f32) -> reshape -> matmul -> permute, then
+// parallel cos/sin branches each scaled in f32, typecast to bf16, and
+// concatenated on the last dim. Trace hoist fails here because the D2M
+// lowering of the cross-type typecast + concat fanout materializes a
+// non-hoistable ttnn.empty interleaved between hoistable ops (issue #8402).
+
+module {
+  func.func @rope_cos_sin_concat_prefill(
+      %position_ids : tensor<17xi32>,
+      %inv_freq     : tensor<1x32x1xf32>,
+      %scale_cos    : tensor<1x1x1xf32>,
+      %scale_sin    : tensor<1x1x1xf32>)
+      -> tensor<1x17x64xbf16> {
+    %0 = "ttir.typecast"(%position_ids) : (tensor<17xi32>) -> tensor<17xf32>
+    %1 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 17 : i32]}> : (tensor<17xf32>) -> tensor<1x1x17xf32>
+    %2 = "ttir.matmul"(%inv_freq, %1) <{transpose_a = false, transpose_b = false}> : (tensor<1x32x1xf32>, tensor<1x1x17xf32>) -> tensor<1x32x17xf32>
+    %3 = "ttir.permute"(%2) <{permutation = array<i64: 0, 2, 1>}> : (tensor<1x32x17xf32>) -> tensor<1x17x32xf32>
+    %4 = "ttir.cos"(%3) : (tensor<1x17x32xf32>) -> tensor<1x17x32xf32>
+    %5 = "ttir.multiply"(%4, %scale_cos) : (tensor<1x17x32xf32>, tensor<1x1x1xf32>) -> tensor<1x17x32xf32>
+    %6 = "ttir.sin"(%3) : (tensor<1x17x32xf32>) -> tensor<1x17x32xf32>
+    %7 = "ttir.multiply"(%6, %scale_sin) : (tensor<1x17x32xf32>, tensor<1x1x1xf32>) -> tensor<1x17x32xf32>
+    %8 = "ttir.typecast"(%5) : (tensor<1x17x32xf32>) -> tensor<1x17x32xbf16>
+    %9 = "ttir.typecast"(%7) : (tensor<1x17x32xf32>) -> tensor<1x17x32xbf16>
+    %10 = "ttir.concat"(%8, %9) <{dim = 2 : si32}> : (tensor<1x17x32xbf16>, tensor<1x17x32xbf16>) -> tensor<1x17x64xbf16>
+    return %10 : tensor<1x17x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_prepare_d2m_subgraphs_for_trace.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_prepare_d2m_subgraphs_for_trace.mlir
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttnn-prepare-d2m-subgraphs-for-trace -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Unit tests for TTNNPrepareD2MSubgraphsForTrace. The pass runs on
+// forward-device functions and, ahead of trace hoisting, (1) merges all
+// ttnn.get_device ops into a single one at the top of the block and (2) moves
+// all ttnn.empty scratch buffers into the prelude right after that device. The
+// ttnn.add ops below stand in for the surrounding hoistable ops / D2M generics;
+// the pass only relocates the get_device and empty ops.
+
+#l = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<dram>>, <interleaved>>
+
+module {
+  // Two subgraphs, each with its own get_device + empty interleaved in the
+  // middle. Expect: one get_device at the top, both (distinct) empties right
+  // after it, the duplicate get_device gone, and the original op order of the
+  // rest preserved.
+  // CHECK-LABEL: func.func @interleaved_subgraphs
+  // CHECK-NEXT:    %[[DEV:.+]] = "ttnn.get_device"
+  // CHECK-NEXT:    %[[E0:.+]] = "ttnn.empty"(%[[DEV]])
+  // CHECK-NEXT:    %[[E1:.+]] = "ttnn.empty"(%[[DEV]])
+  // CHECK-NEXT:    %[[A0:.+]] = "ttnn.add"(%arg0, %arg1)
+  // CHECK-NEXT:    %[[A1:.+]] = "ttnn.add"(%[[A0]], %[[E0]])
+  // CHECK-NEXT:    %[[A2:.+]] = "ttnn.add"(%[[A1]], %[[E1]])
+  // CHECK-NEXT:    return %[[A2]]
+  func.func @interleaved_subgraphs(%arg0: tensor<1x17x32xf32, #l>, %arg1: tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l> attributes {tt.function_type = "forward_device"} {
+    %0 = "ttnn.add"(%arg0, %arg1) : (tensor<1x17x32xf32, #l>, tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l>
+    %d0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %e0 = "ttnn.empty"(%d0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<1x17x32>}> : (!ttnn.device) -> tensor<1x17x32xf32, #l>
+    %1 = "ttnn.add"(%0, %e0) : (tensor<1x17x32xf32, #l>, tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l>
+    %d1 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %e1 = "ttnn.empty"(%d1) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<1x17x32>}> : (!ttnn.device) -> tensor<1x17x32xf32, #l>
+    %2 = "ttnn.add"(%1, %e1) : (tensor<1x17x32xf32, #l>, tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l>
+    return %2 : tensor<1x17x32xf32, #l>
+  }
+
+  // Single subgraph with the device mid-block: nothing to dedup, but the
+  // device and its empty are still moved up into the prelude.
+  // CHECK-LABEL: func.func @single_subgraph
+  // CHECK-NEXT:    %[[DEV:.+]] = "ttnn.get_device"
+  // CHECK-NEXT:    %[[E:.+]] = "ttnn.empty"(%[[DEV]])
+  // CHECK-NEXT:    %[[A0:.+]] = "ttnn.add"(%arg0, %arg0)
+  // CHECK-NEXT:    %[[A1:.+]] = "ttnn.add"(%[[A0]], %[[E]])
+  // CHECK-NEXT:    return %[[A1]]
+  func.func @single_subgraph(%arg0: tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l> attributes {tt.function_type = "forward_device"} {
+    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<1x17x32xf32, #l>, tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l>
+    %d0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %e0 = "ttnn.empty"(%d0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<1x17x32>}> : (!ttnn.device) -> tensor<1x17x32xf32, #l>
+    %1 = "ttnn.add"(%0, %e0) : (tensor<1x17x32xf32, #l>, tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l>
+    return %1 : tensor<1x17x32xf32, #l>
+  }
+
+  // No get_device: the pass should early-return and leave the function
+  // untouched (first op stays an add, no device injected).
+  // CHECK-LABEL: func.func @no_device
+  // CHECK-NEXT:    %[[A0:.+]] = "ttnn.add"(%arg0, %arg1)
+  // CHECK-NEXT:    %[[A1:.+]] = "ttnn.add"(%[[A0]], %arg0)
+  // CHECK-NEXT:    return %[[A1]]
+  func.func @no_device(%arg0: tensor<1x17x32xf32, #l>, %arg1: tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l> attributes {tt.function_type = "forward_device"} {
+    %0 = "ttnn.add"(%arg0, %arg1) : (tensor<1x17x32xf32, #l>, tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l>
+    %1 = "ttnn.add"(%0, %arg0) : (tensor<1x17x32xf32, #l>, tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l>
+    return %1 : tensor<1x17x32xf32, #l>
+  }
+
+  // Not a forward-device function: the pass must skip it, so the interleaved
+  // get_device/empty stay exactly where they were (device still after the add).
+  // CHECK-LABEL: func.func @not_forward_device
+  // CHECK-NEXT:    %[[A0:.+]] = "ttnn.add"(%arg0, %arg1)
+  // CHECK-NEXT:    "ttnn.get_device"
+  // CHECK-NEXT:    "ttnn.empty"
+  // CHECK-NEXT:    "ttnn.add"
+  // CHECK-NEXT:    return
+  func.func @not_forward_device(%arg0: tensor<1x17x32xf32, #l>, %arg1: tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l> {
+    %0 = "ttnn.add"(%arg0, %arg1) : (tensor<1x17x32xf32, #l>, tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l>
+    %d0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %e0 = "ttnn.empty"(%d0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<1x17x32>}> : (!ttnn.device) -> tensor<1x17x32xf32, #l>
+    %1 = "ttnn.add"(%0, %e0) : (tensor<1x17x32xf32, #l>, tensor<1x17x32xf32, #l>) -> tensor<1x17x32xf32, #l>
+    return %1 : tensor<1x17x32xf32, #l>
+  }
+}


### PR DESCRIPTION
### Ticket
Solves errors related to #8402.  

### Problem description
When D2M subgraphs and trace are enabled together, compilation fails in `TTNNTraceHoistTransform` with:

```
error: Non-hoistable op found in the middle of hoistable ops
```

D2M subgraph lowering (`TTNNCollaspeD2M`) emits each subgraph as a `ttnn.get_device → ttnn.empty → ttnn.generic` triple. The `get_device` and `empty` ops are not hoistable [[1]](https://github.com/tenstorrent/tt-mlir/blob/f21b6a3577cdc22604379e77cbe33d740b17e984/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp#L56-L65), and they land interleaved *between* the surrounding hoistable ops. Trace hoisting requires a contiguous run of hoistable ops [[2]](https://github.com/tenstorrent/tt-mlir/blob/f21b6a3577cdc22604379e77cbe33d740b17e984/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp#L871C5-L871C79), so it errors out — making trace unusable on any model that goes through D2M subgraph passes.

### What's changed
Added a new pass, **`TTNNPrepareD2MSubgraphsForTrace`** (`ttnn-prepare-d2m-subgraphs-for-trace`), that runs right before trace hoisting and normalizes each forward-device function so the trace boundary is clean:
- **Merges** all `ttnn.get_device` ops into a single one at the top of the function (device handles are interchangeable) and redirects all uses to it.
- **Moves** every `ttnn.empty` scratch buffer into the prelude, right after that device, kept distinct (no merging — each subgraph needs its own buffer).

The pass is wired into `TTNNPipelines.cpp` inside the `enableCreateD2MSubgraphs` block, gated on `enableTrace`, so the non-trace pipeline is unchanged.


### Checklist
- [x] New/Existing tests provide coverage for changes