### PR TITLE
[d2m-jit] add dram memspace option to jit kernels

### DIFF
--- a/test/d2m-jit/lit/kernel_io_in_dram.py
+++ b/test/d2m-jit/lit/kernel_io_in_dram.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR-shape coverage for forcing d2m-jit kernel boundary tensors into DRAM."""
+
+import d2m_jit as d2m
+from ttmlir.dialects import ttcore
+
+from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise
+
+
+@d2m.kernel
+def k_add(lhs, rhs, out):
+    a = remote_load(lhs, [0, 0])
+    b = remote_load(rhs, [0, 0])
+    remote_store(out, [0, 0], a + b)
+
+
+L = d2m.Layout(shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1])
+lhs = d2m.empty(L)
+rhs = d2m.empty(L)
+out = d2m.empty(L)
+k_add(lhs, rhs, out, grid=(1, 1), kernel_io_in_dram=True)
+assert out.layout.mem_space == ttcore.MemorySpace.DeviceDRAM
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [out])
+builder.module.operation.verify()
+print(builder.module)
+_Builder.reset()
+
+
+# CHECK-DAG:   #[[DRAM_LAYOUT:layout[0-9]*]] = #ttcore.metal_layout{{.*}}dram
+# CHECK-LABEL: func.func @main
+# CHECK:       d2m.to_layout
+# CHECK-SAME:  #[[DRAM_LAYOUT]]
+# CHECK:       d2m.to_layout
+# CHECK-SAME:  #[[DRAM_LAYOUT]]
+# CHECK:       d2m.to_layout
+# CHECK-SAME:  #[[DRAM_LAYOUT]]
+# CHECK:       d2m.generic
+# CHECK:       ins({{.*}}#[[DRAM_LAYOUT]]
+# CHECK:       outs({{.*}}#[[DRAM_LAYOUT]]
+# CHECK:       d2m.remote_load
+# CHECK:       d2m.remote_store

--- a/test/d2m-jit/lit/kernel_io_in_dram.py
+++ b/test/d2m-jit/lit/kernel_io_in_dram.py
@@ -20,30 +20,61 @@ def k_add(lhs, rhs, out):
     remote_store(out, [0, 0], a + b)
 
 
-L = d2m.Layout(shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1])
-lhs = d2m.empty(L)
-rhs = d2m.empty(L)
-out = d2m.empty(L)
-k_add(lhs, rhs, out, grid=(1, 1), kernel_io_in_dram=True)
-assert out.layout.mem_space == ttcore.MemorySpace.DeviceDRAM
+def emit_kernel_io_in_dram(label, *, kernel_io_in_dram=None, config_default=False):
+    old_config = d2m.config.kernel_io_in_dram
+    try:
+        d2m.config.kernel_io_in_dram = config_default
+        L = d2m.Layout(shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1])
+        lhs = d2m.empty(L)
+        rhs = d2m.empty(L)
+        out = d2m.empty(L)
 
-builder = _Builder.get()
-_emit_returns_and_finalise(builder, [out])
-builder.module.operation.verify()
-print(builder.module)
-_Builder.reset()
+        if kernel_io_in_dram is None:
+            k_add(lhs, rhs, out, grid=(1, 1))
+        else:
+            k_add(lhs, rhs, out, grid=(1, 1), kernel_io_in_dram=kernel_io_in_dram)
+        assert out.layout.mem_space == ttcore.MemorySpace.DeviceDRAM
+
+        builder = _Builder.get()
+        _emit_returns_and_finalise(builder, [out])
+        builder.module.operation.verify()
+        print(label)
+        print(builder.module)
+    finally:
+        d2m.config.kernel_io_in_dram = old_config
+        _Builder.reset()
 
 
-# CHECK-DAG:   #[[DRAM_LAYOUT:layout[0-9]*]] = #ttcore.metal_layout{{.*}}dram
+emit_kernel_io_in_dram("EXPLICIT_OVERRIDE_IR", kernel_io_in_dram=True)
+emit_kernel_io_in_dram("CONFIG_DEFAULT_IR", config_default=True)
+
+
+# CHECK-LABEL: EXPLICIT_OVERRIDE_IR
+# CHECK-DAG:   #[[EXPLICIT_DRAM_LAYOUT:layout[0-9]*]] = #ttcore.metal_layout{{.*}}dram
 # CHECK-LABEL: func.func @main
 # CHECK:       d2m.to_layout
-# CHECK-SAME:  #[[DRAM_LAYOUT]]
+# CHECK-SAME:  #[[EXPLICIT_DRAM_LAYOUT]]
 # CHECK:       d2m.to_layout
-# CHECK-SAME:  #[[DRAM_LAYOUT]]
+# CHECK-SAME:  #[[EXPLICIT_DRAM_LAYOUT]]
 # CHECK:       d2m.to_layout
-# CHECK-SAME:  #[[DRAM_LAYOUT]]
+# CHECK-SAME:  #[[EXPLICIT_DRAM_LAYOUT]]
 # CHECK:       d2m.generic
-# CHECK:       ins({{.*}}#[[DRAM_LAYOUT]]
-# CHECK:       outs({{.*}}#[[DRAM_LAYOUT]]
+# CHECK:       ins({{.*}}#[[EXPLICIT_DRAM_LAYOUT]]
+# CHECK:       outs({{.*}}#[[EXPLICIT_DRAM_LAYOUT]]
+# CHECK:       d2m.remote_load
+# CHECK:       d2m.remote_store
+
+# CHECK-LABEL: CONFIG_DEFAULT_IR
+# CHECK-DAG:   #[[CONFIG_DRAM_LAYOUT:layout[0-9]*]] = #ttcore.metal_layout{{.*}}dram
+# CHECK-LABEL: func.func @main
+# CHECK:       d2m.to_layout
+# CHECK-SAME:  #[[CONFIG_DRAM_LAYOUT]]
+# CHECK:       d2m.to_layout
+# CHECK-SAME:  #[[CONFIG_DRAM_LAYOUT]]
+# CHECK:       d2m.to_layout
+# CHECK-SAME:  #[[CONFIG_DRAM_LAYOUT]]
+# CHECK:       d2m.generic
+# CHECK:       ins({{.*}}#[[CONFIG_DRAM_LAYOUT]]
+# CHECK:       outs({{.*}}#[[CONFIG_DRAM_LAYOUT]]
 # CHECK:       d2m.remote_load
 # CHECK:       d2m.remote_store

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -201,6 +201,11 @@ Argument conventions:
 - `grid=(Y, X)` is required; it controls the physical grid the kernel runs on.
 - `num_outs`, `block_factors`, `indexing_maps`, `iterator_types` are optional
   advanced knobs (see `CompiledKernel.__call__`).
+- Set `kernel_io_in_dram=True` on a call, or
+  `d2m.config.kernel_io_in_dram = True` globally, to convert every tensor input
+  and out-param for the kernel to `mem_space="dram"` before emitting the
+  `d2m.generic`. The process-wide default can also be set with
+  `D2M_JIT_KERNEL_IO_IN_DRAM=1`.
 
 Inside a kernel body, the following names are available (registered via the
 `@syntax` decorator and dispatched by `D2MCompiler`):

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -966,6 +966,12 @@ def _affine_map_from_lambda(fn):
     return AffineMap.get(len(dims), 0, exprs), spec
 
 
+def _to_dram_kernel_arg(lt: LazyTensor) -> LazyTensor:
+    if lt.layout.mem_space == ttcore.MemorySpace.DeviceDRAM:
+        return lt
+    return to_layout(lt, lt.layout.replace(mem_space=ttcore.MemorySpace.DeviceDRAM))
+
+
 def _emit_kernel_generic(
     kernel: "CompiledKernel",
     args,
@@ -974,6 +980,7 @@ def _emit_kernel_generic(
     block_factors,
     indexing_maps,
     iterator_types,
+    kernel_io_in_dram=None,
 ):
     """Append a d2m.GenericOp to the open host func that invokes `kernel`."""
     b = _get_scope()
@@ -1035,6 +1042,28 @@ def _emit_kernel_generic(
         )
     input_lts = lazy_args[: len(lazy_args) - num_outs]
     output_lts = lazy_args[len(lazy_args) - num_outs :]
+    user_output_lts = output_lts
+
+    if kernel_io_in_dram is None:
+        kernel_io_in_dram = config.kernel_io_in_dram
+    elif not isinstance(kernel_io_in_dram, bool):
+        raise _call_error(
+            f"kernel_io_in_dram must be a bool, got {type(kernel_io_in_dram).__name__}",
+            cause=TypeError(),
+        )
+
+    if kernel_io_in_dram:
+        dram_arg_cache = {}
+
+        def to_dram(lt):
+            key = id(lt)
+            if key not in dram_arg_cache:
+                dram_arg_cache[key] = _to_dram_kernel_arg(lt)
+            return dram_arg_cache[key]
+
+        input_lts = [to_dram(lt) for lt in input_lts]
+        output_lts = [to_dram(lt) for lt in output_lts]
+        lazy_args = input_lts + output_lts
 
     # Compile the kernel body in the current builder's context. D2MCompiler
     # picks up b.ctx via get_default_loc_context.
@@ -1109,6 +1138,13 @@ def _emit_kernel_generic(
     for i, lt in enumerate(output_lts):
         lt.value = generic.results[i]
         lt.generation = b.generation
+    if kernel_io_in_dram:
+        for i, (user_lt, kernel_lt) in enumerate(zip(user_output_lts, output_lts)):
+            user_lt.layout = kernel_lt.layout
+            user_lt.value = generic.results[i]
+            user_lt.generation = b.generation
+            user_lt.materialized = None
+            user_lt.is_view = kernel_lt.is_view
 
 
 class CompiledKernel:
@@ -1135,6 +1171,7 @@ class CompiledKernel:
         block_factors=None,
         indexing_maps=None,
         iterator_types=None,
+        kernel_io_in_dram=None,
     ):
         _emit_kernel_generic(
             self,
@@ -1144,6 +1181,7 @@ class CompiledKernel:
             block_factors=block_factors,
             indexing_maps=indexing_maps,
             iterator_types=iterator_types,
+            kernel_io_in_dram=kernel_io_in_dram,
         )
 
 

--- a/tools/d2m-jit/_src/config.py
+++ b/tools/d2m-jit/_src/config.py
@@ -42,6 +42,8 @@ class _Config:
     print_ir_debug_info: bool = _env_bool("D2M_JIT_PRINT_IR_DEBUG_INFO")
     # PassManager.enable_verifier toggle. Default True.
     verify_passes: bool = _env_bool("D2M_JIT_VERIFY", default=True)
+    # Convert all tensor inputs and out-params to DRAM before each kernel call.
+    kernel_io_in_dram: bool = _env_bool("D2M_JIT_KERNEL_IO_IN_DRAM")
     # If set, write the post-pipeline flatbuffer to this path before
     # device submit. Useful for offline inspection with ttrt.
     save_flatbuffer_path: Optional[str] = os.environ.get("D2M_JIT_SAVE_FLATBUFFER_PATH")


### PR DESCRIPTION
### Problem description
Set the input/output tensor memspace to dram if needed so we can do testing against ttnn easier and in general need this

### What's changed
- Added `kernel_io_in_dram` per-call flag, `d2m.config.kernel_io_in_dram` global config, and `D2M_JIT_KERNEL_IO_IN_DRAM` env var to enable DRAM layouts for kernel boundary tensors
- Added tests and updated docs

### Checklist
- [ ] New/Existing tests provide coverage for changes
