### PR TITLE
[Optimizer] Tests for inserted reshards + clear error when CBs overlap an un-evictable reshard

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -196,6 +196,11 @@ public:
   MemoryTracker &getMemoryTracker() { return memoryTracker; }
   const MemoryTracker &getMemoryTracker() const { return memoryTracker; }
 
+  /// True if run() hit an unrecoverable condition and emitted an error. The
+  /// driving pass must signalPassFailure() when this is set (emitError alone
+  /// does not fail the pass).
+  bool hasFailed() const { return compilationFailed; }
+
 private:
   func::FuncOp func;
   ttcore::GridAttr deviceGrid;
@@ -203,6 +208,9 @@ private:
 
   /// Precomputed CB fragmentation cushion (bytes). See kCBFragCushionFraction.
   uint64_t cbFragCushion;
+
+  /// Set when run() emits an error for an unrecoverable condition.
+  bool compilationFailed = false;
 
   /// Observer (NullObject pattern: always non-null).
   std::unique_ptr<L1SpillObserver> observer_;

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1561,6 +1561,7 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
     op->emitError("L1SpillManagement: DRAM output config failed validation "
                   "after demotion (")
         << result.errorMessage << "); this indicates a compiler bug";
+    compilationFailed = true;
     return;
   }
   if (result.cbPeakUsage == 0) {
@@ -1576,6 +1577,22 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
                memoryTracker.getLowestOccupiedAddress());
 
   evictForCBOverlap(dramCBCushioned, pos, data);
+
+  // If the CB region still overlaps a live tensor after eviction, that tensor
+  // is an inserted reshard we cannot evict (it restores a required L1 input).
+  // Demotion freed the output but not this input, so the op cannot be placed:
+  // its CBs would clobber an L1 input it requires. Fail with a clear error
+  // rather than emit IR that overflows L1 at runtime.
+  if (!liveValues.empty() &&
+      dramCBCushioned > memoryTracker.getLowestOccupiedAddress()) {
+    op->emitError("L1SpillManagement: ")
+        << op->getName()
+        << " requires an L1 input restored by an inserted reshard, but its "
+           "circular-buffer region overlaps that reshard's L1 slot and the "
+           "reshard cannot be evicted or relocated; the op cannot be placed "
+           "within the L1 budget";
+    compilationFailed = true;
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -70,6 +70,14 @@ public:
           func, deviceGrid, l1BudgetPerCore, std::move(observer));
       spill.run();
 
+      // run() emits a diagnostic but cannot fail the pass on its own; surface
+      // any unrecoverable condition (e.g. an op whose CBs overlap a required
+      // inserted-reshard input) as a pass failure.
+      if (spill.hasFailed()) {
+        signalPassFailure();
+        return;
+      }
+
       // Sync D2M subgraph function types to match dispatch op's current inputs
       // (e.g. after spill, operand types may have changed to DRAM).
       d2m_optimizer_utils::syncAllD2MFuncTypes(func);

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -55,9 +55,9 @@ public:
                  utils::getTensorL1UsageCap(moduleOp),
                  utils::getReservedL1Usage(moduleOp));
 
-    moduleOp->walk([&](func::FuncOp func) {
+    moduleOp->walk([&](func::FuncOp func) -> WalkResult {
       if (!ttmlir::utils::isForwardDeviceFunc(func)) {
-        return;
+        return WalkResult::advance();
       }
 
       // Create observer if tracing is enabled.
@@ -72,10 +72,12 @@ public:
 
       // run() emits a diagnostic but cannot fail the pass on its own; surface
       // any unrecoverable condition (e.g. an op whose CBs overlap a required
-      // inserted-reshard input) as a pass failure.
+      // inserted-reshard input) as a pass failure. Interrupt the walk too: the
+      // pass is already doomed, so don't keep mutating later forward-device
+      // funcs.
       if (spill.hasFailed()) {
         signalPassFailure();
-        return;
+        return WalkResult::interrupt();
       }
 
       // Sync D2M subgraph function types to match dispatch op's current inputs
@@ -99,6 +101,8 @@ public:
           }
         }
       }
+
+      return WalkResult::advance();
     });
 #endif
   }

--- a/test/unittests/Optimizer/L1SpillTestFixture.h
+++ b/test/unittests/Optimizer/L1SpillTestFixture.h
@@ -15,7 +15,9 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -143,6 +145,10 @@ public:
     uint64_t cbPeakUsage = 0;     // CB peak when output is L1-sharded
     uint64_t dramCBPeakUsage = 0; // CB peak when output is DRAM-interleaved
                                   // (used by evictForDramCBGrowth probe)
+    // Hard sharded-input constraint (e.g. paged_update_cache): when set, the op
+    // returns MetalBackendError if any input is DRAM. Drives the
+    // constraint-driven reshard path once a producer is spilled.
+    bool requiresShardedInput = false;
   };
   llvm::DenseMap<mlir::Operation *, PerOpConfig> perOpConfigs;
 
@@ -176,6 +182,12 @@ public:
     perOpConfigs[op].forceStatus = ValidationStatus::NotImplemented;
   }
 
+  /// Mark `op` as requiring sharded (L1) inputs: it fails validation once any
+  /// input is DRAM (i.e. after its producer is spilled).
+  void setRequiresShardedInput(mlir::Operation *op) {
+    perOpConfigs[op].requiresShardedInput = true;
+  }
+
   // --- Layout helpers ---
 
   /// Default grid {8, 1} is the canonical HeightSharded layout (M, 1).
@@ -188,6 +200,12 @@ public:
         .setMemoryLayout(TensorMemoryLayout::HeightSharded)
         .setGridShape(grid)
         .buildWithCanonicalCorePlacement(deviceAttr);
+  }
+
+  /// Per-core L1 bytes for `layout` (matches how the pass sizes reshards).
+  uint64_t perCoreL1Usage(TTNNLayoutAttr layout) const {
+    return utils::getPerCoreL1Usage(
+        layout, ttmlir::utils::volume(layout.getGridShape()));
   }
 
   TTNNLayoutAttr makeDRAM(llvm::ArrayRef<int64_t> shape) {
@@ -276,12 +294,27 @@ public:
   SumL1MemoryTracker::BackendValidatorFn makeValidator() const {
     uint64_t budget = l1BudgetPerCore;
     return [this, budget](mlir::Operation *op,
-                          llvm::ArrayRef<TTNNLayoutAttr> /*inputLayouts*/,
+                          llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                           const OpConfig &config,
                           uint64_t additionalL1) -> ValidationResult {
       auto it = perOpConfigs.find(op);
-      uint64_t outL1 =
-          (it != perOpConfigs.end()) ? it->second.outputL1Usage : 0;
+      uint64_t outL1 = 0;
+      if (it != perOpConfigs.end()) {
+        outL1 = it->second.outputL1Usage;
+      } else if (op->getNumResults() > 0) {
+        // Pass-inserted reshard (no explicit setL1Usage): default to its
+        // layout's per-core L1 so it occupies a real address-sim slot. DRAM
+        // spills contribute 0 via the configIsDRAM branch below.
+        if (auto rt = mlir::dyn_cast<mlir::RankedTensorType>(
+                op->getResult(0).getType())) {
+          if (auto enc =
+                  mlir::dyn_cast_or_null<TTNNLayoutAttr>(rt.getEncoding())) {
+            if (enc.hasL1BufferType()) {
+              outL1 = perCoreL1Usage(enc);
+            }
+          }
+        }
+      }
 
       // CB peak depends on whether the probed config is L1 or DRAM. The pass
       // queries DRAM CB after demotion via evictForDramCBGrowth — read
@@ -314,6 +347,17 @@ public:
           return ValidationResult::outOfMemoryError("injected OOM");
         }
         return ValidationResult::metalBackendError("injected backend error");
+      }
+
+      // Hard sharded-input constraint: reject a DRAM input (triggers the
+      // constraint-driven reshard once a producer is spilled).
+      if (it != perOpConfigs.end() && it->second.requiresShardedInput) {
+        for (TTNNLayoutAttr inLayout : inputLayouts) {
+          if (inLayout && !inLayout.hasL1BufferType()) {
+            return ValidationResult::metalBackendError(
+                "requires sharded input");
+          }
+        }
       }
 
       if (additionalL1 + effectiveOutL1 > budget) {

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "L1SpillTestFixture.h"
+
+#include "mlir/IR/Diagnostics.h"
+
 #include "gtest/gtest.h"
 
 using namespace mlir::tt::ttnn::test;
@@ -699,4 +702,116 @@ TEST_F(ViewEligibleReshapeAliasTest,
   EXPECT_EQ(countSpills(), 0u);
   EXPECT_FALSE(wasSpilled(opA->getResult(0)))
       << "opA must stay in L1; reshape aliases its slot";
+}
+
+//===----------------------------------------------------------------------===//
+// ReshardCbOverlapTest
+//
+// Exercises the address simulation end to end. Tensors are placed top-down, so
+// the inserted reshard occupies the top `reshardL1` bytes and pushes cons's
+// output down to [budget-reshardL1-consOut, budget-reshardL1]. cons's cushioned
+// CB region (grows bottom-up) is sized to land inside that gap: it overlaps the
+// pushed-down output yet stays clear of the reshard slot itself, so the reshard
+// input remains valid in memory — the conflict is purely the output placement
+// the reshard forced. The pass can't evict the protected reshard, so it demotes
+// cons. Without the fix the reshard isn't tracked, the output sits at the top
+// clear of the CB, and cons stays L1 — so this fails without the fix.
+//===----------------------------------------------------------------------===//
+
+class ReshardCbOverlapTest : public L1SpillTestFixture {};
+
+TEST_F(ReshardCbOverlapTest, TrackedReshardSlotForcesConsumerDemotion) {
+  l1BudgetPerCore = 1300 * kKiB;
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto l1 = makeL1Sharded(shape);
+  auto tt = tensorType(shape, l1);
+
+  // The reshard restores prod's L1 layout, so it occupies that layout's
+  // per-core footprint: a 1024x1024 bf16 tensor (2 MiB) height-sharded across
+  // the 8-core grid -> 256 KiB per core (~20% of the 1300-KiB budget).
+  uint64_t reshardL1 = perCoreL1Usage(l1);
+  uint64_t cushion = l1BudgetPerCore / 10; // kCBFragCushionFraction
+  uint64_t consOut = 50 * kKiB;
+  // Centre the cushioned CB in the gap (output, reshard) the reshard opens up:
+  // cb + cushion = budget - reshardL1 - consOut/2 sits above the pushed-down
+  // output (budget - reshardL1 - consOut) and below the reshard slot
+  // (budget - reshardL1). Untracked, the output sits at the top and clears it.
+  uint64_t cbPeak = l1BudgetPerCore - reshardL1 - consOut / 2 - cushion;
+
+  auto args = beginFunc({tt});
+  auto *prod = addUnary(args[0], tt, /*l1UsageBytes=*/800 * kKiB);
+  auto *trigger = addUnary(args[0], tt, /*l1UsageBytes=*/800 * kKiB);
+  auto *cons = addUnary(prod->getResult(0), tt, /*l1UsageBytes=*/consOut);
+  setL1Usage(cons, consOut, /*cb=*/cbPeak);
+  setRequiresShardedInput(cons);
+  finishFunc({trigger->getResult(0), cons->getResult(0)});
+
+  auto [obs] = run();
+
+  // prod is the sole farthest-last-use victim: one eviction, then spilled.
+  ASSERT_EQ(obs->evictions.size(), 1u);
+  EXPECT_EQ(obs->evictions[0].victim, prod);
+  ASSERT_TRUE(wasSpilled(prod->getResult(0)));
+
+  // cons reads the inserted reshard; that tracked slot pushed cons's output
+  // into the CB region, so the pass demotes cons to DRAM.
+  ASSERT_TRUE(mlir::isa_and_nonnull<mlir::tt::ttnn::ToMemoryConfigOp>(
+      cons->getOperand(0).getDefiningOp()));
+  EXPECT_FALSE(resultIsL1(cons->getResult(0)))
+      << "cons must be demoted: the tracked reshard pushed its output into the "
+         "CB region";
+}
+
+//===----------------------------------------------------------------------===//
+// ReshardCbOverlapTest.OverlapWithReshardInputFailsCompilation
+//
+// The unresolvable counterpart to the demotion case above. cons is CB-heavy:
+// its L1-output CB overlaps its pushed-down output, so the pass demotes cons to
+// DRAM (as above). But its DRAM-output CB is larger still (locally-allocated
+// CBs grow for DRAM outputs) and overlaps the reshard slot *itself* — which the
+// pass can neither evict nor relocate. So even after demotion the op cannot be
+// placed. The pass must fail compilation with a clear error rather than emit IR
+// that overflows L1 at runtime.
+//===----------------------------------------------------------------------===//
+
+TEST_F(ReshardCbOverlapTest, OverlapWithReshardInputFailsCompilation) {
+  l1BudgetPerCore = 1300 * kKiB;
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto l1 = makeL1Sharded(shape);
+  auto tt = tensorType(shape, l1);
+
+  uint64_t reshardL1 = perCoreL1Usage(l1); // 256 KiB at the top of L1
+  uint64_t cushion = l1BudgetPerCore / 10;
+  uint64_t consOut = 50 * kKiB;
+  // L1 CB overlaps the pushed-down output (forces the demote, as above).
+  uint64_t cbL1 = l1BudgetPerCore - reshardL1 - consOut / 2 - cushion;
+  // DRAM CB lands midway between the reshard slot (budget - reshardL1) and the
+  // top of L1: it overlaps the reshard itself yet still fits the budget (so
+  // this is genuinely "CB clashes with the reshard input", not "CB too big").
+  uint64_t cbDram = l1BudgetPerCore - reshardL1 / 2 - cushion;
+
+  auto args = beginFunc({tt});
+  auto *prod = addUnary(args[0], tt, /*l1UsageBytes=*/800 * kKiB);
+  auto *trigger = addUnary(args[0], tt, /*l1UsageBytes=*/800 * kKiB);
+  auto *cons = addUnary(prod->getResult(0), tt, /*l1UsageBytes=*/consOut);
+  setL1Usage(cons, consOut, /*cb=*/cbL1);
+  setDramCBPeak(cons, cbDram);
+  setRequiresShardedInput(cons);
+  finishFunc({trigger->getResult(0), cons->getResult(0)});
+
+  // Capture the emitted diagnostic instead of letting it print to stderr.
+  std::string diag;
+  mlir::ScopedDiagnosticHandler handler(&context, [&](mlir::Diagnostic &d) {
+    if (d.getSeverity() == mlir::DiagnosticSeverity::Error) {
+      diag += d.str();
+    }
+    return mlir::success();
+  });
+
+  run();
+
+  EXPECT_TRUE(pass->hasFailed())
+      << "CB overlapping the un-evictable reshard input must fail compilation";
+  EXPECT_NE(diag.find("cannot be placed"), std::string::npos)
+      << "expected a clear placement error; got: " << diag;
 }


### PR DESCRIPTION
### Summary

Promised follow-up to #8567, which added pass-inserted reshards to restore an op's required L1-sharded inputs — adds unit-test coverage for inserted-reshard handling.

Also handles a case surfaced while writing them: when an op's circular-buffer region overlaps an inserted reshard it depends on and eviction can't resolve it (the reshard is guarded from eviction and can't be relocated), the pass now fails compilation with a clear error instead of silently emitting IR that overflows L1 at runtime.