### PR TITLE
Add EmitPy conversion for PagedFillCacheOp and fix GatherOp dim signedness

### DIFF
--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -2257,7 +2257,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
         emitter.emit(srcOp.getIndex()),
         emitter.emit(/*sparse_grad=*/false, "sparse_grad"),
         emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
@@ -2672,6 +2672,43 @@ public:
         emitter.emit(srcOp.getUpdateIndex(), "update_idxs_tensor"),
         emitter.emit(srcOp.getShareCache(), "share_cache"),
         emitter.emit(srcOp.getPageTable(), "page_table")};
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
+// PagedFillCacheOp
+//
+namespace {
+class PagedFillCacheOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::PagedFillCacheOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.paged_fill_cache";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn.experimental.paged_fill_cache";
+  }
+
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::PagedFillCacheOp>::TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::PagedFillCacheOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::PagedFillCacheOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getCache()), emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getPageTable()),
+        emitter.emit(srcOp.getBatchIdxTensor(), "batch_idx_tensor")};
 
     emitter.replaceOp(*this, args);
 
@@ -5323,6 +5360,7 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<FillCacheOpConversionPattern>(typeConverter, ctx);
   patterns.add<UpdateCacheOpConversionPattern>(typeConverter, ctx);
   patterns.add<PagedUpdateCacheOpConversionPattern>(typeConverter, ctx);
+  patterns.add<PagedFillCacheOpConversionPattern>(typeConverter, ctx);
   patterns.add<SamplingOpConversionPattern>(typeConverter, ctx);
 
   // Trace ops


### PR DESCRIPTION
### Problem description
The TTNN-to-EmitPy pipeline cannot convert vLLM prefill graphs: `ttnn.paged_fill_cache` has an EmitC conversion pattern but no EmitPy pattern, so any model using paged KV cache fails to legalize when emitting Python (`error: failed to legalize operation 'ttnn.paged_fill_cache'`). Additionally, GatherOp's `dim` attribute is declared as a signless `I32Attr` whose C++ getter returns `uint32_t`, so `dim = -1` is emitted as `4294967295` in generated Python, which `ttnn.gather` rejects.

### What's changed
- Added `PagedFillCacheOpConversionPattern` for EmitPy, mirroring the existing EmitC pattern and the EmitPy `PagedUpdateCacheOp` pattern. It emits `ttnn.experimental.paged_fill_cache(cache, input, page_table, batch_idx_tensor=...)`, matching the ttnn Python binding (positional `cache, input, page_table`; kw-only `batch_idx_tensor`). The EmitC-only positional args (`batch_offset`, `compute_kernel_config`, `mesh_coords`) are covered by Python defaults.
- Cast GatherOp's `dim` through `static_cast<int32_t>` before emission so negative dims print correctly.

With these fixes, vLLM prefill/decode graphs (paged KV cache + gather) emit valid Python; verified end-to-end through tt-xla EmitPy execution (generated tokens match the flatbuffer runtime path on a 1-layer Qwen3 TP run on llmbox).

### Checklist
- [ ] New/Existing tests provide coverage for changes