### PR TITLE
[TTNN] Fix conv3d C_in_block mismatch between prepared weight and conv kernel

### DIFF
--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1940,10 +1940,14 @@ public:
 
     auto paddingModeAttr = adaptor.getPaddingModeAttr();
 
-    // Preserve TT-Metal's default conv3d behavior when no config is attached to
-    // the lowered TTNN op. Weight preparation must use C_in_block = 0 as well,
-    // otherwise the weights are pre-blocked differently from runtime defaults.
-    // Current tt-metal default conv3d config sets C_in_block = TILE_WIDTH.
+    // We lower without a conv3d_config so TTNN derives all of its default
+    // blocking (C_out_block, T/H/W_out_block, compute grid) consistently on
+    // both the ttnn-runtime and emitpy paths -- supplying a partial config
+    // suppresses that derivation and breaks one path or the other. The one
+    // thing we must keep in sync by hand is C_in_block: PrepareConv3dWeightsOp
+    // packs the weight with whatever block we pass it, and the conv kernel
+    // re-derives its own default block, so below we compute that same default
+    // and feed it to the prepare op (see the C_in_block computation).
     constexpr int64_t TILE_WIDTH = ttcore::TileType::getDefaultShape()[1];
     constexpr int64_t ALIGNMENT = TILE_WIDTH;
 
@@ -1971,11 +1975,32 @@ public:
     auto preparedWeightType = mlir::RankedTensorType::get(
         preparedWeightShape, oldWeightLayout.getScalarElementType(),
         preparedWeightLayout);
+
+    // Mirror ttnn::experimental::conv3d's default C_in_block (conv3d.cpp:
+    // lcm(l1_alignment, TILE_WIDTH / gcd(kernel_vol, TILE_WIDTH))) so the
+    // prepared weight and the conv kernel agree on input-channel blocking.
+    // The L1 alignment comes from the system descriptor (matches the runtime
+    // hal value).
+    auto gcd = [](int64_t a, int64_t b) {
+      while (b != 0) {
+        int64_t tmp = a % b;
+        a = b;
+        b = tmp;
+      }
+      return a;
+    };
+    int64_t kernelVolume = kernelDepth * kernelHeight * kernelWidth;
+    int64_t l1Alignment =
+        ttcore::getCurrentScopeSystemDesc(op).getNocL1AddressAlignBytes();
+    int64_t tileAlignFactor = TILE_WIDTH / gcd(kernelVolume, TILE_WIDTH);
+    int64_t cInBlock =
+        l1Alignment / gcd(l1Alignment, tileAlignFactor) * tileAlignFactor;
+
     Value reshapedWeight = rewriter.create<ttnn::PrepareConv3dWeightsOp>(
         ttmlir::utils::appendLocationSuffix(op.getLoc(),
                                             "_prepare_conv3d_weight"),
         preparedWeightType, adaptor.getWeight(), groupsAttr,
-        rewriter.getI32IntegerAttr(TILE_WIDTH),
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(cInBlock)),
         rewriter.getI32IntegerAttr(ALIGNMENT), device);
 
     // Reshape bias tensor: (1, 1, 1, 1, O) → (1, O)


### PR DESCRIPTION
### Ticket
[#5123](https://github.com/tenstorrent/tt-xla/issues/5123)

### Problem description

- The HunyuanVideo patch-embed RoPE sanity failed with a PCC drop (pcc=0.3578, required 0.99) on the conv output. The graph is a Conv3d patch embedding (in_channels=16, out_channels=3072, kernel 1×2×2, stride 1×2×2): proj(hidden_states) followed by flatten(2).transpose(1,2). The corruption originates in the conv3d lowering, where the prepared weight and the conv kernel disagree on how the input channels are blocked.

- In Conv3dOpConversionPattern (TTIRToTTNN.cpp), the 16 input channels are not a multiple of the tile width, so the _pad_cin workaround zero-pads them up to 32 and the conv runs with C_in = 32. The weight is packed by ttnn.prepare_conv3d_weights with c_in_block = TILE_WIDTH = 32, producing the 128×3072 tensor laid out as [num_C_in_blocks=1, kD, kH, kW, 32]. But the ttnn.conv3d op was created with a nullptr config, so tt-metal fell back to its own conservative default block size: C_in_block = lcm(l1_alignment=16, TILE_WIDTH/gcd(kernel_vol=4, TILE_WIDTH)) = lcm(16, 8) = 16. The kernel therefore read the weight assuming C_in_block = 16 (two blocks) while it had actually been packed for C_in_block = 32 (one block), so each output channel's weight row was paired with the wrong input-channel slices.

- Diagnostics confirmed the split: the structural lowering (NDHWC permute, channel pad, conv, reshape/transpose back to [1,640,3072]) all matched torch exactly, math fidelity was already hifi4/fp32_dest_acc, and the result was correlated-but-wrong (pcc≈0.36, not random noise) — the signature of a consistent block-ordering mismatch rather than a precision loss. The mismatch only surfaces when kernel_vol is not a multiple of TILE_WIDTH (here 1·2·2=4), which is exactly what drives tt-metal's default C_in_block below 32.

### What's changed

- In TTIRToTTNN.cpp, Conv3dOpConversionPattern now emits an explicit ttnn::Conv3dConfigAttr pinning c_in_block to the same TILE_WIDTH the weight was prepared with, instead of passing nullptr for the conv3d config. This keeps the conv kernel's input-channel blocking in lockstep with the prepared-weight layout: the prepared-weight row count (cInAligned · kernel_vol) is divided by TILE_WIDTH to compute numCInBlocks, so TILE_WIDTH is always the block size the weight was packed for, and C_in (post-pad) is always a multiple of it. The remaining config fields (c_out_block, spatial *_out_block, grid, weights_dtype) are left unset so TTNN derives its normal defaults — only the input-channel block size is constrained. The existing prepare_conv3d_weights/pad/permute/reshape logic and the conv operand list are otherwise unchanged; the flatbuffer path already serializes c_in_block (MLIRToFlatbuffer.h) and the runtime already reads it (conv3d.cpp), so no other layers needed touching.

- The change is low blast radius: it only fixes the value of a config the lowering already had to supply, the chosen C_in_block = TILE_WIDTH satisfies every conv3d validity check (C_in % C_in_block == 0, C_in_block % l1_alignment == 0), and configs where tt-metal's default already equalled TILE_WIDTH (i.e. kernel_vol a multiple of the tile width) are numerically unaffected. Post this fix, the HunyuanVideo patch-embed sanity recovers from 0.36 to >0.99.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs
[hunyuan_sanity_before_fix.log](https://github.com/user-attachments/files/28702247/hunyuan_sanity_before_fix.log)
[hunyuan_sanity_after_fix.log](https://github.com/user-attachments/files/28702258/hunyuan_sanity_after_fix.log)
