### PR TITLE
[CI] Add sfpi install to cbw (manylinux) docker

### DIFF
--- a/.github/Dockerfile.cibuildwheel
+++ b/.github/Dockerfile.cibuildwheel
@@ -17,7 +17,8 @@ RUN rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW
 # Setup / install metal dependencies
 RUN wget https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_VERSION}/{install_dependencies.sh,tt_metal/sfpi-info.sh,tt_metal/sfpi-version} && \
     chmod u+x sfpi-info.sh && \
-    bash install_dependencies.sh --docker
+    bash install_dependencies.sh --docker && \
+    bash install_dependencies.sh --sfpi
 
 FROM ciwheel-base AS toolchain-source
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/5198

### Problem description
Latest matal->mlir uplift requires separate sfpi install. However, in cibuildwheel (manylinux) docker it is missing.
tt-xla manylinux build fails without sfpi installed.

### What's changed
Added sfpi install to manylinux docker

### Checklist
- [x] New/Existing tests provide coverage for changes
tt-mlir build wheels: https://github.com/tenstorrent/tt-mlir/actions/runs/27538514161
tt-xla manylinux build with release tests: https://github.com/tenstorrent/tt-xla/actions/runs/27544827503