### PR TITLE
[TTNN] Fix RMS norm output scale in distributed decomposition fallback

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -352,10 +352,26 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
       scalarRowShape, inputType.getElementType(), scalarEncoding);
 
   ArrayAttr dimArg = rewriter.getI32ArrayAttr({static_cast<int32_t>(rank - 1)});
-  // global_stats = mean(flattened per-device E(x^2), dim=-1, keep_dim=true)
+  // mean of the per-device partial stats across devices.
   auto globalMeanOp = rewriter.create<ttnn::MeanOp>(
       ttmlir::utils::appendLocationSuffix(loc, "_global_mean"), scalarRowType,
       flattenedStats.getResult(), /*keep_dim=*/true, dimArg);
+
+  // rms_norm_pre_all_gather emits the per-device *sum* of squares (sum(x^2)),
+  // not the per-device mean. The MeanOp above only divided the gathered sums by
+  // numDevices; to recover the global E(x^2) = sum(x^2) / H we must additionally
+  // divide by the per-device hidden size N (= input's last dim). Omitting this
+  // leaves the variance N times too large, shrinking the normalized output by
+  // sqrt(N).
+  double invHiddenPerDevice = 1.0 / static_cast<double>(inputShape.back());
+  auto invHiddenTensor = rewriter.create<ttnn::FullOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_inv_hidden"), scalarRowType,
+      rewriter.getF32FloatAttr(static_cast<float>(invHiddenPerDevice)),
+      op.getDevice());
+  // global_stats = E(x^2) = mean_over_devices(sum(x^2)) / N
+  auto globalStatsOp = rewriter.create<ttnn::MultiplyOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_scale_ex2"), scalarRowType,
+      globalMeanOp.getResult(), invHiddenTensor.getResult());
 
   // eps_tensor = full(epsilon)
   auto epsTensor = rewriter.create<ttnn::FullOp>(
@@ -366,7 +382,7 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
   // stabilized = add(global_stats, eps_tensor)
   auto addEpsOp = rewriter.create<ttnn::AddOp>(
       ttmlir::utils::appendLocationSuffix(loc, "_add_eps"), scalarRowType,
-      globalMeanOp.getResult(), epsTensor.getResult());
+      globalStatsOp.getResult(), epsTensor.getResult());
 
   // inv_rms = rsqrt(stabilized)
   auto rsqrtOp = rewriter.create<ttnn::RsqrtOp>(

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -359,7 +359,7 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
 
   // rms_norm_pre_all_gather emits the per-device *sum* of squares (sum(x^2)),
   // not the per-device mean. The MeanOp above only divided the gathered sums by
-  // numDevices; to recover the global E(x^2) = sum(x^2) / H we must additionally
+  // numDevices; to recover the global E(x^2) = sum(x^2) / N we must additionally
   // divide by the per-device hidden size N (= input's last dim). Omitting this
   // leaves the variance N times too large, shrinking the normalized output by
   // sqrt(N).

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -359,10 +359,10 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
 
   // rms_norm_pre_all_gather emits the per-device *sum* of squares (sum(x^2)),
   // not the per-device mean. The MeanOp above only divided the gathered sums by
-  // numDevices; to recover the global E(x^2) = sum(x^2) / N we must additionally
-  // divide by the per-device hidden size N (= input's last dim). Omitting this
-  // leaves the variance N times too large, shrinking the normalized output by
-  // sqrt(N).
+  // numDevices; to recover the global E(x^2) = sum(x^2) / N we must
+  // additionally divide by the per-device hidden size N (= input's last dim).
+  // Omitting this leaves the variance N times too large, shrinking the
+  // normalized output by sqrt(N).
   double invHiddenPerDevice = 1.0 / static_cast<double>(inputShape.back());
   auto invHiddenTensor = rewriter.create<ttnn::FullOp>(
       ttmlir::utils::appendLocationSuffix(loc, "_inv_hidden"), scalarRowType,

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -357,12 +357,7 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
       ttmlir::utils::appendLocationSuffix(loc, "_global_mean"), scalarRowType,
       flattenedStats.getResult(), /*keep_dim=*/true, dimArg);
 
-  // rms_norm_pre_all_gather emits the per-device *sum* of squares (sum(x^2)),
-  // not the per-device mean. The MeanOp above only divided the gathered sums by
-  // numDevices; to recover the global E(x^2) = sum(x^2) / N we must
-  // additionally divide by the per-device hidden size N (= input's last dim).
-  // Omitting this leaves the variance N times too large, shrinking the
-  // normalized output by sqrt(N).
+  // Stats are per-device sum(x^2); divide by hidden size N to get E(x^2).
   double invHiddenPerDevice = 1.0 / static_cast<double>(inputShape.back());
   auto invHiddenTensor = rewriter.create<ttnn::FullOp>(
       ttmlir::utils::appendLocationSuffix(loc, "_inv_hidden"), scalarRowType,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
@@ -131,4 +131,19 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     %1 = "ttnn.distributed_rms_norm"(%arg0, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0, 1>}> : (tensor<1x64x128xbf16, #ttnn_layout_supported_rank3_h64>, !ttnn.device) -> tensor<1x64x128xbf16, #ttnn_layout_supported_rank3_h64>
     return %1 : tensor<1x64x128xbf16, #ttnn_layout_supported_rank3_h64>
   }
+
+  // Cross-device mean of per-device sum(x^2) must be scaled by 1/N
+  // (N=128 -> 7.812500e-03) before adding epsilon.
+  func.func public @test_pre_all_gather_divides_stats_by_hidden_size(
+      %arg0: tensor<1x1x64x128xbf16, #ttnn_layout>,
+      %arg1: tensor<128xbf16, #ttnn_layout_weight>) -> tensor<1x1x64x128xbf16, #ttnn_layout> {
+    // CHECK-LABEL: func.func public @test_pre_all_gather_divides_stats_by_hidden_size
+    // CHECK: %[[MEAN:[0-9]+]] = "ttnn.mean"
+    // CHECK: %[[INVH:[0-9]+]] = "ttnn.full"(%{{[0-9]+}}) <{fill_value = 7.812500e-03 : f32
+    // CHECK: %[[EX2:[0-9]+]] = "ttnn.multiply"(%[[MEAN]], %[[INVH]])
+    // CHECK: "ttnn.add"(%[[EX2]],
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x64x128xbf16, #ttnn_layout>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x1x64x128xbf16, #ttnn_layout>
+    return %1 : tensor<1x1x64x128xbf16, #ttnn_layout>
+  }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/5209

### Problem description
`rms_norm_pre_all_gather` emits the per-device sum of squares `sum(x^2)`, not the per-device mean `E(x^2) = sum(x^2) / N` (where `N` is the per-device hidden size) that `DistributedRMSNormDecompositionRewritePattern.cpp` expects. This leaves the variance N times too large, shrinking the normalized output by `sqrt(N)`. Found and fixed by @sshonTT 

### What's changed
In `DistributedRMSNormDecompositionRewritePattern.cpp`, divide the gathered stats by the per-device hidden size so they become the mean of x² rather than the sum, fixing the output magnitude. Added a unit test for this case.

### Checklist
- [x] New/Existing tests provide coverage for changes
