### PR TITLE
[TTIR] Add interleaved-pair RoPE fusion pattern

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.h
@@ -47,6 +47,32 @@ public:
                   mlir::PatternRewriter &rewriter) const override;
 };
 
+// Fuses interleaved-pair RoPE:
+//   x_   = reshape(x, [..., D/2, 1, 2])
+//   out  = reshape(freqs[..., 0] * x_[..., 0] + freqs[..., 1] * x_[..., 1],
+//                  [..., D])
+//   where freqs is shape (..., D/2, 2, 2) packing per-pair
+//   [[cos,-sin],[sin,cos]]
+//
+// Rewrites to rotate-half form so it lowers to the existing rotary_embedding
+// op:
+//   x_rh   = cat([x[..., 0::2], x[..., 1::2]], dim=-1)
+//   cos    = cat([freqs[..., 0, 0], freqs[..., 0, 0]], dim=-1)
+//   sin    = cat([freqs[..., 1, 0], freqs[..., 1, 0]], dim=-1)
+//   out_rh = rotary_embedding(x_rh, cos, sin)
+//   result = reshape(permute(reshape(out_rh, [..., 2, D/2]), [0,1,2,4,3]),
+//                    [..., D])
+//
+// Anchors on AddOp. Walks back through Broadcast/Reshape to identify the
+// 6D reshape of x and the freqs_cis slices.
+class RoPEInterleavedPairFusingPattern : public mlir::OpRewritePattern<AddOp> {
+public:
+  using OpRewritePattern<AddOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(AddOp srcOp, mlir::PatternRewriter &rewriter) const override;
+};
+
 } // namespace mlir::tt::ttir::fusing
 
 #endif // TTMLIR_DIALECT_TTIR_TRANSFORMS_FUSING_ROPEFUSINGPATTERN_H

--- a/lib/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.cpp
@@ -450,4 +450,373 @@ mlir::LogicalResult RoPEComplexRotationFusingPattern::matchAndRewrite(
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// RoPEInterleavedPairFusingPattern
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// Build a slice on one dim (begin, end, step), identity on all other dims.
+static SliceStaticOp buildSliceOnDim(PatternRewriter &rewriter, Location loc,
+                                     Value input, int64_t targetDim,
+                                     int32_t begin, int32_t end,
+                                     int32_t step = 1) {
+  auto inputType = mlir::cast<RankedTensorType>(input.getType());
+  int64_t rank = inputType.getRank();
+  ArrayRef<int64_t> shape = inputType.getShape();
+
+  SmallVector<int32_t> begins(rank, 0);
+  SmallVector<int32_t> ends(rank);
+  SmallVector<int32_t> steps(rank, 1);
+  for (int64_t i = 0; i < rank; ++i) {
+    ends[i] = static_cast<int32_t>(shape[i]);
+  }
+  begins[targetDim] = begin;
+  ends[targetDim] = end;
+  steps[targetDim] = step;
+
+  SmallVector<int64_t> resultShape(shape);
+  resultShape[targetDim] = llvm::divideCeil(end - begin, step);
+
+  auto resultType =
+      RankedTensorType::get(resultShape, inputType.getElementType());
+
+  return rewriter.create<SliceStaticOp>(
+      loc, resultType, input, rewriter.getI32ArrayAttr(begins),
+      rewriter.getI32ArrayAttr(ends), rewriter.getI32ArrayAttr(steps));
+}
+
+// Helper: walk back through reshape/broadcast chain to find a SliceStaticOp.
+// Returns the slice and the value it slices from.
+static SliceStaticOp findSliceThroughTMs(Value v) {
+  while (Operation *defOp = v.getDefiningOp()) {
+    if (auto slice = dyn_cast<SliceStaticOp>(defOp)) {
+      return slice;
+    }
+    if (isa<ReshapeOp, BroadcastOp, TypecastOp>(defOp)) {
+      v = defOp->getOperand(0);
+      continue;
+    }
+    break;
+  }
+  return nullptr;
+}
+
+// For a slice on a 6D reshape of x at pair dim, returns the pair index
+// (0 or 1) if the slice has the form [..., 0:1, 0:1] or [..., 0:1, 1:2]
+// on the last two dims of a (..., 1, 2) shape. Returns nullopt otherwise.
+static std::optional<int64_t> getPairIndex(SliceStaticOp slice) {
+  auto inputType = mlir::cast<RankedTensorType>(slice.getOperand().getType());
+  int64_t rank = inputType.getRank();
+  if (rank < 2) {
+    return std::nullopt;
+  }
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  if (inputShape[rank - 2] != 1 || inputShape[rank - 1] != 2) {
+    return std::nullopt;
+  }
+
+  auto begins = slice.getBegins();
+  auto ends = slice.getEnds();
+  auto steps = slice.getStep();
+  for (int64_t i = 0; i < rank; ++i) {
+    auto step = mlir::cast<IntegerAttr>(steps[i]).getInt();
+    if (step != 1) {
+      return std::nullopt;
+    }
+    auto begin = mlir::cast<IntegerAttr>(begins[i]).getInt();
+    auto end = mlir::cast<IntegerAttr>(ends[i]).getInt();
+    if (i < rank - 1) {
+      // All dims except the last must be identity (or [0:1] on size-1 dim).
+      if (begin != 0 || end != inputShape[i]) {
+        return std::nullopt;
+      }
+    }
+  }
+  auto lastBegin = mlir::cast<IntegerAttr>(begins[rank - 1]).getInt();
+  auto lastEnd = mlir::cast<IntegerAttr>(ends[rank - 1]).getInt();
+  if (lastBegin == 0 && lastEnd == 1) {
+    return 0;
+  }
+  if (lastBegin == 1 && lastEnd == 2) {
+    return 1;
+  }
+  return std::nullopt;
+}
+
+// For a slice on freqs_cis (..., D/2, 2, 2), returns the column index (0 or 1)
+// if the slice picks one column of the trailing 2x2 (i.e. slices [..., :,
+// c:c+1] where c is 0 or 1) and is identity elsewhere.
+static std::optional<int64_t> getColumnIndex(SliceStaticOp slice) {
+  auto inputType = mlir::cast<RankedTensorType>(slice.getOperand().getType());
+  int64_t rank = inputType.getRank();
+  if (rank < 2) {
+    return std::nullopt;
+  }
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  if (inputShape[rank - 1] != 2) {
+    return std::nullopt;
+  }
+
+  auto begins = slice.getBegins();
+  auto ends = slice.getEnds();
+  auto steps = slice.getStep();
+  for (int64_t i = 0; i < rank - 1; ++i) {
+    auto step = mlir::cast<IntegerAttr>(steps[i]).getInt();
+    auto begin = mlir::cast<IntegerAttr>(begins[i]).getInt();
+    auto end = mlir::cast<IntegerAttr>(ends[i]).getInt();
+    if (step != 1 || begin != 0 || end != inputShape[i]) {
+      return std::nullopt;
+    }
+  }
+  auto lastStep = mlir::cast<IntegerAttr>(steps[rank - 1]).getInt();
+  auto lastBegin = mlir::cast<IntegerAttr>(begins[rank - 1]).getInt();
+  auto lastEnd = mlir::cast<IntegerAttr>(ends[rank - 1]).getInt();
+  if (lastStep != 1) {
+    return std::nullopt;
+  }
+  if (lastBegin == 0 && lastEnd == 1) {
+    return 0;
+  }
+  if (lastBegin == 1 && lastEnd == 2) {
+    return 1;
+  }
+  return std::nullopt;
+}
+
+// Tracks one half of the matched pattern (cos branch or sin branch).
+struct InterleavedBranch {
+  MultiplyOp mulOp;
+  SliceStaticOp xSlice;     // slice on the 6D reshape of x; pair index encoded
+  SliceStaticOp freqsSlice; // slice on freqs_cis; column index encoded
+  int64_t pairIdx;          // 0 or 1
+  int64_t colIdx;           // 0 or 1
+  Value xReshape6D;         // the 6D reshape of x (slice's input)
+  Value freqsSrc;           // freqs_cis source tensor
+};
+
+// Try to interpret a MultiplyOp as one branch of the interleaved RoPE pattern.
+// Returns the populated branch if both operands trace back to a pair-slice on
+// x's 6D reshape and a column-slice on freqs_cis; nullopt otherwise.
+static std::optional<InterleavedBranch> matchBranch(MultiplyOp mulOp) {
+  for (int swap = 0; swap < 2; ++swap) {
+    Value xSide = mulOp.getOperand(swap);
+    Value freqsSide = mulOp.getOperand(1 - swap);
+
+    SliceStaticOp xSlice = findSliceThroughTMs(xSide);
+    SliceStaticOp freqsSlice = findSliceThroughTMs(freqsSide);
+    if (!xSlice || !freqsSlice) {
+      continue;
+    }
+
+    auto pairIdx = getPairIndex(xSlice);
+    if (!pairIdx) {
+      continue;
+    }
+    auto colIdx = getColumnIndex(freqsSlice);
+    if (!colIdx) {
+      continue;
+    }
+
+    InterleavedBranch br;
+    br.mulOp = mulOp;
+    br.xSlice = xSlice;
+    br.freqsSlice = freqsSlice;
+    br.pairIdx = *pairIdx;
+    br.colIdx = *colIdx;
+    br.xReshape6D = xSlice.getOperand();
+    br.freqsSrc = freqsSlice.getOperand();
+    return br;
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
+mlir::LogicalResult RoPEInterleavedPairFusingPattern::matchAndRewrite(
+    AddOp addOp, mlir::PatternRewriter &rewriter) const {
+  // 1. Both add operands must be multiplies.
+  auto mul0 = dyn_cast_or_null<MultiplyOp>(addOp.getOperand(0).getDefiningOp());
+  auto mul1 = dyn_cast_or_null<MultiplyOp>(addOp.getOperand(1).getDefiningOp());
+  if (!mul0 || !mul1) {
+    return failure();
+  }
+
+  // 2. Identify both branches.
+  auto br0 = matchBranch(mul0);
+  auto br1 = matchBranch(mul1);
+  if (!br0 || !br1) {
+    return failure();
+  }
+
+  // 3. Both branches must share the same x 6D reshape and same freqs_cis.
+  if (br0->xReshape6D != br1->xReshape6D || br0->freqsSrc != br1->freqsSrc) {
+    return failure();
+  }
+
+  // 4. The two branches must select pair indices {0, 1} and columns {0, 1}.
+  //    The "real" branch pairs pair[0] with col[0]; "imag" branch pairs
+  //    pair[1] with col[1]. We accept either order across mul0/mul1.
+  if (br0->pairIdx == br1->pairIdx || br0->colIdx == br1->colIdx) {
+    return failure();
+  }
+  if (br0->pairIdx != br0->colIdx || br1->pairIdx != br1->colIdx) {
+    return failure();
+  }
+
+  // 5. The x 6D reshape must come from a ReshapeOp that produced shape
+  //    (..., D/2, 1, 2) from (..., D).
+  auto xReshapeOp =
+      dyn_cast_or_null<ReshapeOp>(br0->xReshape6D.getDefiningOp());
+  if (!xReshapeOp) {
+    return failure();
+  }
+  Value x4d = xReshapeOp.getOperand();
+  auto x4dType = mlir::cast<RankedTensorType>(x4d.getType());
+  if (x4dType.getRank() != 4) {
+    return failure();
+  }
+  int64_t D = x4dType.getShape().back();
+  if (D % 2 != 0 || D < 2) {
+    return failure();
+  }
+  int64_t halfD = D / 2;
+
+  auto x6dType = mlir::cast<RankedTensorType>(br0->xReshape6D.getType());
+  ArrayRef<int64_t> x6dShape = x6dType.getShape();
+  int64_t x6dRank = x6dShape.size();
+  if (x6dRank != 6 || x6dShape[x6dRank - 3] != halfD ||
+      x6dShape[x6dRank - 2] != 1 || x6dShape[x6dRank - 1] != 2) {
+    return failure();
+  }
+
+  // 6. freqs_cis must be 6D shape (..., D/2, 2, 2).
+  auto freqsType = mlir::cast<RankedTensorType>(br0->freqsSrc.getType());
+  ArrayRef<int64_t> freqsShape = freqsType.getShape();
+  int64_t fRank = freqsShape.size();
+  if (fRank != 6 || freqsShape[fRank - 3] != halfD ||
+      freqsShape[fRank - 2] != 2 || freqsShape[fRank - 1] != 2) {
+    return failure();
+  }
+
+  // 7. AddOp must have a single ReshapeOp user that flattens
+  //    (..., D/2, 2) -> (..., D).
+  if (!addOp->hasOneUse()) {
+    return failure();
+  }
+  auto finalReshape = dyn_cast<ReshapeOp>(*addOp->getUsers().begin());
+  if (!finalReshape) {
+    return failure();
+  }
+  auto finalType = mlir::cast<RankedTensorType>(finalReshape.getType());
+  if (finalType.getShape() != x4dType.getShape()) {
+    return failure();
+  }
+
+  // 8. Single-use guards on critical intermediates.
+  if (!mul0->hasOneUse() || !mul1->hasOneUse()) {
+    return failure();
+  }
+
+  // -------- Rewrite --------
+  Location loc = addOp.getLoc();
+  Type elemType = x4dType.getElementType();
+
+  // 9. Extract cos_half and sin_half from freqs_cis.
+  //    cos = freqs_cis[..., 0, 0]  (row 0, col 0)
+  //    sin = freqs_cis[..., 1, 0]  (row 1, col 0)
+  // First slice on the row dim (rank-2), then on the col dim (rank-1).
+  SliceStaticOp cosRowSlice =
+      buildSliceOnDim(rewriter, loc, br0->freqsSrc, fRank - 2, 0, 1);
+  SliceStaticOp cosColSlice =
+      buildSliceOnDim(rewriter, loc, cosRowSlice.getResult(), fRank - 1, 0, 1);
+
+  SliceStaticOp sinRowSlice =
+      buildSliceOnDim(rewriter, loc, br0->freqsSrc, fRank - 2, 1, 2);
+  SliceStaticOp sinColSlice =
+      buildSliceOnDim(rewriter, loc, sinRowSlice.getResult(), fRank - 1, 0, 1);
+
+  // Squeeze the trailing two singleton dims so the cache is 4D and
+  // broadcastable to the 4D x. freqs_cis (B, S, ?, D/2, 1, 1) -> (B, S, ?, D/2)
+  SmallVector<int64_t> cacheShape4D(freqsShape.begin(),
+                                    freqsShape.begin() + fRank - 2);
+  auto cacheType4D = RankedTensorType::get(cacheShape4D, elemType);
+  SmallVector<int32_t> cacheShape4DAttr(cacheShape4D.size());
+  for (size_t i = 0; i < cacheShape4D.size(); ++i) {
+    cacheShape4DAttr[i] = static_cast<int32_t>(cacheShape4D[i]);
+  }
+  auto cosHalf =
+      rewriter.create<ReshapeOp>(loc, cacheType4D, cosColSlice.getResult(),
+                                 rewriter.getI32ArrayAttr(cacheShape4DAttr));
+  auto sinHalf =
+      rewriter.create<ReshapeOp>(loc, cacheType4D, sinColSlice.getResult(),
+                                 rewriter.getI32ArrayAttr(cacheShape4DAttr));
+
+  // 10. Duplicate caches to full D: cos_full = concat([cos_half, cos_half]).
+  SmallVector<int64_t> cacheShapeFull(cacheShape4D);
+  cacheShapeFull.back() = D;
+  auto cacheTypeFull = RankedTensorType::get(cacheShapeFull, elemType);
+  auto cosFull = rewriter.create<ConcatOp>(
+      loc, cacheTypeFull, ValueRange{cosHalf.getResult(), cosHalf.getResult()},
+      rewriter.getSI32IntegerAttr(cacheShapeFull.size() - 1));
+  auto sinFull = rewriter.create<ConcatOp>(
+      loc, cacheTypeFull, ValueRange{sinHalf.getResult(), sinHalf.getResult()},
+      rewriter.getSI32IntegerAttr(cacheShapeFull.size() - 1));
+
+  // 11. Permute x: interleaved [x0,x1,x2,x3,...] -> rotate-half
+  // [x0,x2,...|x1,x3,...]
+  //     via slice (step 2) on the last dim, then concat.
+  auto xEvens =
+      buildSliceOnDim(rewriter, loc, x4d, /*dim=*/3, 0, D, /*step=*/2);
+  auto xOdds = buildSliceOnDim(rewriter, loc, x4d, /*dim=*/3, 1, D, /*step=*/2);
+  auto xPerm = rewriter.create<ConcatOp>(
+      loc, x4dType, ValueRange{xEvens.getResult(), xOdds.getResult()},
+      rewriter.getSI32IntegerAttr(3));
+
+  // 12. Apply ttir.rotary_embedding.
+  auto rotEmb = rewriter.create<RotaryEmbeddingOp>(
+      loc, x4dType, xPerm.getResult(), cosFull.getResult(),
+      sinFull.getResult());
+
+  // 13. Permute back: rotate-half [r0,r1,...|i0,i1,...] -> interleaved
+  // [r0,i0,r1,i1,...]
+  //     via reshape -> permute (swap last two dims) -> reshape.
+  // Reshape (B,S,H,D) -> (B,S,H,2,D/2): the leading "2" is "which half".
+  SmallVector<int64_t> splitShape;
+  for (int64_t d : x4dType.getShape().drop_back()) {
+    splitShape.push_back(d);
+  }
+  splitShape.push_back(2);
+  splitShape.push_back(halfD);
+  auto splitType = RankedTensorType::get(splitShape, elemType);
+  SmallVector<int32_t> splitShapeAttr(splitShape.size());
+  for (size_t i = 0; i < splitShape.size(); ++i) {
+    splitShapeAttr[i] = static_cast<int32_t>(splitShape[i]);
+  }
+  auto split =
+      rewriter.create<ReshapeOp>(loc, splitType, rotEmb.getResult(),
+                                 rewriter.getI32ArrayAttr(splitShapeAttr));
+
+  // Permute last two dims: (B,S,H,2,D/2) -> (B,S,H,D/2,2).
+  SmallVector<int64_t> permShape(splitShape);
+  std::swap(permShape[permShape.size() - 2], permShape[permShape.size() - 1]);
+  auto permType = RankedTensorType::get(permShape, elemType);
+  SmallVector<int64_t> perm = {0, 1, 2, 4, 3};
+  auto permuted =
+      rewriter.create<PermuteOp>(loc, permType, split.getResult(), perm);
+
+  // Flatten back: (B,S,H,D/2,2) -> (B,S,H,D).
+  SmallVector<int32_t> finalShapeAttr;
+  for (int64_t d : x4dType.getShape()) {
+    finalShapeAttr.push_back(static_cast<int32_t>(d));
+  }
+  auto flat =
+      rewriter.create<ReshapeOp>(loc, x4dType, permuted.getResult(),
+                                 rewriter.getI32ArrayAttr(finalShapeAttr));
+
+  // 14. Replace the final reshape's result with our flattened output.
+  rewriter.replaceOp(finalReshape, flat.getResult());
+  return success();
+}
+
 } // namespace mlir::tt::ttir::fusing

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -3126,6 +3126,7 @@ public:
       patterns.add<ReshapeBroadcastReshapeToRepeatPattern>(&getContext());
       patterns.add<fusing::RoPERotateHalfFusingPattern>(&getContext());
       patterns.add<fusing::RoPEComplexRotationFusingPattern>(&getContext());
+      patterns.add<fusing::RoPEInterleavedPairFusingPattern>(&getContext());
       patterns.add<fusing::TopKFusingPattern>(&getContext());
 
       GreedyRewriteConfig config;

--- a/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
+++ b/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
@@ -349,3 +349,173 @@ def test_rope_complex_rotation(
     )
 
     assert check_op(output, "rotary_embedding")
+
+
+# ---------------------------------------------------------------------------
+# Pattern 3: interleaved-pair
+#   x_   = reshape(x, [..., D/2, 1, 2])
+#   out  = reshape(freqs[..., 0] * x_[..., 0] + freqs[..., 1] * x_[..., 1],
+#                  [..., D])
+#   where freqs is shape (..., D/2, 2, 2) packing per-pair [[cos,-sin],[sin,cos]]
+# ---------------------------------------------------------------------------
+
+
+def torch_rope_interleaved_pair(x, freqs):
+    """Golden reference for interleaved-pair RoPE."""
+    x_ = x.float().reshape(*x.shape[:-1], -1, 1, 2)
+    out = freqs[..., 0] * x_[..., 0] + freqs[..., 1] * x_[..., 1]
+    return out.reshape(*x.shape).type_as(x)
+
+
+def build_rope_interleaved_pair(
+    input: Operand,
+    freqs_input: Operand,
+    builder: TTIRBuilder,
+):
+    """Build Pattern 3 (interleaved-pair) as a sequence of TTIR ops.
+
+    input is [B, H, S, D]; freqs is [B, 1, S, D/2, 2, 2] with heads=1 broadcast
+    across H.
+    """
+    input_shape = list(input.type.shape)
+    freqs_shape = list(freqs_input.type.shape)
+    B, H, S, D = input_shape
+    half_dim = D // 2
+
+    # x_ = reshape(x, [..., D/2, 1, 2])
+    x_6d = builder.reshape(input, shape=[B, H, S, half_dim, 1, 2])
+
+    # x_[..., 0] (real) and x_[..., 1] (imag) — slice + reshape + broadcast
+    # to align with the (..., D/2, 2) shape used by the multiplies.
+    x_p0 = builder.slice(
+        x_6d,
+        begins=[0, 0, 0, 0, 0, 0],
+        ends=[B, H, S, half_dim, 1, 1],
+        step=[1, 1, 1, 1, 1, 1],
+    )
+    x_p1 = builder.slice(
+        x_6d,
+        begins=[0, 0, 0, 0, 0, 1],
+        ends=[B, H, S, half_dim, 1, 2],
+        step=[1, 1, 1, 1, 1, 1],
+    )
+    x_real_bc = builder.broadcast(
+        builder.reshape(
+            builder.reshape(x_p0, shape=[B, H, S, half_dim]),
+            shape=[B, H, S, half_dim, 1],
+        ),
+        broadcast_dimensions=[1, 1, 1, 1, 2],
+    )
+    x_imag_bc = builder.broadcast(
+        builder.reshape(
+            builder.reshape(x_p1, shape=[B, H, S, half_dim]),
+            shape=[B, H, S, half_dim, 1],
+        ),
+        broadcast_dimensions=[1, 1, 1, 1, 2],
+    )
+
+    # freqs[..., 0] = [cos, sin] and freqs[..., 1] = [-sin, cos]
+    # — slice the last dim, then broadcast over the heads dim.
+    freqs_c0 = builder.slice(
+        freqs_input,
+        begins=[0, 0, 0, 0, 0, 0],
+        ends=[freqs_shape[0], freqs_shape[1], freqs_shape[2], half_dim, 2, 1],
+        step=[1, 1, 1, 1, 1, 1],
+    )
+    freqs_c1 = builder.slice(
+        freqs_input,
+        begins=[0, 0, 0, 0, 0, 1],
+        ends=[freqs_shape[0], freqs_shape[1], freqs_shape[2], half_dim, 2, 2],
+        step=[1, 1, 1, 1, 1, 1],
+    )
+    # Squeeze the size-1 heads-broadcast dim (position [1]) and the trailing
+    # size-1 dim from the column slice, then re-add the heads-broadcast dim.
+    cos_bc = builder.broadcast(
+        builder.reshape(
+            builder.reshape(
+                freqs_c0, shape=[freqs_shape[0], freqs_shape[2], half_dim, 2]
+            ),
+            shape=[freqs_shape[0], 1, freqs_shape[2], half_dim, 2],
+        ),
+        broadcast_dimensions=[1, H, 1, 1, 1],
+    )
+    sin_bc = builder.broadcast(
+        builder.reshape(
+            builder.reshape(
+                freqs_c1, shape=[freqs_shape[0], freqs_shape[2], half_dim, 2]
+            ),
+            shape=[freqs_shape[0], 1, freqs_shape[2], half_dim, 2],
+        ),
+        broadcast_dimensions=[1, H, 1, 1, 1],
+    )
+
+    # freqs[..., 0] * x_[..., 0] + freqs[..., 1] * x_[..., 1], reshaped to [..., D]
+    sum_5d = builder.add(
+        builder.multiply(cos_bc, x_real_bc),
+        builder.multiply(sin_bc, x_imag_bc),
+    )
+    return builder.reshape(sum_5d, shape=input_shape)
+
+
+# Representative shapes for Pattern 3 (interleaved-pair)
+INTERLEAVED_PAIR_SHAPES = [
+    pytest.param(
+        (1, 20, 128, 128),
+        (1, 1, 128, 64, 2, 2),
+        id="hidream_i1_fast-prefill",
+    ),
+]
+
+
+@pytest.mark.parametrize("input_shape, freqs_shape", INTERLEAVED_PAIR_SHAPES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_rope_interleaved_pair(
+    input_shape, freqs_shape, dtype, target, request, device
+):
+    """
+    Pattern 3: interleaved-pair RoPE.
+    Used by HiDream-I1.
+
+    Verifies that the decomposed RoPE pattern fuses into ttnn.rotary_embedding
+    through the full pipeline.
+    """
+    shapes = [input_shape, freqs_shape]
+    dtypes = [dtype] * 2
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def rotary_embedding(
+            input: Operand,
+            freqs_input: Operand,
+            builder: TTIRBuilder,
+        ):
+            input_data = torch.randn(input_shape, dtype=dtype)
+
+            # Build a valid freqs_cis: per pair, 2x2 = [[c, -s], [s, c]].
+            angles = torch.randn(freqs_shape[:-2], dtype=torch.float32)
+            c, s = torch.cos(angles), torch.sin(angles)
+            freqs_data = (
+                torch.stack([c, -s, s, c], dim=-1).reshape(freqs_shape).to(dtype)
+            )
+
+            golden = torch_rope_interleaved_pair(input_data, freqs_data)
+
+            result = build_rope_interleaved_pair(input, freqs_input, builder)
+
+            builder.set_goldens(
+                {input: input_data, freqs_input: freqs_data},
+                {result: golden},
+            )
+            return result
+
+    output = compile_and_execute_ttir(
+        module,
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+        pipeline_options=["enable-ttnn-decomposition-pass=false"],
+        save_artifacts=True,
+    )
+
+    assert check_op(output, "rotary_embedding")

--- a/test/ttmlir/Dialect/TTIR/fusing/rotary_embedding/rope.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/rotary_embedding/rope.mlir
@@ -185,3 +185,58 @@ module {
     return %result : tensor<1x8x1x64xbf16>
   }
 }
+
+// =========================================================================
+// Pattern 3: interleaved-pair RoPE
+// =========================================================================
+
+// Interleaved-pair RoPE chain at TTIR level. The matcher should fold the
+// entire reshape -> slice -> reshape -> broadcast -> multiply -> add ->
+// reshape chain into a single ttir.rotary_embedding (with surrounding
+// permutations for interleaved <-> rotate-half conversion).
+// CHECK-LABEL: @rope_interleaved_pair_basic
+// CHECK: "ttir.rotary_embedding"
+// CHECK-NOT: ttir.multiply
+// CHECK-NOT: ttir.add
+module {
+  func.func @rope_interleaved_pair_basic(
+      %x: tensor<1x4x2x8xf32>,
+      %freqs: tensor<1x4x1x4x2x2xf32>) -> tensor<1x4x2x8xf32> {
+
+    // ---- col 0 of freqs_cis 2x2 = [cos, sin] ----
+    %f0_slice = "ttir.slice_static"(%freqs) <{begins = [0:i32, 0:i32, 0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 4:i32, 1:i32, 4:i32, 2:i32, 1:i32], step = [1:i32, 1:i32, 1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x4x1x4x2x2xf32>) -> tensor<1x4x1x4x2x1xf32>
+    %f0_r1 = "ttir.reshape"(%f0_slice) <{shape = [1:i32, 4:i32, 4:i32, 2:i32]}> : (tensor<1x4x1x4x2x1xf32>) -> tensor<1x4x4x2xf32>
+    %f0_r2 = "ttir.reshape"(%f0_r1) <{shape = [1:i32, 4:i32, 1:i32, 4:i32, 2:i32]}> : (tensor<1x4x4x2xf32>) -> tensor<1x4x1x4x2xf32>
+    %f0_bc = "ttir.broadcast"(%f0_r2) <{broadcast_dimensions = array<i64: 1, 1, 2, 1, 1>}> : (tensor<1x4x1x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+
+    // ---- col 1 of freqs_cis 2x2 = [-sin, cos] ----
+    %f1_slice = "ttir.slice_static"(%freqs) <{begins = [0:i32, 0:i32, 0:i32, 0:i32, 0:i32, 1:i32], ends = [1:i32, 4:i32, 1:i32, 4:i32, 2:i32, 2:i32], step = [1:i32, 1:i32, 1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x4x1x4x2x2xf32>) -> tensor<1x4x1x4x2x1xf32>
+    %f1_r1 = "ttir.reshape"(%f1_slice) <{shape = [1:i32, 4:i32, 4:i32, 2:i32]}> : (tensor<1x4x1x4x2x1xf32>) -> tensor<1x4x4x2xf32>
+    %f1_r2 = "ttir.reshape"(%f1_r1) <{shape = [1:i32, 4:i32, 1:i32, 4:i32, 2:i32]}> : (tensor<1x4x4x2xf32>) -> tensor<1x4x1x4x2xf32>
+    %f1_bc = "ttir.broadcast"(%f1_r2) <{broadcast_dimensions = array<i64: 1, 1, 2, 1, 1>}> : (tensor<1x4x1x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+
+    // ---- reshape x to expose pairs: (1,4,2,8) -> (1,4,2,4,1,2) ----
+    %x_6d = "ttir.reshape"(%x) <{shape = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32, 2:i32]}> : (tensor<1x4x2x8xf32>) -> tensor<1x4x2x4x1x2xf32>
+
+    // ---- pair index 0 (real) ----
+    %x0_slice = "ttir.slice_static"(%x_6d) <{begins = [0:i32, 0:i32, 0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32, 1:i32], step = [1:i32, 1:i32, 1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x4x2x4x1x2xf32>) -> tensor<1x4x2x4x1x1xf32>
+    %x0_r1 = "ttir.reshape"(%x0_slice) <{shape = [1:i32, 4:i32, 2:i32, 4:i32]}> : (tensor<1x4x2x4x1x1xf32>) -> tensor<1x4x2x4xf32>
+    %x0_r2 = "ttir.reshape"(%x0_r1) <{shape = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<1x4x2x4xf32>) -> tensor<1x4x2x4x1xf32>
+    %x0_bc = "ttir.broadcast"(%x0_r2) <{broadcast_dimensions = array<i64: 1, 1, 1, 1, 2>}> : (tensor<1x4x2x4x1xf32>) -> tensor<1x4x2x4x2xf32>
+
+    // ---- pair index 1 (imag) ----
+    %x1_slice = "ttir.slice_static"(%x_6d) <{begins = [0:i32, 0:i32, 0:i32, 0:i32, 0:i32, 1:i32], ends = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32, 2:i32], step = [1:i32, 1:i32, 1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x4x2x4x1x2xf32>) -> tensor<1x4x2x4x1x1xf32>
+    %x1_r1 = "ttir.reshape"(%x1_slice) <{shape = [1:i32, 4:i32, 2:i32, 4:i32]}> : (tensor<1x4x2x4x1x1xf32>) -> tensor<1x4x2x4xf32>
+    %x1_r2 = "ttir.reshape"(%x1_r1) <{shape = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<1x4x2x4xf32>) -> tensor<1x4x2x4x1xf32>
+    %x1_bc = "ttir.broadcast"(%x1_r2) <{broadcast_dimensions = array<i64: 1, 1, 1, 1, 2>}> : (tensor<1x4x2x4x1xf32>) -> tensor<1x4x2x4x2xf32>
+
+    // ---- multiply col0 * x_real + col1 * x_imag ----
+    %cos_branch = "ttir.multiply"(%f0_bc, %x0_bc) : (tensor<1x4x2x4x2xf32>, tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+    %sin_branch = "ttir.multiply"(%f1_bc, %x1_bc) : (tensor<1x4x2x4x2xf32>, tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+    %sum = "ttir.add"(%cos_branch, %sin_branch) : (tensor<1x4x2x4x2xf32>, tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+
+    // ---- flatten back to 4D ----
+    %result = "ttir.reshape"(%sum) <{shape = [1:i32, 4:i32, 2:i32, 8:i32]}> : (tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x8xf32>
+    return %result : tensor<1x4x2x8xf32>
+  }
+}


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4761

### Problem description

- The existing TTIR `--ttir-fusing` pass has two RoPE matchers: `RoPERotateHalfFusingPattern` and `RoPEComplexRotationFusingPattern`. Both expect the rotation chain to slice on the last dim's halves. Neither matches the **interleaved-pair** scheme where adjacent elements form pairs:

```
x_  = reshape(x, [..., D/2, 1, 2])                            # (1, 2) sub-tile inner dims
out = reshape(freqs[..., 0] * x_[..., 0] +
freqs[..., 1] * x_[..., 1], [..., D])
```

- The `(1, 2)` inner dims pad 512× under `tile<32x32>`, causing per-chip allocation requests around the 5.47 GB (in model run - 4 chip) / 23.5 GB (in sanity- 1 chip) range depending on sharding — large enough to OOM on real model runs.

### What's changed

- Added a third TTIR matcher, **`RoPEInterleavedPairFusingPattern`**, anchored on `AddOp`. It identifies the four-multiply / two-slice / two-cache-column structure of interleaved-pair RoPE, then rewrites it as a rotate-half-equivalent chain that lowers to the existing `ttir.rotary_embedding` op:
  - Permute `x` from interleaved to rotate-half layout via stride-2 slices + concat.
  - Build full-D cos/sin caches as self-concat of half-D extracts from `freqs_cis`.
  - Emit `ttir.rotary_embedding(x_perm, cos, sin)`.
  - Permute the result back to interleaved layout (reshape → permute → reshape).

- Why `ttir.rotary_embedding` is not visible in the post-compile IR (with the matcher applied):
  - The op is **transient** in the pipeline. `RotaryEmbeddingDecompositionRewritePattern` (at the TTNN level) sees `ttnn.rotary_embedding` with `cos = concat(cos_half, cos_half)` / `sin = concat(sin_half, sin_half)`, recognises the self-concat pattern, and immediately takes its **self-concat fast path** — algebraically identical to rotate-half but using half-D multiplies + subtract + add + concat:
```
loCos  = x_lo * cos_half
hiSin  = x_hi * sin_half
first  = loCos - hiSin                  # real half
hiCos  = x_hi * cos_half
loSin  = x_lo * sin_half
second = hiCos + loSin                  # imag half
result = concat(first, second, dim=-1)
```

- Since `ttnn.rotary_embedding` is rewritten in the very next pass, standard IR snapshots (taken at coarser pipeline checkpoints) do not capture it. Two logs are attached for clarity:
  - **Without intermediate dumps** — runtime ops contain `ttnn.subtract` (12), `ttnn.permute` (12), etc. — signatures of the matcher's rewrite + the self-concat decomposition. No `ttnn.rotary_embedding`.
  - **With intermediate dumps** (added inside `RotaryEmbeddingDecompositionRewritePattern` for debugging) — `ttnn.rotary_embedding` is visible in the BEFORE-rewrite snapshot, confirming the full chain `matcher → ttir.rotary_embedding → ttnn.rotary_embedding → decomposition`.

- The matcher therefore correctly eliminates the sub-tile bloat by avoiding the `reshape(..., D/2, 1, 2)` step entirely — every intermediate operates at tile-aligned `(B, S, H, D)` or `(B, S, H, D/2)` shapes. Sanity test peak per-bank DRAM drops from a 23.5 GB OOM to ~300 MB; the original HiDream `concatenate.524` allocation (5.47 GB) no longer appears in the model log.

### Checklist 

- [x] verify the changes through local testing in WH

### Logs

- [jun9_hidream_rope_before_fix.log](https://github.com/user-attachments/files/28762728/jun9_hidream_rope.log)
- [jun9_hidream_transformer_before_fix.log](https://github.com/user-attachments/files/28762730/jun9_hidream_transformer_details.log)
- [jun9_hidream_rope_after_fix.log](https://github.com/user-attachments/files/28762750/jun9_hidream_rope_after_fix.log)
- [jun9_hidream_transformer_after_fix.log](https://github.com/user-attachments/files/28762752/jun9_hidream_transformer_after_fix.log)
- [jun9_hidream_rope_after_fix_with_intermediate_IR_dumps.log](https://github.com/user-attachments/files/28762763/jun9_hidream_rope_debug_info.log)
- [jun9_hidream_transformer_after_fix_with_intermediate_IR_dumps.log](https://github.com/user-attachments/files/28762764/jun9_hidream_transformer_debug_details.log)


