### PR TITLE
[TTIR] Preserve per-tensor weight dtype overrides through matmul fusions

### DIFF
--- a/lib/Dialect/TTIR/Transforms/PropagateWeightDtype.cpp
+++ b/lib/Dialect/TTIR/Transforms/PropagateWeightDtype.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
@@ -9,50 +10,119 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 
+#include <optional>
+
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRPROPAGATEWEIGHTDTYPE
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
 namespace {
 
-// Trace the weight operand backward through allowed ops (TM, CCL, Broadcast,
-// MeshShard, MeshPartition, Typecast, RepeatInterleave) to find the originating
-// func arg. If it carries "ttcore.weight_dtype", set it on the consumer op.
-static void resolveAndSetWeightDtype(mlir::Value weight,
-                                     mlir::Operation *consumerOp) {
-  // Trace backward through allowed ops to find the originating func arg.
+constexpr llvm::StringLiteral kWeightDtypeAttrName = "ttcore.weight_dtype";
+
+// Trace the weight operand backward to the originating func arg(s) and return
+// the per-tensor weight dtype override they carry.
+//
+// The walk passes through ops that don't change which weight tensor this is
+// (TM, CCL, Broadcast, MeshShard, MeshPartition, Typecast, RepeatInterleave).
+// A ConcatOp (e.g. a fused QKV weight built by SharedLHSMatmulFusion) is a
+// genuine combination of multiple weights: each branch is resolved
+// independently and the results merged by keeping the highest-precision (most
+// bits) dtype, so the fused weight never loses precision relative to any
+// constituent. `sawMissing`/`sawDisagreement` record whether the branches were
+// only partially annotated or disagreed, so the caller can warn.
+static std::optional<ttcore::DataType>
+resolveWeightDtype(mlir::Value weight, bool &sawMissing,
+                   bool &sawDisagreement) {
   mlir::Value source = weight;
   while (auto *op = source.getDefiningOp()) {
+    if (auto concatOp = mlir::dyn_cast<ConcatOp>(op)) {
+      std::optional<ttcore::DataType> merged;
+      for (mlir::Value operand : concatOp->getOperands()) {
+        std::optional<ttcore::DataType> branch =
+            resolveWeightDtype(operand, sawMissing, sawDisagreement);
+        if (!branch) {
+          sawMissing = true;
+          continue;
+        }
+        if (!merged) {
+          merged = branch;
+        } else if (*merged != *branch) {
+          sawDisagreement = true;
+          // Keep the highest-precision (most bits) dtype.
+          if (ttcore::getNumberOfBits(*branch) >
+              ttcore::getNumberOfBits(*merged)) {
+            merged = branch;
+          }
+        }
+      }
+      return merged;
+    }
+
     if (op->hasTrait<TensorManipulation::Trait>() ||
         op->hasTrait<CCL::Trait>() ||
         mlir::isa<BroadcastOp, MeshShardOp, MeshPartitionOp, TypecastOp,
                   RepeatInterleaveOp>(op)) {
       source = op->getOperand(0);
-    } else {
-      TTMLIR_DEBUG(ttmlir::LogComponent::General,
-                   "PropagateWeightDtype: unable to trace through op '{0}', "
-                   "stopping backward walk",
-                   op->getName().getStringRef());
-      break;
+      continue;
     }
+
+    TTMLIR_DEBUG(ttmlir::LogComponent::General,
+                 "PropagateWeightDtype: unable to trace through op '{0}', "
+                 "stopping backward walk",
+                 op->getName().getStringRef());
+    return std::nullopt;
   }
 
   auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(source);
   if (!blockArg) {
-    return;
+    return std::nullopt;
   }
 
   auto funcOp = mlir::dyn_cast_or_null<mlir::func::FuncOp>(
       blockArg.getOwner()->getParentOp());
   if (!funcOp) {
-    return;
+    return std::nullopt;
   }
 
   auto dtypeAttr = funcOp.getArgAttrOfType<mlir::StringAttr>(
-      blockArg.getArgNumber(), "ttcore.weight_dtype");
-  if (dtypeAttr) {
-    consumerOp->setAttr("ttcore.weight_dtype", dtypeAttr);
+      blockArg.getArgNumber(), kWeightDtypeAttrName);
+  if (!dtypeAttr) {
+    return std::nullopt;
   }
+  auto parsed = ttcore::DataTypeStringToEnum(dtypeAttr.getValue());
+  if (!parsed) {
+    funcOp.emitWarning() << "ignoring invalid " << kWeightDtypeAttrName << " \""
+                         << dtypeAttr.getValue() << "\" on argument "
+                         << blockArg.getArgNumber();
+  }
+  return parsed;
+}
+
+// Resolve the weight dtype override for a matmul/linear weight operand and, if
+// found, set it on the consumer op for the TTNN weight dtype conversion pass.
+static void resolveAndSetWeightDtype(mlir::Value weight,
+                                     mlir::Operation *consumerOp) {
+  bool sawMissing = false;
+  bool sawDisagreement = false;
+  std::optional<ttcore::DataType> dtype =
+      resolveWeightDtype(weight, sawMissing, sawDisagreement);
+  if (!dtype) {
+    return;
+  }
+
+  if (sawDisagreement || sawMissing) {
+    consumerOp->emitWarning()
+        << "fusing matmuls with differing weight dtype overrides; using "
+           "highest-precision dtype '"
+        << ttcore::DataTypeEnumToString(*dtype)
+        << "' for the fused weight to avoid precision loss";
+  }
+
+  consumerOp->setAttr(
+      kWeightDtypeAttrName,
+      mlir::StringAttr::get(consumerOp->getContext(),
+                            ttcore::DataTypeEnumToString(*dtype)));
 }
 
 } // namespace

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -1369,6 +1369,15 @@ public:
         addOp.getLoc(), linearOutputType, matmulOp.getA(), matmulOp.getB(),
         bias, matmulOp.getTransposeA(), matmulOp.getTransposeB());
 
+    // Carry over the per-tensor weight dtype override (lifted from
+    // tt.weight_dtype_override) so it survives the matmul->linear rewrite.
+    // Without this, weights followed by a residual add (e.g. o_proj,
+    // down_proj) silently fall back to the global weight dtype.
+    if (auto weightDtype =
+            matmulOp->getAttrOfType<mlir::StringAttr>("ttcore.weight_dtype")) {
+      linearOp->setAttr("ttcore.weight_dtype", weightDtype);
+    }
+
     Value result = linearOp.getResult();
 
     if (!llvm::equal(broadcastShape, addOutputShape)) {
@@ -2854,16 +2863,27 @@ public:
     bool newTransposeB =
         inputBCanonical ? !op.getTransposeB() : op.getTransposeB();
 
+    // Preserve the per-tensor weight dtype override across the rewrite (read
+    // before the op is erased). Without this, weights whose permute is fused
+    // into the matmul would fall back to the global weight dtype.
+    auto weightDtype =
+        op->template getAttrOfType<mlir::StringAttr>("ttcore.weight_dtype");
+
+    mlir::Operation *newOp;
     if constexpr (std::is_same_v<OpType, MatmulOp>) {
-      rewriter.replaceOpWithNewOp<MatmulOp>(op, op.getType(), newA, newB,
-                                            newTransposeA, newTransposeB);
+      newOp = rewriter.replaceOpWithNewOp<MatmulOp>(
+          op, op.getType(), newA, newB, newTransposeA, newTransposeB);
     } else if constexpr (std::is_same_v<OpType, LinearOp>) {
-      rewriter.replaceOpWithNewOp<LinearOp>(op, op.getType(), newA, newB,
-                                            op.getBias(), newTransposeA,
-                                            newTransposeB);
+      newOp = rewriter.replaceOpWithNewOp<LinearOp>(
+          op, op.getType(), newA, newB, op.getBias(), newTransposeA,
+          newTransposeB);
     } else {
       static_assert(ttmlir::utils::always_false<OpType>(),
                     "Unsupported OpType for PermuteMatmulFusionPattern");
+    }
+
+    if (weightDtype) {
+      newOp->setAttr("ttcore.weight_dtype", weightDtype);
     }
 
     return mlir::success();

--- a/test/ttmlir/Dialect/TTIR/fusing/matmul_bias_preserves_weight_dtype.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/matmul_bias_preserves_weight_dtype.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --ttir-fusing -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Test that the matmul + add -> linear fusion preserves the per-tensor
+// weight dtype override. Without this, weights followed by a residual add
+// (e.g. o_proj, down_proj) would fall back to the global weight dtype.
+
+module {
+  // CHECK-LABEL: func.func @matmul_bias_preserves_weight_dtype
+  func.func @matmul_bias_preserves_weight_dtype(
+    %arg0: tensor<32x512xbf16>,
+    %w: tensor<512x256xbf16>,
+    %bias: tensor<32x256xbf16>) -> tensor<32x256xbf16> {
+    // CHECK: "ttir.linear"
+    // CHECK-SAME: ttcore.weight_dtype = "bfp_bf4"
+    // CHECK-NOT: "ttir.matmul"
+    // CHECK-NOT: "ttir.add"
+    %0 = "ttir.matmul"(%arg0, %w) <{transpose_a = false, transpose_b = false}> {ttcore.weight_dtype = "bfp_bf4"} : (tensor<32x512xbf16>, tensor<512x256xbf16>) -> tensor<32x256xbf16>
+    %1 = "ttir.add"(%0, %bias) : (tensor<32x256xbf16>, tensor<32x256xbf16>) -> tensor<32x256xbf16>
+    return %1 : tensor<32x256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/fusing/permute_matmul_preserves_weight_dtype.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/permute_matmul_preserves_weight_dtype.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt --ttir-fusing="enable-permute-matmul-fusion=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Test that fusing a weight permute into the matmul transpose attribute
+// preserves the per-tensor weight dtype override.
+
+module {
+  // CHECK-LABEL: func.func @permute_matmul_preserves_weight_dtype
+  func.func @permute_matmul_preserves_weight_dtype(
+    %arg0: tensor<32x512xbf16>,
+    %w: tensor<256x512xbf16>) -> tensor<32x256xbf16> {
+    %0 = "ttir.permute"(%w) <{permutation = array<i64: 1, 0>}> : (tensor<256x512xbf16>) -> tensor<512x256xbf16>
+    // CHECK: "ttir.matmul"
+    // CHECK-SAME: ttcore.weight_dtype = "bfp_bf4"
+    // CHECK-NOT: "ttir.permute"
+    %1 = "ttir.matmul"(%arg0, %0) <{transpose_a = false, transpose_b = false}> {ttcore.weight_dtype = "bfp_bf4"} : (tensor<32x512xbf16>, tensor<512x256xbf16>) -> tensor<32x256xbf16>
+    return %1 : tensor<32x256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/propagate_weight_dtype/propagate_through_concat.mlir
+++ b/test/ttmlir/Dialect/TTIR/propagate_weight_dtype/propagate_through_concat.mlir
@@ -1,0 +1,20 @@
+// RUN: ttmlir-opt --ttir-propagate-weight-dtype %s | FileCheck %s
+
+// Test that weight_dtype propagates through a concat (e.g. a fused QKV weight
+// built by SharedLHSMatmulFusion) when all concatenated weights agree.
+
+module {
+  // CHECK-LABEL: func.func @propagate_through_concat
+  func.func @propagate_through_concat(
+    %arg0: tensor<32x512xbf16>,
+    %q: tensor<512x256xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.weight_dtype = "bfp_bf4"},
+    %k: tensor<512x128xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.weight_dtype = "bfp_bf4"},
+    %v: tensor<512x128xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.weight_dtype = "bfp_bf4"}
+  ) -> tensor<32x512xbf16> {
+    %0 = "ttir.concat"(%q, %k, %v) <{dim = 1 : si32}> : (tensor<512x256xbf16>, tensor<512x128xbf16>, tensor<512x128xbf16>) -> tensor<512x512xbf16>
+    // CHECK: "ttir.matmul"
+    // CHECK-SAME: ttcore.weight_dtype = "bfp_bf4"
+    %1 = "ttir.matmul"(%arg0, %0) : (tensor<32x512xbf16>, tensor<512x512xbf16>) -> tensor<32x512xbf16>
+    return %1 : tensor<32x512xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/propagate_weight_dtype/propagate_through_concat_mixed.mlir
+++ b/test/ttmlir/Dialect/TTIR/propagate_weight_dtype/propagate_through_concat_mixed.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt --ttir-propagate-weight-dtype --verify-diagnostics %s | FileCheck %s
+
+// Test that when concatenated weights carry differing overrides, the fused
+// matmul gets the highest-precision (most bits) dtype so no constituent loses
+// precision, and a warning is emitted. Here bfp_bf4 (4 bits) and bfp_bf8 (8
+// bits) merge to bfp_bf8.
+
+module {
+  // CHECK-LABEL: func.func @propagate_through_concat_mixed
+  func.func @propagate_through_concat_mixed(
+    %arg0: tensor<32x512xbf16>,
+    %q: tensor<512x256xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.weight_dtype = "bfp_bf4"},
+    %k: tensor<512x128xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.weight_dtype = "bfp_bf8"},
+    %v: tensor<512x128xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.weight_dtype = "bfp_bf4"}
+  ) -> tensor<32x512xbf16> {
+    %0 = "ttir.concat"(%q, %k, %v) <{dim = 1 : si32}> : (tensor<512x256xbf16>, tensor<512x128xbf16>, tensor<512x128xbf16>) -> tensor<512x512xbf16>
+    // CHECK: "ttir.matmul"
+    // CHECK-SAME: ttcore.weight_dtype = "bfp_bf8"
+    // expected-warning @+1 {{fusing matmuls with differing weight dtype overrides}}
+    %1 = "ttir.matmul"(%arg0, %0) : (tensor<32x512xbf16>, tensor<512x512xbf16>) -> tensor<32x512xbf16>
+    return %1 : tensor<32x512xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #8743 

### Problem description
Per-tensor weight dtype overrides (`ttcore.weight_dtype`, lifted from the `tt.weight_dtype_override` frontend custom call onto func args) were being silently dropped for several weights, which then fell back to the global weight dtype. Two root causes, both around TTIRPropagateWeightDtype:

1. Fused QKV: SharedLHSMatmulFusion concatenates q/k/v weights into one matmul (via ttir.concat) before propagation runs. The propagation backward walk only followed operand(0) through a fixed allow-list and stopped at the concat, so the fused matmul never got the override.

2. o_proj / down_proj: these are tagged by propagation while still matmuls, but the later matmul+residual_add -> ttir.linear fusion (MatmulWithBiasFusionPattern) rebuilt the op without copying the discardable attribute, dropping it before the conversion pass.

### What's changed
- PropagateWeightDtype: recurse the backward walk through ConcatOp, resolving each branch independently and merging by keeping the highest-precision (most bits) dtype so the fused weight never loses precision. Warn when the constituents are only partially annotated or disagree.
- MatmulWithBiasFusionPattern: copy ttcore.weight_dtype onto the fused linear.
- PermuteMatmulFusionPattern: same class of bug (rewrites via replaceOpWithNewOp); preserve the attribute across the rewrite. Reachable via the experimental permute-matmul-fusion option.


Tests:
- test/ttmlir/Dialect/TTIR/propagate_weight_dtype/propagate_through_concat.mlir — concat of three bfp_bf4 weights → fused matmul gets bfp_bf4 (QKV concat propagation, happy path).
- test/ttmlir/Dialect/TTIR/propagate_weight_dtype/propagate_through_concat_mixed.mlir — concat of bfp_bf4/bfp_bf8/bfp_bf4 → fused matmul gets bfp_bf8 (highest precision) and emits the disagreement warning (--verify-diagnostics).
- test/ttmlir/Dialect/TTIR/fusing/matmul_bias_preserves_weight_dtype.mlir — matmul(bfp_bf4) + add → ttir.linear keeps bfp_bf4 (MatmulWithBiasFusionPattern).
- test/ttmlir/Dialect/TTIR/fusing/permute_matmul_preserves_weight_dtype.mlir — weight permute fused into transpose_b=true, matmul keeps bfp_bf4 (PermuteMatmulFusionPattern, enable-permute-matmul-fusion=true).


Verified end-to-end on Mistral-7B with a "default": "bfp_bf4" override: all weight matmuls (QKV, o_proj, down_proj, gate/up, lm_head) now emit bfp_bf4, where previously QKV/o_proj/down_proj fell back to bfp_bf8.