### PR TITLE
[OpModel] Clear cache when MLIR context changes

### DIFF
--- a/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
@@ -94,6 +94,14 @@ public:
   llvm::Expected<ValueT> getOrCompute(Callable &&computeFunc, Operation *op,
                                       Args &&...args) {
     assert(op != nullptr);
+    // Cached values may contain MLIR attributes/types, which are owned by the
+    // MLIRContext that created them. Drop entries before crossing context
+    // boundaries.
+    MLIRContext *opContext = op->getContext();
+    if (opContext != context) {
+      clear();
+      context = opContext;
+    }
 #ifdef TTMLIR_ENABLE_OPMODEL
     // Cached entries are computed against the active device's grid. If the
     // device session's grid changed, drop the now-stale entries. The device
@@ -169,6 +177,8 @@ private:
 
   Cache cache;
   CacheStats stats;
+  // MLIR context that owns any attributes/types stored in cached values.
+  MLIRContext *context = nullptr;
   // Device generation this cache was last filled under; see getOrCompute.
   uint64_t generation = 0;
 };


### PR DESCRIPTION
### Problem description

We're seeing frequent CI failures in `test_sdpa_fusing.py::test_sdpa_post_scale_simple`, example: https://github.com/tenstorrent/tt-mlir/actions/runs/27430698945/job/81084227609

To reproduce locally:

```bash
pip install pytest-repeat
pytest -v -s --count=50 test/python/golden/ttir_ops/fusing/test_sdpa_fusing.py::test_sdpa_post_scale_simple
```

Cause: the TTNN OpModel cache is process-global, but the `OpConstraints` it caches contains `TTNNLayoutAttr` handles, which are technically owned by the `MLIRContext`.

For real world usage this is benign since all the modules are under the same compilation context. But builder tests create a fresh context in `build_module()` for each test case, and call `gc.collect()` to cleanup these objects after each compile-execute call.

In a long-running compiler process, after the old MLIR context has gone out of scope, the greedy layout propagation might hit a stale cache entry and call `layout.hasL1BufferType()`, leading to a segfault.

### What's changed

Clear the OpModel cache when `op->getContext()` changes.