### PR TITLE
[Shardy] Keep scaled_dot_product_attention composite fused under sharding

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
@@ -45,6 +45,10 @@ inline constexpr llvm::StringLiteral
 inline constexpr llvm::StringLiteral
     kTTRMSNormCustomCallTargetName("tenstorrent.rms_norm");
 
+// Composite name emitted by the frontend for scaled_dot_product_attention.
+inline constexpr llvm::StringLiteral
+    kTTSDPACompositeName("tenstorrent.scaled_dot_product_attention");
+
 // Composite names that have custom sharding rules. These composites are
 // converted to stablehlo.custom_call ops so that Shardy can propagate shardings
 // defined by the custom sharding rule for that composite as if the composite
@@ -53,6 +57,7 @@ inline constexpr llvm::StringLiteral
 // FlattenOrConvertCompositesPass and RegisterCustomShardingRulePass).
 inline constexpr llvm::StringLiteral kCompositesWithCustomSharding[] = {
     kTTRMSNormCustomCallTargetName,
+    kTTSDPACompositeName,
 };
 
 // Target name for the distributed RMS norm custom_call op.

--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -778,6 +778,82 @@ public:
 //   2. `attention_sink` is hard-coded to operand-segment size 0; the frontend
 //      cannot supply it yet. Tracked by
 //      https://github.com/tenstorrent/tt-xla/issues/4030.
+// Shared lowering of scaled_dot_product_attention (composite or custom_call
+// form) to ttir.scaled_dot_product_attention. Operands are [query, key, value]
+// and optionally a 4th attention_mask; is_causal/scale come from the composite
+// attribute dictionary.
+static LogicalResult convertToTTIRScaledDotProductAttention(
+    mlir::Operation *srcOp, mlir::ValueRange operands,
+    DictionaryAttr compositeAttrs, RankedTensorType outputType,
+    ConversionPatternRewriter &rewriter) {
+  size_t numOperands = operands.size();
+  if (numOperands < 3) {
+    return rewriter.notifyMatchFailure(
+        srcOp, "scaled_dot_product_attention must have at least 3 operands "
+               "(query, key, value).");
+  }
+
+  // For now, frontend composite doesnt support attention_sink.
+  // Issue: https://github.com/tenstorrent/tt-xla/issues/4030
+  if (numOperands > 4) {
+    return rewriter.notifyMatchFailure(
+        srcOp, "scaled_dot_product_attention must have at most 4 operands "
+               "(query, key, value, attention_mask). "
+               "Attention sink is not supported yet.");
+  }
+
+  SmallVector<NamedAttribute> namedAttrs;
+
+  bool isCausal = true;
+  if (compositeAttrs) {
+    if (auto attr = compositeAttrs.getAs<BoolAttr>("is_causal")) {
+      isCausal = attr.getValue();
+      namedAttrs.push_back(rewriter.getNamedAttr("is_causal", attr));
+    }
+    if (auto attr = compositeAttrs.getAs<FloatAttr>("scale")) {
+      namedAttrs.push_back(rewriter.getNamedAttr(
+          "scale", rewriter.getF32FloatAttr(
+                       static_cast<float>(attr.getValueAsDouble()))));
+    }
+  }
+
+  // The first 3 operands are always query, key, value. A 4th operand
+  // (attention_mask) is present only when is_causal is false.
+  bool hasAttnMask = !isCausal && numOperands == 4;
+  SmallVector<Value> sdpaOperands = {operands[0], operands[1], operands[2]};
+  if (hasAttnMask) {
+    // Left-pad mask with unit dims to 4D — matches PyTorch broadcast semantics.
+    Value mask = operands[3];
+    auto maskType = mlir::cast<RankedTensorType>(mask.getType());
+    int64_t maskRank = maskType.getRank();
+    if (maskRank > 4) {
+      return rewriter.notifyMatchFailure(srcOp,
+                                         "attention_mask rank must be <= 4");
+    }
+    if (maskRank < 4) {
+      SmallVector<int64_t> paddedShape(4 - maskRank, 1);
+      paddedShape.append(maskType.getShape().begin(),
+                         maskType.getShape().end());
+      auto paddedType =
+          RankedTensorType::get(paddedShape, maskType.getElementType());
+      mask = rewriter.create<ttir::ReshapeOp>(
+          srcOp->getLoc(), paddedType, mask,
+          rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(paddedShape)));
+    }
+    sdpaOperands.push_back(mask);
+  }
+
+  // ttir.scaled_dot_product_attention has AttrSizedOperandSegments:
+  //   [query, key, value, attention_mask, attention_sink]
+  SmallVector<int32_t> segmentSizes = {1, 1, 1, hasAttnMask ? 1 : 0, 0};
+  namedAttrs.push_back(rewriter.getNamedAttr(
+      "operandSegmentSizes", rewriter.getDenseI32ArrayAttr(segmentSizes)));
+
+  rewriter.replaceOpWithNewOp<ttir::ScaledDotProductAttentionOp>(
+      srcOp, outputType, sdpaOperands, namedAttrs);
+  return success();
+}
+
 class TenstorrentScaledDotProductAttentionConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CompositeOp> {
 
@@ -798,83 +874,49 @@ public:
           srcOp, "CompositeOp must have exactly one result.");
     }
 
-    size_t numOperands = adaptor.getOperands().size();
-    if (numOperands < 3) {
-      return rewriter.notifyMatchFailure(
-          srcOp,
-          "tenstorrent.scaled_dot_product_attention composite op must have "
-          "at least 3 operands (query, key, value).");
-    }
-
-    // For now, frontend composite doesnt support attention_sink.
-    // Issue: https://github.com/tenstorrent/tt-xla/issues/4030
-    if (numOperands > 4) {
-      return rewriter.notifyMatchFailure(
-          srcOp,
-          "tenstorrent.scaled_dot_product_attention composite op must have "
-          "at most 4 operands (query, key, value, attention_mask). "
-          "Attention sink is not supported yet.");
-    }
-
     auto outputType =
         mlir::cast<RankedTensorType>(srcOp.getResult(0).getType());
 
-    DictionaryAttr compositeAttrs = srcOp.getCompositeAttributes();
+    return convertToTTIRScaledDotProductAttention(
+        srcOp, adaptor.getOperands(), srcOp.getCompositeAttributes(),
+        outputType, rewriter);
+  }
+};
 
-    SmallVector<NamedAttribute> namedAttrs;
+// Converts the sharded form, stablehlo.custom_call
+// @tenstorrent.scaled_dot_product_attention, to
+// ttir.scaled_dot_product_attention. FlattenOrConvertCompositesPass converts
+// the composite into this custom_call so Shardy can propagate the head
+// sharding; this lowers it back, mirroring CustomCallRMSNormConversionPattern.
+class CustomCallScaledDotProductAttentionConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
 
-    bool isCausal = true;
-    if (compositeAttrs) {
-      if (auto attr = compositeAttrs.getAs<BoolAttr>("is_causal")) {
-        isCausal = attr.getValue();
-        namedAttrs.push_back(rewriter.getNamedAttr("is_causal", attr));
-      }
-      if (auto attr = compositeAttrs.getAs<FloatAttr>("scale")) {
-        namedAttrs.push_back(rewriter.getNamedAttr(
-            "scale", rewriter.getF32FloatAttr(
-                         static_cast<float>(attr.getValueAsDouble()))));
-      }
+public:
+  CustomCallScaledDotProductAttentionConversionPattern(MLIRContext *context)
+      : OpConversionPattern<mlir::stablehlo::CustomCallOp>(context) {}
+
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CustomCallOp srcOp,
+                  mlir::stablehlo::CustomCallOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (adaptor.getCallTargetNameAttr() != kTTSDPACompositeName ||
+        !srcOp->hasAttr(kHasCustomShardingAttr)) {
+      return failure();
     }
-
-    // The composite's first 3 operands are always query, key, value.
-    // A 4th boundary input (attention_mask) is present only when
-    // is_causal is false and the frontend marked 4 inputs.
-    bool hasAttnMask = !isCausal && numOperands == 4;
-    SmallVector<Value> sdpaOperands = {adaptor.getOperands()[0],
-                                       adaptor.getOperands()[1],
-                                       adaptor.getOperands()[2]};
-    if (hasAttnMask) {
-      // Left-pad mask with unit dims to 4D — matches PyTorch broadcast
-      // semantics.
-      Value mask = adaptor.getOperands()[3];
-      auto maskType = mlir::cast<RankedTensorType>(mask.getType());
-      int64_t maskRank = maskType.getRank();
-      if (maskRank > 4) {
-        return rewriter.notifyMatchFailure(srcOp,
-                                           "attention_mask rank must be <= 4");
-      }
-      if (maskRank < 4) {
-        SmallVector<int64_t> paddedShape(4 - maskRank, 1);
-        paddedShape.append(maskType.getShape().begin(),
-                           maskType.getShape().end());
-        auto paddedType =
-            RankedTensorType::get(paddedShape, maskType.getElementType());
-        mask = rewriter.create<ttir::ReshapeOp>(
-            srcOp.getLoc(), paddedType, mask,
-            rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(paddedShape)));
-      }
-      sdpaOperands.push_back(mask);
+    if (srcOp.getNumResults() != 1) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "CustomCallOp must have exactly one result.");
     }
-
-    // ttir.scaled_dot_product_attention has AttrSizedOperandSegments:
-    //   [query, key, value, attention_mask, attention_sink]
-    SmallVector<int32_t> segmentSizes = {1, 1, 1, hasAttnMask ? 1 : 0, 0};
-    namedAttrs.push_back(rewriter.getNamedAttr(
-        "operandSegmentSizes", rewriter.getDenseI32ArrayAttr(segmentSizes)));
-
-    rewriter.replaceOpWithNewOp<ttir::ScaledDotProductAttentionOp>(
-        srcOp, outputType, sdpaOperands, namedAttrs);
-    return success();
+    auto compositeAttrs = mlir::dyn_cast_or_null<DictionaryAttr>(
+        srcOp->getDiscardableAttr(kCustomCallCompositeAttrsKey));
+    if (!compositeAttrs) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "missing attributes on converted custom_call op");
+    }
+    auto outputType =
+        mlir::cast<RankedTensorType>(srcOp.getResult(0).getType());
+    return convertToTTIRScaledDotProductAttention(
+        srcOp, adaptor.getOperands(), compositeAttrs, outputType, rewriter);
   }
 };
 
@@ -981,6 +1023,7 @@ void populateStableHLOCompositeLegalizationPatterns(
   patterns.add<TenstorrentUniformToRandConversionPattern>(context);
   patterns.add<TenstorrentTopKConversionPattern>(context);
   patterns.add<TenstorrentScaledDotProductAttentionConversionPattern>(context);
+  patterns.add<CustomCallScaledDotProductAttentionConversionPattern>(context);
   patterns.add<TenstorrentGatherConversionPattern>(context);
   patterns.add<ShardyAllSliceToTTIRMeshPartitionConversionPattern>(context);
 }

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -204,9 +204,12 @@ getSDPAShardingRule(mlir::stablehlo::CustomCallOp op) {
   // Branch explicitly between the identical-head MHA case and the grouped-head
   // GQA/MQA case for clarity.
 
-  // For standard MHA (qHeads == kvHeads), all tensors have identical shapes
-  // so we can use the efficient addPointwise builder.
-  if (qHeads == kvHeads) {
+  // For standard MHA (qHeads == kvHeads) with no extra operands, all tensors
+  // have identical shapes so we can use the efficient addPointwise builder.
+  // When an attention_mask is present its shape differs from Q (e.g.
+  // [1, 1, S, S] vs [B, H, S, D]), so addPointwise cannot be used; fall through
+  // to the explicit per-operand builder below, which leaves the mask unsharded.
+  if (qHeads == kvHeads && op.getNumOperands() == 3) {
     auto getFactorType = [](int64_t dim) -> mlir::sdy::FactorType {
       if (dim == 0 || dim == 1) {
         return mlir::sdy::FactorType::kPassThrough;
@@ -1127,6 +1130,11 @@ private:
                                       mlir::stablehlo::CustomCallOp)>>
       customCallShardingRules = {
           {sdpaTargetName, getSDPAShardingRule},
+          // Composite SDPA (frontend
+          // "tenstorrent.scaled_dot_product_attention") is converted to a
+          // custom_call keeping its composite name as the target, so map that
+          // name to the same head-sharding rule.
+          {utils::kTTSDPACompositeName, getSDPAShardingRule},
           {pagedSdpaDecodeTargetName, getPagedAttentionShardingRule},
           {pagedUpdateCacheTargetName, getPagedAttentionShardingRule},
           {pagedFillCacheTargetName, getPagedAttentionShardingRule},

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdpa_custom_call.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdpa_custom_call.mlir
@@ -1,0 +1,31 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --flatten-or-convert-composites -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// SDPA is registered in kCompositesWithCustomSharding, so in a sharded module
+// FlattenOrConvertComposites keeps the composite as a custom_call (so Shardy can
+// propagate the head sharding) instead of flattening it to its f32 decomposition.
+module @jit_sdpa attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0_updated"=1, "_axis_0"=2]>
+  // CHECK: stablehlo.custom_call @tenstorrent.scaled_dot_product_attention
+  // CHECK-SAME: tt.composite_attributes
+  // CHECK-SAME: tt.has_custom_sharding
+  // CHECK-NOT: stablehlo.composite
+  func.func @main(
+    %q: tensor<1x2x32x16xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"_axis_0"}, {}, {}]>, ttcore.shard_status = #ttcore.shard_status<presharded>},
+    %k: tensor<1x2x32x16xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"_axis_0"}, {}, {}]>, ttcore.shard_status = #ttcore.shard_status<presharded>},
+    %v: tensor<1x2x32x16xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"_axis_0"}, {}, {}]>, ttcore.shard_status = #ttcore.shard_status<presharded>},
+    %mask: tensor<1x1x32x32xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {}, {}]>, ttcore.shard_status = #ttcore.shard_status<presharded>}
+  ) -> (tensor<1x2x32x16xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %0 = stablehlo.composite "tenstorrent.scaled_dot_product_attention" %q, %k, %v, %mask {
+        composite_attributes = {is_causal = false},
+        decomposition = @sdpa_impl
+    } : (tensor<1x2x32x16xbf16>, tensor<1x2x32x16xbf16>, tensor<1x2x32x16xbf16>, tensor<1x1x32x32xbf16>) -> tensor<1x2x32x16xbf16>
+    return %0 : tensor<1x2x32x16xbf16>
+  }
+  func.func private @sdpa_impl(
+      %arg0: tensor<1x2x32x16xbf16>, %arg1: tensor<1x2x32x16xbf16>,
+      %arg2: tensor<1x2x32x16xbf16>, %arg3: tensor<1x1x32x32xbf16>) -> tensor<1x2x32x16xbf16> {
+    return %arg0 : tensor<1x2x32x16xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4780

### Problem description
Under tensor-parallel sharding (Shardy), a `tenstorrent.scaled_dot_product_attention` composite is **flattened to its f32 math decomposition** instead of being lowered to the fused `ttnn.scaled_dot_product_attention` — materializing a `[B, H, S, S]` score matrix and OOMing on large-seq models. `FlattenOrConvertCompositesPass` only keeps composites listed in `kCompositesWithCustomSharding` as a (shardable) `custom_call`; SDPA wasn't listed (only RMS norm was), so it got inlined. Single-chip/unsharded fused fine — the gap is sharding-only.


### What's changed
1. **Register SDPA for custom sharding** (`StableHLOUtils.h`) — add the composite to `kCompositesWithCustomSharding`, so `FlattenOrConvertComposites` keeps it as a `custom_call` instead of flattening it.
2. **Sharding rule** (`RegisterCustomShardingRule.cpp`) — map the SDPA custom_call target to `getSDPAShardingRule` (shard on heads). Also fix the MHA fast-path: `addPointwise` assumes all operands share Q's shape and breaks when an `attention_mask` operand is present — masked SDPA now uses the explicit per-operand builder (mask left replicated).
3. **custom_call → TTIR lowering** (`StableHLOLegalizeCompositePass.cpp`) — add `CustomCallScaledDotProductAttentionConversionPattern` to lower the post-shardy `custom_call` form to `ttir.scaled_dot_product_attention` (shared helper with the composite pattern), mirroring the RMS-norm composite+custom_call setup.


### Checklist
- [x] Verify the changes via local testing in WH

### Logs

- [jun10_sdpa_bfp16_mc_before_fix.log](https://github.com/user-attachments/files/28821783/jun10_sdpa_bfp16_mc.log)
- [jun10_HunyuanImage_2_1_transformer_bfp16_4_chips_before_fix.log.zip](https://github.com/user-attachments/files/28821784/jun10_HunyuanImage_2_1_transformer_bfp16_4_chips_after_try_fix.log.zip)
- [jun10_HunyuanImage_2_1_transformer_bfp16_4_chips_after_fix.log.zip](https://github.com/user-attachments/files/28821764/jun10_HunyuanImage_2_1_transformer_bfp16_4_chips_after_f_fix1.log.zip)
- [jun10_sdpa_bfp16_mc_after_fix.log](https://github.com/user-attachments/files/28821772/jun10_sdpa_bfp16_mc_after_f_fix1.log)


