### PR TITLE
[d2m] Cache local lowering analyses

### DIFF
--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -150,8 +150,7 @@ static void transferBlockingMaps(GenericOp genericOp) {
 // Add a scratch buffer inside a single d2m.generic op's region
 // (post-bufferization). Creates a memref.alloc + scratch_init at the start of
 // the region body.
-static void addScratchToGeneric(GenericOp genericOp,
-                                const utils::DstRegisterAnalysis &dstAnalysis) {
+static void addScratchToGeneric(GenericOp genericOp) {
   // Skip if not in compute-only form.
   if (!genericOp.isComputeOnlyForm()) {
     return;
@@ -173,6 +172,7 @@ static void addScratchToGeneric(GenericOp genericOp,
   ttcore::TileType tileType = getTileType(refMemRefType);
 
   // Calculate number of scratch tiles using the DST packing analysis.
+  utils::DstRegisterAnalysis dstAnalysis(genericOp);
   size_t numTiles = computeScratchNumTiles(genericOp, tileType, dstAnalysis);
 
   // Build scratch shard shape: [1, numTiles].
@@ -202,17 +202,13 @@ class D2MInsertScratchBuffers
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
 
-    // Run DST packing analysis on the module to compute per-generic scratch
-    // size estimates.
-    utils::DstRegisterAnalysis dstAnalysis(moduleOp);
-
     SmallVector<GenericOp> genericsToProcess;
     moduleOp.walk(
         [&](GenericOp genericOp) { genericsToProcess.push_back(genericOp); });
 
     for (GenericOp genericOp : genericsToProcess) {
       transferBlockingMaps(genericOp);
-      addScratchToGeneric(genericOp, dstAnalysis);
+      addScratchToGeneric(genericOp);
     }
   }
 };

--- a/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/DenseMap.h"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MMARKSYNCHRONIZEDBUFFERS
@@ -46,6 +47,17 @@ public:
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
     IRRewriter rewriter(&getContext());
+    llvm::DenseMap<Operation *, bool> containsAccumulatingComputeCache;
+
+    auto cachedContainsAccumulatingCompute = [&](Operation *op) {
+      auto it = containsAccumulatingComputeCache.find(op);
+      if (it != containsAccumulatingComputeCache.end()) {
+        return it->second;
+      }
+      bool result = containsAccumulatingCompute(op);
+      containsAccumulatingComputeCache[op] = result;
+      return result;
+    };
 
     moduleOp->walk([&](d2m::GenericOp genericOp) {
       auto cbUsageInfo = utils::getCBUsageInfo(genericOp.getRegion(0));
@@ -54,7 +66,7 @@ public:
                 mlir::dyn_cast<memref::AllocOp>(cb.getDefiningOp())) {
           int32_t bufferCount = numStreamBuffers;
           for (Operation *producer : usageInfo.producers) {
-            if (containsAccumulatingCompute(producer)) {
+            if (cachedContainsAccumulatingCompute(producer)) {
               bufferCount = 1;
               break;
             }


### PR DESCRIPTION
## Summary
- Build DST register analysis only for eligible fused compute generics in `D2MInsertScratchBuffers`
- Cache accumulating-compute detection in `D2MMarkSynchronizedBuffers`

Split out from commit `a6fb2036db858ffc5affea62fb60c0854ca67842`.

## Testing
- `git diff --check`