### PR TITLE
[d2m] multi output generics

### DIFF
--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1480,7 +1480,8 @@ void d2m::GenericOp::build(
   TT_assertv(!outputs.empty(), "expected at least one output");
 
   if (!grid) {
-    // Derive the generic grid from the first output.
+    // TODO (dloke): Generalize multi-output generic grid selection. Issue:
+    // #8736
     auto output = outputs[0];
     SmallVector<int64_t> gridShape;
     TT_assert(ttcore::hasDeviceLayout(output));
@@ -3181,7 +3182,8 @@ analyzeLocalBufferAssociation(Value localBuffer,
           if (init.get() != value) {
             continue;
           }
-          unsigned initIdx = init.getOperandNumber() - dps.getNumDpsInputs();
+          unsigned initIdx = init.getOperandNumber() -
+                             dps.getDpsInits().getBeginOperandIndex();
           if (initIdx >= userOp->getNumResults()) {
             continue;
           }

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1477,9 +1477,10 @@ void d2m::GenericOp::build(
     ArrayRef<int64_t> blockFactors,
     ttcore::FabricConnectionConfigAttr fabricConnectionConfig) {
   TT_assertv(!indexingMaps.empty(), "expected non-empty indexing maps");
-  TT_assertv(outputs.size() == 1u, "expected single output");
+  TT_assertv(!outputs.empty(), "expected at least one output");
 
   if (!grid) {
+    // Derive the generic grid from the first output.
     auto output = outputs[0];
     SmallVector<int64_t> gridShape;
     TT_assert(ttcore::hasDeviceLayout(output));
@@ -1624,7 +1625,9 @@ void d2m::GenericOp::build(
     ThreadType singleThreadType, ttcore::GridAttr grid,
     ArrayRef<int64_t> blockFactors,
     ttcore::FabricConnectionConfigAttr fabricConnectionConfig) {
-  TT_assertv(outputs.size() == 1u, "expected single output");
+  TT_assertv(!outputs.empty(), "expected at least one output");
+  // All outputs share the same shard rank, so derive iterator/indexing-map
+  // arity from the first one.
   RankedTensorType tensorType =
       mlir::cast<RankedTensorType>(outputs[0].getType());
   ttcore::MetalLayoutAttr maybeLayout =
@@ -1825,8 +1828,8 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
     }
   }
 
-  if (getOutputs().size() != 1) {
-    return emitOpError("must currently have exactly one output operand");
+  if (getOutputs().empty()) {
+    return emitOpError("must have at least one output operand");
   }
 
   if (getThreads().empty()) {
@@ -1967,6 +1970,17 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
   bool hasGrid = mlir::isa<MemRefType>(getOutputs().front().getType()) ||
                  (rankedTensorType && rankedTensorType.getEncoding());
   SmallVector<AffineMap> indexingMaps = getIndexingMapsValue();
+  if (getOutputs().size() > 1 && !indexingMaps.empty()) {
+    AffineMap firstOutputMap =
+        indexingMaps[getOperandIndex(getOutputs().front())];
+    for (Value output : getOutputs().drop_front()) {
+      if (indexingMaps[getOperandIndex(output)] != firstOutputMap) {
+        return emitOpError(
+            "all output operands must share the same indexing map");
+      }
+    }
+  }
+
   if (hasGrid && !indexingMaps.empty()) {
     // Validate that all operands have device layouts before calling
     // getInputOutputOperandGridShapes(), which assumes layouts are present.
@@ -2029,9 +2043,8 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
       }
     }
 
-    assert(getNumDpsInits() == 1);
+    assert(getNumDpsInits() >= 1);
     ::mlir::OpOperand *output = getDpsInitOperand(0);
-    // Op grid map is implicitly derived from the output operand.
     AffineMap opGridMap = indexingMaps[output->getOperandNumber()];
     LogicalResult blockFactorResult =
         verifyAffineBlocking("grid", indexingMaps, gridShapes, blockFactors,
@@ -2256,7 +2269,6 @@ void GenericOp::getCanonicalizationPatterns(mlir::RewritePatternSet &patterns,
                 dps) {
               for (OpOperand &initOperand : dps.getDpsInitsMutable()) {
                 assert(op.getNumDpsInits() == dps.getNumDpsInits());
-                assert(op.getNumDpsInits() == 1);
 
                 updated |=
                     replaceWithEmpty(rewriter, region, regionOp, initOperand);
@@ -2298,8 +2310,8 @@ AffineMap d2m::GenericOp::getIndexingMapForOperand(Value operand) {
 }
 
 AffineMap d2m::GenericOp::getOutputIndexingMap() {
-  TT_assertv(getNumDpsInits() == 1,
-             "getOutputIndexingMap expects exactly one output operand");
+  TT_assertv(getNumDpsInits() >= 1,
+             "getOutputIndexingMap expects at least one output operand");
   return getIndexingMapForOperand(getOutputs().front());
 }
 
@@ -2313,8 +2325,8 @@ std::optional<unsigned> d2m::GenericOp::getOutputOperandIndex(Value operand) {
 }
 
 mlir::SmallVector<int64_t> d2m::GenericOp::getOutputGridDimPositions() {
-  TT_assertv(getNumDpsInits() == 1,
-             "getOutputGridDimPositions expects exactly one output operand");
+  TT_assertv(getNumDpsInits() >= 1,
+             "getOutputGridDimPositions expects at least one output operand");
   auto outputOperandIndex = getOperandIndex(getOutputs().front());
   return getParticipatingLoopDims(outputOperandIndex);
 }
@@ -2930,11 +2942,14 @@ mlir::LogicalResult d2m::GenericOp::bufferize(
     return failure();
   }
 
-  assert(getNumResults() == 1 && "GenericOp should have exactly one result");
-  assert(getOutputs().size() == 1 &&
-         "GenericOp should have exactly one output");
+  assert(getNumResults() == getOutputs().size() &&
+         "GenericOp should have one result per output");
 
-  if (!mlir::isa<mlir::RankedTensorType>(getResult(0).getType())) {
+  // Skip if already bufferized.
+  bool anyTensor = llvm::any_of(getResults(), [](Value r) {
+    return mlir::isa<mlir::RankedTensorType>(r.getType());
+  });
+  if (!anyTensor) {
     return failure();
   }
   mlir::SmallVector<mlir::Value> bufferInputs;
@@ -3134,20 +3149,47 @@ analyzeLocalBufferAssociation(Value localBuffer,
   };
 
   bool hasRemoteUse = false;
-  for (Operation *userOp : localBuffer.getUsers()) {
-    if (auto loadOp = mlir::dyn_cast<RemoteLoadOp>(userOp)) {
-      if (loadOp.getLocalBuffer() == localBuffer) {
-        hasRemoteUse = true;
-        noteOperand(loadOperand, hasConflictingLoadOperands,
-                    loadOp.getMemref());
+
+  // Follow DPS aliases until a remote_load/remote_store identifies the parent
+  // generic operand associated with this local buffer.
+  llvm::SmallVector<Value, 4> worklist;
+  llvm::SmallPtrSet<Value, 8> visited;
+  worklist.push_back(localBuffer);
+  visited.insert(localBuffer);
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    for (Operation *userOp : value.getUsers()) {
+      if (auto loadOp = mlir::dyn_cast<RemoteLoadOp>(userOp)) {
+        if (loadOp.getLocalBuffer() == value) {
+          hasRemoteUse = true;
+          noteOperand(loadOperand, hasConflictingLoadOperands,
+                      loadOp.getMemref());
+        }
+        continue;
       }
-      continue;
-    }
-    if (auto storeOp = mlir::dyn_cast<RemoteStoreOp>(userOp)) {
-      if (storeOp.getLocalBuffer() == localBuffer) {
-        hasRemoteUse = true;
-        noteOperand(storeOperand, hasConflictingStoreOperands,
-                    storeOp.getMemref());
+      if (auto storeOp = mlir::dyn_cast<RemoteStoreOp>(userOp)) {
+        if (storeOp.getLocalBuffer() == value) {
+          hasRemoteUse = true;
+          noteOperand(storeOperand, hasConflictingStoreOperands,
+                      storeOp.getMemref());
+        }
+        continue;
+      }
+      // Follow matching DPS init -> result aliases.
+      if (auto dps = mlir::dyn_cast<DestinationStyleOpInterface>(userOp)) {
+        for (OpOperand &init : dps.getDpsInitsMutable()) {
+          if (init.get() != value) {
+            continue;
+          }
+          unsigned initIdx = init.getOperandNumber() - dps.getNumDpsInputs();
+          if (initIdx >= userOp->getNumResults()) {
+            continue;
+          }
+          Value matchingResult = userOp->getResult(initIdx);
+          if (visited.insert(matchingResult).second) {
+            worklist.push_back(matchingResult);
+          }
+        }
       }
     }
   }
@@ -3190,16 +3232,11 @@ Value d2m::GenericOp::findAssocOperand(mlir::tensor::EmptyOp emptyOp) {
     return Value();
   }
 
-  // Assert that the parent GenericOp has a single output
-  int64_t numOutputs = static_cast<int64_t>(genericOp.getOutputs().size());
-  TT_assertv(numOutputs == 1,
-             "tensor.empty within generic op with multiple outputs - "
-             "cannot determine associated operand");
-
-  // By default, assume the associated operand is the sole output operand.
-  return analyzeLocalBufferAssociation(emptyOp.getResult(),
-                                       genericOp.getOutputs()[0])
-      .operand;
+  // Only the single-output case has an unambiguous fallback.
+  Value fallback = (genericOp.getOutputs().size() == 1)
+                       ? genericOp.getOutputs()[0]
+                       : Value();
+  return analyzeLocalBufferAssociation(emptyOp.getResult(), fallback).operand;
 }
 
 Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
@@ -3223,8 +3260,7 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
   //    declaration order; allocs without remote use there are local working
   //    buffers, not operand allocations.
   //
-  // d2m.get_cb ops are matched by operand_index when present, otherwise by
-  // their remote_load/remote_store binding.
+  // d2m.get_cb ops are matched by cb_operand_idx.
   Value result;
   unsigned idx = 0;
   std::function<void(Block &, bool)> scanBlock = [&](Block &block,
@@ -3233,10 +3269,18 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
       if (result) {
         return;
       }
-      if (auto emptyOp = mlir::dyn_cast<mlir::tensor::EmptyOp>(&op)) {
-        LocalBufferAssociation assoc = analyzeLocalBufferAssociation(
-            emptyOp.getResult(),
-            generic ? generic.getOutputs().front() : Value());
+      if (auto getCbOp = mlir::dyn_cast<d2m::GetCBOp>(&op)) {
+        if (getCbOp.getCbOperandIdx() == operandIndex) {
+          result = getCbOp.getResult();
+          return;
+        }
+      } else if (auto emptyOp = mlir::dyn_cast<mlir::tensor::EmptyOp>(&op)) {
+        // Only the single-output case has an unambiguous fallback.
+        Value fallback = (generic && generic.getOutputs().size() == 1)
+                             ? generic.getOutputs().front()
+                             : Value();
+        LocalBufferAssociation assoc =
+            analyzeLocalBufferAssociation(emptyOp.getResult(), fallback);
         if (assoc.hasRemoteUse || (assoc.operand && !insideComputeLoop)) {
           if (generic && assoc.operand &&
               generic.getOperandIndex(assoc.operand) ==

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -21,7 +21,6 @@
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
-#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -483,11 +482,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
               if (dpsOp && op->getNumResults() == dpsOp.getNumDpsInits()) {
                 for (OpOperand &init : dpsOp.getDpsInitsMutable()) {
                   if (init.get() == allocResult) {
-                    unsigned resultIdx =
-                        init.getOperandNumber() - dpsOp.getNumDpsInputs();
-                    if (resultIdx < op->getNumResults()) {
-                      resultsToRetype.push_back(resultIdx);
-                    }
+                    resultsToRetype.push_back(
+                        dpsOp.getTiedOpResult(&init).getResultNumber());
                   }
                 }
               } else {

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -20,6 +20,8 @@
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -475,10 +477,29 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
 
             // Check if this is a compute operation with results
             if (op->getNumResults() > 0) {
-              // Update result types for operations that produce values
+              // Re-type only the DPS result that aliases this alloc.
+              auto dpsOp = mlir::dyn_cast<DestinationStyleOpInterface>(op);
+              llvm::SmallVector<unsigned, 2> resultsToRetype;
+              if (dpsOp && op->getNumResults() == dpsOp.getNumDpsInits()) {
+                for (OpOperand &init : dpsOp.getDpsInitsMutable()) {
+                  if (init.get() == allocResult) {
+                    unsigned resultIdx =
+                        init.getOperandNumber() - dpsOp.getNumDpsInputs();
+                    if (resultIdx < op->getNumResults()) {
+                      resultsToRetype.push_back(resultIdx);
+                    }
+                  }
+                }
+              } else {
+                // Preserve legacy behavior for non-DPS/asymmetric ops.
+                for (unsigned i = 0; i < op->getNumResults(); ++i) {
+                  resultsToRetype.push_back(i);
+                }
+              }
+
               rewriter.modifyOpInPlace(op, [&]() {
-                for (OpResult result : op->getResults()) {
-                  // Only update if the result is a memref type
+                for (unsigned idx : resultsToRetype) {
+                  OpResult result = op->getResult(idx);
                   if (mlir::isa<MemRefType>(result.getType())) {
                     result.setType(allocType);
                   }

--- a/test/ttmlir/Dialect/D2M/generic/generic_verify_indexing_maps.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_verify_indexing_maps.mlir
@@ -90,3 +90,43 @@ func.func @test_explicit_datamovement_form(%arg0: tensor<1x1x1x1x!ttcore.tile<32
 
   return %1 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>
 }
+
+// -----
+
+#layout = #ttcore.metal_layout<logical_shape = 32x32, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#transpose = affine_map<(d0, d1) -> (d1, d0)>
+
+func.func @test_multi_output_mismatched_indexing_maps(
+    %arg0: tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>)
+    -> (tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>,
+        tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>) {
+  %0 = d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>
+  %1 = d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>
+
+  // expected-error @+1 {{all output operands must share the same indexing map}}
+  %2:2 = d2m.generic {
+    block_factors = [1, 1],
+    grid = #ttcore.grid<1x1>,
+    indexing_maps = [#map, #map, #transpose],
+    iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>],
+    threads = [#d2m.thread<compute>]
+  }
+  ins(%arg0 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>)
+  outs(%0, %1 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>,
+                tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>)  {
+  ^compute0:
+    %cb_out0 = d2m.get_cb(1) : !d2m.cb<tensor<1x1x!ttcore.tile<32x32, f32>>>
+    %cb_out1 = d2m.get_cb(2) : !d2m.cb<tensor<1x1x!ttcore.tile<32x32, f32>>>
+    %out0 = d2m.reserve %cb_out0 : <tensor<1x1x!ttcore.tile<32x32, f32>>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %out1 = d2m.reserve %cb_out1 : <tensor<1x1x!ttcore.tile<32x32, f32>>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    d2m.yield %out0, %out1
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         tensor<1x1x!ttcore.tile<32x32, f32>>)
+  } : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>,
+      tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>
+
+  return %2#0, %2#1
+    : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>,
+      tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>
+}

--- a/test/ttmlir/Dialect/D2M/generic/multi_output_generic_bufferization.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/multi_output_generic_bufferization.mlir
@@ -1,0 +1,80 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttir-bufferization-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#layout = #ttcore.metal_layout<logical_shape = 64x64, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+
+// CHECK-LABEL: func.func @multi_output_generic_bufferization
+func.func @multi_output_generic_bufferization(
+    %input: tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>)
+    -> (tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>,
+        tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>) {
+  // CHECK-DAG: %[[OUT0:.*]] = memref.alloc() : memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+  %out0 = d2m.empty() : tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>
+  // CHECK-DAG: %[[OUT1:.*]] = memref.alloc() : memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+  %out1 = d2m.empty() : tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>
+
+  // CHECK: d2m.generic
+  // CHECK-NEXT: ins(%{{.*}} : memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+  // CHECK-NEXT: outs(%[[OUT0]], %[[OUT1]] : memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+  %results:2 = d2m.generic {
+      block_factors = [1, 1],
+      grid = #ttcore.grid<2x2>,
+      indexing_maps = [#map, #map, #map],
+      iterator_types = [#parallel, #parallel],
+      threads = [#d2m.thread<unified>]
+    }
+    ins(%input : tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>)
+    outs(%out0, %out1 : tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>,
+                       tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>) {
+  ^unified0:
+    %i = d2m.block_index(0) : index
+    %j = d2m.block_index(1) : index
+
+    // CHECK: %[[IN_SHARD:.*]] = memref.alloc
+    %in_shard = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+    %loaded = d2m.remote_load %in_shard %input[%i, %j]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>,
+        tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>
+      -> tensor<1x1x!ttcore.tile<32x32, f32>>
+
+    // CHECK: %[[TMP0:.*]] = memref.alloc
+    %tmp0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+    // CHECK: d2m.local_copy %[[IN_SHARD]], %[[TMP0]]
+    %copied0 = d2m.local_copy %loaded, %tmp0 indexing_maps = [#map, #map]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>,
+        tensor<1x1x!ttcore.tile<32x32, f32>>
+      -> tensor<1x1x!ttcore.tile<32x32, f32>>
+
+    // CHECK: %[[TMP1:.*]] = memref.alloc
+    %tmp1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+    // CHECK: d2m.local_copy %[[IN_SHARD]], %[[TMP1]]
+    %copied1 = d2m.local_copy %loaded, %tmp1 indexing_maps = [#map, #map]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>,
+        tensor<1x1x!ttcore.tile<32x32, f32>>
+      -> tensor<1x1x!ttcore.tile<32x32, f32>>
+
+    // CHECK: d2m.remote_store %[[OUT0]]
+    %store0 = d2m.remote_store %out0[%i, %j] %copied0
+      : tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>,
+        tensor<1x1x!ttcore.tile<32x32, f32>>
+      -> tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>
+    // CHECK: d2m.remote_store %[[OUT1]]
+    %store1 = d2m.remote_store %out1[%i, %j] %copied1
+      : tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>,
+        tensor<1x1x!ttcore.tile<32x32, f32>>
+      -> tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>
+
+    d2m.yield %store0, %store1
+      : (tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>,
+         tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>)
+  } : tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>,
+      tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>
+
+  // CHECK: return %[[OUT0]], %[[OUT1]]
+  return %results#0, %results#1
+    : tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>,
+      tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout>
+}


### PR DESCRIPTION
### Problem description
Need to support multi output generics for sort/topk

### What's changed
- Updated generic verifier and checks to remove 1 output assumption for generics
- Shard shape and affine mapping must be the same between both outputs, this is the case for those ops. We might have to expand this later as we fuse more and more things together and potentially have multiple different kinds of results #8736 
- Added lit tests
### Checklist
- [ ] New/Existing tests provide coverage for changes
