### PR TITLE
Fuse reshape and gather when reshape is unsqueezing at index vector dim

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/StableHLOFusing.cpp
+++ b/lib/Dialect/StableHLO/Transforms/StableHLOFusing.cpp
@@ -245,6 +245,68 @@ private:
   }
 };
 
+// Fuses reshape + gather when the reshape is an unsqueeze at index_vector_dim
+// and index_vector_dim is the last dim.
+//
+class ReshapeGatherFusionPattern
+    : public OpRewritePattern<::mlir::stablehlo::GatherOp> {
+  using OpRewritePattern<::mlir::stablehlo::GatherOp>::OpRewritePattern;
+
+public:
+  LogicalResult matchAndRewrite(::mlir::stablehlo::GatherOp gatherOp,
+                                ::mlir::PatternRewriter &rewriter) const final {
+    auto reshapeOp = mlir::dyn_cast_or_null<::mlir::stablehlo::ReshapeOp>(
+        gatherOp.getStartIndices().getDefiningOp());
+    if (!reshapeOp) {
+      return failure();
+    }
+
+    if (shardy_utils::opHasShardySharding(reshapeOp.getOperation()) ||
+        shardy_utils::opHasShardySharding(gatherOp.getOperation())) {
+      return failure();
+    }
+
+    auto reshapeInput = reshapeOp.getOperand();
+    auto reshapeOutput = reshapeOp.getResult();
+    ArrayRef<int64_t> inputShape = reshapeInput.getType().getShape();
+    ArrayRef<int64_t> outputShape = reshapeOutput.getType().getShape();
+
+    // Reshape must add exactly one dimension.
+    if (outputShape.size() != inputShape.size() + 1) {
+      return failure();
+    }
+
+    auto dimNumbers = gatherOp.getDimensionNumbers();
+    int64_t indexVectorDim = dimNumbers.getIndexVectorDim();
+
+    // The unsqueezed dimension must be at index_vector_dim and have size 1.
+    if (indexVectorDim >= static_cast<int64_t>(outputShape.size()) ||
+        outputShape[indexVectorDim] != 1) {
+      return failure();
+    }
+
+    // All other dims must be preserved in order.
+    for (size_t i = 0; i < inputShape.size(); i++) {
+      size_t outIdx = static_cast<int64_t>(i) < indexVectorDim ? i : i + 1;
+      if (outputShape[outIdx] != inputShape[i]) {
+        return failure();
+      }
+    }
+
+    // index_vector_dim must be the last dim.
+    if (indexVectorDim != static_cast<int64_t>(outputShape.size()) - 1) {
+      return failure();
+    }
+
+    rewriter.replaceOpWithNewOp<::mlir::stablehlo::GatherOp>(
+        gatherOp, gatherOp.getResult().getType(), gatherOp.getOperand(),
+        reshapeInput, gatherOp.getDimensionNumbers(), gatherOp.getSliceSizes(),
+        gatherOp.getIndicesAreSorted());
+
+    return success();
+  }
+};
+
 struct StableHLOFusingPass
     : public impl::StableHLOFusingPassBase<StableHLOFusingPass> {
 public:
@@ -254,6 +316,7 @@ public:
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
     patterns.add<ConcatenateToBroadcastInDimFusionPattern>(&getContext());
+    patterns.add<ReshapeGatherFusionPattern>(&getContext());
 
     GreedyRewriteConfig config;
     config.setUseTopDownTraversal(true);

--- a/test/ttmlir/Dialect/StableHLO/Transforms/StableHLOFusing/gather.mlir
+++ b/test/ttmlir/Dialect/StableHLO/Transforms/StableHLOFusing/gather.mlir
@@ -1,0 +1,101 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline="enable-aggressive-simplification=true" --split-input-file -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module {
+  // Reshape unsqueezes at index_vector_dim, should fuse.
+  // CHECK-LABEL: func.func @reshape_gather_basic
+  func.func @reshape_gather_basic(%arg0: tensor<1993728x80xf32>, %arg1: tensor<1836732xi64>) -> tensor<1836732x80xf32> {
+    %0 = stablehlo.reshape %arg1 : (tensor<1836732xi64>) -> tensor<1836732x1xi64>
+    %1 = "stablehlo.gather"(%arg0, %0) <{
+      dimension_numbers = #stablehlo.gather<
+        offset_dims = [1],
+        collapsed_slice_dims = [0],
+        start_index_map = [0],
+        index_vector_dim = 1>,
+      slice_sizes = array<i64: 1, 80>,
+      indices_are_sorted = false
+    }> : (tensor<1993728x80xf32>, tensor<1836732x1xi64>) -> tensor<1836732x80xf32>
+    // CHECK-NOT: stablehlo.reshape
+    // CHECK: "stablehlo.gather"(%arg0, %arg1)
+    return %1 : tensor<1836732x80xf32>
+  }
+
+  // Reshape unsqueezes at index_vector_dim with a batch dim, should fuse.
+  // CHECK-LABEL: func.func @reshape_gather_batched
+  func.func @reshape_gather_batched(%arg0: tensor<4x1024x64xf32>, %arg1: tensor<4x512xi64>) -> tensor<4x512x64xf32> {
+    %0 = stablehlo.reshape %arg1 : (tensor<4x512xi64>) -> tensor<4x512x1xi64>
+    %1 = "stablehlo.gather"(%arg0, %0) <{
+      dimension_numbers = #stablehlo.gather<
+        offset_dims = [2],
+        collapsed_slice_dims = [1],
+        operand_batching_dims = [0],
+        start_indices_batching_dims = [0],
+        start_index_map = [1],
+        index_vector_dim = 2>,
+      slice_sizes = array<i64: 1, 1, 64>,
+      indices_are_sorted = false
+    }> : (tensor<4x1024x64xf32>, tensor<4x512x1xi64>) -> tensor<4x512x64xf32>
+    // CHECK-NOT: stablehlo.reshape
+    // CHECK: "stablehlo.gather"(%arg0, %arg1)
+    return %1 : tensor<4x512x64xf32>
+  }
+  // Reshape unsqueezes at a batch dim (not index_vector_dim), should NOT fuse.
+  // CHECK-LABEL: func.func @reshape_gather_unsqueeze_wrong_dim
+  func.func @reshape_gather_unsqueeze_wrong_dim(%arg0: tensor<1024x64xf32>, %arg1: tensor<512xi64>) -> tensor<1x512x64xf32> {
+    %0 = stablehlo.reshape %arg1 : (tensor<512xi64>) -> tensor<1x512xi64>
+    %1 = "stablehlo.gather"(%arg0, %0) <{
+      dimension_numbers = #stablehlo.gather<
+        offset_dims = [2],
+        collapsed_slice_dims = [0],
+        start_index_map = [0],
+        index_vector_dim = 2>,
+      slice_sizes = array<i64: 1, 64>,
+      indices_are_sorted = false
+    }> : (tensor<1024x64xf32>, tensor<1x512xi64>) -> tensor<1x512x64xf32>
+    // CHECK: %[[IDX:.*]] = stablehlo.reshape
+    // CHECK: "stablehlo.gather"(%arg0, %[[IDX]])
+    return %1 : tensor<1x512x64xf32>
+  }
+  // Reshape unsqueezes at index_vector_dim, but index_vector_dim is not the
+  // last dim (there is a batch dim after it), should NOT fuse.
+  func.func @reshape_gather_index_vector_not_last(%arg0: tensor<1024x64xf32>, %arg1: tensor<4x512xi64>) -> tensor<4x512x64xf32> {
+    %0 = stablehlo.reshape %arg1 : (tensor<4x512xi64>) -> tensor<4x1x512xi64>
+    %1 = "stablehlo.gather"(%arg0, %0) <{
+      dimension_numbers = #stablehlo.gather<
+        offset_dims = [2],
+        collapsed_slice_dims = [0],
+        start_index_map = [0],
+        index_vector_dim = 1>,
+      slice_sizes = array<i64: 1, 64>,
+      indices_are_sorted = false
+    }> : (tensor<1024x64xf32>, tensor<4x1x512xi64>) -> tensor<4x512x64xf32>
+    // CHECK: stablehlo.reshape
+    // CHECK: "stablehlo.gather"
+    return %1 : tensor<4x512x64xf32>
+  }
+}
+
+// -----
+
+// Sharded start indices: pattern skips fusion, reshape must remain.
+module {
+  sdy.mesh @mesh = <["x"=2, "y"=2]>
+  func.func @reshape_gather_sharded(
+      %arg0: tensor<1993728x80xf32>,
+      %arg1: tensor<1836732xi64> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}]>}
+  ) -> tensor<1836732x80xf32> {
+    %0 = stablehlo.reshape %arg1 : (tensor<1836732xi64>) -> tensor<1836732x1xi64>
+    %1 = "stablehlo.gather"(%arg0, %0) <{
+      dimension_numbers = #stablehlo.gather<
+        offset_dims = [1],
+        collapsed_slice_dims = [0],
+        start_index_map = [0],
+        index_vector_dim = 1>,
+      slice_sizes = array<i64: 1, 80>,
+      indices_are_sorted = false
+    }> : (tensor<1993728x80xf32>, tensor<1836732x1xi64>) -> tensor<1836732x80xf32>
+    // CHECK: stablehlo.reshape
+    return %1 : tensor<1836732x80xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
#8329 

### Problem description
A reshape which unsqueezes operand of gather op could result in verbose and suboptimal sequence of operations. Example can be seen in #8300.

### What's changed
Reshape which is an unsqueeze operation can be absorbed by gather op under the condition that unsqueeze dim = index vector dim. 

### Checklist
- [X] New/Existing tests provide coverage for changes
