### PR TITLE
[TTIRToTTIRDecomposition] Decompose non-overlapping conv3d patchify to matmul

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1499,6 +1499,111 @@ struct ConvChannelLastDecompositionPattern
   }
 };
 
+// A conv3d whose single window spans the whole spatial input is just a matmul:
+//   out[b, o] = sum_{c,d,h,w} in[b, c, d, h, w] * weight[o, c, d, h, w]
+// so we flatten each patch and the weight and contract them. We rewrite rather
+// than lower because ttnn.conv3d is wrong here (tt-xla #1662, device PCC ~0).
+// Guarded to the full-window case; overlapping/strided conv3d falls through.
+struct Conv3dPatchEmbedToMatmulPattern
+    : public OpConversionPattern<ttir::Conv3dOp> {
+  using OpConversionPattern<ttir::Conv3dOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::Conv3dOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Bias and grouping aren't part of the matmul equivalence we build here.
+    if (op.getGroups() != 1 || adaptor.getBias()) {
+      return failure();
+    }
+    // Any padding makes the conv touch elements the flat matmul wouldn't.
+    auto isAllZero = [](mlir::Attribute attr) -> bool {
+      if (auto arr = mlir::dyn_cast<mlir::DenseI32ArrayAttr>(attr)) {
+        return llvm::all_of(arr.asArrayRef(), [](int32_t p) { return p == 0; });
+      }
+      if (auto scalar = mlir::dyn_cast<mlir::IntegerAttr>(attr)) {
+        return scalar.getInt() == 0;
+      }
+      return false;
+    };
+    if (!isAllZero(op.getPadding())) {
+      return failure();
+    }
+
+    auto inputType = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
+    auto weightType =
+        mlir::cast<RankedTensorType>(adaptor.getWeight().getType());
+    auto outputType = mlir::cast<RankedTensorType>(op.getResult().getType());
+
+    int64_t batchDim = op.getBatchDim();
+    int64_t channelDim = op.getChannelDim();
+    int64_t depthDim = op.getDepthDim();
+    int64_t heightDim = op.getHeightDim();
+    int64_t widthDim = op.getWidthDim();
+
+    ArrayRef<int64_t> inShape = inputType.getShape();
+    ArrayRef<int64_t> wShape = weightType.getShape(); // [O, I, Kd, Kh, Kw]
+    int64_t outChannels = wShape[0];
+    int64_t kernelDepth = wShape[2];
+    int64_t kernelHeight = wShape[3];
+    int64_t kernelWidth = wShape[4];
+
+    // Exact only when one window covers the whole spatial extent (so stride is
+    // irrelevant and no input element is dropped).
+    if (inShape[depthDim] != kernelDepth ||
+        inShape[heightDim] != kernelHeight ||
+        inShape[widthDim] != kernelWidth) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+    Type elementType = inputType.getElementType();
+    Attribute encoding = inputType.getEncoding();
+    int64_t batch = inShape[batchDim];
+    int64_t patchSize =
+        wShape[1] * kernelDepth * kernelHeight * kernelWidth; // I*Kd*Kh*Kw
+
+    // Permute to canonical [B, C, D, H, W] so the flat reshape lays each patch
+    // out in the same [C, D, H, W] order as the weight.
+    SmallVector<int64_t, 5> toNCDHW{batchDim, channelDim, depthDim, heightDim,
+                                    widthDim};
+    SmallVector<int64_t> ncdhwShape =
+        ttmlir::utils::applyPermutation(inShape, toNCDHW);
+    auto ncdhwType = RankedTensorType::get(ncdhwShape, elementType, encoding);
+    Value ncdhwInput = rewriter.create<ttir::PermuteOp>(
+        loc, ncdhwType, adaptor.getInput(), toNCDHW);
+
+    auto flatInputType =
+        RankedTensorType::get({batch, patchSize}, elementType, encoding);
+    Value flatInput = rewriter.create<ttir::ReshapeOp>(
+        loc, flatInputType, ncdhwInput,
+        rewriter.getI32ArrayAttr(
+            {static_cast<int32_t>(batch), static_cast<int32_t>(patchSize)}));
+
+    auto flatWeightType = RankedTensorType::get(
+        {outChannels, patchSize}, elementType, weightType.getEncoding());
+    Value flatWeight = rewriter.create<ttir::ReshapeOp>(
+        loc, flatWeightType, adaptor.getWeight(),
+        rewriter.getI32ArrayAttr({static_cast<int32_t>(outChannels),
+                                  static_cast<int32_t>(patchSize)}));
+
+    // [B, K] x [O, K]^T -> [B, O].
+    auto matmulType =
+        RankedTensorType::get({batch, outChannels}, elementType, encoding);
+    Value matmul = rewriter.create<ttir::MatmulOp>(
+        loc, matmulType, flatInput, flatWeight, /*transpose_a=*/false,
+        /*transpose_b=*/true);
+
+    // Restore the conv's output shape (its spatial dims are all 1).
+    SmallVector<int32_t> outShapeI32(outputType.getShape().begin(),
+                                     outputType.getShape().end());
+    Value result = rewriter.create<ttir::ReshapeOp>(
+        loc, outputType, matmul, rewriter.getI32ArrayAttr(outShapeI32));
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 struct Conv3dChannelLastDecompositionPattern
     : public OpConversionPattern<ttir::Conv3dOp> {
   using OpConversionPattern<ttir::Conv3dOp>::OpConversionPattern;
@@ -2020,6 +2125,10 @@ void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
       typeConverter, ctx);
   patterns.add<ConvChannelLastDecompositionPattern<ttir::ConvTranspose2dOp>>(
       typeConverter, ctx);
+  // Higher benefit than the channel-last normalization so a patchify conv3d is
+  // turned into a matmul before it would otherwise be reshaped into NDHWC.
+  patterns.add<Conv3dPatchEmbedToMatmulPattern>(typeConverter, ctx,
+                                                /*benefit=*/2);
   patterns.add<Conv3dChannelLastDecompositionPattern>(typeConverter, ctx);
 }
 

--- a/test/ttmlir/Dialect/TTIR/Decomposition/conv3d_patch_embed_to_matmul.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/conv3d_patch_embed_to_matmul.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition %s | FileCheck %s
+
+// A patchify conv3d (kernel spans the whole spatial input, stride == kernel, no
+// padding, groups == 1) is exactly a matmul, so it is rewritten away from the
+// conv kernel. This is the Qwen2.5-VL vision patch-embed shape (tt-xla #1662).
+module {
+  // CHECK-LABEL: func.func @conv3d_patch_embed
+  func.func @conv3d_patch_embed(%input: tensor<2x3x2x4x4xf32>, %weight: tensor<8x3x2x4x4xf32>) -> tensor<2x8x1x1x1xf32> {
+    // CHECK-NOT: ttir.conv3d
+    // CHECK: ttir.matmul
+    // CHECK-SAME: transpose_b = true
+    %0 = "ttir.conv3d"(%input, %weight) <{batch_dim = 0 : i64, channel_dim = 1 : i64, depth_dim = 2 : i64, groups = 1 : i32, height_dim = 3 : i64, padding = array<i32: 0, 0, 0>, padding_mode = "zeros", stride = array<i32: 2, 4, 4>, width_dim = 4 : i64}> : (tensor<2x3x2x4x4xf32>, tensor<8x3x2x4x4xf32>) -> tensor<2x8x1x1x1xf32>
+    return %0 : tensor<2x8x1x1x1xf32>
+  }
+
+  // A real conv3d whose kernel does NOT cover the full spatial extent must stay
+  // a convolution (here already NDHWC so the channel-last pass leaves it alone).
+  // CHECK-LABEL: func.func @conv3d_real_stays_conv
+  func.func @conv3d_real_stays_conv(%input: tensor<2x4x8x8x3xf32>, %weight: tensor<8x3x2x4x4xf32>) -> tensor<2x2x2x2x8xf32> {
+    // CHECK-NOT: ttir.matmul
+    // CHECK: ttir.conv3d
+    %0 = "ttir.conv3d"(%input, %weight) <{batch_dim = 0 : i64, channel_dim = 4 : i64, depth_dim = 1 : i64, groups = 1 : i32, height_dim = 2 : i64, padding = array<i32: 0, 0, 0>, padding_mode = "zeros", stride = array<i32: 2, 4, 4>, width_dim = 3 : i64}> : (tensor<2x4x8x8x3xf32>, tensor<8x3x2x4x4xf32>) -> tensor<2x2x2x2x8xf32>
+    return %0 : tensor<2x2x2x2x8xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/47316)

### Problem description
A `Conv3d` with `stride == kernel_size` over a small channel count (Qwen2.5-VL's vision patch embed: `in=3, out=1280, kernel=stride=[2,14,14]`) lowers `ttir.conv3d` → `ttnn.conv3d` and produces a result **uncorrelated** with the reference:

The op legalizes and runs the numbers are incorrect. Because this is thefirst op of the vision tower, it sinks the whole Qwen2.5-VL model (full-model PCC ~0.24).

### Fix
Because `stride == kernel` and the kernel spans the entire spatial extent, this is a non-overlapping patchify mathematically a matmul:

`out[b, o] = Σ_{c,d,h,w} in[b, c, d, h, w] · weight[o, c, d, h, w]`

This adds `Conv3dPatchEmbedToMatmulPattern` to `TTIRToTTIRDecomposition`, which rewrites the non-overlapping case to `permute → reshape → ttir.matmul(transpose_b) → reshape`. Registered at benefit 2 so it runs before the channel-last normalization. Real overlapping/strided conv3d falls through to the conv kernel untouched.

### Gate (decomposition is exact only when all hold)
- `groups == 1`
- padding all zero
- input spatial dims == kernel spatial dims (one full window; stride irrelevant,
  no element dropped)
- no bias

### Results
| | device op | PCC |
|---|---|---|
| before | `ttnn.conv3d` | 0.0048 |
| after  | `ttnn.matmul` | passes (full Qwen2.5-VL 0.24 → ~0.90) |


### What's changed

- Added Conv3dPatchEmbedToMatmulPattern in TTIRToTTIRDecomposition.cpp  a new OpConversionPattern<ttir::Conv3dOp> that rewrites a non-overlapping patchify conv3d into a matmul.
- Gating logic so it fires only when the rewrite is exact: groups == 1, no bias, zero padding, and input spatial dims == kernel spatial dims (one full window).
- The rewrite itself: permute input to [B,C,D,H,W] → reshape to [B, C·D·H·W] → reshape weight to [O, C·D·H·W] → ttir.matmul(transpose_b=true) → reshape back to the conv's output shape.
- Added a lit test conv3d_patch_embed_to_matmul.mlir with two cases: a patchify conv3d decomposes to matmul, and a real (overlapping) conv3d stays a conv3d.

### Checklist
- [ ] New/Existing tests provide coverage for changes
