### PR TITLE
[TTNN] Add chunked_scaled_dot_product_attention op for chunked prefill

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6161,6 +6161,41 @@ def TTIR_PagedScaledDotProductAttentionDecodeOp : TTIR_NamedOp<"paged_scaled_dot
   let hasVerifier = 1;
 }
 
+def TTIR_ChunkedScaledDotProductAttentionOp : TTIR_NamedOp<"chunked_scaled_dot_product_attention"> {
+  let summary = "Chunked prefill scaled dot product attention over a paged KV cache.";
+  let description = [{
+    Chunked-prefill attention (tt-xla #4986). A prefill chunk of `query` attends
+    causally over the prefix tokens `[0, chunk_start_idx + chunk_len)` that are
+    resident in the paged K/V cache, read on device via `page_table`. The prefix
+    offset is supplied by the device tensor `chunk_start_idx` (`[1]` int32), so the
+    op is trace-compatible (page table consumed on device). Causal masking is
+    handled internally; no host attention mask.
+
+    Args:
+        query (AnyRankedTensor): `[B x Hq x chunk_len x D]`.
+        key (AnyRankedTensor): paged K cache `[num_blocks x Hkv x block_size x D]`.
+        value (AnyRankedTensor): paged V cache, same layout as `key`.
+        page_table (AnyRankedTensor): `[B x num_blocks_per_user]` int32.
+        chunk_start_idx (AnyRankedTensor): `[1]` int32 prefix offset.
+        scale (float, optional): Softmax scale. Defaults to `1 / sqrt(D)`.
+
+    Returns:
+        AnyRankedTensor: same shape/type as `query`.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$query,
+                       AnyRankedTensor:$key,
+                       AnyRankedTensor:$value,
+                       AnyRankedTensor:$page_table,
+                       AnyRankedTensor:$chunk_start_idx,
+                       AnyRankedTensor:$output,
+                       OptionalAttr<F32Attr>:$scale);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 0;
+}
+
 def TTIR_PagedFlashMultiLatentAttentionDecodeOp : TTIR_NamedOp<"paged_flash_multi_latent_attention_decode", [AttrSizedOperandSegments]> {
   let summary = "Paged flash multi-latent attention decode operation.";
   let description = [{

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6164,7 +6164,7 @@ def TTIR_PagedScaledDotProductAttentionDecodeOp : TTIR_NamedOp<"paged_scaled_dot
 def TTIR_ChunkedScaledDotProductAttentionOp : TTIR_NamedOp<"chunked_scaled_dot_product_attention"> {
   let summary = "Chunked prefill scaled dot product attention over a paged KV cache.";
   let description = [{
-    Chunked-prefill attention (tt-xla #4986). A prefill chunk of `query` attends
+    Chunked-prefill attention. A prefill chunk of `query` attends
     causally over the prefix tokens `[0, chunk_start_idx + chunk_len)` that are
     resident in the paged K/V cache, read on device via `page_table`. The prefix
     offset is supplied by the device tensor `chunk_start_idx` (`[1]` int32), so the

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6167,9 +6167,8 @@ def TTIR_ChunkedScaledDotProductAttentionOp : TTIR_NamedOp<"chunked_scaled_dot_p
     Chunked-prefill attention. A prefill chunk of `query` attends
     causally over the prefix tokens `[0, chunk_start_idx + chunk_len)` that are
     resident in the paged K/V cache, read on device via `page_table`. The prefix
-    offset is supplied by the device tensor `chunk_start_idx` (`[1]` int32), so the
-    op is trace-compatible (page table consumed on device). Causal masking is
-    handled internally; no host attention mask.
+    offset is supplied by the device tensor `chunk_start_idx` (`[1]` int32). Causal
+    masking is handled internally; no host attention mask.
 
     Args:
         query (AnyRankedTensor): `[B x Hq x chunk_len x D]`.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6193,7 +6193,7 @@ def TTIR_ChunkedScaledDotProductAttentionOp : TTIR_NamedOp<"chunked_scaled_dot_p
 
   let results = (outs AnyRankedTensor:$result);
 
-  let hasVerifier = 0;
+  let hasVerifier = 1;
 }
 
 def TTIR_PagedFlashMultiLatentAttentionDecodeOp : TTIR_NamedOp<"paged_flash_multi_latent_attention_decode", [AttrSizedOperandSegments]> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3869,7 +3869,7 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
 def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_product_attention", [OpModelExempt]> {
   let summary = "Chunked prefill scaled dot product attention over a paged KV cache.";
   let description = [{
-    Chunked-prefill attention (tt-xla #4986). A prefill chunk of `query` attends
+    Chunked-prefill attention. A prefill chunk of `query` attends
     causally over the prefix `[0, chunk_start_idx + chunk_len)` resident in the
     paged K/V cache, read on device via `page_table`, with the prefix offset given
     by the device tensor `chunk_start_idx` (`[1]` int32). Trace-compatible.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3891,7 +3891,7 @@ def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_produc
     }
   }];
 
-  let hasVerifier = 0;
+  let hasVerifier = 1;
 }
 
 def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_latent_attention_decode", [AttrSizedOperandSegments]> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3872,7 +3872,12 @@ def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_produc
     Chunked-prefill attention. A prefill chunk of `query` attends
     causally over the prefix `[0, chunk_start_idx + chunk_len)` resident in the
     paged K/V cache, read on device via `page_table`, with the prefix offset given
-    by the device tensor `chunk_start_idx` (`[1]` int32). Trace-compatible.
+    by the device tensor `chunk_start_idx` (`[1]` int32).
+
+    Because the prefix offset is a device tensor (not a host scalar) and the page
+    table is consumed on device, the op holds no host-side state: it can be
+    captured inside a trace and replayed across invocations with a different
+    `chunk_start_idx` without recompiling.
   }];
 
   let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3866,6 +3866,34 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
   let hasVerifier = 1;
 }
 
+def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_product_attention", [OpModelExempt]> {
+  let summary = "Chunked prefill scaled dot product attention over a paged KV cache.";
+  let description = [{
+    Chunked-prefill attention (tt-xla #4986). A prefill chunk of `query` attends
+    causally over the prefix `[0, chunk_start_idx + chunk_len)` resident in the
+    paged K/V cache, read on device via `page_table`, with the prefix offset given
+    by the device tensor `chunk_start_idx` (`[1]` int32). Trace-compatible.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$query,
+                       AnyRankedTensor:$key,
+                       AnyRankedTensor:$value,
+                       AnyRankedTensor:$page_table,
+                       AnyRankedTensor:$chunk_start_idx,
+                       OptionalAttr<F32Attr>:$scale,
+                       OptionalAttr<TTNN_SDPAProgramConfigAttr>:$program_config);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+      return wa::TTNNOperandsWorkaroundsFactory::createChunkedScaledDotProductAttentionOpOperandsWorkarounds(getOperation());
+    }
+  }];
+
+  let hasVerifier = 0;
+}
+
 def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_latent_attention_decode", [AttrSizedOperandSegments]> {
   let summary = "Paged flash multi-latent attention decode operation.";
   let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -370,6 +370,9 @@ public:
       Operation *op);
 
   static TTNNOperandsWorkarounds
+  createChunkedScaledDotProductAttentionOpOperandsWorkarounds(Operation *op);
+
+  static TTNNOperandsWorkarounds
   createPagedFlashMultiLatentAttentionDecodeOpOperandsWorkarounds(
       Operation *op);
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -369,6 +369,11 @@ public:
   createPagedScaledDotProductAttentionDecodeOpOperandsWorkarounds(
       Operation *op);
 
+  // TODO(#8842): The ROW_MAJOR coercion of page_table /
+  // chunk_start_idx / cur_pos_tensor for the chunked and paged SDPA decode
+  // factories below is a permanent tt-metal kernel ABI, not a temporary
+  // workaround. Move it to TTNNLayout's shouldForceInputRowMajor (this op and
+  // the paged SDPA decode op above) and drop these factories.
   static TTNNOperandsWorkarounds
   createChunkedScaledDotProductAttentionOpOperandsWorkarounds(Operation *op);
 

--- a/include/ttmlir/Target/TTNN/operations/transformer.fbs
+++ b/include/ttmlir/Target/TTNN/operations/transformer.fbs
@@ -133,6 +133,18 @@ table PagedScaledDotProductAttentionDecodeOp {
   program_config: tt.target.ttnn.SDPAConfig;
 }
 
+table ChunkedScaledDotProductAttentionOp {
+  query: tt.target.ttnn.TensorRef;
+  key: tt.target.ttnn.TensorRef;
+  value: tt.target.ttnn.TensorRef;
+  page_table: tt.target.ttnn.TensorRef;
+  chunk_start_idx: tt.target.ttnn.TensorRef;
+  scale: float = null;
+  out: tt.target.ttnn.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+  program_config: tt.target.ttnn.SDPAConfig;
+}
+
 table PagedFlashMultiLatentAttentionDecodeOp {
   query: tt.target.ttnn.TensorRef;
   key: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -47,6 +47,7 @@ union OpType {
   BitcastConvertOp,
   BeginTraceCaptureOp,
   CaptureOrExecuteTraceOp,
+  ChunkedScaledDotProductAttentionOp,
   ConcatOp,
   ConcatenateHeadsOp,
   RotaryEmbeddingLlamaOp,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -8618,6 +8618,61 @@ public:
 } // namespace
 
 namespace {
+class StableHLOToTTIRChunkedScaledDotProductAttentionOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
+  using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CustomCallOp srcOp,
+                  mlir::stablehlo::CustomCallOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    StringAttr funcName = adaptor.getCallTargetNameAttr();
+    if (funcName != "tt.chunked_scaled_dot_product_attention") {
+      return failure();
+    }
+
+    // scale is the only (optional) frontend attribute; causal masking is
+    // internal and there are no optional operands.
+    FloatAttr scaleAttr = nullptr;
+    mlir::DictionaryAttr frontendAttributes =
+        mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+            srcOp->getDiscardableAttr("mhlo.frontend_attributes"));
+    if (frontendAttributes) {
+      auto scaleStringAttr =
+          frontendAttributes.getAs<mlir::StringAttr>("scale");
+      if (scaleStringAttr) {
+        float scale;
+        if (failed(parseFloatFromStringAttr(scaleStringAttr, scale))) {
+          return rewriter.notifyMatchFailure(
+              srcOp, "Failed to parse scale attribute.");
+        }
+        scaleAttr = rewriter.getF32FloatAttr(scale);
+      }
+    }
+
+    Value query = adaptor.getOperands()[0];
+    Value key = adaptor.getOperands()[1];
+    Value value = adaptor.getOperands()[2];
+    Value pageTable = adaptor.getOperands()[3];
+    Value chunkStartIdx = adaptor.getOperands()[4];
+
+    RankedTensorType outputType = cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult(0).getType()));
+    ttir::EmptyOp outputTensor = rewriter.create<ttir::EmptyOp>(
+        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+
+    rewriter
+        .replaceOpWithNewOp<mlir::tt::ttir::ChunkedScaledDotProductAttentionOp>(
+            srcOp, outputType, query, key, value, pageTable, chunkStartIdx,
+            outputTensor, scaleAttr);
+
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class StableHLOToTTIROpOptimizationBarrierOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::OptimizationBarrierOp> {
   using OpConversionPattern<
@@ -9624,7 +9679,9 @@ static void addScaledDotProductAttentionDecodeOpConversionPattern(
       StableHLOToTTIRScaledDotProductAttentionDecodeOpConversionPattern,
       StableHLOToTTIRScaledDotProductAttentionOpConversionPattern,
       StableHLOToTTIRPagedScaledDotProductAttentionDecodeOpConversionPattern,
-      StableHLOToTTCoreFlashMlaPrefillOpConversionPattern>(typeConverter, ctx);
+      StableHLOToTTCoreFlashMlaPrefillOpConversionPattern,
+      StableHLOToTTIRChunkedScaledDotProductAttentionOpConversionPattern>(
+      typeConverter, ctx);
 }
 
 namespace {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3233,6 +3233,27 @@ public:
 } // namespace
 
 namespace {
+class ChunkedScaledDotProductAttentionOpConversionPattern
+    : public OpConversionPattern<ttir::ChunkedScaledDotProductAttentionOp> {
+public:
+  using OpConversionPattern<
+      ttir::ChunkedScaledDotProductAttentionOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ttir::ChunkedScaledDotProductAttentionOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ttnn::ChunkedScaledDotProductAttentionOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getQuery(), adaptor.getKey(), adaptor.getValue(),
+        adaptor.getPageTable(), adaptor.getChunkStartIdx(),
+        adaptor.getScaleAttr(),
+        /*program_config=*/nullptr);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class PagedFlashMultiLatentAttentionDecodeOpConversionPattern
     : public OpConversionPattern<ttir::PagedFlashMultiLatentAttentionDecodeOp> {
 public:
@@ -3728,6 +3749,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            ScaledDotProductAttentionOpConversionPattern,
            ScaledDotProductAttentionDecodeOpConversionPattern,
            PagedScaledDotProductAttentionDecodeOpConversionPattern,
+           ChunkedScaledDotProductAttentionOpConversionPattern,
            PagedFlashMultiLatentAttentionDecodeOpConversionPattern,
            SplitQueryKeyValueAndSplitHeadsOpConversionPattern,
            GeluBackwardOpConversionPattern,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3587,8 +3587,6 @@ public:
         emitter(srcOp, adaptor, rewriter);
 
     // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
-    // Matches the "flexible" ttnn overload: the prefix offset is a device
-    // tensor (chunk_start_idx) rather than a scalar, so the op is trace-safe.
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getQuery()),
         emitter.emit(srcOp.getKey()),

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3560,6 +3560,56 @@ public:
 } // namespace
 
 namespace {
+class ChunkedScaledDotProductAttentionOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.chunked_scaled_dot_product_attention";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn::transformer::chunked_scaled_dot_product_attention";
+  }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp>::
+      TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<
+        mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
+    // Matches the "flexible" ttnn overload: the prefix offset is a device
+    // tensor (chunk_start_idx) rather than a scalar, so the op is trace-safe.
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getQuery()),
+        emitter.emit(srcOp.getKey()),
+        emitter.emit(srcOp.getValue()),
+        emitter.emit(srcOp.getPageTable()),
+        emitter.emit(srcOp.getChunkStartIdx()),
+        emitter.emit(srcOp.getScale()),
+        emitter.emit(srcOp.getMemoryConfig()),
+        emitter.emit(srcOp.getProgramConfig()),
+        emitter.emit(/*compute_kernel_config=*/std::nullopt),
+    };
+    // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class PagedFlashMultiLatentAttentionDecodeOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<
           mlir::tt::ttnn::PagedFlashMultiLatentAttentionDecodeOp> {
@@ -5701,6 +5751,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   patterns.add<RotaryEmbeddingOpConversionPattern>(typeConverter, ctx);
   patterns.add<NLPConcatHeadsDecodeOpConversionPattern>(typeConverter, ctx);
   patterns.add<PagedScaledDotProductAttentionDecodeOpConversionPattern>(
+      typeConverter, ctx);
+  patterns.add<ChunkedScaledDotProductAttentionOpConversionPattern>(
       typeConverter, ctx);
   patterns.add<PagedFlashMultiLatentAttentionDecodeOpConversionPattern>(
       typeConverter, ctx);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -4556,6 +4556,56 @@ public:
 };
 } // namespace
 
+// ChunkedScaledDotProductAttentionOp conversion pattern
+//
+namespace {
+class ChunkedScaledDotProductAttentionOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.chunked_scaled_dot_product_attention";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn.transformer.chunked_scaled_dot_product_attention";
+  }
+
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp>::
+      TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<
+        mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
+    // Flexible ttnn overload: chunk_start_idx is a device tensor (trace-safe).
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getQuery()),
+        emitter.emit(srcOp.getKey()),
+        emitter.emit(srcOp.getValue()),
+        emitter.emit(srcOp.getPageTable(), "page_table_tensor"),
+        emitter.emit(srcOp.getChunkStartIdx(), "chunk_start_idx_tensor"),
+        emitter.emit(srcOp.getScale(), "scale"),
+        emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
+        emitter.emit(srcOp.getProgramConfig(), "program_config"),
+    };
+    // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // PagedFlashMultiLatentAttentionDecodeOp conversion pattern
 //
 namespace {
@@ -5451,6 +5501,8 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<ScaledDotProductAttentionDecodeOpConversionPattern>(
       typeConverter, ctx);
   patterns.add<PagedScaledDotProductAttentionDecodeOpConversionPattern>(
+      typeConverter, ctx);
+  patterns.add<ChunkedScaledDotProductAttentionOpConversionPattern>(
       typeConverter, ctx);
   patterns.add<PagedFlashMultiLatentAttentionDecodeOpConversionPattern>(
       typeConverter, ctx);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -4586,7 +4586,6 @@ public:
         emitter(srcOp, adaptor, rewriter);
 
     // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
-    // Flexible ttnn overload: chunk_start_idx is a device tensor (trace-safe).
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getQuery()),
         emitter.emit(srcOp.getKey()),

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -521,6 +521,55 @@ static mlir::sdy::OpShardingRuleAttr buildHeadShardedCustomCallRule(
 
 // Dispatch function for paged attention CustomCall sharding rules.
 static mlir::sdy::OpShardingRuleAttr
+getChunkedSdpaShardingRule(mlir::stablehlo::CustomCallOp op) {
+  // Chunked prefill SDPA over paged K/V:
+  //  0: query  [num_users, num_heads, chunk_len, head_size]
+  //  1: key    [num_blocks_total, num_kv_heads, block_size, head_size]
+  //  2: value  [num_blocks_total, num_kv_heads, block_size, head_size]
+  //  3: page_table, 4: chunk_start_idx (null-shardable)
+  auto queryType = llvm::cast<RankedTensorType>(op.getOperand(0).getType());
+  auto keyType = llvm::cast<RankedTensorType>(op.getOperand(1).getType());
+  auto valueType = llvm::cast<RankedTensorType>(op.getOperand(2).getType());
+  auto outputType = llvm::cast<RankedTensorType>(op.getResult(0).getType());
+
+  if (queryType.getShape() != outputType.getShape()) {
+    op.getOperation()->emitWarning()
+        << "Chunked SDPA: query and output shapes must match.";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  llvm::SmallVector<RankedTensorType> qkvTypes = {queryType, keyType,
+                                                  valueType};
+  if (llvm::any_of(qkvTypes, [&](RankedTensorType type) {
+        return type.getRank() != 4;
+      })) {
+    op.getOperation()->emitWarning()
+        << "Chunked SDPA: unexpected Q/K/V layouts, q rank: "
+        << queryType.getRank() << ", key rank: " << keyType.getRank()
+        << ", value rank: " << valueType.getRank();
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  // Query [U, H, chunk_len, D], K/V [B, H, S, D], and output all carry the
+  // head dim at index 1.
+  const int64_t headDim = 1;
+
+  int64_t headSize = queryType.getShape()[headDim];
+
+  SmallVector<int64_t> operandHeadDims(op.getNumOperands(),
+                                       mlir::sdy::kNullDim);
+  SmallVector<int64_t> resultHeadDims(op.getNumResults(), mlir::sdy::kNullDim);
+
+  operandHeadDims[0] = headDim; // query
+  operandHeadDims[1] = headDim; // key
+  operandHeadDims[2] = headDim; // value
+  resultHeadDims[0] = headDim;  // output
+
+  return buildHeadShardedCustomCallRule(op, operandHeadDims, resultHeadDims,
+                                        headSize);
+}
+
+static mlir::sdy::OpShardingRuleAttr
 getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
   llvm::StringRef target = op.getCallTargetName();
 
@@ -574,52 +623,7 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
   }
 
   if (target == chunkedSdpaTargetName) {
-    // Chunked prefill SDPA over paged K/V:
-    //  0: query  [num_users, num_heads, chunk_len, head_size]
-    //  1: key    [num_blocks_total, num_kv_heads, block_size, head_size]
-    //  2: value  [num_blocks_total, num_kv_heads, block_size, head_size]
-    //  3: page_table, 4: chunk_start_idx (null-shardable)
-    auto queryType = llvm::cast<RankedTensorType>(op.getOperand(0).getType());
-    auto keyType = llvm::cast<RankedTensorType>(op.getOperand(1).getType());
-    auto valueType = llvm::cast<RankedTensorType>(op.getOperand(2).getType());
-    auto outputType = llvm::cast<RankedTensorType>(op.getResult(0).getType());
-
-    if (queryType.getShape() != outputType.getShape()) {
-      op.getOperation()->emitWarning()
-          << "Chunked SDPA: query and output shapes must match.";
-      return mlir::sdy::OpShardingRuleAttr();
-    }
-
-    llvm::SmallVector<RankedTensorType> qkvTypes = {queryType, keyType,
-                                                    valueType};
-    if (llvm::any_of(qkvTypes, [&](RankedTensorType type) {
-          return type.getRank() != 4;
-        })) {
-      op.getOperation()->emitWarning()
-          << "Chunked SDPA: unexpected Q/K/V layouts, q rank: "
-          << queryType.getRank() << ", key rank: " << keyType.getRank()
-          << ", value rank: " << valueType.getRank();
-      return mlir::sdy::OpShardingRuleAttr();
-    }
-
-    // Query [U, H, chunk_len, D], K/V [B, H, S, D], and output all carry the
-    // head dim at index 1.
-    const int64_t headDim = 1;
-
-    int64_t headSize = queryType.getShape()[headDim];
-
-    SmallVector<int64_t> operandHeadDims(op.getNumOperands(),
-                                         mlir::sdy::kNullDim);
-    SmallVector<int64_t> resultHeadDims(op.getNumResults(),
-                                        mlir::sdy::kNullDim);
-
-    operandHeadDims[0] = headDim; // query
-    operandHeadDims[1] = headDim; // key
-    operandHeadDims[2] = headDim; // value
-    resultHeadDims[0] = headDim;  // output
-
-    return buildHeadShardedCustomCallRule(op, operandHeadDims, resultHeadDims,
-                                          headSize);
+    return getChunkedSdpaShardingRule(op);
   }
 
   if (target == pagedUpdateCacheTargetName) {

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -602,21 +602,21 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
       return mlir::sdy::OpShardingRuleAttr();
     }
 
-    const int64_t queryHeadDim = 1; // [U, H, chunk_len, D]
-    const int64_t kvHeadDim = 1;    // [B, H, S, D]
-    const int64_t outputHeadDim = 1;
+    // Query [U, H, chunk_len, D], K/V [B, H, S, D], and output all carry the
+    // head dim at index 1.
+    const int64_t headDim = 1;
 
-    int64_t headSize = queryType.getShape()[queryHeadDim];
+    int64_t headSize = queryType.getShape()[headDim];
 
     SmallVector<int64_t> operandHeadDims(op.getNumOperands(),
                                          mlir::sdy::kNullDim);
     SmallVector<int64_t> resultHeadDims(op.getNumResults(),
                                         mlir::sdy::kNullDim);
 
-    operandHeadDims[0] = queryHeadDim; // query
-    operandHeadDims[1] = kvHeadDim;    // key
-    operandHeadDims[2] = kvHeadDim;    // value
-    resultHeadDims[0] = outputHeadDim; // output
+    operandHeadDims[0] = headDim; // query
+    operandHeadDims[1] = headDim; // key
+    operandHeadDims[2] = headDim; // value
+    resultHeadDims[0] = headDim;  // output
 
     return buildHeadShardedCustomCallRule(op, operandHeadDims, resultHeadDims,
                                           headSize);

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -21,6 +21,9 @@ static constexpr llvm::StringLiteral sdpaTargetName =
 static constexpr llvm::StringLiteral pagedSdpaDecodeTargetName =
     "tt.paged_scaled_dot_product_attention_decode";
 
+static constexpr llvm::StringLiteral chunkedSdpaTargetName =
+    "tt.chunked_scaled_dot_product_attention";
+
 static constexpr llvm::StringLiteral pagedUpdateCacheTargetName =
     "tt.paged_update_cache";
 
@@ -553,6 +556,55 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
     const int64_t queryHeadDim = 2; // [1, U, H, D]
     const int64_t kvHeadDim = 1;    // [B, H, S, D]
     const int64_t outputHeadDim = 2;
+
+    int64_t headSize = queryType.getShape()[queryHeadDim];
+
+    SmallVector<int64_t> operandHeadDims(op.getNumOperands(),
+                                         mlir::sdy::kNullDim);
+    SmallVector<int64_t> resultHeadDims(op.getNumResults(),
+                                        mlir::sdy::kNullDim);
+
+    operandHeadDims[0] = queryHeadDim; // query
+    operandHeadDims[1] = kvHeadDim;    // key
+    operandHeadDims[2] = kvHeadDim;    // value
+    resultHeadDims[0] = outputHeadDim; // output
+
+    return buildHeadShardedCustomCallRule(op, operandHeadDims, resultHeadDims,
+                                          headSize);
+  }
+
+  if (target == chunkedSdpaTargetName) {
+    // Chunked prefill SDPA over paged K/V:
+    //  0: query  [num_users, num_heads, chunk_len, head_size]
+    //  1: key    [num_blocks_total, num_kv_heads, block_size, head_size]
+    //  2: value  [num_blocks_total, num_kv_heads, block_size, head_size]
+    //  3: page_table, 4: chunk_start_idx (null-shardable)
+    auto queryType = llvm::cast<RankedTensorType>(op.getOperand(0).getType());
+    auto keyType = llvm::cast<RankedTensorType>(op.getOperand(1).getType());
+    auto valueType = llvm::cast<RankedTensorType>(op.getOperand(2).getType());
+    auto outputType = llvm::cast<RankedTensorType>(op.getResult(0).getType());
+
+    if (queryType.getShape() != outputType.getShape()) {
+      op.getOperation()->emitWarning()
+          << "Chunked SDPA: query and output shapes must match.";
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+
+    llvm::SmallVector<RankedTensorType> qkvTypes = {queryType, keyType,
+                                                    valueType};
+    if (llvm::any_of(qkvTypes, [&](RankedTensorType type) {
+          return type.getRank() != 4;
+        })) {
+      op.getOperation()->emitWarning()
+          << "Chunked SDPA: unexpected Q/K/V layouts, q rank: "
+          << queryType.getRank() << ", key rank: " << keyType.getRank()
+          << ", value rank: " << valueType.getRank();
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+
+    const int64_t queryHeadDim = 1; // [U, H, chunk_len, D]
+    const int64_t kvHeadDim = 1;    // [B, H, S, D]
+    const int64_t outputHeadDim = 1;
 
     int64_t headSize = queryType.getShape()[queryHeadDim];
 
@@ -1432,6 +1484,7 @@ private:
           // name to the same head-sharding rule.
           {utils::kTTSDPACompositeName, getSDPAShardingRule},
           {pagedSdpaDecodeTargetName, getPagedAttentionShardingRule},
+          {chunkedSdpaTargetName, getPagedAttentionShardingRule},
           {pagedUpdateCacheTargetName, getPagedAttentionShardingRule},
           {pagedFillCacheTargetName, getPagedAttentionShardingRule},
           {sparseMatmulTargetName, getSparseMatmulShardingRule},

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7517,6 +7517,10 @@ mlir::tt::ttir::ChunkedScaledDotProductAttentionOp::verify() {
   if (chunkStartIdxType.getRank() != 1) {
     return emitOpError("Chunk start index must be a 1D tensor.");
   }
+  if (chunkStartIdxType.getDimSize(0) != 1) {
+    return emitOpError("Chunk start index must have shape [1] (a single prefix "
+                       "offset shared by all users).");
+  }
 
   // Verify element types. The BFP8/BFP4 KV cache typecast happens later in the
   // TTNN pipeline, so at TTIR query/key/value share one float element type.

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7491,6 +7491,90 @@ mlir::tt::ttir::PagedScaledDotProductAttentionDecodeOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// ChunkedScaledDotProductAttentionOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult
+mlir::tt::ttir::ChunkedScaledDotProductAttentionOp::verify() {
+  RankedTensorType queryType = getQuery().getType();
+  RankedTensorType keyType = getKey().getType();
+  RankedTensorType valueType = getValue().getType();
+  RankedTensorType pageTableType = getPageTable().getType();
+  RankedTensorType chunkStartIdxType = getChunkStartIdx().getType();
+  RankedTensorType resultType = getResult().getType();
+
+  // Verify ranks. query: [num_users, num_heads, chunk_len, head_size];
+  // key/value: paged cache [num_blocks, num_kv_heads, block_size, head_size].
+  if (queryType.getRank() != 4) {
+    return emitOpError("Query must be a 4D tensor.");
+  }
+  if (keyType.getRank() != 4 || valueType.getRank() != 4) {
+    return emitOpError("Key and value must be 4D tensors.");
+  }
+  if (pageTableType.getRank() != 2) {
+    return emitOpError("Page table must be a 2D tensor.");
+  }
+  if (chunkStartIdxType.getRank() != 1) {
+    return emitOpError("Chunk start index must be a 1D tensor.");
+  }
+
+  // Verify element types. The BFP8/BFP4 KV cache typecast happens later in the
+  // TTNN pipeline, so at TTIR query/key/value share one float element type.
+  if (queryType.getElementType() != keyType.getElementType() ||
+      queryType.getElementType() != valueType.getElementType()) {
+    return emitOpError(
+        "Query, key, and value must have the same element type.");
+  }
+  if (!queryType.getElementType().isFloat()) {
+    return emitOpError("Query, key, and value must be float tensors.");
+  }
+  if (!pageTableType.getElementType().isInteger()) {
+    return emitOpError("Page table must be an integer tensor.");
+  }
+  if (!chunkStartIdxType.getElementType().isInteger()) {
+    return emitOpError("Chunk start index must be an integer tensor.");
+  }
+
+  // Verify key and value are identical shapes/dtypes.
+  if (keyType != valueType) {
+    return emitOpError("Key and value must have the same shape and data type.");
+  }
+
+  ArrayRef<int64_t> queryShape = queryType.getShape();
+  ArrayRef<int64_t> keyShape = keyType.getShape();
+  int64_t numUsers = queryShape[0];
+  int64_t numQueryHeads = queryShape[1];
+  int64_t queryHeadSize = queryShape[3];
+  int64_t numKVHeads = keyShape[1];
+  int64_t blockSize = keyShape[2];
+  int64_t keyHeadSize = keyShape[3];
+
+  // Verify shapes.
+  if (queryHeadSize != keyHeadSize) {
+    return emitOpError("Query head size must match key/value head size.");
+  }
+  if (numKVHeads == 0 || numQueryHeads % numKVHeads != 0) {
+    return emitOpError(
+        "Query num heads must be divisible by key/value num heads.");
+  }
+  // The ttnn kernel reads the paged cache by 32-element sticks.
+  if (blockSize % 32 != 0) {
+    return emitOpError("Key/value block size must be divisible by 32.");
+  }
+  if (pageTableType.getShape()[0] != numUsers) {
+    return emitOpError(
+        "Page table number of users must match query number of users.");
+  }
+
+  // The result is the attended query chunk and mirrors the query shape.
+  if (resultType.getShape() != queryShape) {
+    return emitOpError("Result shape must match query shape.");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // PagedFlashMultiLatentAttentionDecodeOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -6039,6 +6039,10 @@ mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp::verify() {
   if (chunkStartIdxType.getRank() != 1) {
     return emitOpError("Chunk start index must be a 1D tensor.");
   }
+  if (chunkStartIdxType.getDimSize(0) != 1) {
+    return emitOpError("Chunk start index must have shape [1] (a single prefix "
+                       "offset shared by all users).");
+  }
 
   // The query may be higher precision than the key/value: the kernel reads a
   // BFP8/BFP4 paged cache with a BF16 query. Require float here; key/value

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -6013,6 +6013,88 @@ mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// ChunkedScaledDotProductAttentionOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult
+mlir::tt::ttnn::ChunkedScaledDotProductAttentionOp::verify() {
+  RankedTensorType queryType = getQuery().getType();
+  RankedTensorType keyType = getKey().getType();
+  RankedTensorType valueType = getValue().getType();
+  RankedTensorType pageTableType = getPageTable().getType();
+  RankedTensorType chunkStartIdxType = getChunkStartIdx().getType();
+  RankedTensorType resultType = getResult().getType();
+
+  // Verify ranks. query: [num_users, num_heads, chunk_len, head_size];
+  // key/value: paged cache [num_blocks, num_kv_heads, block_size, head_size].
+  if (queryType.getRank() != 4) {
+    return emitOpError("Query must be a 4D tensor.");
+  }
+  if (keyType.getRank() != 4 || valueType.getRank() != 4) {
+    return emitOpError("Key and value must be 4D tensors.");
+  }
+  if (pageTableType.getRank() != 2) {
+    return emitOpError("Page table must be a 2D tensor.");
+  }
+  if (chunkStartIdxType.getRank() != 1) {
+    return emitOpError("Chunk start index must be a 1D tensor.");
+  }
+
+  // The query may be higher precision than the key/value: the kernel reads a
+  // BFP8/BFP4 paged cache with a BF16 query. Require float here; key/value
+  // dtype equality is enforced separately below.
+  if (!queryType.getElementType().isFloat() ||
+      !keyType.getElementType().isFloat() ||
+      !valueType.getElementType().isFloat()) {
+    return emitOpError("Query, key, and value must be float tensors.");
+  }
+  if (!pageTableType.getElementType().isInteger()) {
+    return emitOpError("Page table must be an integer tensor.");
+  }
+  if (!chunkStartIdxType.getElementType().isInteger()) {
+    return emitOpError("Chunk start index must be an integer tensor.");
+  }
+
+  // Verify key and value are identical shapes/dtypes.
+  if (keyType != valueType) {
+    return emitOpError("Key and value must have the same shape and data type.");
+  }
+
+  ArrayRef<int64_t> queryShape = queryType.getShape();
+  ArrayRef<int64_t> keyShape = keyType.getShape();
+  int64_t numUsers = queryShape[0];
+  int64_t numQueryHeads = queryShape[1];
+  int64_t queryHeadSize = queryShape[3];
+  int64_t numKVHeads = keyShape[1];
+  int64_t blockSize = keyShape[2];
+  int64_t keyHeadSize = keyShape[3];
+
+  // Verify shapes.
+  if (queryHeadSize != keyHeadSize) {
+    return emitOpError("Query head size must match key/value head size.");
+  }
+  if (numKVHeads == 0 || numQueryHeads % numKVHeads != 0) {
+    return emitOpError(
+        "Query num heads must be divisible by key/value num heads.");
+  }
+  // The ttnn kernel reads the paged cache by 32-element sticks.
+  if (blockSize % 32 != 0) {
+    return emitOpError("Key/value block size must be divisible by 32.");
+  }
+  if (pageTableType.getShape()[0] != numUsers) {
+    return emitOpError(
+        "Page table number of users must match query number of users.");
+  }
+
+  // The result is the attended query chunk and mirrors the query shape.
+  if (resultType.getShape() != queryShape) {
+    return emitOpError("Result shape must match query shape.");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // PagedFlashMultiLatentAttentionDecodeOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1209,6 +1209,39 @@ TTNNOperandsWorkarounds TTNNOperandsWorkaroundsFactory::
 }
 
 // Factory method to create workarounds for
+// chunked_scaled_dot_product_attention op operands.
+// page_table and chunk_start_idx require ROW_MAJOR layout.
+TTNNOperandsWorkarounds TTNNOperandsWorkaroundsFactory::
+    createChunkedScaledDotProductAttentionOpOperandsWorkarounds(Operation *op) {
+  TTNNOperandWorkarounds emptyWorkaround;
+  TTNNOperandWorkarounds rowMajorLayoutWorkaround;
+  rowMajorLayoutWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
+
+  TTNNOperandsWorkarounds operandsWorkaround =
+      TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds();
+
+  // Query, key, and value need no workarounds.
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(emptyWorkaround);
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(emptyWorkaround);
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(emptyWorkaround);
+
+  // page_table and chunk_start_idx require ROW_MAJOR layout.
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(rowMajorLayoutWorkaround);
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(rowMajorLayoutWorkaround);
+
+  // Need no workaround for output tensor.
+  operandsWorkaround =
+      operandsWorkaround.addOutputOperandWorkaround(emptyWorkaround);
+
+  return operandsWorkaround;
+}
+
+// Factory method to create workarounds for
 // paged_flash_multi_latent_attention_decode op operands.
 // page_table and cur_pos_tensor require ROW_MAJOR layout.
 TTNNOperandsWorkarounds TTNNOperandsWorkaroundsFactory::

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3343,6 +3343,37 @@ createOp(FlatbufferObjectCache &cache,
       programConfig.value_or(0));
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::ChunkedScaledDotProductAttentionOp>
+createOp(FlatbufferObjectCache &cache, ChunkedScaledDotProductAttentionOp op) {
+  auto query = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getQuery()));
+  auto key = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getKey()));
+  auto value = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getValue()));
+  auto pageTable = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getPageTable()));
+  auto chunkStartIdx = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getChunkStartIdx()));
+
+  auto scale = toFlatbuffer(
+      cache, op.getScale()
+                 ? std::make_optional(op.getScale().value().convertToFloat())
+                 : std::nullopt);
+  auto memoryConfig = toFlatbuffer(cache, op.getMemoryConfigAttr());
+
+  auto out =
+      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
+                                  /*local_shape*/ std::nullopt);
+
+  std::optional<::flatbuffers::Offset<::tt::target::ttnn::SDPAConfig>>
+      programConfig = toFlatbuffer(cache, op.getProgramConfig());
+
+  return ::tt::target::ttnn::CreateChunkedScaledDotProductAttentionOp(
+      *cache.fbb, query, key, value, pageTable, chunkStartIdx, scale, out,
+      memoryConfig, programConfig.value_or(0));
+}
+
 ::flatbuffers::Offset<
     ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOp>
 createOp(FlatbufferObjectCache &cache,
@@ -4866,6 +4897,13 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
     return createOperation(
         cache, createOp(cache, pagedScaledDotProductAttentionDecodeOp),
         debugString, locInfo);
+  }
+  if (auto chunkedScaledDotProductAttentionOp =
+          dyn_cast<ChunkedScaledDotProductAttentionOp>(op);
+      chunkedScaledDotProductAttentionOp) {
+    return createOperation(cache,
+                           createOp(cache, chunkedScaledDotProductAttentionOp),
+                           debugString, locInfo);
   }
   if (auto pagedFlashMlaDecodeOp =
           dyn_cast<PagedFlashMultiLatentAttentionDecodeOp>(op);

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3345,6 +3345,7 @@ createOp(FlatbufferObjectCache &cache,
 
 ::flatbuffers::Offset<::tt::target::ttnn::ChunkedScaledDotProductAttentionOp>
 createOp(FlatbufferObjectCache &cache, ChunkedScaledDotProductAttentionOp op) {
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
   auto query = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getQuery()));
   auto key = cache.at<::tt::target::ttnn::TensorRef>(
@@ -3368,6 +3369,7 @@ createOp(FlatbufferObjectCache &cache, ChunkedScaledDotProductAttentionOp op) {
 
   std::optional<::flatbuffers::Offset<::tt::target::ttnn::SDPAConfig>>
       programConfig = toFlatbuffer(cache, op.getProgramConfig());
+  // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
   return ::tt::target::ttnn::CreateChunkedScaledDotProductAttentionOp(
       *cache.fbb, query, key, value, pageTable, chunkStartIdx, scale, out,

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -119,6 +119,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/transformer/paged_flash_multi_latent_attention_decode.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/transformer/paged_scaled_dot_product_attention_decode.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/transformer/flash_mla_prefill.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/transformer/chunked_scaled_dot_product_attention.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/utils.cpp
 )
 

--- a/runtime/lib/ttnn/operations/transformer/chunked_scaled_dot_product_attention.cpp
+++ b/runtime/lib/ttnn/operations/transformer/chunked_scaled_dot_product_attention.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/transformer/chunked_scaled_dot_product_attention.h"
+
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::transformer {
+static void runChunkedScaledDotProductAttentionOp(
+    const ::tt::target::ttnn::ChunkedScaledDotProductAttentionOp *op,
+    ProgramTensorPool &tensorPool) {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+
+  const ::ttnn::Tensor &query =
+      tensorPool.getTTNNTensorAndValidate(op->query());
+  const ::ttnn::Tensor &key = tensorPool.getTTNNTensorAndValidate(op->key());
+  const ::ttnn::Tensor &value =
+      tensorPool.getTTNNTensorAndValidate(op->value());
+  const ::ttnn::Tensor &pageTable =
+      tensorPool.getTTNNTensorAndValidate(op->page_table());
+  // Prefix offset lives in a device tensor (the "flexible" overload) so the op
+  // is trace-compatible: the offset is read at runtime, no recompile per chunk.
+  const ::ttnn::Tensor &chunkStartIdx =
+      tensorPool.getTTNNTensorAndValidate(op->chunk_start_idx());
+
+  std::optional<float> scale = op->scale();
+
+  // Like the (prefill) scaled_dot_product_attention runtime, leave the program
+  // config null unless one was provided: ttnn computes valid q/k chunk sizes
+  // from the shapes. Forcing q/k_chunk_size=0 here divides-by-zero in the
+  // prefill SDPAProgramFactory (unlike the decode kernel, which accepts
+  // 0=auto).
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      programConfig = std::nullopt;
+  if (op->program_config()) {
+    programConfig = utils::createSDPAProgramConfig(op->program_config());
+  }
+
+  ::ttnn::Tensor out =
+      ::ttnn::transformer::chunked_scaled_dot_product_attention(
+          query, key, value, pageTable, chunkStartIdx, scale,
+          outputMemoryConfig,
+          /*program_config=*/programConfig,
+          /*compute_kernel_config=*/std::nullopt);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+
+void run(const ::tt::target::ttnn::ChunkedScaledDotProductAttentionOp *op,
+         ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  runChunkedScaledDotProductAttentionOp(op, tensorPool);
+}
+
+} // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/chunked_scaled_dot_product_attention.h
+++ b/runtime/lib/ttnn/operations/transformer/chunked_scaled_dot_product_attention.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CHUNKED_SCALED_DOT_PRODUCT_ATTENTION_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CHUNKED_SCALED_DOT_PRODUCT_ATTENTION_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::transformer {
+void run(const ::tt::target::ttnn::ChunkedScaledDotProductAttentionOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::transformer
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -108,6 +108,7 @@
 #include "operations/trace/capture_or_execute_trace.h"
 #include "operations/trace/end_trace_capture.h"
 #include "operations/trace/execute_trace.h"
+#include "operations/transformer/chunked_scaled_dot_product_attention.h"
 #include "operations/transformer/concatenate_heads.h"
 #include "operations/transformer/flash_mla_prefill.h"
 #include "operations/transformer/nlp_concat_heads.h"
@@ -652,6 +653,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   case ::tt::target::ttnn::OpType::PagedScaledDotProductAttentionDecodeOp: {
     return operations::transformer::run(
         op->type_as_PagedScaledDotProductAttentionDecodeOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::ChunkedScaledDotProductAttentionOp: {
+    return operations::transformer::run(
+        op->type_as_ChunkedScaledDotProductAttentionOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::PagedFlashMultiLatentAttentionDecodeOp: {
     return operations::transformer::run(

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1449,6 +1449,11 @@ std::vector<tt::runtime::TensorRef> getOpOutputRefs(OpContext opContextHandle) {
         opContext.type_as_PagedScaledDotProductAttentionDecodeOp()->out()};
     break;
   }
+  case ::tt::target::ttnn::OpType::ChunkedScaledDotProductAttentionOp: {
+    tensorRefs = {
+        opContext.type_as_ChunkedScaledDotProductAttentionOp()->out()};
+    break;
+  }
   case ::tt::target::ttnn::OpType::PagedFlashMultiLatentAttentionDecodeOp: {
     tensorRefs = {
         opContext.type_as_PagedFlashMultiLatentAttentionDecodeOp()->out()};
@@ -2233,6 +2238,12 @@ std::vector<tt::runtime::TensorRef> getOpInputRefs(OpContext opContextHandle) {
             ->cur_pos_tensor(),
         opContext.type_as_PagedScaledDotProductAttentionDecodeOp()
             ->attention_sink()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::ChunkedScaledDotProductAttentionOp: {
+    auto *chunkedOp = opContext.type_as_ChunkedScaledDotProductAttentionOp();
+    tensorRefs = {chunkedOp->query(), chunkedOp->key(), chunkedOp->value(),
+                  chunkedOp->page_table(), chunkedOp->chunk_start_idx()};
     break;
   }
   case ::tt::target::ttnn::OpType::PagedFlashMultiLatentAttentionDecodeOp: {

--- a/test/python/golden/ttir_ops/attention/test_sdpa.py
+++ b/test/python/golden/ttir_ops/attention/test_sdpa.py
@@ -354,6 +354,114 @@ def test_sdpa_decode_mask_broadcast(
 
 
 @pytest.mark.parametrize(
+    "batch,num_heads,num_kv_heads,head_dim,chunk_len,chunk_start_idx,block_size,blocks_per_user,scale",
+    [
+        # No GQA: heads=8, head_dim=64, prefix=128, chunk=128, seq_len=256.
+        (1, 8, 8, 64, 128, 128, 32, 8, 0.125),
+        # No GQA: heads=8, head_dim=128, prefix=128, chunk=128, seq_len=256.
+        (1, 8, 8, 128, 128, 128, 32, 8, 0.0883883387),
+        # GQA (4:1): heads=8, kv_heads=2, head_dim=64.
+        (1, 8, 2, 64, 128, 128, 32, 8, 0.125),
+        # GQA (4:1): heads=8, kv_heads=2, head_dim=128.
+        (1, 8, 2, 128, 128, 128, 32, 8, 0.0883883387),
+    ],
+    ids=[
+        "no_gqa_d64",
+        "no_gqa_d128",
+        "gqa_d64",
+        "gqa_d128",
+    ],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_chunked_sdpa(
+    batch: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    chunk_len: int,
+    chunk_start_idx: int,
+    block_size: int,
+    blocks_per_user: int,
+    scale: float,
+    target: str,
+    request,
+    device,
+):
+    """
+    Test Chunked Scaled Dot Product Attention (chunked prefill, tt-xla #4986).
+
+    A prefill chunk attends causally over the prefix tokens
+    [0, chunk_start_idx + chunk_len) resident in the paged K/V cache.
+    """
+    seq_len = blocks_per_user * block_size
+    assert chunk_start_idx + chunk_len <= seq_len
+    num_blocks = batch * blocks_per_user
+
+    query_shape = (batch, num_heads, chunk_len, head_dim)
+    kv_shape = (num_blocks, num_kv_heads, block_size, head_dim)
+    page_table_shape = (batch, blocks_per_user)
+    chunk_start_idx_shape = (1,)
+    output_shape = query_shape
+
+    shapes = [
+        query_shape,
+        kv_shape,
+        kv_shape,
+        page_table_shape,
+        chunk_start_idx_shape,
+        output_shape,
+    ]
+    dtypes = [
+        torch.bfloat16,
+        torch.bfloat16,
+        torch.bfloat16,
+        torch.int32,
+        torch.int32,
+        torch.bfloat16,
+    ]
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def chunked_sdpa(
+            query: Operand,
+            key: Operand,
+            value: Operand,
+            page_table: Operand,
+            chunk_start: Operand,
+            output: Operand,
+            builder: TTIRBuilder,
+        ):
+            # Page table maps each user's logical blocks to physical blocks.
+            valid_page_table = (
+                torch.arange(blocks_per_user, dtype=torch.int32)
+                .unsqueeze(0)
+                .expand(batch, -1)
+                .contiguous()
+            )
+            valid_chunk_start = torch.tensor([chunk_start_idx], dtype=torch.int32)
+            builder.set_goldens(
+                {page_table: valid_page_table, chunk_start: valid_chunk_start}
+            )
+
+            return builder.chunked_scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                page_table,
+                chunk_start,
+                output,
+                scale=scale,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+    )
+
+
+@pytest.mark.parametrize(
     "shapes,scale",
     [
         # --- No GQA (Q heads == KV heads) ---

--- a/test/python/golden/ttir_ops/attention/test_sdpa.py
+++ b/test/python/golden/ttir_ops/attention/test_sdpa.py
@@ -356,20 +356,26 @@ def test_sdpa_decode_mask_broadcast(
 @pytest.mark.parametrize(
     "batch,num_heads,num_kv_heads,head_dim,chunk_len,chunk_start_idx,block_size,blocks_per_user,scale",
     [
-        # No GQA: heads=8, head_dim=64, prefix=128, chunk=128, seq_len=256.
+        # MHA: heads=8, head_dim=64, prefix=128, chunk=128, seq_len=256.
         (1, 8, 8, 64, 128, 128, 32, 8, 0.125),
-        # No GQA: heads=8, head_dim=128, prefix=128, chunk=128, seq_len=256.
+        # MHA: heads=8, head_dim=128, prefix=128, chunk=128, seq_len=256.
         (1, 8, 8, 128, 128, 128, 32, 8, 0.0883883387),
         # GQA (4:1): heads=8, kv_heads=2, head_dim=64.
         (1, 8, 2, 64, 128, 128, 32, 8, 0.125),
         # GQA (4:1): heads=8, kv_heads=2, head_dim=128.
         (1, 8, 2, 128, 128, 128, 32, 8, 0.0883883387),
+        # MQA: heads=8, kv_heads=1, head_dim=64.
+        (1, 8, 1, 64, 128, 128, 32, 8, 0.125),
+        # MQA: heads=8, kv_heads=1, head_dim=128.
+        (1, 8, 1, 128, 128, 128, 32, 8, 0.0883883387),
     ],
     ids=[
-        "no_gqa_d64",
-        "no_gqa_d128",
+        "mha_d64",
+        "mha_d128",
         "gqa_d64",
         "gqa_d128",
+        "mqa_d64",
+        "mqa_d128",
     ],
 )
 @pytest.mark.parametrize("target", ["ttnn"])

--- a/test/ttmlir/Conversion/StableHLOToTTIR/transformer/chunked_scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/transformer/chunked_scaled_dot_product_attention.mlir
@@ -1,0 +1,24 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module @chunked_sdpa attributes {} {
+  // query: [num_users, num_heads, chunk_len, head_size]; key/value: paged cache
+  // [num_blocks, num_kv_heads, block_size, head_size].
+  func.func public @chunked_sdpa(%query: tensor<1x12x64x64xbf16>, %key: tensor<128x12x32x64xbf16>, %value: tensor<128x12x32x64xbf16>, %page_table: tensor<1x4xi32>, %chunk_start_idx: tensor<1xi32>) -> tensor<1x12x64x64xbf16> {
+    // CHECK-LABEL: @chunked_sdpa
+    // CHECK: "ttir.chunked_scaled_dot_product_attention"
+    // CHECK-SAME: <{scale = 1.250000e-01 : f32}>
+    // CHECK-SAME: (tensor<1x12x64x64xbf16>, tensor<128x12x32x64xbf16>, tensor<128x12x32x64xbf16>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xbf16>) -> tensor<1x12x64x64xbf16>
+    %0 = stablehlo.custom_call @tt.chunked_scaled_dot_product_attention(%query, %key, %value, %page_table, %chunk_start_idx) {api_version = 0 : i32, mhlo.frontend_attributes = {scale = "0.125"}} : (tensor<1x12x64x64xbf16>, tensor<128x12x32x64xbf16>, tensor<128x12x32x64xbf16>, tensor<1x4xi32>, tensor<1xi32>) -> tensor<1x12x64x64xbf16>
+    return %0 : tensor<1x12x64x64xbf16>
+  }
+
+  // No scale frontend attribute: defaults to 1/sqrt(head_size) inside the op.
+  func.func public @chunked_sdpa_no_scale(%query: tensor<1x12x64x64xbf16>, %key: tensor<128x12x32x64xbf16>, %value: tensor<128x12x32x64xbf16>, %page_table: tensor<1x4xi32>, %chunk_start_idx: tensor<1xi32>) -> tensor<1x12x64x64xbf16> {
+    // CHECK-LABEL: @chunked_sdpa_no_scale
+    // CHECK: "ttir.chunked_scaled_dot_product_attention"
+    // CHECK-NOT: scale
+    %0 = stablehlo.custom_call @tt.chunked_scaled_dot_product_attention(%query, %key, %value, %page_table, %chunk_start_idx) {api_version = 0 : i32} : (tensor<1x12x64x64xbf16>, tensor<128x12x32x64xbf16>, tensor<128x12x32x64xbf16>, tensor<1x4xi32>, tensor<1xi32>) -> tensor<1x12x64x64xbf16>
+    return %0 : tensor<1x12x64x64xbf16>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/transformer/chunked_scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/transformer/chunked_scaled_dot_product_attention.mlir
@@ -13,7 +13,7 @@ module @chunked_sdpa attributes {} {
     return %0 : tensor<1x12x64x64xbf16>
   }
 
-  // No scale frontend attribute: defaults to 1/sqrt(head_size) inside the op.
+  // No scale frontend attribute.
   func.func public @chunked_sdpa_no_scale(%query: tensor<1x12x64x64xbf16>, %key: tensor<128x12x32x64xbf16>, %value: tensor<128x12x32x64xbf16>, %page_table: tensor<1x4xi32>, %chunk_start_idx: tensor<1xi32>) -> tensor<1x12x64x64xbf16> {
     // CHECK-LABEL: @chunked_sdpa_no_scale
     // CHECK: "ttir.chunked_scaled_dot_product_attention"

--- a/test/ttmlir/Dialect/TTIR/transformer/chunked_scaled_dot_product_attention_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/transformer/chunked_scaled_dot_product_attention_negative.mlir
@@ -1,0 +1,53 @@
+// RUN: ttmlir-opt --split-input-file --verify-diagnostics %s
+
+// Query must be a 4D tensor: [num_users, num_heads, chunk_len, head_size].
+func.func @query_not_4d(%q: tensor<12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<12x64x64xf32>) -> tensor<12x64x64xf32> {
+  // expected-error @+1 {{Query must be a 4D tensor.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<12x64x64xf32>) -> tensor<12x64x64xf32>
+  return %1 : tensor<12x64x64xf32>
+}
+
+// -----
+
+// chunk_start_idx must be a 1D tensor.
+func.func @chunk_start_idx_not_1d(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1x1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+  // expected-error @+1 {{Chunk start index must be a 1D tensor.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1x1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
+  return %1 : tensor<1x12x64x64xf32>
+}
+
+// -----
+
+// Chunk start index must have shape [1] (a single shared offset), not [N>1].
+func.func @chunk_start_idx_not_len1(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<4xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+  // expected-error @+1 {{Chunk start index must have shape [1]}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<4xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
+  return %1 : tensor<1x12x64x64xf32>
+}
+
+// -----
+
+// Query head size (last dim) must match key/value head size.
+func.func @head_size_mismatch(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x128xf32>, %v: tensor<128x12x32x128xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+  // expected-error @+1 {{Query head size must match key/value head size.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x12x32x128xf32>, tensor<128x12x32x128xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
+  return %1 : tensor<1x12x64x64xf32>
+}
+
+// -----
+
+// Query num heads must be divisible by key/value num heads (12 % 8 != 0).
+func.func @heads_not_divisible(%q: tensor<1x12x64x64xf32>, %k: tensor<128x8x32x64xf32>, %v: tensor<128x8x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+  // expected-error @+1 {{Query num heads must be divisible by key/value num heads.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x8x32x64xf32>, tensor<128x8x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
+  return %1 : tensor<1x12x64x64xf32>
+}
+
+// -----
+
+// Page table number of users (dim 0) must match query number of users.
+func.func @page_table_users_mismatch(%q: tensor<2x12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<2x12x64x64xf32>) -> tensor<2x12x64x64xf32> {
+  // expected-error @+1 {{Page table number of users must match query number of users.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<2x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<2x12x64x64xf32>) -> tensor<2x12x64x64xf32>
+  return %1 : tensor<2x12x64x64xf32>
+}

--- a/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
@@ -1,0 +1,16 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+module attributes {} {
+  // query: [num_users, num_heads, chunk_len, head_size]; key/value: paged cache
+  // [num_blocks, num_kv_heads, block_size, head_size].
+  func.func @chunked_sdpa(%arg0: tensor<1x12x64x64xf32>, %arg1: tensor<128x12x32x64xf32>, %arg2: tensor<128x12x32x64xf32>, %arg3: tensor<1x4xi32>, %arg4: tensor<1xi32>) -> tensor<1x12x64x64xf32> {
+    // CHECK-LABEL: @chunked_sdpa
+    // page_table and chunk_start_idx are forced to ROW_MAJOR for the ttnn kernel.
+    // CHECK-DAG: "ttnn.to_layout"(%arg3) <{layout = #ttnn.layout<row_major>}>
+    // CHECK-DAG: "ttnn.to_layout"(%arg4) <{layout = #ttnn.layout<row_major>}>
+    // CHECK: "ttnn.chunked_scaled_dot_product_attention"
+    // CHECK-SAME: <{scale = 1.250000e-01 : f32}>
+    %0 = ttir.empty() : tensor<1x12x64x64xf32>
+    %1 = "ttir.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4, %0) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
+    return %1 : tensor<1x12x64x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention_negative.mlir
@@ -1,0 +1,44 @@
+// RUN: ttmlir-opt --split-input-file --verify-diagnostics %s
+
+// Query must be a 4D tensor: [num_users, num_heads, chunk_len, head_size].
+func.func @query_not_4d(%q: tensor<12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<12x64x64xf32>) -> tensor<12x64x64xf32> {
+  // expected-error @+1 {{Query must be a 4D tensor.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<12x64x64xf32>) -> tensor<12x64x64xf32>
+  return %1 : tensor<12x64x64xf32>
+}
+
+// -----
+
+// chunk_start_idx must be a 1D tensor.
+func.func @chunk_start_idx_not_1d(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1x1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+  // expected-error @+1 {{Chunk start index must be a 1D tensor.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1x1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
+  return %1 : tensor<1x12x64x64xf32>
+}
+
+// -----
+
+// Query head size (last dim) must match key/value head size.
+func.func @head_size_mismatch(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x128xf32>, %v: tensor<128x12x32x128xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+  // expected-error @+1 {{Query head size must match key/value head size.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x12x32x128xf32>, tensor<128x12x32x128xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
+  return %1 : tensor<1x12x64x64xf32>
+}
+
+// -----
+
+// Query num heads must be divisible by key/value num heads (12 % 8 != 0).
+func.func @heads_not_divisible(%q: tensor<1x12x64x64xf32>, %k: tensor<128x8x32x64xf32>, %v: tensor<128x8x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+  // expected-error @+1 {{Query num heads must be divisible by key/value num heads.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x8x32x64xf32>, tensor<128x8x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
+  return %1 : tensor<1x12x64x64xf32>
+}
+
+// -----
+
+// Page table number of users (dim 0) must match query number of users.
+func.func @page_table_users_mismatch(%q: tensor<2x12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<2x12x64x64xf32>) -> tensor<2x12x64x64xf32> {
+  // expected-error @+1 {{Page table number of users must match query number of users.}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<2x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<2x12x64x64xf32>) -> tensor<2x12x64x64xf32>
+  return %1 : tensor<2x12x64x64xf32>
+}

--- a/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention_negative.mlir
@@ -18,6 +18,15 @@ func.func @chunk_start_idx_not_1d(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x
 
 // -----
 
+// Chunk start index must have shape [1] (a single shared offset), not [N>1].
+func.func @chunk_start_idx_not_len1(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<4xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+  // expected-error @+1 {{Chunk start index must have shape [1]}}
+  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<4xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
+  return %1 : tensor<1x12x64x64xf32>
+}
+
+// -----
+
 // Query head size (last dim) must match key/value head size.
 func.func @head_size_mismatch(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x128xf32>, %v: tensor<128x12x32x128xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
   // expected-error @+1 {{Query head size must match key/value head size.}}

--- a/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention_negative.mlir
@@ -1,53 +1,89 @@
 // RUN: ttmlir-opt --split-input-file --verify-diagnostics %s
 
+#dram = #ttnn.buffer_type<dram>
+
 // Query must be a 4D tensor: [num_users, num_heads, chunk_len, head_size].
-func.func @query_not_4d(%q: tensor<12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<12x64x64xf32>) -> tensor<12x64x64xf32> {
+#q3d_layout = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<24x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#kv_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 384 + d1 * 32 + d2, d3), <1x1>, memref<1536x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#pt_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4xi32, #dram>, <interleaved>>
+#csi_layout = #ttnn.ttnn_layout<(d0) -> (d0), <1x1>, memref<1xi32, #dram>, <interleaved>>
+func.func @query_not_4d(%q: tensor<12x64x64xbf16, #q3d_layout>, %k: tensor<128x12x32x64xbf16, #kv_layout>, %v: tensor<128x12x32x64xbf16, #kv_layout>, %pt: tensor<1x4xi32, #pt_layout>, %csi: tensor<1xi32, #csi_layout>) -> tensor<12x64x64xbf16, #q3d_layout> {
   // expected-error @+1 {{Query must be a 4D tensor.}}
-  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<12x64x64xf32>) -> tensor<12x64x64xf32>
-  return %1 : tensor<12x64x64xf32>
+  %0 = "ttnn.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi) <{scale = 1.250000e-01 : f32}> : (tensor<12x64x64xbf16, #q3d_layout>, tensor<128x12x32x64xbf16, #kv_layout>, tensor<128x12x32x64xbf16, #kv_layout>, tensor<1x4xi32, #pt_layout>, tensor<1xi32, #csi_layout>) -> tensor<12x64x64xbf16, #q3d_layout>
+  return %0 : tensor<12x64x64xbf16, #q3d_layout>
 }
 
 // -----
+
+#dram = #ttnn.buffer_type<dram>
 
 // chunk_start_idx must be a 1D tensor.
-func.func @chunk_start_idx_not_1d(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1x1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+#q_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 768 + d1 * 64 + d2, d3), <1x1>, memref<24x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#kv_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 384 + d1 * 32 + d2, d3), <1x1>, memref<1536x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#pt_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4xi32, #dram>, <interleaved>>
+#csi2d_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1xi32, #dram>, <interleaved>>
+func.func @chunk_start_idx_not_1d(%q: tensor<1x12x64x64xbf16, #q_layout>, %k: tensor<128x12x32x64xbf16, #kv_layout>, %v: tensor<128x12x32x64xbf16, #kv_layout>, %pt: tensor<1x4xi32, #pt_layout>, %csi: tensor<1x1xi32, #csi2d_layout>) -> tensor<1x12x64x64xbf16, #q_layout> {
   // expected-error @+1 {{Chunk start index must be a 1D tensor.}}
-  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1x1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
-  return %1 : tensor<1x12x64x64xf32>
+  %0 = "ttnn.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16, #q_layout>, tensor<128x12x32x64xbf16, #kv_layout>, tensor<128x12x32x64xbf16, #kv_layout>, tensor<1x4xi32, #pt_layout>, tensor<1x1xi32, #csi2d_layout>) -> tensor<1x12x64x64xbf16, #q_layout>
+  return %0 : tensor<1x12x64x64xbf16, #q_layout>
 }
 
 // -----
+
+#dram = #ttnn.buffer_type<dram>
 
 // Chunk start index must have shape [1] (a single shared offset), not [N>1].
-func.func @chunk_start_idx_not_len1(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<4xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+#q_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 768 + d1 * 64 + d2, d3), <1x1>, memref<24x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#kv_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 384 + d1 * 32 + d2, d3), <1x1>, memref<1536x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#pt_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4xi32, #dram>, <interleaved>>
+#csi4_layout = #ttnn.ttnn_layout<(d0) -> (d0), <1x1>, memref<4xi32, #dram>, <interleaved>>
+func.func @chunk_start_idx_not_len1(%q: tensor<1x12x64x64xbf16, #q_layout>, %k: tensor<128x12x32x64xbf16, #kv_layout>, %v: tensor<128x12x32x64xbf16, #kv_layout>, %pt: tensor<1x4xi32, #pt_layout>, %csi: tensor<4xi32, #csi4_layout>) -> tensor<1x12x64x64xbf16, #q_layout> {
   // expected-error @+1 {{Chunk start index must have shape [1]}}
-  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<4xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
-  return %1 : tensor<1x12x64x64xf32>
+  %0 = "ttnn.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16, #q_layout>, tensor<128x12x32x64xbf16, #kv_layout>, tensor<128x12x32x64xbf16, #kv_layout>, tensor<1x4xi32, #pt_layout>, tensor<4xi32, #csi4_layout>) -> tensor<1x12x64x64xbf16, #q_layout>
+  return %0 : tensor<1x12x64x64xbf16, #q_layout>
 }
 
 // -----
+
+#dram = #ttnn.buffer_type<dram>
 
 // Query head size (last dim) must match key/value head size.
-func.func @head_size_mismatch(%q: tensor<1x12x64x64xf32>, %k: tensor<128x12x32x128xf32>, %v: tensor<128x12x32x128xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+#q_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 768 + d1 * 64 + d2, d3), <1x1>, memref<24x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#kv128_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 384 + d1 * 32 + d2, d3), <1x1>, memref<1536x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#pt_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4xi32, #dram>, <interleaved>>
+#csi_layout = #ttnn.ttnn_layout<(d0) -> (d0), <1x1>, memref<1xi32, #dram>, <interleaved>>
+func.func @head_size_mismatch(%q: tensor<1x12x64x64xbf16, #q_layout>, %k: tensor<128x12x32x128xbf16, #kv128_layout>, %v: tensor<128x12x32x128xbf16, #kv128_layout>, %pt: tensor<1x4xi32, #pt_layout>, %csi: tensor<1xi32, #csi_layout>) -> tensor<1x12x64x64xbf16, #q_layout> {
   // expected-error @+1 {{Query head size must match key/value head size.}}
-  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x12x32x128xf32>, tensor<128x12x32x128xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
-  return %1 : tensor<1x12x64x64xf32>
+  %0 = "ttnn.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16, #q_layout>, tensor<128x12x32x128xbf16, #kv128_layout>, tensor<128x12x32x128xbf16, #kv128_layout>, tensor<1x4xi32, #pt_layout>, tensor<1xi32, #csi_layout>) -> tensor<1x12x64x64xbf16, #q_layout>
+  return %0 : tensor<1x12x64x64xbf16, #q_layout>
 }
 
 // -----
+
+#dram = #ttnn.buffer_type<dram>
 
 // Query num heads must be divisible by key/value num heads (12 % 8 != 0).
-func.func @heads_not_divisible(%q: tensor<1x12x64x64xf32>, %k: tensor<128x8x32x64xf32>, %v: tensor<128x8x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32> {
+#q_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 768 + d1 * 64 + d2, d3), <1x1>, memref<24x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#kv8_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 256 + d1 * 32 + d2, d3), <1x1>, memref<1024x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#pt_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4xi32, #dram>, <interleaved>>
+#csi_layout = #ttnn.ttnn_layout<(d0) -> (d0), <1x1>, memref<1xi32, #dram>, <interleaved>>
+func.func @heads_not_divisible(%q: tensor<1x12x64x64xbf16, #q_layout>, %k: tensor<128x8x32x64xbf16, #kv8_layout>, %v: tensor<128x8x32x64xbf16, #kv8_layout>, %pt: tensor<1x4xi32, #pt_layout>, %csi: tensor<1xi32, #csi_layout>) -> tensor<1x12x64x64xbf16, #q_layout> {
   // expected-error @+1 {{Query num heads must be divisible by key/value num heads.}}
-  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<1x12x64x64xf32>, tensor<128x8x32x64xf32>, tensor<128x8x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
-  return %1 : tensor<1x12x64x64xf32>
+  %0 = "ttnn.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16, #q_layout>, tensor<128x8x32x64xbf16, #kv8_layout>, tensor<128x8x32x64xbf16, #kv8_layout>, tensor<1x4xi32, #pt_layout>, tensor<1xi32, #csi_layout>) -> tensor<1x12x64x64xbf16, #q_layout>
+  return %0 : tensor<1x12x64x64xbf16, #q_layout>
 }
 
 // -----
 
+#dram = #ttnn.buffer_type<dram>
+
 // Page table number of users (dim 0) must match query number of users.
-func.func @page_table_users_mismatch(%q: tensor<2x12x64x64xf32>, %k: tensor<128x12x32x64xf32>, %v: tensor<128x12x32x64xf32>, %pt: tensor<1x4xi32>, %csi: tensor<1xi32>, %o: tensor<2x12x64x64xf32>) -> tensor<2x12x64x64xf32> {
+#q2_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 768 + d1 * 64 + d2, d3), <1x1>, memref<48x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#kv_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 384 + d1 * 32 + d2, d3), <1x1>, memref<1536x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#pt_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4xi32, #dram>, <interleaved>>
+#csi_layout = #ttnn.ttnn_layout<(d0) -> (d0), <1x1>, memref<1xi32, #dram>, <interleaved>>
+func.func @page_table_users_mismatch(%q: tensor<2x12x64x64xbf16, #q2_layout>, %k: tensor<128x12x32x64xbf16, #kv_layout>, %v: tensor<128x12x32x64xbf16, #kv_layout>, %pt: tensor<1x4xi32, #pt_layout>, %csi: tensor<1xi32, #csi_layout>) -> tensor<2x12x64x64xbf16, #q2_layout> {
   // expected-error @+1 {{Page table number of users must match query number of users.}}
-  %1 = "ttir.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi, %o) : (tensor<2x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<2x12x64x64xf32>) -> tensor<2x12x64x64xf32>
-  return %1 : tensor<2x12x64x64xf32>
+  %0 = "ttnn.chunked_scaled_dot_product_attention"(%q, %k, %v, %pt, %csi) <{scale = 1.250000e-01 : f32}> : (tensor<2x12x64x64xbf16, #q2_layout>, tensor<128x12x32x64xbf16, #kv_layout>, tensor<128x12x32x64xbf16, #kv_layout>, tensor<1x4xi32, #pt_layout>, tensor<1xi32, #csi_layout>) -> tensor<2x12x64x64xbf16, #q2_layout>
+  return %0 : tensor<2x12x64x64xbf16, #q2_layout>
 }

--- a/test/ttmlir/EmitC/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
@@ -7,10 +7,10 @@
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 // RUN: FileCheck %s --input-file=%basename_t.cpp
 module @chunked_sdpa {
-    func.func public @chunked_sdpa(%arg0: tensor<1x12x64x64xbf16>, %arg1: tensor<128x12x32x64xbf16>, %arg2: tensor<128x12x32x64xbf16>, %arg3: tensor<1x4xi32>, %arg4: tensor<1xi32>) -> tensor<1x12x64x64xbf16> {
+    func.func public @chunked_sdpa(%arg0: tensor<1x12x64x64xbf16>, %arg1: tensor<128x12x32x64xbf16>, %arg2: tensor<128x12x32x64xbf16>, %arg3: tensor<1x8xi32>, %arg4: tensor<1xi32>) -> tensor<1x12x64x64xbf16> {
         // CHECK: ttnn::transformer::chunked_scaled_dot_product_attention(
         %0 = ttir.empty() : tensor<1x12x64x64xbf16>
-        %1 = "ttir.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4, %0) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16>, tensor<128x12x32x64xbf16>, tensor<128x12x32x64xbf16>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xbf16>) -> tensor<1x12x64x64xbf16>
+        %1 = "ttir.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4, %0) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16>, tensor<128x12x32x64xbf16>, tensor<128x12x32x64xbf16>, tensor<1x8xi32>, tensor<1xi32>, tensor<1x12x64x64xbf16>) -> tensor<1x12x64x64xbf16>
         return %1 : tensor<1x12x64x64xbf16>
     }
 }

--- a/test/ttmlir/EmitC/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
@@ -1,0 +1,16 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline %t.mlir > %t_rt.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t_rt.mlir > %basename_t.ttnn
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+// RUN: FileCheck %s --input-file=%basename_t.cpp
+module @chunked_sdpa {
+    func.func public @chunked_sdpa(%arg0: tensor<1x12x64x64xbf16>, %arg1: tensor<128x12x32x64xbf16>, %arg2: tensor<128x12x32x64xbf16>, %arg3: tensor<1x4xi32>, %arg4: tensor<1xi32>) -> tensor<1x12x64x64xbf16> {
+        // CHECK: ttnn::transformer::chunked_scaled_dot_product_attention(
+        %0 = ttir.empty() : tensor<1x12x64x64xbf16>
+        %1 = "ttir.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4, %0) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16>, tensor<128x12x32x64xbf16>, tensor<128x12x32x64xbf16>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xbf16>) -> tensor<1x12x64x64xbf16>
+        return %1 : tensor<1x12x64x64xbf16>
+    }
+}

--- a/test/ttmlir/EmitPy/transformer/chunked_scaled_dot_product_attention.mlir
+++ b/test/ttmlir/EmitPy/transformer/chunked_scaled_dot_product_attention.mlir
@@ -1,0 +1,8 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround --convert-ttnn-to-emitpy -o %t.mlir %s
+// RUN: ttmlir-translate --mlir-to-python %t.mlir | FileCheck %s
+
+func.func @chunked_sdpa(%arg0: tensor<1x12x64x64xbf16>, %arg1: tensor<128x12x32x64xbf16>, %arg2: tensor<128x12x32x64xbf16>, %arg3: tensor<1x8xi32>, %arg4: tensor<1xi32>) -> tensor<1x12x64x64xbf16> {
+  // CHECK: ttnn.transformer.chunked_scaled_dot_product_attention(
+  %0 = "ttnn.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16>, tensor<128x12x32x64xbf16>, tensor<128x12x32x64xbf16>, tensor<1x8xi32>, tensor<1xi32>) -> tensor<1x12x64x64xbf16>
+  return %0 : tensor<1x12x64x64xbf16>
+}

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -14245,6 +14245,233 @@ class TTIRBuilder(Builder):
 
         return psdpad_module, psdpad_builder
 
+    ############### ttir.ChunkedScaledDotProductAttentionOp ###############
+
+    @tag(ttir.ChunkedScaledDotProductAttentionOp)
+    def chunked_scaled_dot_product_attention(
+        self,
+        query: Operand,
+        key: Operand,
+        value: Operand,
+        page_table: Operand,
+        chunk_start_idx: Operand,
+        output: Operand,
+        scale: Optional[float] = None,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        ttir_op = self.get_opview_from_method(
+            TTIRBuilder.chunked_scaled_dot_product_attention
+        )
+
+        if output_type is None:
+            mlir_output_type = self.get_type(query)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        scale_attr = FloatAttr.get_f32(scale) if scale is not None else None
+
+        golden_args = [
+            self._get_golden_tensor(query),
+            self._get_golden_tensor(key),
+            self._get_golden_tensor(value),
+            self._get_golden_tensor(page_table),
+            self._get_golden_tensor(chunk_start_idx),
+            self._get_golden_tensor(output),
+        ]
+
+        golden_kwargs = {
+            "scale_attr": scale_attr,
+            "output_type_mlir": mlir_output_type,
+        }
+
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(*golden_args, **golden_kwargs)
+        result = self._create_ranked_tensor_type(golden_output.shape, mlir_output_type)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = ttir_op(
+            result,
+            query,
+            key,
+            value,
+            page_table,
+            chunk_start_idx,
+            output,
+            scale=scale_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(ttir.ChunkedScaledDotProductAttentionOp)
+    def chunked_scaled_dot_product_attention_parser(
+        self,
+        old_op: ttir.ChunkedScaledDotProductAttentionOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttir_op = self.get_opview_from_parser(
+            TTIRBuilder.chunked_scaled_dot_product_attention_parser
+        )
+
+        query = global_dict[old_op.query]
+        key = global_dict[old_op.key]
+        value = global_dict[old_op.value]
+        page_table = global_dict[old_op.page_table]
+        chunk_start_idx = global_dict[old_op.chunk_start_idx]
+        output = global_dict[old_op.output]
+        result = old_op.result.type
+        scale_attr = old_op.scale if "scale" in old_op.attributes else None
+
+        new_op = ttir_op(
+            result,
+            query,
+            key,
+            value,
+            page_table,
+            chunk_start_idx,
+            output,
+            scale=scale_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        golden_args = [
+            self._get_golden_tensor(query),
+            self._get_golden_tensor(key),
+            self._get_golden_tensor(value),
+            self._get_golden_tensor(page_table),
+            self._get_golden_tensor(chunk_start_idx),
+            self._get_golden_tensor(output),
+        ]
+        golden_kwargs = {
+            "scale_attr": scale_attr,
+            "output_type_mlir": result.element_type,
+        }
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(*golden_args, **golden_kwargs)
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(ttir.ChunkedScaledDotProductAttentionOp)
+    def chunked_scaled_dot_product_attention_split(
+        self,
+        old_op: ttir.ChunkedScaledDotProductAttentionOp,
+    ) -> Tuple[Module, TTIRBuilder]:
+        ttir_op = self.get_opview_from_split(
+            TTIRBuilder.chunked_scaled_dot_product_attention_split
+        )
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            csdpa_module = Module.create()
+            csdpa_builder = TTIRBuilder(
+                old_ctx, old_loc, mesh_name=self._mesh_name, mesh_dict=self._mesh_dict
+            )
+
+            op_input_types = [
+                old_op.query.type,
+                old_op.key.type,
+                old_op.value.type,
+                old_op.page_table.type,
+                old_op.chunk_start_idx.type,
+                old_op.output.type,
+            ]
+
+            with InsertionPoint(csdpa_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(
+                    *op_input_types,
+                    name="chunked_scaled_dot_product_attention_module",
+                )
+                def decorated_func(*inputs):
+                    query = inputs[0]
+                    key = inputs[1]
+                    value = inputs[2]
+                    page_table = inputs[3]
+                    chunk_start_idx = inputs[4]
+                    output = inputs[5]
+
+                    result = old_op.result.type
+                    scale_attr = old_op.scale if "scale" in old_op.attributes else None
+
+                    new_op = ttir_op(
+                        result,
+                        query,
+                        key,
+                        value,
+                        page_table,
+                        chunk_start_idx,
+                        output,
+                        scale=scale_attr,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    csdpa_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    csdpa_builder._set_golden_tensor(
+                        query, self._get_golden_tensor(old_op.query)
+                    )
+                    ordered_inputs.append(query)
+
+                    csdpa_builder._set_golden_tensor(
+                        key, self._get_golden_tensor(old_op.key)
+                    )
+                    ordered_inputs.append(key)
+
+                    csdpa_builder._set_golden_tensor(
+                        value, self._get_golden_tensor(old_op.value)
+                    )
+                    ordered_inputs.append(value)
+
+                    csdpa_builder._set_golden_tensor(
+                        page_table, self._get_golden_tensor(old_op.page_table)
+                    )
+                    ordered_inputs.append(page_table)
+
+                    csdpa_builder._set_golden_tensor(
+                        chunk_start_idx,
+                        self._get_golden_tensor(old_op.chunk_start_idx),
+                    )
+                    ordered_inputs.append(chunk_start_idx)
+
+                    csdpa_builder._set_golden_tensor(
+                        output, self._get_golden_tensor(old_op.output)
+                    )
+                    ordered_inputs.append(output)
+
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                csdpa_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return csdpa_module, csdpa_builder
+
     @tag(ttir.Conv2dOp)
     def conv2d(
         self,

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -8596,6 +8596,77 @@ def ttir_paged_sdpa_decode_golden(
     )
 
 
+def ttir_chunked_scaled_dot_product_attention_golden(
+    query: GoldenMapTensor,
+    key: GoldenMapTensor,
+    value: GoldenMapTensor,
+    page_table: GoldenMapTensor,
+    chunk_start_idx: GoldenMapTensor,
+    output: GoldenMapTensor,
+    scale_attr: Optional[FloatAttr] = None,
+    output_type_mlir: Optional[Type] = None,
+) -> GoldenMapTensor:
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    scale_val = unpack_mlir_attr(scale_attr) if scale_attr is not None else None
+
+    query_t = _gmt_leaf_torch(query)
+    key_t = _gmt_leaf_torch(key)
+    value_t = _gmt_leaf_torch(value)
+    pt = _gmt_leaf_torch(page_table.long())
+    start_t = _gmt_leaf_torch(chunk_start_idx.long())
+
+    # Query is already [B, H, S, D] for chunked prefill (no permute).
+    q = query_t.float()
+    b, nh, s_q, d = q.shape
+
+    # K/V are paged: [num_blocks, num_kv_heads, block_size, head_dim].
+    num_blocks, nkv, block_size, _ = key_t.shape
+    blocks_per_user = pt.shape[-1]
+    seq_len = blocks_per_user * block_size
+
+    # Clamp indices so random golden page tables stay in-range (parse tests only).
+    pt_flat = pt.view(-1).clamp(0, num_blocks - 1)
+
+    # Unpage K using page table -> [B, num_kv_heads, seq_len, D].
+    k_unpaged = key_t[pt_flat]
+    k_unpaged = k_unpaged.reshape(b, blocks_per_user, nkv, block_size, d)
+    k_unpaged = k_unpaged.transpose(1, 2).reshape(b, nkv, seq_len, d).float()
+
+    # Unpage V using page table.
+    dv = value_t.shape[-1]
+    v_unpaged = value_t[pt_flat]
+    v_unpaged = v_unpaged.reshape(b, blocks_per_user, nkv, block_size, dv)
+    v_unpaged = v_unpaged.transpose(1, 2).reshape(b, nkv, seq_len, dv).float()
+
+    # GQA expansion.
+    head_rep = nh // nkv
+    if head_rep > 1:
+        k_unpaged = k_unpaged.repeat_interleave(head_rep, dim=1)
+        v_unpaged = v_unpaged.repeat_interleave(head_rep, dim=1)
+
+    # Causal mask: query row j (absolute position start + j) attends to key
+    # columns [0, start + j] inclusive; everything else is masked.
+    start = int(start_t.view(-1)[0].item())
+    col = torch.arange(seq_len).view(1, seq_len)
+    row = (start + torch.arange(s_q)).view(s_q, 1)
+    allowed = col <= row
+    attn_mask = torch.zeros((1, 1, s_q, seq_len), dtype=torch.float32)
+    attn_mask.masked_fill_(
+        ~allowed.view(1, 1, s_q, seq_len), torch.finfo(torch.float32).min
+    )
+
+    out = torch.nn.functional.scaled_dot_product_attention(
+        q, k_unpaged, v_unpaged, attn_mask=attn_mask, scale=scale_val, is_causal=False
+    )
+
+    # Output mirrors query shape [B, H, S, D].
+    out = out.to(output_dtype)
+    return GoldenMapTensor(
+        {k: out.clone() for k in query.shard_map.keys()},
+        query.mesh_shape,
+    )
+
+
 def _gmt_leaf_torch(t: Union[GoldenMapTensor, torch.Tensor]) -> torch.Tensor:
     """Resolve GoldenMapTensor (recursively) to a torch.Tensor for scalar/index ops."""
     while isinstance(t, GoldenMapTensor):
@@ -8890,6 +8961,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     # Attention operations
     ttir.PagedFlashMultiLatentAttentionDecodeOp: ttir_paged_flash_multi_latent_attention_decode_golden,
     ttir.PagedScaledDotProductAttentionDecodeOp: ttir_paged_sdpa_decode_golden,
+    ttir.ChunkedScaledDotProductAttentionOp: ttir_chunked_scaled_dot_product_attention_golden,
     # ----- D2M OPS -----
     # D2M Layout operations (identity functions)
     d2m.ToLayoutOp: (lambda x, **kwargs: x),


### PR DESCRIPTION
## Ticket

- https://github.com/tenstorrent/tt-mlir/issues/8788 
- https://github.com/tenstorrent/tt-xla/issues/4986

### Problem description

Chunked prefill processes a long prompt in fixed-size chunks, so prefill activations stay bounded by the chunk size instead of the full context — this is what lets large contexts (e.g. 32K/64K at batch 32) fit on device. To do that, each continuation chunk must attend causally over the prefix tokens already resident in the paged KV cache. And to keep the decode-throughput win from trace, it has to attend on device by consuming the `page_table` directly — moving the page table to host (`from_device`) is forbidden under trace.

The TTNN library already has the kernel for this (`ttnn::transformer::chunked_scaled_dot_product_attention`), but the compiler had no path to reach it: there was no TTIR/TTNN op, lowering, or flatbuffer/runtime wiring, so it couldn't be invoked from a StableHLO graph through tt-xla → tt-mlir. Without that path there was no trace-compatible on-device cached-prefix prefill, and large-context configs that depend on chunking couldn't run.

## What this unlocks / how

Adds the end-to-end compiler path to that kernel — a `chunked_scaled_dot_product_attention` op from StableHLO custom-call down through TTIR, TTNN, flatbuffer, and runtime — so a prefill chunk attends causally over `[0, chunk_start_idx + chunk_len)` entirely on device via `page_table` + a device `chunk_start_idx` tensor (the "flexible" overload: the offset is read at runtime, so one graph is trace-captured once and reused for every chunk). It mirrors `paged_scaled_dot_product_attention_decode`. This makes on-device, trace-compatible chunked prefill viable, which is what brings 32K/64K context within reach (configs that previously did not fit now run — see the validation comment).

## What's changed

- **Op definitions + verifiers** — TTIR and TTNN `chunked_scaled_dot_product_attention` with verifiers (ranks, `chunk_start_idx` shape `[1]`, head-size match, head divisibility, `block_size % 32`, page-table users, result shape); TTNN allows a higher-precision query over a BFP8/BFP4 paged cache.
- **Lowering** — StableHLO custom-call → TTIR → TTNN (optional `scale`), plus TTNN → EmitC / EmitPy.
- **Flatbuffer + runtime** — schema table + `OpType` entry + serialization, and the runtime op calling `ttnn::transformer::chunked_scaled_dot_product_attention` (flexible `chunk_start_idx`-tensor overload; program config left null so the prefill SDPA factory derives valid q/k chunk sizes).
- **Sharding + layout** — head-sharded custom-call sharding rule, and row-major coercion for `page_table` and `chunk_start_idx` (kept as a workaround for now; tracked to move into the TTNN layout pass in #8842).
- **Tests** — lit tests for StableHLO→TTIR, TTIR→TTNN (incl. the row-major workarounds), the verifier (negative cases in both the TTIR and TTNN dialect dirs), and the EmitC + EmitPy pipelines; plus golden/PCC tests at MHA/GQA/MQA shapes in `test_sdpa.py`.

## Notes

- The ttnn kernel reads the paged cache by 32-element sticks (`page_table` stick size `% 32 == 0`), so the prefix chunk needs enough blocks per user (seq >= ~1024 at block_size 32).
- OpModel is left `OpModelExempt` for now (follow-up); this matches recent new ops.
- Op-level verification (golden/PCC + the discriminator runs) is described in a follow-up comment.
- Follow-ups tracked: migrate the TTIR op to a `ttcore.composite` (#8843), and move the row-major coercion into the TTNN layout pass (#8842).

## Checklist

- [x] New/existing tests pass.
- [x] Lit tests added for the new op (conversion, verifier, EmitC, EmitPy).
- [x] Golden/PCC tests added (MHA/GQA/MQA).
