### PR TITLE
Uplift third_party/tt-metal to 8d90104 2026-06-08

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -44,6 +44,7 @@ apt-get install -y -qq python3.12 python3.12-dev python3.12-venv
 wget -q https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_DEPENDENCIES_COMMIT}/{install_dependencies.sh,tt_metal/sfpi-info.sh,tt_metal/sfpi-version}
 chmod u+x sfpi-info.sh
 bash install_dependencies.sh --docker
+bash install_dependencies.sh --sfpi
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -46,16 +46,10 @@ chmod u+x sfpi-info.sh
 bash install_dependencies.sh --docker
 bash install_dependencies.sh --sfpi
 
-# tt-metal's install_dependencies.sh --docker no longer installs ULFM OpenMPI
-# (it expects it to come from container layers). Without it, libtt_metal.so
-# resolves libmpi.so.40 to the system OpenMPI 4.x (ORTE), whose singleton
-# MPI_Init forks a daemon that dies on the CI process limit. Reuse the pinned
-# metal script's own install_mpi_ulfm so the ULFM version stays in sync with
-# TT_METAL_DEPENDENCIES_COMMIT instead of hardcoding it here.
-source install_dependencies.sh --source-only
-detect_os
-distributed=1
-install_mpi_ulfm
+# tt-metal's install_dependencies.sh --docker no longer installs ULFM OpenMPI,
+# so install it here so libtt_metal.so links against the ULFM build instead of
+# the system OpenMPI.
+( source install_dependencies.sh --source-only && detect_os && distributed=1 && install_mpi_ulfm )
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -59,9 +59,9 @@ RUN wget https://apt.llvm.org/llvm.sh && \
     rm llvm.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/bin/clang-20 /usr/bin/clang && \
-    ln -s /usr/bin/clang++-20 /usr/bin/clang++ && \
-    ln -s /usr/bin/clangd-20 /usr/bin/clangd
+    ln -sf /usr/bin/clang-20 /usr/bin/clang && \
+    ln -sf /usr/bin/clang++-20 /usr/bin/clang++ && \
+    ln -sf /usr/bin/clangd-20 /usr/bin/clangd
 
 # Install python packages
 RUN python3.12 -m pip install --no-cache-dir --break-system-packages cmake \

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -46,6 +46,17 @@ chmod u+x sfpi-info.sh
 bash install_dependencies.sh --docker
 bash install_dependencies.sh --sfpi
 
+# tt-metal's install_dependencies.sh --docker no longer installs ULFM OpenMPI
+# (it expects it to come from container layers). Without it, libtt_metal.so
+# resolves libmpi.so.40 to the system OpenMPI 4.x (ORTE), whose singleton
+# MPI_Init forks a daemon that dies on the CI process limit. Reuse the pinned
+# metal script's own install_mpi_ulfm so the ULFM version stays in sync with
+# TT_METAL_DEPENDENCIES_COMMIT instead of hardcoding it here.
+source install_dependencies.sh --source-only
+detect_os
+distributed=1
+install_mpi_ulfm
+
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 # ANCHOR_END: developer_dependencies

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=68e82deb155ec50633cbb505d33a5a014cf678e2
+ARG TT_METAL_DEPENDENCIES_COMMIT=8d901046bb169c9c3de1a68d284fba502371a820
 
 # Install dependencies
 RUN <<EOT

--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -5,6 +5,6 @@
 
 # Calculate hash from the following files. This hash is used to tag the docker images.
 # Any change in these files will result in a new docker image build
-DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci .github/Dockerfile.ird .github/Dockerfile.cibuildwheel env/CMakeLists.txt env/init_venv.sh env/build-requirements.txt env/ttnn-requirements.txt env/patches/shardy.patch env/patches/shardy_mpmd_pybinds.patch env/patches/stablehlo-complex-mul-expander.patch test/python/requirements.txt env/install-tt-triage.sh"
+DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci .github/Dockerfile.ird .github/Dockerfile.cibuildwheel env/CMakeLists.txt env/init_venv.sh env/build-requirements.txt env/ttnn-requirements.txt env/pip-constraints.txt env/patches/shardy.patch env/patches/shardy_mpmd_pybinds.patch env/patches/stablehlo-complex-mul-expander.patch test/python/requirements.txt env/install-tt-triage.sh"
 DOCKERFILE_HASH=$(sha256sum $DOCKERFILE_HASH_FILES | sha256sum | cut -d ' ' -f 1)
 echo dt-$DOCKERFILE_HASH

--- a/env/pip-constraints.txt
+++ b/env/pip-constraints.txt
@@ -1,1 +1,1 @@
-nanobind==2.10.2
+nanobind==2.12.0

--- a/include/tt-metalium/experimental/mock_device.hpp
+++ b/include/tt-metalium/experimental/mock_device.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_COMPAT_TT_METALIUM_EXPERIMENTAL_MOCK_DEVICE_H
+#define TTMLIR_COMPAT_TT_METALIUM_EXPERIMENTAL_MOCK_DEVICE_H
+
+#include <tt-metalium/experimental/mock_device/mock_device.hpp>
+
+#endif // TTMLIR_COMPAT_TT_METALIUM_EXPERIMENTAL_MOCK_DEVICE_H

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -12,7 +12,7 @@
 #include "tt-metalium/buffer_types.hpp"
 #include "tt-metalium/core_coord.hpp"
 #include "tt-metalium/device.hpp"
-#include "tt-metalium/experimental/mock_device.hpp"
+#include "tt-metalium/experimental/mock_device/mock_device.hpp"
 #include "tt-metalium/host_api.hpp"
 #include "ttnn/graph/graph_processor.hpp"
 // using namespace removed in metal

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1094,8 +1094,7 @@ public:
     SmallVector<Value, 1> operands;
     std::string nocName = ensureNocReference(op.getOperation(), rewriter,
                                              operands, adaptor.getNoc());
-    std::string callStr =
-        nocName + "." + methodName + "<Noc::BarrierMode::FULL>();";
+    std::string callStr = nocName + "." + methodName + "();";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);
@@ -1123,8 +1122,8 @@ public:
     std::string nocName = ensureNocReference(op.getOperation(), rewriter,
                                              operands, adaptor.getNoc());
     operands.push_back(adaptor.getTrid());
-    std::string callStr =
-        nocName + "." + methodName + "<Noc::BarrierMode::TXN_ID>({});";
+    std::string callStr = nocName + "." + methodName +
+                          "<NocOptions::TXN_ID>(NocOptVals{.trid = {}});";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1123,7 +1123,7 @@ public:
                                              operands, adaptor.getNoc());
     operands.push_back(adaptor.getTrid());
     std::string callStr = nocName + "." + methodName +
-                          "<NocOptions::TXN_ID>(NocOptVals{.trid = {}});";
+                          "<NocOptions::TXN_ID>(NocOptVals{{.trid = {}}});";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1232,10 +1232,13 @@ public:
     std::string endpoint = ensureEndpointDeclaration(
         op.getOperation(), rewriter, "MulticastEndpoint", "mcast_ep");
 
-    llvm::StringRef mcastMode =
+    // EXCLUDE_SRC maps to default NocOptions (no MCAST_INCL_SRC flag), so we
+    // omit the template argument entirely. INCLUDE_SRC maps to
+    // NocOptions::MCAST_INCL_SRC.
+    std::string templateArg =
         std::is_same_v<SourceOp, ttkernel::NocAsyncWriteMulticastOp>
-            ? "Noc::McastMode::EXCLUDE_SRC"
-            : "Noc::McastMode::INCLUDE_SRC";
+            ? ""
+            : "<NocOptions::MCAST_INCL_SRC>";
     bool linked = op.getLinked().value_or(false);
 
     operands.append({adaptor.getSrcLocalL1Addr(), adaptor.getSize(),
@@ -1248,9 +1251,9 @@ public:
         ".noc_x_end = {}, .noc_y_end = {}, "
         ".addr = static_cast<uint32_t>({})}";
 
-    std::string callStr = nocName + ".async_write_multicast<" +
-                          mcastMode.str() + ">(CoreLocalMem<uint32_t>({}), " +
-                          endpoint + ", {}, {}, {{} , " + dstArgs + ", " +
+    std::string callStr = nocName + ".async_write_multicast" + templateArg +
+                          "(CoreLocalMem<uint32_t>({}), " + endpoint +
+                          ", {}, {}, {{} , " + dstArgs + ", " +
                           (linked ? "true" : "false") + ");";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.10.2", "wheel", "pip", "ninja"]
+requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.12.0", "wheel", "pip", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -41,7 +41,8 @@ static ::tt::tt_metal::SemaphoreDescriptor createSemaphoreDescriptor(
       .buffer_index = bufferIndex,
       .data_format = dataFormat,
       .page_size = pageSize,
-      .tile = std::nullopt};
+      .tile = std::nullopt,
+      .face_geometry = std::nullopt};
   return cbFormatDescriptor;
 }
 

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -712,6 +712,11 @@ def test_sort(
     request,
     device,
 ):
+    if is_stable:
+        pytest.xfail(
+            "stable=True is not implemented in ttnn::sort: https://github.com/tenstorrent/tt-metal/issues/33492"
+        )
+
     def module(builder: StableHLOBuilder):
         @builder.func([shape], [dtype])
         def sort(

--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -480,6 +480,11 @@ def test_sort(
             "Sorting along batch dimension is not supported: https://github.com/tenstorrent/tt-metal/issues/31187"
         )
 
+    if stable:
+        pytest.xfail(
+            "stable=True is not implemented in ttnn::sort: https://github.com/tenstorrent/tt-metal/issues/33492"
+        )
+
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
         def sort_wrapper(

--- a/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
@@ -17,7 +17,7 @@
 // CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
 // CHECK-NEXT: emitc.call_opaque "noc_async_read_set_trid"(%[[TRID]], %[[NOC_IDX]]) : (i32, i8) -> ()
 // CHECK-NEXT: emitc.call_opaque "noc_async_read_one_packet_with_state_with_trid"(%[[SRC_BASE]], %[[SRC_ADDR]], %[[DST_L1]], %[[TRID]], %[[NOC_IDX]]) : (i32, i32, i32, i32, i8) -> ()
-// CHECK-NEXT: emitc.verbatim "noc0.async_read_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32
+// CHECK-NEXT: emitc.verbatim "noc0.async_read_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}][}]}});" args %[[TRID]] : i32
 func.func @trid_read_path() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
   %noc_idx = arith.constant 0 : i8
@@ -50,7 +50,7 @@ func.func @trid_read_path() -> () attributes {ttkernel.thread = #ttkernel.thread
 // CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
 // CHECK-NEXT: emitc.call_opaque "noc_async_write_set_trid"(%[[TRID]], %[[NOC_IDX]]) : (i32, i8) -> ()
 // CHECK-NEXT: emitc.call_opaque "noc_async_write_one_packet_with_trid"(%[[DST]], %[[NOC_ADDR]], %[[SIZE]], %[[TRID]], %[[NOC_IDX]]) : (i32, i64, i32, i32, i8) -> ()
-// CHECK-NEXT: emitc.verbatim "noc0.async_write_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32
+// CHECK-NEXT: emitc.verbatim "noc0.async_write_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}][}]}});" args %[[TRID]] : i32
 // CHECK-NEXT: emitc.call_opaque "reset_noc_trid_barrier_counter"(%[[MASK]], %[[NOC_IDX]]) : (i32, i8) -> ()
 func.func @trid_write_path() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
@@ -75,7 +75,7 @@ func.func @trid_write_path() -> () attributes {ttkernel.thread = #ttkernel.threa
 // CHECK-LABEL: func @trid_barrier_default_noc
 // CHECK: emitc.verbatim "Noc noc;"
 // CHECK: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
-// CHECK: emitc.verbatim "noc.async_write_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[TRID]] : i32
+// CHECK: emitc.verbatim "noc.async_write_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}][}]}});" args %[[TRID]] : i32
 func.func @trid_barrier_default_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
   "ttkernel.noc_async_write_barrier_with_trid"(%trid) : (i32) -> ()
@@ -90,7 +90,7 @@ func.func @trid_barrier_default_noc() -> () attributes {ttkernel.thread = #ttker
 // CHECK-LABEL: func @trid_barrier_dynamic_noc
 // CHECK: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
 // CHECK: %[[NOC:.*]] = emitc.cast
-// CHECK: emitc.verbatim "Noc({}).async_read_barrier<Noc::BarrierMode::TXN_ID>({});" args %[[NOC]], %[[TRID]] : i8, i32
+// CHECK: emitc.verbatim "Noc({}).async_read_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}][}]}});" args %[[NOC]], %[[TRID]] : i8, i32
 func.func @trid_barrier_dynamic_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
   %noc_arg = arith.constant 262400 : i32

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2048,11 +2048,11 @@ module {
       // CHECK: %[[SIZE:.*]] = "emitc.constant"() <{value = 64 : i32}>
       // CHECK: %[[NUM_DESTS:.*]] = "emitc.constant"() <{value = 4 : i32}>
       // CHECK: %[[NOC:.*]] = "emitc.constant"() <{value = 1 : i8}>
-      // CHECK: emitc.verbatim "noc1.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>
+      // CHECK: emitc.verbatim "noc1.async_write_multicast(
       // CHECK-SAME: noc_traits_t<MulticastEndpoint>::dst_args_mcast_type
       // CHECK-SAME: args %[[SRC]], %[[SIZE]], %[[NUM_DESTS]], %[[XE]], %[[YE]], %[[XS]], %[[YS]], %[[ADDR]]
       ttkernel.noc_async_write_multicast(%src, %size, %num_dests, start_xy[%xe, %ye], end_xy[%xs, %ys], %addr, %noc) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
-      // CHECK: emitc.verbatim "noc1.async_write_multicast<Noc::McastMode::INCLUDE_SRC>
+      // CHECK: emitc.verbatim "noc1.async_write_multicast<NocOptions::MCAST_INCL_SRC>
       // CHECK-SAME: noc_traits_t<MulticastEndpoint>::dst_args_mcast_type
       // CHECK-SAME: args %[[SRC]], %[[SIZE]], %[[NUM_DESTS]], %[[XE]], %[[YE]], %[[XS]], %[[YS]], %[[ADDR]]
       ttkernel.noc_async_write_multicast_loopback_src(%src, %size, %num_dests, start_xy[%xe, %ye], end_xy[%xs, %ys], %addr, %noc) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
@@ -2083,7 +2083,7 @@ module {
       // CHECK: %[[NOC2:.*]] = "emitc.constant"() <{value = 1 : i8}>
       // CHECK: emitc.verbatim "noc.async_write_barrier();"
       "ttkernel.noc_async_write_barrier"() : () -> ()
-      // CHECK: emitc.verbatim "noc1.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>
+      // CHECK: emitc.verbatim "noc1.async_write_multicast(
       // CHECK-SAME: args %[[SRC2]], %[[SIZE2]], %[[NUM_DESTS2]], %[[XE2]], %[[YE2]], %[[XS2]], %[[YS2]], %[[ADDR2]]
       ttkernel.noc_async_write_multicast(%src, %size, %num_dests, start_xy[%xe, %ye], end_xy[%xs, %ys], %addr, %noc) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
       return
@@ -2117,7 +2117,7 @@ module {
       // CHECK: %[[NOC_SLOT:.*]] = emitc.subscript %[[NOC_PTR]][%[[NOC_OFFSET]]
       // CHECK: %[[LOADED_NOC:.*]] = emitc.load %[[NOC_SLOT]]
       // CHECK: %[[DYNAMIC_NOC:.*]] = emitc.cast %[[LOADED_NOC]]
-      // CHECK: emitc.verbatim "Noc({}).async_write_multicast<Noc::McastMode::EXCLUDE_SRC>
+      // CHECK: emitc.verbatim "Noc({}).async_write_multicast(
       // CHECK-SAME: args %[[DYNAMIC_NOC]], %[[SRC3]], %[[SIZE3]], %[[NUM_DESTS3]], %[[XE3]], %[[YE3]], %[[XS3]], %[[YS3]], %[[ADDR3]]
       ttkernel.noc_async_write_multicast(%src, %size, %num_dests, start_xy[%xe, %ye], end_xy[%xs, %ys], %addr, %noc) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
       return

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1992,7 +1992,7 @@ module {
     // CHECK-LABEL: func @noc_async_read_barrier
     func.func @noc_async_read_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.verbatim "Noc noc;"
-      // CHECK: emitc.verbatim "noc.async_read_barrier<Noc::BarrierMode::FULL>();"
+      // CHECK: emitc.verbatim "noc.async_read_barrier();"
       "ttkernel.noc_async_read_barrier"() : () -> ()
       return
     }
@@ -2002,7 +2002,7 @@ module {
       // CHECK: emitc.verbatim "Noc noc1(1);"
       // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
       %noc_id = arith.constant 1 : i8
-      // CHECK: emitc.verbatim "noc1.async_read_barrier<Noc::BarrierMode::FULL>();"
+      // CHECK: emitc.verbatim "noc1.async_read_barrier();"
       ttkernel.noc_async_read_barrier(%noc_id) : (i8) -> ()
       return
     }
@@ -2081,7 +2081,7 @@ module {
       // CHECK: %[[SIZE2:.*]] = "emitc.constant"() <{value = 64 : i32}>
       // CHECK: %[[NUM_DESTS2:.*]] = "emitc.constant"() <{value = 4 : i32}>
       // CHECK: %[[NOC2:.*]] = "emitc.constant"() <{value = 1 : i8}>
-      // CHECK: emitc.verbatim "noc.async_write_barrier<Noc::BarrierMode::FULL>();"
+      // CHECK: emitc.verbatim "noc.async_write_barrier();"
       "ttkernel.noc_async_write_barrier"() : () -> ()
       // CHECK: emitc.verbatim "noc1.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>
       // CHECK-SAME: args %[[SRC2]], %[[SIZE2]], %[[NUM_DESTS2]], %[[XE2]], %[[YE2]], %[[XS2]], %[[YS2]], %[[ADDR2]]
@@ -2126,7 +2126,7 @@ module {
     // CHECK-LABEL: func @noc_async_write_barrier
     func.func @noc_async_write_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.verbatim "Noc noc;"
-      // CHECK: emitc.verbatim "noc.async_write_barrier<Noc::BarrierMode::FULL>();"
+      // CHECK: emitc.verbatim "noc.async_write_barrier();"
       "ttkernel.noc_async_write_barrier"() : () -> ()
       return
     }
@@ -2136,7 +2136,7 @@ module {
       // CHECK: emitc.verbatim "Noc noc1(1);"
       // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
       %noc_id = arith.constant 1 : i8
-      // CHECK: emitc.verbatim "noc1.async_write_barrier<Noc::BarrierMode::FULL>();"
+      // CHECK: emitc.verbatim "noc1.async_write_barrier();"
       ttkernel.noc_async_write_barrier(%noc_id) : (i8) -> ()
       return
     }

--- a/test/ttmlir/Silicon/StableHLO/n150/data_movement/sort_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/data_movement/sort_op.mlir
@@ -22,19 +22,7 @@ func.func @test_sort_ascending_none_stable(%arg0: tensor<1x128x256x256xbf16>) ->
   return %2#0, %2#1 : tensor<1x128x256x256xbf16>, tensor<1x128x256x256xi32>
 }
 
-func.func @test_sort_descending_stable(%arg0: tensor<1x128x256x256xbf16>) -> (tensor<1x128x256x256xbf16>, tensor<1x128x256x256xi32>) {
-  // CHECK-LABEL: @test_sort_descending_stable
-  %0 = stablehlo.iota dim = 0 : tensor<256xi32>
-  %1 = stablehlo.broadcast_in_dim %0, dims = [3] : (tensor<256xi32>) -> tensor<1x128x256x256xi32>
-  // CHECK: %{{.*}}, %{{.*}} = "ttnn.sort"(%arg0)
-  // CHECK-SAME: <{descending = true, dim = 3 : si8, stable = true}>
-  // CHECK-SAME: (tensor<1x128x256x256xbf16,
-  // CHECK-SAME: -> (tensor<1x128x256x256xbf16,
-  // CHECK-SAME: tensor<1x128x256x256xui16,
-  %2:2 = "stablehlo.sort"(%arg0, %1) <{dimension = 3 : i64, is_stable = true}> ({
-  ^bb0(%arg1: tensor<bf16>, %arg2: tensor<bf16>, %arg3: tensor<i32>, %arg4: tensor<i32>):
-    %4 = stablehlo.compare  GT, %arg1, %arg2,  TOTALORDER : (tensor<bf16>, tensor<bf16>) -> tensor<i1>
-    stablehlo.return %4 : tensor<i1>
-  }) : (tensor<1x128x256x256xbf16>, tensor<1x128x256x256xi32>) -> (tensor<1x128x256x256xbf16>, tensor<1x128x256x256xi32>)
-  return %2#0, %2#1 : tensor<1x128x256x256xbf16>, tensor<1x128x256x256xi32>
-}
+// stable=true case is covered by the StableHLOToTTIR conversion test
+// (test/ttmlir/Conversion/StableHLOToTTIR/data_movement/sort_op.mlir).
+// It is omitted here because tt-metal's ttnn::sort TT_FATALs on stable=true.
+// See https://github.com/tenstorrent/tt-metal/issues/33492.

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -25,7 +25,7 @@ func.func @ttkernel_noc_cb() -> () attributes {ttkernel.arg_spec = #ttkernel.arg
     %wptr = "ttkernel.get_write_ptr"(%cb) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>) -> i32
     // CHECK: [[NOC]].async_read([[EP]], CoreLocalMem<uint32_t>([[CB]].get_write_ptr()), [[C0]]
     ttkernel.noc_async_read core[%c0_idx, %c0_idx], %c262144_i32, %wptr, %c32_i32 : (index, index, i32, i32, i32) -> ()
-    // CHECK: [[NOC]].async_read_barrier<Noc::BarrierMode::FULL>()
+    // CHECK: [[NOC]].async_read_barrier()
     ttkernel.noc_async_read_barrier() : () -> ()
     // CHECK: [[CB]].push_back
     "ttkernel.cb_push_back"(%cb, %c1_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, i32) -> ()
@@ -71,7 +71,7 @@ func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<n
     ttkernel.noc_async_atomic_barrier() : () -> ()
     // CHECK: noc1.async_atomic_barrier()
     ttkernel.noc_async_atomic_barrier(%noc) : (i8) -> ()
-    // CHECK: [[NOC1]].async_read_barrier<Noc::BarrierMode::FULL>()
+    // CHECK: [[NOC1]].async_read_barrier()
     ttkernel.noc_async_read_barrier() : () -> ()
     // CHECK: return
     func.return
@@ -91,9 +91,9 @@ func.func @ttkernel_noc_with_noc_id() -> () attributes {ttkernel.thread = #ttker
     %noc_id = arith.constant 1 : i8
     // CHECK: uint64_t [[EXPLICIT_NOC_ADDR:.*]] = [[EXPLICIT_EP]].get_noc_unicast_addr(static_cast<uint32_t>([[EXPLICIT_X]]), static_cast<uint32_t>([[EXPLICIT_Y]]), static_cast<uint32_t>([[EXPLICIT_ADDR]]), [[EXPLICIT_NOC]].get_noc_id())
     %noc_addr = ttkernel.get_noc_addr(%x, %y, %addr, %noc_id) : (index, index, i32, i8) -> !ttkernel.noc_addr
-    // CHECK: [[EXPLICIT_NOC]].async_read_barrier<Noc::BarrierMode::FULL>()
+    // CHECK: [[EXPLICIT_NOC]].async_read_barrier()
     ttkernel.noc_async_read_barrier(%noc_id) : (i8) -> ()
-    // CHECK: [[EXPLICIT_NOC]].async_write_barrier<Noc::BarrierMode::FULL>()
+    // CHECK: [[EXPLICIT_NOC]].async_write_barrier()
     ttkernel.noc_async_write_barrier(%noc_id) : (i8) -> ()
     // CHECK: return
     func.return

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -1429,13 +1429,12 @@ TEST_F(OpModelTest, Sort) {
 
   constraintsExp = op_model::OpModel<SortOp>::getOpConstraints(
       tensorShape, layoutL1Interleaved, 0, false, false, layoutL1WSharded);
-  EXPECT_FALSE(static_cast<bool>(constraintsExp));
-  llvm::consumeError(constraintsExp.takeError());
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   runtimeExp = op_model::OpModel<SortOp>::getOpRuntime(
       tensorShape, layoutL1Interleaved, 0, false, false, layoutL1WSharded);
-  EXPECT_FALSE(static_cast<bool>(runtimeExp));
-  llvm::consumeError(runtimeExp.takeError());
+  EXPECT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_TRUE(runtimeExp.get() > 0);
 }
 
 TEST_F(OpModelTest, TopK) {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "68e82deb155ec50633cbb505d33a5a014cf678e2")
+set(TT_METAL_VERSION "8d901046bb169c9c3de1a68d284fba502371a820")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")

--- a/tools/pykernel/pyproject.toml
+++ b/tools/pykernel/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.10.2", "wheel", "pip", "ninja"]
+requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.12.0", "wheel", "pip", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tools/ttrt/requirements.txt
+++ b/tools/ttrt/requirements.txt
@@ -2,4 +2,4 @@
 torch@https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl; sys_platform == "linux" and platform_machine == "x86_64"
 torch@https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl; sys_platform == "linux" and platform_machine == "aarch64"
 torch==2.9.1; sys_platform == "darwin"
-nanobind==2.10.2
+nanobind==2.12.0


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 8d90104 - 2026-06-08

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI links**
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):https://github.com/tenstorrent/tt-xla/actions/runs/27315048589/job/80703514048, https://github.com/tenstorrent/tt-xla/actions/runs/27360099616 (This job couldn't get a machine assigned on a dedicated runner (stuck queued). It doesn't actually require a dedicated runner, so I ran it separately on a shared runner and confirmed it works.)
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): (passing) https://github.com/tenstorrent/tt-forge-onnx/actions/runs/27319248137

- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):

𝚃̶𝚃̶𝚂̶𝚒̶𝚖̶ ̶𝚋̶𝚕̶𝚊̶𝚌̶𝚔̶𝚑̶𝚘̶𝚕̶𝚎̶ ̶𝚝̶𝚎̶𝚜̶𝚝̶ ̶𝚒̶𝚜̶ ̶𝚏̶𝚊̶𝚒̶𝚕̶𝚒̶𝚗̶𝚐̶ ̶𝚍̶𝚞̶𝚎̶ ̶𝚝̶𝚘̶ ̶𝚝̶𝚝̶-̶𝚖̶𝚎̶𝚝̶𝚊̶𝚕̶ ̶𝚌̶𝚘̶𝚖̶𝚖̶𝚒̶𝚝̶ ̶𝚑̶𝚝̶𝚝̶𝚙̶𝚜̶:̶/̶/̶𝚐̶𝚒̶𝚝̶𝚑̶𝚞̶𝚋̶.̶𝚌̶𝚘̶𝚖̶/̶𝚝̶𝚎̶𝚗̶𝚜̶𝚝̶𝚘̶𝚛̶𝚛̶𝚎̶𝚗̶𝚝̶/̶𝚝̶𝚝̶-̶𝚖̶𝚎̶𝚝̶𝚊̶𝚕̶/̶𝚌̶𝚘̶𝚖̶𝚖̶𝚒̶𝚝̶/̶𝚏̶𝚌̶𝟽̶𝟺̶𝟽̶𝟺̶𝚌̶𝚌̶𝚎̶𝟽̶𝟹̶𝟾̶.̶ ̶𝚃̶𝚑̶𝚎̶ ̶𝚏̶𝚒̶𝚡̶ ̶𝚒̶𝚜̶ ̶𝚒̶𝚗̶ ̶𝚛̶𝚎̶𝚟̶𝚒̶𝚎̶𝚠̶:̶ ̶𝚑̶𝚝̶𝚝̶𝚙̶𝚜̶:̶/̶/̶𝚐̶𝚒̶𝚝̶𝚑̶𝚞̶𝚋̶.̶𝚌̶𝚘̶𝚖̶/̶𝚝̶𝚎̶𝚗̶𝚜̶𝚝̶𝚘̶𝚛̶𝚛̶𝚎̶𝚗̶𝚝̶/̶𝚝̶𝚝̶-̶𝚖̶𝚎̶𝚝̶𝚊̶𝚕̶/̶𝚙̶𝚞̶𝚕̶𝚕̶/̶𝟺̶𝟼̶𝟻̶𝟿̶𝟾̶.̶ ̶𝚆̶𝚎̶ ̶𝚖̶𝚒̶𝚐̶𝚑̶𝚝̶ ̶𝚠̶𝚊̶𝚗̶𝚝̶ ̶𝚝̶𝚘̶ ̶𝚌̶𝚑̶𝚎̶𝚛̶𝚛̶𝚢̶-̶𝚙̶𝚒̶𝚌̶𝚔̶ ̶𝚒̶𝚝̶ ̶-̶ ̶𝚠̶𝚒̶𝚕̶𝚕̶ ̶𝚌̶𝚘̶𝚗̶𝚏̶𝚒̶𝚛̶𝚖̶ ̶𝚠̶𝚑̶𝚎̶𝚝̶𝚑̶𝚎̶𝚛̶ ̶𝚝̶𝚑̶𝚒̶𝚜̶ ̶𝚒̶𝚜̶ ̶𝚝̶𝚑̶𝚎̶ ̶𝚙̶𝚛̶𝚘̶𝚙̶𝚎̶𝚛̶ ̶𝚙̶𝚊̶𝚝̶𝚑̶.̶ (turned out to be false positive, this change was in main on may26, which means it was included with our previous uplift with no issues)

TTSim blackhole test is failing, cause needs to be investigated.

Update: Fixed — TTSim blackhole was failing because the CI base image lost ULFM OpenMPI after the metal dependency bump. Installing ULFM in Dockerfile.base resolves it; TTSim BH/WH now pass.
