### PR TITLE
[L1SpillManagement] Replace bare assert with bounds-checked continue to prevent OOB in Release builds

### DIFF
--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -380,10 +380,16 @@ void L1SpillManagement<MemoryTracker>::applyOutputConfig(
     }
 
     size_t ri = opResult.getResultNumber();
-    assert(ri < result.actualOutputLayouts.size() &&
-           "validation result has fewer output layouts than tensor results");
+    if (ri >= result.actualOutputLayouts.size()) {
+      assert(false &&
+             "validation result has fewer output layouts than tensor results");
+      continue;
+    }
     TTNNLayoutAttr resultLayout = result.actualOutputLayouts[ri];
-    assert(resultLayout && "result layout is null for tensor result");
+    if (!resultLayout) {
+      assert(false && "result layout is null for tensor result");
+      continue;
+    }
 
     llvm::ArrayRef<int64_t> tensorShape = tensorType.getShape();
 


### PR DESCRIPTION
## Summary

While running the ResNet50 ONNX benchmark, a SIGSEGV was observed after the test passed. The crash traced back to commit [[L1SpillManagement] Remove ttnn.output_l1_usage IR attribute](https://github.com/tenstorrent/tt-mlir/commit/f9896cb73a4eec4cf13ff5754d9b8c9f38b857dd) which replaced safe bounds/null guards in `applyOutputConfig()` with bare `assert()` calls. forge-onnx builds as Release (`NDEBUG`), so both asserts compiled away, leaving an out-of-bounds vector read and a potential null dereference that silently corrupted the heap and crashed during process teardown.

## Fix / Solution

In `lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp`, the bare `assert()` calls are replaced with explicit `if` checks that fire `assert(false)` in Debug and `continue` safely in Release, eliminating the OOB access and heap corruption.