### PR TITLE
[ttrt] bind scalar program inputs via create_scalar_tensor

### DIFF
--- a/tools/ttrt/common/run.py
+++ b/tools/ttrt/common/run.py
@@ -706,8 +706,15 @@ class Run:
 
                         inputs = []
                         outputs = []
-                        for i in program.input_tensors:
-                            new_input = create_tensor(i, fb_mesh_shape)
+                        use_goldens = len(golden_inputs) > 0
+                        for idx, i in enumerate(program.input_tensors):
+                            desc = program.inputs[idx]["desc"]
+                            if is_scalar_input(desc):
+                                new_input = create_scalar_input(
+                                    i, desc, self.logging, use_goldens
+                                )
+                            else:
+                                new_input = create_tensor(i, fb_mesh_shape)
                             inputs.append(new_input)
 
                         for i in program.output_tensors:

--- a/tools/ttrt/common/util.py
+++ b/tools/ttrt/common/util.py
@@ -4,8 +4,10 @@
 
 import importlib.util
 import json
+import operator
 import os
 import shutil
+from functools import reduce
 from pprint import pprint
 import re
 
@@ -269,6 +271,44 @@ def convert_input_layouts(device, inputs, fbb, program_index):
             ttrt.runtime.to_layout(inputs[input_index], device, input_layout, True)
         )
     return inputs_converted
+
+
+def is_scalar_input(desc):
+    """Heuristic: a TTMetal scalar program input is serialized as a single-element,
+    non-sharded TensorRef (see scalarValueToFlatbuffer / isSupportedScalarType in
+    lib/Target/TTMetal/TTMetalToFlatbuffer.cpp). The flatbuffer carries no explicit
+    is_scalar flag (TODO #3127), so we key off volume==1 here. Such inputs must be
+    bound via create_scalar_tensor (packed as a uint32_t in the MetalTensor variant)
+    rather than as a host tensor, otherwise the kernel's KernelArgScalar lookup hits
+    `std::get: wrong index for variant`."""
+    if desc.get("shard_status") == "Presharded":
+        return False
+    shape = desc.get("shape", [])
+    return len(shape) > 0 and reduce(operator.mul, shape, 1) == 1
+
+
+def create_scalar_input(tensor_shards, desc, logging, use_golden):
+    """Bind a scalar program input. When a golden value is available it is used
+    verbatim; otherwise the value is a placeholder (1) -- ttrt has no way to know
+    the intended scalar, and scalars often drive kernel control flow (loop bounds,
+    core offsets), so a placeholder may produce wrong results or faults."""
+    import ttrt.runtime
+
+    dtype = Binary.Program.from_data_type(desc["layout"]["memory_desc"]["data_type"])
+
+    if use_golden:
+        value = tensor_shards[0].reshape(()).item()
+    else:
+        value = 1
+        logging.warning(
+            f"scalar program input bound to placeholder value {value} "
+            f"(no golden available); pass --enable-golden or expect incorrect "
+            f"results if this scalar drives kernel control flow"
+        )
+
+    if dtype.is_floating_point:
+        return ttrt.runtime.create_scalar_tensor(float(value))
+    return ttrt.runtime.create_scalar_tensor(int(value))
 
 
 def create_tensor(tensor_shards, mesh_shape):


### PR DESCRIPTION
d2m-jit kernels take scalar (index/int) function arguments (e.g. m_blocks/n_blocks) that the compiler serializes as single-element, non-sharded TensorRef program inputs (scalarValueToFlatbuffer in TTMetalToFlatbuffer.cpp). The in-process d2m-jit runner special-cases these and binds them with runtime.create_scalar_tensor, packing them as a uint32_t in the MetalTensor variant.

ttrt, however, materialized every program input as a host tensor, so the kernel's KernelArgScalar lookup did std::get<uint32_t> on a variant holding a HostBuffer -> "std::get: wrong index for variant". This made flatbuffers dumped via D2M_JIT_SAVE_FLATBUFFER_PATH unrunnable under `ttrt run`.

Detect scalar inputs (volume==1, non-sharded) and bind them with create_scalar_tensor. The scalar's value is taken from the golden when available; otherwise it defaults to 1 with a warning, since ttrt cannot recover the intended value from the flatbuffer alone.

Note: the flatbuffer has no explicit is_scalar marker (TODO #3127); the volume==1 heuristic is a PoC and would misclassify a genuine 1-element tensor input.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
