### PR TITLE
[StableHLOToTTIR] Add partial-slice integer gather test coverage

### DIFF
--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_gather_integer_operand.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_gather_integer_operand.mlir
@@ -31,4 +31,16 @@ module attributes {} {
     %0 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<6x4xbf16>, tensor<3x1xi32>) -> tensor<3x4xbf16>
     return %0 : tensor<3x4xbf16>
   }
+
+  // 2D integer operand, single indexed dim with a partial (non-full, non-1)
+  // slice, so start indices are expanded to gather the implied consecutive
+  // rows (needsExpansion == true). Must stay on ttir.gather to keep integer
+  // precision rather than rounding through the embedding bf16 weight.
+  // CHECK-LABEL: func.func @gather_int_partial_slice
+  func.func @gather_int_partial_slice(%operand: tensor<6x4xi32>, %start_indices: tensor<2x1xi32>) -> tensor<2x3x4xi32> {
+    // CHECK-NOT: "ttir.embedding"
+    // CHECK: "ttir.gather"
+    %0 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1, 2], collapsed_slice_dims = [], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 3, 4>}> : (tensor<6x4xi32>, tensor<2x1xi32>) -> tensor<2x3x4xi32>
+    return %0 : tensor<2x3x4xi32>
+  }
 }


### PR DESCRIPTION
### Ticket
Follow up https://github.com/tenstorrent/tt-mlir/pull/8680

### Problem description
Adds the partial-slice integer gather test case requested in review (`needsExpansion == true`, e.g. `tensor<6x4xi32>`, `start_index_map=[0]`, `slice_sizes=[3,4]`).

Test-only confirms the case stays on `ttir.gather`, not `ttir.embedding`. No code change.

### What's changed
Added one lit test case, gather_int_partial_slice, to gather_to_gather_integer_operand.mlir using the exact shape from the review comment. It checks that a single-index integer gather with a partial slice (needsExpansion == true) lowers to ttir.gather, not ttir.embedding, preserving integer precision.

### Checklist
- [ ] New/Existing tests provide coverage for changes
