### PR TITLE
Adding AR workaround on/off switch

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -277,6 +277,13 @@ struct TTIRToTTNNCommonPipelineOptions
       llvm::cl::desc("Enable decomposition workaround pass."),
       llvm::cl::init(true)};
 
+  Option<bool> allReduceWorkaroundEnabled{
+      *this, "enable-all-reduce-workaround",
+      llvm::cl::desc("Enable the all_reduce decomposition workaround which "
+                     "breaks all_reduce down into reduce_scatter + all_gather "
+                     "(or all_gather + local reduce)."),
+      llvm::cl::init(true)};
+
   Option<bool> ttnnDecompositionEnabled{
       *this, "enable-ttnn-decomposition-pass",
       llvm::cl::desc("Enable TTNN decomposition pass."), llvm::cl::init(true)};

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -44,6 +44,12 @@ def TTNNWorkarounds : Pass<"ttnn-workaround", "::mlir::ModuleOp"> {
              "ttnn-enable-decomposition-workaround-pass",
              "bool", /*default=*/"true",
              "TTNN Decompsition Workarounds Pass">,
+      Option<"allReduceWorkaroundEnabled",
+             "ttnn-enable-all-reduce-workaround",
+             "bool", /*default=*/"true",
+             "Enable the all_reduce decomposition workaround which breaks "
+             "all_reduce down into reduce_scatter + all_gather (or "
+             "all_gather + local reduce).">,
       Option<"optimizationLevel",
              "ttnn-optimization-level",
              "int", /*default=*/"0",

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -245,6 +245,8 @@ void createTTNNPipelineWorkaroundPass(
       options.layoutWorkaroundsEnabled,
       options.decompositionWorkaroundsEnabled};
 
+  workaroundOptions.allReduceWorkaroundEnabled =
+      options.allReduceWorkaroundEnabled;
   workaroundOptions.optimizationLevel = options.optimizationLevel;
 
   pm.addPass(createTTNNWorkarounds(workaroundOptions));

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -644,7 +644,7 @@ public:
     if (decompositionWorkaroundsEnabled) {
       RewritePatternSet patterns(&getContext());
       patterns.add<
-          GatherSi32Workaround, TTNNAllReduceWorkarounds,
+          GatherSi32Workaround,
           workarounds::decomposition::GatherOpRank1RewritePattern,
           workarounds::decomposition::TTNNAllReduceReshapeWorkarounds,
           workarounds::decomposition::TTNNAllGatherWorkarounds,
@@ -693,6 +693,12 @@ public:
           &getContext());
       patterns.add<workarounds::decomposition::LinearOpRewritePattern>(
           &getContext(), /*benefit=*/2);
+
+      // The all_reduce decomposition workaround can be disabled via a pass
+      // option, e.g. once TTNN provides stable native all_reduce support.
+      if (allReduceWorkaroundEnabled) {
+        patterns.add<TTNNAllReduceWorkarounds>(&getContext());
+      }
 
       // PagedUpdateCacheOpRewritePattern is only needed below opt-level 2.
       // At level >= 2 the greedy sharding optimizer (PagedUpdateCacheRuleBook

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/all_reduce_workaround_toggle.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/all_reduce_workaround_toggle.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,2" -o %t %s
+// RUN: FileCheck %s --check-prefix=ENABLED --input-file=%t
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,2 enable-all-reduce-workaround=false" -o %t2 %s
+// RUN: FileCheck %s --check-prefix=DISABLED --input-file=%t2
+
+// Tests for the all_reduce decomposition workaround toggle
+// (enable-all-reduce-workaround / ttnn-enable-all-reduce-workaround).
+//
+// When enabled (default), TTNNAllReduceWorkarounds decomposes ttir.all_reduce
+// into reduce_scatter + all_gather. When disabled, ttir.all_reduce lowers to
+// ttnn.all_reduce and is left untouched.
+
+module attributes {} {
+  // ENABLED-LABEL: all_reduce_workaround_toggle
+  // DISABLED-LABEL: all_reduce_workaround_toggle
+  func.func @all_reduce_workaround_toggle(%arg0: tensor<256x256xbf16>) -> tensor<256x256xbf16> {
+    %0 = "ttir.all_reduce"(%arg0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<256x256xbf16>) -> tensor<256x256xbf16>
+    // Default: workaround enabled, all_reduce is decomposed.
+    // ENABLED: "ttnn.reduce_scatter"
+    // ENABLED: "ttnn.all_gather"
+    // ENABLED-NOT: "ttnn.all_reduce"
+
+    // Workaround disabled: all_reduce is preserved.
+    // DISABLED: "ttnn.all_reduce"
+    // DISABLED-NOT: "ttnn.reduce_scatter"
+    // DISABLED-NOT: "ttnn.all_gather"
+    return %0 : tensor<256x256xbf16>
+  }
+}


### PR DESCRIPTION
Adding AR on/off switch to unblock models which are using AR shapes which when decomposed to RS + AG hang.

#closes 8462