### PR TITLE
[TTNN]: `moe_gpt`: allow const-eval for L1-resident expert_mapping tensor

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -48,6 +48,11 @@ struct TTNNOperandWorkarounds {
   // Tensor data format workaround.
   TensorDataTypeWorkaround tensorDataTypeWorkaround;
 
+  // Tags the inserted ToLayoutOp with "ttnn.const_eval_allowed" so
+  // ConstEvalHoist may hoist its L1-resident result. Opt in only for constant
+  // operands whose L1 residency is meant to be const-eval'd.
+  bool allowL1ConstEval = false;
+
   // Default constructor.
   TTNNOperandWorkarounds() = default;
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -106,7 +106,8 @@ struct TTNNOperandWorkarounds {
     return tensorLayoutWorkaround == rhs.tensorLayoutWorkaround &&
            tensorBufferTypeWorkaround == rhs.tensorBufferTypeWorkaround &&
            tensorMemoryLayoutWorkaround == rhs.tensorMemoryLayoutWorkaround &&
-           tensorDataTypeWorkaround == rhs.tensorDataTypeWorkaround;
+           tensorDataTypeWorkaround == rhs.tensorDataTypeWorkaround &&
+           allowL1ConstEval == rhs.allowL1ConstEval;
   }
 
   // Inequality operator.
@@ -117,7 +118,8 @@ struct TTNNOperandWorkarounds {
   // Returns true if any of the workarounds is set.
   bool hasAnyWorkaround() const {
     return tensorLayoutWorkaround || tensorBufferTypeWorkaround ||
-           tensorMemoryLayoutWorkaround || tensorDataTypeWorkaround;
+           tensorMemoryLayoutWorkaround || tensorDataTypeWorkaround ||
+           allowL1ConstEval;
   }
 };
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1353,6 +1353,9 @@ TTNNOperandsWorkaroundsFactory::createMoeGptOpOperandsWorkarounds(
   l1RowMajorUint16Workaround.tensorDataTypeWorkaround =
       ttcore::DataType::UInt16;
   l1RowMajorUint16Workaround.tensorBufferTypeWorkaround = BufferType::L1;
+  // expert_mapping is a constant argument; its L1 copy is meant to be
+  // const-eval'd, so opt in to tagging the inserted op as const-eval-allowed.
+  l1RowMajorUint16Workaround.allowL1ConstEval = true;
 
   // expert_indices: UINT16 ROW_MAJOR L1 HEIGHT_SHARDED — must match dispatch
   // output dtype to avoid host round-trip that destroys shard placement.

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -130,6 +130,14 @@ static bool workaroundInputOperand(
       inputWorkaroundResults.tensorMemoryLayoutResult.targetValue,
       inputWorkaroundResults.tensorDataTypeResult.targetValue, "_workaround");
 
+  // When the operand is a const-eval'able constant whose L1 residency is
+  // intended, tag the inserted op so ConstEvalHoist permits hoisting it
+  // despite the L1-resident result.
+  if (inputWorkaround.allowL1ConstEval) {
+    insertedToLayoutOpValue.getDefiningOp()->setAttr(
+        utils::g_ConstEvalAllowedAttrName, rewriter.getUnitAttr());
+  }
+
   // Insert to layout op between the current op and the input operand
   // to convert the input operand to the desired tensor layout, buffer type.
   rewriter.modifyOpInPlace(op, [&]() {


### PR DESCRIPTION
### Ticket
#8750

### Problem description
`expert_mapping` input of `moe_gpt` op gets `L1 INTERLEAVED` layout assigned as part of `TTNNWorkarounds`.

Since this is a small (config-like) tensor, it it safe to const-eval it.

### What's changed
- Thread `allowL1ConstEval` flag through TTNN workarounds
- Enable the flag for `expert_mapping` input of `moe_gpt` op

### Checklist
- [x] New/Existing tests provide coverage for changes
