### PR TITLE
[TTIR] Canonicalize prod of boolean input to min

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -3025,6 +3025,8 @@ def TTIR_ProdOp : TTIR_ReductionOp<"prod"> {
     Output:
     - `result` (Tensor): The result tensor after applying the reduction.
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def TTIR_EmbeddingOp : TTIR_NamedOp<"embedding"> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -6543,6 +6543,30 @@ verifyReduceOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
                         getDimArg(), getKeepDim(), getType().getShape());
 }
 
+// ProdOp canonicalization: prod(bool) -> min(bool).
+//
+// For inputs restricted to {0, 1} (e.g. the result of a comparison/logical op),
+// the product reduction is equivalent to a logical AND, which is exactly a min
+// reduction. We rewrite to MinOp because tt-metal's ttnn::prod reduces along a
+// dimension by first permuting that dimension, materializing a full-size copy
+// of the input (which OOMs for large tensors such as attention masks). The
+// generic min reduction reduces the last dimension in place and avoids that
+// extra allocation, while producing identical results for boolean inputs.
+void mlir::tt::ttir::ProdOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+  patterns.add(+[](mlir::tt::ttir::ProdOp op, mlir::PatternRewriter &rewriter) {
+    if (!isBooleanValued(op.getInput())) {
+      return mlir::failure();
+    }
+    rewriter.replaceOpWithNewOp<mlir::tt::ttir::MinOp>(
+        op, op.getResult().getType(), op.getInput(), op.getKeepDim(),
+        op.getDimArgAttr());
+    return mlir::success();
+  });
+  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
+}
+
 //===----------------------------------------------------------------------===//
 // ReduceAndOp
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/TTIR/canonicalize/prod_bool_to_min.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/prod_bool_to_min.mlir
@@ -1,0 +1,26 @@
+// RUN: ttmlir-opt --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // A product reduction over a boolean (comparison) input is equivalent to a
+  // logical AND, i.e. a min reduction. It should be rewritten to ttir.min to
+  // avoid the memory-heavy ttnn::prod permute on large tensors.
+  // CHECK-LABEL: func.func @prod_bool_to_min
+  func.func @prod_bool_to_min(%arg0: tensor<1x4x32x32xf32>, %arg1: tensor<1x4x32x32xf32>) -> tensor<1x4x32x1xf32> {
+    // CHECK: "ttir.eq"
+    // CHECK: "ttir.min"
+    // CHECK-NOT: "ttir.prod"
+    %0 = "ttir.eq"(%arg0, %arg1) : (tensor<1x4x32x32xf32>, tensor<1x4x32x32xf32>) -> tensor<1x4x32x32xf32>
+    %1 = "ttir.prod"(%0) <{dim_arg = [3 : i32], keep_dim = true}> : (tensor<1x4x32x32xf32>) -> tensor<1x4x32x1xf32>
+    return %1 : tensor<1x4x32x1xf32>
+  }
+
+  // A product reduction over a non-boolean input must be left untouched.
+  // CHECK-LABEL: func.func @prod_nonbool_unchanged
+  func.func @prod_nonbool_unchanged(%arg0: tensor<1x4x32x32xf32>) -> tensor<1x4x32x1xf32> {
+    // CHECK: "ttir.prod"
+    // CHECK-NOT: "ttir.min"
+    %0 = "ttir.prod"(%arg0) <{dim_arg = [3 : i32], keep_dim = true}> : (tensor<1x4x32x32xf32>) -> tensor<1x4x32x1xf32>
+    return %0 : tensor<1x4x32x1xf32>
+  }
+}


### PR DESCRIPTION
## Issue
https://github.com/tenstorrent/tt-xla/issues/5144

## Summary
- Adds a canonicalization that rewrites `ttir.prod` -> `ttir.min` when the reduction input is boolean-valued (result of a comparison/logical op).
- For `{0, 1}` inputs, product == logical AND == min, so the rewrite is exact.

## Motivation
tt-metal's `ttnn::prod` reduces a dimension by first permuting it, which materializes a full-size copy of the input. For large tensors this OOMs — e.g. the SDPA "safe-softmax" pattern `prod(eq(scores, -inf))` over a `1x4x12100x12100` attention matrix tries to allocate a 9.4 GB DRAM buffer and fails. The generic `min` reduction reduces the last dim in place and avoids the extra allocation. This unblocks Pixtral / Mistral-Small-3.1 vision encoders at optimization_level=0.

## Test plan
- Added `test/ttmlir/Dialect/TTIR/canonicalize/prod_bool_to_min.mlir` (prod over `ttir.eq` becomes `ttir.min`; prod over a non-boolean input is unchanged).
- Verified end-to-end that the vision-encoder OOM no longer occurs.