### PR TITLE
[SHLO] [TTNN] Add users-dim factor to paged ops + force MeshWorkloadFactory for DP

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -605,24 +605,48 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
       return mlir::sdy::OpShardingRuleAttr();
     }
 
-    const int64_t queryHeadDim = 2; // [1, U, H, D]
-    const int64_t kvHeadDim = 1;    // [B, H, S, D]
+    const int64_t queryUsersDim = 1; // [1, U, H, D]
+    const int64_t queryHeadDim = 2;  // [1, U, H, D]
+    const int64_t kvHeadDim = 1;     // [B, H, S, D]
+    const int64_t outputUsersDim = 1;
     const int64_t outputHeadDim = 2;
 
-    int64_t headSize = queryType.getShape()[queryHeadDim];
+    int64_t numHeads = queryType.getShape()[queryHeadDim];
+    int64_t numUsers = queryType.getShape()[queryUsersDim];
 
-    SmallVector<int64_t> operandHeadDims(op.getNumOperands(),
-                                         mlir::sdy::kNullDim);
-    SmallVector<int64_t> resultHeadDims(op.getNumResults(),
-                                        mlir::sdy::kNullDim);
+    int64_t numOperands = op.getNumOperands();
+    int64_t numResults = op.getNumResults();
 
-    operandHeadDims[0] = queryHeadDim; // query
-    operandHeadDims[1] = kvHeadDim;    // key
-    operandHeadDims[2] = kvHeadDim;    // value
-    resultHeadDims[0] = outputHeadDim; // output
+    mlir::sdy::OpShardingRuleBuilder builder(op);
 
-    return buildHeadShardedCustomCallRule(op, operandHeadDims, resultHeadDims,
-                                          headSize);
+    // Head factor (kPassThrough, size = num_heads): links Q/K/V/Out head dims.
+    SmallVector<int64_t> headOperandDims(numOperands, mlir::sdy::kNullDim);
+    SmallVector<int64_t> headResultDims(numResults, mlir::sdy::kNullDim);
+    headOperandDims[0] = queryHeadDim; // query
+    headOperandDims[1] = kvHeadDim;    // key
+    headOperandDims[2] = kvHeadDim;    // value
+    headResultDims[0] = outputHeadDim; // output
+    builder.addFactor(headOperandDims, headResultDims, numHeads,
+                      mlir::sdy::FactorType::kPassThrough);
+
+    // Users factor (kPassThrough, size = num_users): required so the SPMD
+    // partitioner can keep each DP replica's decode local. Without it, page
+    // table / cur_pos sharding can't propagate and a single replica observes
+    // KV cache corruption from the other replica's writes.
+    SmallVector<int64_t> usersOperandDims(numOperands, mlir::sdy::kNullDim);
+    SmallVector<int64_t> usersResultDims(numResults, mlir::sdy::kNullDim);
+    usersOperandDims[0] = queryUsersDim; // query
+    if (numOperands > 3) {
+      usersOperandDims[3] = 0; // page_table
+    }
+    if (numOperands > 4) {
+      usersOperandDims[4] = 0; // cur_pos_tensor
+    }
+    usersResultDims[0] = outputUsersDim; // output
+    builder.addFactor(usersOperandDims, usersResultDims, numUsers,
+                      mlir::sdy::FactorType::kPassThrough);
+
+    return builder.build();
   }
 
   if (target == chunkedSdpaTargetName) {
@@ -644,22 +668,48 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
     }
 
     const int64_t cacheHeadDim = 1;
+    const int64_t fillValueUsersDim = 1;
     const int64_t fillValueHeadDim = 2;
     const int64_t outputHeadDim = 1;
 
-    int64_t headSize = cacheType.getShape()[cacheHeadDim];
+    auto fillValueType =
+        llvm::cast<RankedTensorType>(op.getOperand(1).getType());
 
-    SmallVector<int64_t> operandHeadDims(op.getNumOperands(),
-                                         mlir::sdy::kNullDim);
-    SmallVector<int64_t> resultHeadDims(op.getNumResults(),
-                                        mlir::sdy::kNullDim);
+    int64_t numHeads = cacheType.getShape()[cacheHeadDim];
+    int64_t numUsers = fillValueType.getShape()[fillValueUsersDim];
 
-    operandHeadDims[0] = cacheHeadDim;     // cache
-    operandHeadDims[1] = fillValueHeadDim; // fill_value
-    resultHeadDims[0] = outputHeadDim;     // output
+    int64_t numOperands = op.getNumOperands();
+    int64_t numResults = op.getNumResults();
 
-    return buildHeadShardedCustomCallRule(op, operandHeadDims, resultHeadDims,
-                                          headSize);
+    mlir::sdy::OpShardingRuleBuilder builder(op);
+
+    // Head factor (kPassThrough, size = num_heads): links cache / fill_value /
+    // output head dims.
+    SmallVector<int64_t> headOperandDims(numOperands, mlir::sdy::kNullDim);
+    SmallVector<int64_t> headResultDims(numResults, mlir::sdy::kNullDim);
+    headOperandDims[0] = cacheHeadDim;     // cache
+    headOperandDims[1] = fillValueHeadDim; // fill_value
+    headResultDims[0] = outputHeadDim;     // output
+    builder.addFactor(headOperandDims, headResultDims, numHeads,
+                      mlir::sdy::FactorType::kPassThrough);
+
+    // Users factor (kPassThrough, size = num_users): cache and output have NO
+    // users dim. This tells the SPMD partitioner each replica writes a
+    // disjoint cache slice, so no cross-device sync is needed for the update.
+    SmallVector<int64_t> usersOperandDims(numOperands, mlir::sdy::kNullDim);
+    SmallVector<int64_t> usersResultDims(numResults, mlir::sdy::kNullDim);
+    usersOperandDims[1] = fillValueUsersDim; // fill_value
+    if (numOperands > 2) {
+      usersOperandDims[2] = 0; // update_indices
+    }
+    if (numOperands > 3) {
+      usersOperandDims[3] = 0; // page_table
+    }
+    // operand[0] (cache) and result[0] (cache) stay kNullDim — critical.
+    builder.addFactor(usersOperandDims, usersResultDims, numUsers,
+                      mlir::sdy::FactorType::kPassThrough);
+
+    return builder.build();
   }
 
   if (target == pagedFillCacheTargetName) {

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -502,26 +502,6 @@ getFlashMlaPrefillShardingRule(mlir::stablehlo::CustomCallOp op) {
   return builder.build();
 }
 
-static mlir::sdy::OpShardingRuleAttr buildHeadShardedCustomCallRule(
-    mlir::stablehlo::CustomCallOp op, llvm::ArrayRef<int64_t> operandHeadDims,
-    llvm::ArrayRef<int64_t> resultHeadDims, int64_t headSize) {
-  assert(static_cast<int64_t>(operandHeadDims.size()) == op.getNumOperands() &&
-         "operandHeadDims size must match number of operands");
-  assert(static_cast<int64_t>(resultHeadDims.size()) == op.getNumResults() &&
-         "resultHeadDims size must match number of results");
-
-  mlir::sdy::OpShardingRuleBuilder builder(op);
-
-  SmallVector<int64_t> resolvedOperandDims(operandHeadDims.begin(),
-                                           operandHeadDims.end());
-  SmallVector<int64_t> resolvedResultDims(resultHeadDims.begin(),
-                                          resultHeadDims.end());
-
-  builder.addFactor(resolvedOperandDims, resolvedResultDims, headSize,
-                    mlir::sdy::FactorType::kPassThrough);
-  return builder.build();
-}
-
 // Dispatch function for paged attention CustomCall sharding rules.
 static mlir::sdy::OpShardingRuleAttr
 getChunkedSdpaShardingRule(mlir::stablehlo::CustomCallOp op) {
@@ -714,9 +694,10 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
 
   if (target == pagedFillCacheTargetName) {
     // Paged fill cache
-    //  0: cache        [num_pages_total, num_heads, block_size, hidden_size]
-    //  1: fill_value   [1, num_heads, seq_len, hidden_size]
-    //  2+: page_table, ...
+    //  0: cache       [num_pages_total, num_heads, block_size, hidden_size]
+    //  1: fill_value  [batch, num_heads, seq_len, hidden_size]
+    //  2: page_table  [batch, num_blocks_per_user]
+    //  3: batch_idx   [batch]   (optional)
     auto cacheType = llvm::cast<RankedTensorType>(op.getOperand(0).getType());
     auto outputType = llvm::cast<RankedTensorType>(op.getResult(0).getType());
 
@@ -726,23 +707,48 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
       return mlir::sdy::OpShardingRuleAttr();
     }
 
+    const int64_t numOperands = op.getNumOperands();
+    const int64_t numResults = op.getNumResults();
+
+    // Head factor (TP): num_heads, on cache/fill_value/output dim 1.
     const int64_t cacheHeadDim = 1;
     const int64_t fillValueHeadDim = 1;
     const int64_t outputHeadDim = 1;
-
     int64_t headSize = cacheType.getShape()[cacheHeadDim];
 
-    SmallVector<int64_t> operandHeadDims(op.getNumOperands(),
-                                         mlir::sdy::kNullDim);
-    SmallVector<int64_t> resultHeadDims(op.getNumResults(),
-                                        mlir::sdy::kNullDim);
+    // Batch factor (DP): link the batch dim of fill_value/page_table/batch_idx
+    // so the indices shard with the (DP-sharded) fill_value; without it they
+    // stay replicated and lowering fails. Cache/output have no batch dim.
+    const int64_t fillValueBatchDim = 0;
+    const int64_t pageTableBatchDim = 0;
+    const int64_t batchIdxBatchDim = 0;
+    auto fillValueType =
+        llvm::cast<RankedTensorType>(op.getOperand(1).getType());
+    int64_t batchSize = fillValueType.getShape()[fillValueBatchDim];
 
-    operandHeadDims[0] = cacheHeadDim;     // cache
-    operandHeadDims[1] = fillValueHeadDim; // fill_value
-    resultHeadDims[0] = outputHeadDim;     // output
+    mlir::sdy::OpShardingRuleBuilder builder(op);
 
-    return buildHeadShardedCustomCallRule(op, operandHeadDims, resultHeadDims,
-                                          headSize);
+    SmallVector<int64_t> headOperandDims(numOperands, mlir::sdy::kNullDim);
+    SmallVector<int64_t> headResultDims(numResults, mlir::sdy::kNullDim);
+    headOperandDims[0] = cacheHeadDim;     // cache
+    headOperandDims[1] = fillValueHeadDim; // fill_value
+    headResultDims[0] = outputHeadDim;     // output
+    builder.addFactor(headOperandDims, headResultDims, headSize,
+                      mlir::sdy::FactorType::kPassThrough);
+
+    SmallVector<int64_t> batchOperandDims(numOperands, mlir::sdy::kNullDim);
+    SmallVector<int64_t> batchResultDims(numResults, mlir::sdy::kNullDim);
+    batchOperandDims[1] = fillValueBatchDim; // fill_value
+    if (numOperands > 2) {
+      batchOperandDims[2] = pageTableBatchDim; // page_table
+    }
+    if (numOperands > 3) {
+      batchOperandDims[3] = batchIdxBatchDim; // batch_idx
+    }
+    builder.addFactor(batchOperandDims, batchResultDims, batchSize,
+                      mlir::sdy::FactorType::kPassThrough);
+
+    return builder.build();
   }
 
   if (target == pagedFlashMlaDecodeTargetName) {

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -637,13 +637,14 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
     SmallVector<int64_t> usersResultDims(numResults, mlir::sdy::kNullDim);
     usersOperandDims[0] = queryUsersDim; // query
 
-    // Operand layout (see tt_torch/custom_ops.py): the base operands are
-    // [query, key, value, page_table]; an optional attention_mask, then an
-    // optional cur_pos_tensor, then an optional attention_sink follow. Only
-    // page_table (fixed at index 3) and cur_pos_tensor carry the users/batch
-    // dim, so we must not assume cur_pos_tensor is at index 4 -- with an
-    // attention_mask present, index 4 is the mask and cur_pos_tensor shifts
-    // to 5. Use the has_* frontend flags to locate it.
+    // Operand layout (see TTIR_PagedScaledDotProductAttentionDecodeOp in
+    // TTIROps.td): the base operands are [query, key, value, page_table];
+    // an optional attention_mask, then an optional cur_pos_tensor, then an
+    // optional attention_sink follow in that order. Only page_table (fixed at
+    // index 3) and cur_pos_tensor carry the users/batch dim, so we must not
+    // assume cur_pos_tensor is at index 4 -- with an attention_mask present,
+    // index 4 is the mask and cur_pos_tensor shifts to 5. Use the has_*
+    // frontend flags to locate it.
     mlir::DictionaryAttr frontendAttrs =
         mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
             op->getDiscardableAttr("mhlo.frontend_attributes"));

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -616,11 +616,36 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
     SmallVector<int64_t> usersOperandDims(numOperands, mlir::sdy::kNullDim);
     SmallVector<int64_t> usersResultDims(numResults, mlir::sdy::kNullDim);
     usersOperandDims[0] = queryUsersDim; // query
-    if (numOperands > 3) {
-      usersOperandDims[3] = 0; // page_table
+
+    // Operand layout (see tt_torch/custom_ops.py): the base operands are
+    // [query, key, value, page_table]; an optional attention_mask, then an
+    // optional cur_pos_tensor, then an optional attention_sink follow. Only
+    // page_table (fixed at index 3) and cur_pos_tensor carry the users/batch
+    // dim, so we must not assume cur_pos_tensor is at index 4 -- with an
+    // attention_mask present, index 4 is the mask and cur_pos_tensor shifts
+    // to 5. Use the has_* frontend flags to locate it.
+    mlir::DictionaryAttr frontendAttrs =
+        mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+            op->getDiscardableAttr("mhlo.frontend_attributes"));
+    auto hasFlag = [&](llvm::StringRef name) {
+      if (frontendAttrs) {
+        if (auto strAttr = frontendAttrs.getAs<mlir::StringAttr>(name)) {
+          return strAttr.getValue().equals_insensitive("true");
+        }
+      }
+      return false;
+    };
+
+    constexpr int64_t pageTableIdx = 3;
+    if (numOperands > pageTableIdx) {
+      usersOperandDims[pageTableIdx] = 0; // page_table
     }
-    if (numOperands > 4) {
-      usersOperandDims[4] = 0; // cur_pos_tensor
+    if (hasFlag("has_cur_pos_tensor")) {
+      const int64_t curPosIdx =
+          pageTableIdx + 1 + (hasFlag("has_attention_mask") ? 1 : 0);
+      if (curPosIdx < numOperands) {
+        usersOperandDims[curPosIdx] = 0; // cur_pos_tensor
+      }
     }
     usersResultDims[0] = outputUsersDim; // output
     builder.addFactor(usersOperandDims, usersResultDims, numUsers,

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -502,6 +502,26 @@ getFlashMlaPrefillShardingRule(mlir::stablehlo::CustomCallOp op) {
   return builder.build();
 }
 
+static mlir::sdy::OpShardingRuleAttr buildHeadShardedCustomCallRule(
+    mlir::stablehlo::CustomCallOp op, llvm::ArrayRef<int64_t> operandHeadDims,
+    llvm::ArrayRef<int64_t> resultHeadDims, int64_t headSize) {
+  assert(static_cast<int64_t>(operandHeadDims.size()) == op.getNumOperands() &&
+         "operandHeadDims size must match number of operands");
+  assert(static_cast<int64_t>(resultHeadDims.size()) == op.getNumResults() &&
+         "resultHeadDims size must match number of results");
+
+  mlir::sdy::OpShardingRuleBuilder builder(op);
+
+  SmallVector<int64_t> resolvedOperandDims(operandHeadDims.begin(),
+                                           operandHeadDims.end());
+  SmallVector<int64_t> resolvedResultDims(resultHeadDims.begin(),
+                                          resultHeadDims.end());
+
+  builder.addFactor(resolvedOperandDims, resolvedResultDims, headSize,
+                    mlir::sdy::FactorType::kPassThrough);
+  return builder.build();
+}
+
 // Dispatch function for paged attention CustomCall sharding rules.
 static mlir::sdy::OpShardingRuleAttr
 getChunkedSdpaShardingRule(mlir::stablehlo::CustomCallOp op) {

--- a/runtime/lib/ttnn/operations/kv_cache/paged_fill_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/paged_fill_cache.cpp
@@ -32,6 +32,10 @@ void run(const ::tt::target::ttnn::PagedFillCacheOp *op,
   // single-program factory, which under DP partitioning runs the kernel on
   // the mesh root only - so per-rank cache writes from non-root devices are
   // silently dropped.
+  //
+  // TODO(#47955): ttnn could infer these coords from the cache tensor (it is
+  // already an op input) and select the MeshWorkloadFactory by default, letting
+  // us drop this explicit pass. Tracked in tenstorrent/tt-metal#47955.
   const auto &coordVec = cacheTensor.tensor_topology().mesh_coords();
   std::set<::ttnn::MeshCoordinate> meshCoords(coordVec.begin(), coordVec.end());
 

--- a/runtime/lib/ttnn/operations/kv_cache/paged_fill_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/paged_fill_cache.cpp
@@ -27,10 +27,18 @@ void run(const ::tt::target::ttnn::PagedFillCacheOp *op,
                 op->batch_idx_tensor()))
           : std::nullopt;
 
+  // Force the MeshWorkloadFactory by passing the cache tensor's full set of
+  // mesh coordinates. With std::nullopt, the device op selects the
+  // single-program factory, which under DP partitioning runs the kernel on
+  // the mesh root only - so per-rank cache writes from non-root devices are
+  // silently dropped.
+  const auto &coordVec = cacheTensor.tensor_topology().mesh_coords();
+  std::set<::ttnn::MeshCoordinate> meshCoords(coordVec.begin(), coordVec.end());
+
   ::ttnn::experimental::paged_fill_cache(cacheTensor, inputTensor,
                                          pageTableTensor, batchIdxTensor,
                                          /*batch_offset=*/0,
                                          /*compute_kernel_config*/ std::nullopt,
-                                         /*mesh_coords*/ std::nullopt);
+                                         /*mesh_coords*/ meshCoords);
 }
 } // namespace tt::runtime::ttnn::operations::kv_cache

--- a/runtime/lib/ttnn/operations/kv_cache/paged_update_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/paged_update_cache.cpp
@@ -31,11 +31,21 @@ void run(const ::tt::target::ttnn::PagedUpdateCacheOp *op,
           : std::nullopt;
 
   const std::vector<uint32_t> emptyUpdateIndex = {};
+
+  // Force the MeshWorkloadFactory by passing the cache tensor's full set of
+  // mesh coordinates. With std::nullopt, the device op selects the
+  // single-program factory, which under DP partitioning runs the kernel on
+  // the mesh root only - so per-rank cache writes from non-root devices are
+  // silently dropped. Per-rank divergent updates require one program per
+  // mesh coordinate, which is what the MeshWorkloadFactory provides.
+  const auto &coordVec = cacheTensor.tensor_topology().mesh_coords();
+  std::set<::ttnn::MeshCoordinate> meshCoords(coordVec.begin(), coordVec.end());
+
   ::ttnn::experimental::paged_update_cache(
       cacheTensor, inputTensor, emptyUpdateIndex, updateIndexTensor, shareCache,
       pageTableTensor,
       /*batch_offset=*/0,
       /*compute_kernel_config*/ std::nullopt,
-      /*mesh_coords*/ std::nullopt);
+      /*mesh_coords*/ meshCoords);
 }
 } // namespace tt::runtime::ttnn::operations::kv_cache

--- a/runtime/lib/ttnn/operations/kv_cache/paged_update_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/paged_update_cache.cpp
@@ -38,6 +38,10 @@ void run(const ::tt::target::ttnn::PagedUpdateCacheOp *op,
   // the mesh root only - so per-rank cache writes from non-root devices are
   // silently dropped. Per-rank divergent updates require one program per
   // mesh coordinate, which is what the MeshWorkloadFactory provides.
+  //
+  // TODO(#47955): ttnn could infer these coords from the cache tensor (it is
+  // already an op input) and select the MeshWorkloadFactory by default, letting
+  // us drop this explicit pass. Tracked in tenstorrent/tt-metal#47955.
   const auto &coordVec = cacheTensor.tensor_topology().mesh_coords();
   std::set<::ttnn::MeshCoordinate> meshCoords(coordVec.begin(), coordVec.end());
 

--- a/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/paged_attention.mlir
+++ b/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/paged_attention.mlir
@@ -101,3 +101,24 @@ module @PagedFillCacheSeqlenSharding attributes {mhlo.cross_program_prefetches =
     return %2 : tensor<4x16x32x16xbf16>
   }
 }
+
+// -----
+
+// When an attention_mask is present (has_attention_mask = "True"), the optional
+// cur_pos_tensor shifts from operand index 4 to index 5. The users factor must
+// still attach to cur_pos (and page_table), NOT to the attention_mask: the mask
+// stays replicated (full tensor<2x12x1x32xbf16>) while the head dim shards
+// 12 -> 6. This guards the operand-index logic in getPagedAttentionShardingRule.
+module @PagedSDPADecodeWithMaskQUserSharding attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<2xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_0"}, %arg1: tensor<2x4xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_1"}, %arg2: tensor<8x12x32x16xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_2"}, %arg3: tensor<8x12x32x16xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_3"}, %arg4: tensor<1x2x12x16xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_4"}, %arg5: tensor<2x12x1x32xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_5"}) -> tensor<1x2x12x16xbf16> {
+    %0 = stablehlo.reshape %arg1 : (tensor<2x4xi64>) -> tensor<1x2x4xi64>
+    %1 = stablehlo.reshape %0 : (tensor<1x2x4xi64>) -> tensor<2x4xi64>
+    %2 = stablehlo.reshape %arg0 : (tensor<2xi64>) -> tensor<1x1x2xi64>
+    %3 = stablehlo.reshape %2 : (tensor<1x1x2xi64>) -> tensor<2xi64>
+    // CHECK: stablehlo.custom_call @tt.paged_scaled_dot_product_attention_decode
+    // CHECK-SAME: tensor<1x2x6x16xbf16>, tensor<8x6x32x16xbf16>, tensor<8x6x32x16xbf16>, tensor<2x4xi64>, tensor<2x12x1x32xbf16>, tensor<2xi64>
+    // CHECK-SAME: -> tensor<1x2x6x16xbf16>
+    %4 = stablehlo.custom_call @tt.paged_scaled_dot_product_attention_decode(%arg4, %arg3, %arg2, %1, %arg5, %3) {api_version = 0 : i32, mhlo.frontend_attributes = {has_attention_mask = "True", has_attention_sink = "False", has_cur_pos_tensor = "True", is_causal = "False", scale = "1.0"}} : (tensor<1x2x12x16xbf16>, tensor<8x12x32x16xbf16>, tensor<8x12x32x16xbf16>, tensor<2x4xi64>, tensor<2x12x1x32xbf16>, tensor<2xi64>) -> tensor<1x2x12x16xbf16>
+    return %4 : tensor<1x2x12x16xbf16>
+  }
+}


### PR DESCRIPTION
## Summary
- Add users-dim factor to Shardy custom sharding rules for `paged_update_cache`, `paged_fill_cache`, and `paged_scaled_dot_product_attention_decode` so the SPMD partitioner can keep each DP replica's cache update local (KV cache corruption across replicas otherwise).
- Force `MeshWorkloadFactory` for `paged_update_cache` and `paged_fill_cache` by passing the cache tensor's full set of mesh coords, so the mesh-aware factory is always selected under DP partitioning.
- Drop unused `buildHeadShardedCustomCallRule` helper (all three paged ops now inline their builders).

Co-authored with @ssaliceTT, who rebased on top of the tt-mlir commit pinned by tt-xla `main` (`464a5f341`) and added the `paged_fill_cache` rule update.

## Test plan
- Exercised by tt-xla DP+TP integration tests on n300-llmbox (tt-xla PR tenstorrent/tt-xla#4947, CI green against this tt-mlir tree).
- tt-mlir unit tests pass.