### PR TITLE
[d2m] handle view chains over composite DMA reads

### DIFF
--- a/lib/Dialect/D2M/Transforms/ExpandDMAReadCompositeView.cpp
+++ b/lib/Dialect/D2M/Transforms/ExpandDMAReadCompositeView.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 
@@ -409,38 +410,57 @@ static LogicalResult expandCompositeDMAReadRowMajor(
   return success();
 }
 
+static CompositeViewOp getCompositeViewSource(Value value) {
+  while (value) {
+    if (auto compositeView = value.getDefiningOp<CompositeViewOp>()) {
+      return compositeView;
+    }
+
+    auto viewLayout = value.getDefiningOp<ViewLayoutOp>();
+    if (!viewLayout) {
+      return nullptr;
+    }
+    value = viewLayout.getInput();
+  }
+
+  return nullptr;
+}
+
 static LogicalResult expandCompositeViewsInGeneric(IRRewriter &rewriter,
                                                    GenericOp gOp) {
   CompositeViewOp compositeView = nullptr;
+  Value compositeSource = nullptr;
   gOp.walk([&](DMAReadOp dmaRead) {
-    auto maybeCompositeView = dmaRead.getSrc().getDefiningOp<CompositeViewOp>();
+    auto maybeCompositeView = getCompositeViewSource(dmaRead.getSrc());
     if (maybeCompositeView) {
       TT_assertv(
           compositeView == nullptr,
           "Unsupported multiple composite views in one GenericOp (#7600).");
       compositeView = maybeCompositeView;
+      compositeSource = dmaRead.getSrc();
     }
   });
   TT_assert(compositeView != nullptr);
+  TT_assert(compositeSource != nullptr);
 
   SmallVector<Value> compositeInputs = compositeView.getCompositeInputs();
   TT_assert(compositeInputs.size() > 1u);
 
-  int64_t oldNumInputs = static_cast<int64_t>(gOp.getInputs().size());
   int64_t extraNumInputs = static_cast<int64_t>(compositeInputs.size() - 1);
 
   // Step 1: recreate the GenericOp w/ expanded list of inputs.
   SmallVector<Value> newInputs;
-  newInputs.reserve(oldNumInputs + extraNumInputs);
+  newInputs.reserve(gOp.getInputs().size() + extraNumInputs);
   for (auto input : gOp.getInputs()) {
-    if (input == compositeView.getResult()) {
+    if (input == compositeSource) {
       newInputs.append(compositeInputs.begin(), compositeInputs.end());
       continue;
     }
     newInputs.push_back(input);
   }
 
-  int64_t compositeOperandIdx = gOp.getOperandIndex(compositeView.getResult());
+  uint64_t compositeOperandIdx =
+      static_cast<uint64_t>(gOp.getOperandIndex(compositeSource));
 
   rewriter.setInsertionPoint(gOp);
   // Passing empty block_factors/indexing_maps/iterator_types.
@@ -478,16 +498,18 @@ static LogicalResult expandCompositeViewsInGeneric(IRRewriter &rewriter,
 
     // Shift the affected d2m.get_cb ops.
     newBlock->walk([&](GetCBOp getCBOp) {
-      getCBOp.setCbOperandIdx(getCBOp.getCbOperandIdx() + extraNumInputs);
+      if (getCBOp.getCbOperandIdx() > compositeOperandIdx) {
+        getCBOp.setCbOperandIdx(getCBOp.getCbOperandIdx() + extraNumInputs);
+      }
     });
   }
 
   // Step 3: lower the composite DMA read in the new GenericOp.
   DMAReadOp clonedCompositeRead = nullptr;
   newGOp.walk([&](DMAReadOp dmaRead) {
-    auto maybeCompositeView = dmaRead.getSrc().getDefiningOp<CompositeViewOp>();
+    auto maybeCompositeView = getCompositeViewSource(dmaRead.getSrc());
     if (maybeCompositeView) {
-      TT_assert(dmaRead.getSrc() == compositeView.getResult());
+      TT_assert(dmaRead.getSrc() == compositeSource);
       TT_assert(clonedCompositeRead == nullptr);
       clonedCompositeRead = dmaRead;
     }
@@ -496,9 +518,10 @@ static LogicalResult expandCompositeViewsInGeneric(IRRewriter &rewriter,
 
   auto expandedGenericInputs =
       newGOp.getInputs().slice(compositeOperandIdx, compositeInputs.size());
-  const bool isTiled = mlir::isa<ttcore::TileType>(
-      mlir::cast<MemRefType>(compositeView.getResult().getType())
-          .getElementType());
+  auto compositeSourceType =
+      mlir::cast<MemRefType>(clonedCompositeRead.getSrc().getType());
+  const bool isTiled =
+      mlir::isa<ttcore::TileType>(compositeSourceType.getElementType());
 
   const int32_t compositeDim = compositeView.getDim();
   LogicalResult result = success();
@@ -509,8 +532,7 @@ static LogicalResult expandCompositeViewsInGeneric(IRRewriter &rewriter,
     // This value is only used to determine if we need the guard to skip the
     // padded portions of the output shards.
     const int64_t totalConcatShards =
-        mlir::cast<MemRefType>(compositeView.getResult().getType())
-            .getShape()[compositeDim];
+        compositeSourceType.getShape()[compositeDim];
     result = expandCompositeDMAReadRowMajor(
         rewriter, clonedCompositeRead, expandedGenericInputs, compositeDim,
         compositeView.getLogicalSizes().value(), totalConcatShards);
@@ -523,13 +545,28 @@ static LogicalResult expandCompositeViewsInGeneric(IRRewriter &rewriter,
   return result;
 }
 
+static void eraseDeadViewLayoutChain(IRRewriter &rewriter, Operation *op) {
+  auto viewLayout = mlir::dyn_cast<ViewLayoutOp>(op);
+  if (!viewLayout) {
+    return;
+  }
+
+  for (Operation *user : llvm::make_early_inc_range(viewLayout->getUsers())) {
+    eraseDeadViewLayoutChain(rewriter, user);
+  }
+
+  if (viewLayout->use_empty()) {
+    rewriter.eraseOp(viewLayout);
+  }
+}
+
 static LogicalResult expandCompositeViews(ModuleOp moduleOp) {
   IRRewriter rewriter(moduleOp.getContext());
   SmallVector<GenericOp> genericsToExpand;
 
   moduleOp.walk([&](GenericOp gOp) {
     gOp.walk([&](DMAReadOp dmaRead) {
-      if (dmaRead.getSrc().getDefiningOp<CompositeViewOp>()) {
+      if (getCompositeViewSource(dmaRead.getSrc())) {
         genericsToExpand.push_back(gOp);
         return WalkResult::interrupt();
       }
@@ -543,8 +580,18 @@ static LogicalResult expandCompositeViews(ModuleOp moduleOp) {
     }
   }
 
-  auto status = success();
+  SmallVector<CompositeViewOp> compositeViews;
   moduleOp.walk([&](CompositeViewOp compositeView) {
+    compositeViews.push_back(compositeView);
+  });
+
+  auto status = success();
+  for (CompositeViewOp compositeView : compositeViews) {
+    for (Operation *user :
+         llvm::make_early_inc_range(compositeView->getUsers())) {
+      eraseDeadViewLayoutChain(rewriter, user);
+    }
+
     if (compositeView->use_empty()) {
       compositeView.erase();
     } else {
@@ -552,7 +599,7 @@ static LogicalResult expandCompositeViews(ModuleOp moduleOp) {
           "Composite view has remaining uses after expansion.");
       status = failure();
     }
-  });
+  }
   return status;
 }
 

--- a/lib/Dialect/D2M/Transforms/ExpandDMAReadCompositeView.cpp
+++ b/lib/Dialect/D2M/Transforms/ExpandDMAReadCompositeView.cpp
@@ -428,6 +428,8 @@ static CompositeViewOp getCompositeViewSource(Value value) {
 
 static LogicalResult expandCompositeViewsInGeneric(IRRewriter &rewriter,
                                                    GenericOp gOp) {
+  // DMA read source that is the direct or indirect result of a composite view.
+  // The indirect case comes from a chain of d2m.view_layout ops.
   CompositeViewOp compositeView = nullptr;
   Value compositeSource = nullptr;
   gOp.walk([&](DMAReadOp dmaRead) {

--- a/test/ttmlir/Dialect/D2M/Transforms/expand_dma_read_composite_view.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/expand_dma_read_composite_view.mlir
@@ -84,15 +84,20 @@ module attributes {} {
         outs(%alloc_2 : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
     ^datamovement0:
       // CHECK: d2m.get_cb(2)
+      // CHECK-NOT: d2m.composite_view
+      // CHECK-NOT: d2m.view_layout
       %1 = d2m.get_cb(1) : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
       %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
       %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
       %2 = d2m.reserve %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x2x!ttcore.tile<32x32, f32>, #l1>
       // CHECK: d2m.dma_read
+      // CHECK-NOT: d2m.composite_view
+      // CHECK-NOT: d2m.view_layout
       %tx = d2m.dma_read %view[%core0, %core1], %2, <0> : (memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
       d2m.dma_wait %tx : !d2m.mem_tx<read>
       d2m.push %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
     }
+    // CHECK: return
     return %alloc_2 : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
   }
 
@@ -111,15 +116,20 @@ module attributes {} {
         outs(%alloc_2 : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
     ^datamovement0:
       // CHECK: d2m.get_cb(2)
+      // CHECK-NOT: d2m.composite_view
+      // CHECK-NOT: d2m.view_layout
       %1 = d2m.get_cb(1) : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
       %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
       %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
       %2 = d2m.reserve %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x2x!ttcore.tile<32x32, f32>, #l1>
       // CHECK: d2m.dma_read
+      // CHECK-NOT: d2m.composite_view
+      // CHECK-NOT: d2m.view_layout
       %tx = d2m.dma_read %view_1[%core0, %core1], %2, <0> : (memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
       d2m.dma_wait %tx : !d2m.mem_tx<read>
       d2m.push %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
     }
+    // CHECK: return
     return %alloc_2 : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
   }
 

--- a/test/ttmlir/Dialect/D2M/Transforms/expand_dma_read_composite_view.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/expand_dma_read_composite_view.mlir
@@ -70,6 +70,59 @@ module attributes {} {
     return %alloc_2 : memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
   }
 
+  // CHECK-LABEL: func.func @test_view_layout_of_composite_view
+  func.func @test_view_layout_of_composite_view() -> memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> {
+    %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %alloc_1 = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<1x1x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    // CHECK-NOT: d2m.composite_view
+    // CHECK-NOT: d2m.view_layout
+    %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32}> : (memref<1x1x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> memref<1x1x1x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %view = d2m.view_layout %0 remapping = affine_map<(d0, d1, d2, d3) -> (0, 0, 0, d1 * 2 + d3)> : memref<1x1x1x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %alloc_2 = memref.alloc() {address = 120096 : i64, alignment = 16 : i64} : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x2>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%view : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>)
+        outs(%alloc_2 : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^datamovement0:
+      // CHECK: d2m.get_cb(2)
+      %1 = d2m.get_cb(1) : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %2 = d2m.reserve %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x2x!ttcore.tile<32x32, f32>, #l1>
+      // CHECK: d2m.dma_read
+      %tx = d2m.dma_read %view[%core0, %core1], %2, <0> : (memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+      d2m.dma_wait %tx : !d2m.mem_tx<read>
+      d2m.push %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    return %alloc_2 : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+  }
+
+  // CHECK-LABEL: func.func @test_view_layout_chain_of_composite_view
+  func.func @test_view_layout_chain_of_composite_view() -> memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> {
+    %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %alloc_1 = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<1x1x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    // CHECK-NOT: d2m.composite_view
+    // CHECK-NOT: d2m.view_layout
+    %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32}> : (memref<1x1x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> memref<1x1x1x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %view_0 = d2m.view_layout %0 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x1x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<1x1x1x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %view_1 = d2m.view_layout %view_0 remapping = affine_map<(d0, d1, d2, d3) -> (0, 0, 0, d1 * 2 + d3)> : memref<1x1x1x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %alloc_2 = memref.alloc() {address = 120096 : i64, alignment = 16 : i64} : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x2>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%view_1 : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>)
+        outs(%alloc_2 : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^datamovement0:
+      // CHECK: d2m.get_cb(2)
+      %1 = d2m.get_cb(1) : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %2 = d2m.reserve %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x2x!ttcore.tile<32x32, f32>, #l1>
+      // CHECK: d2m.dma_read
+      %tx = d2m.dma_read %view_1[%core0, %core1], %2, <0> : (memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+      d2m.dma_wait %tx : !d2m.mem_tx<read>
+      d2m.push %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    return %alloc_2 : memref<1x2x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+  }
+
   // CHECK-LABEL: func.func @test_composite_view_row_major_width
   func.func @test_composite_view_row_major_width() -> memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1> {
     %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<4x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>


### PR DESCRIPTION
### Problem description
Qwen model IR produces a view layout chain on top of a composite view

### What's changed
- `ExpandDMAReadCompositeView` can now find a d2m.composite_view through one or more d2m.view_layout wrappers so DMA reads from view_layout(composite_view) or deeper view chains are expanded correctly
- Rebuild the affected d2m.generic using the actual viewed source operand, replacing it with the composite’s underlying inputs, and fixes shifted CB operand indices after that input expansion
- Use the viewed DMA source type for tiled/row-major shape decisions, then removes the now-dead view_layout chain and composite_view after expansion
- Added lit coverage for both a single outer view_layout and a chained view_layout(view_layout(composite_view))

IR Snippet:
```
        %0 = "d2m.composite_view"(%view_367, %view_371) <{dim = 3 : si32}> : (memref<1x2x16x2x1x4x1x1x!ttcore.tile<32x32, bf16>, #ttcore.view<8>, #dram>, memref<1x2x16x2x1x4x1x1x!ttcore.tile<32x32, bf16>, #ttcore.view<8>, #dram>) -> memref<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #ttcore.view<8>, #dram>
        %alloc_372 = memref.alloc() {address = 590848 : i64, alignment = 32 : i64, d2m.virtualGridForwardMapping = #map104, d2m.virtualGridInverseMapping = #map105} : memref<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<16384x2048x2048x2048, 1>, #dram>
        %view_373 = d2m.view_layout %0 remapping = #map111 : memref<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #ttcore.view<8>, #dram> -> memref<1x2x16x4x1x4x1x1x!ttcore.tile<32x32, bf16>, #ttcore.view<8>, #dram>
        %view_374 = d2m.view_layout %alloc_372 remapping = #map111 : memref<1x1x16x4x1x8x1x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<16384x2048x2048x2048, 1>, #dram> -> memref<1x2x16x4x1x4x1x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<8192x2048x2048x2048, 1>, #dram>
        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1x16x4, virt_to_physical_map = (d0, d1, d2, d3) -> (0, ((d3 + d2 * 4) floordiv 8) mod 8, (d3 + d2 * 4) mod 8), physical_to_virt_map = (d0, d1) -> (0, 0, 0, (d1 floordiv 4 + d0 * 2) mod 16, d1 mod 4)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
            ins(%view_373 : memref<1x2x16x4x1x4x1x1x!ttcore.tile<32x32, bf16>, #ttcore.view<8>, #dram>)
            outs(%view_374 : memref<1x2x16x4x1x4x1x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<8192x2048x2048x2048, 1>, #dram>)
         {
          %c1 = arith.constant 1 : index
          %c2 = arith.constant 2 : index
          %c0 = arith.constant 0 : index
          scf.for %arg294 = %c0 to %c2 step %c1 {
            %alloc_26132 = memref.alloc() {address = 1024 : i64, alignment = 16 : i64, d2m.synchronized_buffer = 2 : i32} : memref<1x4x1x1x!ttcore.tile<32x32, bf16>, #l1>
            %core0 = d2m.core_index(0) : index
            %core1 = d2m.core_index(1) : index
            %72 = arith.muli %core1, %c2 : index
            %73 = arith.addi %arg294, %72 : index
            %core2 = d2m.core_index(2) : index
            %core3 = d2m.core_index(3) : index
            d2m.remote_load %alloc_26132 %view_373[%core0, %73, %core2, %core3] : memref<1x4x1x1x!ttcore.tile<32x32, bf16>, #l1>, memref<1x2x16x4x1x4x1x1x!ttcore.tile<32x32, bf16>, #ttcore.view<8>, #dram>
            d2m.remote_store %view_374[%core0, %73, %core2, %core3] %alloc_26132 : memref<1x2x16x4x1x4x1x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<8192x2048x2048x2048, 1>, #dram>, memref<1x4x1x1x!ttcore.tile<32x32, bf16>, #l1>
          } {d2m.blocking_loop = 1 : i64}
        }
```

### Checklist
- [ ] New/Existing tests provide coverage for changes
