### PR TITLE
Uplift third_party/tt-metal to 1efd27ca 2026-06-09

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=8d901046bb169c9c3de1a68d284fba502371a820
+ARG TT_METAL_DEPENDENCIES_COMMIT=1efd27cafdb43765593130b72b78084999eb8f45
 
 # Install dependencies
 RUN <<EOT

--- a/runtime/lib/ttnn/operations/ccl/selective_reduce_combine.cpp
+++ b/runtime/lib/ttnn/operations/ccl/selective_reduce_combine.cpp
@@ -45,7 +45,7 @@ void run(const ::tt::target::ttnn::SelectiveReduceCombineOp *op,
   ::ttnn::Tensor output = ::ttnn::prim::selective_reduce_combine(
       denseInputTensor, denseActivationsTensor, denseTokenMapsTensor,
       denseTokenCountsTensor, op->hidden_size(), op->batch_size(),
-      op->seq_size(), op->select_experts_k(), op->experts(),
+      op->seq_size(), op->select_experts_k(),
       /*axis=*/kDefaultClusterAxis,
       /*topology=*/::tt::tt_fabric::Topology::Ring,
       /*num_links=*/kDefaultNumLinks,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "8d901046bb169c9c3de1a68d284fba502371a820")
+set(TT_METAL_VERSION "1efd27cafdb43765593130b72b78084999eb8f45")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
uplift pin to 1efd27ca

Note Dockerfile.base is modified due to dependency updates. 

https://github.com/tenstorrent/tt-mlir/pull/8774 uplift is blocked by tt-xla [regression](https://github.com/tenstorrent/tt-xla/actions/runs/27388208225/job/80943200995). So uplift the base commit first.

### Checklist

 - Frontend CI links

   - [tt-xla(full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): (passing) https://github.com/tenstorrent/tt-xla/actions/runs/27577986822
     - Note that the test branch is based on 
     - 464a5f341908d5a3f790e697be5ffa6fd3fb6f32 (latest tt-xla->tt-mlir pin) +
     - https://github.com/tenstorrent/tt-mlir/pull/8728 (formal uplift, tt-xla pin is not yet point here) +
     - This change

   -  [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): (passing) https://github.com/tenstorrent/tt-forge-onnx/actions/runs/27565715134

 - Follow-up Actions

- [ ]  Issues filed to follow up on incomplete changes (if any):
- [ ]  Frontend fix PRs ready (if needed by this uplift):
