### PR TITLE
[SDPA] Support query-broadcast (dim2==1) attention mask

### DIFF
--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3284,10 +3284,31 @@ private:
   LogicalResult lowerToSDPAOp(ttir::ScaledDotProductAttentionOp op,
                               OpAdaptor adaptor,
                               ConversionPatternRewriter &rewriter) const {
+    // The TTNN SDPA kernel streams over the query dim and cannot broadcast it,
+    // so materialize a query-broadcast mask ([.., 1, Sk]) to [.., Sq, Sk].
+    Value mask = adaptor.getAttentionMask();
+    if (mask) {
+      auto maskType = mlir::cast<RankedTensorType>(mask.getType());
+      int64_t seqLen =
+          mlir::cast<RankedTensorType>(adaptor.getQuery().getType())
+              .getDimSize(kSeqLenDim);
+      if (maskType.getDimSize(kSeqLenDim) == 1 && seqLen != 1) {
+        SmallVector<int64_t> broadcastShape(maskType.getShape());
+        broadcastShape[kSeqLenDim] = seqLen;
+        auto broadcastType = ttnn::utils::RankedTensorTypeFactory::create(
+            maskType, broadcastShape);
+        auto broadcastDims = ttmlir::utils::getBroadcastDimensions<int64_t>(
+            maskType.getShape(), broadcastShape);
+        mask = rewriter.create<ttnn::RepeatOp>(
+            op.getLoc(), broadcastType, mask,
+            ttnn::ShapeAttr::get(rewriter.getContext(), broadcastDims));
+      }
+    }
+
     rewriter.replaceOpWithNewOp<ttnn::ScaledDotProductAttentionOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getQuery(), adaptor.getKey(), adaptor.getValue(),
-        adaptor.getAttentionMask(), op.getIsCausal(), adaptor.getScaleAttr(),
+        adaptor.getQuery(), adaptor.getKey(), adaptor.getValue(), mask,
+        op.getIsCausal(), adaptor.getScaleAttr(),
         adaptor.getSlidingWindowSizeAttr(), adaptor.getAttentionSink());
 
     return success();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7556,9 +7556,10 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
       return emitOpError("Attention mask dim 1 must be 1 (broadcast) or match "
                          "query num heads");
     }
-    if (attentionMaskType.getShape()[2] != seqLen) {
-      return emitOpError(
-          "Attention mask at dim 2 must match query sequence length");
+    if (attentionMaskType.getShape()[2] != 1 &&
+        attentionMaskType.getShape()[2] != seqLen) {
+      return emitOpError("Attention mask dim 2 must be 1 (broadcast) or match "
+                         "query sequence length");
     }
     if (attentionMaskType.getShape()[3] != maxSeqLen) {
       return emitOpError("Attention mask at dim 3 must match key/value "

--- a/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention.mlir
@@ -14,4 +14,14 @@ module {
         %1 = "ttir.scaled_dot_product_attention"(%query, %key, %value, %attn_mask) <{operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<8x12x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x1x32x32xbf16>) -> tensor<8x12x32x32xbf16>
         return %1 : tensor<8x12x32x32xbf16>
     }
+
+    // Query-broadcast mask (dim2 == 1): the verifier accepts it, and the
+    // TTIR->TTNN lowering materializes dim2 -> query seq_len (ttnn.repeat) before
+    // the fused kernel, which cannot broadcast the query dim.
+    func.func @qkv_query_broadcast_mask_sdpa(%query: tensor<8x12x32x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %attn_mask: tensor<8x1x1x32xbf16>) -> tensor<8x12x32x32xbf16> {
+        // CHECK: "ttnn.repeat"
+        // CHECK: "ttnn.scaled_dot_product_attention"
+        %1 = "ttir.scaled_dot_product_attention"(%query, %key, %value, %attn_mask) <{operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<8x12x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x1x1x32xbf16>) -> tensor<8x12x32x32xbf16>
+        return %1 : tensor<8x12x32x32xbf16>
+    }
 }


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4780#issuecomment-4672413108

### Problem description

- In HunyuanImage-2.1's transformer, there are SDPA cases where the 3rd dim of the attention mask is `1`. Torch's SDPA accepts it (broadcasts over the query dim), but `ttnn.sdpa` doesn't, and tt-mlir's verifier rejects it too.

### What's changed

- **TTIR verifier** (`TTIROps.cpp`): relax the SDPA attention-mask check to accept `dim2 == 1` (query-broadcast), not only `dim2 == query_seq_len`.
- **TTIR→TTNN lowering** (`TTIRToTTNN.cpp`): the TTNN SDPA kernel streams over the query dim and can't broadcast it, so materialize the broadcast — expand mask `dim2` from `1` → `seq_len` via `ttnn.repeat` — before creating `ttnn.scaled_dot_product_attention`. The TTNN verifier stays strict; the lowering guarantees it always receives a full mask.
- **Test**: added a `dim2==1` broadcast-mask case to the Silicon SDPA lit test.

### Checklist
- [x] Verify the changes through local testing in N150

### Logs

- [jun11_sdpa_before_fix.log](https://github.com/user-attachments/files/28833180/jun11_sdpa_before_fix.log)
- [jun11_sdpa_after_fix_opt1.log](https://github.com/user-attachments/files/28833177/jun11_sdpa_after_fix_opt1.log)

