### PR TITLE
Fix code emission of signless integer types

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -916,6 +916,37 @@ struct EmitCTypeConverter<ttcore::ReduceType> {
   }
 };
 
+// Maps a ttcore::ReduceType to the optional reduction string accepted by
+// `ttnn::scatter`'s reduction argument. This is distinct from the
+// reduction_common::ReduceType enum that the reduce ops take
+// (EmitCTypeConverter<ReduceType> above), so it is intentionally a separate
+// helper rather than a converter overload. Mirrors the runtime mapping
+// (runtime/.../data_movement/scatter.cpp); reductions that ttnn::scatter does
+// not support map to std::nullopt (no reduction / plain overwrite).
+inline std::optional<std::string>
+reduceTypeToScatterString(ttcore::ReduceType type) {
+  switch (type) {
+  case ttcore::ReduceType::Sum:
+    return "add";
+  case ttcore::ReduceType::Prod:
+    return "multiply";
+  case ttcore::ReduceType::Max:
+    return "amax";
+  case ttcore::ReduceType::Min:
+    return "amin";
+  // Invalid is the deliberate "no reduction" mode: a plain (overwrite) scatter.
+  case ttcore::ReduceType::Invalid:
+    return std::nullopt;
+  // Not valid ttnn::scatter reductions; scatter never carries these (the
+  // StableHLO scatter region only yields add/mul/max/min/invalid).
+  case ttcore::ReduceType::Mean:
+  case ttcore::ReduceType::Std:
+  case ttcore::ReduceType::Var:
+    break;
+  }
+  llvm_unreachable("Unsupported ttnn::scatter reduction type");
+}
+
 template <>
 struct EmitCTypeConverter<::ttnn::QueueId> {
   static std::optional<std::string> convert(mlir::Attribute attr) {

--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -921,8 +921,9 @@ struct EmitCTypeConverter<ttcore::ReduceType> {
 // reduction_common::ReduceType enum that the reduce ops take
 // (EmitCTypeConverter<ReduceType> above), so it is intentionally a separate
 // helper rather than a converter overload. Mirrors the runtime mapping
-// (runtime/.../data_movement/scatter.cpp); reductions that ttnn::scatter does
-// not support map to std::nullopt (no reduction / plain overwrite).
+// (runtime/.../data_movement/scatter.cpp): Invalid is the no reduction mode
+// and maps to std::nullopt (a plain overwrite scatter). Reductions that
+// ttnn::scatter cannot express (Mean/Std/Var) never reach scatter.
 inline std::optional<std::string>
 reduceTypeToScatterString(ttcore::ReduceType type) {
   switch (type) {
@@ -934,11 +935,8 @@ reduceTypeToScatterString(ttcore::ReduceType type) {
     return "amax";
   case ttcore::ReduceType::Min:
     return "amin";
-  // Invalid is the deliberate "no reduction" mode: a plain (overwrite) scatter.
   case ttcore::ReduceType::Invalid:
     return std::nullopt;
-  // Not valid ttnn::scatter reductions; scatter never carries these (the
-  // StableHLO scatter region only yields add/mul/max/min/invalid).
   case ttcore::ReduceType::Mean:
   case ttcore::ReduceType::Std:
   case ttcore::ReduceType::Var:

--- a/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
@@ -458,11 +458,13 @@ struct EmitPyTypeConverter<mlir::tt::ttcore::ReduceType> {
 };
 
 // Maps a ttcore::ReduceType to the optional reduction string accepted by
-// `ttnn.scatter`'s `reduce` argument. This is distinct from the ttnn.ReduceType
+// `ttnn.scatter`'s reduce argument. This is distinct from the ttnn.ReduceType
 // enum that the reduce ops take (EmitPyTypeConverter<ReduceType> above), so it
 // is intentionally a separate helper rather than a converter overload. Mirrors
-// the runtime mapping (runtime/.../data_movement/scatter.cpp); reductions that
-// ttnn.scatter does not support map to std::nullopt (no reduction / overwrite).
+// the runtime mapping (runtime/.../data_movement/scatter.cpp). Invalid is the
+// no reduction mode and maps to std::nullopt (a plain overwrite scatter).
+// Reductions that ttnn.scatter cannot express (Mean/Std/Var) never reach
+// scatter.
 inline std::optional<std::string>
 reduceTypeToScatterString(::mlir::tt::ttcore::ReduceType type) {
   switch (type) {
@@ -474,11 +476,8 @@ reduceTypeToScatterString(::mlir::tt::ttcore::ReduceType type) {
     return "amax";
   case ::mlir::tt::ttcore::ReduceType::Min:
     return "amin";
-  // Invalid is the deliberate "no reduction" mode: a plain (overwrite) scatter.
   case ::mlir::tt::ttcore::ReduceType::Invalid:
     return std::nullopt;
-  // Not valid ttnn.scatter reductions; scatter never carries these (the
-  // StableHLO scatter region only yields add/mul/max/min/invalid).
   case ::mlir::tt::ttcore::ReduceType::Mean:
   case ::mlir::tt::ttcore::ReduceType::Std:
   case ::mlir::tt::ttcore::ReduceType::Var:

--- a/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
@@ -457,6 +457,36 @@ struct EmitPyTypeConverter<mlir::tt::ttcore::ReduceType> {
   }
 };
 
+// Maps a ttcore::ReduceType to the optional reduction string accepted by
+// `ttnn.scatter`'s `reduce` argument. This is distinct from the ttnn.ReduceType
+// enum that the reduce ops take (EmitPyTypeConverter<ReduceType> above), so it
+// is intentionally a separate helper rather than a converter overload. Mirrors
+// the runtime mapping (runtime/.../data_movement/scatter.cpp); reductions that
+// ttnn.scatter does not support map to std::nullopt (no reduction / overwrite).
+inline std::optional<std::string>
+reduceTypeToScatterString(::mlir::tt::ttcore::ReduceType type) {
+  switch (type) {
+  case ::mlir::tt::ttcore::ReduceType::Sum:
+    return "add";
+  case ::mlir::tt::ttcore::ReduceType::Prod:
+    return "multiply";
+  case ::mlir::tt::ttcore::ReduceType::Max:
+    return "amax";
+  case ::mlir::tt::ttcore::ReduceType::Min:
+    return "amin";
+  // Invalid is the deliberate "no reduction" mode: a plain (overwrite) scatter.
+  case ::mlir::tt::ttcore::ReduceType::Invalid:
+    return std::nullopt;
+  // Not valid ttnn.scatter reductions; scatter never carries these (the
+  // StableHLO scatter region only yields add/mul/max/min/invalid).
+  case ::mlir::tt::ttcore::ReduceType::Mean:
+  case ::mlir::tt::ttcore::ReduceType::Std:
+  case ::mlir::tt::ttcore::ReduceType::Var:
+    break;
+  }
+  llvm_unreachable("Unsupported ttnn.scatter reduction type");
+}
+
 // Converter for integral types.
 template <typename T>
 struct EmitPyTypeConverter<T, std::enable_if_t<std::is_integral_v<T>, void>> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2908,9 +2908,9 @@ def TTNN_ArangeOp : TTNN_CreationOp<"arange", [CanExecuteOnHostTrait]> {
   }];
 
   let arguments = (ins Optional<TTNN_Device>:$device,
-                       I64Attr:$start,
-                       I64Attr:$end,
-                       I64Attr:$step);
+                       SI64Attr:$start,
+                       SI64Attr:$end,
+                       SI64Attr:$step);
 
   let results = (outs AnyRankedTensor:$result);
   let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -944,7 +944,7 @@ def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
   }];
 
   let arguments = (ins AnyRankedTensor:$input,
-                       OptionalAttr<I32Attr>:$dim,
+                       OptionalAttr<SI32Attr>:$dim,
                        DefaultValuedAttr<BoolAttr, "false">:$keep_dim);
 
   let extraClassDeclaration = [{
@@ -980,7 +980,7 @@ def TTNN_ProdOp : TTNN_Op<"prod"> {
   }];
 
   let arguments = (ins AnyRankedTensor:$input,
-                       OptionalAttr<I64Attr>:$dim_arg,
+                       OptionalAttr<SI64Attr>:$dim_arg,
                        BoolAttr:$keep_dim);
 
   let results = (outs AnyRankedTensor:$result);
@@ -1135,7 +1135,7 @@ def TTNN_CumSumOp : TTNN_Op<"cumsum"> {
   }];
 
   let arguments = (ins AnyRankedTensor:$input,
-                       I32Attr:$dim);
+                       SI32Attr:$dim);
 
   let results = (outs AnyRankedTensor:$result);
 }
@@ -1159,7 +1159,7 @@ def TTNN_CumProdOp : TTNN_Op<"cumprod"> {
   }];
 
   let arguments = (ins AnyRankedTensor:$input,
-                       I32Attr:$dim);
+                       SI32Attr:$dim);
 
   let results = (outs AnyRankedTensor:$result);
 }
@@ -3114,7 +3114,7 @@ def TTNN_ScatterOp : TTNN_Op<"scatter">{
     let arguments = (ins AnyRankedTensor:$input,
                          AnyRankedTensor:$index,
                          AnyRankedTensor:$source,
-                         I32Attr:$dim,
+                         SI32Attr:$dim,
                          TTCore_ReduceTypeAttr:$scatter_reduce_type);
 
     let results = (outs AnyRankedTensor:$result);
@@ -3143,7 +3143,7 @@ def TTNN_GatherOp : TTNN_Op<"gather"> {
 
     let arguments = (ins AnyRankedTensor:$input,
                          AnyRankedTensor:$index,
-                         I32Attr:$dim);
+                         SI32Attr:$dim);
 
     let results = (outs AnyRankedTensor:$result);
 
@@ -4201,7 +4201,7 @@ def TTNN_TopKOp : TTNN_Op<"topk"> {
 
   let arguments = (ins AnyRankedTensor:$input_tensor,
                        I32Attr:$k,
-                       DefaultValuedAttr<I32Attr, "-1">:$dim,
+                       DefaultValuedAttr<SI32Attr, "-1">:$dim,
                        DefaultValuedAttr<BoolAttr, "true">:$largest,
                        DefaultValuedAttr<BoolAttr, "false">:$sorted);
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -266,8 +266,8 @@ public:
     mlir::IntegerAttr newDimArg = nullptr;
     if (dimArg && dimArg->size() == 1) {
       auto int32Attr = mlir::cast<mlir::IntegerAttr>(dimArg->getValue()[0]);
-      newDimArg =
-          mlir::IntegerAttr::get(rewriter.getI64Type(), int32Attr.getInt());
+      newDimArg = mlir::IntegerAttr::get(
+          rewriter.getIntegerType(64, /*isSigned=*/true), int32Attr.getInt());
     }
 
     rewriter.replaceOpWithNewOp<ttnn::ProdOp>(
@@ -287,7 +287,7 @@ public:
   LogicalResult
   matchAndRewrite(ttir::ArgMaxOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Most of the frontends uses signed or sign less integer as return type for
+    // Most of the frontends uses signed or signless integer as return type for
     // argmax op (tt-mlir uses signed integer in this case); whereas, tt-metal
     // uses UINT32 as return type. This difference is ignored as the output
     // indices will always be positive.
@@ -297,7 +297,10 @@ public:
     if (dimArg) {
       assert(dimArg->size() == 1 &&
              "ttir::ArgMaxOp dim argument must be a single integer");
-      reductionAxis = *dimArg->getAsRange<mlir::IntegerAttr>().begin();
+
+      auto int32Attr = mlir::cast<mlir::IntegerAttr>(dimArg->getValue()[0]);
+      reductionAxis =
+          rewriter.getSI32IntegerAttr(static_cast<int32_t>(int32Attr.getInt()));
     }
     rewriter.replaceOpWithNewOp<ttnn::ArgMaxOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
@@ -456,8 +459,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<ttnn::CumSumOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(),
-        rewriter.getI32IntegerAttr(static_cast<int32_t>(adaptor.getDim())));
+        adaptor.getInput(), static_cast<int32_t>(adaptor.getDim()));
     return success();
   }
 };
@@ -473,8 +475,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<ttnn::CumProdOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(),
-        rewriter.getI32IntegerAttr(static_cast<int32_t>(adaptor.getDim())));
+        adaptor.getInput(), static_cast<int32_t>(adaptor.getDim()));
     return success();
   }
 };
@@ -2949,7 +2950,7 @@ public:
     rewriter.replaceOpWithNewOp<ttnn::ScatterOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getInput(), adaptor.getIndex(), adaptor.getSource(),
-        rewriter.getI32IntegerAttr(op.getDim()),
+        rewriter.getSI32IntegerAttr(op.getDim()),
         adaptor.getScatterReduceTypeAttr());
     return success();
   }
@@ -2966,8 +2967,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<ttnn::GatherOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), adaptor.getIndex(),
-        rewriter.getI32IntegerAttr(adaptor.getDim()));
+        adaptor.getInput(), adaptor.getIndex(), adaptor.getDim());
     return success();
   }
 };

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3122,8 +3122,9 @@ public:
         emitter.emit(srcOp.getIndex()),
         emitter.emit(srcOp.getSource()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
-        emitter.emit(std::nullopt), // opt_reduction_string
-        emitter.emit(std::nullopt)  // sub_core_grid
+        emitter.emit(ttnn_to_emitc::reduceTypeToScatterString(
+            srcOp.getScatterReduceType())), // opt_reduction_string
+        emitter.emit(std::nullopt)          // sub_core_grid
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -574,10 +574,10 @@ public:
     mlir::Attribute exponentAttr;
     if (auto attr = mlir::dyn_cast<FloatAttr>(srcOp.getRhs())) {
       auto exponent = attr.getValue().convertToFloat();
-      exponentAttr = emitter.template emit<float>(exponent);
+      exponentAttr = emitter.emit<float>(exponent);
     } else if (auto attr = mlir::dyn_cast<IntegerAttr>(srcOp.getRhs())) {
       auto exponent = static_cast<int32_t>(attr.getValue().getSExtValue());
-      exponentAttr = emitter.template emit<int32_t>(exponent);
+      exponentAttr = emitter.emit<int32_t>(exponent);
     } else {
       return failure();
     }
@@ -728,14 +728,14 @@ public:
         emitter.emit(srcOp.getA()),
         emitter.emit(srcOp.getB()),
         emitter.emit(srcOp.getSparsity()),
-        emitter.template emit<ttnn_to_emitc::SparseMatmulProgramConfig>(
+        emitter.emit<ttnn_to_emitc::SparseMatmulProgramConfig>(
             srcOp.getProgramConfig()),
         emitter.emit(srcOp.getNnz()),
         emitter.emit(srcOp.getIsInputASparse()),
         emitter.emit(srcOp.getIsInputBSparse()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
         emitter.emit(srcOp.getDtypeAttr()),
-        emitter.template emit<::ttnn::WormholeComputeKernelConfig>(
+        emitter.emit<::ttnn::WormholeComputeKernelConfig>(
             srcOp.getComputeConfig()),
     };
 
@@ -780,10 +780,9 @@ public:
         emitter.emit(srcOp.getInputHeight()),
         emitter.emit(srcOp.getInputWidth()),
         emitter.emit(srcOp.getChannels()),
-        emitter.template emit<std::array<uint32_t, 2>>(
-            srcOp.getKernelSizeAttr()),
-        emitter.template emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
-        emitter.template emit<
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getKernelSizeAttr()),
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
+        emitter.emit<
             std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>>>(
             rewriter.getI32ArrayAttr(padding)),
         emitter.emit(srcOp.getCeilMode()),
@@ -839,13 +838,12 @@ public:
         emitter.emit(srcOp.getInputHeight()),
         emitter.emit(srcOp.getInputWidth()),
         emitter.emit(srcOp.getChannels()),
-        emitter.template emit<std::array<uint32_t, 2>>(
-            srcOp.getKernelSizeAttr()),
-        emitter.template emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
-        emitter.template emit<
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getKernelSizeAttr()),
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
+        emitter.emit<
             std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>>>(
             rewriter.getI32ArrayAttr(padding)),
-        emitter.template emit<std::array<uint32_t, 2>>(srcOp.getDilationAttr()),
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getDilationAttr()),
         emitter.emit(srcOp.getCeilMode()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
         /*dram_slice_config=*/emitter.emit(std::nullopt),
@@ -908,13 +906,12 @@ public:
         emitter.emit(srcOp.getInput()), emitter.emit(srcOp.getBatchSize()),
         emitter.emit(srcOp.getInputHeight()),
         emitter.emit(srcOp.getInputWidth()), emitter.emit(srcOp.getChannels()),
-        emitter.template emit<std::array<uint32_t, 2>>(
-            srcOp.getKernelSizeAttr()),
-        emitter.template emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
-        emitter.template emit<
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getKernelSizeAttr()),
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
+        emitter.emit<
             std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>>>(
             rewriter.getI32ArrayAttr(padding)),
-        emitter.template emit<std::array<uint32_t, 2>>(srcOp.getDilationAttr()),
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getDilationAttr()),
         emitter.emit(srcOp.getCeilMode()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
         /*dram_slice_config=*/emitter.emit(std::nullopt),
@@ -1199,7 +1196,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
         /*dtype=*/emitter.emit(srcOp.getDtypeAttr()),
         /*reverse_order=*/emitter.emit(false),
         /*optional_out=*/emitter.emit(std::nullopt),
@@ -1232,7 +1229,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
         /*dtype=*/emitter.emit(srcOp.getDtypeAttr()),
         /*reverse_order=*/emitter.emit(false),
         /*optional_out=*/emitter.emit(std::nullopt),
@@ -1299,7 +1296,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit<int32_t>(srcOp.getDim()),
         /*keepdim=*/emitter.emit(srcOp.getKeepDim()),
         /*sub_core_grids=*/emitter.emit(std::nullopt),
         emitter.emit(srcOp.getMemoryConfigAttr()),
@@ -1332,7 +1329,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDimArg()),
+        emitter.emit<int32_t>(srcOp.getDimArg()),
         emitter.emit(srcOp.getKeepDim()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
     };
@@ -3121,7 +3118,7 @@ public:
         srcOp, adaptor, rewriter);
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
         emitter.emit(srcOp.getIndex()),
         emitter.emit(srcOp.getSource()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
@@ -3152,7 +3149,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
         emitter.emit(srcOp.getIndex()),
         emitter.emit(/*sparse_grad=*/false),
         emitter.emit(srcOp.getMemoryConfig()),
@@ -5445,7 +5442,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInputTensor()),
         emitter.emit(srcOp.getK()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
         emitter.emit(srcOp.getLargest()),
         emitter.emit(srcOp.getSorted()),
         emitter.emit(srcOp.getMemoryConfigAttr()),

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1196,7 +1196,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
+        emitter.emit(srcOp.getDim()),
         /*dtype=*/emitter.emit(srcOp.getDtypeAttr()),
         /*reverse_order=*/emitter.emit(false),
         /*optional_out=*/emitter.emit(std::nullopt),
@@ -1229,7 +1229,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
+        emitter.emit(srcOp.getDim()),
         /*dtype=*/emitter.emit(srcOp.getDtypeAttr()),
         /*reverse_order=*/emitter.emit(false),
         /*optional_out=*/emitter.emit(std::nullopt),
@@ -1296,7 +1296,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit<int32_t>(srcOp.getDim()),
+        emitter.emit(srcOp.getDim()),
         /*keepdim=*/emitter.emit(srcOp.getKeepDim()),
         /*sub_core_grids=*/emitter.emit(std::nullopt),
         emitter.emit(srcOp.getMemoryConfigAttr()),
@@ -1329,7 +1329,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit<int32_t>(srcOp.getDimArg()),
+        emitter.emit(srcOp.getDimArg()),
         emitter.emit(srcOp.getKeepDim()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
     };
@@ -3118,7 +3118,7 @@ public:
         srcOp, adaptor, rewriter);
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
+        emitter.emit(srcOp.getDim()),
         emitter.emit(srcOp.getIndex()),
         emitter.emit(srcOp.getSource()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
@@ -3149,7 +3149,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
+        emitter.emit(srcOp.getDim()),
         emitter.emit(srcOp.getIndex()),
         emitter.emit(/*sparse_grad=*/false),
         emitter.emit(srcOp.getMemoryConfig()),
@@ -5442,7 +5442,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInputTensor()),
         emitter.emit(srcOp.getK()),
-        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
+        emitter.emit(srcOp.getDim()),
         emitter.emit(srcOp.getLargest()),
         emitter.emit(srcOp.getSorted()),
         emitter.emit(srcOp.getMemoryConfigAttr()),

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -889,7 +889,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
+        emitter.emit(srcOp.getDim()),
         emitter.emit(srcOp.getDtypeAttr(), "dtype"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
@@ -920,7 +920,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
+        emitter.emit(srcOp.getDim()),
         emitter.emit(srcOp.getDtypeAttr(), "dtype"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
@@ -1559,7 +1559,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit<int32_t>(srcOp.getDimArg()),
+        emitter.emit(srcOp.getDimArg()),
         emitter.emit(srcOp.getKeepDim()),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
@@ -1626,7 +1626,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit<int32_t>(srcOp.getDim()),
+        emitter.emit(srcOp.getDim()),
         emitter.emit(srcOp.getKeepDim()),
         emitter.emit(std::nullopt, "sub_core_grids"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
@@ -2282,7 +2282,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput(), "input"),
-        emitter.emit(static_cast<int32_t>(srcOp.getDim()), "dim"),
+        emitter.emit(srcOp.getDim(), "dim"),
         emitter.emit(srcOp.getIndex(), "index"),
         emitter.emit(srcOp.getSource(), "src"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
@@ -2313,7 +2313,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
+        emitter.emit(srcOp.getDim()),
         emitter.emit(srcOp.getIndex()),
         emitter.emit(/*sparse_grad=*/false, "sparse_grad"),
         emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
@@ -4864,7 +4864,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInputTensor()),
         emitter.emit(srcOp.getK()),
-        emitter.emit<int32_t>(srcOp.getDim()),
+        emitter.emit(srcOp.getDim()),
         emitter.emit(srcOp.getLargest()),
         emitter.emit(srcOp.getSorted()),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -423,7 +423,7 @@ private:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getLhs()),
-        emitter.template emit<ExponentT>(exponent),
+        emitter.emit<ExponentT>(exponent),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
 
@@ -673,10 +673,9 @@ public:
         emitter.emit(srcOp.getInputHeight()),
         emitter.emit(srcOp.getInputWidth()),
         emitter.emit(srcOp.getChannels()),
-        emitter.template emit<std::array<uint32_t, 2>>(
-            srcOp.getKernelSizeAttr()),
-        emitter.template emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
-        emitter.template emit<
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getKernelSizeAttr()),
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
+        emitter.emit<
             std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>>>(
             rewriter.getI32ArrayAttr(padding)),
         emitter.emit(srcOp.getCeilMode()),
@@ -730,15 +729,12 @@ public:
         emitter.emit(maxPool2dOp.getInputHeight()),
         emitter.emit(maxPool2dOp.getInputWidth()),
         emitter.emit(maxPool2dOp.getChannels()),
-        emitter.template emit<std::vector<uint32_t>>(
-            maxPool2dOp.getKernelSizeAttr()),
-        emitter.template emit<std::vector<uint32_t>>(
-            maxPool2dOp.getStrideAttr()),
-        emitter.template emit<
+        emitter.emit<std::vector<uint32_t>>(maxPool2dOp.getKernelSizeAttr()),
+        emitter.emit<std::vector<uint32_t>>(maxPool2dOp.getStrideAttr()),
+        emitter.emit<
             std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>>>(
             rewriter.getI32ArrayAttr(padding)),
-        emitter.template emit<std::vector<uint32_t>>(
-            maxPool2dOp.getDilationAttr()),
+        emitter.emit<std::vector<uint32_t>>(maxPool2dOp.getDilationAttr()),
         emitter.emit(maxPool2dOp.getCeilMode(), "ceil_mode"),
         emitter.emit(maxPool2dOp.getMemoryConfigAttr(), "memory_config"),
         emitter.emit(maxPool2dOp.getAppliedShardScheme(),
@@ -805,14 +801,14 @@ public:
         emitter.emit(maxPool2dWithIndicesOp.getInputHeight()),
         emitter.emit(maxPool2dWithIndicesOp.getInputWidth()),
         emitter.emit(maxPool2dWithIndicesOp.getChannels()),
-        emitter.template emit<std::vector<uint32_t>>(
+        emitter.emit<std::vector<uint32_t>>(
             maxPool2dWithIndicesOp.getKernelSizeAttr()),
-        emitter.template emit<std::vector<uint32_t>>(
+        emitter.emit<std::vector<uint32_t>>(
             maxPool2dWithIndicesOp.getStrideAttr()),
-        emitter.template emit<
+        emitter.emit<
             std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>>>(
             rewriter.getI32ArrayAttr(padding)),
-        emitter.template emit<std::vector<uint32_t>>(
+        emitter.emit<std::vector<uint32_t>>(
             maxPool2dWithIndicesOp.getDilationAttr()),
         emitter.emit(maxPool2dWithIndicesOp.getCeilMode(), "ceil_mode"),
         emitter.emit(maxPool2dWithIndicesOp.getMemoryConfigAttr(),
@@ -893,7 +889,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
         emitter.emit(srcOp.getDtypeAttr(), "dtype"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
@@ -924,7 +920,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit(static_cast<int32_t>(srcOp.getDim())),
         emitter.emit(srcOp.getDtypeAttr(), "dtype"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
@@ -1339,9 +1335,9 @@ public:
         srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getStart()),
-        emitter.emit(srcOp.getEnd()),
-        emitter.emit(srcOp.getStep()),
+        emitter.emit(static_cast<int64_t>(srcOp.getStart())),
+        emitter.emit(static_cast<int64_t>(srcOp.getEnd())),
+        emitter.emit(static_cast<int64_t>(srcOp.getStep())),
         emitter.emit(srcOp.getDtypeAttr(), "dtype"),
         emitter.emit(srcOp.getDevice(), "device"),
         emitter.emit(srcOp.getLayoutAttr().getValue(), "layout"),
@@ -1563,7 +1559,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDimArg()),
+        emitter.emit<int32_t>(srcOp.getDimArg()),
         emitter.emit(srcOp.getKeepDim()),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
@@ -1630,7 +1626,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit(srcOp.getDim()),
+        emitter.emit<int32_t>(srcOp.getDim()),
         emitter.emit(srcOp.getKeepDim()),
         emitter.emit(std::nullopt, "sub_core_grids"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
@@ -1670,14 +1666,13 @@ public:
         emitter.emit(conv2dOp.getBatchSize(), "batch_size"),
         emitter.emit(conv2dOp.getInputHeight(), "input_height"),
         emitter.emit(conv2dOp.getInputWidth(), "input_width"),
-        emitter.template emit<std::vector<uint32_t>>(
-            conv2dOp.getKernelSizeAttr(), "kernel_size"),
-        emitter.template emit<std::vector<uint32_t>>(conv2dOp.getStrideAttr(),
-                                                     "stride"),
-        emitter.template emit<std::vector<uint32_t>>(conv2dOp.getPaddingAttr(),
-                                                     "padding"),
-        emitter.template emit<std::vector<uint32_t>>(conv2dOp.getDilationAttr(),
-                                                     "dilation"),
+        emitter.emit<std::vector<uint32_t>>(conv2dOp.getKernelSizeAttr(),
+                                            "kernel_size"),
+        emitter.emit<std::vector<uint32_t>>(conv2dOp.getStrideAttr(), "stride"),
+        emitter.emit<std::vector<uint32_t>>(conv2dOp.getPaddingAttr(),
+                                            "padding"),
+        emitter.emit<std::vector<uint32_t>>(conv2dOp.getDilationAttr(),
+                                            "dilation"),
         emitter.emit(conv2dOp.getGroups(), "groups"),
         emitter.emit(conv2dOp.getDtypeAttr(), "dtype"),
         emitter.emit(conv2dOp.getBias(), "bias_tensor"),
@@ -2287,7 +2282,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput(), "input"),
-        emitter.emit(srcOp.getDim(), "dim"),
+        emitter.emit(static_cast<int32_t>(srcOp.getDim()), "dim"),
         emitter.emit(srcOp.getIndex(), "index"),
         emitter.emit(srcOp.getSource(), "src"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
@@ -2553,7 +2548,7 @@ public:
         emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getBegins()),
         emitter.emit(srcOp.getEnds()),
-        emitter.template emit<::ttsl::SmallVector<int32_t>>(srcOp.getStep()),
+        emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getStep()),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
 
@@ -2589,9 +2584,9 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.template emit<::ttsl::SmallVector<int32_t>>(srcOp.getBegins()),
-        emitter.template emit<::ttsl::SmallVector<int32_t>>(srcOp.getEnds()),
-        emitter.template emit<::ttsl::SmallVector<int32_t>>(srcOp.getStep()),
+        emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getBegins()),
+        emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getEnds()),
+        emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getStep()),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
 
@@ -4869,7 +4864,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInputTensor()),
         emitter.emit(srcOp.getK()),
-        emitter.template emit<int32_t>(srcOp.getDim()),
+        emitter.emit<int32_t>(srcOp.getDim()),
         emitter.emit(srcOp.getLargest()),
         emitter.emit(srcOp.getSorted()),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -2286,6 +2286,9 @@ public:
         emitter.emit(srcOp.getIndex(), "index"),
         emitter.emit(srcOp.getSource(), "src"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
+        emitter.emit(ttnn_to_emitpy::reduceTypeToScatterString(
+                         srcOp.getScatterReduceType()),
+                     "reduce"),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1335,9 +1335,9 @@ public:
         srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(static_cast<int64_t>(srcOp.getStart())),
-        emitter.emit(static_cast<int64_t>(srcOp.getEnd())),
-        emitter.emit(static_cast<int64_t>(srcOp.getStep())),
+        emitter.emit(srcOp.getStart()),
+        emitter.emit(srcOp.getEnd()),
+        emitter.emit(srcOp.getStep()),
         emitter.emit(srcOp.getDtypeAttr(), "dtype"),
         emitter.emit(srcOp.getDevice(), "device"),
         emitter.emit(srcOp.getLayoutAttr().getValue(), "layout"),

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1254,23 +1254,15 @@ verifyPoolingOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
 
 ::mlir::LogicalResult mlir::tt::ttnn::ArangeOp::verify() {
 
-  // start/end/step are signless I64Attr, so the generated getters return
-  // uint64_t. Cast to int64_t before doing arithmetic, otherwise negative
-  // bounds/step are interpreted as huge unsigned values (e.g. a valid
-  // descending range like arange(5, -5, -1) would be wrongly rejected).
-  int64_t start = static_cast<int64_t>(getStart());
-  int64_t end = static_cast<int64_t>(getEnd());
-  int64_t step = static_cast<int64_t>(getStep());
-
-  if (step == 0) {
+  if (getStep() == 0) {
     return emitOpError("Step cannot be zero.");
   }
 
-  int64_t numValues = (end - start) / step;
+  int64_t numValues = (getEnd() - getStart()) / getStep();
 
   if (numValues <= 0) {
     return emitOpError("Invalid range: start=")
-           << start << ", end=" << end << ", step=" << step;
+           << getStart() << ", end=" << getEnd() << ", step=" << getStep();
   }
 
   std::vector<int64_t> expectedShape = {numValues};

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1254,15 +1254,23 @@ verifyPoolingOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
 
 ::mlir::LogicalResult mlir::tt::ttnn::ArangeOp::verify() {
 
-  if (getStep() == 0) {
+  // start/end/step are signless I64Attr, so the generated getters return
+  // uint64_t. Cast to int64_t before doing arithmetic, otherwise negative
+  // bounds/step are interpreted as huge unsigned values (e.g. a valid
+  // descending range like arange(5, -5, -1) would be wrongly rejected).
+  int64_t start = static_cast<int64_t>(getStart());
+  int64_t end = static_cast<int64_t>(getEnd());
+  int64_t step = static_cast<int64_t>(getStep());
+
+  if (step == 0) {
     return emitOpError("Step cannot be zero.");
   }
 
-  int64_t numValues = (getEnd() - getStart()) / getStep();
+  int64_t numValues = (end - start) / step;
 
   if (numValues <= 0) {
     return emitOpError("Invalid range: start=")
-           << getStart() << ", end=" << getEnd() << ", step=" << getStep();
+           << start << ", end=" << end << ", step=" << step;
   }
 
   std::vector<int64_t> expectedShape = {numValues};

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/GatherOpRank1RewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/GatherOpRank1RewritePattern.cpp
@@ -60,7 +60,7 @@ GatherOpRank1RewritePattern::matchAndRewrite(ttnn::GatherOp srcOp,
   auto gather = rewriter.create<ttnn::GatherOp>(
       ttmlir::utils::appendLocationSuffix(loc, "_gather"), gatherOutputType,
       inputReshaped.getResult(), indexReshaped.getResult(),
-      rewriter.getI32IntegerAttr(adjustedDim));
+      rewriter.getSI32IntegerAttr(adjustedDim));
 
   // Reshape the result back to the original rank, reusing the original output
   // type so downstream consumers see the exact same layout.

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -408,9 +408,13 @@ createOp(FlatbufferObjectCache &cache, ArangeOp op) {
 
                                   /*local_shape*/ std::nullopt);
 
+  // start/end/step are signless I64Attr (getters return uint64_t); cast through
+  // int64_t so negative bounds/step are not turned into huge float values.
   return ::tt::target::ttnn::CreateArangeOp(
-      *cache.fbb, device /* optional */, static_cast<float>(op.getStart()),
-      static_cast<float>(op.getEnd()), static_cast<float>(op.getStep()),
+      *cache.fbb, device /* optional */,
+      static_cast<float>(static_cast<int64_t>(op.getStart())),
+      static_cast<float>(static_cast<int64_t>(op.getEnd())),
+      static_cast<float>(static_cast<int64_t>(op.getStep())),
       dtype /* optional */, layout /* optional */, memoryConfig /* optional */,
       output);
 }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -408,13 +408,9 @@ createOp(FlatbufferObjectCache &cache, ArangeOp op) {
 
                                   /*local_shape*/ std::nullopt);
 
-  // start/end/step are signless I64Attr (getters return uint64_t); cast through
-  // int64_t so negative bounds/step are not turned into huge float values.
   return ::tt::target::ttnn::CreateArangeOp(
-      *cache.fbb, device /* optional */,
-      static_cast<float>(static_cast<int64_t>(op.getStart())),
-      static_cast<float>(static_cast<int64_t>(op.getEnd())),
-      static_cast<float>(static_cast<int64_t>(op.getStep())),
+      *cache.fbb, device /* optional */, static_cast<float>(op.getStart()),
+      static_cast<float>(op.getEnd()), static_cast<float>(op.getStep()),
       dtype /* optional */, layout /* optional */, memoryConfig /* optional */,
       output);
 }

--- a/test/python/golden/mlir_snippets/ttnn/ttnn_gather.mlir
+++ b/test/python/golden/mlir_snippets/ttnn/ttnn_gather.mlir
@@ -3,7 +3,7 @@
 #ttnn_layout_index = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
 module {
   func.func @model(%arg0: tensor<32x256xf32, #ttnn_layout>, %arg1: tensor<32x32xui32, #ttnn_layout_index>) -> tensor<32x32xf32, #ttnn_layout_index> {
-    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 1 : i32}> : (tensor<32x256xf32, #ttnn_layout>, tensor<32x32xui32, #ttnn_layout_index>) -> tensor<32x32xf32, #ttnn_layout_index>
+    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 1 : si32}> : (tensor<32x256xf32, #ttnn_layout>, tensor<32x32xui32, #ttnn_layout_index>) -> tensor<32x32xf32, #ttnn_layout_index>
     return %0 : tensor<32x32xf32, #ttnn_layout_index>
   }
 }

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -974,8 +974,14 @@ def test_upsample2d(shapes: List[Shape], scale_factor: List[int], request, devic
         pytest.param(
             (5, 3), torch.int64, 0, 3, 1, 1, marks=pytest.mark.skip_config(["sim"])
         ),
+        pytest.param(
+            (5,), torch.float32, -5, 0, 1, 0, marks=pytest.mark.skip_config(["sim"])
+        ),
     ],
 )
+# NOTE: emitc omitted — arange has no dedicated EmitC conversion (the generic
+# DefaultOpConversionPattern emits `ttnn::arange()` with no start/end/step args).
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
 def test_arange(
     shape: Shape,
     dtype: torch.dtype,
@@ -983,6 +989,7 @@ def test_arange(
     end: int,
     step: int,
     dim: int,
+    target: str,
     request,
     device,
 ):
@@ -999,6 +1006,7 @@ def test_arange(
         module,
         **get_request_kwargs(request),
         device=device,
+        target=target,
     )
 
 

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -3003,8 +3003,9 @@ def test_presharded_arg(target, mesh_shape, request, device):
     [
         ((32, 64), (32, 16), 1),
         ((64, 32), (16, 32), 0),
+        ((32, 64), (32, 16), -1),
     ],
-    ids=["dim1", "dim0"],
+    ids=["dim1", "dim0", "negdim"],
 )
 @pytest.mark.parametrize(
     "target",

--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -624,8 +624,13 @@ def test_typecast(
         ((32,), (300,), 0),
         ((512,), (284,), 0),
         ((32, 64), (4, 64), 0),
+        # Negative dim: validates the signed SI32Attr dim end-to-end. Kept on the
+        # ttnn target only — scatter's emitpy/emitc execution has a pre-existing
+        # accuracy gap (fails for positive dims too); negative-dim *emission* is
+        # covered hermetically by test/ttmlir/Emit{C,Py}/TTNN/negative_dim.mlir.
+        ((32, 64), (32, 16), -1),
     ],
-    ids=["1d_small", "1d_index300", "1d_index284", "2d_dim0"],
+    ids=["1d_small", "1d_index300", "1d_index284", "2d_dim0", "2d_negdim"],
 )
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
 @pytest.mark.parametrize("target", ["ttnn"])

--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -624,16 +624,12 @@ def test_typecast(
         ((32,), (300,), 0),
         ((512,), (284,), 0),
         ((32, 64), (4, 64), 0),
-        # Negative dim: validates the signed SI32Attr dim end-to-end. Kept on the
-        # ttnn target only — scatter's emitpy/emitc execution has a pre-existing
-        # accuracy gap (fails for positive dims too); negative-dim *emission* is
-        # covered hermetically by test/ttmlir/Emit{C,Py}/TTNN/negative_dim.mlir.
         ((32, 64), (32, 16), -1),
     ],
     ids=["1d_small", "1d_index300", "1d_index284", "2d_dim0", "2d_negdim"],
 )
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
 def test_scatter(
     input_shape: Shape,
     index_shape: Shape,

--- a/test/python/golden/ttir_ops/reduction/test_reduction.py
+++ b/test/python/golden/ttir_ops/reduction/test_reduction.py
@@ -39,6 +39,7 @@ dim_arg_options = [
     [0],
     [2],
     [1, 2],
+    [-1],
     None,
 ]
 
@@ -163,6 +164,12 @@ def test_reduction_cpu_hoisted_ops(
     )
 
 
+cumulative_op_names = [
+    "cumsum",
+    "cumprod",
+]
+
+
 @pytest.mark.parametrize(
     "shapes, dim",
     [
@@ -172,18 +179,34 @@ def test_reduction_cpu_hoisted_ops(
         pytest.param([(4, 128)], 0, id="rank2_dim0"),
         pytest.param([(4, 4, 128)], 1, id="rank3_dim1"),
         pytest.param([(4, 4, 128)], 2, id="rank3_dim2"),
+        pytest.param([(4, 4, 128, 128)], -1, id="rank4_negdim"),
     ],
 )
-@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
-def test_cumsum(shapes: List[Shape], dim: int, request, target, device):
+@pytest.mark.parametrize("cumulative_op_name", cumulative_op_names)
+@pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
+def test_cumulative_ops(
+    shapes: List[Shape],
+    dim: int,
+    cumulative_op_name: str,
+    target: str,
+    request,
+    device,
+):
     def module(builder: TTIRBuilder):
         @builder.func(shapes, [torch.float32] * len(shapes))
-        def cumsum(
+        def cumulative_op_wrapper(
             in0: Operand,
             builder: TTIRBuilder,
             unit_attrs: Optional[List[str]] = None,
         ):
-            return builder.cumsum(in0, dim=dim, unit_attrs=unit_attrs)
+            cumulative_op_builder_map = {
+                "cumsum": builder.cumsum,
+                "cumprod": builder.cumprod,
+            }
+
+            cumulative_func = cumulative_op_builder_map.get(cumulative_op_name)
+
+            return cumulative_func(in0, dim=dim, unit_attrs=unit_attrs)
 
     compile_and_execute_ttir(
         module,

--- a/test/ttmlir/Conversion/TTIRToTTNN/gather.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTNN/gather.mlir
@@ -3,7 +3,7 @@
 // Test: ttir.gather along dim 0 with ui32 index lowers to ttnn.gather.
 // CHECK-LABEL: func.func @gather_dim0
 // CHECK: "ttnn.gather"(%arg0, %arg1)
-// CHECK-SAME: dim = 0 : i32
+// CHECK-SAME: dim = 0 : si32
 module attributes {} {
   func.func @gather_dim0(%arg0: tensor<5x3xf32>, %arg1: tensor<2x3xui32>) -> tensor<2x3xf32> {
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<5x3xf32>, tensor<2x3xui32>) -> tensor<2x3xf32>
@@ -16,7 +16,7 @@ module attributes {} {
 // Test: ttir.gather along dim 1 with ui32 index lowers to ttnn.gather.
 // CHECK-LABEL: func.func @gather_dim1
 // CHECK: "ttnn.gather"(%arg0, %arg1)
-// CHECK-SAME: dim = 1 : i32
+// CHECK-SAME: dim = 1 : si32
 module attributes {} {
   func.func @gather_dim1(%arg0: tensor<3x5xbf16>, %arg1: tensor<3x2xui32>) -> tensor<3x2xbf16> {
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 1 : i32}> : (tensor<3x5xbf16>, tensor<3x2xui32>) -> tensor<3x2xbf16>
@@ -29,7 +29,7 @@ module attributes {} {
 // Test: ttir.gather with negative dim lowers to ttnn.gather preserving the sign.
 // CHECK-LABEL: func.func @gather_negative_dim
 // CHECK: "ttnn.gather"(%arg0, %arg1)
-// CHECK-SAME: dim = -1 : i32
+// CHECK-SAME: dim = -1 : si32
 module attributes {} {
   func.func @gather_negative_dim(%arg0: tensor<4x6xf32>, %arg1: tensor<4x3xui32>) -> tensor<4x3xf32> {
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = -1 : i32}> : (tensor<4x6xf32>, tensor<4x3xui32>) -> tensor<4x3xf32>
@@ -42,7 +42,7 @@ module attributes {} {
 // Test: ttir.gather on 3D tensors along dim 2 lowers to ttnn.gather.
 // CHECK-LABEL: func.func @gather_3d
 // CHECK: "ttnn.gather"(%arg0, %arg1)
-// CHECK-SAME: dim = 2 : i32
+// CHECK-SAME: dim = 2 : si32
 module attributes {} {
   func.func @gather_3d(%arg0: tensor<2x4x6xf32>, %arg1: tensor<2x4x3xui32>) -> tensor<2x4x3xf32> {
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 2 : i32}> : (tensor<2x4x6xf32>, tensor<2x4x3xui32>) -> tensor<2x4x3xf32>
@@ -56,7 +56,7 @@ module attributes {} {
 // CHECK-LABEL: func.func @gather_ui16_index
 // CHECK-NOT: "ttnn.typecast"
 // CHECK: "ttnn.gather"(%arg0, %arg1)
-// CHECK-SAME: dim = 0 : i32
+// CHECK-SAME: dim = 0 : si32
 module attributes {} {
   func.func @gather_ui16_index(%arg0: tensor<5x3xbf16>, %arg1: tensor<2x3xui16>) -> tensor<2x3xbf16> {
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<5x3xbf16>, tensor<2x3xui16>) -> tensor<2x3xbf16>
@@ -76,7 +76,7 @@ module attributes {} {
 // CHECK: "ttnn.reshape"(%arg1)
 // CHECK-SAME: shape = [1 : i32, 3 : i32]
 // CHECK: "ttnn.gather"
-// CHECK-SAME: dim = 1 : i32
+// CHECK-SAME: dim = 1 : si32
 // CHECK-SAME: (tensor<1x8xf32, {{.*}}>, tensor<1x3xui32, {{.*}}>) -> tensor<1x3xf32
 // CHECK: "ttnn.reshape"
 // CHECK-SAME: shape = [3 : i32]

--- a/test/ttmlir/Conversion/TTNNToTTIR/reduction_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/reduction_op.mlir
@@ -70,7 +70,7 @@ module {
 
         // CHECK: %{{[0-9]+}} = "ttir.prod"(%{{[0-9]+}}) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<96x32xf32, #ttnn_layout{{[0-9]+}}>) -> tensor<96xf32, #ttnn_layout{{[0-9]+}}>
         // CHECK-NOT: "ttnn.prod"
-        %2 = "ttnn.prod"(%1) {ttnn.hoist_generic_via_d2m, dim_arg = 1, keep_dim = false} : (tensor<96x32xf32, #l1_layout>) -> tensor<96xf32, #l1_layout>
+        %2 = "ttnn.prod"(%1) {ttnn.hoist_generic_via_d2m, dim_arg = 1 : si64, keep_dim = false} : (tensor<96x32xf32, #l1_layout>) -> tensor<96xf32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<96xf32, #l1_layout>) -> tensor<96xf32, #dram_layout>
 
@@ -82,7 +82,7 @@ module {
 
         // CHECK: %{{[0-9]+}} = "ttir.argmax"(%{{[0-9]+}}) <{dim_arg = [0 : i32], keep_dim = false}> : (tensor<64x32xbf16, #ttnn_layout{{[0-9]+}}>) -> tensor<32xi32, #ttnn_layout{{[0-9]+}}>
         // CHECK-NOT: "ttnn.argmax"
-        %2 = "ttnn.argmax"(%1) {ttnn.hoist_generic_via_d2m, dim = 0 : i32, keep_dim = false} : (tensor<64x32xbf16, #l1_layout>) -> tensor<32xi32, #l1_layout>
+        %2 = "ttnn.argmax"(%1) {ttnn.hoist_generic_via_d2m, dim = 0 : si32, keep_dim = false} : (tensor<64x32xbf16, #l1_layout>) -> tensor<32xi32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<32xi32, #l1_layout>) -> tensor<32xi32, #dram_layout>
 
@@ -94,7 +94,7 @@ module {
 
         // CHECK: %{{[0-9]+}} = "ttir.cumsum"(%{{[0-9]+}}) <{dim = 0 : i64}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
         // CHECK-NOT: "ttnn.cumsum"
-        %2 = "ttnn.cumsum"(%1) <{dim = 0 : i32}> {ttnn.hoist_generic_via_d2m} : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
+        %2 = "ttnn.cumsum"(%1) <{dim = 0 : si32}> {ttnn.hoist_generic_via_d2m} : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #dram_layout>
 
@@ -106,7 +106,7 @@ module {
 
         // CHECK: %{{[0-9]+}} = "ttir.cumprod"(%{{[0-9]+}}) <{dim = 1 : i64}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
         // CHECK-NOT: "ttnn.cumprod"
-        %2 = "ttnn.cumprod"(%1) <{dim = 1 : i32}> {ttnn.hoist_generic_via_d2m} : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
+        %2 = "ttnn.cumprod"(%1) <{dim = 1 : si32}> {ttnn.hoist_generic_via_d2m} : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #dram_layout>
 

--- a/test/ttmlir/Conversion/TTNNToTTIR/skip_reduction_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/skip_reduction_op.mlir
@@ -32,8 +32,8 @@ module {
 
         // CHECK-NOT: %{{[0-9]+}} = ttir.empty() : tensor<32xi32, #ttnn_layout1>
         // CHECK-NOT: %{{[0-9]+}} = "ttir.argmax"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32xi32, #ttnn_layout1>) -> tensor<32xi32, #ttnn_layout1>
-        // CHECK: %{{[0-9]+}} = "ttnn.argmax"(%{{[0-9]+}}) <{dim = 1 : i32, keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32xi32, #ttnn_layout1>
-        %2 = "ttnn.argmax"(%1) {dim = 1 : i32, keep_dim = false} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xi32, #l1_layout>
+        // CHECK: %{{[0-9]+}} = "ttnn.argmax"(%{{[0-9]+}}) <{dim = 1 : si32, keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32xi32, #ttnn_layout1>
+        %2 = "ttnn.argmax"(%1) {dim = 1 : si32, keep_dim = false} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xi32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<32xi32, #l1_layout>) -> tensor<32xi32, #dram_layout>
 
@@ -45,8 +45,8 @@ module {
 
         // CHECK-NOT: %{{[0-9]+}} = ttir.empty() : tensor<32x32xf32, #ttnn_layout1>
         // CHECK-NOT: %{{[0-9]+}} = "ttir.cumsum"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim = 1 : i64}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
-        // CHECK: %{{[0-9]+}} = "ttnn.cumsum"(%{{[0-9]+}}) <{dim = 1 : i32}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
-        %2 = "ttnn.cumsum"(%1) <{dim = 1 : i32}> : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
+        // CHECK: %{{[0-9]+}} = "ttnn.cumsum"(%{{[0-9]+}}) <{dim = 1 : si32}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
+        %2 = "ttnn.cumsum"(%1) <{dim = 1 : si32}> : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #dram_layout>
 
@@ -58,8 +58,8 @@ module {
 
         // CHECK-NOT: %{{[0-9]+}} = ttir.empty() : tensor<32x32xf32, #ttnn_layout1>
         // CHECK-NOT: %{{[0-9]+}} = "ttir.cumprod"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim = 1 : i64}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
-        // CHECK: %{{[0-9]+}} = "ttnn.cumprod"(%{{[0-9]+}}) <{dim = 1 : i32}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
-        %2 = "ttnn.cumprod"(%1) <{dim = 1 : i32}> : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
+        // CHECK: %{{[0-9]+}} = "ttnn.cumprod"(%{{[0-9]+}}) <{dim = 1 : si32}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
+        %2 = "ttnn.cumprod"(%1) <{dim = 1 : si32}> : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #dram_layout>
 

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/layout_to_creation_ops_canonicalizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/layout_to_creation_ops_canonicalizer.mlir
@@ -85,8 +85,8 @@ module attributes {} {
     // CHECK-SAME: memref<32x
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.arange"() <{layout = #ttnn.layout<tile>, start = 0 : i64, step = 1 : i64, end = 32 : i64}> : () -> tensor<32xf32, #ttnn_layout_1_device_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32xf32, #ttnn_layout_1_device_bf16_tile>) -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
+    %1 = "ttnn.arange"() <{ start = 0 : si64, step = 1 : si64, end = 32 : si64}> : () -> tensor<32xf32, #ttnn_layout_1_device_bf16_tile>
+    %2 = "ttnn.to_layout"(%1) : (tensor<32xf32, #ttnn_layout_1_device_bf16_tile>) -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
     return %2 : tensor<32xf32, #ttnn_layout_1_host_f32_rm>
   }
 

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/layout_to_creation_ops_canonicalizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/layout_to_creation_ops_canonicalizer.mlir
@@ -73,7 +73,7 @@ module attributes {} {
     // CHECK-SAME: !ttcore.tile<32x32,
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.arange"() <{ start = 0 : i64, step = 1 : i64, end = 32 : i64}> : () -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
+    %1 = "ttnn.arange"() <{ start = 0 : si64, step = 1 : si64, end = 32 : si64}> : () -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
     %2 = "ttnn.to_layout"(%1) : (tensor<32xf32, #ttnn_layout_1_host_f32_rm>) -> tensor<32xbf16, #ttnn_layout_1_device_bf16_tile>
     return %2 : tensor<32xbf16, #ttnn_layout_1_device_bf16_tile>
   }
@@ -85,8 +85,8 @@ module attributes {} {
     // CHECK-SAME: memref<32x
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.arange"() <{ start = 0 : i64, step = 1 : i64, end = 32 : i64}> : () -> tensor<32xf32, #ttnn_layout_1_device_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32xf32, #ttnn_layout_1_device_bf16_tile>) -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
+    %1 = "ttnn.arange"() <{layout = #ttnn.layout<tile>, start = 0 : i64, step = 1 : i64, end = 32 : i64}> : () -> tensor<32xf32, #ttnn_layout_1_device_bf16_tile>
+    %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32xf32, #ttnn_layout_1_device_bf16_tile>) -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
     return %2 : tensor<32xf32, #ttnn_layout_1_host_f32_rm>
   }
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/gather_rank1_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/gather_rank1_workaround.mlir
@@ -18,12 +18,12 @@ module {
     // CHECK-SAME: shape = [1 : i32, 2 : i32]
     // CHECK-SAME: -> tensor<1x2xui32
     // CHECK: "ttnn.gather"
-    // CHECK-SAME: dim = 1 : i32
+    // CHECK-SAME: dim = 1 : si32
     // CHECK-SAME: (tensor<1x5xf32, {{.*}}>, tensor<1x2xui32, {{.*}}>) -> tensor<1x2xf32
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [2 : i32]
     // CHECK-SAME: -> tensor<2xf32
-    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<5xf32>, tensor<2xui32>) -> tensor<2xf32>
+    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 0 : si32}> : (tensor<5xf32>, tensor<2xui32>) -> tensor<2xf32>
     return %0 : tensor<2xf32>
   }
 
@@ -38,12 +38,12 @@ module {
     // CHECK-SAME: shape = [1 : i32, 2 : i32]
     // CHECK-SAME: -> tensor<1x2xui32
     // CHECK: "ttnn.gather"
-    // CHECK-SAME: dim = -1 : i32
+    // CHECK-SAME: dim = -1 : si32
     // CHECK-SAME: (tensor<1x5xf32, {{.*}}>, tensor<1x2xui32, {{.*}}>) -> tensor<1x2xf32
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [2 : i32]
     // CHECK-SAME: -> tensor<2xf32
-    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = -1 : i32}> : (tensor<5xf32>, tensor<2xui32>) -> tensor<2xf32>
+    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = -1 : si32}> : (tensor<5xf32>, tensor<2xui32>) -> tensor<2xf32>
     return %0 : tensor<2xf32>
   }
 
@@ -52,8 +52,8 @@ module {
     // CHECK-LABEL: func.func public @gather_rank2_noop
     // CHECK-NOT: "ttnn.reshape"
     // CHECK: "ttnn.gather"
-    // CHECK-SAME: dim = 0 : i32
-    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<5x3xf32>, tensor<2x3xui32>) -> tensor<2x3xf32>
+    // CHECK-SAME: dim = 0 : si32
+    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 0 : si32}> : (tensor<5x3xf32>, tensor<2x3xui32>) -> tensor<2x3xf32>
     return %0 : tensor<2x3xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/gather_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/gather_workaround.mlir
@@ -29,7 +29,7 @@ module attributes {} {
     // CHECK-SAME: -> tensor<2x3xui32,
     // CHECK-SAME: !ttcore.tile<32x32,
     %0 = "ttnn.gather"(%arg0, %arg1)
-        <{dim = 0 : i32}>
+        <{dim = 0 : si32}>
         : (tensor<5x3xf32, #ttnn_layout_input_rm>,
            tensor<2x3xui32, #ttnn_layout_index_rm>)
         -> tensor<2x3xf32, #ttnn_layout_output>
@@ -47,7 +47,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     // CHECK: "ttnn.gather"
     %0 = "ttnn.gather"(%arg0, %arg1)
-        <{dim = 0 : i32}>
+        <{dim = 0 : si32}>
         : (tensor<5x3xf32, #ttnn_layout_input_tile>,
            tensor<2x3xui32, #ttnn_layout_index_tile>)
         -> tensor<2x3xf32, #ttnn_layout_output>
@@ -81,7 +81,7 @@ module attributes {} {
     // %result = ttnn.where(mask, NaN, raw)
     // CHECK: "ttnn.where"({{.*}}, %[[NAN]], %[[RAW]])
     %0 = "ttnn.gather"(%arg0, %arg1)
-        <{dim = 0 : i32}>
+        <{dim = 0 : si32}>
         : (tensor<5x3xf32, #ttnn_layout_input_tile>,
            tensor<2x3xi32, #ttnn_layout_index_tile_i32>)
         -> tensor<2x3xf32, #ttnn_layout_output>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/integer_prod_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/integer_prod_workaround.mlir
@@ -15,7 +15,7 @@ module {
   // CHECK: "ttnn.multiply"
   // CHECK: "ttnn.reshape"
   func.func public @test_integer_prod(%arg0: tensor<1x3xsi32, #ttnn_layout>) -> tensor<1xsi32, #ttnn_layout1> {
-    %0 = "ttnn.prod"(%arg0) <{dim_arg = 1 : i64, keep_dim = false}> : (tensor<1x3xsi32, #ttnn_layout>) -> tensor<1xsi32, #ttnn_layout1>
+    %0 = "ttnn.prod"(%arg0) <{dim_arg = 1 : si64, keep_dim = false}> : (tensor<1x3xsi32, #ttnn_layout>) -> tensor<1xsi32, #ttnn_layout1>
     return %0 : tensor<1xsi32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_f32_input_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_f32_input_workaround.mlir
@@ -9,7 +9,7 @@ module {
     // CHECK-SAME: tensor<2x3x32x128xf32
     // CHECK-SAME: -> tensor<2x3x32x128xbf16
     // CHECK: %[[VALUES:.*]], %[[INDICES:.*]] = "ttnn.topk"(%[[INPUT_BF16]])
-    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: <{dim = -1 : si32, k = 5 : i32, largest = true, sorted = false}>
     // CHECK-SAME: tensor<2x3x32x128xbf16
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16
     // CHECK-SAME: tensor<2x3x32x5xui16

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround.mlir
@@ -5,7 +5,7 @@ module {
   func.func public @test_topk_datatype_workaround_ui16(%arg0: tensor<2x3x32x128xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>) {
     // CHECK-LABEL: func.func public @test_topk_datatype_workaround_ui16
     // CHECK: %{{.*}}, %[[INDICES:.*]] = "ttnn.topk"
-    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: <{dim = -1 : si32, k = 5 : i32, largest = true, sorted = false}>
     // CHECK-SAME: tensor<2x3x32x128xbf16,
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
     // CHECK-SAME: tensor<2x3x32x5xui16,
@@ -22,7 +22,7 @@ module {
   func.func public @test_topk_datatype_workaround_ui32(%arg0: tensor<2x3x32x128000xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>) {
     // CHECK-LABEL: func.func public @test_topk_datatype_workaround_ui32
     // CHECK: %{{.*}}, %[[INDICES:.*]] = "ttnn.topk"
-    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: <{dim = -1 : si32, k = 5 : i32, largest = true, sorted = false}>
     // CHECK-SAME: tensor<2x3x32x128000xbf16,
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
     // CHECK-SAME: tensor<2x3x32x5xui32,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround_with_optimizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround_with_optimizer.mlir
@@ -28,7 +28,7 @@ module {
   func.func public @test_topk_workaround_with_optimizer_ui16(%arg0: tensor<2x3x32x128xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>) {
     // CHECK-LABEL: func.func public @test_topk_workaround_with_optimizer_ui16
     // CHECK: %{{.*}}, %[[INDICES:.*]] = "ttnn.topk"
-    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: <{dim = -1 : si32, k = 5 : i32, largest = true, sorted = false}>
     // CHECK-SAME: tensor<2x3x32x128xbf16,
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
     // CHECK-SAME: tensor<2x3x32x5xui16,
@@ -45,7 +45,7 @@ module {
   func.func public @test_topk_workaround_with_optimizer_ui32(%arg0: tensor<2x3x32x128000xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>) {
     // CHECK-LABEL: func.func public @test_topk_workaround_with_optimizer_ui32
     // CHECK: %{{.*}}, %[[INDICES:.*]] = "ttnn.topk"
-    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: <{dim = -1 : si32, k = 5 : i32, largest = true, sorted = false}>
     // CHECK-SAME: tensor<2x3x32x128000xbf16,
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
     // CHECK-SAME: tensor<2x3x32x5xui32,
@@ -68,7 +68,7 @@ module {
     // CHECK-SAME: tensor<2x3x32x128xf32
     // CHECK-SAME: -> tensor<2x3x32x128xbf16
     // CHECK: %[[VALUES:.*]], %[[INDICES:.*]] = "ttnn.topk"(%[[INPUT_BF16]])
-    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: <{dim = -1 : si32, k = 5 : i32, largest = true, sorted = false}>
     // CHECK-SAME: tensor<2x3x32x128xbf16
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16
     // CHECK-SAME: tensor<2x3x32x5xui16

--- a/test/ttmlir/Dialect/TTNN/const-eval/cacheable-creation-ops.mlir
+++ b/test/ttmlir/Dialect/TTNN/const-eval/cacheable-creation-ops.mlir
@@ -92,7 +92,7 @@ module {
   // CHECK-LABEL: func.func @arange_op(
   func.func @arange_op(%arg0: tensor<32xbf16, #ttnn_layout_1d> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32xbf16, #ttnn_layout_1d> {
     // CHECK: %[[CACHED:.*]] = ttcore.load_cached(@arange_op_const_eval_0, [])
-    %arange = "ttnn.arange"() <{end = 32 : i64, layout = #ttnn.layout<tile>, start = 0 : i64, step = 1 : i64}> : () -> tensor<32xbf16, #ttnn_layout_1d>
+    %arange = "ttnn.arange"() <{end = 32 : si64, layout = #ttnn.layout<tile>, start = 0 : si64, step = 1 : si64}> : () -> tensor<32xbf16, #ttnn_layout_1d>
     // CHECK: %[[RESULT:.*]] = "ttnn.add"(%arg0, %[[CACHED]])
     %result = "ttnn.add"(%arg0, %arange) : (tensor<32xbf16, #ttnn_layout_1d>, tensor<32xbf16, #ttnn_layout_1d>) -> tensor<32xbf16, #ttnn_layout_1d>
     return %result : tensor<32xbf16, #ttnn_layout_1d>

--- a/test/ttmlir/Dialect/TTNN/data_movement/gather/gather_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/gather/gather_tests_negative.mlir
@@ -5,7 +5,7 @@
 module {
   func.func @gather_rank_mismatch(%arg0: tensor<5x3xf32>, %arg1: tensor<2x3x1xui32>) -> tensor<2x3xf32> {
     // CHECK: error: 'ttnn.gather' op Input tensor and index tensor must have the same rank.
-    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<5x3xf32>, tensor<2x3x1xui32>) -> tensor<2x3xf32>
+    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 0 : si32}> : (tensor<5x3xf32>, tensor<2x3x1xui32>) -> tensor<2x3xf32>
     return %0 : tensor<2x3xf32>
   }
 }
@@ -16,7 +16,7 @@ module {
 module {
   func.func @gather_dim_too_large(%arg0: tensor<5x3xf32>, %arg1: tensor<2x3xui32>) -> tensor<2x3xf32> {
     // CHECK: error: 'ttnn.gather' op Dimension must be in the range [-2, 2), got dim = 2
-    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 2 : i32}> : (tensor<5x3xf32>, tensor<2x3xui32>) -> tensor<2x3xf32>
+    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 2 : si32}> : (tensor<5x3xf32>, tensor<2x3xui32>) -> tensor<2x3xf32>
     return %0 : tensor<2x3xf32>
   }
 }
@@ -27,7 +27,7 @@ module {
 module {
   func.func @gather_dim_too_negative(%arg0: tensor<5x3xf32>, %arg1: tensor<2x3xui32>) -> tensor<2x3xf32> {
     // CHECK: error: 'ttnn.gather' op Dimension must be in the range [-2, 2), got dim = -3
-    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = -3 : i32}> : (tensor<5x3xf32>, tensor<2x3xui32>) -> tensor<2x3xf32>
+    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = -3 : si32}> : (tensor<5x3xf32>, tensor<2x3xui32>) -> tensor<2x3xf32>
     return %0 : tensor<2x3xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/data_movement/gather/gather_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/gather/gather_tests_positive.mlir
@@ -6,7 +6,7 @@ module attributes {} {
   func.func @gather0(%arg0: tensor<5x3xf32>, %arg1: tensor<2x3xui32>) -> tensor<2x3xf32> {
     // CHECK-LABEL: func.func @gather0
     // CHECK: "ttnn.gather"
-    // CHECK-SAME: dim = 0 : i32
+    // CHECK-SAME: dim = 0 : si32
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<5x3xf32>, tensor<2x3xui32>) -> tensor<2x3xf32>
     return %0 : tensor<2x3xf32>
   }
@@ -15,7 +15,7 @@ module attributes {} {
   func.func @gather1(%arg0: tensor<3x5xbf16>, %arg1: tensor<3x2xui32>) -> tensor<3x2xbf16> {
     // CHECK-LABEL: func.func @gather1
     // CHECK: "ttnn.gather"
-    // CHECK-SAME: dim = 1 : i32
+    // CHECK-SAME: dim = 1 : si32
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 1 : i32}> : (tensor<3x5xbf16>, tensor<3x2xui32>) -> tensor<3x2xbf16>
     return %0 : tensor<3x2xbf16>
   }
@@ -24,7 +24,7 @@ module attributes {} {
   func.func @gather_negative_dim(%arg0: tensor<4x6xf32>, %arg1: tensor<4x3xui32>) -> tensor<4x3xf32> {
     // CHECK-LABEL: func.func @gather_negative_dim
     // CHECK: "ttnn.gather"
-    // CHECK-SAME: dim = -1 : i32
+    // CHECK-SAME: dim = -1 : si32
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = -1 : i32}> : (tensor<4x6xf32>, tensor<4x3xui32>) -> tensor<4x3xf32>
     return %0 : tensor<4x3xf32>
   }
@@ -33,7 +33,7 @@ module attributes {} {
   func.func @gather_3d(%arg0: tensor<2x4x6xf32>, %arg1: tensor<2x4x3xui32>) -> tensor<2x4x3xf32> {
     // CHECK-LABEL: func.func @gather_3d
     // CHECK: "ttnn.gather"
-    // CHECK-SAME: dim = 2 : i32
+    // CHECK-SAME: dim = 2 : si32
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 2 : i32}> : (tensor<2x4x6xf32>, tensor<2x4x3xui32>) -> tensor<2x4x3xf32>
     return %0 : tensor<2x4x3xf32>
   }

--- a/test/ttmlir/Dialect/TTNN/gather/simple_gather.mlir
+++ b/test/ttmlir/Dialect/TTNN/gather/simple_gather.mlir
@@ -5,21 +5,21 @@ module attributes {} {
   // Test: Basic gather along dim 0
   func.func @gather_dim0(%arg0: tensor<3x4xbf16>, %arg1: tensor<2x4xui32>) -> tensor<2x4xbf16> {
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xui32>) -> tensor<2x4xbf16>
-    // CHECK: %{{[0-9]+}} = "ttnn.gather"({{.*}}) <{dim = 0 : i32}> : (tensor<3x4xbf16, {{.*}}>, tensor<2x4xui32, {{.*}}>) -> tensor<2x4xbf16, {{.*}}>
+    // CHECK: %{{[0-9]+}} = "ttnn.gather"({{.*}}) <{dim = 0 : si32}> : (tensor<3x4xbf16, {{.*}}>, tensor<2x4xui32, {{.*}}>) -> tensor<2x4xbf16, {{.*}}>
     return %0 : tensor<2x4xbf16>
   }
 
   // Test: Gather along dim 1
   func.func @gather_dim1(%arg0: tensor<3x4xf32>, %arg1: tensor<3x2xui32>) -> tensor<3x2xf32> {
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 1 : i32}> : (tensor<3x4xf32>, tensor<3x2xui32>) -> tensor<3x2xf32>
-    // CHECK: %{{[0-9]+}} = "ttnn.gather"({{.*}}) <{dim = 1 : i32}> : (tensor<3x4xf32, {{.*}}>, tensor<3x2xui32, {{.*}}>) -> tensor<3x2xf32, {{.*}}>
+    // CHECK: %{{[0-9]+}} = "ttnn.gather"({{.*}}) <{dim = 1 : si32}> : (tensor<3x4xf32, {{.*}}>, tensor<3x2xui32, {{.*}}>) -> tensor<3x2xf32, {{.*}}>
     return %0 : tensor<3x2xf32>
   }
 
   // Test: Gather on higher-rank tensor
   func.func @gather_4d(%arg0: tensor<2x3x4x5xbf16>, %arg1: tensor<2x3x2x5xui32>) -> tensor<2x3x2x5xbf16> {
     %0 = "ttir.gather"(%arg0, %arg1) <{dim = 2 : i32}> : (tensor<2x3x4x5xbf16>, tensor<2x3x2x5xui32>) -> tensor<2x3x2x5xbf16>
-    // CHECK: %{{[0-9]+}} = "ttnn.gather"({{.*}}) <{dim = 2 : i32}> : (tensor<2x3x4x5xbf16, {{.*}}>, tensor<2x3x2x5xui32, {{.*}}>) -> tensor<2x3x2x5xbf16, {{.*}}>
+    // CHECK: %{{[0-9]+}} = "ttnn.gather"({{.*}}) <{dim = 2 : si32}> : (tensor<2x3x4x5xbf16, {{.*}}>, tensor<2x3x2x5xui32, {{.*}}>) -> tensor<2x3x2x5xbf16, {{.*}}>
     return %0 : tensor<2x3x2x5xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/argmax_layout_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/argmax_layout_validation.mlir
@@ -25,7 +25,7 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x1x32x32xbf16,
     // CHECK-NEXT: "ttnn.argmax"
 
-    %1 = "ttnn.argmax"(%arg0) <{dim = 3 : i32, keep_dim = false}> : (tensor<1x1x32x32xf32, #ttnn_layout_tile_f32>) -> tensor<1x1x32xui32, #ttnn_layout_row_major_uint32>
+    %1 = "ttnn.argmax"(%arg0) <{dim = 3 : si32, keep_dim = false}> : (tensor<1x1x32x32xf32, #ttnn_layout_tile_f32>) -> tensor<1x1x32xui32, #ttnn_layout_row_major_uint32>
 
     return %1 : tensor<1x1x32xui32, #ttnn_layout_row_major_uint32>
   }

--- a/test/ttmlir/Dialect/TTNN/reduction/negative_argmax_op.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/negative_argmax_op.mlir
@@ -3,7 +3,7 @@
 
 // CHECK: error: 'ttnn.argmax' op dim attribute value 3 is out of range for input tensor of rank 2, expected value in range [-2, 1]
 func.func @test_argmax_dim_out_of_range_positive(%arg0: tensor<64x64xf32>) -> tensor<64xui32> {
-  %0 = "ttnn.argmax"(%arg0) <{dim = 3 : i32, keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
+  %0 = "ttnn.argmax"(%arg0) <{dim = 3 : si32, keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
   return %0 : tensor<64xui32>
 }
 
@@ -11,7 +11,7 @@ func.func @test_argmax_dim_out_of_range_positive(%arg0: tensor<64x64xf32>) -> te
 
 // CHECK: error: 'ttnn.argmax' op dim attribute value -3 is out of range for input tensor of rank 2, expected value in range [-2, 1]
 func.func @test_argmax_dim_out_of_range_negative(%arg0: tensor<64x64xf32>) -> tensor<64xui32> {
-  %0 = "ttnn.argmax"(%arg0) <{dim = -3 : i32, keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
+  %0 = "ttnn.argmax"(%arg0) <{dim = -3 : si32, keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
   return %0 : tensor<64xui32>
 }
 
@@ -19,7 +19,7 @@ func.func @test_argmax_dim_out_of_range_negative(%arg0: tensor<64x64xf32>) -> te
 
 // CHECK: error: 'ttnn.argmax' op expected output shape (64), got (64, 64)
 func.func @test_argmax_wrong_output_shape(%arg0: tensor<64x64xf32>) -> tensor<64x64xui32> {
-  %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64x64xui32>
+  %0 = "ttnn.argmax"(%arg0) <{dim = 1 : si32, keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64x64xui32>
   return %0 : tensor<64x64xui32>
 }
 
@@ -27,7 +27,7 @@ func.func @test_argmax_wrong_output_shape(%arg0: tensor<64x64xf32>) -> tensor<64
 
 // CHECK: error: 'ttnn.argmax' op expected output shape (64, 1), got (64, 64)
 func.func @test_argmax_wrong_output_shape_keep_dim(%arg0: tensor<64x64xf32>) -> tensor<64x64xui32> {
-  %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = true}> : (tensor<64x64xf32>) -> tensor<64x64xui32>
+  %0 = "ttnn.argmax"(%arg0) <{dim = 1 : si32, keep_dim = true}> : (tensor<64x64xf32>) -> tensor<64x64xui32>
   return %0 : tensor<64x64xui32>
 }
 

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
@@ -16,7 +16,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_3d(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 2 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 1 : si32, keep_dim = false}>
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x28x28xf32>) -> tensor<128x28xi32>
     return %1 : tensor<128x28xi32>
   }
@@ -25,7 +25,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_3d_dim0(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 0 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 0 : si32, keep_dim = false}>
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [0 : i32], keep_dim = false}> : (tensor<128x32x64xf32>) -> tensor<32x64xi32>
     return %1 : tensor<32x64xi32>
   }
@@ -34,7 +34,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_4d_dim1_keepdim(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 1 : i32, keep_dim = true}>
+    // CHECK-SAME: {dim = 1 : si32, keep_dim = true}>
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x8x32x64xf32>) -> tensor<2x1x32x64xi32>
     return %1 : tensor<2x1x32x64xi32>
   }
@@ -43,7 +43,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_3d_last_dim(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 2 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 2 : si32, keep_dim = false}>
     // CHECK-SAME: tensor<128x28x28xf32
     // CHECK-SAME: -> tensor<128x28xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<128x28x28xf32>) -> tensor<128x28xi32>
@@ -54,7 +54,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_4d(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 3 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 3 : si32, keep_dim = false}>
     // CHECK-SAME: tensor<4x8x128x64xf32
     // CHECK-SAME: -> tensor<4x8x128xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<4x8x128x64xf32>) -> tensor<4x8x128xi32>

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
@@ -5,7 +5,7 @@ module attributes {} {
   func.func public @argmax_2d(%arg0: tensor<64x64xf32>) -> tensor<64x1xi32> {
     // CHECK-LABEL: func.func public @argmax_2d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 1 : i32, keep_dim = true}>
+    // CHECK-SAME: {dim = 1 : si32, keep_dim = true}>
     // CHECK-SAME: tensor<64x64xf32
     // CHECK-SAME: -> tensor<64x1xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<64x64xf32>) -> tensor<64x1xi32>
@@ -16,7 +16,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_3d(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 1 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 2 : i32, keep_dim = false, use_multicore = true}>
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x28x28xf32>) -> tensor<128x28xi32>
     return %1 : tensor<128x28xi32>
   }
@@ -43,7 +43,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_3d_last_dim(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 2 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 2 : i32, keep_dim = false, use_multicore = true}>
     // CHECK-SAME: tensor<128x28x28xf32
     // CHECK-SAME: -> tensor<128x28xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<128x28x28xf32>) -> tensor<128x28xi32>
@@ -54,7 +54,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_4d(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 3 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 3 : i32, keep_dim = false, use_multicore = true}>
     // CHECK-SAME: tensor<4x8x128x64xf32
     // CHECK-SAME: -> tensor<4x8x128xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<4x8x128x64xf32>) -> tensor<4x8x128xi32>

--- a/test/ttmlir/Dialect/TTNN/simple_cumprod.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_cumprod.mlir
@@ -5,7 +5,7 @@ module @cumprod attributes {} {
   func.func public @test_cumprod_dim0(%arg0: tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16> {
     // CHECK-LABEL: func.func public @test_cumprod_dim0
     // CHECK: ttnn.cumprod
-    // CHECK-SAME: dim = 0 : i32
+    // CHECK-SAME: dim = 0 : si32
     // CHECK-SAME: tensor<1x32x128x128xbf16,
     // CHECK-SAME: -> tensor<1x32x128x128xbf16,
     %1 = "ttir.cumprod"(%arg0) <{dim = 0 : i64}> : (tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16>
@@ -15,7 +15,7 @@ module @cumprod attributes {} {
   func.func public @test_cumprod_dim1(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumprod_dim1
     // CHECK: ttnn.cumprod
-    // CHECK-SAME: dim = 1 : i32
+    // CHECK-SAME: dim = 1 : si32
     // CHECK-SAME: tensor<4x4x128x128xf32,
     // CHECK-SAME: -> tensor<4x4x128x128xf32,
     %1 = "ttir.cumprod"(%arg0) <{dim = 1 : i64}> : (tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>

--- a/test/ttmlir/Dialect/TTNN/simple_cumsum.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_cumsum.mlir
@@ -5,7 +5,7 @@ module @cumsum attributes {} {
   func.func public @test_cumsum_dim0(%arg0: tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16> {
     // CHECK-LABEL: func.func public @test_cumsum_dim0
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 0 : i32
+    // CHECK-SAME: dim = 0 : si32
     // CHECK-SAME: tensor<1x32x128x128xbf16,
     // CHECK-SAME: -> tensor<1x32x128x128xbf16,
     %1 = "ttir.cumsum"(%arg0) <{dim = 0 : i64}> : (tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16>
@@ -15,7 +15,7 @@ module @cumsum attributes {} {
   func.func public @test_cumsum_dim1(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumsum_dim1
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 1 : i32
+    // CHECK-SAME: dim = 1 : si32
     // CHECK-SAME: tensor<4x4x128x128xf32,
     // CHECK-SAME: -> tensor<4x4x128x128xf32,
     %1 = "ttir.cumsum"(%arg0) <{dim = 1 : i64}> : (tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>

--- a/test/ttmlir/Dialect/TTNN/simple_scatter.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_scatter.mlir
@@ -5,7 +5,7 @@ module attributes {} {
   // default - INVALID reduction type
   func.func @forward(%arg0: tensor<1x3x320x320xf32>, %arg1: tensor<1x3x32x32xi32>, %arg2: tensor<1x3x32x32xf32>) -> tensor<1x3x320x320xf32> {
     %0 = "ttir.scatter"(%arg0, %arg1, %arg2) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<1x3x320x320xf32>, tensor<1x3x32x32xi32>, tensor<1x3x32x32xf32>) -> tensor<1x3x320x320xf32>
-    // CHECK: %{{[0-9]+}} = "ttnn.scatter"({{.*}}) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<1x3x320x320xf32, {{.*}}>, tensor<1x3x32x32xsi32, {{.*}}>, tensor<1x3x32x32xf32, {{.*}}>) -> tensor<1x3x320x320xf32, {{.*}}>
+    // CHECK: %{{[0-9]+}} = "ttnn.scatter"({{.*}}) <{dim = 0 : si32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<1x3x320x320xf32, {{.*}}>, tensor<1x3x32x32xsi32, {{.*}}>, tensor<1x3x32x32xf32, {{.*}}>) -> tensor<1x3x320x320xf32, {{.*}}>
     return %0 : tensor<1x3x320x320xf32>
     // CHECK: return %{{[0-9]+}} : tensor<1x3x320x320xf32, {{.*}}>
   }
@@ -16,7 +16,7 @@ module attributes {} {
 
     // CHECK-LABEL: func.func @forward_bf16
     // CHECK: "ttnn.scatter"
-    // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>
+    // CHECK-SAME: <{dim = 0 : si32, scatter_reduce_type = #ttcore.reduce_type<sum>}>
 
     return %0 : tensor<151936x2048xbf16>
   }
@@ -35,7 +35,7 @@ module attributes {} {
     %14 = "ttir.reshape"(%arg2) <{shape = [284 : i32]}> : (tensor<71x4xbf16>) -> tensor<284xbf16>
     %16 = "ttir.scatter"(%12, %10, %14) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<2272xbf16>, tensor<284xi64>, tensor<284xbf16>) -> tensor<2272xbf16>
     %18 = "ttir.reshape"(%16) <{shape = [71 : i32, 32 : i32]}> : (tensor<2272xbf16>) -> tensor<71x32xbf16>
-    // CHECK: %{{[0-9]+}} = "ttnn.scatter"({{.*}}) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<2272xbf16, {{.*}}>, tensor<284xsi32, {{.*}}>, tensor<284xbf16, {{.*}}>) -> tensor<2272xbf16, {{.*}}>
+    // CHECK: %{{[0-9]+}} = "ttnn.scatter"({{.*}}) <{dim = 0 : si32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<2272xbf16, {{.*}}>, tensor<284xsi32, {{.*}}>, tensor<284xbf16, {{.*}}>) -> tensor<2272xbf16, {{.*}}>
     return %18 : tensor<71x32xbf16>
     // CHECK: return %{{[0-9]+}} : tensor<71x32xbf16, {{.*}}>
   }

--- a/test/ttmlir/Dialect/TTNN/simple_topk.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_topk.mlir
@@ -5,7 +5,7 @@ module attributes {} {
   func.func @test_basic_top_k(%input: tensor<2x3x32x128xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xui16>) {
     // CHECK-LABEL: func.func @test_basic_top_k
     // CHECK: %{{.*}}, %{{.*}} = "ttnn.topk"(%arg0)
-    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: <{dim = -1 : si32, k = 5 : i32, largest = true, sorted = false}>
     // CHECK-SAME: tensor<2x3x32x128xbf16,
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
     // CHECK-SAME: tensor<2x3x32x5xui16,

--- a/test/ttmlir/EmitC/TTNN/negative_dim.mlir
+++ b/test/ttmlir/EmitC/TTNN/negative_dim.mlir
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --convert-ttnn-to-emitc -o %t.mlir %s
+// RUN: ttmlir-translate --mlir-to-cpp %t.mlir | FileCheck %s
+
+// Regression test for negative dim/axis emission in TTNN->EmitC.
+// These ops declare their dim as a signless I32Attr/I64Attr, so the generated
+// getter returns an unsigned value; without a signed cast a dim of -1 would be
+// emitted as 4294967295 (or 18446744073709551615 for the i64 dim_arg). The
+// conversion casts to a signed type so the negative dim is preserved as -1.
+
+#dram = #ttnn.buffer_type<dram>
+#l_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l_u32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+#l_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+#l_in4d = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l_in4d64 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l_4d_u32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+#l_out3d_u32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xui32, #dram>, <interleaved>>
+#l_out3d_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xf32, #dram>, <interleaved>>
+
+// CHECK-LABEL: gather_neg
+func.func @gather_neg(%a: tensor<32x32xf32, #l_f32>, %i: tensor<32x32xui32, #l_u32>) -> tensor<32x32xf32, #l_f32> {
+  // CHECK: ttnn::gather(
+  // CHECK-SAME: -1
+  %0 = "ttnn.gather"(%a, %i) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>, tensor<32x32xui32, #l_u32>) -> tensor<32x32xf32, #l_f32>
+  return %0 : tensor<32x32xf32, #l_f32>
+}
+
+// CHECK-LABEL: scatter_neg
+func.func @scatter_neg(%a: tensor<32x32xf32, #l_f32>, %i: tensor<32x32xi32, #l_si32>, %s: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+  // CHECK: ttnn::scatter(
+  // CHECK-SAME: -1
+  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #l_f32>, tensor<32x32xi32, #l_si32>, tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
+  return %0 : tensor<32x32xf32, #l_f32>
+}
+
+// CHECK-LABEL: cumsum_neg
+func.func @cumsum_neg(%a: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+  // CHECK: ttnn::cumsum(
+  // CHECK-SAME: -1
+  %0 = "ttnn.cumsum"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
+  return %0 : tensor<32x32xf32, #l_f32>
+}
+
+// CHECK-LABEL: cumprod_neg
+func.func @cumprod_neg(%a: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+  // CHECK: ttnn::cumprod(
+  // CHECK-SAME: -1
+  %0 = "ttnn.cumprod"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
+  return %0 : tensor<32x32xf32, #l_f32>
+}
+
+// CHECK-LABEL: argmax_neg
+func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xui32, #l_out3d_u32> {
+  // CHECK: ttnn::argmax(
+  // CHECK-SAME: -1
+  %0 = "ttnn.argmax"(%a) <{dim = -1 : i32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xui32, #l_out3d_u32>
+  return %0 : tensor<1x1x32xui32, #l_out3d_u32>
+}
+
+// CHECK-LABEL: prod_neg
+func.func @prod_neg(%a: tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xf32, #l_out3d_f32> {
+  // CHECK: ttnn::prod(
+  // CHECK-SAME: -1
+  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : i64, keep_dim = false}> : (tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xf32, #l_out3d_f32>
+  return %0 : tensor<1x1x32xf32, #l_out3d_f32>
+}
+
+// CHECK-LABEL: topk_neg
+func.func @topk_neg(%a: tensor<1x1x32x64xf32, #l_in4d64>) -> (tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>) {
+  // CHECK: ttnn::topk(
+  // CHECK-SAME: -1
+  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #l_in4d64>) -> (tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>)
+  return %v, %i : tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>
+}

--- a/test/ttmlir/EmitC/TTNN/negative_dim.mlir
+++ b/test/ttmlir/EmitC/TTNN/negative_dim.mlir
@@ -12,67 +12,67 @@
 // conversion casts to a signed type so the negative dim is preserved as -1.
 
 #dram = #ttnn.buffer_type<dram>
-#l_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#l_u32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
-#l_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
-#l_in4d = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#l_in4d64 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#l_4d_u32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
-#l_out3d_u32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xui32, #dram>, <interleaved>>
-#l_out3d_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xf32, #dram>, <interleaved>>
+#tile_2d_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#tile_2d_u32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+#tile_2d_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+#tile_4d_f32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#tile_4d_f32_x64 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#tile_4d_u32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+#row_major_3d_u32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xui32, #dram>, <interleaved>>
+#row_major_3d_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xf32, #dram>, <interleaved>>
 
 // CHECK-LABEL: gather_neg
-func.func @gather_neg(%a: tensor<32x32xf32, #l_f32>, %i: tensor<32x32xui32, #l_u32>) -> tensor<32x32xf32, #l_f32> {
+func.func @gather_neg(%a: tensor<32x32xf32, #tile_2d_f32>, %i: tensor<32x32xui32, #tile_2d_u32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn::gather(
   // CHECK-SAME: -1
-  %0 = "ttnn.gather"(%a, %i) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>, tensor<32x32xui32, #l_u32>) -> tensor<32x32xf32, #l_f32>
-  return %0 : tensor<32x32xf32, #l_f32>
+  %0 = "ttnn.gather"(%a, %i) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>, tensor<32x32xui32, #tile_2d_u32>) -> tensor<32x32xf32, #tile_2d_f32>
+  return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
 // CHECK-LABEL: scatter_neg
-func.func @scatter_neg(%a: tensor<32x32xf32, #l_f32>, %i: tensor<32x32xi32, #l_si32>, %s: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+func.func @scatter_neg(%a: tensor<32x32xf32, #tile_2d_f32>, %i: tensor<32x32xi32, #tile_2d_si32>, %s: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn::scatter(
   // CHECK-SAME: -1
-  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #l_f32>, tensor<32x32xi32, #l_si32>, tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
-  return %0 : tensor<32x32xf32, #l_f32>
+  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #tile_2d_f32>, tensor<32x32xi32, #tile_2d_si32>, tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
 // CHECK-LABEL: cumsum_neg
-func.func @cumsum_neg(%a: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+func.func @cumsum_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn::cumsum(
   // CHECK-SAME: -1
-  %0 = "ttnn.cumsum"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
-  return %0 : tensor<32x32xf32, #l_f32>
+  %0 = "ttnn.cumsum"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
 // CHECK-LABEL: cumprod_neg
-func.func @cumprod_neg(%a: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+func.func @cumprod_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn::cumprod(
   // CHECK-SAME: -1
-  %0 = "ttnn.cumprod"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
-  return %0 : tensor<32x32xf32, #l_f32>
+  %0 = "ttnn.cumprod"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
 // CHECK-LABEL: argmax_neg
-func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xui32, #l_out3d_u32> {
+func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32> {
   // CHECK: ttnn::argmax(
   // CHECK-SAME: -1
-  %0 = "ttnn.argmax"(%a) <{dim = -1 : i32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xui32, #l_out3d_u32>
-  return %0 : tensor<1x1x32xui32, #l_out3d_u32>
+  %0 = "ttnn.argmax"(%a) <{dim = -1 : i32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32>
+  return %0 : tensor<1x1x32xui32, #row_major_3d_u32>
 }
 
 // CHECK-LABEL: prod_neg
-func.func @prod_neg(%a: tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xf32, #l_out3d_f32> {
+func.func @prod_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32> {
   // CHECK: ttnn::prod(
   // CHECK-SAME: -1
-  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : i64, keep_dim = false}> : (tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xf32, #l_out3d_f32>
-  return %0 : tensor<1x1x32xf32, #l_out3d_f32>
+  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : i64, keep_dim = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32>
+  return %0 : tensor<1x1x32xf32, #row_major_3d_f32>
 }
 
 // CHECK-LABEL: topk_neg
-func.func @topk_neg(%a: tensor<1x1x32x64xf32, #l_in4d64>) -> (tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>) {
+func.func @topk_neg(%a: tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>) {
   // CHECK: ttnn::topk(
   // CHECK-SAME: -1
-  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #l_in4d64>) -> (tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>)
-  return %v, %i : tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>
+  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>)
+  return %v, %i : tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>
 }

--- a/test/ttmlir/EmitC/TTNN/negative_dim.mlir
+++ b/test/ttmlir/EmitC/TTNN/negative_dim.mlir
@@ -6,10 +6,9 @@
 // RUN: ttmlir-translate --mlir-to-cpp %t.mlir | FileCheck %s
 
 // Regression test for negative dim/axis emission in TTNN->EmitC.
-// These ops declare their dim as a signless I32Attr/I64Attr, so the generated
-// getter returns an unsigned value; without a signed cast a dim of -1 would be
-// emitted as 4294967295 (or 18446744073709551615 for the i64 dim_arg). The
-// conversion casts to a signed type so the negative dim is preserved as -1.
+// These ops declare their dim/dim_arg as a signed SI32Attr/SI64Attr, so the
+// generated getter returns a signed value and a dim of -1 is emitted directly
+// as -1.
 
 #dram = #ttnn.buffer_type<dram>
 #tile_2d_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
@@ -25,7 +24,7 @@
 func.func @gather_neg(%a: tensor<32x32xf32, #tile_2d_f32>, %i: tensor<32x32xui32, #tile_2d_u32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn::gather(
   // CHECK-SAME: -1
-  %0 = "ttnn.gather"(%a, %i) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>, tensor<32x32xui32, #tile_2d_u32>) -> tensor<32x32xf32, #tile_2d_f32>
+  %0 = "ttnn.gather"(%a, %i) <{dim = -1 : si32}> : (tensor<32x32xf32, #tile_2d_f32>, tensor<32x32xui32, #tile_2d_u32>) -> tensor<32x32xf32, #tile_2d_f32>
   return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
@@ -33,7 +32,7 @@ func.func @gather_neg(%a: tensor<32x32xf32, #tile_2d_f32>, %i: tensor<32x32xui32
 func.func @scatter_neg(%a: tensor<32x32xf32, #tile_2d_f32>, %i: tensor<32x32xi32, #tile_2d_si32>, %s: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn::scatter(
   // CHECK-SAME: -1
-  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #tile_2d_f32>, tensor<32x32xi32, #tile_2d_si32>, tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : si32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #tile_2d_f32>, tensor<32x32xi32, #tile_2d_si32>, tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
   return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
@@ -41,7 +40,7 @@ func.func @scatter_neg(%a: tensor<32x32xf32, #tile_2d_f32>, %i: tensor<32x32xi32
 func.func @cumsum_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn::cumsum(
   // CHECK-SAME: -1
-  %0 = "ttnn.cumsum"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  %0 = "ttnn.cumsum"(%a) <{dim = -1 : si32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
   return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
@@ -49,7 +48,7 @@ func.func @cumsum_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, 
 func.func @cumprod_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn::cumprod(
   // CHECK-SAME: -1
-  %0 = "ttnn.cumprod"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  %0 = "ttnn.cumprod"(%a) <{dim = -1 : si32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
   return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
@@ -57,7 +56,7 @@ func.func @cumprod_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32,
 func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32> {
   // CHECK: ttnn::argmax(
   // CHECK-SAME: -1
-  %0 = "ttnn.argmax"(%a) <{dim = -1 : i32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32>
+  %0 = "ttnn.argmax"(%a) <{dim = -1 : si32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32>
   return %0 : tensor<1x1x32xui32, #row_major_3d_u32>
 }
 
@@ -65,7 +64,7 @@ func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32x
 func.func @prod_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32> {
   // CHECK: ttnn::prod(
   // CHECK-SAME: -1
-  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : i64, keep_dim = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32>
+  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : si64, keep_dim = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32>
   return %0 : tensor<1x1x32xf32, #row_major_3d_f32>
 }
 
@@ -73,6 +72,6 @@ func.func @prod_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf3
 func.func @topk_neg(%a: tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>) {
   // CHECK: ttnn::topk(
   // CHECK-SAME: -1
-  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>)
+  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : si32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>)
   return %v, %i : tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>
 }

--- a/test/ttmlir/EmitPy/TTNN/negative_dim.mlir
+++ b/test/ttmlir/EmitPy/TTNN/negative_dim.mlir
@@ -13,78 +13,70 @@
 // conversion casts to a signed type so the negative dim is preserved as -1.
 
 #dram = #ttnn.buffer_type<dram>
-#l_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#l_u32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
-#l_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
-#l_in4d = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#l_in4d64 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#l_4d_u32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
-#l_out3d_u32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xui32, #dram>, <interleaved>>
-#l_out3d_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xf32, #dram>, <interleaved>>
-#l_1d_bf16 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-
-// CHECK-LABEL: def gather_neg
-func.func @gather_neg(%a: tensor<32x32xf32, #l_f32>, %i: tensor<32x32xui32, #l_u32>) -> tensor<32x32xf32, #l_f32> {
-  // CHECK: ttnn.gather(
-  // CHECK-SAME: -1
-  %0 = "ttnn.gather"(%a, %i) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>, tensor<32x32xui32, #l_u32>) -> tensor<32x32xf32, #l_f32>
-  return %0 : tensor<32x32xf32, #l_f32>
-}
+#tile_2d_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#tile_2d_u32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+#tile_2d_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+#tile_4d_f32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#tile_4d_f32_x64 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#tile_4d_u32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+#row_major_3d_u32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xui32, #dram>, <interleaved>>
+#row_major_3d_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xf32, #dram>, <interleaved>>
+#tile_1d_bf16 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
 // CHECK-LABEL: def scatter_neg
-func.func @scatter_neg(%a: tensor<32x32xf32, #l_f32>, %i: tensor<32x32xi32, #l_si32>, %s: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+func.func @scatter_neg(%a: tensor<32x32xf32, #tile_2d_f32>, %i: tensor<32x32xi32, #tile_2d_si32>, %s: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn.scatter(
   // CHECK-SAME: dim=-1
-  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #l_f32>, tensor<32x32xi32, #l_si32>, tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
-  return %0 : tensor<32x32xf32, #l_f32>
+  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #tile_2d_f32>, tensor<32x32xi32, #tile_2d_si32>, tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
 // CHECK-LABEL: def cumsum_neg
-func.func @cumsum_neg(%a: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+func.func @cumsum_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn.cumsum(
   // CHECK-SAME: -1
-  %0 = "ttnn.cumsum"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
-  return %0 : tensor<32x32xf32, #l_f32>
+  %0 = "ttnn.cumsum"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
 // CHECK-LABEL: def cumprod_neg
-func.func @cumprod_neg(%a: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+func.func @cumprod_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn.cumprod(
   // CHECK-SAME: -1
-  %0 = "ttnn.cumprod"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
-  return %0 : tensor<32x32xf32, #l_f32>
+  %0 = "ttnn.cumprod"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
 // CHECK-LABEL: def argmax_neg
-func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xui32, #l_out3d_u32> {
+func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32> {
   // CHECK: ttnn.argmax(
   // CHECK-SAME: -1
-  %0 = "ttnn.argmax"(%a) <{dim = -1 : i32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xui32, #l_out3d_u32>
-  return %0 : tensor<1x1x32xui32, #l_out3d_u32>
+  %0 = "ttnn.argmax"(%a) <{dim = -1 : i32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32>
+  return %0 : tensor<1x1x32xui32, #row_major_3d_u32>
 }
 
 // CHECK-LABEL: def prod_neg
-func.func @prod_neg(%a: tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xf32, #l_out3d_f32> {
+func.func @prod_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32> {
   // CHECK: ttnn.prod(
   // CHECK-SAME: -1
-  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : i64, keep_dim = false}> : (tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xf32, #l_out3d_f32>
-  return %0 : tensor<1x1x32xf32, #l_out3d_f32>
+  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : i64, keep_dim = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32>
+  return %0 : tensor<1x1x32xf32, #row_major_3d_f32>
 }
 
 // CHECK-LABEL: def topk_neg
-func.func @topk_neg(%a: tensor<1x1x32x64xf32, #l_in4d64>) -> (tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>) {
+func.func @topk_neg(%a: tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>) {
   // CHECK: ttnn.topk(
   // CHECK-SAME: -1
-  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #l_in4d64>) -> (tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>)
-  return %v, %i : tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>
+  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>)
+  return %v, %i : tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>
 }
 
 // arange start/step are signless I64Attr (getter returns uint64_t); a negative
 // start would otherwise be emitted as 18446744073709551611.
 // CHECK-LABEL: def arange_neg
-func.func @arange_neg() -> tensor<32xbf16, #l_1d_bf16> {
+func.func @arange_neg() -> tensor<32xbf16, #tile_1d_bf16> {
   // CHECK: ttnn.arange(
   // CHECK-SAME: -5
-  %0 = "ttnn.arange"() <{start = -5 : i64, end = 27 : i64, step = 1 : i64, layout = #ttnn.layout<tile>}> : () -> tensor<32xbf16, #l_1d_bf16>
-  return %0 : tensor<32xbf16, #l_1d_bf16>
+  %0 = "ttnn.arange"() <{start = -5 : si64, end = 27 : si64, step = 1 : si64, layout = #ttnn.layout<tile>}> : () -> tensor<32xbf16, #tile_1d_bf16>
+  return %0 : tensor<32xbf16, #tile_1d_bf16>
 }

--- a/test/ttmlir/EmitPy/TTNN/negative_dim.mlir
+++ b/test/ttmlir/EmitPy/TTNN/negative_dim.mlir
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --convert-ttnn-to-emitpy -o %t.mlir %s
+// RUN: ttmlir-translate --mlir-to-python -o %t.py %t.mlir
+// RUN: FileCheck %s --input-file=%t.py
+
+// Regression test for negative dim/axis emission in TTNN->EmitPy.
+// These ops declare their dim as a signless I32Attr/I64Attr, so the generated
+// getter returns an unsigned value; without a signed cast a dim of -1 would be
+// emitted as 4294967295 (or 18446744073709551615 for the i64 dim_arg). The
+// conversion casts to a signed type so the negative dim is preserved as -1.
+
+#dram = #ttnn.buffer_type<dram>
+#l_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l_u32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+#l_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+#l_in4d = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l_in4d64 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l_4d_u32 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+#l_out3d_u32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xui32, #dram>, <interleaved>>
+#l_out3d_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1xf32, #dram>, <interleaved>>
+#l_1d_bf16 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// CHECK-LABEL: def gather_neg
+func.func @gather_neg(%a: tensor<32x32xf32, #l_f32>, %i: tensor<32x32xui32, #l_u32>) -> tensor<32x32xf32, #l_f32> {
+  // CHECK: ttnn.gather(
+  // CHECK-SAME: -1
+  %0 = "ttnn.gather"(%a, %i) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>, tensor<32x32xui32, #l_u32>) -> tensor<32x32xf32, #l_f32>
+  return %0 : tensor<32x32xf32, #l_f32>
+}
+
+// CHECK-LABEL: def scatter_neg
+func.func @scatter_neg(%a: tensor<32x32xf32, #l_f32>, %i: tensor<32x32xi32, #l_si32>, %s: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+  // CHECK: ttnn.scatter(
+  // CHECK-SAME: dim=-1
+  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #l_f32>, tensor<32x32xi32, #l_si32>, tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
+  return %0 : tensor<32x32xf32, #l_f32>
+}
+
+// CHECK-LABEL: def cumsum_neg
+func.func @cumsum_neg(%a: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+  // CHECK: ttnn.cumsum(
+  // CHECK-SAME: -1
+  %0 = "ttnn.cumsum"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
+  return %0 : tensor<32x32xf32, #l_f32>
+}
+
+// CHECK-LABEL: def cumprod_neg
+func.func @cumprod_neg(%a: tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32> {
+  // CHECK: ttnn.cumprod(
+  // CHECK-SAME: -1
+  %0 = "ttnn.cumprod"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #l_f32>) -> tensor<32x32xf32, #l_f32>
+  return %0 : tensor<32x32xf32, #l_f32>
+}
+
+// CHECK-LABEL: def argmax_neg
+func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xui32, #l_out3d_u32> {
+  // CHECK: ttnn.argmax(
+  // CHECK-SAME: -1
+  %0 = "ttnn.argmax"(%a) <{dim = -1 : i32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xui32, #l_out3d_u32>
+  return %0 : tensor<1x1x32xui32, #l_out3d_u32>
+}
+
+// CHECK-LABEL: def prod_neg
+func.func @prod_neg(%a: tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xf32, #l_out3d_f32> {
+  // CHECK: ttnn.prod(
+  // CHECK-SAME: -1
+  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : i64, keep_dim = false}> : (tensor<1x1x32x32xf32, #l_in4d>) -> tensor<1x1x32xf32, #l_out3d_f32>
+  return %0 : tensor<1x1x32xf32, #l_out3d_f32>
+}
+
+// CHECK-LABEL: def topk_neg
+func.func @topk_neg(%a: tensor<1x1x32x64xf32, #l_in4d64>) -> (tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>) {
+  // CHECK: ttnn.topk(
+  // CHECK-SAME: -1
+  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #l_in4d64>) -> (tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>)
+  return %v, %i : tensor<1x1x32x4xf32, #l_in4d>, tensor<1x1x32x4xui32, #l_4d_u32>
+}
+
+// arange start/step are signless I64Attr (getter returns uint64_t); a negative
+// start would otherwise be emitted as 18446744073709551611.
+// CHECK-LABEL: def arange_neg
+func.func @arange_neg() -> tensor<32xbf16, #l_1d_bf16> {
+  // CHECK: ttnn.arange(
+  // CHECK-SAME: -5
+  %0 = "ttnn.arange"() <{start = -5 : i64, end = 27 : i64, step = 1 : i64, layout = #ttnn.layout<tile>}> : () -> tensor<32xbf16, #l_1d_bf16>
+  return %0 : tensor<32xbf16, #l_1d_bf16>
+}

--- a/test/ttmlir/EmitPy/TTNN/negative_dim.mlir
+++ b/test/ttmlir/EmitPy/TTNN/negative_dim.mlir
@@ -7,10 +7,9 @@
 // RUN: FileCheck %s --input-file=%t.py
 
 // Regression test for negative dim/axis emission in TTNN->EmitPy.
-// These ops declare their dim as a signless I32Attr/I64Attr, so the generated
-// getter returns an unsigned value; without a signed cast a dim of -1 would be
-// emitted as 4294967295 (or 18446744073709551615 for the i64 dim_arg). The
-// conversion casts to a signed type so the negative dim is preserved as -1.
+// These ops declare their dim/dim_arg as a signed SI32Attr/SI64Attr, so the
+// generated getter returns a signed value and a dim of -1 is emitted directly
+// as -1.
 
 #dram = #ttnn.buffer_type<dram>
 #tile_2d_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
@@ -27,7 +26,7 @@
 func.func @scatter_neg(%a: tensor<32x32xf32, #tile_2d_f32>, %i: tensor<32x32xi32, #tile_2d_si32>, %s: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn.scatter(
   // CHECK-SAME: dim=-1
-  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #tile_2d_f32>, tensor<32x32xi32, #tile_2d_si32>, tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  %0 = "ttnn.scatter"(%a, %i, %s) <{dim = -1 : si32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xf32, #tile_2d_f32>, tensor<32x32xi32, #tile_2d_si32>, tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
   return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
@@ -35,7 +34,7 @@ func.func @scatter_neg(%a: tensor<32x32xf32, #tile_2d_f32>, %i: tensor<32x32xi32
 func.func @cumsum_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn.cumsum(
   // CHECK-SAME: -1
-  %0 = "ttnn.cumsum"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  %0 = "ttnn.cumsum"(%a) <{dim = -1 : si32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
   return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
@@ -43,7 +42,7 @@ func.func @cumsum_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, 
 func.func @cumprod_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32> {
   // CHECK: ttnn.cumprod(
   // CHECK-SAME: -1
-  %0 = "ttnn.cumprod"(%a) <{dim = -1 : i32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
+  %0 = "ttnn.cumprod"(%a) <{dim = -1 : si32}> : (tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32, #tile_2d_f32>
   return %0 : tensor<32x32xf32, #tile_2d_f32>
 }
 
@@ -51,7 +50,7 @@ func.func @cumprod_neg(%a: tensor<32x32xf32, #tile_2d_f32>) -> tensor<32x32xf32,
 func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32> {
   // CHECK: ttnn.argmax(
   // CHECK-SAME: -1
-  %0 = "ttnn.argmax"(%a) <{dim = -1 : i32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32>
+  %0 = "ttnn.argmax"(%a) <{dim = -1 : si32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xui32, #row_major_3d_u32>
   return %0 : tensor<1x1x32xui32, #row_major_3d_u32>
 }
 
@@ -59,7 +58,7 @@ func.func @argmax_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32x
 func.func @prod_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32> {
   // CHECK: ttnn.prod(
   // CHECK-SAME: -1
-  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : i64, keep_dim = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32>
+  %0 = "ttnn.prod"(%a) <{dim_arg = -1 : si64, keep_dim = false}> : (tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf32, #row_major_3d_f32>
   return %0 : tensor<1x1x32xf32, #row_major_3d_f32>
 }
 
@@ -67,12 +66,12 @@ func.func @prod_neg(%a: tensor<1x1x32x32xf32, #tile_4d_f32>) -> tensor<1x1x32xf3
 func.func @topk_neg(%a: tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>) {
   // CHECK: ttnn.topk(
   // CHECK-SAME: -1
-  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>)
+  %v, %i = "ttnn.topk"(%a) <{k = 4 : i32, dim = -1 : si32, largest = true, sorted = true}> : (tensor<1x1x32x64xf32, #tile_4d_f32_x64>) -> (tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>)
   return %v, %i : tensor<1x1x32x4xf32, #tile_4d_f32>, tensor<1x1x32x4xui32, #tile_4d_u32>
 }
 
-// arange start/step are signless I64Attr (getter returns uint64_t); a negative
-// start would otherwise be emitted as 18446744073709551611.
+// arange start/end/step are SI64Attr, so a negative start is emitted as the
+// signed value -5 (not the unsigned wraparound 18446744073709551611).
 // CHECK-LABEL: def arange_neg
 func.func @arange_neg() -> tensor<32xbf16, #tile_1d_bf16> {
   // CHECK: ttnn.arange(

--- a/test/ttmlir/Silicon/StableHLO/n150/cumsum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/cumsum_op.mlir
@@ -10,7 +10,7 @@ module @cumsum attributes {} {
     // CHECK-LABEL: func.func @test_cumsum_dim0
     %cst = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 0 : i32
+    // CHECK-SAME: dim = 0 : si32
     // CHECK-SAME: tensor<8x2x4x16xbf16,
     // CHECK-SAME: -> tensor<8x2x4x16xbf16,
     %0 = "stablehlo.reduce_window"(%arg0, %cst) <{padding = dense<[[7, 0], [0, 0], [0, 0], [0, 0]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 8, 1, 1, 1>, window_strides = array<i64: 1, 1, 1, 1>}> ({
@@ -25,7 +25,7 @@ module @cumsum attributes {} {
     // CHECK-LABEL: func.func @test_cumsum_dim1
     %cst = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 1 : i32
+    // CHECK-SAME: dim = 1 : si32
     // CHECK-SAME: tensor<8x2x4x16xbf16,
     // CHECK-SAME: -> tensor<8x2x4x16xbf16,
     %0 = "stablehlo.reduce_window"(%arg0, %cst) <{padding = dense<[[0, 0], [1, 0], [0, 0], [0, 0]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 2, 1, 1>, window_strides = array<i64: 1, 1, 1, 1>}> ({
@@ -40,7 +40,7 @@ module @cumsum attributes {} {
     // CHECK-LABEL: func.func @test_cumsum_dim2
     %cst = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 2 : i32
+    // CHECK-SAME: dim = 2 : si32
     // CHECK-SAME: tensor<8x2x4x16xbf16,
     // CHECK-SAME: -> tensor<8x2x4x16xbf16,
     %0 = "stablehlo.reduce_window"(%arg0, %cst) <{padding = dense<[[0, 0], [0, 0], [3, 0], [0, 0]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 4, 1>, window_strides = array<i64: 1, 1, 1, 1>}> ({
@@ -55,7 +55,7 @@ module @cumsum attributes {} {
     // CHECK-LABEL: func.func @test_cumsum_dim3
     %cst = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 3 : i32
+    // CHECK-SAME: dim = 3 : si32
     // CHECK-SAME: tensor<8x2x4x16xbf16,
     // CHECK-SAME: -> tensor<8x2x4x16xbf16,
     %0 = "stablehlo.reduce_window"(%arg0, %cst) <{padding = dense<[[0, 0], [0, 0], [0, 0], [15, 0]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 1, 16>, window_strides = array<i64: 1, 1, 1, 1>}> ({
@@ -70,7 +70,7 @@ module @cumsum attributes {} {
     // CHECK-LABEL: func.func @test_cumsum_low_rank(
     %c = stablehlo.constant dense<0> : tensor<i64>
     // CHECK: %[[CUMSUM:[0-9]+]] = "ttnn.cumsum"
-    // CHECK-SAME: dim = 1 : i32
+    // CHECK-SAME: dim = 1 : si32
     // CHECK-SAME: tensor<1x10xsi32
     // CHECK-SAME: -> tensor<1x10xsi32
     %0 = "stablehlo.reduce_window"(%arg0, %c) <{padding = dense<[[0, 0], [9, 0]]> : tensor<2x2xi64>, window_dilations = array<i64: 1, 1>, window_dimensions = array<i64: 1, 10>, window_strides = array<i64: 1, 1>}> ({

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/argmax_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/argmax_op.mlir
@@ -9,7 +9,7 @@ module @module_argmax attributes {} {
   func.func public @argmax_torch_2d(%arg0: tensor<1x32128xf32>) -> tensor<1xi64> {
     // CHECK-LABEL: func.func public @argmax_torch_2d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 1 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 1 : si32, keep_dim = false}>
     // CHECK-SAME: tensor<1x32128xf32
     // CHECK-SAME: -> tensor<1xui32
     %cst = stablehlo.constant dense<0xFF800000> : tensor<f32>
@@ -31,7 +31,7 @@ module @module_argmax attributes {} {
   func.func public @argmax_jax_3d(%arg0: tensor<1x32x32xf32>) -> tensor<1x32xi32> {
     // CHECK-LABEL: func.func public @argmax_jax_3d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 2 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 2 : si32, keep_dim = false}>
     // CHECK-SAME: tensor<1x32x32xf32
     // CHECK-SAME: -> tensor<1x32xui32
     %0 = stablehlo.iota dim = 2 : tensor<1x32x32xi32>
@@ -56,7 +56,7 @@ module @module_argmax attributes {} {
   func.func public @argmax_torch_4d(%arg0: tensor<1x1x128x64xf32>) -> tensor<1x1x128xi64> {
     // CHECK-LABEL: func.func public @argmax_torch_4d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 3 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 3 : si32, keep_dim = false}>
     // CHECK-SAME: tensor<1x1x128x64xf32
     // CHECK-SAME: -> tensor<1x1x128xui32
     %cst = stablehlo.constant dense<0xFF800000> : tensor<f32>

--- a/test/ttmlir/Silicon/TTNN/n150/creation/arange/arange_ttnn_variations.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/creation/arange/arange_ttnn_variations.mlir
@@ -16,7 +16,7 @@ module attributes {} {
     // Test case when arange is created on host
     func.func @arange_on_host() -> tensor<128xbf16, #ttnn_layout_host_rm_bf16> {
         // CHECK: ttnn.arange
-        %0 = "ttnn.arange"() <{end = 128 : i64, layout = #ttnn.layout<row_major>, start = 0 : i64, step = 1 : i64}> : () -> tensor<128xbf16, #ttnn_layout_host_rm_bf16>
+        %0 = "ttnn.arange"() <{end = 128 : si64, layout = #ttnn.layout<row_major>, start = 0 : si64, step = 1 : si64}> : () -> tensor<128xbf16, #ttnn_layout_host_rm_bf16>
         return %0 : tensor<128xbf16, #ttnn_layout_host_rm_bf16>
     }
 
@@ -24,7 +24,7 @@ module attributes {} {
     func.func @arange_on_device_row_major() -> tensor<128xbf16, #ttnn_layout_device_rm_bf16> {
         %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
         // CHECK: ttnn.arange
-        %1 = "ttnn.arange"(%0) <{end = 128 : i64, layout = #ttnn.layout<row_major>, start = 0 : i64, step = 1 : i64}> : (!ttnn.device) -> tensor<128xbf16, #ttnn_layout_device_rm_bf16>
+        %1 = "ttnn.arange"(%0) <{end = 128 : si64, layout = #ttnn.layout<row_major>, start = 0 : si64, step = 1 : si64}> : (!ttnn.device) -> tensor<128xbf16, #ttnn_layout_device_rm_bf16>
         return %1 : tensor<128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
@@ -32,7 +32,7 @@ module attributes {} {
     func.func @arange_on_device_tile() -> tensor<128xbf16, #ttnn_layout_device_tile_bf16> {
         %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
         // CHECK: ttnn.arange
-        %1 = "ttnn.arange"(%0) <{end = 128 : i64, layout = #ttnn.layout<tile>, start = 0 : i64, step = 1 : i64}> : (!ttnn.device) -> tensor<128xbf16, #ttnn_layout_device_tile_bf16>
+        %1 = "ttnn.arange"(%0) <{end = 128 : si64, layout = #ttnn.layout<tile>, start = 0 : si64, step = 1 : si64}> : (!ttnn.device) -> tensor<128xbf16, #ttnn_layout_device_tile_bf16>
         return %1 : tensor<128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -40,7 +40,7 @@ module attributes {} {
     func.func @arange_on_l1_tile() -> tensor<128xbf16, #ttnn_layout_l1_tile_bf16> {
         %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
         // CHECK: ttnn.arange
-        %1 = "ttnn.arange"(%0) <{end = 128 : i64, layout = #ttnn.layout<tile>, start = 0 : i64, step = 1 : i64}> : (!ttnn.device) -> tensor<128xbf16, #ttnn_layout_l1_tile_bf16>
+        %1 = "ttnn.arange"(%0) <{end = 128 : si64, layout = #ttnn.layout<tile>, start = 0 : si64, step = 1 : si64}> : (!ttnn.device) -> tensor<128xbf16, #ttnn_layout_l1_tile_bf16>
         return %1 : tensor<128xbf16, #ttnn_layout_l1_tile_bf16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/data_movement/scatter/scatter.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/data_movement/scatter/scatter.mlir
@@ -8,7 +8,7 @@
 
 func.func @scatter_simple_1(%arg0: tensor<1x3x320x320xf32>, %arg1: tensor<1x3x32x32xi32>, %arg2: tensor<1x3x32x32xf32>) -> tensor<1x3x320x320xf32> {
   %0 = "ttir.scatter"(%arg0, %arg1, %arg2) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<1x3x320x320xf32>, tensor<1x3x32x32xi32>, tensor<1x3x32x32xf32>) -> tensor<1x3x320x320xf32>
-  // CHECK: "ttnn.scatter"({{.*}}) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}>
+  // CHECK: "ttnn.scatter"({{.*}}) <{dim = 0 : si32, scatter_reduce_type = #ttcore.reduce_type<invalid>}>
   // CHECK-SAME: (tensor<1x3x320x320xf32, {{.*}}>, tensor<1x3x32x32xsi32, {{.*}}>, tensor<1x3x32x32xf32, {{.*}}>) -> tensor<1x3x320x320xf32, {{.*}}>
   return %0 : tensor<1x3x320x320xf32>
 }
@@ -16,7 +16,7 @@ func.func @scatter_simple_1(%arg0: tensor<1x3x320x320xf32>, %arg1: tensor<1x3x32
 func.func @scatter_simple_2(%arg0: tensor<32x32xi32>, %arg1: tensor<16x32xi32>, %arg2: tensor<16x32xi32>) -> tensor<32x32xi32> {
   %0 = "ttir.scatter"(%arg0, %arg1, %arg2) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<32x32xi32>, tensor<16x32xi32>, tensor<16x32xi32>) -> tensor<32x32xi32>
   // CHECK-LABEL: func.func @scatter_simple_2
-  // CHECK: "ttnn.scatter"({{.*}}) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}>
+  // CHECK: "ttnn.scatter"({{.*}}) <{dim = 0 : si32, scatter_reduce_type = #ttcore.reduce_type<invalid>}>
   // CHECK-SAME: (tensor<32x32xsi32, {{.*}}>, tensor<16x32xsi32, {{.*}}>, tensor<16x32xsi32, {{.*}}>) -> tensor<32x32xsi32, {{.*}}>
   return %0 : tensor<32x32xi32>
 }
@@ -50,7 +50,7 @@ func.func @scatter_simple_3(%arg0: tensor<71x32xbf16>, %arg1: tensor<71x4x2xi64>
   // CHECK: "ttnn.reshape"({{.*}}) <{shape = [284 : i32]}>
   // Single scatter op — the operand workaround converts the int32 index tensor
   // to row-major, avoiding the 256-element tiled limit.
-  // CHECK: "ttnn.scatter"({{.*}}) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<2272xbf16, {{.*}}>, tensor<284xsi32, {{.*}}>, tensor<284xbf16, {{.*}}>) -> tensor<2272xbf16, {{.*}}>
+  // CHECK: "ttnn.scatter"({{.*}}) <{dim = 0 : si32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<2272xbf16, {{.*}}>, tensor<284xsi32, {{.*}}>, tensor<284xbf16, {{.*}}>) -> tensor<2272xbf16, {{.*}}>
   // reshape flattened output to expected output shape
   // CHECK: "ttnn.reshape"({{.*}}) <{shape = [71 : i32, 32 : i32]}>
 }
@@ -60,7 +60,7 @@ func.func @scatter_simple_4(%arg0: tensor<1000x32xf32>, %arg1: tensor<10x32xi64>
   // CHECK-LABEL: func.func @scatter_simple_4
   // CHECK: "ttnn.to_layout"({{.*}})
   // CHECK: "ttnn.to_layout"({{.*}})
-  // CHECK: "ttnn.scatter"({{.*}}) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<1000x32xf32, {{.*}}>, tensor<10x32xsi32, {{.*}}>, tensor<10x32xf32, {{.*}}>) -> tensor<1000x32xf32, {{.*}}>
+  // CHECK: "ttnn.scatter"({{.*}}) <{dim = 0 : si32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<1000x32xf32, {{.*}}>, tensor<10x32xsi32, {{.*}}>, tensor<10x32xf32, {{.*}}>) -> tensor<1000x32xf32, {{.*}}>
   // CHECK: "ttnn.to_layout"({{.*}})
   %0 = "ttir.scatter"(%arg0, %arg1, %arg2) <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}> : (tensor<1000x32xf32>, tensor<10x32xi64>, tensor<10x32xf32>) -> tensor<1000x32xf32>
   return %0 : tensor<1000x32xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_cumprod.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_cumprod.mlir
@@ -6,7 +6,7 @@ module @cumprod attributes {} {
   func.func public @test_cumprod_dim0(%arg0: tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumprod_dim0
     // CHECK: ttnn.cumprod
-    // CHECK-SAME: dim = 0 : i32
+    // CHECK-SAME: dim = 0 : si32
     // CHECK-SAME: tensor<1x32x128x128xf32,
     // CHECK-SAME: -> tensor<1x32x128x128xf32,
     %1 = "ttir.cumprod"(%arg0) <{dim = 0 : i64}> : (tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_cumsum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_cumsum.mlir
@@ -6,7 +6,7 @@ module @cumsum attributes {} {
   func.func public @test_cumsum_dim0(%arg0: tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumsum_dim0
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 0 : i32
+    // CHECK-SAME: dim = 0 : si32
     // CHECK-SAME: tensor<1x32x128x128xf32,
     // CHECK-SAME: -> tensor<1x32x128x128xf32,
     %1 = "ttir.cumsum"(%arg0) <{dim = 0 : i64}> : (tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/simple_argmax.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_argmax.mlir
@@ -8,7 +8,7 @@ module attributes {} {
   func.func public @argmax_2d(%arg0: tensor<64x64xf32>) -> tensor<64xi32> {
     // CHECK-LABEL: func.func public @argmax_2d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 1 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 1 : si32, keep_dim = false}>
     // CHECK-SAME: tensor<64x64xf32
     // CHECK-SAME: -> tensor<64xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64xi32>
@@ -18,7 +18,7 @@ module attributes {} {
   func.func public @argmax_3d(%arg0: tensor<1x28x28xf32>) -> tensor<1x28xi32> {
     // CHECK-LABEL: func.func public @argmax_3d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 2 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 2 : si32, keep_dim = false}>
     // CHECK-SAME: tensor<1x28x28xf32
     // CHECK-SAME: -> tensor<1x28xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<1x28x28xf32>) -> tensor<1x28xi32>
@@ -28,7 +28,7 @@ module attributes {} {
   func.func public @argmax_4d(%arg0: tensor<1x1x128x64xf32>) -> tensor<1x1x128xi32> {
     // CHECK-LABEL: func.func public @argmax_4d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 3 : i32, keep_dim = false}>
+    // CHECK-SAME: {dim = 3 : si32, keep_dim = false}>
     // CHECK-SAME: tensor<1x1x128x64xf32
     // CHECK-SAME: -> tensor<1x1x128xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<1x1x128x64xf32>) -> tensor<1x1x128xi32>
@@ -48,7 +48,7 @@ module attributes {} {
   func.func public @argmax_keepdim(%arg0: tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xui32> {
     // CHECK-LABEL: func.func public @argmax_keepdim(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 3 : i32, keep_dim = true}>
+    // CHECK-SAME: {dim = 3 : si32, keep_dim = true}>
     // CHECK-SAME: tensor<2x4x32x32xf32
     // CHECK-SAME: -> tensor<2x4x32x1xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [3 : i32], keep_dim = true}> : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xui32>

--- a/test/ttmlir/Silicon/TTNN/n150/simple_cumprod.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_cumprod.mlir
@@ -8,7 +8,7 @@ module @cumprod attributes {} {
   func.func public @test_cumprod_dim0(%arg0: tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumprod_dim0
     // CHECK: ttnn.cumprod
-    // CHECK-SAME: dim = 0 : i32
+    // CHECK-SAME: dim = 0 : si32
     // CHECK-SAME: tensor<1x32x128x128xf32,
     // CHECK-SAME: -> tensor<1x32x128x128xf32,
     %1 = "ttir.cumprod"(%arg0) <{dim = 0 : i64}> : (tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32>
@@ -18,7 +18,7 @@ module @cumprod attributes {} {
   func.func public @test_cumprod_dim1(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumprod_dim1
     // CHECK: ttnn.cumprod
-    // CHECK-SAME: dim = 1 : i32
+    // CHECK-SAME: dim = 1 : si32
     // CHECK-SAME: tensor<4x4x128x128xf32,
     // CHECK-SAME: -> tensor<4x4x128x128xf32,
     %1 = "ttir.cumprod"(%arg0) <{dim = 1 : i64}> : (tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
@@ -28,7 +28,7 @@ module @cumprod attributes {} {
   func.func public @test_cumprod_dim2(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumprod_dim2
     // CHECK: ttnn.cumprod
-    // CHECK-SAME: dim = 2 : i32
+    // CHECK-SAME: dim = 2 : si32
     // CHECK-SAME: tensor<4x4x128x128xf32,
     // CHECK-SAME: -> tensor<4x4x128x128xf32,
     %1 = "ttir.cumprod"(%arg0) <{dim = 2 : i64}> : (tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
@@ -38,7 +38,7 @@ module @cumprod attributes {} {
   func.func public @test_cumprod_dim3(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumprod_dim3
     // CHECK: ttnn.cumprod
-    // CHECK-SAME: dim = 3 : i32
+    // CHECK-SAME: dim = 3 : si32
     // CHECK-SAME: tensor<4x4x128x128xf32,
     // CHECK-SAME: -> tensor<4x4x128x128xf32,
     %1 = "ttir.cumprod"(%arg0) <{dim = 3 : i64}> : (tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/simple_cumsum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_cumsum.mlir
@@ -8,7 +8,7 @@ module @cumsum attributes {} {
   func.func public @test_cumsum_dim0(%arg0: tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumsum_dim0
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 0 : i32
+    // CHECK-SAME: dim = 0 : si32
     // CHECK-SAME: tensor<1x32x128x128xf32,
     // CHECK-SAME: -> tensor<1x32x128x128xf32,
     %1 = "ttir.cumsum"(%arg0) <{dim = 0 : i64}> : (tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32>
@@ -18,7 +18,7 @@ module @cumsum attributes {} {
   func.func public @test_cumsum_dim1(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumsum_dim1
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 1 : i32
+    // CHECK-SAME: dim = 1 : si32
     // CHECK-SAME: tensor<4x4x128x128xf32,
     // CHECK-SAME: -> tensor<4x4x128x128xf32,
     %1 = "ttir.cumsum"(%arg0) <{dim = 1 : i64}> : (tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
@@ -28,7 +28,7 @@ module @cumsum attributes {} {
   func.func public @test_cumsum_dim2(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumsum_dim2
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 2 : i32
+    // CHECK-SAME: dim = 2 : si32
     // CHECK-SAME: tensor<4x4x128x128xf32,
     // CHECK-SAME: -> tensor<4x4x128x128xf32,
     %1 = "ttir.cumsum"(%arg0) <{dim = 2 : i64}> : (tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
@@ -38,7 +38,7 @@ module @cumsum attributes {} {
   func.func public @test_cumsum_dim3(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
     // CHECK-LABEL: func.func public @test_cumsum_dim3
     // CHECK: ttnn.cumsum
-    // CHECK-SAME: dim = 3 : i32
+    // CHECK-SAME: dim = 3 : si32
     // CHECK-SAME: tensor<4x4x128x128xf32,
     // CHECK-SAME: -> tensor<4x4x128x128xf32,
     %1 = "ttir.cumsum"(%arg0) <{dim = 3 : i64}> : (tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -9966,7 +9966,7 @@ class TTNNBuilder(Builder):
         else:
             mlir_output_type = self._get_type_from_torch_dtype(output_type)
 
-        dim_attr = IntegerAttr.get(IntegerType.get_signless(32), dim)
+        dim_attr = IntegerAttr.get(IntegerType.get_signed(32), dim)
 
         input0 = self._get_golden_tensor(in0)
         input_index = self._get_golden_tensor(index)


### PR DESCRIPTION
### Ticket
N/A
### Problem description
When an argument is declared as a signless integer (`I32Attr/I64Attr`) in tablegen, the generated getter returns an unsigned value (`uint32_t/uint64_t`). For dim/axis-style arguments that legitimately accept negative values, this is wrong (e.g., when the value is emitted as a literal in the TTNN EmitC/EmitPy conversions, a dim of -1 is emitted as 4294967295 for the i32 case).
### What's changed
TTNN dialect: 
- Changed the `dim` attributes from signless to signed for `CumSumOp`, `CumProdOp`, `ProdOp`, `ArgMax`, `TopKOp`, `GatherOp`, `ScatterOp` 
- Changed `start`, `end`, and `step` args of `ArangeOp` from signless to signed to align with TTIR
- Fix `reduce_type` string emission for `ScatterOp` 
    
### Checklist
- [x] New/Existing tests provide coverage for changes
