### PR TITLE
Add attributes to Exp

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -1683,9 +1683,25 @@ def TTKernel_ExpTileInitOp : TTKernel_InitOp<"exp_tile_init"> {
     let summary = "Short init function which configures compute unit for execution of exp_tile.";
     let description = [{
       Must be run before exp_tile.
+
+      The optional attributes map onto the metal template parameters
+      `exp_tile_init<bool approx, uint32_t scale, InputClamping input_clamping>()`.
+      When all attributes are omitted the op lowers to a bare `exp_tile_init()`
+      call, preserving the metal defaults
+      (approx=false, scale=0x3F800000, input_clamping=ClampToNegative).
     }];
 
-    let arguments = (ins);
+    let arguments = (ins
+      OptionalAttr<BoolAttr>:$approx,
+      OptionalAttr<I32Attr>:$scale,
+      OptionalAttr<TTKernel_InputClampingAttr>:$input_clamping);
+
+    let builders = [
+      OpBuilder<(ins), [{
+        build($_builder, $_state, /*approx=*/nullptr, /*scale=*/nullptr,
+              /*input_clamping=*/nullptr);
+      }]>,
+    ];
 
     let assemblyFormat = [{
       `(` `)` attr-dict `:` functional-type(operands, results)
@@ -1699,9 +1715,31 @@ def TTKernel_ExpTileOp : TTKernel_SFPUOp<"exp_tile", [TTKernel_UnaryOpTrait]> {
       in DST register at index tile_index. The DST register buffer must be in
       acquired state via *tile_regs_acquire* call. This call is blocking and is only
       available on the compute engine.
+
+      The optional attributes map onto the metal template parameters
+      `exp_tile<bool approx, bool scale_en, InputClamping input_clamping, int iterations>(idst, vector_mode, scale)`.
+      When all attributes are omitted the op lowers to a bare `exp_tile(idst)`
+      call, preserving the metal defaults
+      (approx=false, scale_en=false, input_clamping=ClampToNegative, iterations=8).
+      `scale` holds the runtime scale argument; when present and not equal to
+      the default 1.0 value it enables metal's `scale_en` template parameter and
+      is emitted as the third positional argument with `vector_mode` defaulted
+      to `VectorMode::RC`.
     }];
 
-    let arguments = (ins IndexLike:$tile_index);
+    let arguments = (ins IndexLike:$tile_index,
+      OptionalAttr<BoolAttr>:$approx,
+      OptionalAttr<TTKernel_InputClampingAttr>:$input_clamping,
+      OptionalAttr<I32Attr>:$iterations,
+      OptionalAttr<I32Attr>:$scale);
+
+    let builders = [
+      OpBuilder<(ins "::mlir::Value":$tile_index), [{
+        build($_builder, $_state, tile_index, /*approx=*/nullptr,
+              /*input_clamping=*/nullptr, /*iterations=*/nullptr,
+              /*scale=*/nullptr);
+      }]>,
+    ];
 
     let assemblyFormat = [{
       `(` $tile_index `)` attr-dict `:` functional-type(operands, results)

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -110,4 +110,19 @@ def TTKernel_EltwiseBinaryType
   let cppNamespace = "::mlir::tt::ttkernel";
 }
 
+// Mirrors tt-metal's `ckernel::InputClamping` (see compute_kernel_api
+// eltwise_unary/exp.h). Controls whether the approximate exponential clamps
+// very negative inputs. `None` skips the clamp (the positive/non-zero check).
+def TTKernel_InputClampingNone : I32EnumAttrCase<"None", 0, "none">;
+def TTKernel_InputClampingClampToNegative
+    : I32EnumAttrCase<"ClampToNegative", 1, "clamp_to_negative">;
+
+def TTKernel_InputClamping
+    : I32EnumAttr<"InputClamping", "TTKernel SFPU Input Clamping Modes",
+                  [TTKernel_InputClampingNone,
+                   TTKernel_InputClampingClampToNegative]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttkernel";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -74,6 +74,10 @@ def TTKernel_ReduceDimAttr : EnumAttr<TTKernel_Dialect, TTKernel_ReduceDim, "red
   let assemblyFormat = "`<` $value `>`";
 }
 
+def TTKernel_InputClampingAttr : EnumAttr<TTKernel_Dialect, TTKernel_InputClamping, "input_clamping"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
 def TTKernel_L1Addr : TTKernel_Type<"L1Addr", "l1_addr"> {
     let summary = "TTKernel l1 address";
     let description = "L1 address type in TTKernel dialect";

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -611,6 +611,21 @@ public:
     }
   }
 
+  StringRef getInputClamping(ttkernel::InputClamping inputClamping) const {
+    switch (inputClamping) {
+    case ttkernel::InputClamping::None:
+      return "InputClamping::None";
+    case ttkernel::InputClamping::ClampToNegative:
+      return "InputClamping::ClampToNegative";
+    }
+  }
+
+  static bool hasNonDefaultExpTileScale(IntegerAttr scaleAttr) {
+    constexpr uint32_t defaultScale = 0x3F80u; // 1.0 encoded for exp_tile().
+    return scaleAttr &&
+           static_cast<uint32_t>(scaleAttr.getInt()) != defaultScale;
+  }
+
   ArrayAttr getTemplateArgs(Builder &builder, SourceOp op) const {
     if constexpr (std::is_same_v<SourceOp, ttkernel::ReduceInitOp> ||
                   std::is_same_v<SourceOp, ttkernel::ReduceTileOp>) {
@@ -773,6 +788,119 @@ public:
       template_args.push_back(
           emitc::OpaqueAttr::get(op.getContext(), "DataFormat::Int32"));
       return ArrayAttr::get(op.getContext(), template_args);
+    } else if constexpr (std::is_same_v<SourceOp, ttkernel::ExpTileInitOp>) {
+      // exp_tile_init<bool approx, uint32_t scale, InputClamping
+      // input_clamping>() Emit template args only up to the last explicitly-set
+      // parameter, filling in metal defaults for any preceding unset parameter.
+      // When nothing is set the op lowers to a bare `exp_tile_init()`.
+      auto approxAttr = op.getApproxAttr();
+      auto scaleAttr = op.getScaleAttr();
+      auto clampAttr = op.getInputClampingAttr();
+      int lastSet = -1;
+      if (approxAttr) {
+        lastSet = 0;
+      }
+      if (scaleAttr) {
+        lastSet = 1;
+      }
+      if (clampAttr) {
+        lastSet = 2;
+      }
+      if (lastSet < 0) {
+        return ArrayAttr();
+      }
+      SmallVector<Attribute, 3> template_args;
+      template_args.push_back(emitc::OpaqueAttr::get(
+          op.getContext(),
+          (approxAttr && approxAttr.getValue()) ? "true" : "false"));
+      if (lastSet >= 1) {
+        uint32_t scale =
+            scaleAttr ? static_cast<uint32_t>(scaleAttr.getInt()) : 0x3F800000u;
+        template_args.push_back(
+            emitc::OpaqueAttr::get(op.getContext(), std::to_string(scale)));
+      }
+      if (lastSet >= 2) {
+        ttkernel::InputClamping inputClamping =
+            clampAttr ? clampAttr.getValue()
+                      : ttkernel::InputClamping::ClampToNegative;
+        template_args.push_back(emitc::OpaqueAttr::get(
+            op.getContext(), getInputClamping(inputClamping)));
+      }
+      return ArrayAttr::get(op.getContext(), template_args);
+    } else if constexpr (std::is_same_v<SourceOp, ttkernel::ExpTileOp>) {
+      // exp_tile<bool approx, bool scale_en, InputClamping input_clamping,
+      //          int iterations>(idst, vector_mode, scale)
+      // Emit template args only up to the last explicitly-set parameter,
+      // filling in metal defaults for any preceding unset parameter. When
+      // nothing is set the op lowers to a bare `exp_tile(idst)`. The runtime
+      // `scale` argument is handled separately by getCallArgs().
+      auto approxAttr = op.getApproxAttr();
+      auto scaleAttr = op.getScaleAttr();
+      bool scaleEn = hasNonDefaultExpTileScale(scaleAttr);
+      auto clampAttr = op.getInputClampingAttr();
+      auto iterationsAttr = op.getIterationsAttr();
+      int lastSet = -1;
+      if (approxAttr) {
+        lastSet = 0;
+      }
+      if (scaleEn) {
+        lastSet = 1;
+      }
+      if (clampAttr) {
+        lastSet = 2;
+      }
+      if (iterationsAttr) {
+        lastSet = 3;
+      }
+      if (lastSet < 0) {
+        return ArrayAttr();
+      }
+      SmallVector<Attribute, 4> template_args;
+      template_args.push_back(emitc::OpaqueAttr::get(
+          op.getContext(),
+          (approxAttr && approxAttr.getValue()) ? "true" : "false"));
+      if (lastSet >= 1) {
+        template_args.push_back(emitc::OpaqueAttr::get(
+            op.getContext(), scaleEn ? "true" : "false"));
+      }
+      if (lastSet >= 2) {
+        ttkernel::InputClamping inputClamping =
+            clampAttr ? clampAttr.getValue()
+                      : ttkernel::InputClamping::ClampToNegative;
+        template_args.push_back(emitc::OpaqueAttr::get(
+            op.getContext(), getInputClamping(inputClamping)));
+      }
+      if (lastSet >= 3) {
+        int64_t iterations = iterationsAttr ? iterationsAttr.getInt() : 8;
+        template_args.push_back(emitc::OpaqueAttr::get(
+            op.getContext(), std::to_string(iterations)));
+      }
+      return ArrayAttr::get(op.getContext(), template_args);
+    }
+    return ArrayAttr();
+  }
+
+  // Build the positional call `args` interleaving. Returns a null ArrayAttr to
+  // pass all operands in their natural order (the common case). Op-specific
+  // overrides can insert literal runtime arguments alongside operand
+  // references (operand indices are encoded as IndexType IntegerAttrs).
+  ArrayAttr getCallArgs(Builder &builder, SourceOp op) const {
+    if constexpr (std::is_same_v<SourceOp, ttkernel::ExpTileOp>) {
+      // exp_tile(idst, vector_mode, scale): only materialize the runtime
+      // vector_mode/scale arguments when an explicit scale is provided.
+      // Otherwise fall back to the bare exp_tile(idst) call.
+      auto scaleAttr = op.getScaleAttr();
+      if (!hasNonDefaultExpTileScale(scaleAttr)) {
+        return ArrayAttr();
+      }
+      SmallVector<Attribute, 3> args;
+      args.push_back(builder.getIndexAttr(0)); // idst (operand 0)
+      args.push_back(
+          emitc::OpaqueAttr::get(op.getContext(), "(int)VectorMode::RC"));
+      args.push_back(emitc::OpaqueAttr::get(
+          op.getContext(),
+          std::to_string(static_cast<uint32_t>(scaleAttr.getInt()))));
+      return ArrayAttr::get(op.getContext(), args);
     }
     return ArrayAttr();
   }
@@ -790,8 +918,8 @@ public:
     }
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        op, resultTypes, getOpName(op), nullptr, getTemplateArgs(rewriter, op),
-        adaptor.getOperands());
+        op, resultTypes, getOpName(op), getCallArgs(rewriter, op),
+        getTemplateArgs(rewriter, op), adaptor.getOperands());
 
     return success();
   }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -895,6 +895,71 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @exp_tile_init_approx
+    func.func @exp_tile_init_approx() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: emitc.call_opaque "exp_tile_init"() {template_args = [#emitc.opaque<"true">]}
+      "ttkernel.exp_tile_init"() <{approx = true}> : () -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @exp_tile_init_clamping
+    func.func @exp_tile_init_clamping() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // The unset `scale` template arg is backfilled with the metal default (0x3F800000).
+      // CHECK: emitc.call_opaque "exp_tile_init"() {template_args = [#emitc.opaque<"false">, #emitc.opaque<"1065353216">, #emitc.opaque<"InputClamping::None">]}
+      "ttkernel.exp_tile_init"() <{input_clamping = #ttkernel.input_clamping<none>}> : () -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @exp_tile_init_scale
+    func.func @exp_tile_init_scale() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // The unset `approx` template arg is backfilled with the metal default (false).
+      // CHECK: emitc.call_opaque "exp_tile_init"() {template_args = [#emitc.opaque<"false">, #emitc.opaque<"1077936128">]}
+      "ttkernel.exp_tile_init"() <{scale = 1077936128 : i32}> : () -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @exp_tile_flags
+    func.func @exp_tile_flags() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
+      %dst_index = arith.constant 3 : i32
+      // CHECK: emitc.call_opaque "exp_tile"(%[[DST_INDEX]]) {template_args = [#emitc.opaque<"true">, #emitc.opaque<"false">, #emitc.opaque<"InputClamping::None">]}
+      "ttkernel.exp_tile"(%dst_index) <{approx = true, input_clamping = #ttkernel.input_clamping<none>}> : (i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @exp_tile_runtime_scale
+    func.func @exp_tile_runtime_scale() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
+      %dst_index = arith.constant 3 : i32
+      // CHECK: emitc.call_opaque "exp_tile"(%[[DST_INDEX]])
+      // CHECK-SAME: args = [0 : index, #emitc.opaque<"(int)VectorMode::RC">, #emitc.opaque<"16384">]
+      // CHECK-SAME: template_args = [#emitc.opaque<"true">, #emitc.opaque<"true">, #emitc.opaque<"InputClamping::None">]
+      "ttkernel.exp_tile"(%dst_index) <{approx = true, input_clamping = #ttkernel.input_clamping<none>, scale = 16384 : i32}> : (i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @exp_tile_default_scale
+    func.func @exp_tile_default_scale() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
+      %dst_index = arith.constant 3 : i32
+      // CHECK: emitc.call_opaque "exp_tile"(%[[DST_INDEX]])
+      // CHECK-NOT: args =
+      // CHECK-NOT: template_args
+      "ttkernel.exp_tile"(%dst_index) <{scale = 16256 : i32}> : (i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @exp_tile_iterations
+    func.func @exp_tile_iterations() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
+      %dst_index = arith.constant 3 : i32
+      // Unset approx/scale_en are backfilled with metal defaults; unset
+      // input_clamping is backfilled with ClampToNegative when iterations is set.
+      // CHECK: emitc.call_opaque "exp_tile"(%[[DST_INDEX]]) {template_args = [#emitc.opaque<"false">, #emitc.opaque<"false">, #emitc.opaque<"InputClamping::ClampToNegative">, #emitc.opaque<"12">]}
+      "ttkernel.exp_tile"(%dst_index) <{iterations = 12 : i32}> : (i32) -> ()
+      return
+    }
+
     // CHECK-LABEL: func @exp2_tile_init
     func.func @exp2_tile_init() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.call_opaque "exp2_tile_init"()


### PR DESCRIPTION
### Ticket
None

### Problem description
Exp OP on tt-metal level has scale argument, which is not exposed here.

### What's changed
Expose arguments, that are available on tt-metal level: approximation, clamping, scaling, iterations.

### Checklist
- [X] New tests provide coverage for changes
