### PR TITLE
[TTNN] Add `conv3d_config` override and post-optimizer weight preparation

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.h
@@ -20,17 +20,25 @@ struct LegalOpConfigAnalysisInput {
   // Conv2d config overrides.
   llvm::StringMap<Conv2dConfigOverrideParams> *conv2dConfigOverrides;
 
-  LegalOpConfigAnalysisInput() : conv2dConfigOverrides(nullptr) {}
+  // Conv3d config overrides.
+  llvm::StringMap<Conv3dConfigOverrideParams> *conv3dConfigOverrides;
+
+  LegalOpConfigAnalysisInput()
+      : conv2dConfigOverrides(nullptr), conv3dConfigOverrides(nullptr) {}
 
   LegalOpConfigAnalysisInput(
       std::vector<OpConfig> legalConfigs,
-      llvm::StringMap<Conv2dConfigOverrideParams> *conv2dConfigOverrides)
+      llvm::StringMap<Conv2dConfigOverrideParams> *conv2dConfigOverrides,
+      llvm::StringMap<Conv3dConfigOverrideParams> *conv3dConfigOverrides =
+          nullptr)
       : legalConfigs(legalConfigs),
-        conv2dConfigOverrides(conv2dConfigOverrides) {}
+        conv2dConfigOverrides(conv2dConfigOverrides),
+        conv3dConfigOverrides(conv3dConfigOverrides) {}
 
   bool operator==(const LegalOpConfigAnalysisInput &rhs) const {
     return legalConfigs == rhs.legalConfigs &&
-           conv2dConfigOverrides == rhs.conv2dConfigOverrides;
+           conv2dConfigOverrides == rhs.conv2dConfigOverrides &&
+           conv3dConfigOverrides == rhs.conv3dConfigOverrides;
   }
 
   bool operator!=(const LegalOpConfigAnalysisInput &rhs) const {

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
@@ -23,7 +23,7 @@ struct OpConfig {
   // Holds attributes for the op. For most cases, a new type should be
   // added to the following std::variant.
   using OpSpecificAttrs =
-      std::variant<UninitializedAttrs, Conv2dAttrs, MatmulAttrs>;
+      std::variant<UninitializedAttrs, Conv2dAttrs, Conv3dAttrs, MatmulAttrs>;
   OpSpecificAttrs opSpecificAttrs;
 
   // Default Config Constructors.
@@ -34,6 +34,8 @@ struct OpConfig {
       : outputLayout(outputLayout), opSpecificAttrs(std::move(attrs)) {}
   // Op Specific Constructors.
   OpConfig(TTNNLayoutAttr outputLayout, Conv2dAttrs config)
+      : outputLayout(outputLayout), opSpecificAttrs(std::move(config)) {}
+  OpConfig(TTNNLayoutAttr outputLayout, Conv3dAttrs config)
       : outputLayout(outputLayout), opSpecificAttrs(std::move(config)) {}
 
   // Some utility functions.
@@ -160,6 +162,22 @@ struct DenseMapInfo<mlir::tt::ttnn::OpConfig::OpSpecificAttrs> {
             }
 
             // Combine hashes using LLVM's method.
+            return hash_combine(h1, h2);
+          } else if constexpr (std::is_same_v<T, mlir::tt::ttnn::Conv3dAttrs>) {
+            unsigned h1 = 0;
+            unsigned h2 = 0;
+
+            if (attr.conv3dConfig.has_value() && attr.conv3dConfig.value()) {
+              h1 = static_cast<unsigned>(
+                  mlir::hash_value(attr.conv3dConfig.value()));
+            }
+
+            if (attr.deviceComputeKernelConfig.has_value() &&
+                attr.deviceComputeKernelConfig.value()) {
+              h2 = static_cast<unsigned>(
+                  mlir::hash_value(attr.deviceComputeKernelConfig.value()));
+            }
+
             return hash_combine(h1, h2);
           } else if constexpr (std::is_same_v<T, mlir::tt::ttnn::MatmulAttrs>) {
             if (attr.matmulProgramConfig.has_value() &&

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAttrs.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAttrs.h
@@ -73,6 +73,45 @@ struct Conv2dAttrs {
   void dump() const { llvm::outs() << toString(); }
 };
 
+struct Conv3dAttrs {
+  std::optional<mlir::tt::ttnn::Conv3dConfigAttr> conv3dConfig;
+  std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+      deviceComputeKernelConfig;
+
+  bool operator==(const Conv3dAttrs &other) const {
+    return conv3dConfig == other.conv3dConfig &&
+           deviceComputeKernelConfig == other.deviceComputeKernelConfig;
+  }
+  bool operator!=(const Conv3dAttrs &other) const { return !(*this == other); }
+
+  std::string toString() const {
+    std::string result = "Conv3dAttrs{";
+    if (conv3dConfig.has_value() && conv3dConfig.value()) {
+      std::string attrStr;
+      llvm::raw_string_ostream stream(attrStr);
+      stream << conv3dConfig.value();
+      stream.flush();
+      result += "conv3dConfig=" + attrStr;
+    } else {
+      result += "conv3dConfig=<null>";
+    }
+    if (deviceComputeKernelConfig.has_value() &&
+        deviceComputeKernelConfig.value()) {
+      std::string attrStr;
+      llvm::raw_string_ostream stream(attrStr);
+      stream << deviceComputeKernelConfig.value();
+      stream.flush();
+      result += ", deviceComputeKernelConfig=" + attrStr;
+    } else {
+      result += ", deviceComputeKernelConfig=<null>";
+    }
+    result += "}";
+    return result;
+  }
+
+  void dump() const { llvm::outs() << toString(); }
+};
+
 struct MatmulAttrs {
   std::optional<mlir::Attribute> matmulProgramConfig;
   std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/ConvRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/ConvRules.h
@@ -53,6 +53,22 @@ struct Conv2dRuleBook : OpRuleBook {
       llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) const override;
 };
 
+//===----------------------------------------------------------------------===//
+// Conv3d rules:
+//
+// Output hints:
+//   Default (no shard-layout embedding — Conv3d is interleaved-only today).
+//
+// Op-specific attributes:
+//   Set Conv3dConfig + DeviceComputeKernelConfig from candidate.
+//===----------------------------------------------------------------------===//
+
+struct Conv3dRuleBook : OpRuleBook {
+  /// Apply Conv3dConfig + DeviceComputeKernelConfig from candidate.
+  void applyOpSpecificAttrs(Operation *op,
+                            const BeamCandidate &candidate) const override;
+};
+
 /// Set L1Full slice config on all Conv2d ops before validation.
 void applyConvSliceConfig(ModuleOp moduleOp);
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -165,6 +165,20 @@ struct TTIRToTTNNCommonPipelineOptions
           llvm::cl::desc("Override Conv2d configuration for specific ops."),
           llvm::cl::init(llvm::StringMap<Conv2dConfigOverrideParams>())};
 
+  // Override Conv3d block sizes / weights_dtype per op (matched by NameLoc).
+  // Grammar mirrors override-conv2d-config:
+  //   "loc1=t_out_block#3:h_out_block#2:c_in_block#128,loc2=weights_dtype#bf16"
+  //
+  // Recognized parameters:
+  //   weights_dtype, t_out_block, w_out_block, h_out_block, c_out_block,
+  //   c_in_block
+  Option<llvm::StringMap<Conv3dConfigOverrideParams>,
+         Conv3dConfigOverrideParser>
+      overrideConv3dConfig{
+          *this, OptionNames::overrideConv3dConfig,
+          llvm::cl::desc("Override Conv3d configuration for specific ops."),
+          llvm::cl::init(llvm::StringMap<Conv3dConfigOverrideParams>())};
+
   // Enable memory layout analysis for performant tensor layouts (sharding).
   // If not explicitly set, determined by optimization_level.
   mutable Option<bool> memoryLayoutAnalysisEnabled{

--- a/include/ttmlir/Dialect/TTNN/Transforms/GreedyMemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/GreedyMemoryLayoutPropagation.h
@@ -24,6 +24,7 @@ struct TTNNGreedyMemoryLayoutPropagationPipelineOptions {
   bool enableL1ShardingLayouts = true;
   llvm::StringMap<OutputLayoutOverrideParams> overrideOutputLayout;
   llvm::StringMap<Conv2dConfigOverrideParams> overrideConv2dConfig;
+  llvm::StringMap<Conv3dConfigOverrideParams> overrideConv3dConfig;
   bool enableDecisionTrace = false;
   std::string decisionTraceDir = "ttrt-artifacts/decision_trace";
   bool enableCompileTimeStats = false;

--- a/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
@@ -27,6 +27,8 @@ struct TTNNOptimizerOptions {
       llvm::StringMap<OutputLayoutOverrideParams>();
   llvm::StringMap<Conv2dConfigOverrideParams> overrideConv2dConfig =
       llvm::StringMap<Conv2dConfigOverrideParams>();
+  llvm::StringMap<Conv3dConfigOverrideParams> overrideConv3dConfig =
+      llvm::StringMap<Conv3dConfigOverrideParams>();
   bool memoryLayoutAnalysisEnabled = false;
   bool l1InterleavedFallbackAnalysisEnabled = false;
   MemoryLayoutAnalysisPolicyType memoryLayoutAnalysisPolicy =

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -333,6 +333,18 @@ def TTNNDeduceMoEComputeLayouts : Pass<"ttnn-deduce-moe-compute-layouts", "::mli
   }];
 }
 
+def TTNNPrepareConv3dWeights : Pass<"ttnn-prepare-conv3d-weights", "::mlir::ModuleOp"> {
+  let summary = "Insert PrepareConv3dWeightsOp before every Conv3dOp.";
+  let description = [{
+    TTIRToTTNN lowers ttir.conv3d to ttnn.conv3d with the raw 5D weight still attached.
+    This pass walks every Conv3dOp, derives c_in_block from the optimizer's
+    Conv3dConfigAttr (or falls back to TILE_WIDTH = 32), and inserts a
+    PrepareConv3dWeightsOp that reshapes the raw 5D weight into the 2D layout the
+    tt-metal runtime expects. The Conv3dOp's weight operand is then rewired to the
+    prepared result. Mirrors TTNNPrepareConv2dWeightsAndBias.
+  }];
+}
+
 def TTNNFusing: Pass<"ttnn-fusing", "::mlir::ModuleOp">
 {
   let summary = "TTNN fusing pass.";

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -22,6 +22,7 @@ struct OptionNames {
   static constexpr StringRef insertMemReconfig = "insert-memreconfig";
   static constexpr StringRef overrideOutputLayout = "override-output-layout";
   static constexpr StringRef overrideConv2dConfig = "override-conv2d-config";
+  static constexpr StringRef overrideConv3dConfig = "override-conv3d-config";
   static constexpr StringRef memoryLayoutAnalysisEnabled =
       "memory-layout-analysis-enabled";
   static constexpr StringRef l1InterleavedFallbackAnalysisEnabled =
@@ -43,6 +44,42 @@ struct OptionNames {
 };
 
 using Conv2dConfigOverrideParams = Conv2dConfigParams;
+
+// Selective overrides for Conv3dConfigAttr. All fields are std::optional so
+// the user can pin one parameter and leave the rest unset.
+//
+// Grammar (matches Conv2d's grammar; see Conv3dConfigOverrideParser):
+//   "loc1=weights_dtype#bf16:t_out_block#3:h_out_block#2,loc2=c_in_block#128"
+struct Conv3dConfigOverrideParams {
+  std::optional<ttcore::DataType> weightsDtype = std::nullopt;
+  std::optional<uint32_t> tOutBlock = std::nullopt;
+  std::optional<uint32_t> wOutBlock = std::nullopt;
+  std::optional<uint32_t> hOutBlock = std::nullopt;
+  std::optional<uint32_t> cOutBlock = std::nullopt;
+  std::optional<uint32_t> cInBlock = std::nullopt;
+
+  bool empty() const {
+    return !weightsDtype.has_value() && !tOutBlock.has_value() &&
+           !wOutBlock.has_value() && !hOutBlock.has_value() &&
+           !cOutBlock.has_value() && !cInBlock.has_value();
+  }
+
+  // True when every field has been pinned.
+  bool fullConfigOverride() const {
+    return weightsDtype.has_value() && tOutBlock.has_value() &&
+           wOutBlock.has_value() && hOutBlock.has_value() &&
+           cOutBlock.has_value() && cInBlock.has_value();
+  }
+
+  bool operator==(const Conv3dConfigOverrideParams &rhs) const {
+    return weightsDtype == rhs.weightsDtype && tOutBlock == rhs.tOutBlock &&
+           wOutBlock == rhs.wOutBlock && hOutBlock == rhs.hOutBlock &&
+           cOutBlock == rhs.cOutBlock && cInBlock == rhs.cInBlock;
+  }
+  bool operator!=(const Conv3dConfigOverrideParams &rhs) const {
+    return !(*this == rhs);
+  }
+};
 
 struct OutputLayoutOverrideParams {
   std::optional<SmallVector<int64_t, 2>> grid = std::nullopt;
@@ -171,6 +208,26 @@ public:
 
   static void print(llvm::raw_ostream &os,
                     const llvm::StringMap<Conv2dConfigOverrideParams> &value);
+};
+
+struct Conv3dConfigOverrideParser
+    : public llvm::cl::parser<llvm::StringMap<Conv3dConfigOverrideParams>> {
+public:
+  Conv3dConfigOverrideParser(llvm::cl::Option &opt)
+      : llvm::cl::parser<llvm::StringMap<Conv3dConfigOverrideParams>>(opt) {}
+
+  // Parse string in override-conv3d-config format.
+  // Return true on error.
+  // Example:
+  // "conv3d_1=weights_dtype#bf16:t_out_block#3:h_out_block#2:w_out_block#2:c_in_block#128:c_out_block#32"
+  bool parse(llvm::cl::Option &opt, StringRef argName, StringRef arg,
+             llvm::StringMap<Conv3dConfigOverrideParams> &value);
+
+  static std::string
+  toString(const llvm::StringMap<Conv3dConfigOverrideParams> &);
+
+  static void print(llvm::raw_ostream &os,
+                    const llvm::StringMap<Conv3dConfigOverrideParams> &value);
 };
 
 struct OutputLayoutOverrideParser

--- a/include/ttmlir/OpModel/TTNN/TTNNOutputTensorInference.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOutputTensorInference.h
@@ -36,6 +36,12 @@ getPreparedMoEComputeW0W1WeightsOutputType(PrepareMoEComputeW0W1WeightsOp *op);
 mlir::RankedTensorType
 getPreparedMoEComputeW2WeightsOutputType(PrepareMoEComputeW2WeightsOp *op);
 
+// Calculate the output tensor type of the prepared weights for a conv3d op.
+// The prepared weight is a 2D tensor [numCInBlocks*kD*kH*kW*TILE_WIDTH, O]
+// in DRAM/Interleaved/RowMajor layout, and is fully determined by Conv3dOp's
+// attributes — the shape is invariant in c_in_block.
+mlir::RankedTensorType getPreparedConv3dWeightsOutputTensor(Conv3dOp *op);
+
 } // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOUTPUTTENSORINFERENCE_H

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -2053,14 +2053,36 @@ public:
     RankedTensorType outputType = mlir::cast<RankedTensorType>(
         getTypeConverter()->convertType(op.getResult().getType()));
 
+    // Attach a *complete* default Conv3dConfigAttr. tt-metal only auto-derives
+    // a full default config when conv3d_config is entirely absent (conv3d.cpp
+    // `config_opt.value_or(<full default>)`); given any partial config it
+    // leaves the unset fields at their C++ struct defaults (C_out_block = 0,
+    // compute grid = {1, 1}), which violate the kernel's blocking invariants
+    // for some shapes (C_out_block = 0 collapses to the full padded output
+    // channels, breaking `matmul_N_t % out_subblock_w`; a 1x1 grid breaks
+    // `C_in_blocks <= total_cores`). So mirror tt-metal's own defaults here —
+    // spatial out-blocks = 1, c_out_block = TILE_WIDTH, c_in_block =
+    // TILE_WIDTH, and the compute grid taken from the device's worker grid — so
+    // the op's config is the single source of truth on every backend. This is
+    // the one place that encodes tt-metal's default knowledge; the optimizer
+    // may refine fields later (its overrides merge onto this config, preserving
+    // the rest), and TTNNPrepareConv3dWeights only reads c_in_block back out.
+    auto computeGrid = ttcore::GridAttr::get(
+        getContext(), ttcore::lookupDevice(op).getWorkerGrid().getShape());
+    auto defaultConv3dConfig = ttnn::Conv3dConfigAttr::get(
+        getContext(), /*weights_dtype=*/std::nullopt, /*t_out_block=*/1,
+        /*w_out_block=*/1, /*h_out_block=*/1, /*c_out_block=*/TILE_WIDTH,
+        /*c_in_block=*/TILE_WIDTH,
+        /*compute_with_storage_grid_size=*/computeGrid);
+
     // The raw 5D weight is passed through unchanged; TTNNPrepareConv3dWeights
     // (a post-optimizer pass) inserts the PrepareConv3dWeightsOp once the
-    // optimizer has chosen a Conv3dConfigAttr.
+    // optimizer has chosen (or kept) the Conv3dConfigAttr.
     auto convOp = rewriter.create<ttnn::Conv3dOp>(
         op.getLoc(), outputType, input, adaptor.getWeight(), reshapedBias,
         device, inChannelsAttr, outChannelsAttr, batchSizeAttr, inputDepthAttr,
         inputHeightAttr, inputWidthAttr, kernelSizeAttr, *strideAttr,
-        *paddingAttr, paddingModeAttr, groupsAttr, /*conv3d_config=*/nullptr,
+        *paddingAttr, paddingModeAttr, groupsAttr, defaultConv3dConfig,
         /*compute_config=*/nullptr);
 
     rewriter.replaceOp(op, convOp.getResult());

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -2025,43 +2025,7 @@ public:
 
     auto paddingModeAttr = adaptor.getPaddingModeAttr();
 
-    // Preserve TT-Metal's default conv3d behavior when no config is attached to
-    // the lowered TTNN op. Weight preparation must use C_in_block = 0 as well,
-    // otherwise the weights are pre-blocked differently from runtime defaults.
-    // Current tt-metal default conv3d config sets C_in_block = TILE_WIDTH.
     constexpr int64_t TILE_WIDTH = ttcore::TileType::getDefaultShape()[1];
-    constexpr int64_t ALIGNMENT = TILE_WIDTH;
-
-    auto weightShape = weightTy.getShape();
-    int64_t outChannels = weightShape[0];
-    int64_t inChannelsPerGroup = weightShape[1];
-    int64_t kernelDepth = weightShape[2];
-    int64_t kernelHeight = weightShape[3];
-    int64_t kernelWidth = weightShape[4];
-    int64_t cInAligned =
-        llvm::divideCeil(inChannelsPerGroup, ALIGNMENT) * ALIGNMENT;
-    int64_t numCInBlocks = cInAligned / TILE_WIDTH;
-    llvm::SmallVector<int64_t> preparedWeightShape = {
-        numCInBlocks * kernelDepth * kernelHeight * kernelWidth * TILE_WIDTH,
-        outChannels};
-    auto oldWeightLayout =
-        mlir::cast<ttnn::TTNNLayoutAttr>(weightTy.getEncoding());
-    auto preparedWeightLayout =
-        ttnn::TTNNLayoutAttr::Builder(rewriter.getContext(),
-                                      preparedWeightShape,
-                                      oldWeightLayout.getScalarElementType())
-            .setBufferType(ttnn::BufferType::DRAM)
-            .setMemoryLayout(ttnn::TensorMemoryLayout::Interleaved)
-            .build();
-    auto preparedWeightType = mlir::RankedTensorType::get(
-        preparedWeightShape, oldWeightLayout.getScalarElementType(),
-        preparedWeightLayout);
-    Value reshapedWeight = rewriter.create<ttnn::PrepareConv3dWeightsOp>(
-        ttmlir::utils::appendLocationSuffix(op.getLoc(),
-                                            "_prepare_conv3d_weight"),
-        preparedWeightType, adaptor.getWeight(), groupsAttr,
-        rewriter.getI32IntegerAttr(TILE_WIDTH),
-        rewriter.getI32IntegerAttr(ALIGNMENT), device);
 
     // Reshape bias tensor: (1, 1, 1, 1, O) → (1, O)
     Value reshapedBias = adaptor.getBias();
@@ -2089,9 +2053,12 @@ public:
     RankedTensorType outputType = mlir::cast<RankedTensorType>(
         getTypeConverter()->convertType(op.getResult().getType()));
 
+    // The raw 5D weight is passed through unchanged; TTNNPrepareConv3dWeights
+    // (a post-optimizer pass) inserts the PrepareConv3dWeightsOp once the
+    // optimizer has chosen a Conv3dConfigAttr.
     auto convOp = rewriter.create<ttnn::Conv3dOp>(
-        op.getLoc(), outputType, input, reshapedWeight, reshapedBias, device,
-        inChannelsAttr, outChannelsAttr, batchSizeAttr, inputDepthAttr,
+        op.getLoc(), outputType, input, adaptor.getWeight(), reshapedBias,
+        device, inChannelsAttr, outChannelsAttr, batchSizeAttr, inputDepthAttr,
         inputHeightAttr, inputWidthAttr, kernelSizeAttr, *strideAttr,
         *paddingAttr, paddingModeAttr, groupsAttr, /*conv3d_config=*/nullptr,
         /*compute_config=*/nullptr);

--- a/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
@@ -317,10 +317,12 @@ void LegalOpConfigAnalysis::fillOpSpecificAttrs() {
           conv3dConfig = convOp.getConv3dConfigAttr();
         }
 
-        // Default compute config attached to every emitted Conv3dOp. At
-        // optimization-level=1 the TTNNSetComputeKernelConfig pass is
-        // skipped (it defers to the optimizer), but Conv3dOp's runtime
-        // kernel rejects IR without compute_config.
+        // Default compute config attached to every emitted Conv3dOp.
+        // TTNNSetComputeKernelConfig runs before the optimizer but only
+        // materializes a compute_config when fidelity/fp32 fields are set, so
+        // it can leave Conv3dOp without one; the chosen Conv3dAttrs here
+        // supersede it regardless. Conv3dOp's runtime kernel rejects IR
+        // without compute_config, so attach a default.
         auto defaultComputeCfg =
             DeviceComputeKernelConfigAttr::get(op->getContext())
                 .withMathFidelity(MathFidelity::HiFi4)

--- a/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
@@ -4,7 +4,6 @@
 
 #include "ttmlir/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.h"
 
-#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfigAttrs.h"
@@ -21,8 +20,8 @@ namespace mlir::tt::ttnn {
 
 static bool isOpEnabledForAnalysis(Operation *op) {
   // Enable only for specific ops.
-  if (llvm::isa<ttnn::Conv2dOp, ttnn::ConvTranspose2dOp, ttnn::MatmulOp,
-                ttnn::LinearOp>(op)) {
+  if (llvm::isa<ttnn::Conv2dOp, ttnn::ConvTranspose2dOp, ttnn::Conv3dOp,
+                ttnn::MatmulOp, ttnn::LinearOp>(op)) {
     return true;
   }
 
@@ -126,6 +125,42 @@ applyConv2dConfigOverrides(ConvOpT op,
   }
 }
 
+static void
+applyConv3dConfigOverrides(ttnn::Conv3dOp op,
+                           const Conv3dConfigOverrideParams &overrides,
+                           std::vector<OpConfig> &analysisResult) {
+  // Build a Conv3dConfigAttr from the op's current config plus overrides.
+  // If the op has no config yet, start from an empty one (all fields unset).
+  Conv3dConfigAttr base = op.getConv3dConfigAttr();
+  if (!base) {
+    base = Conv3dConfigAttr::get(op.getContext(), std::nullopt, std::nullopt,
+                                 std::nullopt, std::nullopt, std::nullopt,
+                                 std::nullopt, std::nullopt);
+  }
+
+  auto pick = [](auto overrideVal, auto existingVal) {
+    return overrideVal.has_value() ? overrideVal : existingVal;
+  };
+
+  auto built = Conv3dConfigAttr::get(
+      op.getContext(), pick(overrides.weightsDtype, base.getWeightsDtype()),
+      pick(overrides.tOutBlock, base.getTOutBlock()),
+      pick(overrides.wOutBlock, base.getWOutBlock()),
+      pick(overrides.hOutBlock, base.getHOutBlock()),
+      pick(overrides.cOutBlock, base.getCOutBlock()),
+      pick(overrides.cInBlock, base.getCInBlock()),
+      base.getComputeWithStorageGridSize());
+
+  TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
+               "Conv3d config after overrides: {}", built);
+
+  for (OpConfig &opConfig : analysisResult) {
+    assert(opConfig.isAttrUninitialized() &&
+           "OpConfig should not have a config set before applying overrides");
+    opConfig.opSpecificAttrs = Conv3dAttrs{built, std::nullopt};
+  }
+}
+
 bool LegalOpConfigAnalysis::applyOverrides() {
   // For now, easiest way to initialize analysisResult is to copy the legal
   // configs here. Proper solution is that init() method is overridden in child
@@ -136,12 +171,11 @@ bool LegalOpConfigAnalysis::applyOverrides() {
     return true;
   }
 
-  if (!analysisInput.conv2dConfigOverrides) {
-    return false;
-  }
-
   return llvm::TypeSwitch<Operation *, bool>(op)
       .Case<ttnn::Conv2dOp, ttnn::ConvTranspose2dOp>([&](auto convOp) {
+        if (!analysisInput.conv2dConfigOverrides) {
+          return false;
+        }
         Conv2dConfigOverrideParams conv2dConfigOverrides;
         if (!isa<NameLoc>(op->getLoc())) {
           return false;
@@ -162,6 +196,22 @@ bool LegalOpConfigAnalysis::applyOverrides() {
       })
       .Case<ttnn::MatmulOp, ttnn::LinearOp>([](auto) {
         // Matmul/Linear ops don't use conv2d config overrides.
+        return false;
+      })
+      .Case<ttnn::Conv3dOp>([&](ttnn::Conv3dOp convOp) {
+        if (!analysisInput.conv3dConfigOverrides ||
+            !isa<NameLoc>(op->getLoc())) {
+          return false;
+        }
+        StringRef opLocName = mlir::cast<NameLoc>(op->getLoc()).getName();
+        auto it = analysisInput.conv3dConfigOverrides->find(opLocName);
+        if (it == analysisInput.conv3dConfigOverrides->end()) {
+          return false;
+        }
+        const Conv3dConfigOverrideParams &overrides = it->getValue();
+        applyConv3dConfigOverrides(convOp, overrides, analysisResult);
+        // Never skip fillOpSpecificAttrs: it preserves the override config
+        // and attaches the default compute kernel config.
         return false;
       })
       .Default([](Operation *op) {
@@ -243,6 +293,47 @@ void LegalOpConfigAnalysis::fillOpSpecificAttrs() {
         TTMLIR_TRACE(
             ttmlir::LogComponent::Optimizer,
             "Filled op specific attrs for conv2d op {}, ending with {} configs",
+            convOp, analysisResult.size());
+      })
+      .Case<ttnn::Conv3dOp>([&](auto convOp) {
+        assert(!analysisResult.empty() &&
+               "Analysis result should not be empty after applying overrides");
+        TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
+                     "Filling op specific attrs for conv3d op {}, starting "
+                     "with {} configs",
+                     convOp, analysisResult.size());
+
+        // If applyConv3dConfigOverrides ran, the analysisResult's first
+        // entry already carries the override config — keep it as the base.
+        // Otherwise fall back to the config already attached to the op (if
+        // any). There is no config search; the override (or the op default)
+        // is taken as-is.
+        std::optional<Conv3dConfigAttr> conv3dConfig;
+        if (const Conv3dAttrs *attrs = std::get_if<Conv3dAttrs>(
+                &analysisResult.begin()->opSpecificAttrs)) {
+          conv3dConfig = attrs->conv3dConfig;
+        }
+        if (!conv3dConfig.has_value() && convOp.getConv3dConfigAttr()) {
+          conv3dConfig = convOp.getConv3dConfigAttr();
+        }
+
+        // Default compute config attached to every emitted Conv3dOp. At
+        // optimization-level=1 the TTNNSetComputeKernelConfig pass is
+        // skipped (it defers to the optimizer), but Conv3dOp's runtime
+        // kernel rejects IR without compute_config.
+        auto defaultComputeCfg =
+            DeviceComputeKernelConfigAttr::get(op->getContext())
+                .withMathFidelity(MathFidelity::HiFi4)
+                .withFp32DestAccEn(true);
+
+        for (OpConfig &opConfig : analysisResult) {
+          opConfig.opSpecificAttrs =
+              Conv3dAttrs{conv3dConfig, defaultComputeCfg};
+        }
+
+        TTMLIR_TRACE(
+            ttmlir::LogComponent::Optimizer,
+            "Filled op specific attrs for conv3d op {}, ending with {} configs",
             convOp, analysisResult.size());
       })
       .Case<ttnn::MatmulOp, ttnn::LinearOp>([&](auto matmulOp) {

--- a/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
@@ -133,6 +133,30 @@ void applyConvSliceConfig(ModuleOp moduleOp) {
   });
 }
 
+//===----------------------------------------------------------------------===//
+// Conv3dRuleBook
+//===----------------------------------------------------------------------===//
+
+void Conv3dRuleBook::applyOpSpecificAttrs(
+    Operation *op, const BeamCandidate &candidate) const {
+  auto conv3d = dyn_cast<Conv3dOp>(op);
+  if (!conv3d) {
+    return;
+  }
+  if (!std::holds_alternative<Conv3dAttrs>(
+          candidate.configHint.opSpecificAttrs)) {
+    return;
+  }
+  Conv3dAttrs attrs =
+      std::get<Conv3dAttrs>(candidate.configHint.opSpecificAttrs);
+  if (attrs.conv3dConfig.has_value()) {
+    conv3d.setConv3dConfigAttr(attrs.conv3dConfig.value());
+  }
+  if (attrs.deviceComputeKernelConfig.has_value()) {
+    conv3d.setComputeConfigAttr(attrs.deviceComputeKernelConfig.value());
+  }
+}
+
 void fixupConvDeallocate(func::FuncOp func) {
   func->walk([&](Operation *op) {
     auto disableDeallocIfMultiUser = [](auto convOp) {

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -66,6 +66,7 @@ bool OpRuleBook::preferCandidate(Operation * /*op*/, const BeamCandidate &a,
 const OpRuleBook &getRuleBook(Operation *op) {
   static OpRuleBook defaultRules;
   static Conv2dRuleBook conv2d;
+  static Conv3dRuleBook conv3d;
   static MatmulRuleBook matmul;
   static ConcatRuleBook concat;
   static SliceRuleBook slice;
@@ -94,6 +95,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     };
     reg(Conv2dOp::getOperationName(), &conv2d);
     reg(ConvTranspose2dOp::getOperationName(), &conv2d);
+    reg(Conv3dOp::getOperationName(), &conv3d);
     reg(MatmulOp::getOperationName(), &matmul);
     reg(LinearOp::getOperationName(), &matmul);
     reg(ConcatOp::getOperationName(), &concat);

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1729,7 +1729,8 @@ TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(
 
 // TT-Metal's Conv3d has operand format constraints:
 // - input must be row-major bf16
-// - weight must be tile bf16
+// - weight must be bf16 (layout is enforced by TTNNPrepareConv3dWeights,
+//   which inserts a prepare op + to_layout(Tile) before Conv3dOp)
 // - bias must be tile bf16 when present
 // - output is forced to bf16
 // Tracked in: https://github.com/tenstorrent/tt-metal/issues/35436
@@ -1739,6 +1740,9 @@ TTNNOperandsWorkaroundsFactory::createConv3dOpOperandsWorkarounds(
   TTNNOperandWorkarounds inputWorkaround;
   inputWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
   inputWorkaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
+
+  TTNNOperandWorkarounds weightWorkaround;
+  weightWorkaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
 
   TTNNOperandWorkarounds tiledBf16Workaround;
   tiledBf16Workaround.tensorLayoutWorkaround = Layout::Tile;
@@ -1750,7 +1754,7 @@ TTNNOperandsWorkaroundsFactory::createConv3dOpOperandsWorkarounds(
   auto workaround =
       wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
           .addInputOperandWorkaround(inputWorkaround)
-          .addInputOperandWorkaround(tiledBf16Workaround)
+          .addInputOperandWorkaround(weightWorkaround)
           .addOutputOperandWorkaround(outputWorkaround);
 
   if (op.getBias()) {

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -14,6 +14,7 @@
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/OpModel/TTNN/D2MOpCostModel.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
+#include "ttmlir/OpModel/TTNN/TTNNOutputTensorInference.h"
 
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -3451,13 +3452,38 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // Conv3dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+// If a config has been specified, use that. Otherwise, use the op property.
+static Conv3dAttrs unpackConv3dAttrs(const OpConfig::OpSpecificAttrs &attrs,
+                                     Conv3dOp op) {
+  assert((std::holds_alternative<Conv3dAttrs>(attrs) ||
+          std::holds_alternative<UninitializedAttrs>(attrs)) &&
+         "Please create a Conv3dAttrs or leave it to be uninitialized.");
+
+  if (std::holds_alternative<UninitializedAttrs>(attrs)) {
+    return Conv3dAttrs{op.getConv3dConfig(), op.getComputeConfig()};
+  }
+
+  Conv3dAttrs conv3dAttrs = std::get<Conv3dAttrs>(attrs);
+
+  return Conv3dAttrs{conv3dAttrs.conv3dConfig ? conv3dAttrs.conv3dConfig
+                                              : op.getConv3dConfig(),
+                     conv3dAttrs.deviceComputeKernelConfig
+                         ? conv3dAttrs.deviceComputeKernelConfig
+                         : op.getComputeConfig()};
+}
+
 llvm::Expected<op_model::OpConstraints>
 Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
 
   const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
+  // tt-metal's conv3d kernel consumes the prepared 2D weight; the in-IR
+  // weight may still be raw 5D (before TTNNPrepareConv3dWeights runs), so
+  // pass the prepared shape/layout regardless of what's currently in IR.
+  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(this);
+  const auto weightShape = preparedWeight.getShape();
+  auto weightLayout = mlir::cast<TTNNLayoutAttr>(preparedWeight.getEncoding());
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
@@ -3466,13 +3492,15 @@ Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
+  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, *this);
+
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<Conv3dOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
-      getOutChannels(), getBatchSize(), getInputDepth(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(), getGroups(),
-      getPaddingMode(), getDtypeAttr(), getConv3dConfig(), getComputeConfig(),
-      opConfig.outputLayout);
+      inputs[0], weightShape, weightLayout, biasShape, biasLayout,
+      getInChannels(), getOutChannels(), getBatchSize(), getInputDepth(),
+      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
+      getPadding(), getGroups(), getPaddingMode(), getDtypeAttr(),
+      attr.conv3dConfig, attr.deviceComputeKernelConfig, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3481,7 +3509,9 @@ Conv3dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
 
   const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
+  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(this);
+  const auto weightShape = preparedWeight.getShape();
+  auto weightLayout = mlir::cast<TTNNLayoutAttr>(preparedWeight.getEncoding());
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
@@ -3490,13 +3520,15 @@ Conv3dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
+  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, *this);
+
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<Conv3dOp>::getOpRuntime, *this, inputShape, inputs[0],
-      weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
+      weightShape, weightLayout, biasShape, biasLayout, getInChannels(),
       getOutChannels(), getBatchSize(), getInputDepth(), getInputHeight(),
       getInputWidth(), getKernelSize(), getStride(), getPadding(), getGroups(),
-      getPaddingMode(), getDtypeAttr(), getConv3dConfig(), getComputeConfig(),
-      opConfig.outputLayout);
+      getPaddingMode(), getDtypeAttr(), attr.conv3dConfig,
+      attr.deviceComputeKernelConfig, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -143,6 +143,7 @@ void createTTNNPipelineAnalysisPasses(
           options.memoryLayoutAnalysisEnabled;
       propagationOptions.overrideOutputLayout = options.overrideOutputLayout;
       propagationOptions.overrideConv2dConfig = options.overrideConv2dConfig;
+      propagationOptions.overrideConv3dConfig = options.overrideConv3dConfig;
       propagationOptions.enableDecisionTrace = options.enableDecisionTrace;
       propagationOptions.decisionTraceDir = options.decisionTraceDir;
       propagationOptions.enableCompileTimeStats =
@@ -426,6 +427,12 @@ void createTTIRToTTNNCommonPipeline(
     }
 
     createTTNNPipelineAnalysisPasses(devicePm, options);
+
+    // Materialize PrepareConv3dWeightsOp for every Conv3dOp. Runs after the
+    // optimizer (so it can read the optimizer's chosen Conv3dConfigAttr) but
+    // unconditionally — at optimization-level=0 there's no Conv3dConfigAttr
+    // and the pass falls back to TILE_WIDTH for c_in_block.
+    devicePm.addPass(mlir::tt::ttnn::createTTNNPrepareConv3dWeights());
 
     if (options.enableCreateD2MSubgraphs) {
       TTNNPipelineD2MPassOptions d2mOptions;

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         OptimizerPasses/RowMajorLayoutPropagation.cpp
         OptimizerPasses/TTNNPrepareConv2dWeightsAndBias.cpp
         OptimizerPasses/TTNNDeduceMoEComputeLayouts.cpp
+        OptimizerPasses/TTNNPrepareConv3dWeights.cpp
         TTNNAdjustDeallocs.cpp
         TTNNAllocateDistributedOpBuffers.cpp
         TTNNAllocateDistributedOpSemaphores.cpp

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
@@ -70,6 +70,7 @@ public:
     enableCompileTimeStats = opts.enableCompileTimeStats;
     overrideOutputLayout = std::move(opts.overrideOutputLayout);
     overrideConv2dConfig = std::move(opts.overrideConv2dConfig);
+    overrideConv3dConfig = std::move(opts.overrideConv3dConfig);
   }
 
   void runOnOperation() final {
@@ -162,7 +163,8 @@ public:
         LegalOpConfigAnalysis legalOpConfigAnalysis =
             getChildAnalysis<LegalOpConfigAnalysis>(op);
         legalOpConfigAnalysis.init(LegalOpConfigAnalysisInput(
-            legalOpLayoutAnalysis.getResult(), &overrideConv2dConfig));
+            legalOpLayoutAnalysis.getResult(), &overrideConv2dConfig,
+            &overrideConv3dConfig));
         legalConfigs[op] = legalOpConfigAnalysis.getResult();
       });
     });
@@ -232,6 +234,12 @@ protected:
           *this, OptionNames::overrideConv2dConfig,
           ::llvm::cl::desc("Override Conv2d configuration for specific ops."),
           ::llvm::cl::init(llvm::StringMap<Conv2dConfigOverrideParams>())};
+  ::mlir::Pass::Option<llvm::StringMap<Conv3dConfigOverrideParams>,
+                       Conv3dConfigOverrideParser>
+      overrideConv3dConfig{
+          *this, OptionNames::overrideConv3dConfig,
+          ::llvm::cl::desc("Override Conv3d configuration for specific ops."),
+          ::llvm::cl::init(llvm::StringMap<Conv3dConfigOverrideParams>())};
 };
 
 // Pipeline create function.

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
@@ -56,6 +56,7 @@ TTNNOptimizerOptions::TTNNOptimizerOptions(
     : insertMemReconfig(pipelineOptions.insertMemReconfig),
       overrideOutputLayout(pipelineOptions.overrideOutputLayout),
       overrideConv2dConfig(pipelineOptions.overrideConv2dConfig),
+      overrideConv3dConfig(pipelineOptions.overrideConv3dConfig),
       memoryLayoutAnalysisEnabled(pipelineOptions.memoryLayoutAnalysisEnabled),
       l1InterleavedFallbackAnalysisEnabled(
           pipelineOptions.l1InterleavedFallbackAnalysisEnabled),
@@ -133,6 +134,7 @@ public:
     insertMemReconfig = std::move(options.insertMemReconfig);
     overrideOutputLayout = std::move(options.overrideOutputLayout);
     overrideConv2dConfig = std::move(options.overrideConv2dConfig);
+    overrideConv3dConfig = std::move(options.overrideConv3dConfig);
     memoryLayoutAnalysisEnabled =
         std::move(options.memoryLayoutAnalysisEnabled);
     l1InterleavedFallbackAnalysisEnabled =
@@ -163,6 +165,12 @@ protected:
           *this, OptionNames::overrideConv2dConfig,
           ::llvm::cl::desc("Override Conv2d configuration for specific ops."),
           ::llvm::cl::init(llvm::StringMap<Conv2dConfigOverrideParams>())};
+  ::mlir::Pass::Option<llvm::StringMap<Conv3dConfigOverrideParams>,
+                       mlir::tt::ttnn::Conv3dConfigOverrideParser>
+      overrideConv3dConfig{
+          *this, OptionNames::overrideConv3dConfig,
+          ::llvm::cl::desc("Override Conv3d configuration for specific ops."),
+          ::llvm::cl::init(llvm::StringMap<Conv3dConfigOverrideParams>())};
   ::mlir::Pass::Option<bool> memoryLayoutAnalysisEnabled{
       *this, OptionNames::memoryLayoutAnalysisEnabled,
       ::llvm::cl::desc("Enable memory layout optimization."),
@@ -299,7 +307,8 @@ public:
         LegalOpConfigAnalysis legalOpConfigAnalysis =
             getChildAnalysis<LegalOpConfigAnalysis>(op);
         legalOpConfigAnalysis.init(LegalOpConfigAnalysisInput(
-            legalOpLayoutAnalysis.getResult(), &overrideConv2dConfig));
+            legalOpLayoutAnalysis.getResult(), &overrideConv2dConfig,
+            &overrideConv3dConfig));
         legalConfigs[op] = legalOpConfigAnalysis.getResult();
 
         // Save only L1 Interleaved legal configs in a separate map for
@@ -520,6 +529,22 @@ public:
                       // well and merge with the Conv2dOp case above.
                     }
                   })
+              .Case<ttnn::Conv3dOp>([&](ttnn::Conv3dOp convOp) {
+                auto opAttributes = opConfigAnalysis.getResult().at(op);
+                if (std::holds_alternative<ttnn::Conv3dAttrs>(
+                        opAttributes.opSpecificAttrs)) {
+                  ttnn::Conv3dAttrs conv3dAttrs =
+                      std::get<ttnn::Conv3dAttrs>(opAttributes.opSpecificAttrs);
+                  if (conv3dAttrs.conv3dConfig.has_value()) {
+                    convOp.setConv3dConfigAttr(
+                        conv3dAttrs.conv3dConfig.value());
+                  }
+                  if (conv3dAttrs.deviceComputeKernelConfig.has_value()) {
+                    convOp.setComputeConfigAttr(
+                        conv3dAttrs.deviceComputeKernelConfig.value());
+                  }
+                }
+              })
               .Case<ttnn::MatmulOp, ttnn::LinearOp>([&](auto matmulOp) {
                 auto opAttributes = opConfigAnalysis.getResult().at(op);
                 if (std::holds_alternative<ttnn::MatmulAttrs>(

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv3dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv3dWeights.cpp
@@ -67,14 +67,16 @@ private:
         static_cast<int32_t>(ttcore::TileType::getDefaultShape()[1]);
     constexpr int32_t ALIGNMENT = TILE_WIDTH;
 
-    // Derive c_in_block from the optimizer's Conv3dConfigAttr when present,
-    // otherwise default to TILE_WIDTH (matching tt-metal's default).
-    int32_t cInBlock = TILE_WIDTH;
-    if (Conv3dConfigAttr config = convOp.getConv3dConfigAttr()) {
-      if (auto chosen = config.getCInBlock()) {
-        cInBlock = static_cast<int32_t>(*chosen);
-      }
-    }
+    // c_in_block is read straight from the op's Conv3dConfigAttr. TTIRToTTNN
+    // attaches a complete config (and the optimizer only refines it), so the
+    // field is always present by the time this pass runs. This pass does not
+    // reason about tt-metal defaults or modify the config — it just consumes
+    // the c_in_block already chosen and prepares the weight with it.
+    Conv3dConfigAttr config = convOp.getConv3dConfigAttr();
+    assert(config && config.getCInBlock() &&
+           "Conv3dOp must carry a Conv3dConfigAttr with c_in_block (set by "
+           "TTIRToTTNN) before TTNNPrepareConv3dWeights runs");
+    int32_t cInBlock = static_cast<int32_t>(*config.getCInBlock());
 
     // The prepare op's MLIR result type must match what tt-metal's runtime
     // produces: a ROW_MAJOR 2D tensor. The helper builds exactly that.

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv3dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv3dWeights.cpp
@@ -40,8 +40,26 @@ public:
 
 private:
   void processConvOp(Conv3dOp convOp, IRRewriter &rewriter) {
-    // Skip if the prepare op is already in place (weight already 2D).
+    // If the weight is already 2D, a prepare op (from a previous run of this
+    // pass or an earlier pass) is already in place, so don't re-prepare. But
+    // the conv3d runtime kernel still requires the weight in TILE layout, and
+    // the weight-layout workaround was relaxed to dtype-only; nothing else
+    // enforces tile here. So ensure the tile layout holds rather than assuming
+    // it, then return.
     if (convOp.getWeight().getType().getRank() == 2) {
+      mlir::TypedValue<RankedTensorType> weight = convOp.getWeight();
+      auto weightLayout =
+          mlir::cast<TTNNLayoutAttr>(weight.getType().getEncoding());
+      if (weightLayout.getLayout() != Layout::Tile) {
+        rewriter.setInsertionPoint(convOp);
+        ToLayoutOp toTileOp = utils::createToLayoutOp(
+            convOp, weight, rewriter, Layout::Tile,
+            weightLayout.getBufferType(), weightLayout.getMemLayout(),
+            weightLayout.getDataType(), "_prepare_conv3d_weight_to_tile");
+        rewriter.modifyOpInPlace(convOp, [&]() {
+          convOp.getWeightMutable().assign(toTileOp.getResult());
+        });
+      }
       return;
     }
 

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv3dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv3dWeights.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/OpModel/TTNN/TTNNOutputTensorInference.h"
+#include "ttmlir/Utils.h"
+
+namespace mlir::tt::ttnn {
+#define GEN_PASS_DEF_TTNNPREPARECONV3DWEIGHTS
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+namespace {
+// Post-optimizer pass that materializes a PrepareConv3dWeightsOp before each
+// Conv3dOp. The TTIRToTTNN conversion leaves Conv3dOp consuming its raw 5D
+// weight; this pass picks up the c_in_block chosen by the optimizer (via
+// Conv3dConfigAttr) and inserts the prepare op with that block size. The
+// prepared weight's shape is invariant in c_in_block, so the shape is fully
+// determined by op attributes.
+//
+// Mirrors TTNNPrepareConv2dWeightsAndBias: by deferring prepare-op creation
+// until after the optimizer has chosen a config, we avoid the layout/c_in_block
+// mistypings that the (deleted) TTNNRefreshConv3dPrepareWeights pass was
+// patching up post-hoc.
+class TTNNPrepareConv3dWeights
+    : public impl::TTNNPrepareConv3dWeightsBase<TTNNPrepareConv3dWeights> {
+public:
+  using impl::TTNNPrepareConv3dWeightsBase<
+      TTNNPrepareConv3dWeights>::TTNNPrepareConv3dWeightsBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    IRRewriter rewriter(&getContext());
+
+    moduleOp.walk([&](Conv3dOp convOp) { processConvOp(convOp, rewriter); });
+  }
+
+private:
+  void processConvOp(Conv3dOp convOp, IRRewriter &rewriter) {
+    // Skip if the prepare op is already in place (weight already 2D).
+    if (convOp.getWeight().getType().getRank() == 2) {
+      return;
+    }
+
+    constexpr int32_t TILE_WIDTH =
+        static_cast<int32_t>(ttcore::TileType::getDefaultShape()[1]);
+    constexpr int32_t ALIGNMENT = TILE_WIDTH;
+
+    // Derive c_in_block from the optimizer's Conv3dConfigAttr when present,
+    // otherwise default to TILE_WIDTH (matching tt-metal's default).
+    int32_t cInBlock = TILE_WIDTH;
+    if (Conv3dConfigAttr config = convOp.getConv3dConfigAttr()) {
+      if (auto chosen = config.getCInBlock()) {
+        cInBlock = static_cast<int32_t>(*chosen);
+      }
+    }
+
+    // The prepare op's MLIR result type must match what tt-metal's runtime
+    // produces: a ROW_MAJOR 2D tensor. The helper builds exactly that.
+    mlir::RankedTensorType preparedWeightType =
+        op_model::getPreparedConv3dWeightsOutputTensor(&convOp);
+
+    rewriter.setInsertionPoint(convOp);
+
+    // tt-metal's prepare_conv3d_weights runtime kernel expects its input
+    // weight to be ROW_MAJOR in SystemMemory. The optimizer's layout
+    // propagation may have re-typed the raw 5D weight (e.g. to TILE in
+    // DRAM); since the prepare op didn't exist at workaround time, the
+    // input-operand workaround couldn't fire. Insert the to_layout here.
+    mlir::TypedValue<RankedTensorType> rawWeight = convOp.getWeight();
+    auto rawWeightLayout =
+        mlir::cast<TTNNLayoutAttr>(rawWeight.getType().getEncoding());
+    if (rawWeightLayout.getLayout() != Layout::RowMajor ||
+        rawWeightLayout.getBufferType() != BufferType::SystemMemory) {
+      rawWeight =
+          utils::createToLayoutOp(convOp, rawWeight, rewriter, Layout::RowMajor,
+                                  BufferType::SystemMemory,
+                                  /*targetTensorMemoryLayout=*/nullptr,
+                                  rawWeightLayout.getDataType(),
+                                  "_prepare_conv3d_weight_to_row_major")
+              .getResult();
+    }
+
+    auto prepareOp = rewriter.create<PrepareConv3dWeightsOp>(
+        ttmlir::utils::appendLocationSuffix(convOp.getLoc(),
+                                            "_prepare_conv3d_weight"),
+        preparedWeightType, rawWeight,
+        rewriter.getI32IntegerAttr(convOp.getGroups()),
+        rewriter.getI32IntegerAttr(cInBlock),
+        rewriter.getI32IntegerAttr(ALIGNMENT), convOp.getDevice());
+
+    // tt-metal's conv3d kernel consumes the weight in TILE layout. The
+    // prepare op outputs ROW_MAJOR (matching runtime), so insert a to_layout
+    // op converting to TILE before the conv3d. Without this, the workaround
+    // pass — which already ran — has not been able to enforce the tile
+    // constraint on the weight (its input was the raw 5D weight).
+    auto preparedLayout =
+        mlir::cast<TTNNLayoutAttr>(preparedWeightType.getEncoding());
+    ToLayoutOp toTileOp = utils::createToLayoutOp(
+        convOp, prepareOp.getResult(), rewriter, Layout::Tile,
+        preparedLayout.getBufferType(), preparedLayout.getMemLayout(),
+        preparedLayout.getDataType(), "_prepare_conv3d_weight_to_tile");
+
+    rewriter.modifyOpInPlace(convOp, [&]() {
+      convOp.getWeightMutable().assign(toTileOp.getResult());
+    });
+  }
+};
+} // namespace
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -774,12 +774,17 @@ const std::set<mlir::StringRef>
         // tt-metal SDPA-supported dtype (bf16). Without it, opt_level>=1 leaves
         // f32 operands
         ttnn::FlashMlaPrefillOp::getOperationName(),
-        // PrepareConv3dWeightsOp is needed for conv3d and it requires ROW_MAJOR
-        // layout. See #8411.
-        ttnn::PrepareConv3dWeightsOp::getOperationName(),
         // The moe_compute weight packers and the op itself require
         // layout and data type workarounds.
         ttnn::PrepareMoEComputeW0W1WeightsOp::getOperationName(),
         ttnn::PrepareMoEComputeW2WeightsOp::getOperationName(),
         ttnn::MoeComputeOp::getOperationName()};
+        // Conv3d's runtime kernel hard-rejects Tile input
+        // (TT_FATAL @ conv3d_device_operation.cpp:49); without the
+        // workaround running here, the optimizer's layout propagation
+        // picks Tile for the input and downstream OpModel queries
+        // (LegalOpConfigAnalysis, OperationValidationAndFallback) see
+        // an inconsistent view between in-IR layouts and runtime
+        // contract.
+        ttnn::Conv3dOp::getOperationName()};
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -778,7 +778,7 @@ const std::set<mlir::StringRef>
         // layout and data type workarounds.
         ttnn::PrepareMoEComputeW0W1WeightsOp::getOperationName(),
         ttnn::PrepareMoEComputeW2WeightsOp::getOperationName(),
-        ttnn::MoeComputeOp::getOperationName()};
+        ttnn::MoeComputeOp::getOperationName(),
         // Conv3d's runtime kernel hard-rejects Tile input
         // (TT_FATAL @ conv3d_device_operation.cpp:49); without the
         // workaround running here, the optimizer's layout propagation

--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -330,6 +330,142 @@ void Conv2dConfigOverrideParser::print(
   os << "\n";
 }
 
+// Example:
+// "conv3d_1=weights_dtype#bf16:t_out_block#3:h_out_block#2:w_out_block#2:c_in_block#128:c_out_block#32"
+bool Conv3dConfigOverrideParser::parse(
+    llvm::cl::Option &opt, StringRef argName, StringRef arg,
+    llvm::StringMap<Conv3dConfigOverrideParams> &value) {
+  SmallVector<StringRef> opOverrideList;
+  constexpr size_t kvPairSize = 2;
+  constexpr size_t iOpName = 0;
+  constexpr size_t iConv3dConfigOverrideParams = 1;
+  constexpr char opSeparator = ',';
+  constexpr char opNameSeparator = '=';
+  constexpr char paramSeparator = ':';
+  constexpr char paramNameValueSeparator = '#';
+
+  auto parseUint = [&](StringRef paramName, StringRef paramValue,
+                       std::optional<uint32_t> &slot) -> bool {
+    uint32_t v;
+    if (paramValue.getAsInteger<uint32_t>(10, v)) {
+      opt.error("Invalid " + paramName + ": " + paramValue);
+      return true;
+    }
+    if (slot.has_value()) {
+      opt.error("Duplicate " + paramName + ": " + paramValue);
+      return true;
+    }
+    slot = v;
+    return false;
+  };
+
+  arg.split(opOverrideList, opSeparator);
+  for (StringRef opOverrides : opOverrideList) {
+    SmallVector<StringRef, kvPairSize> opOverrideParts;
+    opOverrides.split(opOverrideParts, opNameSeparator);
+    if (opOverrideParts.size() != kvPairSize) {
+      opt.error("Invalid override format " + opOverrides);
+      return true;
+    }
+
+    SmallVector<StringRef> conv3dConfigParams;
+    opOverrideParts[iConv3dConfigOverrideParams].split(conv3dConfigParams,
+                                                       paramSeparator,
+                                                       /*MaxSplit=*/-1,
+                                                       /*KeepEmpty=*/false);
+
+    Conv3dConfigOverrideParams params;
+
+    for (StringRef param : conv3dConfigParams) {
+      auto [paramName, paramValue] = param.split(paramNameValueSeparator);
+      if (paramName == "weights_dtype") {
+        auto dt = mlir::tt::ttcore::DataTypeStringToEnum(paramValue);
+        if (!dt) {
+          opt.error("Invalid weights_dtype: " + paramValue);
+          return true;
+        }
+        if (params.weightsDtype.has_value()) {
+          opt.error("Duplicate weights_dtype: " + paramValue);
+          return true;
+        }
+        params.weightsDtype = dt;
+      } else if (paramName == "t_out_block") {
+        if (parseUint("t_out_block", paramValue, params.tOutBlock)) {
+          return true;
+        }
+      } else if (paramName == "w_out_block") {
+        if (parseUint("w_out_block", paramValue, params.wOutBlock)) {
+          return true;
+        }
+      } else if (paramName == "h_out_block") {
+        if (parseUint("h_out_block", paramValue, params.hOutBlock)) {
+          return true;
+        }
+      } else if (paramName == "c_out_block") {
+        if (parseUint("c_out_block", paramValue, params.cOutBlock)) {
+          return true;
+        }
+      } else if (paramName == "c_in_block") {
+        if (parseUint("c_in_block", paramValue, params.cInBlock)) {
+          return true;
+        }
+      } else {
+        opt.error("Invalid override parameter: " + paramName);
+        return true;
+      }
+    }
+
+    value[opOverrideParts[iOpName]] = params;
+  }
+  return false;
+}
+
+std::string Conv3dConfigOverrideParser::toString(
+    const llvm::StringMap<Conv3dConfigOverrideParams> &value) {
+  std::string res;
+  size_t count = 0;
+  for (const auto &[opLoc, params] : value) {
+    std::string s;
+    llvm::raw_string_ostream rso(s);
+    if (params.weightsDtype.has_value()) {
+      rso << "weights_dtype#"
+          << DataTypeEnumToString(params.weightsDtype.value()) << ":";
+    }
+    if (params.tOutBlock.has_value()) {
+      rso << "t_out_block#" << params.tOutBlock.value() << ":";
+    }
+    if (params.wOutBlock.has_value()) {
+      rso << "w_out_block#" << params.wOutBlock.value() << ":";
+    }
+    if (params.hOutBlock.has_value()) {
+      rso << "h_out_block#" << params.hOutBlock.value() << ":";
+    }
+    if (params.cOutBlock.has_value()) {
+      rso << "c_out_block#" << params.cOutBlock.value() << ":";
+    }
+    if (params.cInBlock.has_value()) {
+      rso << "c_in_block#" << params.cInBlock.value() << ":";
+    }
+    rso.flush();
+    if (!s.empty()) {
+      s.pop_back(); // trailing ':'
+    }
+    res += (opLoc.str() + "=" + s);
+    if (++count < value.size()) {
+      res += ",";
+    }
+  }
+  return res;
+}
+
+void Conv3dConfigOverrideParser::print(
+    llvm::raw_ostream &os,
+    const llvm::StringMap<Conv3dConfigOverrideParams> &value) {
+  os << OptionNames::overrideConv3dConfig << "=";
+  os << Conv3dConfigOverrideParser::toString(value);
+  os << "\n";
+}
+
 bool OutputLayoutOverrideParser::parse(
     llvm::cl::Option &opt, StringRef argName, StringRef arg,
     llvm::StringMap<OutputLayoutOverrideParams> &value) {

--- a/lib/Dialect/TTNN/Utils/VerificationUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/VerificationUtils.cpp
@@ -214,8 +214,16 @@ mlir::LogicalResult verifyTensorRanks(mlir::tt::ttnn::Conv3dOp *op) {
   if (op->getInput().getType().getRank() != 5) {
     return op->emitOpError("input must be a 5D tensor [N, D, H, W, C]");
   }
-  if (op->getWeight().getType().getRank() != 2) {
-    return op->emitOpError("weight must be a 2D tensor [kD*kH*kW*C/G, O]");
+  int64_t weightRank = op->getWeight().getType().getRank();
+  // Conv3dOp accepts weight in two shapes:
+  //   - Raw 5D [O, C/G, kD, kH, kW]: present from TTIRToTTNN lowering until
+  //     TTNNPrepareConv3dWeights runs.
+  //   - Prepared 2D [kD*kH*kW*C/G_aligned, O]: emitted by
+  //     PrepareConv3dWeightsOp and consumed by the tt-metal runtime kernel.
+  if (weightRank != 5 && weightRank != 2) {
+    return op->emitOpError(
+        "weight must be either a 5D tensor [O, C/G, kD, kH, kW] (raw) or a "
+        "2D tensor [kD*kH*kW*C/G, O] (prepared)");
   }
   if (op->getBias() && op->getBias().getType().getRank() != 2) {
     return op->emitOpError("bias must be a 2D tensor [1, O]");
@@ -234,10 +242,24 @@ getConv3dInputDims(mlir::tt::ttnn::Conv3dOp *op) {
                                  op->getInputHeight(), op->getInputWidth(),
                                  op->getInChannels()};
 
-  WeightTensorDims3d weightDims = {
-      op->getOutChannels(),
-      op->getWeight().getType().getDimSize(WEIGHT_FLATTENED),
-      op->getKernelSize()[0], op->getKernelSize()[1], op->getKernelSize()[2]};
+  auto weightType = op->getWeight().getType();
+  llvm::ArrayRef<int32_t> kernelSize = op->getKernelSize();
+  WeightTensorDims3d weightDims;
+  if (weightType.getRank() == 5) {
+    // Raw 5D weight: (O, C/G, kD, kH, kW). flattenedKernelChannels is the
+    // unaligned product C/G * kD * kH * kW; alignment padding is applied
+    // later by TTNNPrepareConv3dWeights.
+    weightDims = {weightType.getDimSize(0),
+                  weightType.getDimSize(1) * weightType.getDimSize(2) *
+                      weightType.getDimSize(3) * weightType.getDimSize(4),
+                  weightType.getDimSize(2), weightType.getDimSize(3),
+                  weightType.getDimSize(4)};
+  } else {
+    // Prepared 2D weight: (kD*kH*kW*C/G_aligned, O). Kernel dims come from
+    // op attributes since the weight has been flattened.
+    weightDims = {op->getOutChannels(), weightType.getDimSize(WEIGHT_FLATTENED),
+                  kernelSize[0], kernelSize[1], kernelSize[2]};
+  }
 
   std::optional<BiasTensorDims3d> biasDims;
   if (op->getBias()) {
@@ -332,15 +354,21 @@ verifyConv3dInputDims(mlir::tt::ttnn::Conv3dOp *op,
            << ") must be divisible by groups (" << params.groups << ")";
   }
 
-  int64_t expectedFlattenedDim =
-      (inputDims.inputChannels / params.groups) * params.kernelSize.depth *
-      params.kernelSize.vertical * params.kernelSize.horizontal;
+  // The flattened-dim consistency check applies only to the prepared 2D
+  // weight, where the flattened dim is kD*kH*kW*C/G_aligned. For raw 5D
+  // weight, dim 1 is the unaligned C/G — it doesn't match in_channels
+  // (which is already aligned to TILE_WIDTH by TTIRToTTNN).
+  if (op->getWeight().getType().getRank() == 2) {
+    int64_t expectedFlattenedDim =
+        (inputDims.inputChannels / params.groups) * params.kernelSize.depth *
+        params.kernelSize.vertical * params.kernelSize.horizontal;
 
-  if (expectedFlattenedDim != weightDims.flattenedKernelChannels) {
-    return op->emitOpError() << "weight flattened dimension ("
-                             << weightDims.flattenedKernelChannels
-                             << ") must equal kD*kH*kW*C_in/groups ("
-                             << expectedFlattenedDim << ")";
+    if (expectedFlattenedDim != weightDims.flattenedKernelChannels) {
+      return op->emitOpError() << "weight flattened dimension ("
+                               << weightDims.flattenedKernelChannels
+                               << ") must equal kD*kH*kW*C_in/groups ("
+                               << expectedFlattenedDim << ")";
+    }
   }
 
   if (biasDims) {

--- a/lib/Dialect/TTNN/Utils/VerificationUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/VerificationUtils.cpp
@@ -369,6 +369,20 @@ verifyConv3dInputDims(mlir::tt::ttnn::Conv3dOp *op,
                                << ") must equal kD*kH*kW*C_in/groups ("
                                << expectedFlattenedDim << ")";
     }
+  } else {
+    // Raw 5D weight: (O, C/G, kD, kH, kW). The flattened-dim check above can't
+    // apply (C/G is still unaligned here), so verify the weight's kernel dims
+    // match the op's kernel_size attribute directly.
+    if (weightDims.kernelDepth != params.kernelSize.depth ||
+        weightDims.kernelHeight != params.kernelSize.vertical ||
+        weightDims.kernelWidth != params.kernelSize.horizontal) {
+      return op->emitOpError()
+             << "weight kernel dimensions (" << weightDims.kernelDepth << ", "
+             << weightDims.kernelHeight << ", " << weightDims.kernelWidth
+             << ") must match kernel_size (" << params.kernelSize.depth << ", "
+             << params.kernelSize.vertical << ", "
+             << params.kernelSize.horizontal << ")";
+    }
   }
 
   if (biasDims) {

--- a/lib/OpModel/TTNN/TTNNOutputTensorInference.cpp
+++ b/lib/OpModel/TTNN/TTNNOutputTensorInference.cpp
@@ -218,6 +218,7 @@ getPreparedMoEComputeW2WeightsOutputType(PrepareMoEComputeW2WeightsOp *op) {
   assert(false && "Cannot calculate prepare_moe_compute_w2_weights shape "
                   "without op model");
 #endif
+}
 
 mlir::RankedTensorType getPreparedConv3dWeightsOutputTensor(Conv3dOp *op) {
   auto weightType = op->getWeight().getType();

--- a/lib/OpModel/TTNN/TTNNOutputTensorInference.cpp
+++ b/lib/OpModel/TTNN/TTNNOutputTensorInference.cpp
@@ -218,6 +218,33 @@ getPreparedMoEComputeW2WeightsOutputType(PrepareMoEComputeW2WeightsOp *op) {
   assert(false && "Cannot calculate prepare_moe_compute_w2_weights shape "
                   "without op model");
 #endif
+
+mlir::RankedTensorType getPreparedConv3dWeightsOutputTensor(Conv3dOp *op) {
+  auto weightType = op->getWeight().getType();
+  auto weightLayout = mlir::cast<TTNNLayoutAttr>(weightType.getEncoding());
+
+  constexpr int64_t TILE_WIDTH = ttcore::TileType::getDefaultShape()[1];
+  constexpr int64_t ALIGNMENT = TILE_WIDTH;
+  int64_t inChannelsPerGroup = op->getInChannels() / op->getGroups();
+  llvm::ArrayRef<int32_t> kernelSize = op->getKernelSize();
+  int64_t kernelDepth = kernelSize[0];
+  int64_t kernelHeight = kernelSize[1];
+  int64_t kernelWidth = kernelSize[2];
+  int64_t cInAligned =
+      llvm::divideCeil(inChannelsPerGroup, ALIGNMENT) * ALIGNMENT;
+  int64_t numCInBlocks = cInAligned / TILE_WIDTH;
+  llvm::SmallVector<int64_t> preparedShape = {
+      numCInBlocks * kernelDepth * kernelHeight * kernelWidth * TILE_WIDTH,
+      static_cast<int64_t>(op->getOutChannels())};
+
+  auto preparedLayout =
+      ttnn::TTNNLayoutAttr::Builder(op->getContext(), preparedShape,
+                                    weightLayout.getScalarElementType())
+          .setBufferType(ttnn::BufferType::DRAM)
+          .setMemoryLayout(ttnn::TensorMemoryLayout::Interleaved)
+          .build();
+  return mlir::RankedTensorType::get(
+      preparedShape, weightLayout.getScalarElementType(), preparedLayout);
 }
 
 } // namespace mlir::tt::ttnn::op_model

--- a/test/python/golden/ttir_ops/convolution/test_conv3d.py
+++ b/test/python/golden/ttir_ops/convolution/test_conv3d.py
@@ -151,3 +151,60 @@ def test_conv3d(
         device=device,
         target=target,
     )
+
+
+@pytest.mark.parametrize("enable_greedy", [False, True], ids=["chain", "greedy"])
+def test_conv3d_optimizer(enable_greedy: bool, request, device):
+    """Golden execution of conv3d through the optimizer-enabled pipeline.
+
+    Covers the path introduced alongside post-optimizer conv3d weight
+    preparation: Conv3dOp is handled by LegalOpConfigAnalysis, a Conv3dConfigAttr
+    (here pinned via --override-conv3d-config) is applied, and the
+    TTNNPrepareConv3dWeights pass materializes the prepare op using the
+    optimizer-chosen c_in_block. The default (no-optimizer) pipeline exercised by
+    test_conv3d above never runs the optimizer, so this is the only golden
+    coverage of that path.
+
+    Note: c_in_block only changes how the input-channel reduction is tiled, not
+    the conv result, so this golden test cannot distinguish whether the override
+    was applied — it would pass even if c_in_block were ignored. It validates
+    that the optimizer / override pipeline compiles and executes with correct
+    numerics; that c_in_block=64 was actually selected is verified at the IR
+    level.
+    """
+    # in_channels=128 => c_in_aligned=128, so c_in_block=64 is a legal block.
+    input_shape = (1, 8, 28, 28, 128)
+    weight_shape = (32, 128, 3, 3, 3)
+    input_shapes = [input_shape, weight_shape]
+    input_types = [torch.bfloat16, torch.bfloat16]
+
+    def module(builder: TTIRBuilder):
+        @builder.func(input_shapes, input_types)
+        def conv3d_optimizer_wrapper(
+            in0: Operand,
+            weight: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.conv3d(
+                in0,
+                weight,
+                None,
+                stride=[1, 1, 1],
+                padding=[0, 0, 0],
+                groups=1,
+                loc="conv3d_opt",
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target="ttnn",
+        pipeline_options=[
+            "optimization-level=1",
+            f"enable-greedy-optimizer={'true' if enable_greedy else 'false'}",
+            "override-conv3d-config=conv3d_opt=c_in_block#64",
+        ],
+    )

--- a/test/python/golden/ttir_ops/convolution/test_conv3d.py
+++ b/test/python/golden/ttir_ops/convolution/test_conv3d.py
@@ -208,3 +208,55 @@ def test_conv3d_optimizer(enable_greedy: bool, request, device):
             "override-conv3d-config=conv3d_opt=c_in_block#64",
         ],
     )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_conv3d_c_in_block_divergent(dtype, target, request, device):
+    """Conv3d whose kernel volume is even, so tt-metal's auto-derived c_in_block
+    differs from the TILE_WIDTH=32 the compiler pins.
+
+    tt-metal derives its default c_in_block as
+        lcm(l1_alignment, TILE_WIDTH / gcd(kernel_vol, TILE_WIDTH)).
+    For an even kernel volume that gcd is > 1, so the default is 16, not 32.
+    Here kernel = (2, 2, 2) => kernel_vol = 8, gcd(8, 32) = 8, giving
+        lcm(16, 32 / 8) = lcm(16, 4) = 16  !=  32.
+
+    This guards the "config is the single source of truth" invariant: the weight
+    is prepared with the same c_in_block the runtime kernel consumes (the pinned
+    32), so the result stays numerically correct even when that diverges from
+    the value tt-metal would have chosen on its own (16). It also pins the rest
+    of the config (c_out_block, spatial out-blocks, compute grid); before that
+    fix this path handed tt-metal a partial config and tripped its struct
+    defaults (C_out_block=0 / 1x1 grid).
+    """
+    # in_channels=32 => C_in % c_in_block == 0 for the pinned c_in_block=32.
+    input_shape = (1, 4, 16, 16, 32)
+    weight_shape = (16, 32, 2, 2, 2)
+    input_shapes = [input_shape, weight_shape]
+    input_types = [dtype, dtype]
+
+    def module(builder: TTIRBuilder):
+        @builder.func(input_shapes, input_types)
+        def conv3d_wrapper(
+            in0: Operand,
+            weight: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.conv3d(
+                in0,
+                weight,
+                None,
+                stride=[1, 1, 1],
+                padding=[0, 0, 0],
+                groups=1,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target=target,
+    )

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_prepare_conv3d_weights.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_prepare_conv3d_weights.mlir
@@ -1,8 +1,11 @@
 // RUN: ttmlir-opt --ttcore-register-device --ttnn-prepare-conv3d-weights %s | FileCheck %s
 
 // Verifies that the post-optimizer pass materializes a PrepareConv3dWeightsOp
-// before each Conv3dOp, picking c_in_block from the optimizer's
-// Conv3dConfigAttr when present (falling back to TILE_WIDTH=32 otherwise).
+// before each Conv3dOp, reading c_in_block straight from the op's
+// Conv3dConfigAttr. The pass does not reason about tt-metal defaults and does
+// not modify the config: TTIRToTTNN already attaches a complete config (and the
+// optimizer only refines it), so the config simply passes through unchanged
+// while the prepare op is created with the c_in_block it carries.
 //
 // Shapes: in_channels=128, out_channels=32, kernel=3x3x3. c_in_aligned=128,
 // so c_in_block in {32, 64, 128} all satisfy the divisibility check.
@@ -14,10 +17,10 @@
 #ttnn_layout_out = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4) -> (d0 * 4056 + d1 * 676 + d2 * 26 + d3, d4), <1x1>, memref<4056x32xbf16, #dram>, <interleaved>>
 
 module {
-  // Case 1: optimizer chose c_in_block=64. The pass must insert a
-  // PrepareConv3dWeightsOp with that c_in_block.
-  // CHECK-LABEL: @conv3d_with_chosen_c_in_block
-  func.func @conv3d_with_chosen_c_in_block(
+  // c_in_block = 64: the prepare op must be created with that value, and the
+  // op's config must pass through unchanged.
+  // CHECK-LABEL: @conv3d_c_in_block_64
+  func.func @conv3d_c_in_block_64(
       %arg0: tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
       %arg1: tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>)
       -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out> {
@@ -25,9 +28,11 @@ module {
     // CHECK: "ttnn.prepare_conv3d_weights"
     // CHECK-SAME: c_in_block = 64 : i32
     // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: c_in_block = 64
     %out = "ttnn.conv3d"(%arg0, %arg1, %dev)
         <{batch_size = 1 : i32,
-          conv3d_config = #ttnn.conv3d_config<c_in_block = 64>,
+          conv3d_config = #ttnn.conv3d_config<t_out_block = 1, w_out_block = 1, h_out_block = 1, c_out_block = 32, c_in_block = 64, compute_with_storage_grid_size = #ttcore.grid<8x8>>,
           dtype = #ttcore.supportedDataTypes<bf16>,
           groups = 1 : i32,
           in_channels = 128 : i32,
@@ -44,10 +49,10 @@ module {
     return %out : tensor<1x6x26x26x32xbf16, #ttnn_layout_out>
   }
 
-  // Case 2: no conv3d_config on the op. The pass must insert a prepare op
-  // with c_in_block = TILE_WIDTH = 32 (tt-metal default).
-  // CHECK-LABEL: @conv3d_without_config
-  func.func @conv3d_without_config(
+  // c_in_block = 32: the pass reads whatever the config carries, so the prepare
+  // op must use 32 here.
+  // CHECK-LABEL: @conv3d_c_in_block_32
+  func.func @conv3d_c_in_block_32(
       %arg0: tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
       %arg1: tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>)
       -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out> {
@@ -55,38 +60,11 @@ module {
     // CHECK: "ttnn.prepare_conv3d_weights"
     // CHECK-SAME: c_in_block = 32 : i32
     // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: c_in_block = 32
     %out = "ttnn.conv3d"(%arg0, %arg1, %dev)
         <{batch_size = 1 : i32,
-          dtype = #ttcore.supportedDataTypes<bf16>,
-          groups = 1 : i32,
-          in_channels = 128 : i32,
-          input_depth = 8 : i32, input_height = 28 : i32, input_width = 28 : i32,
-          kernel_size = array<i32: 3, 3, 3>,
-          out_channels = 32 : i32,
-          padding = array<i32: 0, 0, 0>,
-          padding_mode = "zeros",
-          stride = array<i32: 1, 1, 1>}>
-        : (tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
-           tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>,
-           !ttnn.device)
-        -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out>
-    return %out : tensor<1x6x26x26x32xbf16, #ttnn_layout_out>
-  }
-
-  // Case 3: conv3d_config attached but c_in_block field is nullopt. The
-  // pass must fall back to TILE_WIDTH = 32.
-  // CHECK-LABEL: @conv3d_config_without_c_in_block
-  func.func @conv3d_config_without_c_in_block(
-      %arg0: tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
-      %arg1: tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>)
-      -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out> {
-    %dev = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: "ttnn.prepare_conv3d_weights"
-    // CHECK-SAME: c_in_block = 32 : i32
-    // CHECK: "ttnn.conv3d"
-    %out = "ttnn.conv3d"(%arg0, %arg1, %dev)
-        <{batch_size = 1 : i32,
-          conv3d_config = #ttnn.conv3d_config<h_out_block = 2>,
+          conv3d_config = #ttnn.conv3d_config<t_out_block = 1, w_out_block = 1, h_out_block = 1, c_out_block = 32, c_in_block = 32, compute_with_storage_grid_size = #ttcore.grid<8x8>>,
           dtype = #ttcore.supportedDataTypes<bf16>,
           groups = 1 : i32,
           in_channels = 128 : i32,

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_prepare_conv3d_weights.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_prepare_conv3d_weights.mlir
@@ -1,0 +1,105 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-prepare-conv3d-weights %s | FileCheck %s
+
+// Verifies that the post-optimizer pass materializes a PrepareConv3dWeightsOp
+// before each Conv3dOp, picking c_in_block from the optimizer's
+// Conv3dConfigAttr when present (falling back to TILE_WIDTH=32 otherwise).
+//
+// Shapes: in_channels=128, out_channels=32, kernel=3x3x3. c_in_aligned=128,
+// so c_in_block in {32, 64, 128} all satisfy the divisibility check.
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout_in = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4) -> (d0 * 6272 + d1 * 784 + d2 * 28 + d3, d4), <1x1>, memref<6272x128xbf16, #dram>, <interleaved>>
+#ttnn_layout_weight_raw = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4) -> (d0 * 1152 + d1 * 9 + d2 * 3 + d3, d4), <1x1>, memref<4608x3xbf16, #system_memory>>
+#ttnn_layout_out = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4) -> (d0 * 4056 + d1 * 676 + d2 * 26 + d3, d4), <1x1>, memref<4056x32xbf16, #dram>, <interleaved>>
+
+module {
+  // Case 1: optimizer chose c_in_block=64. The pass must insert a
+  // PrepareConv3dWeightsOp with that c_in_block.
+  // CHECK-LABEL: @conv3d_with_chosen_c_in_block
+  func.func @conv3d_with_chosen_c_in_block(
+      %arg0: tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
+      %arg1: tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>)
+      -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out> {
+    %dev = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    // CHECK: "ttnn.prepare_conv3d_weights"
+    // CHECK-SAME: c_in_block = 64 : i32
+    // CHECK: "ttnn.conv3d"
+    %out = "ttnn.conv3d"(%arg0, %arg1, %dev)
+        <{batch_size = 1 : i32,
+          conv3d_config = #ttnn.conv3d_config<c_in_block = 64>,
+          dtype = #ttcore.supportedDataTypes<bf16>,
+          groups = 1 : i32,
+          in_channels = 128 : i32,
+          input_depth = 8 : i32, input_height = 28 : i32, input_width = 28 : i32,
+          kernel_size = array<i32: 3, 3, 3>,
+          out_channels = 32 : i32,
+          padding = array<i32: 0, 0, 0>,
+          padding_mode = "zeros",
+          stride = array<i32: 1, 1, 1>}>
+        : (tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
+           tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>,
+           !ttnn.device)
+        -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out>
+    return %out : tensor<1x6x26x26x32xbf16, #ttnn_layout_out>
+  }
+
+  // Case 2: no conv3d_config on the op. The pass must insert a prepare op
+  // with c_in_block = TILE_WIDTH = 32 (tt-metal default).
+  // CHECK-LABEL: @conv3d_without_config
+  func.func @conv3d_without_config(
+      %arg0: tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
+      %arg1: tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>)
+      -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out> {
+    %dev = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    // CHECK: "ttnn.prepare_conv3d_weights"
+    // CHECK-SAME: c_in_block = 32 : i32
+    // CHECK: "ttnn.conv3d"
+    %out = "ttnn.conv3d"(%arg0, %arg1, %dev)
+        <{batch_size = 1 : i32,
+          dtype = #ttcore.supportedDataTypes<bf16>,
+          groups = 1 : i32,
+          in_channels = 128 : i32,
+          input_depth = 8 : i32, input_height = 28 : i32, input_width = 28 : i32,
+          kernel_size = array<i32: 3, 3, 3>,
+          out_channels = 32 : i32,
+          padding = array<i32: 0, 0, 0>,
+          padding_mode = "zeros",
+          stride = array<i32: 1, 1, 1>}>
+        : (tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
+           tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>,
+           !ttnn.device)
+        -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out>
+    return %out : tensor<1x6x26x26x32xbf16, #ttnn_layout_out>
+  }
+
+  // Case 3: conv3d_config attached but c_in_block field is nullopt. The
+  // pass must fall back to TILE_WIDTH = 32.
+  // CHECK-LABEL: @conv3d_config_without_c_in_block
+  func.func @conv3d_config_without_c_in_block(
+      %arg0: tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
+      %arg1: tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>)
+      -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out> {
+    %dev = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    // CHECK: "ttnn.prepare_conv3d_weights"
+    // CHECK-SAME: c_in_block = 32 : i32
+    // CHECK: "ttnn.conv3d"
+    %out = "ttnn.conv3d"(%arg0, %arg1, %dev)
+        <{batch_size = 1 : i32,
+          conv3d_config = #ttnn.conv3d_config<h_out_block = 2>,
+          dtype = #ttcore.supportedDataTypes<bf16>,
+          groups = 1 : i32,
+          in_channels = 128 : i32,
+          input_depth = 8 : i32, input_height = 28 : i32, input_width = 28 : i32,
+          kernel_size = array<i32: 3, 3, 3>,
+          out_channels = 32 : i32,
+          padding = array<i32: 0, 0, 0>,
+          padding_mode = "zeros",
+          stride = array<i32: 1, 1, 1>}>
+        : (tensor<1x8x28x28x128xbf16, #ttnn_layout_in>,
+           tensor<32x128x3x3x3xbf16, #ttnn_layout_weight_raw>,
+           !ttnn.device)
+        -> tensor<1x6x26x26x32xbf16, #ttnn_layout_out>
+    return %out : tensor<1x6x26x26x32xbf16, #ttnn_layout_out>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/conv/conv3d/conv3d_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv/conv3d/conv3d_tests_negative.mlir
@@ -29,7 +29,7 @@ module {
 module {
   func.func @conv3d_invalid_weight_shape(%arg0: tensor<1x8x28x28x4xbf16>, %arg1: tensor<108x3x16xbf16>, %arg2: tensor<1x16xbf16>) -> tensor<1x6x26x26x16xbf16> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: error: 'ttnn.conv3d' op weight must be a 2D tensor [kD*kH*kW*C/G, O]
+    // CHECK: error: 'ttnn.conv3d' op weight must be either a 5D tensor [O, C/G, kD, kH, kW] (raw) or a 2D tensor [kD*kH*kW*C/G, O] (prepared)
     %1 = "ttnn.conv3d"(%arg0, %arg1, %arg2, %0)
             <{
               in_channels = 4: i32,

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_config_override.mlir
@@ -1,0 +1,52 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=1 enable-greedy-optimizer=false override-conv3d-config=conv3d_full=weights_dtype#bf16:t_out_block#1:w_out_block#1:h_out_block#1:c_out_block#32:c_in_block#64,conv3d_partial=c_in_block#64" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verifies --override-conv3d-config pins config fields on Conv3dOps matched
+// by NameLoc.
+module {
+  // Full override: every field pinned. The emitted conv3d_config must reflect
+  // exactly the override values.
+  func.func @full(
+      %arg0: tensor<1x8x28x28x128xbf16>,
+      %arg1: tensor<32x128x3x3x3xbf16>)
+      -> tensor<1x6x26x26x32xbf16> {
+    // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: weights_dtype = bf16
+    // CHECK-SAME: t_out_block = 1
+    // CHECK-SAME: w_out_block = 1
+    // CHECK-SAME: h_out_block = 1
+    // CHECK-SAME: c_out_block = 32
+    // CHECK-SAME: c_in_block = 64
+    %0 = "ttir.conv3d"(%arg0, %arg1) <{
+        stride = array<i32: 1, 1, 1>,
+        padding = array<i32: 0, 0, 0>,
+        groups = 1 : i32,
+        padding_mode = "zeros"
+      }> : (tensor<1x8x28x28x128xbf16>, tensor<32x128x3x3x3xbf16>)
+        -> tensor<1x6x26x26x32xbf16> loc(#loc_full)
+    return %0 : tensor<1x6x26x26x32xbf16>
+  }
+
+  // Partial override: only c_in_block pinned at 64. There is no config
+  // search on this path, so the remaining fields stay unset and only the
+  // pinned field appears in the emitted conv3d_config.
+  func.func @partial(
+      %arg0: tensor<1x8x28x28x128xbf16>,
+      %arg1: tensor<32x128x3x3x3xbf16>)
+      -> tensor<1x6x26x26x32xbf16> {
+    // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<c_in_block = 64>
+    %0 = "ttir.conv3d"(%arg0, %arg1) <{
+        stride = array<i32: 1, 1, 1>,
+        padding = array<i32: 0, 0, 0>,
+        groups = 1 : i32,
+        padding_mode = "zeros"
+      }> : (tensor<1x8x28x28x128xbf16>, tensor<32x128x3x3x3xbf16>)
+        -> tensor<1x6x26x26x32xbf16> loc(#loc_partial)
+    return %0 : tensor<1x6x26x26x32xbf16>
+  }
+}
+#loc_full = loc("conv3d_full")
+#loc_partial = loc("conv3d_partial")

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_config_override.mlir
@@ -6,7 +6,9 @@
 // by NameLoc.
 module {
   // Full override: every field pinned. The emitted conv3d_config must reflect
-  // exactly the override values.
+  // exactly the override values. TTNNPrepareConv3dWeights additionally fills
+  // compute_with_storage_grid_size from the device worker grid (the override
+  // syntax has no field for it), so a grid must also appear.
   func.func @full(
       %arg0: tensor<1x8x28x28x128xbf16>,
       %arg1: tensor<32x128x3x3x3xbf16>)
@@ -19,6 +21,7 @@ module {
     // CHECK-SAME: h_out_block = 1
     // CHECK-SAME: c_out_block = 32
     // CHECK-SAME: c_in_block = 64
+    // CHECK-SAME: compute_with_storage_grid_size = #ttcore.grid<
     %0 = "ttir.conv3d"(%arg0, %arg1) <{
         stride = array<i32: 1, 1, 1>,
         padding = array<i32: 0, 0, 0>,
@@ -29,15 +32,24 @@ module {
     return %0 : tensor<1x6x26x26x32xbf16>
   }
 
-  // Partial override: only c_in_block pinned at 64. There is no config
-  // search on this path, so the remaining fields stay unset and only the
-  // pinned field appears in the emitted conv3d_config.
+  // Partial override: only c_in_block pinned at 64. No config search runs on
+  // this path, so the override itself sets only c_in_block. TTNNPrepareConv3dWeights
+  // then completes the config with tt-metal's defaults for the unset fields
+  // (t/w/h_out_block = 1, c_out_block = 32) plus the device worker grid, so the
+  // op carries a full config — never a partial one that would leak tt-metal
+  // struct defaults at runtime.
   func.func @partial(
       %arg0: tensor<1x8x28x28x128xbf16>,
       %arg1: tensor<32x128x3x3x3xbf16>)
       -> tensor<1x6x26x26x32xbf16> {
     // CHECK: "ttnn.conv3d"
-    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<c_in_block = 64>
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: t_out_block = 1
+    // CHECK-SAME: w_out_block = 1
+    // CHECK-SAME: h_out_block = 1
+    // CHECK-SAME: c_out_block = 32
+    // CHECK-SAME: c_in_block = 64
+    // CHECK-SAME: compute_with_storage_grid_size = #ttcore.grid<
     %0 = "ttir.conv3d"(%arg0, %arg1) <{
         stride = array<i32: 1, 1, 1>,
         padding = array<i32: 0, 0, 0>,

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_prepare_weights_layout.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_prepare_weights_layout.mlir
@@ -1,0 +1,51 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=1 enable-greedy-optimizer=false" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Regression test for the prepare_conv3d_weights → to_layout → conv3d chain
+// under the optimizer pipeline. tt-metal's prepare_conv3d_weights runtime
+// kernel always returns a ROW_MAJOR tensor (its last op is `reshape`, which
+// preserves ROW_MAJOR). The downstream Conv3dOp's weight workaround forces
+// TILE. If the optimizer's layout propagation elides the to_layout between
+// them, the flatbuffer encodes TILE for the prepare op output while the
+// runtime produces ROW_MAJOR — runtime debug assert at
+// `runtime/lib/ttnn/debug/debug_apis.cpp:31` fires with
+// "Layout mismatch, expected TILE, got ROW_MAJOR" and silicon execution
+// breaks.
+//
+// TTNNPrepareConv3dWeights enforces the invariant. This test pins
+// the IR shape: prepare's result must be ROW_MAJOR, immediately followed
+// by a to_layout that converts to TILE for the consumer Conv3dOp.
+module {
+  func.func @prepare_weights_layout(
+      %arg0: tensor<1x8x28x28x128xbf16>,
+      %arg1: tensor<32x128x3x3x3xbf16>)
+      -> tensor<1x6x26x26x32xbf16> {
+    // prepare_conv3d_weights must produce a ROW_MAJOR memref (no `tile<>`
+    // in its memref element type), followed by a to_layout op converting
+    // to TILE for the consumer Conv3dOp.
+    //
+    // The IR shape is:
+    //   %1 = prepare_conv3d_weights(...) -> tensor<..., #row_major_layout>
+    //   "ttnn.deallocate"(%argweight) ...     // optional dealloc
+    //   %2 = to_layout(%1) <{layout = tile}>
+    //   %3 = conv3d(input, %2, ...)
+    //
+    // We assert structurally: a `to_layout` to tile must appear between
+    // prepare and conv3d, and the prepare op's result memref must NOT be
+    // tiled.
+    //
+    // CHECK: %{{[0-9]+}} = "ttnn.prepare_conv3d_weights"
+    // CHECK-NOT: !ttcore.tile
+    // CHECK: layout = #ttnn.layout<tile>
+    // CHECK: ttnn.conv3d
+    %0 = "ttir.conv3d"(%arg0, %arg1) <{
+        stride = array<i32: 1, 1, 1>,
+        padding = array<i32: 0, 0, 0>,
+        groups = 1 : i32,
+        padding_mode = "zeros"
+      }> : (tensor<1x8x28x28x128xbf16>, tensor<32x128x3x3x3xbf16>)
+        -> tensor<1x6x26x26x32xbf16>
+    return %0 : tensor<1x6x26x26x32xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/conv3d/conv3d_optimizer.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/conv3d/conv3d_optimizer.mlir
@@ -1,0 +1,24 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% optimization-level=1 enable-greedy-optimizer=false" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+// RUN: ttrt run %t.ttnn
+
+// Silicon smoke for the optimizer-enabled vertical slice: lower a single
+// Conv3dOp through the optimizer-enabled pipeline, prepare its weights,
+// and execute on n150 hardware.
+//
+module {
+  func.func @conv3d_silicon_smoke(
+      %arg0: tensor<1x8x28x28x128xbf16>,
+      %arg1: tensor<32x128x3x3x3xbf16>)
+      -> tensor<1x6x26x26x32xbf16> {
+    %0 = "ttir.conv3d"(%arg0, %arg1) <{
+        stride = array<i32: 1, 1, 1>,
+        padding = array<i32: 0, 0, 0>,
+        groups = 1 : i32,
+        padding_mode = "zeros"
+      }> : (tensor<1x8x28x28x128xbf16>, tensor<32x128x3x3x3xbf16>)
+        -> tensor<1x6x26x26x32xbf16>
+    return %0 : tensor<1x6x26x26x32xbf16>
+  }
+}

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -3148,6 +3148,119 @@ TEST_F(OpModelBase, Conv3dInterface) {
   }
 }
 
+// Validates that Conv3dOp::getOpConstraints / getOpRuntime consume
+// OpConfig::opSpecificAttrs (Conv3dAttrs variant) rather than ignoring it.
+// The check is structural: if unpackConv3dAttrs is wired up correctly, a
+// deliberately invalid Conv3dConfigAttr propagates to OpModel and produces an
+// error; if the unpack is broken (uses op->getConv3dConfig() unconditionally),
+// the nullptr stored on the op would silently succeed.
+TEST_F(OpModelBase, Conv3dInterfaceConfigs) {
+  llvm::SmallVector<int64_t> inputShape = {1, 5, 10, 10, 32};
+  llvm::SmallVector<int64_t> weightShape = {864, 64};
+  llvm::SmallVector<int64_t> outputShape = {1, 3, 8, 8, 64};
+
+  auto inputLayout = CreateRowMajorLayout(inputShape, BufferType::DRAM,
+                                          TensorMemoryLayout::Interleaved);
+  auto input =
+      createEmptyTensor(inputShape, builder.getBF16Type(), inputLayout);
+
+  auto weightLayout = CreateTiledLayout(weightShape, BufferType::DRAM,
+                                        TensorMemoryLayout::Interleaved);
+  auto weight =
+      createEmptyTensor(weightShape, builder.getBF16Type(), weightLayout);
+  auto outputType = createRankedTensorType(outputShape);
+
+  GetDeviceOp deviceOp = builder.create<GetDeviceOp>(
+      builder.getUnknownLoc(), builder.getType<DeviceType>(),
+      MeshShapeAttr::get(builder.getContext(), 1, 1),
+      MeshOffsetAttr::get(builder.getContext(), 0, 0));
+
+  Conv3dOp conv3d = builder.create<Conv3dOp>(
+      builder.getUnknownLoc(), outputType, input, weight, /*bias=*/nullptr,
+      deviceOp, /*in_channels=*/32, /*out_channels=*/64, /*batch_size=*/1,
+      /*input_depth=*/5, /*input_height=*/10, /*input_width=*/10,
+      llvm::ArrayRef<int32_t>({3, 3, 3}), llvm::ArrayRef<int32_t>({1, 1, 1}),
+      llvm::ArrayRef<int32_t>({0, 0, 0}), "zeros", /*groups=*/1,
+      /*conv3d_config=*/nullptr,
+      /*compute_kernel_config=*/nullptr);
+
+  OpModel backend = dyn_cast<OpModel>(conv3d.getOperation());
+
+  // Path 1: a Conv3dConfigAttr with values that violate Conv3d block-size
+  // constraints (c_in_block=7 is neither 32-aligned nor a divisor of
+  // kT*kH*kW*c_in_aligned=864). If the unpack consumes the passed config,
+  // OpModel must reject it. If the unpack is broken, OpModel would receive
+  // the op's stored nullptr config and silently succeed — failing this
+  // assertion.
+  auto badConfig = Conv3dConfigAttr::get(
+      &context,
+      /*weights_dtype=*/std::nullopt,
+      /*t_out_block=*/std::optional<uint32_t>(1),
+      /*w_out_block=*/std::optional<uint32_t>(1),
+      /*h_out_block=*/std::optional<uint32_t>(1),
+      /*c_out_block=*/std::optional<uint32_t>(64),
+      /*c_in_block=*/std::optional<uint32_t>(7),
+      /*compute_with_storage_grid_size=*/std::optional<ttcore::GridAttr>());
+
+  auto badConstraintsExp = backend.getOpConstraints(
+      getInputLayouts(conv3d),
+      OpConfig(getOutputLayout(conv3d), Conv3dAttrs{badConfig, std::nullopt}));
+  ASSERT_FALSE(static_cast<bool>(badConstraintsExp))
+      << "unpackConv3dAttrs must propagate the passed bad config to OpModel; "
+         "if the unpack is broken the op's null config would succeed instead.";
+  llvm::consumeError(badConstraintsExp.takeError());
+
+  auto badRuntimeExp = backend.getOpRuntime(
+      getInputLayouts(conv3d),
+      OpConfig(getOutputLayout(conv3d), Conv3dAttrs{badConfig, std::nullopt}));
+  ASSERT_FALSE(static_cast<bool>(badRuntimeExp));
+  llvm::consumeError(badRuntimeExp.takeError());
+
+  // Path 2: a Conv3dConfigAttr with sensible block sizes for this shape.
+  // c_in_block=32 (full C_in), c_out_block=32 (divides C_out=64),
+  // t/h/w=1 (divides T_out=3, H_out=W_out=8). Must succeed and produce
+  // a non-zero circular-buffer footprint.
+  auto goodConfig = Conv3dConfigAttr::get(
+      &context,
+      /*weights_dtype=*/std::nullopt,
+      /*t_out_block=*/std::optional<uint32_t>(1),
+      /*w_out_block=*/std::optional<uint32_t>(1),
+      /*h_out_block=*/std::optional<uint32_t>(1),
+      /*c_out_block=*/std::optional<uint32_t>(32),
+      /*c_in_block=*/std::optional<uint32_t>(32),
+      /*compute_with_storage_grid_size=*/std::optional<ttcore::GridAttr>());
+
+  auto goodConstraintsExp = backend.getOpConstraints(
+      getInputLayouts(conv3d),
+      OpConfig(getOutputLayout(conv3d), Conv3dAttrs{goodConfig, std::nullopt}));
+  ASSERT_TRUE(static_cast<bool>(goodConstraintsExp))
+      << llvm::toString(goodConstraintsExp.takeError());
+  {
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
+        goodConstraintsExp.get();
+    EXPECT_GT(cbSize, 0);
+  }
+
+  auto goodRuntimeExp = backend.getOpRuntime(
+      getInputLayouts(conv3d),
+      OpConfig(getOutputLayout(conv3d), Conv3dAttrs{goodConfig, std::nullopt}));
+  ASSERT_TRUE(static_cast<bool>(goodRuntimeExp));
+  EXPECT_GT(goodRuntimeExp.get(), 0);
+
+  // Path 3: UninitializedAttrs variant falls back to the op's stored config
+  // (nullptr in this fixture). Must produce the same result as calling
+  // getOpConstraints with the bare outputLayout — the legacy path.
+  auto fallbackConstraintsExp = backend.getOpConstraints(
+      getInputLayouts(conv3d), OpConfig(getOutputLayout(conv3d)));
+  ASSERT_TRUE(static_cast<bool>(fallbackConstraintsExp))
+      << llvm::toString(fallbackConstraintsExp.takeError());
+  {
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
+        fallbackConstraintsExp.get();
+    EXPECT_GT(cbSize, 0);
+  }
+}
+
 TEST_F(OpModelBase, ConvTranspose2dInterfaceConfigs) {
   // create ConvTranspose2dOp
   llvm::SmallVector<int64_t> inputShape = {1, 1, 50176, 3};


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8790

### Problem description
We always rely on the default `conv3d_config`. In almost all cases it's suboptimal (can go up to 100x). Override is a first step where we can manually control config for individual `conv3d` ops, with https://github.com/tenstorrent/tt-mlir/issues/8295 as follow up.

### What's changed
Adds `--override-conv3d-config` pipeline option (same grammar as the conv2d override) so conv3d block sizes and weights_dtype can be pinned per op by NameLoc. Conv3dOp is now enabled in LegalOpConfigAnalysis; overrides are applied to all legal configs and a default compute kernel config is attached. There is no config search on this branch; the override (or the op default) is taken as-is.

Moves conv3d weight preparation out of TTIRToTTNN into a post-optimizer TTNNPrepareConv3dWeights pass, which derives c_in_block from the optimizer's chosen Conv3dConfigAttr (falling back to TILE_WIDTH) and inserts the prepare op plus row-major/tile to_layout chain. The optimizer never sees the prepare op, so layout propagation can no longer retype its result.

### Checklist
- [x] New/Existing tests provide coverage for changes
