### PR TITLE
[Optimizer] Cache validateReshard results in addReshardCandidates fanout

### DIFF
--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -856,8 +856,7 @@ void MemoryLayoutPropagation::addReshardCandidates(
     if (candidates.size() >= maxCandidates) {
       break;
     }
-    // Skip redundant validateReshard calls: multiple beam entries can share the
-    // same producerOutput layout, making (producerOutput, reshardLayout) repeat.
+    // Avoid repeated validateReshard for beam entries sharing a producerOutput.
     llvm::SmallVector<std::pair<TTNNLayoutAttr, bool>, 8> validationCache;
     for (size_t pIdx = 0; pIdx < producerBeamSize; ++pIdx) {
       if (candidates.size() >= maxCandidates) {

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -856,6 +856,9 @@ void MemoryLayoutPropagation::addReshardCandidates(
     if (candidates.size() >= maxCandidates) {
       break;
     }
+    // Skip redundant validateReshard calls: multiple beam entries can share the
+    // same producerOutput layout, making (producerOutput, reshardLayout) repeat.
+    llvm::SmallVector<std::pair<TTNNLayoutAttr, bool>, 8> validationCache;
     for (size_t pIdx = 0; pIdx < producerBeamSize; ++pIdx) {
       if (candidates.size() >= maxCandidates) {
         break;
@@ -872,8 +875,21 @@ void MemoryLayoutPropagation::addReshardCandidates(
       if (!producerOutput) {
         continue;
       }
-      if (!validateReshard(op, tensorType.getShape(), producerOutput,
-                           reshardLayout)) {
+      bool valid = false;
+      bool found = false;
+      for (const auto &[cachedLayout, cachedValid] : validationCache) {
+        if (cachedLayout == producerOutput) {
+          valid = cachedValid;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        valid = validateReshard(op, tensorType.getShape(), producerOutput,
+                                reshardLayout);
+        validationCache.push_back({producerOutput, valid});
+      }
+      if (!valid) {
         continue;
       }
       InputCandidate ic;

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -879,8 +879,7 @@ void MemoryLayoutPropagation::addReshardCandidates(
         it->second = validateReshard(op, tensorType.getShape(), producerOutput,
                                      reshardLayout);
       }
-      bool valid = it->second;
-      if (!valid) {
+      if (!it->second) {
         continue;
       }
       InputCandidate ic;

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -857,7 +857,7 @@ void MemoryLayoutPropagation::addReshardCandidates(
       break;
     }
     // Avoid repeated validateReshard for beam entries sharing a producerOutput.
-    llvm::SmallVector<std::pair<TTNNLayoutAttr, bool>, 8> validationCache;
+    llvm::SmallDenseMap<TTNNLayoutAttr, bool, 8> validationCache;
     for (size_t pIdx = 0; pIdx < producerBeamSize; ++pIdx) {
       if (candidates.size() >= maxCandidates) {
         break;
@@ -874,20 +874,12 @@ void MemoryLayoutPropagation::addReshardCandidates(
       if (!producerOutput) {
         continue;
       }
-      bool valid = false;
-      bool found = false;
-      for (const auto &[cachedLayout, cachedValid] : validationCache) {
-        if (cachedLayout == producerOutput) {
-          valid = cachedValid;
-          found = true;
-          break;
-        }
+      auto [it, inserted] = validationCache.try_emplace(producerOutput, false);
+      if (inserted) {
+        it->second = validateReshard(op, tensorType.getShape(), producerOutput,
+                                     reshardLayout);
       }
-      if (!found) {
-        valid = validateReshard(op, tensorType.getShape(), producerOutput,
-                                reshardLayout);
-        validationCache.push_back({producerOutput, valid});
-      }
+      bool valid = it->second;
       if (!valid) {
         continue;
       }

--- a/test/unittests/Optimizer/TestReshardCandidates.cpp
+++ b/test/unittests/Optimizer/TestReshardCandidates.cpp
@@ -366,3 +366,53 @@ TEST_F(ReshardCandidatesTest, ReshardExplorationK1vsK8) {
   EXPECT_GE(candidatesK8, candidatesK1)
       << "K=8 should produce at least as many candidates as K=1";
 }
+
+TEST_F(ReshardCandidatesTest, ReshardCandidatesProducerIndicesInBounds) {
+  // Verify cache hits still emit candidates; a miss would leave
+  // producerCandidateIndices out of bounds.
+  llvm::SmallVector<int64_t> shape = {1, 1, 32, 32};
+  auto layout = createDRAMInterleavedLayout(shape);
+  auto tensorType =
+      mlir::RankedTensorType::get(shape, builder.getBF16Type(), layout);
+
+  createFuncOp({tensorType, tensorType}, {tensorType});
+  mlir::Value arg0 = func.getBody().front().getArgument(0);
+  mlir::Value arg1 = func.getBody().front().getArgument(1);
+
+  auto addOp =
+      builder.create<AddOp>(builder.getUnknownLoc(), tensorType, arg0, arg1);
+  auto reluOp = builder.create<ReluOp>(builder.getUnknownLoc(), tensorType,
+                                       addOp.getResult());
+  auto mulOp = builder.create<MultiplyOp>(builder.getUnknownLoc(), tensorType,
+                                          reluOp.getResult(), arg1);
+  builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(),
+                                       mulOp.getResult());
+
+  llvm::DenseMap<mlir::Operation *, std::vector<OpConfig>> legalConfigs;
+  legalConfigs[addOp.getOperation()] = createElementwiseLegalConfigs(shape);
+  legalConfigs[reluOp.getOperation()] = createElementwiseLegalConfigs(shape);
+  legalConfigs[mulOp.getOperation()] = createElementwiseLegalConfigs(shape);
+
+  auto bareType = mlir::RankedTensorType::get(shape, builder.getBF16Type());
+  TensorTypeLayoutsMap tensorLayouts =
+      buildTensorTypeLayoutsMap(bareType, shape);
+
+  constexpr size_t kBeamWidth = 8;
+  MemoryLayoutPropagation propagation(func, legalConfigs, &tensorLayouts,
+                                      kBeamWidth);
+  propagation.run();
+
+  const auto &beamState = propagation.getBeamState();
+  for (const auto &[op, candidates] : beamState) {
+    for (const auto &candidate : candidates) {
+      for (size_t opIdx = 0;
+           opIdx < candidate.producerCandidateIndices.size(); ++opIdx) {
+        if (candidate.reshardLayouts.count(opIdx) == 0) {
+          continue;
+        }
+        EXPECT_LT(candidate.producerCandidateIndices[opIdx], kBeamWidth)
+            << "Reshard candidate has out-of-bounds producerCandidateIndex";
+      }
+    }
+  }
+}

--- a/test/unittests/Optimizer/TestReshardCandidates.cpp
+++ b/test/unittests/Optimizer/TestReshardCandidates.cpp
@@ -368,8 +368,7 @@ TEST_F(ReshardCandidatesTest, ReshardExplorationK1vsK8) {
 }
 
 TEST_F(ReshardCandidatesTest, ReshardCandidatesProducerIndicesInBounds) {
-  // Verify cache hits still emit candidates; a miss would leave
-  // producerCandidateIndices out of bounds.
+  // Verify reshard candidates have in-bounds producerCandidateIndices.
   llvm::SmallVector<int64_t> shape = {1, 1, 32, 32};
   auto layout = createDRAMInterleavedLayout(shape);
   auto tensorType =
@@ -405,8 +404,8 @@ TEST_F(ReshardCandidatesTest, ReshardCandidatesProducerIndicesInBounds) {
   const auto &beamState = propagation.getBeamState();
   for (const auto &[op, candidates] : beamState) {
     for (const auto &candidate : candidates) {
-      for (size_t opIdx = 0;
-           opIdx < candidate.producerCandidateIndices.size(); ++opIdx) {
+      for (size_t opIdx = 0; opIdx < candidate.producerCandidateIndices.size();
+           ++opIdx) {
         if (candidate.reshardLayouts.count(opIdx) == 0) {
           continue;
         }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/7767


### Problem description
In [addReshardCandidates](https://github.com/tenstorrent/tt-mlir/blob/84c6565bdf585659d6effb65343301e1826dd858/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp#L748), the fan-out loop [calls validateReshard()](https://github.com/tenstorrent/tt-mlir/blob/84c6565bdf585659d6effb65343301e1826dd858/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp#L877) once per (reshardLayout, producerBeamIndex) pair. When multiple beam entries share the same producer output layout, [redundant OpModel backend queries are made](https://github.com/tenstorrent/tt-mlir/blob/84c6565bdf585659d6effb65343301e1826dd858/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp#L650).

### What's changed

Add a per-producerOutput cache scoped to each reshardLayout iteration of the fan-out, so a repeated (producerOutput, reshardLayout) pair reuses the first `validateReshard()` result instead of re-querying.

One InputCandidate is still emitted per producer beam index, so the producerCandidateIndex mapping consumed by consolidateBeam/resolveForForkPoint is unchanged. Since it only skips queries that would return the same result, the emitted IR is identical, confirmed by the optimizer lit suite passing with unchanged FileCheck assertions:

```
llvm-lit test/ttmlir/Dialect/TTNN/optimizer/
Testing Time: 42.09s

Total Discovered Tests: 53
  Unsupported      :  2 (3.77%)
  Passed           : 48 (90.57%)
  Expectedly Failed:  3 (5.66%)
```

0 unexpected failures. The 3 XFAILs (incl. test_override_reshard_edges.mlir) are pre-existing and unrelated.

#### Impact

To get the following table's results, I added temporary [RSH-MISS]/[RSH-HIT] logging in the cache branch (not committed), counted per file:

```
for f in test/ttmlir/Dialect/TTNN/optimizer/*.mlir; do
  miss=$(./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" "$f" 2>&1 >/dev/null | grep -c RSH-MISS)
  hit=$(./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" "$f" 2>&1 >/dev/null | grep -c RSH-HIT)
  echo "$f before=$((miss+hit)) after=$miss redundant=$hit"
done
```

| File | Before | After | Redundant | Reduction |
|------|--------|-------|-----------|-----------|
| threeway_merge_fragmentation_rejection | 224 | 106 | 118 | 53% |
| d2m_greedy_optimizer_linear_chain | 168 | 66 | 102 | 61% |
| max_legal_layouts_override_32 | 120 | 36 | 84 | 70% |
| scalar_tensor | 108 | 30 | 78 | 72% |
| output_layout_override | 113 | 43 | 70 | 62% |
| d2m_greedy_optimizer_fork_join | 120 | 60 | 60 | 50% |
| d2m_optimizer_two_d2m_subgraphs | 145 | 95 | 50 | 34% |
| d2m_greedy_optimizer_nd_bcast | 49 | 29 | 20 | 41% |
| matmul_program_config | 72 | 54 | 18 | 25% |
| insert_memreconfig | 25 | 11 | 14 | 56% |
| sharding_matmul_override_0 | 49 | 39 | 10 | 20% |
| argmax_datatype_conversion | 3 | 3 | 0 | 0% |
| conv2d_config_override | 24 | 24 | 0 | 0% |
| conv2d_l1_oom_fallback | 23 | 23 | 0 | 0% |
| d2m_optimizer_fork_join | 0 | 0 | 0 | — |
| d2m_optimizer_linear_chain | 0 | 0 | 0 | — |
| input_layout_loc_override | 9 | 9 | 0 | 0% |
| insert_memreconfig_const_eval | 0 | 0 | 0 | — |
| integer_input_rm_prop | 3 | 3 | 0 | 0% |
| kv_cache_argument_type | 14 | 14 | 0 | 0% |
| multiple_add_with_loc | 15 | 15 | 0 | 0% |
| partial_output_layout_override | 9 | 9 | 0 | 0% |
| rope | 0 | 0 | 0 | — |
| rope_key_llama3.2_sharding | 20 | 20 | 0 | 0% |
| rope_query_llama3.2_sharding | 10 | 10 | 0 | 0% |
| test_override_reshard_edges | 0 | 0 | 0 | — |
| ttir_to_ttnn_pipeline | 18 | 18 | 0 | 0% |
| **Total** | **1341** | **717** | **624** | **47%** |

### Notes

- As documented [here](https://github.com/tenstorrent/tt-mlir/issues/7767#issuecomment-4640164225), `addL1InterleavedFallbacks` has the same validateReshard fan-out pattern and shows similar redundancy. Left out of scope here to keep this focused on the issue; happy to follow up separately.
- Added `ReshardCandidatesProducerIndicesInBounds` to test/unittests/Optimizer/TestReshardCandidates.cpp, which asserts every reshard candidate keeps an in-bounds producerCandidateIndex, the invariant the cache must preserve. **I have not yet run this test on TT silicon due to the following abort, so I am depending on CI to validate the new test.**

```
[ RUN      ] ReshardCandidatesTest.WithTensorLayoutsMapDoesNotCrash
TT_FATAL @ .../tt_metal/llrt/tt_cluster.cpp:122: num_chips > 0
No chips detected in the cluster
#21 ReshardCandidatesTest::SetUp()
Aborted (core dumped)
```

### Checklist
- [x] New/Existing tests provide coverage for changes
