### PR TITLE
[D2M] Port remaining NoC API to their OO equivalent

### DIFF
--- a/docs/src/pykernel.md
+++ b/docs/src/pykernel.md
@@ -73,16 +73,14 @@ class MyCustomOp(PyKernelOp):
     # Define reader kernel
     @reader_thread()
     def reader_kernel(cb_in: CircularBuffer, cb_out: CircularBuffer,
-                     src_addr, num_tiles, start_id,
-                     src_is_dram: CompileTimeValue):
+                     src_addr, num_tiles, start_id):
         # Reader kernel code here
         return
 
     # Define writer kernel
     @writer_thread()
     def writer_kernel(cb_in: CircularBuffer, cb_out: CircularBuffer,
-                     dst_addr, num_tiles, start_id,
-                     dst_is_dram: CompileTimeValue):
+                     dst_addr, num_tiles, start_id):
         # Writer kernel code here
         return
 
@@ -94,7 +92,6 @@ class MyCustomOp(PyKernelOp):
 
         # Prepare parameters for kernels
         start_id = 0
-        is_dram = in_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
         num_tiles = options["num_tiles"]
 
         # Create kernels with appropriate parameters
@@ -110,14 +107,14 @@ class MyCustomOp(PyKernelOp):
                 cb_in, cb_out,
                 out_tensor.buffer_address(),
                 num_tiles, start_id,
-                dst_is_dram=is_dram
+                tensor_accessor_configs=[out_tensor],
             ),
             self.create_kernel(
                 MyCustomOp.reader_kernel,
                 cb_in, cb_out,
                 in_tensor.buffer_address(),
                 num_tiles, start_id,
-                src_is_dram=is_dram
+                tensor_accessor_configs=[in_tensor],
             )
         ]
 
@@ -284,15 +281,12 @@ def writer_multicore(
     dst_addr,
     num_tiles,
     start_id,
-    dst_is_dram: CompileTimeValue,
 ):
     onetile = 1
     tile_bytes = get_tile_size(cb_out)
-    dataformat = get_dataformat(cb_out)
 
-    s0 = get_interleaved_addr_gen_fast(
-        dst_is_dram, dst_addr, tile_bytes, dataformat
-    )
+    tensor_accessor_args = TensorAccessorArgs(cta_base=1, crta_base=0)
+    s0 = TensorAccessor(tensor_accessor_args, dst_addr, tile_bytes)
 
     end_id = start_id + num_tiles
     for i in range(start_id, end_id, onetile):
@@ -315,23 +309,17 @@ def reader_binary_interleaved(
     src_addr1,
     num_tiles,
     start_id,
-    src0_is_dram: CompileTimeValue,
-    src1_is_dram: CompileTimeValue,
 ):
     onetile = 1
     tile_bytes0 = get_tile_size(cb_in0)
-    dataformat0 = get_dataformat(cb_in0)
 
-    s0 = get_interleaved_addr_gen_fast(
-        src0_is_dram, src_addr0, tile_bytes0, dataformat0
-    )
+    tensor_accessor_args = TensorAccessorArgs(cta_base=2, crta_base=0)
+    s0 = TensorAccessor(tensor_accessor_args, src_addr0, tile_bytes0)
 
     tile_bytes1 = get_tile_size(cb_in1)
-    dataformat1 = get_dataformat(cb_in1)
 
-    s1 = get_interleaved_addr_gen_fast(
-        src1_is_dram, src_addr1, tile_bytes1, dataformat1
-    )
+    tensor_accessor_args = TensorAccessorArgs(cta_base=3, crta_base=0)
+    s1 = TensorAccessor(tensor_accessor_args, src_addr1, tile_bytes1)
 
     end_id = start_id + num_tiles
     for i in range(start_id, end_id, onetile):
@@ -360,11 +348,6 @@ def invoke(self, a_tensor, b_tensor, out_tensor):
     cb_in0 = self.create_cb(a_tensor, 0)
     cb_in1 = self.create_cb(b_tensor, 1)
     cb_out = self.create_cb(out_tensor, 2)
-
-    # Set up parameters
-    is_a_dram = a_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
-    is_b_dram = b_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
-    is_out_dram = out_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
 
     num_tiles = ceil(max(map(lambda t: t.volume(), [a_tensor, b_tensor, out_tensor])) / 1024)
     num_cores = self.get_core_ranges().num_cores()
@@ -396,7 +379,7 @@ def invoke(self, a_tensor, b_tensor, out_tensor):
             out_tensor.buffer_address(),
             num_tiles_per_core,
             start_id_multicore,
-            dst_is_dram=is_out_dram,
+            tensor_accessor_configs=[out_tensor],
         ),
         self.create_kernel(
             VecAddMulticorePyKernelOp.reader_binary_interleaved,
@@ -406,8 +389,7 @@ def invoke(self, a_tensor, b_tensor, out_tensor):
             b_tensor.buffer_address(),
             num_tiles_per_core,
             start_id_multicore,
-            src0_is_dram=is_a_dram,
-            src1_is_dram=is_b_dram,
+            tensor_accessor_configs=[a_tensor, b_tensor],
         ),
     ]
 

--- a/include/ttmlir-c/TTKernelTypes.h
+++ b/include/ttmlir-c/TTKernelTypes.h
@@ -32,9 +32,6 @@ MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelL1AddrTypeGet(MlirContext ctx);
 
 MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelL1AddrPtrTypeGet(MlirContext ctx);
 
-MLIR_CAPI_EXPORTED MlirType
-ttmlirTTKernelInterleavedAddrGenFastTypeGet(MlirContext ctx);
-
 MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelDataFormatTypeGet(MlirContext ctx);
 
 MLIR_CAPI_EXPORTED MlirType

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3515,7 +3515,7 @@ def TTKernel_NocAsyncReadTileOp : TTKernel_Op<"noc_async_read_tile"> {
     }];
 
     let arguments = (ins I32:$id,
-                         AnyTypeOf<[TTKernel_InterleavedAddrGenFast, TTKernel_TensorAccessor]>:$addrGenStruct,
+                         TTKernel_TensorAccessor:$addrGenStruct,
                          I32:$dstLocalL1Addr,
                          Optional<I8>:$noc);
 
@@ -3524,70 +3524,45 @@ def TTKernel_NocAsyncReadTileOp : TTKernel_Op<"noc_async_read_tile"> {
     }];
 }
 
-def TTKernel_NocAsyncReadOnePacketSetStateOp : TTKernel_Op<"noc_async_read_one_packet_set_state"> {
+def TTKernel_NocAsyncReadOnePacketSetStateOp : TTKernel_Op<"noc_async_read_one_packet_set_state",
+                                                           [AttrSizedOperandSegments]> {
     let summary = "NocAsyncReadOnePacketSetState";
     let description = [{
       NocAsyncReadOnePacketSetState
     }];
 
-    let arguments = (ins TTKernel_NocAddr:$srcNocAddr, I32:$size, Optional<I8>:$noc);
+    let arguments = (ins Variadic<IndexLike>:$srcCoreXY,
+                         Variadic<I32>:$srcBankId,
+                         I32:$srcAddress,
+                         I32:$size,
+                         Optional<I8>:$noc);
 
     let assemblyFormat = [{
-      `(` $srcNocAddr `,` $size (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+      `(` (`core` `[` $srcCoreXY^ `]`)? (`bank` `[` $srcBankId^ `]`)? `,` $srcAddress `,` $size (`,` `noc` $noc^)? `)` attr-dict `:` functional-type(operands, results)
     }];
+
+    let hasVerifier = 1;
 }
 
-def TTKernel_NocAsyncReadOnePacketWithStateOp : TTKernel_Op<"noc_async_read_one_packet_with_state"> {
+def TTKernel_NocAsyncReadOnePacketWithStateOp : TTKernel_Op<"noc_async_read_one_packet_with_state",
+                                                            [AttrSizedOperandSegments]> {
     let summary = "NocAsyncReadOnePacketWithState";
     let description = [{
       NocAsyncReadOnePacketWithState
     }];
 
-    let arguments = (ins TTKernel_NocAddr:$srcNocAddr, AnyTypeOf<[I32, TTKernel_L1Addr]>:$dstLocalL1Addr, Optional<I8>:$noc);
+    let arguments = (ins Variadic<IndexLike>:$srcCoreXY,
+                         Variadic<I32>:$srcBankId,
+                         I32:$srcAddress,
+                         AnyTypeOf<[I32, TTKernel_L1Addr]>:$dstLocalL1Addr,
+                         I32:$size,
+                         Optional<I8>:$noc);
 
     let assemblyFormat = [{
-      `(` $srcNocAddr `,` $dstLocalL1Addr (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
-    }];
-}
-
-def TTKernel_NocAsyncReadSetTridOp : TTKernel_Op<"noc_async_read_set_trid", [TTKernel_TridNocOpTrait]> {
-    let summary = "NocAsyncReadSetTrid";
-    let description = [{
-      Sets the transaction ID for subsequent NOC reads. TRID is 0-15, NOC is 0 or 1.
-
-      Example:
-      ```
-      ttkernel.noc_async_read_set_trid(%trid, %noc_idx) : (i32, i8) -> ()
-      ```
+      `(` (`core` `[` $srcCoreXY^ `]`)? (`bank` `[` $srcBankId^ `]`)? `,` $srcAddress `,` $dstLocalL1Addr `,` $size (`,` `noc` $noc^)? `)` attr-dict `:` functional-type(operands, results)
     }];
 
-    let arguments = (ins I32:$trid, Optional<I8>:$noc);
-
-    let assemblyFormat = [{
-      `(` $trid (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
-    }];
-}
-
-def TTKernel_NocAsyncReadOnePacketWithStateWithTridOp : TTKernel_Op<"noc_async_read_one_packet_with_state_with_trid", [TTKernel_TridNocOpTrait]> {
-    let summary = "NocAsyncReadOnePacketWithStateWithTrid";
-    let description = [{
-      Issues a one-packet NOC read with a specific transaction ID. TRID is 0-15, NOC is 0 or 1.
-
-      Example:
-      ```
-      // Must set TRID before calling.
-      // ttkernel.noc_async_read_set_trid(%trid, %noc_idx) : (i32, i8) -> ()
-      ttkernel.noc_async_read_one_packet_with_state_with_trid(%src_base, %src_addr, %dst_l1, %trid, %noc_idx) : (i32, i32, i32, i32, i8) -> ()
-      // TRID-specific barrier should follow.
-      // ttkernel.noc_async_read_barrier_with_trid(%trid, %noc_idx) : (i32, i8) -> ()
-      ```
-    }];
-
-    let arguments = (ins I32:$srcBaseAddr, I32:$srcAddr, AnyTypeOf<[I32, TTKernel_L1Addr]>:$dstLocalL1Addr, I32:$trid, Optional<I8>:$noc);
-
-    let assemblyFormat = [{
-      `(` $srcBaseAddr `,` $srcAddr `,` $dstLocalL1Addr `,` $trid (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
-    }];
+    let hasVerifier = 1;
 }
 
 def TTKernel_NocAsyncReadBarrierOp : TTKernel_Op<"noc_async_read_barrier", [TTKernel_DeviceZoneOpTrait]> {
@@ -3656,7 +3631,7 @@ def TTKernel_NocAsyncWriteTileOp : TTKernel_Op<"noc_async_write_tile"> {
     }];
 
     let arguments = (ins IndexLike:$id,
-                         AnyTypeOf<[TTKernel_InterleavedAddrGenFast, TTKernel_TensorAccessor]>:$addrGenStruct,
+                         TTKernel_TensorAccessor:$addrGenStruct,
                          I32:$srcLocalL1Addr,
                          Optional<I8>:$noc);
 
@@ -3665,44 +3640,33 @@ def TTKernel_NocAsyncWriteTileOp : TTKernel_Op<"noc_async_write_tile"> {
     }];
 }
 
-def TTKernel_NocAsyncWriteSetTridOp : TTKernel_Op<"noc_async_write_set_trid", [TTKernel_TridNocOpTrait]> {
-    let summary = "NocAsyncWriteSetTrid";
-    let description = [{
-      Sets the transaction ID for subsequent NOC writes. TRID is 0-15, NOC is 0 or 1.
-
-      Example:
-      ```
-      ttkernel.noc_async_write_set_trid(%trid, %noc_idx) : (i32, i8) -> ()
-      ```
-    }];
-
-    let arguments = (ins I32:$trid, Optional<I8>:$noc);
-
-    let assemblyFormat = [{
-      `(` $trid (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
-    }];
-}
-
-def TTKernel_NocAsyncWriteOnePacketWithTridOp : TTKernel_Op<"noc_async_write_one_packet_with_trid", [TTKernel_TridNocOpTrait]> {
+def TTKernel_NocAsyncWriteOnePacketWithTridOp : TTKernel_Op<"noc_async_write_one_packet_with_trid",
+                                                            [TTKernel_TridNocOpTrait, AttrSizedOperandSegments]> {
     let summary = "NocAsyncWriteOnePacketWithTrid";
     let description = [{
       Issues a one-packet NOC write with a specific transaction ID. TRID is 0-15, NOC is 0 or 1.
 
       Example:
       ```
-      // Must set TRID before calling.
-      // ttkernel.noc_async_write_set_trid(%trid, %noc_idx) : (i32, i8) -> ()
-      ttkernel.noc_async_write_one_packet_with_trid(%l1_src, %dst_noc, %size, %trid, %noc_idx) : (i32, !ttkernel.noc_addr, i32, i32, i8) -> ()
+      ttkernel.noc_async_write_one_packet_with_trid(%l1_src, core[%x, %y], %dst_addr, %size, %trid, noc %noc_idx) : (i32, index, index, i32, i32, i32, i8) -> ()
       // TRID-specific barrier should follow.
       // ttkernel.noc_async_write_barrier_with_trid(%trid, %noc_idx) : (i32, i8) -> ()
       ```
     }];
 
-    let arguments = (ins I32:$srcLocalL1Addr, TTKernel_NocAddr:$dstNocAddr, I32:$size, I32:$trid, Optional<I8>:$noc);
+    let arguments = (ins I32:$srcLocalL1Addr,
+                         Variadic<IndexLike>:$dstCoreXY,
+                         Variadic<I32>:$dstBankId,
+                         I32:$dstAddress,
+                         I32:$size,
+                         I32:$trid,
+                         Optional<I8>:$noc);
 
     let assemblyFormat = [{
-      `(` $srcLocalL1Addr `,` $dstNocAddr `,` $size `,` $trid (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+      `(` $srcLocalL1Addr `,` (`core` `[` $dstCoreXY^ `]`)? (`bank` `[` $dstBankId^ `]`)? `,` $dstAddress `,` $size `,` $trid (`,` `noc` $noc^)? `)` attr-dict `:` functional-type(operands, results)
     }];
+
+    let hasVerifier = 1;
 }
 
 def TTKernel_NocAsyncWriteBarrierOp : TTKernel_Op<"noc_async_write_barrier", [TTKernel_DeviceZoneOpTrait]> {
@@ -3756,26 +3720,6 @@ def TTKernel_NocAsyncWriteBarrierWithTridOp : TTKernel_Op<"noc_async_write_barri
 
     let assemblyFormat = [{
       `(` $trid (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
-    }];
-}
-
-def TTKernel_ResetNocTridBarrierCounterOp : TTKernel_Op<"reset_noc_trid_barrier_counter"> {
-    let summary = "ResetNocTridBarrierCounter";
-    let description = [{
-      Resets the barrier counters for a set of transaction IDs on a given NOC. Mask bits correspond to TRIDs 0-15; NOC is 0 or 1.
-
-      Example:
-      ```
-      ttkernel.reset_noc_trid_barrier_counter(%mask, %noc_idx) : (i32, i8) -> ()
-      ```
-    }];
-
-    let arguments = (ins I32:$idMask, Optional<I8>:$noc);
-
-    let hasVerifier = 1;
-
-    let assemblyFormat = [{
-      `(` $idMask (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 
@@ -3872,13 +3816,15 @@ def TTKernel_NocInlineDwWriteOp : TTKernel_Op<"noc_inline_dw_write"> {
       staging word.
     }];
 
-    let arguments = (ins TTKernel_NocAddr:$dst_noc_addr,
+    let arguments = (ins IndexLike:$dstNocX,
+                         IndexLike:$dstNocY,
+                         I32:$dstAddress,
                          I32:$val,
                          I8:$byte_enable,
                          Optional<I8>:$noc);
 
     let assemblyFormat = [{
-      `(` $dst_noc_addr `,` $val `,` $byte_enable (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+      `(` `core` `[` $dstNocX `,` $dstNocY `]` `,` $dstAddress `,` $val `,` $byte_enable (`,` `noc` $noc^)? `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 
@@ -4127,34 +4073,6 @@ def TTKernel_LoadFromL1Op : TTKernel_Op<"load_from_l1"> {
 
     let assemblyFormat = [{
       `(` $l1_ptr `,` $offset `)` attr-dict `:` functional-type(operands, results)
-    }];
-}
-
-def TTKernel_GetInterleavedAddrGenFastOp : TTKernel_Op<"get_interleaved_addr_gen_fast"> {
-    let summary = "GetInterleavedAddrGenFastOp";
-    let description = [{
-      Returns an InterleavedAddrGenFast type.
-    }];
-
-    let arguments = (ins I1:$DRAM, I32:$bank_base_address, I32:$page_size, TTKernel_DataFormat:$data_format);
-    let results = (outs TTKernel_InterleavedAddrGenFast:$result);
-
-    let assemblyFormat = [{
-      `(` $DRAM `,` $bank_base_address `,` $page_size `,` $data_format `)` attr-dict `:` functional-type(operands, results)
-    }];
-}
-
-def TTKernel_InterleavedAddrGenFastGetNocAddrOp : TTKernel_Op<"interleaved_addr_gen_fast.get_noc_addr"> {
-    let summary = "InterleavedAddrGenFastGetNocAddr";
-    let description = [{
-      Returns an raw noc address from an interleaved addr gen struct.
-    }];
-
-    let arguments = (ins TTKernel_InterleavedAddrGenFast:$self, I32:$id, I32:$offset, Optional<I8>:$noc);
-    let results = (outs TTKernel_NocAddr:$result);
-
-    let assemblyFormat = [{
-      `(` $self `,` $id `,` $offset `,` $noc `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 
@@ -4433,10 +4351,22 @@ def TTKernel_NocAsyncWriteMulticastOnePacketOp : TTKernel_Op<"noc_async_write_mu
     this issues only a single packet with size <= NOC_MAX_BURST_SIZE (ie maximum packet size)
   }];
 
-  let arguments = (ins I32:$srcLocalL1Addr, TTKernel_NocAddr:$dstNocAddrMulticast, I32:$size, I32:$num_dests, OptionalAttr<BoolAttr>:$linked, Optional<I8>:$noc);
+  let arguments = (ins I32:$srcLocalL1Addr,
+                       I32:$size,
+                       I32:$num_dests,
+                       IndexLike:$dstNocXStart,
+                       IndexLike:$dstNocYStart,
+                       IndexLike:$dstNocXEnd,
+                       IndexLike:$dstNocYEnd,
+                       I32:$dstLocalL1Addr,
+                       Optional<I8>:$noc,
+                       OptionalAttr<BoolAttr>:$linked);
 
     let assemblyFormat = [{
-      `(` $srcLocalL1Addr `,` $dstNocAddrMulticast `,` $size `,` $num_dests (`,` `noc` $noc^)? (`,` `linked` $linked^)? `)` attr-dict `:` functional-type(operands, results)
+      `(` $srcLocalL1Addr `,` $size `,` $num_dests `,`
+          `start_xy` `[` $dstNocXStart `,` $dstNocYStart `]` `,`
+          `end_xy` `[` $dstNocXEnd `,` $dstNocYEnd `]` `,`
+          $dstLocalL1Addr (`,` `noc` $noc^)? (`,` `linked` $linked^)? `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -102,11 +102,6 @@ def TTKernel_L1AddrPtr : TTKernel_Type<"L1AddrPtr", "l1_addr_ptr"> {
     }];
 }
 
-def TTKernel_InterleavedAddrGenFast : TTKernel_Type<"InterleavedAddrGenFast", "interleaved_addr_gen_fast"> {
-    let summary = "TTKernel InterleavedAddrGenFast type";
-    let description = "InterleavedAddrGenFast type in TTKernel dialect";
-}
-
 def TTKernel_TensorAccessorArgs : TTKernel_Type<"TensorAccessorArgs", "TensorAccessorArgs"> {
   let summary = "TensorAccessorArgs type";
   let description = "TensorAccessor args type that stores compile + runtime information";

--- a/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
@@ -33,7 +33,6 @@ inline const llvm::StringMap<HeaderRequirement> &getCalleeToHeadersMap() {
         {"get_compile_time_arg_val",                       {"api/compile_time_args.h", "api/compile_time_args.h"}},
 
         // NoC.
-        // The "get_interleaved_addr_gen_fast" op materializes as "InterleavedAddrGenFast<true>".
         {"get_dataformat",                                 {"", "api/dataflow/dataflow_api.h"}},
         {"get_noc_addr",                                   {"", "api/dataflow/dataflow_api.h"}},
         {"get_noc_addr_from_bank_id",                      {"", "api/dataflow/dataflow_api.h"}},
@@ -42,22 +41,13 @@ inline const llvm::StringMap<HeaderRequirement> &getCalleeToHeadersMap() {
         {"get_tile_size",                                  {"", "api/dataflow/dataflow_api.h"}},
         {"get_write_ptr",                                  {"", "api/dataflow/dataflow_api.h"}},
         {"get_read_ptr",                                   {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_async_read_one_packet_set_state",            {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_async_read_one_packet_with_state",           {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_async_read_one_packet_with_state_with_trid", {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_async_read_set_trid",                        {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_async_read_tile",                            {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_async_write_multicast_one_packet",           {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_async_write_one_packet_with_trid",           {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_async_write_set_trid",                       {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_async_write_tile",                           {"", "api/dataflow/dataflow_api.h"}},
-        {"noc_inline_dw_write",                            {"", "api/dataflow/dataflow_api.h"}},
+        {"TensorAccessor",                                 {"", "api/tensor/noc_traits.h"}},
+        {"TensorAccessorArgs",                             {"", "api/tensor/tensor_accessor_args.h"}},
         {"noc_semaphore_inc",                              {"", "api/dataflow/dataflow_api.h"}},
         {"noc_semaphore_set",                              {"", "api/dataflow/dataflow_api.h"}},
         {"noc_semaphore_set_remote",                       {"", "api/dataflow/dataflow_api.h"}},
         {"noc_semaphore_set_multicast",                    {"", "api/dataflow/dataflow_api.h"}},
         {"noc_semaphore_set_multicast_loopback_src",       {"", "api/dataflow/dataflow_api.h"}},
-        {"reset_noc_trid_barrier_counter",                 {"", "api/dataflow/dataflow_api.h"}},
 
         // Compute.
         {"abs_tile",                                       {"api/compute/compute_kernel_api.h", ""}},

--- a/lib/CAPI/TTKernelTypes.cpp
+++ b/lib/CAPI/TTKernelTypes.cpp
@@ -48,10 +48,6 @@ MlirType ttmlirTTKernelL1AddrPtrTypeGet(MlirContext ctx) {
   return wrap(L1AddrPtrType::get(unwrap(ctx), /*elementWidth=*/32));
 }
 
-MlirType ttmlirTTKernelInterleavedAddrGenFastTypeGet(MlirContext ctx) {
-  return wrap(InterleavedAddrGenFastType::get(unwrap(ctx)));
-}
-
 MlirType ttmlirTTKernelDataFormatTypeGet(MlirContext ctx) {
   return wrap(DataFormatType::get(unwrap(ctx)));
 }

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -384,11 +384,60 @@ static std::string ensureNocDeclaration(Operation *useOp,
                                          /*duplicateCheckPrefix=*/"Noc noc(");
 }
 
+// Like `ensureNocDeclaration`, but for rewriters that splice the endpoint and
+// struct args directly into `callStr` and therefore cannot accommodate a
+// runtime NoC value inlined as `Noc({})` (which would perturb operand order).
+// Fails the match with `opDesc` in the diagnostic when the NoC index is not
+// statically resolvable.
+static FailureOr<std::string>
+ensureStaticNocDeclaration(Operation *useOp,
+                           ConversionPatternRewriter &rewriter, Value nocId,
+                           llvm::StringRef opDesc) {
+  SmallVector<Value, 1> nocOperands;
+  std::string nocName =
+      ensureNocDeclaration(useOp, rewriter, nocOperands, nocId);
+  if (!nocOperands.empty()) {
+    return rewriter.notifyMatchFailure(
+        useOp, "dynamic NoC ID is not supported for " + opDesc.str());
+  }
+  return nocName;
+}
+
 static std::string
 ensureEndpointDeclaration(Operation *useOp, ConversionPatternRewriter &rewriter,
                           llvm::StringRef type, llvm::StringRef name) {
   std::string decl = (type + " " + name + ";").str();
   return ensureFunctionScopedDeclaration(useOp, rewriter, decl, name);
+}
+
+struct NocEndpointEmission {
+  std::string endpointName;
+  std::string args;
+};
+
+static NocEndpointEmission emitNocEndpoint(Operation *useOp,
+                                           ConversionPatternRewriter &rewriter,
+                                           ValueRange coreXY, ValueRange bankId,
+                                           Value address,
+                                           SmallVectorImpl<Value> &operands) {
+  if (!coreXY.empty()) {
+    TT_assert(coreXY.size() == 2u);
+    operands.append(coreXY.begin(), coreXY.end());
+    operands.push_back(address);
+    return {ensureEndpointDeclaration(useOp, rewriter, "UnicastEndpoint",
+                                      "unicast_ep"),
+            "{{.noc_x = {}, .noc_y = {}, "
+            ".addr = static_cast<uint32_t>({})}"};
+  }
+
+  TT_assert(bankId.size() == 1u);
+  operands.push_back(bankId.front());
+  operands.push_back(address);
+  return {ensureEndpointDeclaration(useOp, rewriter,
+                                    "AllocatorBank<AllocatorBankType::DRAM>",
+                                    "dram_ep"),
+          "{{.bank_id = static_cast<uint32_t>({}), "
+          ".addr = static_cast<uint32_t>({})}"};
 }
 
 // Type converter used for TTKernel/TTMetal conversions:
@@ -420,11 +469,6 @@ public:
     addConversion([ctx](mlir::tt::ttkernel::DataFormatType type) -> Type {
       return emitc::OpaqueType::get(ctx, "DataFormat");
     });
-    addConversion(
-        [ctx](mlir::tt::ttkernel::InterleavedAddrGenFastType type) -> Type {
-          // There is never a case in metal kernel code where template is false.
-          return emitc::OpaqueType::get(ctx, "InterleavedAddrGenFast<true>");
-        });
     addConversion(
         [ctx](mlir::tt::ttkernel::TensorAccessorArgsType type) -> Type {
           return emitc::OpaqueType::get(ctx, "TensorAccessorArgs");
@@ -1257,7 +1301,7 @@ public:
                                                operands, adaptor.getNoc());
     operands.push_back(adaptor.getTrid());
     std::string callStr = nocName + "." + methodName +
-                          "<NocOptions::TXN_ID>(NocOptVals{{.trid = {}}});";
+                          "<NocOptions::TXN_ID>(NocOptVals{{.trid = {}});";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);
@@ -1298,57 +1342,200 @@ public:
       remoteAddr = adaptor.getDstAddress();
     }
 
-    SmallVector<Value, 1> nocOperands;
-    std::string nocName = ensureNocDeclaration(op.getOperation(), rewriter,
-                                               nocOperands, adaptor.getNoc());
-    // A dynamic (explicit & non-constant) NoC object is spliced into callStr
-    // and would break operand ordering for async transfers.
-    if (!nocOperands.empty()) {
-      return rewriter.notifyMatchFailure(
-          op, "dynamic NoC ID is not supported for async read/write");
+    FailureOr<std::string> nocName = ensureStaticNocDeclaration(
+        op.getOperation(), rewriter, adaptor.getNoc(), "async read/write");
+    if (failed(nocName)) {
+      return failure();
     }
     SmallVector<Value, 5> operands{localL1Addr, adaptor.getSize()};
     std::string callStr;
 
-    if (!coreXY.empty()) {
-      TT_assert(coreXY.size() == 2u);
-      std::string endpoint = ensureEndpointDeclaration(
-          op.getOperation(), rewriter, "UnicastEndpoint", "unicast_ep");
-      operands.append(coreXY.begin(), coreXY.end());
-      operands.push_back(remoteAddr);
-      if constexpr (isRead) {
-        callStr = nocName + ".async_read(" + endpoint +
-                  ", CoreLocalMem<uint32_t>({}), {}, "
-                  "{{.noc_x = {}, .noc_y = {}, "
-                  ".addr = static_cast<uint32_t>({})}, {{});";
-      } else {
-        callStr = nocName +
-                  ".async_write("
-                  "CoreLocalMem<uint32_t>({}), " +
-                  endpoint +
-                  ", {}, {{} , {{.noc_x = {}, .noc_y = {}, "
-                  ".addr = static_cast<uint32_t>({})});";
-      }
+    NocEndpointEmission endpoint = emitNocEndpoint(
+        op.getOperation(), rewriter, coreXY, bankId, remoteAddr, operands);
+    if constexpr (isRead) {
+      callStr = *nocName + ".async_read(" + endpoint.endpointName +
+                ", CoreLocalMem<uint32_t>({}), {}, " + endpoint.args +
+                ", {{});";
     } else {
-      TT_assert(bankId.size() == 1u);
-      std::string endpoint = ensureEndpointDeclaration(
-          op.getOperation(), rewriter, "AllocatorBank<AllocatorBankType::DRAM>",
-          "dram_ep");
-      operands.push_back(bankId.front());
-      operands.push_back(remoteAddr);
-      if constexpr (isRead) {
-        callStr = nocName + ".async_read(" + endpoint +
-                  ", CoreLocalMem<uint32_t>({}), {}, "
-                  "{{.bank_id = static_cast<uint32_t>({}), "
-                  ".addr = static_cast<uint32_t>({})}, {{});";
-      } else {
-        callStr = nocName +
-                  ".async_write("
-                  "CoreLocalMem<uint32_t>({}), " +
-                  endpoint +
-                  ", {}, {{} , {{.bank_id = static_cast<uint32_t>({}), "
-                  ".addr = static_cast<uint32_t>({})});";
-      }
+      callStr = *nocName + ".async_write(CoreLocalMem<uint32_t>({}), " +
+                endpoint.endpointName + ", {}, {{} , " + endpoint.args + ");";
+    }
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+class TTKernelToEmitCNocAsyncReadOnePacketSetStateRewriter
+    : public OpConversionPattern<ttkernel::NocAsyncReadOnePacketSetStateOp> {
+public:
+  TTKernelToEmitCNocAsyncReadOnePacketSetStateRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern(typeConverter, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(ttkernel::NocAsyncReadOnePacketSetStateOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    FailureOr<std::string> nocName = ensureStaticNocDeclaration(
+        op.getOperation(), rewriter, adaptor.getNoc(), "stateful async read");
+    if (failed(nocName)) {
+      return failure();
+    }
+
+    SmallVector<Value, 4> operands{adaptor.getSize()};
+    NocEndpointEmission endpoint = emitNocEndpoint(
+        op.getOperation(), rewriter, adaptor.getSrcCoreXY(),
+        adaptor.getSrcBankId(), adaptor.getSrcAddress(), operands);
+    std::string callStr =
+        *nocName +
+        ".set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(" +
+        endpoint.endpointName + ", {}, " + endpoint.args + ");";
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+class TTKernelToEmitCNocAsyncReadOnePacketWithStateRewriter
+    : public OpConversionPattern<ttkernel::NocAsyncReadOnePacketWithStateOp> {
+public:
+  TTKernelToEmitCNocAsyncReadOnePacketWithStateRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern(typeConverter, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(ttkernel::NocAsyncReadOnePacketWithStateOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    FailureOr<std::string> nocName = ensureStaticNocDeclaration(
+        op.getOperation(), rewriter, adaptor.getNoc(), "stateful async read");
+    if (failed(nocName)) {
+      return failure();
+    }
+
+    SmallVector<Value, 5> operands{adaptor.getDstLocalL1Addr(),
+                                   adaptor.getSize()};
+    NocEndpointEmission endpoint = emitNocEndpoint(
+        op.getOperation(), rewriter, adaptor.getSrcCoreXY(),
+        adaptor.getSrcBankId(), adaptor.getSrcAddress(), operands);
+    std::string callStr =
+        *nocName +
+        ".async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(" +
+        endpoint.endpointName + ", CoreLocalMem<uint32_t>({}), {}, " +
+        endpoint.args + ", {{});";
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+class TTKernelToEmitCNocAsyncWriteOnePacketWithTridRewriter
+    : public OpConversionPattern<ttkernel::NocAsyncWriteOnePacketWithTridOp> {
+public:
+  TTKernelToEmitCNocAsyncWriteOnePacketWithTridRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern(typeConverter, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(ttkernel::NocAsyncWriteOnePacketWithTridOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    FailureOr<std::string> nocName = ensureStaticNocDeclaration(
+        op.getOperation(), rewriter, adaptor.getNoc(), "async write with TRID");
+    if (failed(nocName)) {
+      return failure();
+    }
+
+    SmallVector<Value, 6> operands{adaptor.getSrcLocalL1Addr(),
+                                   adaptor.getSize()};
+    NocEndpointEmission endpoint = emitNocEndpoint(
+        op.getOperation(), rewriter, adaptor.getDstCoreXY(),
+        adaptor.getDstBankId(), adaptor.getDstAddress(), operands);
+    operands.push_back(adaptor.getTrid());
+
+    std::string callStr =
+        *nocName +
+        ".async_write<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>("
+        "CoreLocalMem<uint32_t>({}), " +
+        endpoint.endpointName + ", {}, {{} , " + endpoint.args +
+        ", NocOptVals{{.trid = {}});";
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+class TTKernelToEmitCNocInlineDwWriteRewriter
+    : public OpConversionPattern<ttkernel::NocInlineDwWriteOp> {
+public:
+  TTKernelToEmitCNocInlineDwWriteRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern(typeConverter, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(ttkernel::NocInlineDwWriteOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    FailureOr<std::string> nocName = ensureStaticNocDeclaration(
+        op.getOperation(), rewriter, adaptor.getNoc(), "inline write");
+    if (failed(nocName)) {
+      return failure();
+    }
+
+    std::string endpoint = ensureEndpointDeclaration(
+        op.getOperation(), rewriter, "UnicastEndpoint", "unicast_ep");
+    SmallVector<Value, 5> operands{
+        adaptor.getVal(), adaptor.getDstNocX(), adaptor.getDstNocY(),
+        adaptor.getDstAddress(), adaptor.getByteEnable()};
+    std::string callStr =
+        *nocName + ".inline_dw_write<NocOptions::INLINE_L1>(" + endpoint +
+        ", {}, {{.noc_x = {}, .noc_y = {}, "
+        ".addr = static_cast<uint32_t>({})}, {});";
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+template <typename SourceOp>
+class TTKernelToEmitCNocAsyncTileRewriter
+    : public OpConversionPattern<SourceOp> {
+  static constexpr bool isRead =
+      std::is_same_v<SourceOp, ttkernel::NocAsyncReadTileOp>;
+
+public:
+  TTKernelToEmitCNocAsyncTileRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern<SourceOp>(typeConverter, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    FailureOr<std::string> nocName = ensureStaticNocDeclaration(
+        op.getOperation(), rewriter, adaptor.getNoc(), "tile async read/write");
+    if (failed(nocName)) {
+      return failure();
+    }
+
+    SmallVector<Value, 4> operands;
+    std::string callStr;
+    if constexpr (isRead) {
+      operands.append({adaptor.getAddrGenStruct(), adaptor.getDstLocalL1Addr(),
+                       adaptor.getAddrGenStruct(), adaptor.getId()});
+      callStr = *nocName + ".async_read({}, CoreLocalMem<uint32_t>({}), "
+                           "{}.get_aligned_page_size(), "
+                           "{{.page_id = static_cast<uint32_t>({})}, {{});";
+    } else {
+      operands.append({adaptor.getSrcLocalL1Addr(), adaptor.getAddrGenStruct(),
+                       adaptor.getAddrGenStruct(), adaptor.getId()});
+      callStr = *nocName + ".async_write(CoreLocalMem<uint32_t>({}), {}, "
+                           "{}.get_aligned_page_size(), {{} , "
+                           "{{.page_id = static_cast<uint32_t>({})});";
     }
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
@@ -1360,6 +1547,11 @@ public:
 template <typename SourceOp>
 class TTKernelToEmitCNocAsyncWriteMulticastRewriter
     : public OpConversionPattern<SourceOp> {
+  static constexpr bool isLoopback =
+      std::is_same_v<SourceOp, ttkernel::NocAsyncWriteMulticastLoopbackSrcOp>;
+  static constexpr bool isOnePacket =
+      std::is_same_v<SourceOp, ttkernel::NocAsyncWriteMulticastOnePacketOp>;
+
 public:
   TTKernelToEmitCNocAsyncWriteMulticastRewriter(
       TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx)
@@ -1377,10 +1569,12 @@ public:
     // EXCLUDE_SRC maps to default NocOptions (no MCAST_INCL_SRC flag), so we
     // omit the template argument entirely. INCLUDE_SRC maps to
     // NocOptions::MCAST_INCL_SRC.
-    std::string templateArg =
-        std::is_same_v<SourceOp, ttkernel::NocAsyncWriteMulticastOp>
-            ? ""
-            : "<NocOptions::MCAST_INCL_SRC>";
+    std::string templateArg;
+    if constexpr (isLoopback) {
+      templateArg = "<NocOptions::MCAST_INCL_SRC>";
+    } else if constexpr (isOnePacket) {
+      templateArg = "<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>";
+    }
     bool linked = op.getLinked().value_or(false);
 
     operands.append({adaptor.getSrcLocalL1Addr(), adaptor.getSize(),
@@ -1633,53 +1827,6 @@ public:
   matchAndRewrite(Op op, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     rewriter.replaceOp(op, adaptor.getOperands());
-    return success();
-  }
-};
-} // namespace
-
-namespace {
-class TTKernelGetInterleavedAddrGenFastOpRewriter
-    : public OpConversionPattern<ttkernel::GetInterleavedAddrGenFastOp> {
-  using Op = ttkernel::GetInterleavedAddrGenFastOp;
-
-public:
-  TTKernelGetInterleavedAddrGenFastOpRewriter(
-      const TypeConverter &typeConverter, MLIRContext *context)
-      : OpConversionPattern(typeConverter, context) {}
-
-  LogicalResult
-  matchAndRewrite(Op op, ttkernel::GetInterleavedAddrGenFastOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const final {
-    if (op.getResult().use_empty()) {
-      rewriter.eraseOp(op);
-      return success();
-    }
-
-    mlir::Type opaqueStructType =
-        this->getTypeConverter()->convertType(op->getResultTypes()[0]);
-    if (!opaqueStructType) {
-      return rewriter.notifyMatchFailure(op, "Failed to convert result type");
-    }
-
-    std::string varName =
-        getResultVariableName(op.getResult(), "interleaved_addr_gen_");
-    rewriter.create<emitc::VerbatimOp>(
-        op.getLoc(), "InterleavedAddrGenFast<true> " + varName + ";");
-    rewriter.create<emitc::VerbatimOp>(
-        op.getLoc(), varName + ".bank_base_address = {};",
-        ValueRange{adaptor.getBankBaseAddress()});
-    rewriter.create<emitc::VerbatimOp>(op.getLoc(),
-                                       varName + ".page_size = {};",
-                                       ValueRange{adaptor.getPageSize()});
-    rewriter.create<emitc::VerbatimOp>(op.getLoc(),
-                                       varName + ".data_format = {};",
-                                       ValueRange{adaptor.getDataFormat()});
-
-    rewriter.replaceOp(op, rewriter
-                               .create<emitc::LiteralOp>(
-                                   op.getLoc(), opaqueStructType, varName)
-                               .getResult());
     return success();
   }
 };
@@ -2437,22 +2584,7 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::ClampScalarTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ClampScalarTileInt32Op>,
 
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadTileOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncReadOnePacketSetStateOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncReadOnePacketWithStateOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncReadOnePacketWithStateWithTridOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadSetTridOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteTileOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteSetTridOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncWriteOnePacketWithTridOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::ResetNocTridBarrierCounterOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocMulticastAddrOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncWriteMulticastOnePacketOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ConvertLogicalXToTranslatedOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ConvertLogicalYToTranslatedOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetMyDeviceIdOp>,
@@ -2487,16 +2619,22 @@ public:
 
     patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::RemoteSramWriteU32Op>>(
         typeConverter, funcOp.getContext(), "noc_semaphore_set_remote");
-    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::NocInlineDwWriteOp>>(
-        typeConverter, funcOp.getContext());
 
     patterns
         .add<TTKernelToEmitCGetNocAddrRewriter,
              TTKernelToEmitCNocAtomicBarrierRewriter,
+             TTKernelToEmitCNocAsyncTileRewriter<ttkernel::NocAsyncReadTileOp>,
+             TTKernelToEmitCNocAsyncTileRewriter<ttkernel::NocAsyncWriteTileOp>,
+             TTKernelToEmitCNocAsyncReadOnePacketSetStateRewriter,
+             TTKernelToEmitCNocAsyncReadOnePacketWithStateRewriter,
+             TTKernelToEmitCNocAsyncWriteOnePacketWithTridRewriter,
+             TTKernelToEmitCNocInlineDwWriteRewriter,
              TTKernelToEmitCNocAsyncTransferRewriter<ttkernel::NocAsyncReadOp>,
              TTKernelToEmitCNocAsyncTransferRewriter<ttkernel::NocAsyncWriteOp>,
              TTKernelToEmitCNocAsyncWriteMulticastRewriter<
                  ttkernel::NocAsyncWriteMulticastOp>,
+             TTKernelToEmitCNocAsyncWriteMulticastRewriter<
+                 ttkernel::NocAsyncWriteMulticastOnePacketOp>,
              TTKernelToEmitCNocAsyncWriteMulticastRewriter<
                  ttkernel::NocAsyncWriteMulticastLoopbackSrcOp>>(
             typeConverter, funcOp.getContext());
@@ -2530,9 +2668,6 @@ public:
     patterns.add<TTKernelLoadFromL1OpToEmitCOpRewriter>(typeConverter,
                                                         funcOp.getContext());
 
-    patterns.add<TTKernelGetInterleavedAddrGenFastOpRewriter>(
-        typeConverter, funcOp.getContext());
-
     patterns.add<TTKernelTensorAccessorArgsOpRewriter>(typeConverter,
                                                        funcOp.getContext());
 
@@ -2546,10 +2681,8 @@ public:
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalBankOp>,
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalAddrOp>,
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalPageOp>,
-        TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalShardOp>,
-        TTKernelClassMethodRewriter<
-            ttkernel::InterleavedAddrGenFastGetNocAddrOp>>(typeConverter,
-                                                           funcOp.getContext());
+        TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalShardOp>>(
+        typeConverter, funcOp.getContext());
 
     patterns
         .add<ArithFloorDivRewriter, ArithBitcastRewriter, ArithMaxUIRewriter,

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -364,19 +364,6 @@ static bool isSFPUReduceDataFormatSupported(ttcore::DataType dt) {
   }
   return success();
 }
-::mlir::LogicalResult ResetNocTridBarrierCounterOp::verify() {
-  Value noc = getNoc();
-  if (noc) {
-    auto nocValue = getConstantIntValue(noc);
-    constexpr int32_t kNumNocs =
-        TTKernelTridNocOpTrait<ResetNocTridBarrierCounterOp>::kNumNocs;
-    if (nocValue && (*nocValue < 0 || *nocValue >= kNumNocs)) {
-      return emitOpError() << "noc must be in [0, " << (kNumNocs - 1) << "].";
-    }
-  }
-  return success();
-}
-
 static ::mlir::LogicalResult verifyNocAsyncAddressMode(Operation *op,
                                                        OperandRange core,
                                                        OperandRange bankId) {
@@ -398,6 +385,21 @@ static ::mlir::LogicalResult verifyNocAsyncAddressMode(Operation *op,
 }
 
 ::mlir::LogicalResult NocAsyncWriteOp::verify() {
+  return verifyNocAsyncAddressMode(getOperation(), getDstCoreXY(),
+                                   getDstBankId());
+}
+
+::mlir::LogicalResult NocAsyncReadOnePacketSetStateOp::verify() {
+  return verifyNocAsyncAddressMode(getOperation(), getSrcCoreXY(),
+                                   getSrcBankId());
+}
+
+::mlir::LogicalResult NocAsyncReadOnePacketWithStateOp::verify() {
+  return verifyNocAsyncAddressMode(getOperation(), getSrcCoreXY(),
+                                   getSrcBankId());
+}
+
+::mlir::LogicalResult NocAsyncWriteOnePacketWithTridOp::verify() {
   return verifyNocAsyncAddressMode(getOperation(), getDstCoreXY(),
                                    getDstBankId());
 }
@@ -595,8 +597,7 @@ void NocAsyncReadBarrierOp::getCanonicalizationPatterns(
       }
       if (mlir::isa<NocAsyncReadOp, NocAsyncReadTileOp,
                     NocAsyncReadOnePacketSetStateOp,
-                    NocAsyncReadOnePacketWithStateOp, NocAsyncReadSetTridOp,
-                    NocAsyncReadOnePacketWithStateWithTridOp>(it) ||
+                    NocAsyncReadOnePacketWithStateOp>(it) ||
           it->getNumRegions() > 0) {
         break;
       }
@@ -619,8 +620,8 @@ void NocAsyncWriteBarrierOp::getCanonicalizationPatterns(
         }
       }
       if (mlir::isa<NocAsyncWriteOp, NocAsyncWriteTileOp,
-                    NocAsyncWriteSetTridOp, NocAsyncWriteOnePacketWithTridOp,
-                    NocAsyncWriteMulticastOp, NocAsyncWriteMulticastOnePacketOp,
+                    NocAsyncWriteOnePacketWithTridOp, NocAsyncWriteMulticastOp,
+                    NocAsyncWriteMulticastOnePacketOp,
                     NocAsyncWriteMulticastLoopbackSrcOp, NocInlineDwWriteOp>(
               it) ||
           it->getNumRegions() > 0) {

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -63,10 +63,6 @@ void populateTTKernelModule(nb::module_ &m) {
   tt_type_class<tt::ttkernel::L1AddrPtrType>(m, "L1AddrPtrType")
       .def_static("get", &ttmlirTTKernelL1AddrPtrTypeGet);
 
-  tt_type_class<tt::ttkernel::InterleavedAddrGenFastType>(
-      m, "InterleavedAddrGenFastType")
-      .def_static("get", &ttmlirTTKernelInterleavedAddrGenFastTypeGet);
-
   tt_type_class<tt::ttkernel::DataFormatType>(m, "DataFormatType")
       .def_static("get", &ttmlirTTKernelDataFormatTypeGet);
 

--- a/test/pykernel/demo/eltwise_sfpu_demo.py
+++ b/test/pykernel/demo/eltwise_sfpu_demo.py
@@ -105,8 +105,6 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
         start_id = 0
         num_tiles = ceil(max(map(lambda t: t.volume(), [in_tensor, out_tensor])) / 1024)
 
-        self.set_tensor_accessor_config([in_tensor, out_tensor])
-
         kernels = [
             self.create_kernel(
                 EltwiseSFPUPyKernelOp.eltwise_sfpu,
@@ -121,6 +119,7 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
                 out_tensor.buffer_address(),
                 num_tiles,
                 start_id,
+                tensor_accessor_configs=[out_tensor],
             ),
             self.create_kernel(
                 EltwiseSFPUPyKernelOp.reader_unary_interleaved,
@@ -128,6 +127,7 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
                 in_tensor.buffer_address(),
                 num_tiles,
                 start_id,
+                tensor_accessor_configs=[in_tensor],
             ),
         ]
 

--- a/test/pykernel/demo/matmul_multicore_demo.py
+++ b/test/pykernel/demo/matmul_multicore_demo.py
@@ -70,7 +70,7 @@ class MatmulMulticorePyKernelOp(PyKernelOp):
         addr_gen_a = TensorAccessor(tensor_accessor_args, src_addr0, in0_tile_bytes)
 
         in1_tile_bytes = get_tile_size(cb_in1)
-        tensor_accessor_args = TensorAccessorArgs(cta_base=2, crta_base=0)
+        tensor_accessor_args = TensorAccessorArgs(cta_base=3, crta_base=0)
         addr_gen_b = TensorAccessor(tensor_accessor_args, src_addr1, in1_tile_bytes)
 
         for output_tile in range(0, num_tiles, 1):
@@ -135,8 +135,6 @@ class MatmulMulticorePyKernelOp(PyKernelOp):
         cb_out = self.create_cb(out_tensor, 2)
         start_id = 0
 
-        self.set_tensor_accessor_config(a_tensor)
-
         Mt = a_tensor.shape[0] // 32
         Kt = a_tensor.shape[1] // 32
         Nt = b_tensor.shape[1] // 32
@@ -181,6 +179,7 @@ class MatmulMulticorePyKernelOp(PyKernelOp):
                 Nt,
                 start_id_multicore,
                 num_tiles_per_core,
+                tensor_accessor_configs=[a_tensor, b_tensor],
             ),
             self.create_kernel(
                 MatmulMulticorePyKernelOp.writer_multicore_matmul,
@@ -188,6 +187,7 @@ class MatmulMulticorePyKernelOp(PyKernelOp):
                 out_tensor.buffer_address(),
                 num_tiles_per_core,
                 start_id_multicore,
+                tensor_accessor_configs=[out_tensor],
             ),
         ]
 

--- a/test/pykernel/demo/matmul_singlecore_demo.py
+++ b/test/pykernel/demo/matmul_singlecore_demo.py
@@ -91,7 +91,7 @@ class MatmulSinglecorePyKernelOp(PyKernelOp):
         s0 = TensorAccessor(tensor_accessor_args, src_addr0, tile_bytes0)
 
         tile_bytes1 = get_tile_size(cb_in1)
-        tensor_accessor_args = TensorAccessorArgs(cta_base=2, crta_base=0)
+        tensor_accessor_args = TensorAccessorArgs(cta_base=3, crta_base=0)
         s1 = TensorAccessor(tensor_accessor_args, src_addr1, tile_bytes1)
 
         for m in range(0, M, 1):
@@ -125,8 +125,6 @@ class MatmulSinglecorePyKernelOp(PyKernelOp):
         cb_in1 = self.create_cb(b_tensor, 1)
         cb_out = self.create_cb(out_tensor, 16)
 
-        self.set_tensor_accessor_config([a_tensor, b_tensor, out_tensor])
-
         # Calculate M, N, K as tile numbers, tiles are 32x32
         # A[MxK], B[KxN], Output[MxN]
         M = a_tensor.shape[0] // 32
@@ -143,6 +141,7 @@ class MatmulSinglecorePyKernelOp(PyKernelOp):
                 out_tensor.buffer_address(),
                 M,
                 N,
+                tensor_accessor_configs=[out_tensor],
             ),
             self.create_kernel(
                 MatmulSinglecorePyKernelOp.reader_single_core_mm,
@@ -153,6 +152,7 @@ class MatmulSinglecorePyKernelOp(PyKernelOp):
                 M,
                 N,
                 K,
+                tensor_accessor_configs=[a_tensor, b_tensor],
             ),
         ]
 

--- a/test/pykernel/demo/vecadd_multicore_demo.py
+++ b/test/pykernel/demo/vecadd_multicore_demo.py
@@ -92,7 +92,7 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
         s0 = TensorAccessor(tensor_accessor_args, src_addr0, tile_bytes0)
 
         tile_bytes1 = get_tile_size(cb_in1)
-        tensor_accessor_args = TensorAccessorArgs(cta_base=2, crta_base=0)
+        tensor_accessor_args = TensorAccessorArgs(cta_base=3, crta_base=0)
         s1 = TensorAccessor(tensor_accessor_args, src_addr1, tile_bytes1)
 
         end_id = start_id + num_tiles
@@ -129,8 +129,6 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
         cb_in1 = self.create_cb(b_tensor, 1)
         cb_out = self.create_cb(out_tensor, 2)
         start_id = 0
-
-        self.set_tensor_accessor_config(a_tensor)
 
         num_tiles = ceil(
             max(map(lambda t: t.volume(), [a_tensor, b_tensor, out_tensor])) / 1024
@@ -172,6 +170,7 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
                 out_tensor.buffer_address(),
                 num_tiles_per_core,
                 start_id_multicore,
+                tensor_accessor_configs=[out_tensor],
             ),
             self.create_kernel(
                 VecAddMulticorePyKernelOp.reader_binary_interleaved,
@@ -181,6 +180,7 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
                 b_tensor.buffer_address(),
                 num_tiles_per_core,
                 start_id_multicore,
+                tensor_accessor_configs=[a_tensor, b_tensor],
             ),
         ]
 

--- a/test/pykernel/matmul_common/reader_bmm_8bank.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank.py
@@ -30,24 +30,17 @@ def reader_bmm_8bank(cb_id_in0: CircularBuffer, cb_id_in1: CircularBuffer):
     batch = get_arg_val(int, 7)
     bcast_B = get_arg_val(int, 8)
 
-    src0_is_dram = get_compile_time_arg_val(int, 0) == 1
-    src1_is_dram = get_compile_time_arg_val(int, 1) == 1
-
     onetile = 1
     src0_tile_bytes = get_tile_size(cb_id_in0)
-    src0_data_format = get_dataformat(cb_id_in0)
     src1_tile_bytes = get_tile_size(cb_id_in1)
-    src1_data_format = get_dataformat(cb_id_in1)
 
     itileA_batch: int = 0
     itileB_batch: int = 0
 
-    s0 = get_interleaved_addr_gen_fast(
-        src0_is_dram, src0_addr, src0_tile_bytes, src0_data_format
-    )
-    s1 = get_interleaved_addr_gen_fast(
-        src1_is_dram, src1_addr, src1_tile_bytes, src1_data_format
-    )
+    tensor_accessor_args = TensorAccessorArgs(cta_base=2, crta_base=0)
+    s0 = TensorAccessor(tensor_accessor_args, src0_addr, src0_tile_bytes)
+    tensor_accessor_args = TensorAccessorArgs(cta_base=3, crta_base=0)
+    s1 = TensorAccessor(tensor_accessor_args, src1_addr, src1_tile_bytes)
 
     for nb in range(0, batch, 1):
         itileA: int = itileA_batch + 0

--- a/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
@@ -38,16 +38,11 @@ def reader_bmm_8bank_output_tiles_partitioned(
     num_output_tiles = get_arg_val(int, 10)
     MtNt = get_arg_val(int, 11)
 
-    src0_is_dram = get_compile_time_arg_val(int, 0) == 1
-    src1_is_dram = get_compile_time_arg_val(int, 1) == 1
-
     itileA: int = output_tile_start_id  # should be: output_tile_start_id / Nt * Kt
 
     onetile = 1
     in0_tile_bytes = get_tile_size(cb_id_in0)
-    in0_data_format = get_dataformat(cb_id_in0)
     in1_tile_bytes = get_tile_size(cb_id_in1)
-    in1_data_format = get_dataformat(cb_id_in1)
 
     outbatch: int = (
         output_tile_start_id * MtNt
@@ -57,12 +52,10 @@ def reader_bmm_8bank_output_tiles_partitioned(
     )  # should be: output_tile_start_id % Nt
     itileB: int = itileB_batch + 0
 
-    s0 = get_interleaved_addr_gen_fast(
-        src0_is_dram, src0_addr, in0_tile_bytes, in0_data_format
-    )
-    s1 = get_interleaved_addr_gen_fast(
-        src1_is_dram, src1_addr, in1_tile_bytes, in1_data_format
-    )
+    tensor_accessor_args = TensorAccessorArgs(cta_base=2, crta_base=0)
+    s0 = TensorAccessor(tensor_accessor_args, src0_addr, in0_tile_bytes)
+    tensor_accessor_args = TensorAccessorArgs(cta_base=3, crta_base=0)
+    s1 = TensorAccessor(tensor_accessor_args, src1_addr, in1_tile_bytes)
 
     for n in range(0, num_output_tiles, 1):
         for kt in range(0, Kt, 1):

--- a/test/pykernel/matmul_common/writer_bmm_8bank.py
+++ b/test/pykernel/matmul_common/writer_bmm_8bank.py
@@ -15,14 +15,12 @@ def writer_bmm_8bank(cb_id_out0: CircularBuffer):
     Nt = get_arg_val(int, 4)
     batch = get_arg_val(int, 7)
 
-    dst_is_dram = get_compile_time_arg_val(int, 0) == 1
-
     onetile = 1
     tile_bytes = get_tile_size(cb_id_out0)
-    data_format = get_dataformat(cb_id_out0)
     itileC: int = 0
 
-    s = get_interleaved_addr_gen_fast(dst_is_dram, dst_addr, tile_bytes, data_format)
+    tensor_accessor_args = TensorAccessorArgs(cta_base=1, crta_base=0)
+    s = TensorAccessor(tensor_accessor_args, dst_addr, tile_bytes)
 
     for nb in range(0, batch, 1):
         for mt_C in range(0, Mt, 1):

--- a/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
@@ -2,33 +2,14 @@
 
 // -----
 
-// CHECK-LABEL: func @trid_read_path
+// CHECK-LABEL: func @trid_read_barrier_static_noc
 // CHECK: emitc.verbatim "Noc noc0(0);"
-// CHECK-NEXT: emitc.verbatim "UnicastEndpoint unicast_ep;"
-// CHECK-NEXT: emitc.verbatim "Noc noc(noc_index);"
 // CHECK-NEXT: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
 // CHECK-NEXT: %[[NOC_IDX:.*]] = "emitc.constant"() <{value = 0 : i8}> : () -> i8
-// CHECK-NEXT: %[[X:.*]] = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
-// CHECK-NEXT: %[[Y:.*]] = "emitc.constant"() <{value = 1 : index}> : () -> !emitc.size_t
-// CHECK-NEXT: %[[DST_L1:.*]] = "emitc.constant"() <{value = 256 : i32}> : () -> i32
-// CHECK-NEXT: %[[SRC_BASE:.*]] = "emitc.constant"() <{value = 1024 : i32}> : () -> i32
-// CHECK-NEXT: %[[SRC_ADDR:.*]] = "emitc.constant"() <{value = 64 : i32}> : () -> i32
-// CHECK-NEXT: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %[[X]], %[[Y]], %[[DST_L1]] : !emitc.size_t, !emitc.size_t, i32
-// CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
-// CHECK-NEXT: emitc.call_opaque "noc_async_read_set_trid"(%[[TRID]], %[[NOC_IDX]]) : (i32, i8) -> ()
-// CHECK-NEXT: emitc.call_opaque "noc_async_read_one_packet_with_state_with_trid"(%[[SRC_BASE]], %[[SRC_ADDR]], %[[DST_L1]], %[[TRID]], %[[NOC_IDX]]) : (i32, i32, i32, i32, i8) -> ()
-// CHECK-NEXT: emitc.verbatim "noc0.async_read_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}][}]}});" args %[[TRID]] : i32
-func.func @trid_read_path() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+// CHECK-NEXT: emitc.verbatim "noc0.async_read_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}]}});" args %[[TRID]] : i32
+func.func @trid_read_barrier_static_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
   %noc_idx = arith.constant 0 : i8
-  %x = arith.constant 0 : index
-  %y = arith.constant 1 : index
-  %dst_l1 = arith.constant 256 : i32
-  %src_base = arith.constant 1024 : i32
-  %src_addr = arith.constant 64 : i32
-  %noc_addr = "ttkernel.get_noc_addr"(%x, %y, %dst_l1) : (index, index, i32) -> !ttkernel.noc_addr
-  "ttkernel.noc_async_read_set_trid"(%trid, %noc_idx) : (i32, i8) -> ()
-  "ttkernel.noc_async_read_one_packet_with_state_with_trid"(%src_base, %src_addr, %dst_l1, %trid, %noc_idx) : (i32, i32, i32, i32, i8) -> ()
   "ttkernel.noc_async_read_barrier_with_trid"(%trid, %noc_idx) : (i32, i8) -> ()
   return
 }
@@ -36,35 +17,26 @@ func.func @trid_read_path() -> () attributes {ttkernel.thread = #ttkernel.thread
 // -----
 
 // CHECK-LABEL: func @trid_write_path
-// CHECK: emitc.verbatim "Noc noc0(0);"
-// CHECK-NEXT: emitc.verbatim "UnicastEndpoint unicast_ep;"
-// CHECK-NEXT: emitc.verbatim "Noc noc(noc_index);"
+// CHECK: emitc.verbatim "UnicastEndpoint unicast_ep;"
+// CHECK-NEXT: emitc.verbatim "Noc noc0(0);"
 // CHECK-NEXT: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
-// CHECK-NEXT: %[[MASK:.*]] = "emitc.constant"() <{value = -1 : i32}> : () -> i32
 // CHECK-NEXT: %[[NOC_IDX:.*]] = "emitc.constant"() <{value = 0 : i8}> : () -> i8
 // CHECK-NEXT: %[[X:.*]] = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
 // CHECK-NEXT: %[[Y:.*]] = "emitc.constant"() <{value = 1 : index}> : () -> !emitc.size_t
 // CHECK-NEXT: %[[DST:.*]] = "emitc.constant"() <{value = 512 : i32}> : () -> i32
 // CHECK-NEXT: %[[SIZE:.*]] = "emitc.constant"() <{value = 128 : i32}> : () -> i32
-// CHECK-NEXT: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %[[X]], %[[Y]], %[[DST]] : !emitc.size_t, !emitc.size_t, i32
-// CHECK-NEXT: %[[NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
-// CHECK-NEXT: emitc.call_opaque "noc_async_write_set_trid"(%[[TRID]], %[[NOC_IDX]]) : (i32, i8) -> ()
-// CHECK-NEXT: emitc.call_opaque "noc_async_write_one_packet_with_trid"(%[[DST]], %[[NOC_ADDR]], %[[SIZE]], %[[TRID]], %[[NOC_IDX]]) : (i32, i64, i32, i32, i8) -> ()
-// CHECK-NEXT: emitc.verbatim "noc0.async_write_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}][}]}});" args %[[TRID]] : i32
-// CHECK-NEXT: emitc.call_opaque "reset_noc_trid_barrier_counter"(%[[MASK]], %[[NOC_IDX]]) : (i32, i8) -> ()
+// CHECK-NEXT: emitc.verbatim "noc0.async_write<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(
+// CHECK-SAME: NocOptVals{{[{][{]}}.trid = {}{{[}]}}
+// CHECK-NEXT: emitc.verbatim "noc0.async_write_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}]}});" args %[[TRID]] : i32
 func.func @trid_write_path() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
-  %mask = arith.constant -1 : i32
   %noc_idx = arith.constant 0 : i8
   %x = arith.constant 0 : index
   %y = arith.constant 1 : index
   %dst = arith.constant 512 : i32
   %size = arith.constant 128 : i32
-  %noc_addr = "ttkernel.get_noc_addr"(%x, %y, %dst) : (index, index, i32) -> !ttkernel.noc_addr
-  "ttkernel.noc_async_write_set_trid"(%trid, %noc_idx) : (i32, i8) -> ()
-  "ttkernel.noc_async_write_one_packet_with_trid"(%dst, %noc_addr, %size, %trid, %noc_idx) : (i32, !ttkernel.noc_addr, i32, i32, i8) -> ()
+  ttkernel.noc_async_write_one_packet_with_trid(%dst, core[%x, %y], %dst, %size, %trid, noc %noc_idx) : (i32, index, index, i32, i32, i32, i8) -> ()
   "ttkernel.noc_async_write_barrier_with_trid"(%trid, %noc_idx) : (i32, i8) -> ()
-  "ttkernel.reset_noc_trid_barrier_counter"(%mask, %noc_idx) : (i32, i8) -> ()
   return
 }
 
@@ -75,7 +47,7 @@ func.func @trid_write_path() -> () attributes {ttkernel.thread = #ttkernel.threa
 // CHECK-LABEL: func @trid_barrier_default_noc
 // CHECK: emitc.verbatim "Noc noc(noc_index);"
 // CHECK: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
-// CHECK: emitc.verbatim "noc.async_write_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}][}]}});" args %[[TRID]] : i32
+// CHECK: emitc.verbatim "noc.async_write_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}]}});" args %[[TRID]] : i32
 func.func @trid_barrier_default_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
   "ttkernel.noc_async_write_barrier_with_trid"(%trid) : (i32) -> ()
@@ -90,7 +62,7 @@ func.func @trid_barrier_default_noc() -> () attributes {ttkernel.thread = #ttker
 // CHECK-LABEL: func @trid_barrier_dynamic_noc
 // CHECK: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
 // CHECK: %[[NOC:.*]] = emitc.cast
-// CHECK: emitc.verbatim "Noc({}).async_read_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}][}]}});" args %[[NOC]], %[[TRID]] : i8, i32
+// CHECK: emitc.verbatim "Noc({}).async_read_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}]}});" args %[[NOC]], %[[TRID]] : i8, i32
 func.func @trid_barrier_dynamic_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
   %noc_arg = arith.constant 262400 : i32

--- a/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc_negative.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc_negative.mlir
@@ -7,8 +7,14 @@ module {
   // Verify trait validation is active - bad TRID
   func.func @bad_trid() {
     %bad_trid = arith.constant 16 : i32
+    %src = arith.constant 0 : i32
+    %x = arith.constant 0 : index
+    %y = arith.constant 0 : index
+    %dst = arith.constant 0 : i32
+    %size = arith.constant 32 : i32
     // expected-error @+1 {{trid must be in [0, 15].}}
-    "ttkernel.noc_async_read_set_trid"(%bad_trid) : (i32) -> ()
+    ttkernel.noc_async_write_one_packet_with_trid(%src, core[%x, %y], %dst, %size, %bad_trid)
+      : (i32, index, index, i32, i32, i32) -> ()
     return
   }
 
@@ -17,16 +23,7 @@ module {
     %trid_ok = arith.constant 1 : i32
     %bad_noc = arith.constant 2 : i8
     // expected-error @+1 {{noc must be in [0, 1].}}
-    "ttkernel.noc_async_write_set_trid"(%trid_ok, %bad_noc) : (i32, i8) -> ()
-    return
-  }
-
-  // Verify ResetNocTridBarrierCounterOp validation is active
-  func.func @bad_noc_reset() {
-    %mask = arith.constant -1 : i32
-    %bad_noc = arith.constant 2 : i8
-    // expected-error @+1 {{noc must be in [0, 1].}}
-    "ttkernel.reset_noc_trid_barrier_counter"(%mask, %bad_noc) : (i32, i8) -> ()
+    "ttkernel.noc_async_write_barrier_with_trid"(%trid_ok, %bad_noc) : (i32, i8) -> ()
     return
   }
 }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2030,12 +2030,10 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %src_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
-      // CHECK: %[[SRC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       // CHECK: %[[SIZE:.*]] = "emitc.constant"
       %size = arith.constant 2048 : i32
-      // CHECK: emitc.call_opaque "noc_async_read_one_packet_set_state"(%[[SRC_ADDR]], %[[SIZE]])
-      "ttkernel.noc_async_read_one_packet_set_state"(%src_addr, %size) : (!ttkernel.noc_addr, i32) -> ()
+      // CHECK: emitc.verbatim "noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+      ttkernel.noc_async_read_one_packet_set_state(core[%x, %y], %temp, %size) : (index, index, i32, i32) -> ()
       return
     }
 
@@ -2044,12 +2042,11 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %src_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
-      // CHECK: %[[SRC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
       // CHECK: %[[DST_ADDR:.*]] = "emitc.constant"
       %dst_addr = arith.constant 327680 : i32
-      // CHECK: emitc.call_opaque "noc_async_read_one_packet_with_state"(%[[SRC_ADDR]], %[[DST_ADDR]])
-      "ttkernel.noc_async_read_one_packet_with_state"(%src_addr, %dst_addr) : (!ttkernel.noc_addr, i32) -> ()
+      %size = arith.constant 2048 : i32
+      // CHECK: emitc.verbatim "noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+      ttkernel.noc_async_read_one_packet_with_state(core[%x, %y], %temp, %dst_addr, %size) : (index, index, i32, i32, i32) -> ()
       // TODO: test %dst_addr of type TTKernel_L1Addr?
       return
     }
@@ -2458,17 +2455,15 @@ module {
       %noc_x = arith.constant 1 : index
       %noc_y = arith.constant 1 : index
       %dst_addr = arith.constant 262400 : i32
-      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %[[NOC_X]], %[[NOC_Y]], %[[DST_ADDR]]
-      // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
-      %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %dst_addr) : (index, index, i32) -> !ttkernel.noc_addr
       // CHECK-DAG: %[[VAL:.*]] = "emitc.constant"() <{value = 7 : i32}> : () -> i32
       // CHECK-DAG: %[[BE:.*]] = "emitc.constant"() <{value = 15 : i8}> : () -> i8
       // CHECK-DAG: %[[NOC:.*]] = "emitc.constant"() <{value = 1 : i8}> : () -> i8
       %val = arith.constant 7 : i32
       %be = arith.constant 15 : i8
       %noc = arith.constant 1 : i8
-      // CHECK: emitc.call_opaque "noc_inline_dw_write"(%[[DST_NOC_ADDR]], %[[VAL]], %[[BE]], %[[NOC]]) {template_args = [#emitc.opaque<"InlineWriteDst::L1">]}
-      ttkernel.noc_inline_dw_write(%dst_noc_addr, %val, %be, %noc) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
+      // CHECK: emitc.verbatim "noc1.inline_dw_write<NocOptions::INLINE_L1>(
+      // CHECK-SAME: args %[[VAL]], %[[NOC_X]], %[[NOC_Y]], %[[DST_ADDR]], %[[BE]]
+      ttkernel.noc_inline_dw_write(core[%noc_x, %noc_y], %dst_addr, %val, %be, noc %noc) : (index, index, i32, i32, i8, i8) -> ()
       return
     }
 
@@ -2551,30 +2546,24 @@ module {
       return
     }
 
-    // CHECK-LABEL: func @interleaved_addr_gen_fast_funcs
-    func.func @interleaved_addr_gen_fast_funcs() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
-      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
-      // CHECK: %[[DATA_FORMAT:.*]]= emitc.call_opaque "get_dataformat"
-      %data_format = "ttkernel.get_dataformat"(%cb) : (!cb0_tiles) -> !ttkernel.DataFormat
-      // CHECK: = "emitc.constant"() <{value = true}>
+    // CHECK-LABEL: func @tensor_accessor_tile_noc
+    func.func @tensor_accessor_tile_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      %cta_offset = arith.constant 2 : i32
+      %crta_offset = arith.constant 0 : i32
       // CHECK: %[[TEMP_ADDR:.*]] = "emitc.constant"()
       // CHECK: %[[TILE_SIZE:.*]] = "emitc.constant"()
       // CHECK: %[[TILE:.*]] = "emitc.constant"()
-      %is_dram = arith.constant 1 : i1
       %temp_addr = arith.constant 262400 : i32
       %tile_size = arith.constant 8 : i32
       %tile = arith.constant 1 : i32
-      // CHECK: emitc.verbatim "InterleavedAddrGenFast<true> [[ADDR_GEN_VAR:interleaved_addr_gen_[0-9]+]];"
-      // CHECK: emitc.verbatim "[[ADDR_GEN_VAR]].bank_base_address = {};" args %[[TEMP_ADDR]]
-      // CHECK: emitc.verbatim "[[ADDR_GEN_VAR]].page_size = {};" args %[[TILE_SIZE]]
-      // CHECK: emitc.verbatim "[[ADDR_GEN_VAR]].data_format = {};" args %[[DATA_FORMAT]]
-      // CHECK: %[[ADDR_GEN:.*]] = emitc.literal "[[ADDR_GEN_VAR]]" : !emitc.opaque<"InterleavedAddrGenFast<true>">
-      %s = "ttkernel.get_interleaved_addr_gen_fast"(%is_dram, %temp_addr, %tile_size, %data_format) : (i1, i32, i32, !ttkernel.DataFormat) -> !ttkernel.interleaved_addr_gen_fast
-      // CHECK: emitc.call_opaque "noc_async_write_tile"(%[[TILE]], %[[ADDR_GEN]], %[[TEMP_ADDR]])
-      "ttkernel.noc_async_write_tile"(%tile, %s, %temp_addr) : (i32, !ttkernel.interleaved_addr_gen_fast, i32) -> ()
-      // CHECK: emitc.call_opaque "noc_async_read_tile"(%[[TILE]], %[[ADDR_GEN]], %[[TEMP_ADDR]])
-      "ttkernel.noc_async_read_tile"(%tile, %s, %temp_addr) : (i32, !ttkernel.interleaved_addr_gen_fast, i32) -> ()
+      // CHECK: emitc.verbatim "auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();"
+      %tensor_accessor_args = ttkernel.TensorAccessorArgs(%cta_offset, %crta_offset)
+      // CHECK: %[[ACCESSOR:.*]] = emitc.call_opaque "TensorAccessor"
+      %s = "ttkernel.TensorAccessor"(%tensor_accessor_args, %temp_addr, %tile_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
+      // CHECK: emitc.verbatim "noc.async_write(CoreLocalMem<uint32_t>({}), {}, {}.get_aligned_page_size()
+      "ttkernel.noc_async_write_tile"(%tile, %s, %temp_addr) : (i32, !ttkernel.TensorAccessor, i32) -> ()
+      // CHECK: emitc.verbatim "noc.async_read({}, CoreLocalMem<uint32_t>({}), {}.get_aligned_page_size()
+      "ttkernel.noc_async_read_tile"(%tile, %s, %temp_addr) : (i32, !ttkernel.TensorAccessor, i32) -> ()
       return
     }
 
@@ -2823,25 +2812,6 @@ module {
       // CHECK: %[[TA:.*]] = emitc.call_opaque "TensorAccessor"(%[[OVERRIDE_LIT]], %[[BANK_ADDR]], %[[PAGE_SIZE]]) : (!emitc.opaque<"TensorAccessorArgs">, i32, i32) -> !emitc.opaque<"TensorAccessor">
       %tensor_accessor = "ttkernel.TensorAccessor"(%args_override, %bank_address, %page_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
 
-      return
-    }
-
-    // CHECK-LABEL: func @interleaved_addr_gen
-    func.func @interleaved_addr_gen() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
-      %data_format = "ttkernel.get_dataformat"(%cb) : (!cb0_tiles) -> !ttkernel.DataFormat
-
-      %is_dram = arith.constant 1 : i1
-      %bank_address = arith.constant 303104 : i32
-      %page_size = arith.constant 32 : i32
-
-      %interleaved_addr_gen = "ttkernel.get_interleaved_addr_gen_fast"(%is_dram, %bank_address, %page_size, %data_format) : (i1, i32, i32, !ttkernel.DataFormat) -> !ttkernel.interleaved_addr_gen_fast
-
-      %temp1 = arith.constant 0 : i32
-      %temp2 = arith.constant 32: i32
-      // CHECK: emitc.verbatim "uint64_t [[NOC_ADDR:.*]] = {}.get_noc_addr({}, {});" args
-      // CHECK: emitc.literal "[[NOC_ADDR]]" : i64
-      %noc_addr = "ttkernel.interleaved_addr_gen_fast.get_noc_addr"(%interleaved_addr_gen, %temp1, %temp2) : (!ttkernel.interleaved_addr_gen_fast, i32, i32) -> !ttkernel.noc_addr
       return
     }
 

--- a/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
+++ b/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
@@ -120,10 +120,10 @@ func.func @test_write_barrier_with_intervening_write(
 
 // CHECK-LABEL: func.func @test_write_barrier_with_intervening_inline_write
 func.func @test_write_barrier_with_intervening_inline_write(
-    %noc_addr: !ttkernel.noc_addr, %val: i32, %byte_enable: i8, %noc_id: i8) {
+    %x: index, %y: index, %dst_addr: i32, %val: i32, %byte_enable: i8, %noc_id: i8) {
   // CHECK: ttkernel.noc_async_write_barrier
   ttkernel.noc_async_write_barrier() : () -> ()
-  ttkernel.noc_inline_dw_write(%noc_addr, %val, %byte_enable, %noc_id) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
+  ttkernel.noc_inline_dw_write(core[%x, %y], %dst_addr, %val, %byte_enable, noc %noc_id) : (index, index, i32, i32, i8, i8) -> ()
   // CHECK: ttkernel.noc_async_write_barrier
   ttkernel.noc_async_write_barrier() : () -> ()
   // CHECK: return

--- a/test/ttmlir/Dialect/TTKernel/invalid.mlir
+++ b/test/ttmlir/Dialect/TTKernel/invalid.mlir
@@ -1,11 +1,17 @@
 // RUN: ttmlir-opt --split-input-file --verify-diagnostics %s
 
-// Test TTKernelTridNocOpTrait validation - bad TRID (read op).
+// Test TTKernelTridNocOpTrait validation - bad TRID.
 module {
   %minus_one = arith.constant -1 : i32
   %noc0 = arith.constant 0 : i8
+  %src = arith.constant 0 : i32
+  %x = arith.constant 0 : index
+  %y = arith.constant 0 : index
+  %dst = arith.constant 0 : i32
+  %size = arith.constant 32 : i32
   // expected-error @+1 {{trid must be in [0, 15].}}
-  ttkernel.noc_async_read_set_trid(%minus_one, %noc0) : (i32, i8) -> ()
+  ttkernel.noc_async_write_one_packet_with_trid(%src, core[%x, %y], %dst, %size, %minus_one, noc %noc0)
+      : (i32, index, index, i32, i32, i32, i8) -> ()
 }
 
 // -----
@@ -25,18 +31,7 @@ module {
   %trid = arith.constant 0 : i32
   %two_i8 = arith.constant 2 : i8
   // expected-error @+1 {{noc must be in [0, 1].}}
-  ttkernel.noc_async_read_one_packet_with_state_with_trid(%trid, %trid, %trid, %trid, %two_i8)
-      : (i32, i32, i32, i32, i8) -> ()
-}
-
-// -----
-
-// Test ResetNocTridBarrierCounterOp validation - bad NOC.
-module {
-  %mask = arith.constant -1 : i32
-  %bad_noc = arith.constant 2 : i8
-  // expected-error @+1 {{noc must be in [0, 1].}}
-  ttkernel.reset_noc_trid_barrier_counter(%mask, %bad_noc) : (i32, i8) -> ()
+  ttkernel.noc_async_read_barrier_with_trid(%trid, %two_i8) : (i32, i8) -> ()
 }
 
 // -----
@@ -207,15 +202,17 @@ func.func @test_noc_semaphore_inc_wrong_addr_type() {
 // NocInlineDwWriteOp type-constraint tests.
 //===----------------------------------------------------------------------===//
 
-// Test: $dst_noc_addr must be !ttkernel.noc_addr.
-func.func @test_noc_inline_dw_write_wrong_dst_type() {
+// Test: $dstNocX must be index-like.
+func.func @test_noc_inline_dw_write_wrong_dst_x_type() {
   // expected-note @below {{prior use here}}
-  %bad_dst = arith.constant 0 : i32
+  %bad_x = arith.constant 0 : i64
+  %y = arith.constant 0 : index
+  %dst = arith.constant 0 : i32
   %val = arith.constant 1 : i32
   %be = arith.constant 15 : i8
   %noc = arith.constant 0 : i8
-  // expected-error @below {{use of value '%bad_dst' expects different type than prior uses: '!ttkernel.noc_addr' vs 'i32'}}
-  "ttkernel.noc_inline_dw_write"(%bad_dst, %val, %be, %noc) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
+  // expected-error @below {{use of value '%bad_x' expects different type than prior uses: 'index' vs 'i64'}}
+  "ttkernel.noc_inline_dw_write"(%bad_x, %y, %dst, %val, %be, %noc) : (index, index, i32, i32, i8, i8) -> ()
   return
 }
 
@@ -226,13 +223,12 @@ func.func @test_noc_inline_dw_write_wrong_val_type() {
   %x = arith.constant 1 : index
   %y = arith.constant 1 : index
   %off = arith.constant 0 : i32
-  %dst = "ttkernel.get_noc_addr"(%x, %y, %off) : (index, index, i32) -> (!ttkernel.noc_addr)
   // expected-note @below {{prior use here}}
   %bad_val = arith.constant 1 : i64
   %be = arith.constant 15 : i8
   %noc = arith.constant 0 : i8
   // expected-error @below {{use of value '%bad_val' expects different type than prior uses: 'i32' vs 'i64'}}
-  "ttkernel.noc_inline_dw_write"(%dst, %bad_val, %be, %noc) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
+  "ttkernel.noc_inline_dw_write"(%x, %y, %off, %bad_val, %be, %noc) : (index, index, i32, i32, i8, i8) -> ()
   return
 }
 
@@ -243,13 +239,12 @@ func.func @test_noc_inline_dw_write_wrong_byte_enable_type() {
   %x = arith.constant 1 : index
   %y = arith.constant 1 : index
   %off = arith.constant 0 : i32
-  %dst = "ttkernel.get_noc_addr"(%x, %y, %off) : (index, index, i32) -> (!ttkernel.noc_addr)
   %val = arith.constant 1 : i32
   // expected-note @below {{prior use here}}
   %bad_be = arith.constant 15 : i32
   %noc = arith.constant 0 : i8
   // expected-error @below {{use of value '%bad_be' expects different type than prior uses: 'i8' vs 'i32'}}
-  "ttkernel.noc_inline_dw_write"(%dst, %val, %bad_be, %noc) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
+  "ttkernel.noc_inline_dw_write"(%x, %y, %off, %val, %bad_be, %noc) : (index, index, i32, i32, i8, i8) -> ()
   return
 }
 
@@ -260,13 +255,12 @@ func.func @test_noc_inline_dw_write_wrong_noc_id_type() {
   %x = arith.constant 1 : index
   %y = arith.constant 1 : index
   %off = arith.constant 0 : i32
-  %dst = "ttkernel.get_noc_addr"(%x, %y, %off) : (index, index, i32) -> (!ttkernel.noc_addr)
   %val = arith.constant 1 : i32
   %be = arith.constant 15 : i8
   // expected-note @below {{prior use here}}
   %bad_noc = arith.constant 0 : i32
   // expected-error @below {{use of value '%bad_noc' expects different type than prior uses: 'i8' vs 'i32'}}
-  "ttkernel.noc_inline_dw_write"(%dst, %val, %be, %bad_noc) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
+  "ttkernel.noc_inline_dw_write"(%x, %y, %off, %val, %be, %bad_noc) : (index, index, i32, i32, i8, i8) -> ()
   return
 }
 

--- a/test/ttmlir/Dialect/TTKernel/ops.mlir
+++ b/test/ttmlir/Dialect/TTKernel/ops.mlir
@@ -123,8 +123,8 @@ func.func @test_copy_dest_values() -> () {
 // CHECK-LABEL: func.func @test_noc_trid_and_noc_nonconst
 // CHECK-SAME: (%[[TRID:.*]]: i32, %[[NOC:.*]]: i8)
 func.func @test_noc_trid_and_noc_nonconst(%trid: i32, %noc: i8) {
-  // CHECK: ttkernel.noc_async_read_set_trid(%[[TRID]], %[[NOC]]) : (i32, i8) -> ()
-  ttkernel.noc_async_read_set_trid(%trid, %noc) : (i32, i8) -> ()
+  // CHECK: ttkernel.noc_async_read_barrier_with_trid(%[[TRID]], %[[NOC]]) : (i32, i8) -> ()
+  ttkernel.noc_async_read_barrier_with_trid(%trid, %noc) : (i32, i8) -> ()
   return
 }
 
@@ -198,14 +198,12 @@ func.func @test_tensor_accessor_args_chaining_with_crta_override() -> !ttkernel.
   return %args2 : !ttkernel.TensorAccessorArgs
 }
 
-// CHECK-LABEL: func.func @test_noc_trid_with_implicit_noc
-// CHECK-SAME: (%[[TRID:.*]]: i32)
-func.func @test_noc_trid_with_implicit_noc(%trid: i32) {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: ttkernel.noc_async_read_one_packet_with_state_with_trid(%[[C0]], %[[C0]], %[[C0]], %[[TRID]]) : (i32, i32, i32, i32) -> ()
-  %c0 = arith.constant 0 : i32
-  "ttkernel.noc_async_read_one_packet_with_state_with_trid"(%c0, %c0, %c0, %trid)
-      : (i32, i32, i32, i32) -> ()
+// CHECK-LABEL: func.func @test_noc_write_one_packet_with_trid_implicit_noc
+// CHECK-SAME: (%[[TRID:.*]]: i32, %[[SRC:.*]]: i32, %[[X:.*]]: index, %[[Y:.*]]: index, %[[DST:.*]]: i32, %[[SIZE:.*]]: i32)
+func.func @test_noc_write_one_packet_with_trid_implicit_noc(%trid: i32, %src: i32, %x: index, %y: index, %dst: i32, %size: i32) {
+  // CHECK: ttkernel.noc_async_write_one_packet_with_trid(%[[SRC]], core[%[[X]], %[[Y]]], %[[DST]], %[[SIZE]], %[[TRID]]) : (i32, index, index, i32, i32, i32) -> ()
+  ttkernel.noc_async_write_one_packet_with_trid(%src, core[%x, %y], %dst, %size, %trid)
+      : (i32, index, index, i32, i32, i32) -> ()
   return
 }
 
@@ -230,10 +228,10 @@ func.func @test_remote_sram_write_u32_computed_sram_addr(%base: i32, %dst: !ttke
 }
 
 // CHECK-LABEL: func.func @test_noc_inline_dw_write
-// CHECK-SAME: (%[[DST:.*]]: !ttkernel.noc_addr, %[[VAL:.*]]: i32, %[[BE:.*]]: i8, %[[NOC:.*]]: i8)
-func.func @test_noc_inline_dw_write(%dst: !ttkernel.noc_addr, %val: i32, %be: i8, %noc: i8) {
-  // CHECK: ttkernel.noc_inline_dw_write(%[[DST]], %[[VAL]], %[[BE]], %[[NOC]]) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
-  ttkernel.noc_inline_dw_write(%dst, %val, %be, %noc) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
+// CHECK-SAME: (%[[X:.*]]: index, %[[Y:.*]]: index, %[[DST:.*]]: i32, %[[VAL:.*]]: i32, %[[BE:.*]]: i8, %[[NOC:.*]]: i8)
+func.func @test_noc_inline_dw_write(%x: index, %y: index, %dst: i32, %val: i32, %be: i8, %noc: i8) {
+  // CHECK: ttkernel.noc_inline_dw_write(core[%[[X]], %[[Y]]], %[[DST]], %[[VAL]], %[[BE]], noc %[[NOC]]) : (index, index, i32, i32, i8, i8) -> ()
+  ttkernel.noc_inline_dw_write(core[%x, %y], %dst, %val, %be, noc %noc) : (index, index, i32, i32, i8, i8) -> ()
   return
 }
 

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -65,8 +65,8 @@ func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<n
     %inline_value = arith.constant 7 : i32
     %be = arith.constant 15 : i8
     %noc = arith.constant 1 : i8
-    // CHECK: noc_inline_dw_write<InlineWriteDst::L1>([[NOCADDR1]], [[INLINE_VALUE]], [[BE]], [[NOC]])
-    ttkernel.noc_inline_dw_write(%4, %inline_value, %be, %noc) : (!ttkernel.noc_addr, i32, i8, i8) -> ()
+    // CHECK: noc1.inline_dw_write<NocOptions::INLINE_L1>([[EP1]], [[INLINE_VALUE]]
+    ttkernel.noc_inline_dw_write(core[%c0_idx, %c0_idx], %c262208_i32, %inline_value, %be, noc %noc) : (index, index, i32, i32, i8, i8) -> ()
     // CHECK: [[NOC1]].async_atomic_barrier()
     ttkernel.noc_async_atomic_barrier() : () -> ()
     // CHECK: noc1.async_atomic_barrier()
@@ -95,6 +95,65 @@ func.func @ttkernel_noc_with_noc_id() -> () attributes {ttkernel.thread = #ttker
     ttkernel.noc_async_read_barrier(%noc_id) : (i8) -> ()
     // CHECK: [[EXPLICIT_NOC]].async_write_barrier()
     ttkernel.noc_async_write_barrier(%noc_id) : (i8) -> ()
+    // CHECK: return
+    func.return
+}
+
+// Render the non-D2M NoC emissions (stateful one-packet, TRID write/barrier,
+// multicast one-packet, tile read/write) all the way to C++ so that brace
+// balance in the emitted OO calls is actually checked. Checking the verbatim
+// format string alone cannot catch a malformed `NocOptVals{...}}` because the
+// `}}` is only collapsed at C++ rendering time, not in the verbatim op.
+// CHECK: void kernel_main
+func.func @ttkernel_noc_oo_render() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+    // CHECK-DAG: UnicastEndpoint [[EP:unicast_ep]]
+    // CHECK-DAG: MulticastEndpoint [[MEP:mcast_ep]]
+    // CHECK-DAG: Noc [[NOC:noc]]
+    %trid = arith.constant 3 : i32
+    %x = arith.constant 0 : index
+    %y = arith.constant 1 : index
+    %addr = arith.constant 512 : i32
+    %size = arith.constant 128 : i32
+    %dstl1 = arith.constant 262400 : i32
+    %num = arith.constant 7 : i32
+    %xe = arith.constant 3 : index
+    %ye = arith.constant 3 : index
+
+    // CHECK: [[NOC]].set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>([[EP]], {{.*}}, {.noc_x = {{.*}}, .noc_y = {{.*}}, .addr = static_cast<uint32_t>({{.*}})});
+    ttkernel.noc_async_read_one_packet_set_state(core[%x, %y], %addr, %size) : (index, index, i32, i32) -> ()
+
+    // CHECK: [[NOC]].async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>([[EP]], CoreLocalMem<uint32_t>({{.*}}), {{.*}}, {.noc_x = {{.*}}, .noc_y = {{.*}}, .addr = static_cast<uint32_t>({{.*}})}, {});
+    ttkernel.noc_async_read_one_packet_with_state(core[%x, %y], %addr, %dstl1, %size) : (index, index, i32, i32, i32) -> ()
+
+    // The TRID write must close with a single balanced `NocOptVals{...}`.
+    // CHECK: [[NOC]].async_write<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(CoreLocalMem<uint32_t>({{.*}}), [[EP]], {{.*}}, {} , {.noc_x = {{.*}}, .noc_y = {{.*}}, .addr = static_cast<uint32_t>({{.*}})}, NocOptVals{.trid = {{[^}]*}}});
+    ttkernel.noc_async_write_one_packet_with_trid(%dstl1, core[%x, %y], %addr, %size, %trid) : (i32, index, index, i32, i32, i32) -> ()
+
+    // CHECK: [[NOC]].async_write_multicast<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(CoreLocalMem<uint32_t>({{.*}}), [[MEP]], {{.*}}, {{.*}}, {} , noc_traits_t<MulticastEndpoint>::dst_args_mcast_type{.noc_x_start = {{.*}}, .noc_y_start = {{.*}}, .noc_x_end = {{.*}}, .noc_y_end = {{.*}}, .addr = static_cast<uint32_t>({{.*}})}, false);
+    ttkernel.noc_async_write_multicast_one_packet(%dstl1, %size, %num, start_xy[%x, %y], end_xy[%xe, %ye], %addr) : (i32, i32, i32, index, index, index, index, i32) -> ()
+
+    // The TRID barrier must close with a single balanced `NocOptVals{...}`.
+    // CHECK: [[NOC]].async_read_barrier<NocOptions::TXN_ID>(NocOptVals{.trid = {{[^}]*}}});
+    ttkernel.noc_async_read_barrier_with_trid(%trid) : (i32) -> ()
+    // CHECK: return
+    func.return
+}
+
+// CHECK: void kernel_main
+func.func @ttkernel_noc_oo_tile_render() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+    // CHECK: Noc [[NOC:noc]]
+    %cta = arith.constant 2 : i32
+    %crta = arith.constant 0 : i32
+    %addr = arith.constant 262400 : i32
+    %tile_size = arith.constant 8 : i32
+    %tile = arith.constant 1 : i32
+    %args = ttkernel.TensorAccessorArgs(%cta, %crta)
+    // CHECK: TensorAccessor [[ACC:v[0-9]+]] = TensorAccessor(
+    %s = "ttkernel.TensorAccessor"(%args, %addr, %tile_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
+    // CHECK: [[NOC]].async_read([[ACC]], CoreLocalMem<uint32_t>({{.*}}), [[ACC]].get_aligned_page_size(), {.page_id = static_cast<uint32_t>({{.*}})}, {});
+    "ttkernel.noc_async_read_tile"(%tile, %s, %addr) : (i32, !ttkernel.TensorAccessor, i32) -> ()
+    // CHECK: [[NOC]].async_write(CoreLocalMem<uint32_t>({{.*}}), [[ACC]], [[ACC]].get_aligned_page_size(), {} , {.page_id = static_cast<uint32_t>({{.*}})});
+    "ttkernel.noc_async_write_tile"(%tile, %s, %addr) : (i32, !ttkernel.TensorAccessor, i32) -> ()
     // CHECK: return
     func.return
 }

--- a/tools/pykernel/_src/kernel_op.py
+++ b/tools/pykernel/_src/kernel_op.py
@@ -8,7 +8,6 @@ from collections import namedtuple
 
 from .kernel_types import *
 
-
 # Import ttnn for only the op.py module
 try:
     import ttnn
@@ -31,7 +30,6 @@ class PyKernelOp:
         """Initialize the PyKernelOp with an empty kernel selection dictionary. Intakes the `ttnn` module to operate."""
         self.kernel_selection = {}
         self.kernel_cache = {}
-        self.tensor_accessor_config = 0
 
         # Keep a mobile statewise reference to the ttnn module
         if isinstance(ttnn, Exception):
@@ -87,31 +85,55 @@ class PyKernelOp:
         core = self.ttnn.CoreCoord(0, 0)
         return self.ttnn.CoreRangeSet([self.ttnn.CoreRange(core, core)])
 
-    def set_tensor_accessor_config(self, tensors):
-        """
-        Set the tensor accessor config based on the passed tensors.
-        Right now, the only relevant flags are IsDram and Sharded.
-        """
-        config = TensorAccessorConfig.NONE
-        if not tensors:
-            raise ValueError("Must provide at least one tensor.")
-        if not isinstance(tensors, (list, tuple)):
-            tensors = [tensors]
-        memory_config = tensors[0].memory_config()
-
+    def _get_tensor_accessor_config(self, tensor):
+        config = TensorAccessorConfig.NONE.value
+        memory_config = tensor.memory_config()
         if memory_config.buffer_type == self.ttnn.BufferType.DRAM:
-            config |= TensorAccessorConfig.IsDram
+            config |= TensorAccessorConfig.IsDram.value
         if memory_config.is_sharded():
-            config |= TensorAccessorConfig.Sharded
+            config |= TensorAccessorConfig.Sharded.value
 
-        self.tensor_accessor_config = config
+        return config
+
+    def _get_tensor_accessor_configs(self, tensors_or_configs):
+        if tensors_or_configs is None:
+            return []
+        if not isinstance(tensors_or_configs, (list, tuple)):
+            tensors_or_configs = [tensors_or_configs]
+
+        configs = []
+        for tensor_or_config in tensors_or_configs:
+            if isinstance(tensor_or_config, TensorAccessorConfig):
+                configs.append(tensor_or_config.value)
+            elif isinstance(tensor_or_config, int):
+                configs.append(tensor_or_config)
+            else:
+                configs.append(self._get_tensor_accessor_config(tensor_or_config))
+
+        return configs
 
     def _compute_input_hash(self, tensors, options):
         """Compute a hash of the input tensors and compile-time options."""
         # Simplified implementation - should be enhanced for production
-        hash_input = str(
-            [(getattr(t, "shape", None), getattr(t, "dtype", None)) for t in tensors]
-        )
+        tensor_metadata = []
+        for tensor in tensors:
+            memory_config = (
+                tensor.memory_config() if hasattr(tensor, "memory_config") else None
+            )
+            memory_metadata = None
+            if memory_config is not None:
+                memory_metadata = (
+                    getattr(memory_config, "buffer_type", None),
+                    memory_config.is_sharded(),
+                )
+            tensor_metadata.append(
+                (
+                    getattr(tensor, "shape", None),
+                    getattr(tensor, "dtype", None),
+                    memory_metadata,
+                )
+            )
+        hash_input = str(tensor_metadata)
         hash_input += str(options)
         return hashlib.md5(hash_input.encode()).hexdigest()
 
@@ -235,7 +257,9 @@ class PyKernelOp:
 
     # Use common runtime args for scalars, otherwise use arg_val for list of lists and template function to resolve this.
     # Who knew function signature theory and resolution order would be relevant one day
-    def create_kernel(self, kernel, *args, core_ranges=None, **kwargs):
+    def create_kernel(
+        self, kernel, *args, core_ranges=None, tensor_accessor_configs=None, **kwargs
+    ):
         # Resolve core_ranges
         core_ranges = self.get_core_ranges(core_ranges)
 
@@ -290,6 +314,9 @@ class PyKernelOp:
 
                 arg_idx += 1
 
+        accessor_config_args = self._get_tensor_accessor_configs(
+            tensor_accessor_configs
+        )
         ct_const_args = self.make_ct_args(**kwargs)
 
         if rt_args is None:
@@ -307,7 +334,7 @@ class PyKernelOp:
         kernel_path = kernel_t.dump_to_file()
 
         config = self._config_from_thread_type(kernel._decorator_name)
-        compile_time_args = [cb.cb_id for cb in cb_args] + [self.tensor_accessor_config]
+        compile_time_args = [cb.cb_id for cb in cb_args] + accessor_config_args
 
         kernel_desc_args = {
             "kernel_source": kernel_path,


### PR DESCRIPTION
### Problem description
Migrate the remaining `noc_*` API, as well as the `inline_dw_write` op, to the new OO interface.

Generally speaking:
- Ops that do not have a direct equivalent are either reproduced with the new API, or removed if there's no actual user.
- Some TTKernel NoC op signatures are changed to match the OO interface's style. 
- Single packet reads/writes requires setting `max_page_size == NOC_MAX_BURST_SIZE` in the template.
- TRID usage means setting `NocOptions::TXN_ID` in the template and passing `NocOptVals{.trid = X}` to the method arguments.
- The compiler does not check if the stateful NoC ops are matching, it assumes the input IR is correct at each stage.

Plan for specific ops:
- `reset_noc_trid_barrier_counter`
  - Deleted: no equivalent and not needed in the new API.
- `noc_async_read_set_trid` & `noc_async_write_set_trid`
  - `Noc::set_async_{read,write}_state<NocOptions::TXN_ID>(..., NocOptVals{.trid = X})`.
  - Deleted: no user, support will be added back in a future refactor of the TTKernel dialect.
- `noc_async_read_one_packet_set_state`
  - `Noc::set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(...)`.
- `noc_async_read_one_packet_with_state`
  - `Noc::async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(...)`.
  - Op signature extended to include XY/Bank, plus transfer size.
- `noc_async_read_one_packet_with_state_with_trid`
  - `Noc::async_read_with_state<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(..., NocOptVals{.trid = X})`.
  - Deleted: no user, support will be added back in a future refactor of the TTKernel dialect.
- `noc_async_write_one_packet_with_trid`
  - `Noc::async_read_with_state<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(..., NocOptVals{.trid = X})`.
  - Op signature extended to include XY/Bank.
- `noc_async_read_tile` & `noc_async_write_tile`
  - `Noc::async_{read,write}(...)`.
  - For `TensorAccessor`, use transfer size `ta.get_aligned_page_size()` and include `api/tensor/noc_traits.h` in the kernel.
  - These ops longer support `InterleavedAddrGenFast` as it's deprecated.
- `noc_async_write_multicast_one_packet`
  - `Noc::async_write_multicast<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(...)`.
  - Extend the TTKernel op signature to accept XY coordinates like the simpler multicast op.
- `noc_inline_dw_write`
  - `Noc::inline_dw_write<NocOptions::INLINE_L1>(...)` (L1-only for now).
- `get_interleaved_addr_gen_fast` & `InterleavedAddrGenFast<true>`
  - Deleted: they are deprecated and we shouldn't use them.

### What's changed

TTKernel dialect:
- The `noc_async_{read,write}_tile` ops now accept `TensorAccessor` exclusively.
- The stateful/TRID/inline NoC ops now take explicit core/bank, explicit transfer size.
- The `noc_async_write_multicast_one_packet` now take explicit start/end coordinates.
- Reduced usage of `TTKernel_NocAddr` because the new API takes local L1 addresses and do conversion internally.
- Removed deprecated ops & definitions.

Op verifiers:
- Added for `noc_async_read_one_packet_{set,with}_state` & `noc_async_write_one_packet_with_trid` to ensure exactly one type of endpoint (core/bank) is specified.
- Deleted the removed TRID ops from the canonicalization patterns for `noc_async_{read,write}_barrier`.

The `TTKernelToEmitC` pass:
- Added a new `emitNocEndpoint()` helper for core/dram endpoint emission.
- Added several `OpConversionPattern` rewriters for the migrated NoC ops.
  - Emit the appropriate template argument enum `NocOptions` and method argument struct `NocOptVals`.
- `TTKernelToEmitCNocAsyncWriteMulticastRewriter` was updated to specify `NOC_MAX_BURST_SIZE` for `noc_async_write_multicast_one_packet`.
- Extracted the repetitive "static-NoC guard" into a `ensureStaticNocDeclaration()` helper for ops that do not support dynamic NoC.
- Removed everything related to `InterleavedAddrGenFast`.
- Corrected a duplicate `TensorAccessorGetNocAddrOp` registration.

PyKernel:
- Replace the use of `AddrGen` with `TensorAccessor` & `TensorAccessorArgs`.
- The `IsDram` and `Sharded` booleans are passed as part of `TensorAccessorConfig` only, removed the CTA for them.
- Support passing multiple `TensorAccessorConfig`s to the same PyKernel in `PyKernelOp.create_kernel()`.
  - The kernels need to manually count the CTA base for tensor accessors, since they are after the CB IDs.
- Cast PyKernel-generated `int32_t` to `uint32_t` for `NocOptVals::page_id` in `TTKernelToEmitC` (else it causes a kernel compiler integer narrowing error).

### Checklist
- [ ] New/Existing tests provide coverage for changes
