### PR TITLE
Uplift third_party/tt-metal to 60ea807 2026-06-10

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=8d901046bb169c9c3de1a68d284fba502371a820
+ARG TT_METAL_DEPENDENCIES_COMMIT=60ea807b6ba8754dcb44b716faaee5e6e4813d89
 
 # Install dependencies
 RUN <<EOT

--- a/runtime/lib/ttnn/operations/ccl/selective_reduce_combine.cpp
+++ b/runtime/lib/ttnn/operations/ccl/selective_reduce_combine.cpp
@@ -45,7 +45,7 @@ void run(const ::tt::target::ttnn::SelectiveReduceCombineOp *op,
   ::ttnn::Tensor output = ::ttnn::prim::selective_reduce_combine(
       denseInputTensor, denseActivationsTensor, denseTokenMapsTensor,
       denseTokenCountsTensor, op->hidden_size(), op->batch_size(),
-      op->seq_size(), op->select_experts_k(), op->experts(),
+      op->seq_size(), op->select_experts_k(),
       /*axis=*/kDefaultClusterAxis,
       /*topology=*/::tt::tt_fabric::Topology::Ring,
       /*num_links=*/kDefaultNumLinks,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "8d901046bb169c9c3de1a68d284fba502371a820")
+set(TT_METAL_VERSION "60ea807b6ba8754dcb44b716faaee5e6e4813d89")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
uplift pin to 60ea807

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI links**
- [ ] [tt-xla(full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
 - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): (passing) https://github.com/tenstorrent/tt-forge-onnx/actions/runs/27374776018

- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):

