### PR TITLE
Extend multihost read timeouts for blocking commands

### DIFF
--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -175,6 +175,10 @@ public:
 private:
   std::chrono::seconds writeTimeout_{300};
   std::chrono::seconds readTimeout_{300};
+  // toHost and memcpy responses are only sent once the device has finished
+  // executing the program (the readback blocks on device completion), so they
+  // can take much longer than other commands.
+  std::chrono::seconds dataTransferReadTimeout_{30000};
   std::chrono::seconds workerShutdownTimeout_{300};
 
   std::atomic<ControllerState> controllerState_{ControllerState::Uninitialized};

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -7,10 +7,14 @@
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/detail/distributed/controller/command_factory.h"
+#include "tt/runtime/detail/distributed/flatbuffer/command_generated.h"
 #include "tt/runtime/detail/distributed/flatbuffer/flatbuffer.h"
 #include "tt/runtime/detail/distributed/utils/utils.h"
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/utils.h"
+
+#include <chrono>
+
 namespace tt::runtime::distributed::controller {
 
 namespace fb = ::tt::runtime::distributed::flatbuffer;
@@ -876,6 +880,8 @@ void Controller::processResponseQueue() {
     std::vector<std::future<SizedBuffer>> readFutures;
     readFutures.reserve(workerConnections_.size());
 
+    auto readStart = std::chrono::steady_clock::now();
+
     for (const auto &workerConnection : workerConnections_) {
       readFutures.push_back(workerConnection->sizePrefixedReadAsync());
     }
@@ -892,10 +898,18 @@ void Controller::processResponseQueue() {
     responseBuffers.reserve(readFutures.size());
     for (std::future<SizedBuffer> &readFuture : readFutures) {
       if (readFuture.wait_for(readTimeout) == std::future_status::timeout) {
-        LOG_FATAL("Read timeout occurred while receiving response from worker");
+        LOG_FATAL("Read timeout occurred while receiving response from worker "
+                  "for ",
+                  fb::EnumNameCommandType(commandType), " after ",
+                  readTimeout.count(), " seconds");
       }
       responseBuffers.push_back(readFuture.get());
     }
+
+    [[maybe_unused]] auto readElapsedMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - readStart)
+            .count();
 
     for (const SizedBuffer &responseBuffer : responseBuffers) {
       if (isResponseType(responseBuffer, fb::ResponseType::ErrorResponse)) {
@@ -908,7 +922,8 @@ void Controller::processResponseQueue() {
     handleResponse(responseBuffers, std::move(awaitingResponseQueueEntry));
 
     LOG_DEBUG("Finished handling response for command id: ", commandId,
-              " and command type: ", fb::EnumNameCommandType(commandType));
+              " and command type: ", fb::EnumNameCommandType(commandType),
+              " (waited ", readElapsedMs, " ms for worker response(s))");
   }
 }
 

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -881,9 +881,17 @@ void Controller::processResponseQueue() {
     }
 
     std::vector<SizedBuffer> responseBuffers;
+    // toHost and memcpy responses are only sent after the device finishes
+    // executing the program, so they need a longer read timeout than other
+    // commands.
+    bool isDataTransferCommand =
+        commandType == fb::CommandType::ToHostCommand ||
+        commandType == fb::CommandType::MemcpyCommand;
+    std::chrono::seconds readTimeout =
+        isDataTransferCommand ? dataTransferReadTimeout_ : readTimeout_;
     responseBuffers.reserve(readFutures.size());
     for (std::future<SizedBuffer> &readFuture : readFutures) {
-      if (readFuture.wait_for(readTimeout_) == std::future_status::timeout) {
+      if (readFuture.wait_for(readTimeout) == std::future_status::timeout) {
         LOG_FATAL("Read timeout occurred while receiving response from worker");
       }
       responseBuffers.push_back(readFuture.get());


### PR DESCRIPTION
### Ticket
None

### Problem description
ReadTimeout is unconditionally set to 300s, which determines how long the controller may wait for a blocking command's response from all workers. 

Most commands in execution hotpath are async, however, there are a few blocking APIs that will wait for execution to complete. This will result in random timeouts mid-execution when profiling a very long-running program (>5m execution) or more easily when running in RUNTIME_DEBUG mode.

### What's changed
Extend worker timeout to 30k s for two blocking commands:  toHost and memcpy.

### Checklist
- [ ] New/Existing tests provide coverage for changes
