### PR TITLE
[d2m] Use walk pattern rewrite driver in compiler passes

### DIFF
--- a/lib/Dialect/D2M/Transforms/GenerateOuterLoops.cpp
+++ b/lib/Dialect/D2M/Transforms/GenerateOuterLoops.cpp
@@ -59,36 +59,32 @@ public:
     return loops;
   }
 
-  static void rewriteBlockIndexOps(PatternRewriter &rewriter, Location loc,
-                                   GenericOp generic) {
-    SmallVector<BlockIndexOp> blockIndices;
-    generic->walk(
-        [&](BlockIndexOp blockIndex) { blockIndices.push_back(blockIndex); });
+  static void lowerIndexOps(PatternRewriter &rewriter, Location loc,
+                            SmallVector<affine::AffineForOp> &loops,
+                            GenericOp generic) {
+    SmallVector<Operation *> indexOps;
+    generic->walk([&](Operation *op) {
+      if (isa<BlockIndexOp, IterIndexOp>(op)) {
+        indexOps.push_back(op);
+      }
+    });
 
-    for (BlockIndexOp blockIndex : blockIndices) {
-      rewriter.setInsertionPoint(blockIndex);
-      int64_t dim = blockIndex.getDim();
-      Value offset = rewriter.create<BlockOffsetOp>(loc, dim);
-      Value iterIndex = rewriter.create<IterIndexOp>(loc, dim);
-      Value index = rewriter.create<arith::AddIOp>(loc, iterIndex, offset);
-      rewriter.replaceOp(blockIndex, index);
-    }
-  }
-
-  static void lowerIterIndexOps(PatternRewriter &rewriter,
-                                SmallVector<affine::AffineForOp> &loops,
-                                GenericOp generic) {
-    SmallVector<IterIndexOp> iterIndices;
-    generic->walk(
-        [&](IterIndexOp iterIndex) { iterIndices.push_back(iterIndex); });
-
-    for (IterIndexOp iterIndex : iterIndices) {
-      uint64_t dim = iterIndex.getDim();
-      TT_assertv(dim < loops.size(),
-                 "iter_index dim {} out of bounds for loop nest size {}", dim,
+    for (Operation *op : indexOps) {
+      int64_t dim = isa<BlockIndexOp>(op) ? cast<BlockIndexOp>(op).getDim()
+                                          : cast<IterIndexOp>(op).getDim();
+      bool dimInBounds = dim >= 0 && static_cast<size_t>(dim) < loops.size();
+      TT_assertv(dimInBounds,
+                 "index dim {} out of bounds for loop nest size {}", dim,
                  loops.size());
       Value loopIv = loops[dim].getInductionVar();
-      rewriter.replaceOp(iterIndex, loopIv);
+      if (auto blockIndex = dyn_cast<BlockIndexOp>(op)) {
+        rewriter.setInsertionPoint(blockIndex);
+        Value offset = rewriter.create<BlockOffsetOp>(loc, dim);
+        Value index = rewriter.create<arith::AddIOp>(loc, loopIv, offset);
+        rewriter.replaceOp(blockIndex, index);
+        continue;
+      }
+      rewriter.replaceOp(op, ValueRange(loopIv));
     }
   }
 
@@ -166,11 +162,10 @@ public:
       }
     }
 
-    // First rewrite block_index(dim) -> block_offset(dim) + iter_index(dim).
-    // Then lower the iter_index ops to the generated blocking loop IVs.
+    // Lower block_index(dim) -> block_offset(dim) + loop_iv(dim), and
+    // iter_index(dim) -> loop_iv(dim).
     rewriter.setInsertionPointToStart(loopedBlock);
-    rewriteBlockIndexOps(rewriter, generic.getLoc(), loopedGeneric);
-    lowerIterIndexOps(rewriter, loops, loopedGeneric);
+    lowerIndexOps(rewriter, generic.getLoc(), loops, loopedGeneric);
 
     rewriter.replaceOp(generic, loopedGeneric.getResults());
 

--- a/lib/Dialect/D2M/Transforms/GenericApplyInterchange.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericApplyInterchange.cpp
@@ -8,9 +8,8 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Rewrite/FrozenRewritePatternSet.h"
-#include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MGENERICAPPLYINTERCHANGE
@@ -32,28 +31,81 @@ static void updateIndexOpsForInterchange(GenericOp generic, Builder &builder,
     inverseInterchange[interchange[i]] = static_cast<int64_t>(i);
   }
 
-  // Update all IterIndexOps in the generic's regions
+  // Update all index ops in one walk over each region.
   for (Region &region : generic->getRegions()) {
-    region.walk([&](IterIndexOp iterIndex) {
-      int64_t oldDim = iterIndex.getDim();
-      if (oldDim < static_cast<int64_t>(inverseInterchange.size())) {
-        int64_t newDim = inverseInterchange[oldDim];
-        iterIndex.setDimAttr(builder.getI64IntegerAttr(newDim));
-      }
-    });
-  }
+    region.walk([&](Operation *op) {
+      auto updateDim = [&](auto indexOp) {
+        int64_t oldDim = indexOp.getDim();
+        if (oldDim < static_cast<int64_t>(inverseInterchange.size())) {
+          int64_t newDim = inverseInterchange[oldDim];
+          indexOp.setDimAttr(builder.getI64IntegerAttr(newDim));
+        }
+      };
 
-  // Update all BlockIndexOps in the generic's regions (same logic)
-  for (Region &region : generic->getRegions()) {
-    region.walk([&](BlockIndexOp blockIndex) {
-      int64_t oldDim = blockIndex.getDim();
-      if (oldDim < static_cast<int64_t>(inverseInterchange.size())) {
-        int64_t newDim = inverseInterchange[oldDim];
-        blockIndex.setDimAttr(builder.getI64IntegerAttr(newDim));
+      if (auto iterIndex = dyn_cast<IterIndexOp>(op)) {
+        updateDim(iterIndex);
+        return;
+      }
+      if (auto blockIndex = dyn_cast<BlockIndexOp>(op)) {
+        updateDim(blockIndex);
       }
     });
   }
 }
+
+static std::tuple<ArrayAttr, ArrayAttr, ArrayAttr>
+applyInterchange(Builder &builder, ArrayRef<AffineMap> indexingMaps,
+                 ArrayAttr iteratorTypes, ArrayAttr blockFactors,
+                 ArrayRef<int64_t> interchange) {
+  SmallVector<AffineMap> newIndexingMaps;
+  SmallVector<Attribute> newIteratorTypes;
+  SmallVector<Attribute> newBlockFactors;
+  AffineMap permutationMap = mlir::inversePermutation(
+      AffineMap::getPermutationMap(interchange, builder.getContext()));
+  for (size_t i = 0; i < indexingMaps.size(); i++) {
+    newIndexingMaps.push_back(indexingMaps[i].compose(permutationMap));
+    newIteratorTypes.push_back(iteratorTypes[interchange[i]]);
+    newBlockFactors.push_back(blockFactors[interchange[i]]);
+  }
+  return {
+      builder.getAffineMapArrayAttr(newIndexingMaps),
+      builder.getArrayAttr(newIteratorTypes),
+      builder.getArrayAttr(newBlockFactors),
+  };
+}
+
+class ApplyInterchangePattern : public OpRewritePattern<GenericOp> {
+public:
+  ApplyInterchangePattern(MLIRContext *ctx, InterchangeOptions options)
+      : OpRewritePattern<GenericOp>(ctx), options(std::move(options)) {}
+
+  LogicalResult matchAndRewrite(GenericOp generic,
+                                PatternRewriter &rewriter) const override {
+    std::optional<SmallVector<int64_t>> interchange =
+        calculateInterchange(generic, options);
+    if (!interchange) {
+      return failure();
+    }
+
+    auto attrs = applyInterchange(rewriter, generic.getIndexingMapsValue(),
+                                  generic.getIteratorTypes(),
+                                  generic.getBlockFactors(), *interchange);
+    ArrayAttr indexingMaps = std::get<0>(attrs);
+    ArrayAttr iteratorTypes = std::get<1>(attrs);
+    ArrayAttr blockFactors = std::get<2>(attrs);
+
+    rewriter.modifyOpInPlace(generic, [&]() {
+      generic.setIndexingMapsAttr(indexingMaps);
+      generic.setIteratorTypesAttr(iteratorTypes);
+      generic.setBlockFactorsAttr(blockFactors);
+      updateIndexOpsForInterchange(generic, rewriter, *interchange);
+    });
+    return success();
+  }
+
+private:
+  InterchangeOptions options;
+};
 
 class D2MGenericApplyInterchange
     : public impl::D2MGenericApplyInterchangeBase<D2MGenericApplyInterchange> {
@@ -62,48 +114,15 @@ public:
       D2MGenericApplyInterchange>::D2MGenericApplyInterchangeBase;
 
   void runOnOperation() final {
-    ModuleOp moduleOp = getOperation();
-    Builder builder(&getContext());
+    if (matmulInterchange.empty()) {
+      return;
+    }
+
     InterchangeOptions options;
     options.matmulInterchange = matmulInterchange;
-
-    moduleOp.walk([&](GenericOp generic) {
-      std::optional<SmallVector<int64_t>> interchange =
-          calculateInterchange(generic, options);
-      if (!interchange) {
-        return;
-      }
-
-      auto [indexingMaps, iteratorTypes, blockFactors] = apply(
-          builder, generic.getIndexingMapsValue(), generic.getIteratorTypes(),
-          generic.getBlockFactors(), *interchange);
-      generic.setIndexingMapsAttr(indexingMaps);
-      generic.setIteratorTypesAttr(iteratorTypes);
-      generic.setBlockFactorsAttr(blockFactors);
-
-      updateIndexOpsForInterchange(generic, builder, *interchange);
-    });
-  }
-
-  static std::tuple<ArrayAttr, ArrayAttr, ArrayAttr>
-  apply(Builder &builder, ArrayRef<AffineMap> indexingMaps,
-        ArrayAttr iteratorTypes, ArrayAttr blockFactors,
-        ArrayRef<int64_t> interchange) {
-    SmallVector<AffineMap> newIndexingMaps;
-    SmallVector<Attribute> newIteratorTypes;
-    SmallVector<Attribute> newBlockFactors;
-    AffineMap permutationMap = mlir::inversePermutation(
-        AffineMap::getPermutationMap(interchange, builder.getContext()));
-    for (size_t i = 0; i < indexingMaps.size(); i++) {
-      newIndexingMaps.push_back(indexingMaps[i].compose(permutationMap));
-      newIteratorTypes.push_back(iteratorTypes[interchange[i]]);
-      newBlockFactors.push_back(blockFactors[interchange[i]]);
-    }
-    return {
-        builder.getAffineMapArrayAttr(newIndexingMaps),
-        builder.getArrayAttr(newIteratorTypes),
-        builder.getArrayAttr(newBlockFactors),
-    };
+    RewritePatternSet patterns(&getContext());
+    patterns.add<ApplyInterchangePattern>(&getContext(), std::move(options));
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
   }
 };
 } // namespace

--- a/lib/Dialect/D2M/Transforms/GenericApplyInterchange.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericApplyInterchange.cpp
@@ -23,7 +23,8 @@ namespace {
 //   IterIndex(0) -> IterIndex(1) (0 is at position 1)
 //   IterIndex(1) -> IterIndex(2) (1 is at position 2)
 // Same logic applies to BlockIndexOp.
-static void updateIndexOpsForInterchange(GenericOp generic, Builder &builder,
+static void updateIndexOpsForInterchange(GenericOp generic,
+                                         PatternRewriter &rewriter,
                                          ArrayRef<int64_t> interchange) {
   // Compute the inverse permutation: maps old dimension to new position
   SmallVector<int64_t> inverseInterchange(interchange.size());
@@ -38,7 +39,9 @@ static void updateIndexOpsForInterchange(GenericOp generic, Builder &builder,
         int64_t oldDim = indexOp.getDim();
         if (oldDim < static_cast<int64_t>(inverseInterchange.size())) {
           int64_t newDim = inverseInterchange[oldDim];
-          indexOp.setDimAttr(builder.getI64IntegerAttr(newDim));
+          rewriter.modifyOpInPlace(indexOp, [&]() {
+            indexOp.setDimAttr(rewriter.getI64IntegerAttr(newDim));
+          });
         }
       };
 
@@ -98,8 +101,8 @@ public:
       generic.setIndexingMapsAttr(indexingMaps);
       generic.setIteratorTypesAttr(iteratorTypes);
       generic.setBlockFactorsAttr(blockFactors);
-      updateIndexOpsForInterchange(generic, rewriter, *interchange);
     });
+    updateIndexOpsForInterchange(generic, rewriter, *interchange);
     return success();
   }
 

--- a/lib/Dialect/D2M/Transforms/GenericApplyInterchange.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericApplyInterchange.cpp
@@ -32,24 +32,22 @@ static void updateIndexOpsForInterchange(GenericOp generic,
     inverseInterchange[interchange[i]] = static_cast<int64_t>(i);
   }
 
-  // Update all index ops in one walk over each region.
+  auto updateDim = [&](auto indexOp) {
+    int64_t oldDim = indexOp.getDim();
+    if (oldDim < static_cast<int64_t>(inverseInterchange.size())) {
+      int64_t newDim = inverseInterchange[oldDim];
+      rewriter.modifyOpInPlace(indexOp, [&]() {
+        indexOp.setDimAttr(rewriter.getI64IntegerAttr(newDim));
+      });
+    }
+  };
+
+  // Walk each region once to avoid re-traversing large generic bodies.
   for (Region &region : generic->getRegions()) {
     region.walk([&](Operation *op) {
-      auto updateDim = [&](auto indexOp) {
-        int64_t oldDim = indexOp.getDim();
-        if (oldDim < static_cast<int64_t>(inverseInterchange.size())) {
-          int64_t newDim = inverseInterchange[oldDim];
-          rewriter.modifyOpInPlace(indexOp, [&]() {
-            indexOp.setDimAttr(rewriter.getI64IntegerAttr(newDim));
-          });
-        }
-      };
-
       if (auto iterIndex = dyn_cast<IterIndexOp>(op)) {
         updateDim(iterIndex);
-        return;
-      }
-      if (auto blockIndex = dyn_cast<BlockIndexOp>(op)) {
+      } else if (auto blockIndex = dyn_cast<BlockIndexOp>(op)) {
         updateDim(blockIndex);
       }
     });

--- a/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
+++ b/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
@@ -13,7 +13,9 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+
+#include <type_traits>
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MMATERIALIZEVIEWRETURNS
@@ -103,6 +105,63 @@ Value materializeView(OpBuilder &builder, Location loc, Value viewResult) {
   return genericOp.getResult(0);
 }
 
+class MaterializeReturnViewPattern : public OpRewritePattern<func::ReturnOp> {
+public:
+  using OpRewritePattern<func::ReturnOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(func::ReturnOp returnOp,
+                                PatternRewriter &rewriter) const override {
+    bool changed = false;
+    rewriter.setInsertionPoint(returnOp);
+
+    // Inspect each return operand to determine if it needs materialization.
+    for (OpOperand &opOperand : returnOp->getOpOperands()) {
+      Operation *definingOp = opOperand.get().getDefiningOp();
+      if (!isViewOp(definingOp)) {
+        continue;
+      }
+
+      // Insert a generic op to materialize the view before returning. This
+      // ensures the tensor transformation represented by the view actually
+      // occurs, rather than just being a symbolic operation.
+      Value materialized =
+          materializeView(rewriter, returnOp.getLoc(), opOperand.get());
+      opOperand.set(materialized);
+      changed = true;
+    }
+
+    return success(changed);
+  }
+};
+
+template <typename OpTy>
+class MaterializeToHostViewPattern : public OpRewritePattern<OpTy> {
+public:
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    if constexpr (std::is_same_v<OpTy, d2m::ToLayoutOp>) {
+      if (!op.isDeviceToHost()) {
+        return failure();
+      }
+    }
+
+    Value toHostInput = op->getOperand(0);
+    Operation *inputDefiningOp = toHostInput.getDefiningOp();
+    if (!isViewOp(inputDefiningOp)) {
+      return failure();
+    }
+
+    // Materialize the view before the device-to-host transfer.
+    rewriter.setInsertionPoint(op);
+    Value materialized = materializeView(rewriter, op->getLoc(), toHostInput);
+    // Update the ToHostOp/ToLayoutOp to use the materialized value.
+    op->setOperand(0, materialized);
+    return success();
+  }
+};
+
 class MaterializeViewReturnsPass
     : public impl::D2MMaterializeViewReturnsBase<MaterializeViewReturnsPass> {
 public:
@@ -110,53 +169,11 @@ public:
       MaterializeViewReturnsPass>::D2MMaterializeViewReturnsBase;
 
   void runOnOperation() final {
-    ModuleOp module = getOperation();
-    OpBuilder builder(&getContext());
-
-    // Process each function in the module to find unmaterialized views.
-    module.walk([&](func::FuncOp funcOp) {
-      // Case 1: Direct view return (should not happen with proper pipelines).
-      funcOp.walk([&](func::ReturnOp returnOp) {
-        builder.setInsertionPoint(returnOp);
-
-        // Inspect each return operand to determine if it needs materialization.
-        for (OpOperand &opOperand : returnOp->getOpOperands()) {
-          Operation *definingOp = opOperand.get().getDefiningOp();
-          if (isViewOp(definingOp)) {
-            // Insert a generic op to materialize the view before returning.
-            // This ensures the tensor transformation represented by the view
-            // actually occurs, rather than just being a symbolic operation.
-            Value materialized =
-                materializeView(builder, returnOp.getLoc(), opOperand.get());
-            opOperand.set(materialized);
-          }
-        }
-      });
-
-      // Case 2: View consumed by ToHostOp (or ToLayoutOp that is
-      // device-to-host). This can happen before the return, or in the middle of
-      // the function for the return-to-host-then-fetch-back pattern.
-      // Materialize the view BEFORE the device-to-host transfer.
-      funcOp.walk([&](Operation *op) {
-        auto toLayoutOp = mlir::dyn_cast_if_present<d2m::ToLayoutOp>(op);
-        bool isToHostOp = mlir::isa_and_nonnull<d2m::ToHostOp>(op) ||
-                          (toLayoutOp && toLayoutOp.isDeviceToHost());
-
-        if (isToHostOp) {
-          Value toHostInput = op->getOperand(0);
-          Operation *inputDefiningOp = toHostInput.getDefiningOp();
-
-          if (isViewOp(inputDefiningOp)) {
-            // Materialize the view before the device-to-host transfer.
-            builder.setInsertionPoint(op);
-            Value materialized =
-                materializeView(builder, op->getLoc(), toHostInput);
-            // Update the ToHostOp to use the materialized value.
-            op->setOperand(0, materialized);
-          }
-        }
-      });
-    });
+    RewritePatternSet patterns(&getContext());
+    patterns.add<MaterializeReturnViewPattern,
+                 MaterializeToHostViewPattern<d2m::ToHostOp>,
+                 MaterializeToHostViewPattern<d2m::ToLayoutOp>>(&getContext());
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
   }
 };
 

--- a/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
+++ b/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 #include <type_traits>
+#include <utility>
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MMATERIALIZEVIEWRETURNS
@@ -111,8 +112,8 @@ public:
 
   LogicalResult matchAndRewrite(func::ReturnOp returnOp,
                                 PatternRewriter &rewriter) const override {
-    bool changed = false;
     rewriter.setInsertionPoint(returnOp);
+    SmallVector<std::pair<unsigned, Value>> replacements;
 
     // Inspect each return operand to determine if it needs materialization.
     for (OpOperand &opOperand : returnOp->getOpOperands()) {
@@ -126,11 +127,19 @@ public:
       // occurs, rather than just being a symbolic operation.
       Value materialized =
           materializeView(rewriter, returnOp.getLoc(), opOperand.get());
-      opOperand.set(materialized);
-      changed = true;
+      replacements.emplace_back(opOperand.getOperandNumber(), materialized);
     }
 
-    return success(changed);
+    if (replacements.empty()) {
+      return failure();
+    }
+
+    rewriter.modifyOpInPlace(returnOp, [&]() {
+      for (auto [operandNumber, materialized] : replacements) {
+        returnOp->setOperand(operandNumber, materialized);
+      }
+    });
+    return success();
   }
 };
 
@@ -157,7 +166,7 @@ public:
     rewriter.setInsertionPoint(op);
     Value materialized = materializeView(rewriter, op->getLoc(), toHostInput);
     // Update the ToHostOp/ToLayoutOp to use the materialized value.
-    op->setOperand(0, materialized);
+    rewriter.modifyOpInPlace(op, [&]() { op->setOperand(0, materialized); });
     return success();
   }
 };


### PR DESCRIPTION
## Summary
- Convert D2M generic interchange application to a walk pattern rewrite and skip it when no interchange is configured
- Lower generated-loop index ops in one pass over cloned generics
- Convert materialize-view-return handling to targeted walk pattern rewrites

Split out from commit `a6fb2036db858ffc5affea62fb60c0854ca67842`.

## Testing
- `git diff --check`