### PR TITLE
[EIO] Reject rms_norm reshape commute that breaks trailing dim

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTIR/Utils/Utils.h
@@ -256,10 +256,13 @@ int64_t findMatchingDim(llvm::ArrayRef<int64_t> fromShape,
 // that dimension maps to. Returns -1 if no matching dimension is found.
 int64_t findMatchingDimRTL(ReshapeOp reshapeOp, int64_t dimRTL);
 
-// Checks if an operation preserves a given dimension.
-// For reshape, this checks both that the dimension size is unchanged and that
-// the product of trailing dimensions (stride) is preserved.
-// Dimension can be negative (counted from back, e.g. -1 for last dimension).
+// Checks if an op preserves a dim's size and trailing stride, allowing the
+// dim to shift across intervening size-1 dims (e.g. `(...,N) -> (...,N,1)`).
+// Dim can be negative (counted from back, e.g. -1 for last).
+bool preservesDimUpToOnes(mlir::Operation *op, int64_t dim);
+
+// Stricter variant: additionally requires the output dim at the same offset
+// from the trailing edge to have the same size as `inputShape[dim]`.
 bool preservesDim(mlir::Operation *op, int64_t dim);
 
 // If `originalOp` consumes values that were typecasted from the same source

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/RMSNormCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/RMSNormCommutePatterns.cpp
@@ -92,8 +92,8 @@ public:
 private:
   bool isCommuteUpwardsViable(RMSNormOpT op,
                               ReshapeOp reshapeUser) const override {
-    // RMSNorm normalizes along the last dim, so it must be preserved by the
-    // reshape.
+    // RMSNorm normalizes along the last dim, so it must remain the trailing
+    // dim of the input after the reshape.
     return utils::preservesDim(reshapeUser, -1);
   }
 

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -2631,7 +2631,7 @@ public:
     auto lookThroughSafeOps = [normalizedDimSize](mlir::Value value) {
       return utils::lookThroughLayoutOpsIf(
           value, [normalizedDimSize](mlir::Operation *op) {
-            if (utils::preservesDim(op, -1)) {
+            if (utils::preservesDimUpToOnes(op, -1)) {
               return true;
             }
             // Allow broadcasts that expand to normalized size.

--- a/lib/Dialect/TTIR/Utils/Utils.cpp
+++ b/lib/Dialect/TTIR/Utils/Utils.cpp
@@ -116,7 +116,7 @@ int64_t findMatchingDimRTL(ReshapeOp reshapeOp, int64_t dimRTL) {
   return outputRank - 1 - ltrResult;
 }
 
-bool preservesDim(mlir::Operation *op, int64_t dim) {
+bool preservesDimUpToOnes(mlir::Operation *op, int64_t dim) {
   auto inputType = mlir::cast<RankedTensorType>(op->getOperand(0).getType());
   auto outputType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
   auto inputShape = inputType.getShape();
@@ -170,6 +170,30 @@ bool preservesDim(mlir::Operation *op, int64_t dim) {
         return inputShape[dim] == outputShape[dim];
       })
       .Default([](mlir::Operation *) { return false; });
+}
+
+bool preservesDim(mlir::Operation *op, int64_t dim) {
+  if (!preservesDimUpToOnes(op, dim)) {
+    return false;
+  }
+
+  auto inputType = mlir::cast<RankedTensorType>(op->getOperand(0).getType());
+  auto outputType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
+  int64_t inputRank = inputType.getRank();
+  int64_t outputRank = outputType.getRank();
+
+  // Normalize negative dimension.
+  if (dim < 0) {
+    dim += inputRank;
+  }
+
+  // The output dim at the same offset from the trailing edge must have the
+  // same size
+  int64_t outputDim = outputRank - inputRank + dim;
+  if (outputDim < 0 || outputDim >= outputRank) {
+    return false;
+  }
+  return inputType.getShape()[dim] == outputType.getShape()[outputDim];
 }
 
 namespace {

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_rms_norm.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_rms_norm.mlir
@@ -64,6 +64,19 @@ module {
         return %2 : tensor<32x2048xbf16>
     }
 
+    // Negative case: reshape appends a trailing 1, (...,N) -> (...,N,1).
+    // Should NOT commute because the trailing dim becomes 1 instead of N.
+    func.func @test_reshape_rms_norm_appends_trailing_one(%arg0: tensor<1x3648x3840xbf16>, %arg1: tensor<3840xbf16>) -> tensor<1x3648x3840x1xbf16> {
+        // CHECK-LABEL: @test_reshape_rms_norm_appends_trailing_one
+        // CHECK: "ttir.rms_norm"
+        // CHECK-SAME: (tensor<1x3648x3840xbf16>, tensor<3840xbf16>) -> tensor<1x3648x3840xbf16>
+        // CHECK: "ttir.reshape"
+        // CHECK-SAME: -> tensor<1x3648x3840x1xbf16>
+        %0 = "ttir.rms_norm"(%arg0, %arg1) <{epsilon = 9.99999974E-6 : f32, normalized_shape = array<i64: 3840>, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<1x3648x3840xbf16>, tensor<3840xbf16>) -> tensor<1x3648x3840xbf16>
+        %1 = "ttir.reshape"(%0) <{shape = [1 : i32, 3648 : i32, 3840 : i32, 1 : i32]}> : (tensor<1x3648x3840xbf16>) -> tensor<1x3648x3840x1xbf16>
+        return %1 : tensor<1x3648x3840x1xbf16>
+    }
+
     // Negative case: rms_norm has non-reshape user.
     // Should NOT commute because not all users are identical reshapes.
     func.func @test_reshape_rms_norm_non_reshape_user(%arg0: tensor<32x2048xbf16>, %arg1: tensor<2048xbf16>) -> (tensor<32x2048xbf16>, tensor<32x1x2048xbf16>) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/7150)

### Problem description
When `reshape` op that adds trailing ones is after `rms_norm` op:
```
rms_norm(inut=[..., H], normalized_shape=[H])
reshape [..., H] -> [..., H, 1]
```
it passes current `preservesDim` check and commutes with the rms_norm as
```
reshape [..., H] -> [..., H, 1]
rms_norm(inut=[..., H, 1], normalized_shape=[H])
```
breaking verification that `normalized_shape` must be `[last_input_dim]`.



## What changed
- Renamed the existing `preservesDim` -> `preservesDimUpToOnes` 
- Reclaimed `preservesDim` for a stricter check that additionally requires the output dim at the same offset from the trailing edge to have the same size.
- Switched `RMSNormCommutePatterns::isCommuteUpwardsViable` to the strict `preservesDim`.

### Checklist
- [x] New/Existing tests provide coverage for changes
