### PR TITLE
D2M: support spilling intermediates of producer-consumer GenericOps

### DIFF
--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -9,19 +9,18 @@
 #include "ttmlir/Dialect/D2M/Analysis/Allocation/Planner.h"
 #include "ttmlir/Dialect/D2M/Analysis/Allocation/Utils.h"
 #include "ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h"
-#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -163,6 +162,7 @@ struct MemrefValueContext {
 };
 
 using OperandDefChain = llvm::SmallVector<Operation *, 4>;
+using OperationSet = llvm::SmallPtrSet<Operation *, 4>;
 
 // The single root discovered by `analyzeOperandDefChain`.
 // Normal operands produce one; composite views produce one per input tensor.
@@ -399,6 +399,11 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     }
 
     if (failed(runMemoryPlanner(funcOp, analysis))) {
+      return failure();
+    }
+
+    if (failed(materializeUnspilledIntermediateAliasedLoadStore(funcOp,
+                                                                analysis))) {
       return failure();
     }
 
@@ -737,11 +742,12 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
   }
 
   // Internal helper used by `analyzeGenericOps()` to create analysis entries
-  // for each operand of `genericOp`.
-  void createOperandContexts(FuncAnalysisData &analysis,
-                             d2m::GenericOp genericOp,
-                             GenericOpContext &genericCtx,
-                             const BlockFactorAnalysis &blockFactorAnalysis) {
+  // and allocation usage closure for each operand of `genericOp`.
+  void createOperandContexts(
+      FuncAnalysisData &analysis, d2m::GenericOp genericOp,
+      GenericOpContext &genericCtx,
+      const BlockFactorAnalysis &blockFactorAnalysis,
+      llvm::DenseMap<memref::AllocOp, OperationSet> &genericUseClosure) {
     [[maybe_unused]] AsOperandPrinter asOperand{genericOp->getParentOp()};
     [[maybe_unused]] ttcore::DeviceAttr device =
         ttcore::lookupDevice(genericOp);
@@ -749,16 +755,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     IRRewriter rewriter(genericOp->getContext());
 
     const bool haveIterationSpaceInfo = !genericCtx.isExplicitDatamovement;
-
-    using OperationSet = llvm::SmallPtrSet<Operation *, 4>;
-
-    // This is temp state to help set `MemrefValueContext::isMemspaceBound`.
-    // This maps every `memref::AllocOp` to a union set of `Operation`s
-    // that are seen on the use/def paths leading to their downstream
-    // `d2m::GenericOp`s. Later, these sets will be intersected
-    // with `memref::AllocOp->getUsers()` to detect if there are
-    // any user not contained within the union sets.
-    llvm::DenseMap<memref::AllocOp, OperationSet> genericUseClosure;
 
     SmallVector<AffineMap> indexingMaps;
     SmallVector<ttcore::IteratorType> iteratorTypes;
@@ -861,17 +857,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     }
     TT_assert(genericCtx.operands.size() ==
               genericOp.getInputsAndOutputs().size());
-
-    // `genericUseClosure` is complete, use it to update
-    // `MemrefValueContext::isMemspaceBound`:
-
-    for (auto &[allocOp, users] : genericUseClosure) {
-      for (Operation *user : allocOp->getUsers()) {
-        if (!llvm::isa<func::ReturnOp>(user) && !users.contains(user)) {
-          analysis.memrefs[allocOp].isMemspaceBound |= true;
-        }
-      }
-    }
   }
 
   /// Populate `analysis.generics`:
@@ -909,6 +894,12 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     bfOpts.numBuffers = numStreamBuffers;
     BlockFactorAnalysis blockFactorAnalysis(funcOp, bfOpts);
 
+    // Collect the full union set of generic users plus def/use-chain ops for
+    // each root alloc across the function. After all generics have contributed,
+    // these sets will be intersected with `memref::AllocOp->getUsers()` to tell
+    // whether an alloc has true non-generic external users and is thus bound.
+    llvm::DenseMap<memref::AllocOp, OperationSet> genericUseClosure;
+
     [[maybe_unused]] int32_t genericsInExplicitDatamovementForm = 0;
 
     funcBody.walk([&](d2m::GenericOp genericOp) {
@@ -917,8 +908,26 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       genericsInExplicitDatamovementForm += genericCtx.isExplicitDatamovement;
 
       createOperandContexts(analysis, genericOp, genericCtx,
-                            blockFactorAnalysis);
+                            blockFactorAnalysis, genericUseClosure);
     });
+
+    // `genericUseClosure` is complete, use it to update
+    // `MemrefValueContext::isMemspaceBound`.
+    for (auto &[allocOp, users] : genericUseClosure) {
+      for (Operation *user : allocOp->getUsers()) {
+        // Nested remote ops are part of the surrounding generic op's operand
+        // path even though they also directly use the root alloc, skip them.
+        if (llvm::isa<d2m::RemoteLoadOp, d2m::RemoteStoreOp>(user)) {
+          if (auto parentGeneric = user->getParentOfType<d2m::GenericOp>();
+              parentGeneric && users.contains(parentGeneric.getOperation())) {
+            continue;
+          }
+        }
+        if (!llvm::isa<func::ReturnOp>(user) && !users.contains(user)) {
+          analysis.memrefs[allocOp.getResult()].isMemspaceBound = true;
+        }
+      }
+    }
 
     if (TT_DEBUG_ENABLED()) {
       for ([[maybe_unused]] auto &[value, valueCtx] : analysis.memrefs) {
@@ -991,14 +1000,20 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
             //  - if the incoming IR indicates that this alloc should be pinned
             //    to its current memspace in any other explicit way (aggregated
             //    into `isMemspaceBound`);
-            //  - if it is the output of a generic op and the enabled pass
-            //    options do not allow output spilling;
+            //  - if it is a generic output and output spilling is disabled, or
+            //    if it is a terminal generic output. When output spilling is
+            //    enabled, only outputs with downstream generic users remain
+            //    spillable because the allocator can remap their def/use chain
+            //    and insert producer/consumer streams as needed;
             //  - (edge case) if it has zero generic op users;
-            const bool bound =
-                (memspace == MemorySpace::DeviceDRAM) ||
-                memrefCtx.isMemspaceBound ||
-                (memrefCtx.usedForOutput && !allowL1OutputSpilling) ||
-                memrefCtx.genericUsers.empty();
+            const bool isIntermediateMemref =
+                memrefCtx.usedForOutput && memrefCtx.genericUsers.size() > 1;
+            const bool bindOutputToL1 =
+                memrefCtx.usedForOutput &&
+                (!allowL1OutputSpilling || !isIntermediateMemref);
+            const bool bound = (memspace == MemorySpace::DeviceDRAM) ||
+                               memrefCtx.isMemspaceBound || bindOutputToL1 ||
+                               memrefCtx.genericUsers.empty();
             const bool forceSpillToDram = forceSpillToDramIfLegal && !bound;
             if (bound) {
               b.bind(asPlannerSpace(memspace));
@@ -1272,6 +1287,23 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     return success();
   }
 
+  void markSynchronizedBuffer(RewriterBase &rewriter, Value buffer) const {
+    if (auto allocOp = buffer.getDefiningOp<memref::AllocOp>()) {
+      allocOp->setAttr("d2m.synchronized_buffer",
+                       rewriter.getI32IntegerAttr(numStreamBuffers));
+    }
+  }
+
+  static bool isIntermediateGenericOutput(const FuncAnalysisData &analysis,
+                                          const OperandContext &operandCtx) {
+    return llvm::any_of(operandCtx.chainRoots, [&](const ChainRoot &chainRoot) {
+      const auto *memrefIt = analysis.memrefs.find(chainRoot.root);
+      TT_debug(memrefIt != analysis.memrefs.end());
+      const MemrefValueContext &memrefCtx = memrefIt->second;
+      return memrefCtx.usedForOutput && memrefCtx.genericUsers.size() > 1;
+    });
+  }
+
   LogicalResult materializeAliasedLoadStore(func::FuncOp funcOp,
                                             FuncAnalysisData &analysis) {
     IRRewriter rewriter(funcOp->getContext());
@@ -1281,6 +1313,11 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
         genericOpRef->walk([&](RemoteLoadOp remoteLoadOp) {
           if (remoteLoadOp.getMemref() == operandCtx.operand->get() &&
               isAliasedLoad(remoteLoadOp)) {
+            if (allowL1OutputSpilling &&
+                isIntermediateGenericOutput(analysis, operandCtx)) {
+              markSynchronizedBuffer(rewriter, remoteLoadOp.getLocalBuffer());
+              return;
+            }
             // Replace memref.alloc with operand alias op
             auto *allocOp = remoteLoadOp.getLocalBuffer().getDefiningOp();
             rewriter.setInsertionPoint(allocOp);
@@ -1304,6 +1341,11 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
 
           if (remoteStoreOp.getMemref() == operandCtx.operand->get() &&
               isAliasedStore(remoteStoreOp)) {
+            if (allowL1OutputSpilling &&
+                isIntermediateGenericOutput(analysis, operandCtx)) {
+              markSynchronizedBuffer(rewriter, remoteStoreOp.getLocalBuffer());
+              return WalkResult::advance();
+            }
             auto *allocOp = remoteStoreOp.getLocalBuffer().getDefiningOp();
             TT_assertv(mlir::isa<memref::AllocOp>(allocOp),
                        "Expected memref::AllocOp");
@@ -1322,6 +1364,94 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
         if (allocOp.getResult().getUsers().empty()) {
           rewriter.eraseOp(allocOp);
         }
+      });
+    }
+
+    return success();
+  }
+
+  static bool
+  isSpilledIntermediateGenericOutput(const FuncAnalysisData &analysis,
+                                     const OperandContext &operandCtx) {
+    return llvm::any_of(operandCtx.chainRoots, [&](const ChainRoot &chainRoot) {
+      const auto *memrefIt = analysis.memrefs.find(chainRoot.root);
+      TT_debug(memrefIt != analysis.memrefs.end());
+      const MemrefValueContext &memrefCtx = memrefIt->second;
+      return memrefCtx.usedForOutput && memrefCtx.genericUsers.size() > 1 &&
+             memrefCtx.remappedMemSpace == MemorySpace::DeviceDRAM;
+    });
+  }
+
+  LogicalResult
+  materializeUnspilledIntermediateAliasedLoadStore(func::FuncOp funcOp,
+                                                   FuncAnalysisData &analysis) {
+    // Re-run aliasing after planner for intermediates that stayed in L1.
+    IRRewriter rewriter(funcOp->getContext());
+    for (const auto &[genericOp, genericCtx] : analysis.generics) {
+      llvm::DenseSet<Value> unspilledIntermediateOperands;
+      for (const OperandContext &operandCtx : genericCtx.operands) {
+        if (!isIntermediateGenericOutput(analysis, operandCtx) ||
+            isSpilledIntermediateGenericOutput(analysis, operandCtx)) {
+          continue;
+        }
+
+        unspilledIntermediateOperands.insert(operandCtx.operand->get());
+      }
+
+      if (unspilledIntermediateOperands.empty()) {
+        continue;
+      }
+
+      genericOp->walk([&](RemoteLoadOp remoteLoadOp) {
+        if (unspilledIntermediateOperands.contains(remoteLoadOp.getMemref()) &&
+            isAliasedLoad(remoteLoadOp)) {
+          auto allocOp =
+              remoteLoadOp.getLocalBuffer().getDefiningOp<memref::AllocOp>();
+          if (!allocOp) {
+            return;
+          }
+          rewriter.setInsertionPoint(allocOp);
+          analysis.memrefs.erase(allocOp.getResult());
+          rewriter.replaceOpWithNewOp<d2m::OperandAliasOp>(
+              allocOp, allocOp->getResultTypes(), remoteLoadOp.getMemref());
+        }
+      });
+    }
+
+    for (const auto &[genericOp, genericCtx] : analysis.generics) {
+      llvm::DenseSet<Value> unspilledIntermediateOperands;
+      for (const OperandContext &operandCtx : genericCtx.operands) {
+        if (!isIntermediateGenericOutput(analysis, operandCtx) ||
+            isSpilledIntermediateGenericOutput(analysis, operandCtx)) {
+          continue;
+        }
+
+        unspilledIntermediateOperands.insert(operandCtx.operand->get());
+      }
+
+      if (unspilledIntermediateOperands.empty()) {
+        continue;
+      }
+
+      genericOp->walk([&](RemoteStoreOp remoteStoreOp) {
+        if (mlir::isa<d2m::OperandAliasOp>(
+                remoteStoreOp.getLocalBuffer().getDefiningOp())) {
+          return WalkResult::advance();
+        }
+
+        if (unspilledIntermediateOperands.contains(remoteStoreOp.getMemref()) &&
+            isAliasedStore(remoteStoreOp)) {
+          auto allocOp =
+              remoteStoreOp.getLocalBuffer().getDefiningOp<memref::AllocOp>();
+          if (!allocOp) {
+            return WalkResult::advance();
+          }
+          rewriter.setInsertionPoint(allocOp);
+          analysis.memrefs.erase(allocOp.getResult());
+          rewriter.replaceOpWithNewOp<d2m::OperandAliasOp>(
+              allocOp, allocOp->getResultTypes(), remoteStoreOp.getMemref());
+        }
+        return WalkResult::advance();
       });
     }
 

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -159,6 +159,11 @@ struct MemrefValueContext {
   // Such allocs are L1-only (no spilling) and do not participate in
   // stream insertion or dealloc insertion at the func-body level.
   bool isInsideGeneric = false;
+  // `true` iff this in-generic alloc is a speculative stream buffer that was
+  // skipped during aliasing because its root intermediate might be spilled.
+  // Once the planner decides, the post-planner step will either alias it away
+  // (root stayed in L1) or keep it for streaming (root was spilled).
+  bool speculativeStreamBuffer = false;
 };
 
 using OperandDefChain = llvm::SmallVector<Operation *, 4>;
@@ -675,6 +680,11 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
           ctx.live = {genericSeqPos, genericSeqPos};
           ctx.isInsideGeneric = true;
           ctx.isMemspaceBound = true;
+          ctx.speculativeStreamBuffer =
+              allocOp->hasAttr("d2m.speculative_stream_buffer");
+          if (ctx.speculativeStreamBuffer) {
+            allocOp->removeAttr("d2m.speculative_stream_buffer");
+          }
           TT_assertv(ttcore::getMemorySpace(allocOp.getType()) ==
                          ttcore::MemorySpace::DeviceL1,
                      "generic allocs must be allocated in L1");
@@ -1294,6 +1304,13 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     }
   }
 
+  static void markSpeculativeStreamBuffer(RewriterBase &rewriter,
+                                          Value buffer) {
+    if (auto allocOp = buffer.getDefiningOp<memref::AllocOp>()) {
+      allocOp->setAttr("d2m.speculative_stream_buffer", rewriter.getUnitAttr());
+    }
+  }
+
   static bool isIntermediateGenericOutput(const FuncAnalysisData &analysis,
                                           const OperandContext &operandCtx) {
     return llvm::any_of(operandCtx.chainRoots, [&](const ChainRoot &chainRoot) {
@@ -1316,6 +1333,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
             if (allowL1OutputSpilling &&
                 isIntermediateGenericOutput(analysis, operandCtx)) {
               markSynchronizedBuffer(rewriter, remoteLoadOp.getLocalBuffer());
+              markSpeculativeStreamBuffer(rewriter,
+                                          remoteLoadOp.getLocalBuffer());
               return;
             }
             // Replace memref.alloc with operand alias op
@@ -1344,6 +1363,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
             if (allowL1OutputSpilling &&
                 isIntermediateGenericOutput(analysis, operandCtx)) {
               markSynchronizedBuffer(rewriter, remoteStoreOp.getLocalBuffer());
+              markSpeculativeStreamBuffer(rewriter,
+                                          remoteStoreOp.getLocalBuffer());
               return WalkResult::advance();
             }
             auto *allocOp = remoteStoreOp.getLocalBuffer().getDefiningOp();
@@ -1370,87 +1391,69 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     return success();
   }
 
-  static bool
-  isSpilledIntermediateGenericOutput(const FuncAnalysisData &analysis,
-                                     const OperandContext &operandCtx) {
-    return llvm::any_of(operandCtx.chainRoots, [&](const ChainRoot &chainRoot) {
-      const auto *memrefIt = analysis.memrefs.find(chainRoot.root);
-      TT_debug(memrefIt != analysis.memrefs.end());
-      const MemrefValueContext &memrefCtx = memrefIt->second;
-      return memrefCtx.usedForOutput && memrefCtx.genericUsers.size() > 1 &&
-             memrefCtx.remappedMemSpace == MemorySpace::DeviceDRAM;
-    });
-  }
-
   LogicalResult
   materializeUnspilledIntermediateAliasedLoadStore(func::FuncOp funcOp,
                                                    FuncAnalysisData &analysis) {
-    // Re-run aliasing after planner for intermediates that stayed in L1.
+    // After the planner has made the decisions, alias speculative stream
+    // buffers whose root intermediate stayed in L1.
     IRRewriter rewriter(funcOp->getContext());
+
     for (const auto &[genericOp, genericCtx] : analysis.generics) {
-      llvm::DenseSet<Value> unspilledIntermediateOperands;
-      for (const OperandContext &operandCtx : genericCtx.operands) {
-        if (!isIntermediateGenericOutput(analysis, operandCtx) ||
-            isSpilledIntermediateGenericOutput(analysis, operandCtx)) {
-          continue;
-        }
-
-        unspilledIntermediateOperands.insert(operandCtx.operand->get());
-      }
-
-      if (unspilledIntermediateOperands.empty()) {
-        continue;
-      }
-
       genericOp->walk([&](RemoteLoadOp remoteLoadOp) {
-        if (unspilledIntermediateOperands.contains(remoteLoadOp.getMemref()) &&
-            isAliasedLoad(remoteLoadOp)) {
-          auto allocOp =
-              remoteLoadOp.getLocalBuffer().getDefiningOp<memref::AllocOp>();
-          if (!allocOp) {
-            return;
-          }
-          rewriter.setInsertionPoint(allocOp);
-          analysis.memrefs.erase(allocOp.getResult());
-          rewriter.replaceOpWithNewOp<d2m::OperandAliasOp>(
-              allocOp, allocOp->getResultTypes(), remoteLoadOp.getMemref());
+        auto allocOp =
+            remoteLoadOp.getLocalBuffer().getDefiningOp<memref::AllocOp>();
+        if (!allocOp) {
+          return;
         }
+        auto *it = analysis.memrefs.find(allocOp.getResult());
+        if (it == analysis.memrefs.end() ||
+            !it->second.speculativeStreamBuffer) {
+          return;
+        }
+
+        Value rootMemref = remoteLoadOp.getMemref();
+        auto *rootIt = analysis.memrefs.find(rootMemref);
+        if (rootIt != analysis.memrefs.end() &&
+            rootIt->second.remappedMemSpace == MemorySpace::DeviceDRAM) {
+          return;
+        }
+
+        rewriter.setInsertionPoint(allocOp);
+        analysis.memrefs.erase(allocOp.getResult());
+        rewriter.replaceOpWithNewOp<d2m::OperandAliasOp>(
+            allocOp, allocOp->getResultTypes(), remoteLoadOp.getMemref());
       });
     }
 
     for (const auto &[genericOp, genericCtx] : analysis.generics) {
-      llvm::DenseSet<Value> unspilledIntermediateOperands;
-      for (const OperandContext &operandCtx : genericCtx.operands) {
-        if (!isIntermediateGenericOutput(analysis, operandCtx) ||
-            isSpilledIntermediateGenericOutput(analysis, operandCtx)) {
-          continue;
-        }
-
-        unspilledIntermediateOperands.insert(operandCtx.operand->get());
-      }
-
-      if (unspilledIntermediateOperands.empty()) {
-        continue;
-      }
-
       genericOp->walk([&](RemoteStoreOp remoteStoreOp) {
         if (mlir::isa<d2m::OperandAliasOp>(
                 remoteStoreOp.getLocalBuffer().getDefiningOp())) {
           return WalkResult::advance();
         }
 
-        if (unspilledIntermediateOperands.contains(remoteStoreOp.getMemref()) &&
-            isAliasedStore(remoteStoreOp)) {
-          auto allocOp =
-              remoteStoreOp.getLocalBuffer().getDefiningOp<memref::AllocOp>();
-          if (!allocOp) {
-            return WalkResult::advance();
-          }
-          rewriter.setInsertionPoint(allocOp);
-          analysis.memrefs.erase(allocOp.getResult());
-          rewriter.replaceOpWithNewOp<d2m::OperandAliasOp>(
-              allocOp, allocOp->getResultTypes(), remoteStoreOp.getMemref());
+        auto allocOp =
+            remoteStoreOp.getLocalBuffer().getDefiningOp<memref::AllocOp>();
+        if (!allocOp) {
+          return WalkResult::advance();
         }
+        auto *it = analysis.memrefs.find(allocOp.getResult());
+        if (it == analysis.memrefs.end() ||
+            !it->second.speculativeStreamBuffer) {
+          return WalkResult::advance();
+        }
+
+        Value rootMemref = remoteStoreOp.getMemref();
+        auto *rootIt = analysis.memrefs.find(rootMemref);
+        if (rootIt != analysis.memrefs.end() &&
+            rootIt->second.remappedMemSpace == MemorySpace::DeviceDRAM) {
+          return WalkResult::advance();
+        }
+
+        rewriter.setInsertionPoint(allocOp);
+        analysis.memrefs.erase(allocOp.getResult());
+        rewriter.replaceOpWithNewOp<d2m::OperandAliasOp>(
+            allocOp, allocOp->getResultTypes(), remoteStoreOp.getMemref());
         return WalkResult::advance();
       });
     }

--- a/test/python/golden/d2m/test_allocate.py
+++ b/test/python/golden/d2m/test_allocate.py
@@ -7,6 +7,8 @@ import torch
 from conftest import get_request_kwargs
 
 from builder.base.builder_apis import compile_and_execute_ttir
+from builder.base.builder_utils import Operand
+from builder.ttir.ttir_builder import TTIRBuilder
 
 # borrow currently constrained way to build matmul inputs:
 from d2m.test_matmul import create_matmul_constrained_inputs as create_matmul_inputs
@@ -86,3 +88,62 @@ def test_allocate_max(
         custom_pipeline=f"ttir-to-ttmetal-pipeline{{{' '.join(options)}}}",
         **get_request_kwargs(request),
     )
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize(
+    "allow_l1_output_spilling", [True, False], ids=["enabled", "disabled"]
+)
+def test_allocate_spills_internal_generic_outputs(
+    allow_l1_output_spilling: bool, target: str, request, device
+):
+    # Keep many intermediate generic outputs live so the allocator must spill
+    # some of them using the real device grid and L1 capacity.
+    shape = (1536, 1536)
+    num_branches = 12
+    dtype = torch.float32
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, shape], [dtype, dtype])
+        def live_fanout_reduce(in0: Operand, in1: Operand, builder: TTIRBuilder):
+            lhs = builder.neg(in0)
+            rhs = builder.abs(in1)
+            vals = [lhs, rhs]
+
+            cur = builder.add(lhs, rhs)
+            vals.append(cur)
+            for i in range(num_branches):
+                if i % 4 == 0:
+                    cur = builder.add(cur, lhs)
+                elif i % 4 == 1:
+                    cur = builder.add(cur, rhs)
+                elif i % 4 == 2:
+                    cur = builder.neg(cur)
+                else:
+                    cur = builder.abs(cur)
+                vals.append(cur)
+
+            acc = vals[0]
+            for val in vals[1:]:
+                acc = builder.add(acc, val)
+            return builder.sigmoid(acc)
+
+    options = [
+        f"allow-l1-output-spilling={str(allow_l1_output_spilling).lower()}",
+        "enable-elementwise-fusion=false",
+    ]
+
+    def run_test():
+        compile_and_execute_ttir(
+            module,
+            target=target,
+            device=device,
+            custom_pipeline=f"ttir-to-ttmetal-pipeline{{{' '.join(options)}}}",
+            **get_request_kwargs(request),
+        )
+
+    if allow_l1_output_spilling:
+        run_test()
+    else:
+        with pytest.raises(Exception, match="exceeds memory capacity"):
+            run_test()

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_intermediate_outputs.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_intermediate_outputs.mlir
@@ -1,0 +1,105 @@
+// RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=force-spill-to-dram-if-legal=true test-buffer-size-policy=max" -o %t.no_spill %s
+// RUN: FileCheck %s --check-prefix=NO-SPILL --input-file=%t.no_spill
+// RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=allow-l1-output-spilling=true test-assume-l1-capacity=12288 test-buffer-size-policy=max" -o %t.spill %s
+// RUN: FileCheck %s --check-prefix=SPILL --input-file=%t.spill
+// RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=allow-l1-output-spilling=true test-assume-l1-capacity=24576 test-buffer-size-policy=max" -o %t.l1 %s
+// RUN: FileCheck %s --check-prefix=L1 --input-file=%t.l1
+
+// Validate the two allocator decisions needed for internal generic outputs:
+//
+//   * By default, generic outputs are not spillable. Even with forced spilling,
+//     the intermediate remains in L1 and uses the old aliasing path.
+//   * With allow-l1-output-spilling=true, an intermediate generic output becomes
+//     spillable while the terminal output remains in L1.
+//   * If that intermediate spills to DRAM, the remote load/store path must stay
+//     materialized as synchronized local buffers. If it stays in L1, the
+//     allocator should restore operand aliases after planning.
+
+// NO-SPILL-LABEL: func.func @intermediate_chain
+// NO-SPILL: %[[TMP:[A-Za-z0-9_]+]] = memref.alloc() {{.*}} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+// NO-SPILL: %[[OUT:[A-Za-z0-9_]+]] = memref.alloc() {{.*}} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+// NO-SPILL: outs(%[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+// NO-SPILL: d2m.operand_alias %[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+// NO-SPILL: ins(%[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+// NO-SPILL: d2m.operand_alias %[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+// NO-SPILL: return %[[OUT]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+
+// SPILL-LABEL: func.func @intermediate_chain
+// SPILL: %[[TMP:[A-Za-z0-9_]+]] = memref.alloc() {{.*}} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>
+// SPILL: %[[OUT:[A-Za-z0-9_]+]] = memref.alloc() {{.*}} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+// SPILL: outs(%[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>)
+// SPILL-NOT: d2m.operand_alias %[[TMP]]
+// SPILL: %[[PRODUCER_BUF:[A-Za-z0-9_]+]] = memref.alloc() {{.*}}d2m.synchronized_buffer = 2{{.*}} : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+// SPILL: d2m.remote_store %[[TMP]]{{.*}} %[[PRODUCER_BUF]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+// SPILL: ins(%[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>)
+// SPILL-NOT: d2m.operand_alias %[[TMP]]
+// SPILL: %[[CONSUMER_BUF:[A-Za-z0-9_]+]] = memref.alloc() {{.*}}d2m.synchronized_buffer = 2{{.*}} : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+// SPILL: d2m.remote_load %[[CONSUMER_BUF]] %[[TMP]]{{.*}} : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>
+// SPILL: return %[[OUT]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+
+// L1-LABEL: func.func @intermediate_chain
+// L1: %[[TMP:[A-Za-z0-9_]+]] = memref.alloc() {{.*}} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+// L1: %[[OUT:[A-Za-z0-9_]+]] = memref.alloc() {{.*}} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+// L1: outs(%[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+// L1: d2m.operand_alias %[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+// L1: ins(%[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+// L1: d2m.operand_alias %[[TMP]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+// L1: return %[[OUT]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+!tile_f32 = !ttcore.tile<32x32, f32>
+!tensor_l1 = memref<1x1x1x1x!tile_f32, #ttcore.shard<4096x4096, 1>, #l1>
+!tile_l1 = memref<1x1x!tile_f32, #l1>
+
+module {
+  func.func @intermediate_chain(%input: !tensor_l1) -> !tensor_l1 {
+    %tmp = memref.alloc() : !tensor_l1
+    %out = memref.alloc() : !tensor_l1
+
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%input : !tensor_l1)
+        outs(%tmp : !tensor_l1)  {
+    ^unified0:
+      %bf0 = d2m.get_block_factor(0) : index
+      %bf1 = d2m.get_block_factor(1) : index
+      affine.for %iter0 = 0 to %bf0 {
+        affine.for %iter1 = 0 to %bf1 {
+          %in_buf = memref.alloc() {d2m.synchronized_buffer = 2} : !tile_l1
+          d2m.remote_load %in_buf %input[%iter0, %iter1] : !tile_l1, !tensor_l1
+          %out_buf = memref.alloc() {d2m.synchronized_buffer = 2} : !tile_l1
+          linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%in_buf : !tile_l1) outs(%out_buf : !tile_l1) {
+          ^bb0(%in_elem: !tile_f32, %out_elem: !tile_f32):
+            %abs = "d2m.tile_abs"(%in_elem) : (!tile_f32) -> !tile_f32
+            linalg.yield %abs : !tile_f32
+          }
+          d2m.remote_store %tmp[%iter0, %iter1] %out_buf : !tensor_l1, !tile_l1
+        } {d2m.blocking_loop = 1}
+      } {d2m.blocking_loop = 0}
+    }
+
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%tmp : !tensor_l1)
+        outs(%out : !tensor_l1)  {
+    ^unified0:
+      %bf0 = d2m.get_block_factor(0) : index
+      %bf1 = d2m.get_block_factor(1) : index
+      affine.for %iter0 = 0 to %bf0 {
+        affine.for %iter1 = 0 to %bf1 {
+          %in_buf = memref.alloc() {d2m.synchronized_buffer = 2} : !tile_l1
+          d2m.remote_load %in_buf %tmp[%iter0, %iter1] : !tile_l1, !tensor_l1
+          %out_buf = memref.alloc() {d2m.synchronized_buffer = 2} : !tile_l1
+          linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%in_buf : !tile_l1) outs(%out_buf : !tile_l1) {
+          ^bb0(%in_elem: !tile_f32, %out_elem: !tile_f32):
+            %neg = "d2m.tile_negative"(%in_elem) : (!tile_f32) -> !tile_f32
+            linalg.yield %neg : !tile_f32
+          }
+          d2m.remote_store %out[%iter0, %iter1] %out_buf : !tensor_l1, !tile_l1
+        } {d2m.blocking_loop = 1}
+      } {d2m.blocking_loop = 0}
+    }
+
+    return %out : !tensor_l1
+  }
+}


### PR DESCRIPTION
### Problem description
Even when `allow-l1-output-spilling=true`, allocations that act as intermediates between producer-consumer GenericOps are still always considered bound and thus not spillable.
- The allocator only checks a single GenericOp to decide if a buffer has external users, so temporary intermediate buffers between GenericOps is always pinned to its original memory space.
  - Remote load/store living inside producer/consumer GenericOps are also being mistaken for external users since they directly use the root memrefs that the allocator is analyzing.
- When L1 output spilling is on, we should allow spilling & streaming of intermediates but keep final function outputs in its original place.
- Logically in-place remote loads/stores on internal GenericOp outputs are converted to `d2m.operand_alias` before the allocation placement is fully respected, but the spilled intermediates shouldn't be aliased since they must be explicitly streamed.

### What's changed
Relaxed the overly conservative logic so intermediate GenericOp outputs in producer-consumer chains can spill, and handled the consequences.
- When `allow-l1-output-spilling=true`: allow intermediate GenericOp outputs to spill, but pin terminal outputs that leave the internal GenericOp chain to match function returns.
- For each root allocation, `genericUseClosure` accumulates the closure across the whole function instead of a single GenericOp.
  - All of the generic users and def/use-chain operations at the function scope are collected.
  - The full producer-consumer chain is seen before deciding whether a root allocation has any truly external users.
  - The external user check ignores nested remote loads/stores whose parent GenericOp is already in the closure and thus part of the producer-consumer chain.
- Use a two-stage strategy for intermediates in aliasing:
  - Pre-planning: aliasing preserve the remote loads/stores on spillable intermediates, so stream insertion works correctly.
    - The local buffers used by remote loads/stores are now exposed to the allocator analysis, tag them as `d2m.synchronized_buffer` as they will eventually be hosted to CBs in the spilled path.
    - Also tag these buffers as `speculativeStreamBuffer` to help the 2nd aliasing stage identify them as candidates.
  - Post-planning: re-run aliasing on unspilled intermediates that are still in L1.
    - Walks the GenericOp body to re-materialize `d2m.operand_alias` for matching loads/stores on buffers tagged as `speculativeStreamBuffer` and whose root memref stayed in L1.
    - For local buffers erased at this step, also erase their allocator analysis entries so address assignment remains correct.
- These changes also made `force-spill-to-dram-if-legal` work on intermediates.
- Added a builder test to validate the new behavior:
  - A fanout-reduce eltwise op graph with 12 live branches and medium sized tensors to create allocator pressure.
  - Disabled fusion to preserve the memory pressure of the intermediates.
  - Expect pass when L1 output spilling is on, and OOM when it's off.
- Added a lit test for the new feature, controlled by L1 size & output spilling availability:
  - No L1 output spilling + tight L1 -> OOM.
  - L1 output spilling + tight L1 -> intermediates spill to DRAM and keep real synchronized remote buffers.
  - L1 output spilling + roomy L1 -> intermediates stay in L1 and get re-aliased.
 
### Checklist
- [x] New/Existing tests provide coverage for changes
