### PR TITLE
Conv ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Conv/Conv3dOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Conv/Conv3dOp.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_CONV_CONV3DOP_H
+#define TTMLIR_OPINVOKE_TTNN_CONV_CONV3DOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/conv_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/experimental/conv3d/conv3d.hpp"
+#include "ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using Conv3dOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct Conv3dResolvedParams {
+  std::array<uint32_t, 3> kernelSize;
+  std::array<uint32_t, 3> stride;
+  std::array<uint32_t, 3> padding;
+  ::ttnn::DataType outputDtype;
+  std::optional<::ttnn::experimental::prim::Conv3dConfig> conv3dConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+Conv3dResolvedParams
+resolveConv3dParams(const ::tt::target::ttnn::Conv3dOpT &conv3dOpT,
+                    ::ttnn::MeshDevice *device);
+
+Conv3dOpResult callConv3d(CallType callType,
+                          const ::tt::target::ttnn::Conv3dOpT &conv3dOpT,
+                          TensorArg input, TensorArg weight,
+                          std::optional<TensorArg> bias,
+                          ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_CONV_CONV3DOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Conv/ConvTranspose2dOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Conv/ConvTranspose2dOp.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_CONV_CONVTRANSPOSE2DOP_H
+#define TTMLIR_OPINVOKE_TTNN_CONV_CONVTRANSPOSE2DOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/conv_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using ConvTranspose2dOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse,
+                 ::ttnn::ConvTranspose2dResultWithOptions>;
+
+struct ConvTranspose2dResolvedParams {
+  std::array<uint32_t, 2> kernelSize;
+  std::array<uint32_t, 2> stride;
+  std::array<uint32_t, 2> padding;
+  std::array<uint32_t, 2> outputPadding;
+  std::array<uint32_t, 2> dilation;
+  std::optional<::ttnn::DataType> outputDtype;
+  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
+};
+
+ConvTranspose2dResolvedParams resolveConvTranspose2dParams(
+    const ::tt::target::ttnn::ConvTranspose2dOpT &convTranspose2dOpT);
+
+ConvTranspose2dOpResult callConvTranspose2d(
+    CallType callType,
+    const ::tt::target::ttnn::ConvTranspose2dOpT &convTranspose2dOpT,
+    TensorArg input, TensorArg weight, std::optional<TensorArg> bias,
+    ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_CONV_CONVTRANSPOSE2DOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dBiasOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dBiasOp.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONV2DBIASOP_H
+#define TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONV2DBIASOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/conv_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PrepareConv2dBiasOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PrepareConv2dBiasResolvedParams {
+  ::ttnn::MemoryConfig inputMemoryConfig;
+  ::ttnn::Layout inputLayout;
+  std::array<uint32_t, 2> kernelSize;
+  std::array<uint32_t, 2> stride;
+  std::array<uint32_t, 2> dilation;
+  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
+  ::ttnn::DataType inputDtype;
+  std::optional<::ttnn::DataType> outputDtype;
+  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
+};
+
+PrepareConv2dBiasResolvedParams resolvePrepareConv2dBiasParams(
+    const ::tt::target::ttnn::PrepareConv2dBiasOpT &op);
+
+PrepareConv2dBiasOpResult
+callPrepareConv2dBias(CallType callType,
+                      const ::tt::target::ttnn::PrepareConv2dBiasOpT &op,
+                      TensorArg biasTensor, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONV2DBIASOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dWeightsOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dWeightsOp.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONV2DWEIGHTSOP_H
+#define TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONV2DWEIGHTSOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/conv_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PrepareConv2dWeightsOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PrepareConv2dWeightsResolvedParams {
+  ::ttnn::MemoryConfig inputMemoryConfig;
+  ::ttnn::Layout inputLayout;
+  std::array<uint32_t, 2> kernelSize;
+  std::array<uint32_t, 2> stride;
+  std::array<uint32_t, 2> dilation;
+  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
+  ::ttnn::DataType inputDtype;
+  std::optional<::ttnn::DataType> outputDtype;
+  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
+};
+
+PrepareConv2dWeightsResolvedParams resolvePrepareConv2dWeightsParams(
+    const ::tt::target::ttnn::PrepareConv2dWeightsOpT &op);
+
+PrepareConv2dWeightsOpResult
+callPrepareConv2dWeights(CallType callType,
+                         const ::tt::target::ttnn::PrepareConv2dWeightsOpT &op,
+                         TensorArg weightTensor, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONV2DWEIGHTSOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConv3dWeightsOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConv3dWeightsOp.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONV3DWEIGHTSOP_H
+#define TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONV3DWEIGHTSOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/conv_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
+
+namespace ttnn_op_invoke {
+
+using PrepareConv3dWeightsOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PrepareConv3dWeightsResolvedParams {};
+
+PrepareConv3dWeightsResolvedParams resolvePrepareConv3dWeightsParams(
+    const ::tt::target::ttnn::PrepareConv3dWeightsOpT &op);
+
+PrepareConv3dWeightsOpResult
+callPrepareConv3dWeights(CallType callType,
+                         const ::tt::target::ttnn::PrepareConv3dWeightsOpT &op,
+                         TensorArg weightTensor, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONV3DWEIGHTSOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dBiasOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dBiasOp.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONVTRANSPOSE2DBIASOP_H
+#define TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONVTRANSPOSE2DBIASOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/conv_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PrepareConvTranspose2dBiasOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PrepareConvTranspose2dBiasResolvedParams {
+  ::ttnn::MemoryConfig inputMemoryConfig;
+  ::ttnn::Layout inputLayout;
+  std::array<uint32_t, 2> kernelSize;
+  std::array<uint32_t, 2> stride;
+  std::array<uint32_t, 2> dilation;
+  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
+  ::ttnn::DataType inputDtype;
+  std::optional<::ttnn::DataType> outputDtype;
+  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
+};
+
+PrepareConvTranspose2dBiasResolvedParams
+resolvePrepareConvTranspose2dBiasParams(
+    const ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT &op);
+
+PrepareConvTranspose2dBiasOpResult callPrepareConvTranspose2dBias(
+    CallType callType,
+    const ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT &op,
+    TensorArg biasTensor, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONVTRANSPOSE2DBIASOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dWeightsOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dWeightsOp.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONVTRANSPOSE2DWEIGHTSOP_H
+#define TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONVTRANSPOSE2DWEIGHTSOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/conv_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PrepareConvTranspose2dWeightsOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PrepareConvTranspose2dWeightsResolvedParams {
+  ::ttnn::MemoryConfig inputMemoryConfig;
+  ::ttnn::Layout inputLayout;
+  std::array<uint32_t, 2> kernelSize;
+  std::array<uint32_t, 2> stride;
+  std::array<uint32_t, 2> dilation;
+  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
+  std::array<uint32_t, 2> outputPadding;
+  ::ttnn::DataType inputDtype;
+  std::optional<::ttnn::DataType> outputDtype;
+  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
+};
+
+PrepareConvTranspose2dWeightsResolvedParams
+resolvePrepareConvTranspose2dWeightsParams(
+    const ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT &op);
+
+PrepareConvTranspose2dWeightsOpResult callPrepareConvTranspose2dWeights(
+    CallType callType,
+    const ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT &op,
+    TensorArg weightTensor, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_CONV_PREPARECONVTRANSPOSE2DWEIGHTSOP_H

--- a/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
+++ b/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
@@ -94,6 +94,80 @@ buildEltwiseUnaryCompositeClampScalarOpTFromMLIR(mlir::Attribute min,
 ::tt::target::ttnn::EltwiseUnaryCompositeOpT
 buildEltwiseUnaryCompositeClampTensorOpTFromMLIR(TTNNLayoutAttr outputLayout);
 
+::tt::target::ttnn::Conv3dOpT buildConv3dOpTFromMLIR(
+    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+    uint32_t input_depth, uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::StringRef padding_mode,
+    uint32_t groups, std::optional<ttcore::DataTypeAttr> outputDtype,
+    std::optional<Conv3dConfigAttr> conv3dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::ConvTranspose2dOpT buildConvTranspose2dOpTFromMLIR(
+    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+    uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
+    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::PrepareConv2dWeightsOpT
+buildPrepareConv2dWeightsOpTFromMLIR(
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    bool hasBias, int32_t groups, ttcore::DataType inputDtype,
+    std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::PrepareConv2dBiasOpT buildPrepareConv2dBiasOpTFromMLIR(
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT
+buildPrepareConvTranspose2dWeightsOpTFromMLIR(
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> outputPadding,
+    llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::PrepareConvTranspose2dBiasOpT
+buildPrepareConvTranspose2dBiasOpTFromMLIR(
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout);
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1357,6 +1357,7 @@ struct OpModel<ConvTranspose2dOp> {
       llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
       uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(
@@ -1370,6 +1371,7 @@ struct OpModel<ConvTranspose2dOp> {
       llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
       uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       TTNNLayoutAttr outputLayout);
 };
 
@@ -1411,6 +1413,7 @@ struct OpModel<PrepareConv2dBiasOp> {
       llvm::ArrayRef<int32_t> dilation, int32_t groups,
       ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
       std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       TTNNLayoutAttr outputLayout);
 };

--- a/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
+++ b/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
@@ -53,6 +53,26 @@ createOp(::mlir::tt::FlatbufferObjectCache &cache, LinearOp op);
 ::flatbuffers::Offset<::tt::target::ttnn::Conv2dOp>
 createOp(::mlir::tt::FlatbufferObjectCache &cache, Conv2dOp op);
 
+::flatbuffers::Offset<::tt::target::ttnn::Conv3dOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, Conv3dOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::ConvTranspose2dOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, ConvTranspose2dOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::PrepareConv2dWeightsOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, PrepareConv2dWeightsOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::PrepareConv2dBiasOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, PrepareConv2dBiasOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::PrepareConvTranspose2dWeightsOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache,
+         PrepareConvTranspose2dWeightsOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::PrepareConvTranspose2dBiasOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache,
+         PrepareConvTranspose2dBiasOp op);
+
 ::flatbuffers::Offset<::tt::target::DeviceRef>
 createDeviceRef(::mlir::tt::FlatbufferObjectCache &cache, ::mlir::Value device);
 

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3598,7 +3598,7 @@ ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
       getKernelSize(), getStride(), getPadding(), getOutputPadding(),
       getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
-      getConv2dSliceConfig(), opConfig.outputLayout);
+      getConv2dSliceConfig(), getComputeConfig(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3625,7 +3625,7 @@ ConvTranspose2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
       getKernelSize(), getStride(), getPadding(), getOutputPadding(),
       getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
-      getConv2dSliceConfig(), opConfig.outputLayout);
+      getConv2dSliceConfig(), getComputeConfig(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3678,8 +3678,8 @@ PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
       getInputWidth(), getKernelSize(), getStride(), getPadding(),
       getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
-      conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
-      opConfig.outputLayout);
+      conv2dAttrs.conv2dConfig, getConv2dSliceConfig(),
+      conv2dAttrs.deviceComputeKernelConfig, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -1,6 +1,13 @@
 add_library(TTNNOpInvokeLib STATIC
   utils/utils.cpp
   Conv/Conv2dOp.cpp
+  Conv/Conv3dOp.cpp
+  Conv/ConvTranspose2dOp.cpp
+  Conv/PrepareConv2dBiasOp.cpp
+  Conv/PrepareConv2dWeightsOp.cpp
+  Conv/PrepareConv3dWeightsOp.cpp
+  Conv/PrepareConvTranspose2dBiasOp.cpp
+  Conv/PrepareConvTranspose2dWeightsOp.cpp
   Eltwise/Binary/EltwiseBinaryCompositeOp.cpp
   Eltwise/Binary/EltwiseBinaryOp.cpp
   Eltwise/Quantization/EltwiseQuantizationOp.cpp

--- a/lib/OpInvoke/TTNN/Conv/Conv3dOp.cpp
+++ b/lib/OpInvoke/TTNN/Conv/Conv3dOp.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Conv/Conv3dOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/experimental/conv3d/conv3d.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+Conv3dResolvedParams
+resolveConv3dParams(const ::tt::target::ttnn::Conv3dOpT &conv3dOp,
+                    ::ttnn::MeshDevice *device) {
+  TT_INVOKE_ASSERT(conv3dOp.kernel_size.size() == 3,
+                   "Kernel size expected to have 3 elements");
+  TT_INVOKE_ASSERT(conv3dOp.stride.size() == 3,
+                   "Stride expected to have 3 elements");
+  TT_INVOKE_ASSERT(conv3dOp.padding.size() == 3,
+                   "Padding expected to have 3 elements");
+
+  Conv3dResolvedParams params;
+  std::copy_n(conv3dOp.kernel_size.begin(), 3, params.kernelSize.begin());
+  std::copy_n(conv3dOp.stride.begin(), 3, params.stride.begin());
+  std::copy_n(conv3dOp.padding.begin(), 3, params.padding.begin());
+
+  params.outputDtype = ::ttnn::DataType::BFLOAT16;
+  if (conv3dOp.out) {
+    params.outputDtype = operations::utils::getDataType(*conv3dOp.out);
+  } else if (conv3dOp.output_dtype.has_value()) {
+    params.outputDtype =
+        operations::utils::toTTNNDataType(*conv3dOp.output_dtype);
+  }
+
+  if (conv3dOp.compute_config) {
+    params.computeConfig = operations::utils::createDeviceComputeKernelConfig(
+        *conv3dOp.compute_config);
+  }
+
+  if (conv3dOp.conv3d_config) {
+    const auto &fbConfig = *conv3dOp.conv3d_config;
+    ::ttnn::experimental::prim::Conv3dConfig config;
+    if (fbConfig.weights_dtype.has_value()) {
+      config.weights_dtype =
+          operations::utils::toTTNNDataType(*fbConfig.weights_dtype);
+    }
+    if (fbConfig.t_out_block.has_value()) {
+      config.T_out_block = *fbConfig.t_out_block;
+    }
+    if (fbConfig.w_out_block.has_value()) {
+      config.W_out_block = *fbConfig.w_out_block;
+    }
+    if (fbConfig.h_out_block.has_value()) {
+      config.H_out_block = *fbConfig.h_out_block;
+    }
+    if (fbConfig.c_out_block.has_value()) {
+      config.C_out_block = *fbConfig.c_out_block;
+    }
+    if (fbConfig.c_in_block.has_value()) {
+      config.C_in_block = *fbConfig.c_in_block;
+    }
+    if (conv3dOp.conv3d_config->compute_with_storage_grid_size) {
+      config.compute_with_storage_grid_size =
+          operations::utils::toTTNNCoreCoord(
+              *conv3dOp.conv3d_config->compute_with_storage_grid_size);
+    } else {
+      config.compute_with_storage_grid_size =
+          device->compute_with_storage_grid_size();
+    }
+    params.conv3dConfig = config;
+  }
+
+  if (conv3dOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*conv3dOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*conv3dOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createConv3dTuple(Tag tag, const ::tt::target::ttnn::Conv3dOpT &conv3dOpT,
+                       TensorArg input, TensorArg weight,
+                       std::optional<TensorArg> bias,
+                       ::ttnn::MeshDevice *device,
+                       Conv3dResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), resolveTensorArg(weight, tag),
+      std::optional<::ttnn::MeshDevice *>(device),
+      bias ? std::make_optional(resolveTensorArg(*bias, tag)) : std::nullopt,
+      params.conv3dConfig, params.outputDtype, conv3dOpT.out_channels,
+      params.kernelSize, params.stride, params.padding,
+      std::array<uint32_t, 3>{1, 1, 1}, conv3dOpT.padding_mode,
+      conv3dOpT.groups, params.outputMemoryConfig, params.computeConfig);
+}
+
+Conv3dOpResult callConv3d(CallType callType,
+                          const ::tt::target::ttnn::Conv3dOpT &conv3dOpT,
+                          TensorArg input, TensorArg weight,
+                          std::optional<TensorArg> bias,
+                          ::ttnn::MeshDevice *device) {
+  Conv3dResolvedParams params = resolveConv3dParams(conv3dOpT, device);
+
+  auto makeTuple = [&](auto tag) {
+    return createConv3dTuple(tag, conv3dOpT, input, weight, bias, device,
+                             params);
+  };
+
+  return callOp<Conv3dOpResult>(WRAP_OP(::ttnn::experimental::conv3d), callType,
+                                makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Conv/ConvTranspose2dOp.cpp
+++ b/lib/OpInvoke/TTNN/Conv/ConvTranspose2dOp.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Conv/ConvTranspose2dOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+ConvTranspose2dResolvedParams resolveConvTranspose2dParams(
+    const ::tt::target::ttnn::ConvTranspose2dOpT &convTranspose2dOpT) {
+  TT_INVOKE_ASSERT(convTranspose2dOpT.kernel_size.size() == 2,
+                   "Kernel size expected to have 2 elements");
+  TT_INVOKE_ASSERT(convTranspose2dOpT.stride.size() == 2,
+                   "Stride expected to have 2 elements");
+  TT_INVOKE_ASSERT(convTranspose2dOpT.padding.size() == 2,
+                   "Padding expected to have 2 elements");
+  TT_INVOKE_ASSERT(convTranspose2dOpT.output_padding.size() == 2,
+                   "Output padding expected to have 2 elements");
+  TT_INVOKE_ASSERT(convTranspose2dOpT.dilation.size() == 2,
+                   "Dilation expected to have 2 elements");
+
+  ConvTranspose2dResolvedParams params;
+
+  std::copy_n(convTranspose2dOpT.kernel_size.begin(), 2,
+              params.kernelSize.begin());
+  std::copy_n(convTranspose2dOpT.stride.begin(), 2, params.stride.begin());
+  std::copy_n(convTranspose2dOpT.padding.begin(), 2, params.padding.begin());
+  std::copy_n(convTranspose2dOpT.output_padding.begin(), 2,
+              params.outputPadding.begin());
+  std::copy_n(convTranspose2dOpT.dilation.begin(), 2, params.dilation.begin());
+
+  if (convTranspose2dOpT.out) {
+    params.outputDtype =
+        operations::utils::getDataType(*convTranspose2dOpT.out);
+  } else if (convTranspose2dOpT.output_dtype.has_value()) {
+    params.outputDtype =
+        operations::utils::toTTNNDataType(*convTranspose2dOpT.output_dtype);
+  }
+
+  if (convTranspose2dOpT.conv2d_config) {
+    params.conv2dConfig = operations::utils::createConv2dConfig(
+        *convTranspose2dOpT.conv2d_config);
+  }
+
+  if (convTranspose2dOpT.compute_config) {
+    params.computeConfig = operations::utils::createDeviceComputeKernelConfig(
+        *convTranspose2dOpT.compute_config);
+  }
+
+  if (convTranspose2dOpT.conv2d_slice_config) {
+    params.sliceConfig = operations::utils::createConv2dSliceConfig(
+        *convTranspose2dOpT.conv2d_slice_config);
+  }
+
+  if (convTranspose2dOpT.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*convTranspose2dOpT.out));
+    TT_INVOKE_ASSERT(
+        operations::utils::inSystemMemory(*convTranspose2dOpT.out) ||
+            params.outputMemoryConfig.has_value(),
+        "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createConvTranspose2dTuple(
+    Tag tag, const ::tt::target::ttnn::ConvTranspose2dOpT &convTranspose2dOpT,
+    TensorArg input, TensorArg weight, std::optional<TensorArg> bias,
+    ::ttnn::MeshDevice *device, const ConvTranspose2dResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), resolveTensorArg(weight, tag), device,
+      convTranspose2dOpT.in_channels, convTranspose2dOpT.out_channels,
+      convTranspose2dOpT.batch_size, convTranspose2dOpT.input_height,
+      convTranspose2dOpT.input_width, params.kernelSize, params.stride,
+      params.padding, params.outputPadding, params.dilation,
+      convTranspose2dOpT.groups, params.outputDtype,
+      bias ? std::make_optional(resolveTensorArg(*bias, tag)) : std::nullopt,
+      params.conv2dConfig, params.computeConfig, params.outputMemoryConfig,
+      params.sliceConfig, /*mirror_kernel=*/true, /*return_output_dim*/ false,
+      /*return_weights_and_bias*/ false);
+}
+
+ConvTranspose2dOpResult callConvTranspose2d(
+    CallType callType,
+    const ::tt::target::ttnn::ConvTranspose2dOpT &convTranspose2dOpT,
+    TensorArg input, TensorArg weight, std::optional<TensorArg> bias,
+    ::ttnn::MeshDevice *device) {
+
+  ConvTranspose2dResolvedParams params =
+      resolveConvTranspose2dParams(convTranspose2dOpT);
+
+  auto makeTuple = [&](auto tag) {
+    return createConvTranspose2dTuple(tag, convTranspose2dOpT, input, weight,
+                                      bias, device, params);
+  };
+
+  return callOp<ConvTranspose2dOpResult>(WRAP_OP(::ttnn::conv_transpose2d),
+                                         callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Conv/PrepareConv2dBiasOp.cpp
+++ b/lib/OpInvoke/TTNN/Conv/PrepareConv2dBiasOp.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dBiasOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+PrepareConv2dBiasResolvedParams resolvePrepareConv2dBiasParams(
+    const ::tt::target::ttnn::PrepareConv2dBiasOpT &op) {
+  TT_INVOKE_ASSERT(op.kernel_size.size() == 2,
+                   "Kernel size expected to have 2 elements");
+  TT_INVOKE_ASSERT(op.stride.size() == 2, "Stride expected to have 2 elements");
+  TT_INVOKE_ASSERT(op.padding.size() == 2 || op.padding.size() == 4,
+                   "Padding expected to have 2 or 4 elements");
+  TT_INVOKE_ASSERT(op.dilation.size() == 2,
+                   "Dilation expected to have 2 elements");
+
+  PrepareConv2dBiasResolvedParams params;
+
+  std::copy_n(op.kernel_size.begin(), 2, params.kernelSize.begin());
+  std::copy_n(op.stride.begin(), 2, params.stride.begin());
+  std::copy_n(op.dilation.begin(), 2, params.dilation.begin());
+
+  if (op.padding.size() == 2) {
+    std::array<uint32_t, 2> symPadding;
+    std::copy_n(op.padding.begin(), 2, symPadding.begin());
+    params.padding = symPadding;
+  } else {
+    std::array<uint32_t, 4> asymPadding;
+    std::copy_n(op.padding.begin(), 4, asymPadding.begin());
+    params.padding = asymPadding;
+  }
+
+  params.inputDtype = operations::utils::toTTNNDataType(op.input_dtype);
+
+  if (op.out) {
+    params.outputDtype = operations::utils::getDataType(*op.out);
+  } else if (op.output_dtype.has_value()) {
+    params.outputDtype = operations::utils::toTTNNDataType(*op.output_dtype);
+  }
+
+  params.inputLayout = operations::utils::toTTNNLayout(op.input_tensor_layout);
+
+  TT_INVOKE_ASSERT(op.input_memory_config,
+                   "Input memory config is required for prepare_conv2d_bias");
+  std::optional<::ttnn::MemoryConfig> inputMemoryConfig =
+      operations::utils::createMemoryConfigIfNeeded(*op.input_memory_config);
+  TT_INVOKE_ASSERT(inputMemoryConfig.has_value(),
+                   "Input memory config expected to have a value");
+  params.inputMemoryConfig = *inputMemoryConfig;
+
+  if (op.conv2d_config) {
+    params.conv2dConfig =
+        operations::utils::createConv2dConfig(*op.conv2d_config);
+  }
+
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+
+  if (op.conv2d_slice_config) {
+    params.sliceConfig =
+        operations::utils::createConv2dSliceConfig(*op.conv2d_slice_config);
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPrepareConv2dBiasTuple(
+    Tag tag, const ::tt::target::ttnn::PrepareConv2dBiasOpT &op,
+    TensorArg biasTensor, ::ttnn::MeshDevice *device,
+    const PrepareConv2dBiasResolvedParams &params) {
+  return std::make_tuple(
+      *std::get<const ::ttnn::Tensor *>(biasTensor), params.inputMemoryConfig,
+      params.inputLayout, op.in_channels, op.out_channels, op.batch_size,
+      op.input_height, op.input_width, params.kernelSize, params.stride,
+      params.padding, params.dilation, op.groups, device, params.inputDtype,
+      params.outputDtype, params.conv2dConfig, params.computeConfig,
+      params.sliceConfig);
+}
+
+PrepareConv2dBiasOpResult
+callPrepareConv2dBias(CallType callType,
+                      const ::tt::target::ttnn::PrepareConv2dBiasOpT &op,
+                      TensorArg biasTensor, ::ttnn::MeshDevice *device) {
+
+  PrepareConv2dBiasResolvedParams params = resolvePrepareConv2dBiasParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createPrepareConv2dBiasTuple(tag, op, biasTensor, device, params);
+  };
+
+  return callOp<PrepareConv2dBiasOpResult, true, false>(
+      WRAP_OP(::ttnn::operations::conv::conv2d::prepare_conv_bias), callType,
+      makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Conv/PrepareConv2dWeightsOp.cpp
+++ b/lib/OpInvoke/TTNN/Conv/PrepareConv2dWeightsOp.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dWeightsOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+PrepareConv2dWeightsResolvedParams resolvePrepareConv2dWeightsParams(
+    const ::tt::target::ttnn::PrepareConv2dWeightsOpT &op) {
+  TT_INVOKE_ASSERT(op.kernel_size.size() == 2,
+                   "Kernel size expected to have 2 elements");
+  TT_INVOKE_ASSERT(op.stride.size() == 2, "Stride expected to have 2 elements");
+  TT_INVOKE_ASSERT(op.padding.size() == 2 || op.padding.size() == 4,
+                   "Padding expected to have 2 or 4 elements");
+  TT_INVOKE_ASSERT(op.dilation.size() == 2,
+                   "Dilation expected to have 2 elements");
+
+  PrepareConv2dWeightsResolvedParams params;
+
+  std::copy_n(op.kernel_size.begin(), 2, params.kernelSize.begin());
+  std::copy_n(op.stride.begin(), 2, params.stride.begin());
+  std::copy_n(op.dilation.begin(), 2, params.dilation.begin());
+
+  if (op.padding.size() == 2) {
+    std::array<uint32_t, 2> symPadding;
+    std::copy_n(op.padding.begin(), 2, symPadding.begin());
+    params.padding = symPadding;
+  } else {
+    std::array<uint32_t, 4> asymPadding;
+    std::copy_n(op.padding.begin(), 4, asymPadding.begin());
+    params.padding = asymPadding;
+  }
+
+  params.inputDtype = operations::utils::toTTNNDataType(op.input_dtype);
+
+  if (op.out) {
+    params.outputDtype = operations::utils::getDataType(*op.out);
+  } else if (op.output_dtype.has_value()) {
+    params.outputDtype = operations::utils::toTTNNDataType(*op.output_dtype);
+  }
+
+  params.inputLayout = operations::utils::toTTNNLayout(op.input_tensor_layout);
+
+  TT_INVOKE_ASSERT(
+      op.input_memory_config,
+      "Input memory config is required for prepare_conv2d_weights");
+  std::optional<::ttnn::MemoryConfig> inputMemoryConfig =
+      operations::utils::createMemoryConfigIfNeeded(*op.input_memory_config);
+  TT_INVOKE_ASSERT(inputMemoryConfig.has_value(),
+                   "Input memory config expected to have a value");
+  params.inputMemoryConfig = *inputMemoryConfig;
+
+  if (op.conv2d_config) {
+    params.conv2dConfig =
+        operations::utils::createConv2dConfig(*op.conv2d_config);
+  }
+
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+
+  if (op.conv2d_slice_config) {
+    params.sliceConfig =
+        operations::utils::createConv2dSliceConfig(*op.conv2d_slice_config);
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPrepareConv2dWeightsTuple(
+    Tag tag, const ::tt::target::ttnn::PrepareConv2dWeightsOpT &op,
+    TensorArg weightTensor, ::ttnn::MeshDevice *device,
+    const PrepareConv2dWeightsResolvedParams &params) {
+  return std::make_tuple(
+      *std::get<const ::ttnn::Tensor *>(weightTensor), params.inputMemoryConfig,
+      params.inputLayout, op.weights_format, op.in_channels, op.out_channels,
+      op.batch_size, op.input_height, op.input_width, params.kernelSize,
+      params.stride, params.padding, params.dilation, op.has_bias, op.groups,
+      device, params.inputDtype, params.outputDtype, params.conv2dConfig,
+      params.computeConfig, params.sliceConfig);
+}
+
+PrepareConv2dWeightsOpResult
+callPrepareConv2dWeights(CallType callType,
+                         const ::tt::target::ttnn::PrepareConv2dWeightsOpT &op,
+                         TensorArg weightTensor, ::ttnn::MeshDevice *device) {
+
+  PrepareConv2dWeightsResolvedParams params =
+      resolvePrepareConv2dWeightsParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createPrepareConv2dWeightsTuple(tag, op, weightTensor, device,
+                                           params);
+  };
+
+  return callOp<PrepareConv2dWeightsOpResult, true, false>(
+      WRAP_OP(::ttnn::operations::conv::conv2d::prepare_conv_weights), callType,
+      makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Conv/PrepareConv3dWeightsOp.cpp
+++ b/lib/OpInvoke/TTNN/Conv/PrepareConv3dWeightsOp.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConv3dWeightsOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+PrepareConv3dWeightsResolvedParams resolvePrepareConv3dWeightsParams(
+    const ::tt::target::ttnn::PrepareConv3dWeightsOpT &op) {
+  PrepareConv3dWeightsResolvedParams params;
+
+  return params;
+}
+
+template <typename Tag>
+auto createPrepareConv3dWeightsTuple(
+    Tag tag, const ::tt::target::ttnn::PrepareConv3dWeightsOpT &op,
+    TensorArg weightTensor, ::ttnn::MeshDevice *device,
+    const PrepareConv3dWeightsResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(weightTensor, tag), op.groups,
+                         op.c_in_block, op.alignment, device);
+}
+
+PrepareConv3dWeightsOpResult
+callPrepareConv3dWeights(CallType callType,
+                         const ::tt::target::ttnn::PrepareConv3dWeightsOpT &op,
+                         TensorArg weightTensor, ::ttnn::MeshDevice *device) {
+  PrepareConv3dWeightsResolvedParams params =
+      resolvePrepareConv3dWeightsParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createPrepareConv3dWeightsTuple(tag, op, weightTensor, device,
+                                           params);
+  };
+
+  return callOp<PrepareConv3dWeightsOpResult, false, false>(
+      WRAP_OP(::ttnn::operations::experimental::conv3d::prepare_conv3d_weights),
+      callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Conv/PrepareConvTranspose2dBiasOp.cpp
+++ b/lib/OpInvoke/TTNN/Conv/PrepareConvTranspose2dBiasOp.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dBiasOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp"
+
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+PrepareConvTranspose2dBiasResolvedParams
+resolvePrepareConvTranspose2dBiasParams(
+    const ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT &op) {
+  TT_INVOKE_ASSERT(op.kernel_size.size() == 2,
+                   "Kernel size expected to have 2 elements");
+  TT_INVOKE_ASSERT(op.stride.size() == 2, "Stride expected to have 2 elements");
+  TT_INVOKE_ASSERT(op.padding.size() == 2 || op.padding.size() == 4,
+                   "Padding expected to have 2 or 4 elements");
+  TT_INVOKE_ASSERT(op.dilation.size() == 2,
+                   "Dilation expected to have 2 elements");
+
+  PrepareConvTranspose2dBiasResolvedParams params;
+
+  std::copy_n(op.kernel_size.begin(), 2, params.kernelSize.begin());
+  std::copy_n(op.stride.begin(), 2, params.stride.begin());
+  std::copy_n(op.dilation.begin(), 2, params.dilation.begin());
+
+  if (op.padding.size() == 2) {
+    std::array<uint32_t, 2> symPadding;
+    std::copy_n(op.padding.begin(), 2, symPadding.begin());
+    params.padding = symPadding;
+  } else {
+    std::array<uint32_t, 4> asymPadding;
+    std::copy_n(op.padding.begin(), 4, asymPadding.begin());
+    params.padding = asymPadding;
+  }
+
+  params.inputDtype = operations::utils::toTTNNDataType(op.input_dtype);
+
+  if (op.out) {
+    params.outputDtype = operations::utils::getDataType(*op.out);
+  } else if (op.output_dtype.has_value()) {
+    params.outputDtype = operations::utils::toTTNNDataType(*op.output_dtype);
+  }
+
+  params.inputLayout = operations::utils::toTTNNLayout(op.input_tensor_layout);
+
+  TT_INVOKE_ASSERT(
+      op.input_memory_config,
+      "Input memory config is required for prepare_conv_transpose2d_bias");
+  std::optional<::ttnn::MemoryConfig> inputMemoryConfig =
+      operations::utils::createMemoryConfigIfNeeded(*op.input_memory_config);
+  TT_INVOKE_ASSERT(inputMemoryConfig.has_value(),
+                   "Input memory config expected to have a value");
+  params.inputMemoryConfig = *inputMemoryConfig;
+
+  if (op.conv2d_config) {
+    params.conv2dConfig =
+        operations::utils::createConv2dConfig(*op.conv2d_config);
+  }
+
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+
+  if (op.conv2d_slice_config) {
+    params.sliceConfig =
+        operations::utils::createConv2dSliceConfig(*op.conv2d_slice_config);
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPrepareConvTranspose2dBiasTuple(
+    Tag tag, const ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT &op,
+    TensorArg biasTensor, ::ttnn::MeshDevice *device,
+    const PrepareConvTranspose2dBiasResolvedParams &params) {
+  return std::make_tuple(
+      *std::get<const ::ttnn::Tensor *>(biasTensor), params.inputMemoryConfig,
+      params.inputLayout, op.in_channels, op.out_channels, op.batch_size,
+      op.input_height, op.input_width, params.kernelSize, params.stride,
+      params.padding, params.dilation, op.groups, device, params.inputDtype,
+      params.outputDtype, params.conv2dConfig, params.computeConfig,
+      params.sliceConfig);
+}
+
+PrepareConvTranspose2dBiasOpResult callPrepareConvTranspose2dBias(
+    CallType callType,
+    const ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT &op,
+    TensorArg biasTensor, ::ttnn::MeshDevice *device) {
+
+  PrepareConvTranspose2dBiasResolvedParams params =
+      resolvePrepareConvTranspose2dBiasParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createPrepareConvTranspose2dBiasTuple(tag, op, biasTensor, device,
+                                                 params);
+  };
+
+  return callOp<PrepareConvTranspose2dBiasOpResult, true, false>(
+      WRAP_OP(::ttnn::operations::conv::conv_transpose2d::
+                  prepare_conv_transpose2d_bias),
+      callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Conv/PrepareConvTranspose2dWeightsOp.cpp
+++ b/lib/OpInvoke/TTNN/Conv/PrepareConvTranspose2dWeightsOp.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dWeightsOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp"
+
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+PrepareConvTranspose2dWeightsResolvedParams
+resolvePrepareConvTranspose2dWeightsParams(
+    const ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT &op) {
+  TT_INVOKE_ASSERT(op.kernel_size.size() == 2,
+                   "Kernel size expected to have 2 elements");
+  TT_INVOKE_ASSERT(op.stride.size() == 2, "Stride expected to have 2 elements");
+  TT_INVOKE_ASSERT(op.padding.size() == 2 || op.padding.size() == 4,
+                   "Padding expected to have 2 or 4 elements");
+  TT_INVOKE_ASSERT(op.output_padding.size() == 2,
+                   "Output padding expected to have 2 elements");
+  TT_INVOKE_ASSERT(op.dilation.size() == 2,
+                   "Dilation expected to have 2 elements");
+
+  PrepareConvTranspose2dWeightsResolvedParams params;
+
+  std::copy_n(op.kernel_size.begin(), 2, params.kernelSize.begin());
+  std::copy_n(op.stride.begin(), 2, params.stride.begin());
+  std::copy_n(op.dilation.begin(), 2, params.dilation.begin());
+  std::copy_n(op.output_padding.begin(), 2, params.outputPadding.begin());
+
+  if (op.padding.size() == 2) {
+    std::array<uint32_t, 2> symPadding;
+    std::copy_n(op.padding.begin(), 2, symPadding.begin());
+    params.padding = symPadding;
+  } else {
+    std::array<uint32_t, 4> asymPadding;
+    std::copy_n(op.padding.begin(), 4, asymPadding.begin());
+    params.padding = asymPadding;
+  }
+
+  params.inputDtype = operations::utils::toTTNNDataType(op.input_dtype);
+
+  if (op.out) {
+    params.outputDtype = operations::utils::getDataType(*op.out);
+  } else if (op.output_dtype.has_value()) {
+    params.outputDtype = operations::utils::toTTNNDataType(*op.output_dtype);
+  }
+
+  params.inputLayout = operations::utils::toTTNNLayout(op.input_tensor_layout);
+
+  TT_INVOKE_ASSERT(
+      op.input_memory_config,
+      "Input memory config is required for prepare_conv_transpose2d_weights");
+  std::optional<::ttnn::MemoryConfig> inputMemoryConfig =
+      operations::utils::createMemoryConfigIfNeeded(*op.input_memory_config);
+  TT_INVOKE_ASSERT(inputMemoryConfig.has_value(),
+                   "Input memory config expected to have a value");
+  params.inputMemoryConfig = *inputMemoryConfig;
+
+  if (op.conv2d_config) {
+    params.conv2dConfig =
+        operations::utils::createConv2dConfig(*op.conv2d_config);
+  }
+
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+
+  if (op.conv2d_slice_config) {
+    params.sliceConfig =
+        operations::utils::createConv2dSliceConfig(*op.conv2d_slice_config);
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPrepareConvTranspose2dWeightsTuple(
+    Tag tag, const ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT &op,
+    TensorArg weightTensor, ::ttnn::MeshDevice *device,
+    const PrepareConvTranspose2dWeightsResolvedParams &params) {
+  return std::make_tuple(
+      *std::get<const ::ttnn::Tensor *>(weightTensor), params.inputMemoryConfig,
+      params.inputLayout, op.weights_format, op.in_channels, op.out_channels,
+      op.batch_size, op.input_height, op.input_width, params.kernelSize,
+      params.stride, params.padding, params.outputPadding, params.dilation,
+      op.has_bias, op.groups, device, params.inputDtype, params.outputDtype,
+      params.conv2dConfig, params.computeConfig, params.sliceConfig,
+      op.mirror_kernel);
+}
+
+PrepareConvTranspose2dWeightsOpResult callPrepareConvTranspose2dWeights(
+    CallType callType,
+    const ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT &op,
+    TensorArg weightTensor, ::ttnn::MeshDevice *device) {
+
+  PrepareConvTranspose2dWeightsResolvedParams params =
+      resolvePrepareConvTranspose2dWeightsParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createPrepareConvTranspose2dWeightsTuple(tag, op, weightTensor,
+                                                    device, params);
+  };
+
+  return callOp<PrepareConvTranspose2dWeightsOpResult, true, false>(
+      WRAP_OP(::ttnn::operations::conv::conv_transpose2d::
+                  prepare_conv_transpose2d_weights),
+      callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpModel/TTNN/NativeFromMLIR.cpp
+++ b/lib/OpModel/TTNN/NativeFromMLIR.cpp
@@ -478,6 +478,348 @@ buildEltwiseUnaryCompositeClampTensorOpTFromMLIR(TTNNLayoutAttr outputLayout) {
   return eltwiseUnaryCompositeOp;
 }
 
+::tt::target::ttnn::Conv3dOpT buildConv3dOpTFromMLIR(
+    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+    uint32_t input_depth, uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::StringRef padding_mode,
+    uint32_t groups, std::optional<ttcore::DataTypeAttr> outputDtype,
+    std::optional<Conv3dConfigAttr> conv3dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::Conv3dOpT conv3dOp;
+  conv3dOp.in_channels = in_channels;
+  conv3dOp.out_channels = out_channels;
+  conv3dOp.batch_size = batch_size;
+  conv3dOp.input_depth = input_depth;
+  conv3dOp.input_height = input_height;
+  conv3dOp.input_width = input_width;
+  conv3dOp.kernel_size =
+      std::vector<int32_t>(kernel_size.begin(), kernel_size.end());
+  conv3dOp.stride = std::vector<int32_t>(stride.begin(), stride.end());
+  conv3dOp.padding = std::vector<int32_t>(padding.begin(), padding.end());
+  conv3dOp.padding_mode = padding_mode.str();
+  conv3dOp.groups = groups;
+  conv3dOp.out = detail::getOutputTensorRefT(outputLayout);
+  if (outputDtype.has_value() && outputDtype.value()) {
+    conv3dOp.output_dtype = toNative(outputDtype.value().getValue());
+  }
+  conv3dOp.conv3d_config =
+      (conv3dConfig.has_value() && *conv3dConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv3dConfigT>(
+                toNative(*conv3dConfig))
+          : nullptr;
+  conv3dOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  auto outputMemoryConfigT = detail::getNullableMemoryConfigT(outputLayout);
+  conv3dOp.memory_config =
+      outputMemoryConfigT.has_value()
+          ? std::make_unique<::tt::target::ttnn::MemoryConfigT>(
+                *outputMemoryConfigT)
+          : nullptr;
+
+  return conv3dOp;
+}
+
+::tt::target::ttnn::ConvTranspose2dOpT buildConvTranspose2dOpTFromMLIR(
+    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+    uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
+    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ConvTranspose2dOpT convTranspose2dOp;
+  convTranspose2dOp.in_channels = in_channels;
+  convTranspose2dOp.out_channels = out_channels;
+  convTranspose2dOp.batch_size = batch_size;
+  convTranspose2dOp.input_height = input_height;
+  convTranspose2dOp.input_width = input_width;
+  convTranspose2dOp.kernel_size =
+      std::vector<int32_t>(kernel_size.begin(), kernel_size.end());
+  convTranspose2dOp.stride = std::vector<int32_t>(stride.begin(), stride.end());
+  convTranspose2dOp.padding =
+      std::vector<int32_t>(padding.begin(), padding.end());
+  convTranspose2dOp.output_padding =
+      std::vector<int32_t>(output_padding.begin(), output_padding.end());
+  convTranspose2dOp.dilation =
+      std::vector<int32_t>(dilation.begin(), dilation.end());
+  convTranspose2dOp.groups = groups;
+  convTranspose2dOp.out = detail::getOutputTensorRefT(outputLayout);
+  convTranspose2dOp.conv2d_config =
+      (conv2dConfig.has_value() && *conv2dConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dConfigT>(
+                toNative(*conv2dConfig))
+          : nullptr;
+  convTranspose2dOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  convTranspose2dOp.conv2d_slice_config =
+      (conv2dSliceConfig.has_value() && *conv2dSliceConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dSliceConfigT>(
+                toNative(*conv2dSliceConfig))
+          : nullptr;
+
+  return convTranspose2dOp;
+}
+
+::tt::target::ttnn::PrepareConv2dWeightsOpT
+buildPrepareConv2dWeightsOpTFromMLIR(
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    bool hasBias, int32_t groups, ttcore::DataType inputDtype,
+    std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::PrepareConv2dWeightsOpT prepareConv2dWeightsOp;
+  prepareConv2dWeightsOp.in_channels = inChannels;
+  prepareConv2dWeightsOp.out_channels = outChannels;
+  prepareConv2dWeightsOp.batch_size = batchSize;
+  prepareConv2dWeightsOp.input_height = inputHeight;
+  prepareConv2dWeightsOp.input_width = inputWidth;
+  prepareConv2dWeightsOp.kernel_size =
+      std::vector<int32_t>(kernelSize.begin(), kernelSize.end());
+  prepareConv2dWeightsOp.stride =
+      std::vector<int32_t>(stride.begin(), stride.end());
+  auto reorderedPadding = detail::reorderPool2dPadding(padding);
+  std::visit(
+      [&prepareConv2dWeightsOp](const auto &arr) {
+        prepareConv2dWeightsOp.padding.assign(arr.begin(), arr.end());
+      },
+      reorderedPadding);
+  prepareConv2dWeightsOp.dilation =
+      std::vector<int32_t>(dilation.begin(), dilation.end());
+  prepareConv2dWeightsOp.has_bias = hasBias;
+  prepareConv2dWeightsOp.groups = groups;
+  prepareConv2dWeightsOp.weights_format = weightsFormat.str();
+  prepareConv2dWeightsOp.input_tensor_layout = toNative(inputTensorLayout);
+  prepareConv2dWeightsOp.input_dtype = toNative(inputDtype);
+  if (outputDtype.has_value()) {
+    prepareConv2dWeightsOp.output_dtype = toNative(outputDtype.value());
+  }
+  prepareConv2dWeightsOp.input_memory_config =
+      std::make_unique<::tt::target::ttnn::MemoryConfigT>(
+          toNative(inputMemConfig));
+  prepareConv2dWeightsOp.conv2d_config =
+      (conv2dConfig.has_value() && *conv2dConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dConfigT>(
+                toNative(*conv2dConfig))
+          : nullptr;
+  prepareConv2dWeightsOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  prepareConv2dWeightsOp.conv2d_slice_config =
+      (conv2dSliceConfig.has_value() && *conv2dSliceConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dSliceConfigT>(
+                toNative(*conv2dSliceConfig))
+          : nullptr;
+  prepareConv2dWeightsOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return prepareConv2dWeightsOp;
+}
+
+::tt::target::ttnn::PrepareConv2dBiasOpT buildPrepareConv2dBiasOpTFromMLIR(
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::PrepareConv2dBiasOpT prepareConv2dBiasOp;
+  prepareConv2dBiasOp.in_channels = inChannels;
+  prepareConv2dBiasOp.out_channels = outChannels;
+  prepareConv2dBiasOp.batch_size = batchSize;
+  prepareConv2dBiasOp.input_height = inputHeight;
+  prepareConv2dBiasOp.input_width = inputWidth;
+  prepareConv2dBiasOp.kernel_size =
+      std::vector<int32_t>(kernelSize.begin(), kernelSize.end());
+  prepareConv2dBiasOp.stride =
+      std::vector<int32_t>(stride.begin(), stride.end());
+  auto reorderedPadding = detail::reorderPool2dPadding(padding);
+  std::visit(
+      [&prepareConv2dBiasOp](const auto &arr) {
+        prepareConv2dBiasOp.padding.assign(arr.begin(), arr.end());
+      },
+      reorderedPadding);
+  prepareConv2dBiasOp.dilation =
+      std::vector<int32_t>(dilation.begin(), dilation.end());
+  prepareConv2dBiasOp.groups = groups;
+  prepareConv2dBiasOp.input_tensor_layout = toNative(inputTensorLayout);
+  prepareConv2dBiasOp.input_dtype = toNative(inputDtype);
+  if (outputDtype.has_value()) {
+    prepareConv2dBiasOp.output_dtype = toNative(outputDtype.value());
+  }
+  prepareConv2dBiasOp.input_memory_config =
+      std::make_unique<::tt::target::ttnn::MemoryConfigT>(
+          toNative(inputMemConfig));
+  prepareConv2dBiasOp.conv2d_config =
+      (conv2dConfig.has_value() && *conv2dConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dConfigT>(
+                toNative(*conv2dConfig))
+          : nullptr;
+  prepareConv2dBiasOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  prepareConv2dBiasOp.conv2d_slice_config =
+      (conv2dSliceConfig.has_value() && *conv2dSliceConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dSliceConfigT>(
+                toNative(*conv2dSliceConfig))
+          : nullptr;
+  prepareConv2dBiasOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return prepareConv2dBiasOp;
+}
+
+::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT
+buildPrepareConvTranspose2dWeightsOpTFromMLIR(
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> outputPadding,
+    llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT
+      prepareConvTranspose2dWeightsOp;
+  prepareConvTranspose2dWeightsOp.in_channels = inChannels;
+  prepareConvTranspose2dWeightsOp.out_channels = outChannels;
+  prepareConvTranspose2dWeightsOp.batch_size = batchSize;
+  prepareConvTranspose2dWeightsOp.input_height = inputHeight;
+  prepareConvTranspose2dWeightsOp.input_width = inputWidth;
+  prepareConvTranspose2dWeightsOp.kernel_size =
+      std::vector<int32_t>(kernelSize.begin(), kernelSize.end());
+  prepareConvTranspose2dWeightsOp.stride =
+      std::vector<int32_t>(stride.begin(), stride.end());
+  auto reorderedPadding = detail::reorderPool2dPadding(padding);
+  std::visit(
+      [&prepareConvTranspose2dWeightsOp](const auto &arr) {
+        prepareConvTranspose2dWeightsOp.padding.assign(arr.begin(), arr.end());
+      },
+      reorderedPadding);
+  prepareConvTranspose2dWeightsOp.output_padding =
+      std::vector<int32_t>(outputPadding.begin(), outputPadding.end());
+  prepareConvTranspose2dWeightsOp.dilation =
+      std::vector<int32_t>(dilation.begin(), dilation.end());
+  prepareConvTranspose2dWeightsOp.has_bias = hasBias;
+  prepareConvTranspose2dWeightsOp.groups = groups;
+  prepareConvTranspose2dWeightsOp.weights_format = weightsFormat.str();
+  prepareConvTranspose2dWeightsOp.mirror_kernel = mirrorKernel;
+  prepareConvTranspose2dWeightsOp.input_tensor_layout =
+      toNative(inputTensorLayout);
+  prepareConvTranspose2dWeightsOp.input_dtype = toNative(inputDtype);
+  if (outputDtype.has_value()) {
+    prepareConvTranspose2dWeightsOp.output_dtype =
+        toNative(outputDtype.value());
+  }
+  prepareConvTranspose2dWeightsOp.input_memory_config =
+      std::make_unique<::tt::target::ttnn::MemoryConfigT>(
+          toNative(inputMemConfig));
+  prepareConvTranspose2dWeightsOp.conv2d_config =
+      (conv2dConfig.has_value() && *conv2dConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dConfigT>(
+                toNative(*conv2dConfig))
+          : nullptr;
+  prepareConvTranspose2dWeightsOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  prepareConvTranspose2dWeightsOp.conv2d_slice_config =
+      (conv2dSliceConfig.has_value() && *conv2dSliceConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dSliceConfigT>(
+                toNative(*conv2dSliceConfig))
+          : nullptr;
+  prepareConvTranspose2dWeightsOp.out =
+      detail::getOutputTensorRefT(outputLayout);
+
+  return prepareConvTranspose2dWeightsOp;
+}
+
+::tt::target::ttnn::PrepareConvTranspose2dBiasOpT
+buildPrepareConvTranspose2dBiasOpTFromMLIR(
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT
+      prepareConvTranspose2dBiasOp;
+  prepareConvTranspose2dBiasOp.in_channels = inChannels;
+  prepareConvTranspose2dBiasOp.out_channels = outChannels;
+  prepareConvTranspose2dBiasOp.batch_size = batchSize;
+  prepareConvTranspose2dBiasOp.input_height = inputHeight;
+  prepareConvTranspose2dBiasOp.input_width = inputWidth;
+  prepareConvTranspose2dBiasOp.kernel_size =
+      std::vector<int32_t>(kernelSize.begin(), kernelSize.end());
+  prepareConvTranspose2dBiasOp.stride =
+      std::vector<int32_t>(stride.begin(), stride.end());
+  auto reorderedPadding = detail::reorderPool2dPadding(padding);
+  std::visit(
+      [&prepareConvTranspose2dBiasOp](const auto &arr) {
+        prepareConvTranspose2dBiasOp.padding.assign(arr.begin(), arr.end());
+      },
+      reorderedPadding);
+  prepareConvTranspose2dBiasOp.dilation =
+      std::vector<int32_t>(dilation.begin(), dilation.end());
+  prepareConvTranspose2dBiasOp.groups = groups;
+  prepareConvTranspose2dBiasOp.input_tensor_layout =
+      toNative(inputTensorLayout);
+  prepareConvTranspose2dBiasOp.input_dtype = toNative(inputDtype);
+  if (outputDtype.has_value()) {
+    prepareConvTranspose2dBiasOp.output_dtype = toNative(outputDtype.value());
+  }
+  prepareConvTranspose2dBiasOp.input_memory_config =
+      std::make_unique<::tt::target::ttnn::MemoryConfigT>(
+          toNative(inputMemConfig));
+  prepareConvTranspose2dBiasOp.conv2d_config =
+      (conv2dConfig.has_value() && *conv2dConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dConfigT>(
+                toNative(*conv2dConfig))
+          : nullptr;
+  prepareConvTranspose2dBiasOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  prepareConvTranspose2dBiasOp.conv2d_slice_config =
+      (conv2dSliceConfig.has_value() && *conv2dSliceConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dSliceConfigT>(
+                toNative(*conv2dSliceConfig))
+          : nullptr;
+  prepareConvTranspose2dBiasOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return prepareConvTranspose2dBiasOp;
+}
+
 } // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -12,6 +12,12 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/Conv3dOp.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/ConvTranspose2dOp.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dBiasOp.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dWeightsOp.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dBiasOp.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dWeightsOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Quantization/EltwiseQuantizationOp.h"
@@ -5318,113 +5324,6 @@ llvm::Expected<size_t> OpModel<Conv2dOp>::getOpRuntime(
 // Conv3dOp
 //===----------------------------------------------------------------------===//
 
-#ifdef TTMLIR_ENABLE_OPMODEL
-namespace {
-
-struct Conv3dSpecs {
-  ::ttnn::TensorSpec inputSpec;
-  ::ttnn::TensorSpec weightSpec;
-  std::optional<::ttnn::TensorSpec> biasSpec;
-  std::optional<::ttnn::experimental::prim::Conv3dConfig> config;
-  ::tt::tt_metal::DataType dtype;
-  uint32_t outputChannels;
-  std::array<uint32_t, 3> kernelSize;
-  std::array<uint32_t, 3> stride;
-  std::array<uint32_t, 3> padding;
-  std::string paddingMode;
-  uint32_t groups;
-  std::optional<::ttnn::DeviceComputeKernelConfig> deviceComputeKernelConfig;
-};
-
-llvm::Expected<Conv3dSpecs> prepareConv3dSpecs(
-    ::tt::tt_metal::distributed::MeshDevice *device,
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, uint32_t out_channels,
-    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::StringRef padding_mode,
-    uint32_t groups, std::optional<ttcore::DataTypeAttr> outputDtype,
-    std::optional<Conv3dConfigAttr> conv3dConfig,
-    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-    TTNNLayoutAttr outputLayout) {
-
-  // Convert input layout to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
-
-  // Convert weight layout to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec weightSpec,
-      detail::convertToTensorSpec(device, weightShape, weightLayout));
-
-  // Convert bias if present
-  std::optional<::ttnn::TensorSpec> biasSpec;
-  if (biasShape && biasLayout) {
-    ASSIGN_OR_RETURN(
-        biasSpec, detail::convertToTensorSpec(device, *biasShape, *biasLayout));
-  }
-
-  std::optional<::ttnn::experimental::prim::Conv3dConfig> config;
-
-  // Apply Conv3dConfig overrides if provided
-  if (conv3dConfig.has_value()) {
-    config.emplace();
-    if (conv3dConfig->getWeightsDtype()) {
-      config->weights_dtype =
-          conversion::getDataType(*conv3dConfig->getWeightsDtype());
-    }
-    if (conv3dConfig->getTOutBlock()) {
-      config->T_out_block = *conv3dConfig->getTOutBlock();
-    }
-    if (conv3dConfig->getWOutBlock()) {
-      config->W_out_block = *conv3dConfig->getWOutBlock();
-    }
-    if (conv3dConfig->getHOutBlock()) {
-      config->H_out_block = *conv3dConfig->getHOutBlock();
-    }
-    if (conv3dConfig->getCOutBlock()) {
-      config->C_out_block = *conv3dConfig->getCOutBlock();
-    }
-    if (conv3dConfig->getCInBlock()) {
-      config->C_in_block = *conv3dConfig->getCInBlock();
-    }
-    config->compute_with_storage_grid_size =
-        device->compute_with_storage_grid_size();
-  }
-
-  // Get output dtype in this order: explicit outputDtype → outputLayout →
-  // BFLOAT16
-  std::optional<::tt::tt_metal::DataType> dtype;
-  if (outputDtype.has_value() && outputDtype.value()) {
-    dtype = conversion::getDataType(outputDtype.value().getValue());
-  }
-  if (!dtype) {
-    dtype = detail::getNullableDataType(outputLayout);
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig>
-      deviceComputeKernelConfigConverted =
-          conversion::getDeviceComputeKernelConfig(deviceComputeKernelConfig);
-
-  return Conv3dSpecs{
-      inputSpec,
-      weightSpec,
-      biasSpec,
-      config,
-      dtype.value_or(::tt::tt_metal::DataType::BFLOAT16),
-      out_channels,
-      conversion::convertLLVMArrayRefToStdArray<uint32_t, 3>(kernel_size),
-      conversion::convertLLVMArrayRefToStdArray<uint32_t, 3>(stride),
-      conversion::convertLLVMArrayRefToStdArray<uint32_t, 3>(padding),
-      padding_mode.str(),
-      groups,
-      deviceComputeKernelConfigConverted};
-}
-} // namespace
-#endif // TTMLIR_ENABLE_OPMODEL
-
 llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -5443,25 +5342,38 @@ llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto specsExp = prepareConv3dSpecs(
-      device, inputShape, inputLayout, weightShape, weightLayout, biasShape,
-      biasLayout, out_channels, kernel_size, stride, padding, padding_mode,
-      groups, outputDtype, conv3dConfig, deviceComputeKernelConfig,
-      outputLayout);
-  if (!specsExp) {
-    return specsExp.takeError();
-  }
-  auto specs = specsExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec weightSpec,
+      detail::convertToTensorSpec(device, weightShape, weightLayout));
 
-  auto conv3dOpQuery = [=, &specs]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::conv3d, device, specs.inputSpec, specs.weightSpec,
-        std::optional<::tt::tt_metal::distributed::MeshDevice *>(device),
-        specs.biasSpec, specs.config, specs.dtype, specs.outputChannels,
-        specs.kernelSize, specs.stride, specs.padding,
-        std::array<uint32_t, 3>{1, 1, 1}, specs.paddingMode, specs.groups,
-        detail::getNullableMemoryConfig(outputLayout),
-        specs.deviceComputeKernelConfig);
+  std::optional<::ttnn::TensorSpec> biasSpec;
+  if (biasShape && biasLayout) {
+    ASSIGN_OR_RETURN(
+        biasSpec, detail::convertToTensorSpec(device, *biasShape, *biasLayout));
+  }
+
+  ::tt::target::ttnn::Conv3dOpT conv3dOpNative = buildConv3dOpTFromMLIR(
+      in_channels, out_channels, batch_size, input_depth, input_height,
+      input_width, kernel_size, stride, padding, padding_mode, groups,
+      outputDtype, conv3dConfig, deviceComputeKernelConfig, outputLayout);
+
+  auto conv3dOpQuery = [=]() {
+    ttnn_op_invoke::Conv3dOpResult result = ttnn_op_invoke::callConv3d(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, conv3dOpNative,
+        inputSpec, weightSpec,
+        biasSpec.has_value()
+            ? std::optional<ttnn_op_invoke::TensorArg>(*biasSpec)
+            : std::nullopt,
+        device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected Conv3dOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), conv3dOpQuery);
@@ -5488,25 +5400,37 @@ llvm::Expected<size_t> OpModel<Conv3dOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto specsExp = prepareConv3dSpecs(
-      device, inputShape, inputLayout, weightShape, weightLayout, biasShape,
-      biasLayout, out_channels, kernel_size, stride, padding, padding_mode,
-      groups, outputDtype, conv3dConfig, deviceComputeKernelConfig,
-      outputLayout);
-  if (!specsExp) {
-    return specsExp.takeError();
-  }
-  auto specs = specsExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec weightSpec,
+      detail::convertToTensorSpec(device, weightShape, weightLayout));
 
-  auto conv3dOpRuntime = [=, &specs]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::experimental::conv3d, device, specs.inputSpec, specs.weightSpec,
-        std::optional<::tt::tt_metal::distributed::MeshDevice *>(device),
-        specs.biasSpec, specs.config, specs.dtype, specs.outputChannels,
-        specs.kernelSize, specs.stride, specs.padding,
-        std::array<uint32_t, 3>{1, 1, 1}, specs.paddingMode, specs.groups,
-        detail::getNullableMemoryConfig(outputLayout),
-        specs.deviceComputeKernelConfig);
+  std::optional<::ttnn::TensorSpec> biasSpec;
+  if (biasShape && biasLayout) {
+    ASSIGN_OR_RETURN(
+        biasSpec, detail::convertToTensorSpec(device, *biasShape, *biasLayout));
+  }
+
+  ::tt::target::ttnn::Conv3dOpT conv3dOpNative = buildConv3dOpTFromMLIR(
+      in_channels, out_channels, batch_size, input_depth, input_height,
+      input_width, kernel_size, stride, padding, padding_mode, groups,
+      outputDtype, conv3dConfig, deviceComputeKernelConfig, outputLayout);
+
+  auto conv3dOpRuntime = [=]() {
+    ttnn_op_invoke::Conv3dOpResult result = ttnn_op_invoke::callConv3d(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, conv3dOpNative, inputSpec,
+        weightSpec,
+        biasSpec.has_value()
+            ? std::optional<ttnn_op_invoke::TensorArg>(*biasSpec)
+            : std::nullopt,
+        device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected Conv3dOp runtime query to return RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(conv3dOpRuntime);
@@ -5518,6 +5442,7 @@ llvm::Expected<size_t> OpModel<Conv3dOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ConvTranspose2dOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -5529,6 +5454,7 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
     llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
     uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Prepare weight tensor first.
@@ -5565,31 +5491,29 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  std::optional<::tt::tt_metal::DataType> outputDtype =
-      detail::getNullableDataType(outputLayout);
-
-  std::optional<::ttnn::Conv2dConfig> conv2dConfigConverted =
-      conversion::getConv2dConfig(conv2dConfig);
-  std::optional<::ttnn::Conv2dSliceConfig> conv2dSliceConfigConverted =
-      conversion::getConv2dSliceConfig(conv2dSliceConfig);
+  ::tt::target::ttnn::ConvTranspose2dOpT convTranspose2dOpNative =
+      buildConvTranspose2dOpTFromMLIR(in_channels, out_channels, batch_size,
+                                      input_height, input_width, kernel_size,
+                                      stride, padding, output_padding, dilation,
+                                      groups, conv2dConfig, conv2dSliceConfig,
+                                      deviceComputeKernelConfig, outputLayout);
 
   // Create query closure
   auto convTranspose2dOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::conv_transpose2d, device, inputSpec, weightSpec, device,
-        in_channels, out_channels, batch_size, input_height, input_width,
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(output_padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, outputDtype, biasSpec, conv2dConfigConverted,
-        /* compute_config */ std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        conv2dSliceConfigConverted,
-        /*mirror_kernel=*/true,
-        /*return_output_dim=*/false,
-        /*return_weights_and_bias=*/false);
+    ttnn_op_invoke::ConvTranspose2dOpResult result =
+        ttnn_op_invoke::callConvTranspose2d(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            convTranspose2dOpNative, inputSpec, weightSpec,
+            biasSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*biasSpec)
+                : std::nullopt,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConvTranspose2dOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -5610,6 +5534,7 @@ llvm::Expected<size_t> OpModel<ConvTranspose2dOp>::getOpRuntime(
     llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
     uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Prepare weight tensor first.
@@ -5647,31 +5572,29 @@ llvm::Expected<size_t> OpModel<ConvTranspose2dOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  std::optional<::tt::tt_metal::DataType> outputDtype =
-      detail::getNullableDataType(outputLayout);
-
-  std::optional<::ttnn::Conv2dConfig> conv2dConfigConverted =
-      conversion::getConv2dConfig(conv2dConfig);
-  std::optional<::ttnn::Conv2dSliceConfig> conv2dSliceConfigConverted =
-      conversion::getConv2dSliceConfig(conv2dSliceConfig);
+  ::tt::target::ttnn::ConvTranspose2dOpT convTranspose2dOpNative =
+      buildConvTranspose2dOpTFromMLIR(in_channels, out_channels, batch_size,
+                                      input_height, input_width, kernel_size,
+                                      stride, padding, output_padding, dilation,
+                                      groups, conv2dConfig, conv2dSliceConfig,
+                                      deviceComputeKernelConfig, outputLayout);
 
   // Create query closure
   auto convTranspose2dOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::conv_transpose2d, device, inputSpec, weightSpec, device,
-        in_channels, out_channels, batch_size, input_height, input_width,
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(output_padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, outputDtype, biasSpec, conv2dConfigConverted,
-        /* compute_config */ std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        conv2dSliceConfigConverted,
-        /*mirror_kernel=*/true,
-        /*return_output_dim=*/false,
-        /*return_weights_and_bias=*/false);
+    ttnn_op_invoke::ConvTranspose2dOpResult result =
+        ttnn_op_invoke::callConvTranspose2d(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, convTranspose2dOpNative,
+            inputSpec, weightSpec,
+            biasSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*biasSpec)
+                : std::nullopt,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected ConvTranspose2dOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(convTranspose2dOpQuery);
@@ -5706,31 +5629,26 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
   // TODO(#4043): Move this to tt-metal side.
   ::tt::tt_metal::Tensor weightTensor =
       createMetalHostTensor(weightShape, weightLayout.getDataType());
-  // Read output data type from output layout (if present) or from outputDtype.
-  std::optional<::tt::tt_metal::DataType> convertedOutputDtype = std::nullopt;
-  if (outputLayout) {
-    convertedOutputDtype = conversion::getDataType(outputLayout.getDataType());
-  } else if (outputDtype.has_value()) {
-    convertedOutputDtype = conversion::getDataType(outputDtype.value());
-  }
 
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfigConverted =
-      conversion::getConv2dSliceConfig(conv2dSliceConfig);
+  ::tt::target::ttnn::PrepareConv2dWeightsOpT prepareConv2dWeightsOpNative =
+      buildPrepareConv2dWeightsOpTFromMLIR(
+          inputMemConfig, inputTensorLayout, weightsFormat, inChannels,
+          outChannels, batchSize, inputHeight, inputWidth, kernelSize, stride,
+          padding, dilation, hasBias, groups, inputDtype, outputDtype,
+          conv2dConfig, deviceComputeKernelConfig, conv2dSliceConfig,
+          outputLayout);
 
   auto prepareConv2dWeightsQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        &::ttnn::operations::conv::conv2d::prepare_conv_weights, device,
-        weightTensor, conversion::getMemoryConfig(inputMemConfig),
-        conversion::getPageLayout(inputTensorLayout), weightsFormat.str(),
-        inChannels, outChannels, batchSize, inputHeight, inputWidth,
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
-        detail::reorderPool2dPadding(padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        hasBias, groups, device, conversion::getDataType(inputDtype),
-        convertedOutputDtype, conversion::getConv2dConfig(conv2dConfig),
-        conversion::getDeviceComputeKernelConfig(deviceComputeKernelConfig),
-        sliceConfigConverted);
+    ttnn_op_invoke::PrepareConv2dWeightsOpResult result =
+        ttnn_op_invoke::callPrepareConv2dWeights(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            prepareConv2dWeightsOpNative, &weightTensor, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected PrepareConv2dWeightsOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(weightLayout.getContext(),
@@ -5753,45 +5671,41 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
     llvm::ArrayRef<int32_t> dilation, int32_t groups,
     ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
     std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
   assert(device != nullptr && "Device is nullptr");
-  assert(biasLayout != nullptr && "Weight layout is nullptr");
+  assert(biasLayout != nullptr && "Bias layout is nullptr");
 
   // TODO(#4043): Move this to tt-metal side.
   ::tt::tt_metal::Tensor biasTensor =
       createMetalHostTensor(biasShape, biasLayout.getDataType());
-  // Read output data type from output layout (if present) or from outputDtype.
-  std::optional<::tt::tt_metal::DataType> convertedOutputDtype = std::nullopt;
-  if (outputLayout) {
-    convertedOutputDtype = conversion::getDataType(outputLayout.getDataType());
-  } else if (outputDtype.has_value()) {
-    convertedOutputDtype = conversion::getDataType(outputDtype.value());
-  }
 
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig = std::nullopt;
+  ::tt::target::ttnn::PrepareConv2dBiasOpT prepareConv2dBiasOp =
+      buildPrepareConv2dBiasOpTFromMLIR(
+          inputMemConfig, inputTensorLayout, inChannels, outChannels, batchSize,
+          inputHeight, inputWidth, kernelSize, stride, padding, dilation,
+          groups, inputDtype, outputDtype, conv2dConfig, conv2dSliceConfig,
+          deviceComputeKernelConfig, outputLayout);
 
-  auto prepareConv2dWeightsQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        &::ttnn::operations::conv::conv2d::prepare_conv_bias, device,
-        biasTensor, conversion::getMemoryConfig(inputMemConfig),
-        conversion::getPageLayout(inputTensorLayout), inChannels, outChannels,
-        batchSize, inputHeight, inputWidth,
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
-        detail::reorderPool2dPadding(padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, device, conversion::getDataType(inputDtype),
-        convertedOutputDtype, conversion::getConv2dConfig(conv2dConfig),
-        conversion::getDeviceComputeKernelConfig(deviceComputeKernelConfig),
-        sliceConfig);
+  auto prepareConv2dBiasQuery = [=]() {
+    ttnn_op_invoke::PrepareConv2dBiasOpResult result =
+        ttnn_op_invoke::callPrepareConv2dBias(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, prepareConv2dBiasOp,
+            &biasTensor, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected PrepareConv2dBiasOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(biasLayout.getContext(),
-                                     prepareConv2dWeightsQuery);
+                                     prepareConv2dBiasQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5824,30 +5738,27 @@ OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
   // TODO(#4043): Move this to tt-metal side.
   ::tt::tt_metal::Tensor weightTensor =
       createMetalHostTensor(weightShape, weightLayout.getDataType());
-  // Read output data type from output layout (if present) or from outputDtype.
-  std::optional<::tt::tt_metal::DataType> convertedOutputDtype = std::nullopt;
-  if (outputLayout) {
-    convertedOutputDtype = conversion::getDataType(outputLayout.getDataType());
-  } else if (outputDtype.has_value()) {
-    convertedOutputDtype = conversion::getDataType(outputDtype.value());
-  }
+
+  ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT
+      prepareConvTranspose2dWeightsOpNative =
+          buildPrepareConvTranspose2dWeightsOpTFromMLIR(
+              inputMemConfig, inputTensorLayout, weightsFormat, inChannels,
+              outChannels, batchSize, inputHeight, inputWidth, kernelSize,
+              stride, padding, output_padding, dilation, hasBias, groups,
+              inputDtype, outputDtype, conv2dConfig, deviceComputeKernelConfig,
+              conv2dSliceConfig, mirrorKernel, outputLayout);
 
   auto prepareConvTranspose2dWeightsQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        &::ttnn::operations::conv::conv_transpose2d::
-            prepare_conv_transpose2d_weights,
-        device, weightTensor, conversion::getMemoryConfig(inputMemConfig),
-        conversion::getPageLayout(inputTensorLayout), weightsFormat.str(),
-        inChannels, outChannels, batchSize, inputHeight, inputWidth,
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
-        detail::reorderPool2dPadding(padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(output_padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        hasBias, groups, device, conversion::getDataType(inputDtype),
-        convertedOutputDtype, conversion::getConv2dConfig(conv2dConfig),
-        conversion::getDeviceComputeKernelConfig(deviceComputeKernelConfig),
-        conversion::getConv2dSliceConfig(conv2dSliceConfig), mirrorKernel);
+    ttnn_op_invoke::PrepareConvTranspose2dWeightsOpResult result =
+        ttnn_op_invoke::callPrepareConvTranspose2dWeights(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            prepareConvTranspose2dWeightsOpNative, &weightTensor, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected PrepareConvTranspose2dWeightsOp constraints query to "
+           "return ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(weightLayout.getContext(),
@@ -5883,29 +5794,26 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
   // TODO(#4043): Move this to tt-metal side.
   ::tt::tt_metal::Tensor biasTensor =
       createMetalHostTensor(biasShape, biasLayout.getDataType());
-  // Read output data type from output layout (if present) or from outputDtype.
-  std::optional<::tt::tt_metal::DataType> convertedOutputDtype = std::nullopt;
-  if (outputLayout) {
-    convertedOutputDtype = conversion::getDataType(outputLayout.getDataType());
-  } else if (outputDtype.has_value()) {
-    convertedOutputDtype = conversion::getDataType(outputDtype.value());
-  }
+
+  ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT
+      prepareConvTranspose2dBiasOpNative =
+          buildPrepareConvTranspose2dBiasOpTFromMLIR(
+              inputMemConfig, inputTensorLayout, inChannels, outChannels,
+              batchSize, inputHeight, inputWidth, kernelSize, stride, padding,
+              dilation, groups, inputDtype, outputDtype, conv2dConfig,
+              deviceComputeKernelConfig, conv2dSliceConfig, outputLayout);
 
   auto prepareConvTranspose2dBiasQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        &::ttnn::operations::conv::conv_transpose2d::
-            prepare_conv_transpose2d_bias,
-        device, biasTensor, conversion::getMemoryConfig(inputMemConfig),
-        conversion::getPageLayout(inputTensorLayout), inChannels, outChannels,
-        batchSize, inputHeight, inputWidth,
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
-        detail::reorderPool2dPadding(padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, device, conversion::getDataType(inputDtype),
-        convertedOutputDtype, conversion::getConv2dConfig(conv2dConfig),
-        conversion::getDeviceComputeKernelConfig(deviceComputeKernelConfig),
-        conversion::getConv2dSliceConfig(conv2dSliceConfig));
+    ttnn_op_invoke::PrepareConvTranspose2dBiasOpResult result =
+        ttnn_op_invoke::callPrepareConvTranspose2dBias(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            prepareConvTranspose2dBiasOpNative, &biasTensor, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected PrepareConvTranspose2dBiasOp constraints query to "
+           "return ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(biasLayout.getContext(),

--- a/runtime/lib/ttnn/operations/conv/conv3d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv3d.cpp
@@ -5,11 +5,9 @@
 #include "operations/conv/conv3d.h"
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/Conv3dOp.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
-#include "ttnn/types.hpp"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::conv {
 void run(const ::tt::target::ttnn::Conv3dOp *op, ProgramContext &context) {
@@ -24,80 +22,22 @@ void run(const ::tt::target::ttnn::Conv3dOp *op, ProgramContext &context) {
     bias = tensorPool.getTTNNTensorAndValidate(op->bias());
   }
 
-  LOG_ASSERT(op->kernel_size()->size() == 3,
-             "Kernel size expected to have 3 elements");
-  LOG_ASSERT(op->stride()->size() == 3, "Stride expected to have 3 elements");
-  LOG_ASSERT(op->padding()->size() == 3, "Padding expected to have 3 elements");
-
-  std::array<uint32_t, 3> kernelSize, stride, padding;
-  std::copy_n(op->kernel_size()->begin(), 3, kernelSize.begin());
-  std::copy_n(op->stride()->begin(), 3, stride.begin());
-  std::copy_n(op->padding()->begin(), 3, padding.begin());
-
-  ::ttnn::DataType outputDtype = ::ttnn::DataType::BFLOAT16;
-  if (op->output_dtype()) {
-    outputDtype = ttnn_op_invoke::operations::utils::toTTNNDataType(
-        *(op->output_dtype()));
-  }
+  ::tt::target::ttnn::Conv3dOpT conv3dOpT;
+  op->UnPackTo(&conv3dOpT);
 
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::experimental::prim::Conv3dConfig> conv3dConfig;
-  if (op->conv3d_config()) {
-    const auto *fbConfig = op->conv3d_config();
-    ::ttnn::experimental::prim::Conv3dConfig config;
-    if (fbConfig->weights_dtype()) {
-      config.weights_dtype = ttnn_op_invoke::operations::utils::toTTNNDataType(
-          *fbConfig->weights_dtype());
-    }
-    if (fbConfig->t_out_block()) {
-      config.T_out_block = *fbConfig->t_out_block();
-    }
-    if (fbConfig->w_out_block()) {
-      config.W_out_block = *fbConfig->w_out_block();
-    }
-    if (fbConfig->h_out_block()) {
-      config.H_out_block = *fbConfig->h_out_block();
-    }
-    if (fbConfig->c_out_block()) {
-      config.C_out_block = *fbConfig->c_out_block();
-    }
-    if (fbConfig->c_in_block()) {
-      config.C_in_block = *fbConfig->c_in_block();
-    }
-    if (const auto *gridCoord = fbConfig->compute_with_storage_grid_size()) {
-      config.compute_with_storage_grid_size =
-          tt::tt_metal::CoreCoord{gridCoord->x(), gridCoord->y()};
-    } else {
-      config.compute_with_storage_grid_size =
-          targetDevice.compute_with_storage_grid_size();
-    }
-    conv3dConfig = config;
-  }
+  ttnn_op_invoke::Conv3dOpResult result = ttnn_op_invoke::callConv3d(
+      ttnn_op_invoke::CallType::EXECUTE, conv3dOpT, &input, &weight,
+      bias.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*bias)
+                       : std::nullopt,
+      &targetDevice);
 
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callConv3d execution");
 
-  auto deviceComputeConfig = ::ttnn::init_device_compute_kernel_config(
-      targetDevice.arch(), computeConfig, ::tt::tt_metal::MathFidelity::HiFi4,
-      true, true, false);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
-
-  ::ttnn::Tensor out = ::ttnn::experimental::conv3d(
-      input, weight, &targetDevice, bias, conv3dConfig, outputDtype,
-      op->out_channels(), kernelSize, stride, padding,
-      std::array<uint32_t, 3>{1, 1, 1}, op->padding_mode()->str(), op->groups(),
-      outputMemoryConfig, deviceComputeConfig);
-
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
@@ -4,16 +4,10 @@
 
 #include "operations/conv/conv_transpose2d.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-#include "ttmlir/Target/TTNN/program_generated.h"
-#include "ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp"
-#include "ttnn/types.hpp"
+#include "ttmlir/OpInvoke/TTNN/Conv/ConvTranspose2dOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::conv {
-using ::ttnn::Conv2dResultWithOptions;
 void run(const ::tt::target::ttnn::ConvTranspose2dOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -27,58 +21,30 @@ void run(const ::tt::target::ttnn::ConvTranspose2dOp *op,
           ? std::make_optional(tensorPool.getTTNNTensorAndValidate(op->bias()))
           : std::nullopt;
 
-  LOG_ASSERT(op->kernel_size()->size() == 2,
-             "Kernel size expected to have 2 elements");
-  LOG_ASSERT(op->stride()->size() == 2, "Stride expected to have 2 elements");
-  LOG_ASSERT(op->padding()->size() == 2, "Padding expected to have 2 elements");
-  LOG_ASSERT(op->output_padding()->size() == 2,
-             "Output padding expected to have 2 elements");
-  LOG_ASSERT(op->dilation()->size() == 2,
-             "Dilation expected to have 2 elements");
-
-  std::array<uint32_t, 2> kernelSize, stride, padding, outputPadding, dilation;
-  std::copy_n(op->kernel_size()->begin(), 2, kernelSize.begin());
-  std::copy_n(op->stride()->begin(), 2, stride.begin());
-  std::copy_n(op->padding()->begin(), 2, padding.begin());
-  std::copy_n(op->output_padding()->begin(), 2, outputPadding.begin());
-  std::copy_n(op->dilation()->begin(), 2, dilation.begin());
-
-  std::optional<::ttnn::DataType> outputDtype;
-  if (op->output_dtype()) {
-    outputDtype = ttnn_op_invoke::operations::utils::toTTNNDataType(
-        *(op->output_dtype()));
-  }
-
-  auto conv2dConfig = ::ttnn::Conv2dConfig();
-  if (op->conv2d_config()) {
-    conv2dConfig = utils::createConv2dConfig(op->conv2d_config());
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
-
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+  ::tt::target::ttnn::ConvTranspose2dOpT convTranspose2dOpT;
+  op->UnPackTo(&convTranspose2dOpT);
 
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
-  if (op->conv2d_slice_config()) {
-    sliceConfig = utils::createConv2dSliceConfig(op->conv2d_slice_config());
-  }
-  Conv2dResultWithOptions result = ::ttnn::conv_transpose2d(
-      input, weight, &targetDevice, op->in_channels(), op->out_channels(),
-      op->batch_size(), op->input_height(), op->input_width(), kernelSize,
-      stride, padding, outputPadding, dilation, op->groups(), outputDtype, bias,
-      conv2dConfig, computeConfig, memoryConfig, sliceConfig);
+  ttnn_op_invoke::ConvTranspose2dOpResult result =
+      ttnn_op_invoke::callConvTranspose2d(
+          ttnn_op_invoke::CallType::EXECUTE, convTranspose2dOpT, &input,
+          &weight,
+          bias.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*bias)
+                           : std::nullopt,
+          &targetDevice);
 
-  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result));
+  LOG_ASSERT(
+      std::holds_alternative<::ttnn::ConvTranspose2dResultWithOptions>(result),
+      "Expected ConvTranspose2dResultWithOptions from callConvTranspose2d "
+      "execution");
 
-  ::ttnn::Tensor out = std::get<::ttnn::Tensor>(result);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(
+                 std::get<::ttnn::ConvTranspose2dResultWithOptions>(result)),
+             "Expected output Tensor in ConvTranspose2dResultWithOptions");
+
+  ::ttnn::Tensor out = std::get<::ttnn::Tensor>(
+      std::get<::ttnn::ConvTranspose2dResultWithOptions>(result));
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/conv/prepare_conv2d_bias.cpp
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv2d_bias.cpp
@@ -3,85 +3,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/conv/prepare_conv2d_bias.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-
-#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dBiasOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::conv {
+
 void run(const ::tt::target::ttnn::PrepareConv2dBiasOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &weightTensor =
+  const ::ttnn::Tensor &biasTensor =
       tensorPool.getTTNNTensorAndValidate(op->bias_tensor());
 
-  std::optional<::ttnn::MemoryConfig> inputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->input_memory_config());
-  LOG_ASSERT(inputMemoryConfig.has_value(),
-             "Input memory expected to have a value");
-
-  LOG_ASSERT(op->kernel_size()->size() == 2,
-             "Kernel size expected to have 2 elements");
-  LOG_ASSERT(op->stride()->size() == 2, "Stride expected to have 2 elements");
-  LOG_ASSERT(op->padding()->size() == 2 || op->padding()->size() == 4,
-             "Padding expected to have 2 or 4 elements");
-  LOG_ASSERT(op->dilation()->size() == 2,
-             "Dilation expected to have 2 elements");
-
-  std::array<uint32_t, 2> kernelSize, stride, dilation;
-  std::copy_n(op->kernel_size()->begin(), 2, kernelSize.begin());
-  std::copy_n(op->stride()->begin(), 2, stride.begin());
-  std::copy_n(op->dilation()->begin(), 2, dilation.begin());
-
-  ::ttnn::DataType inputDtype =
-      ttnn_op_invoke::operations::utils::toTTNNDataType(op->input_dtype());
-
-  std::optional<::ttnn::DataType> outputDtype;
-  if (op->output_dtype()) {
-    outputDtype = ttnn_op_invoke::operations::utils::toTTNNDataType(
-        *(op->output_dtype()));
-  }
-
-  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
-  if (op->conv2d_config()) {
-    conv2dConfig = utils::createConv2dConfig(op->conv2d_config());
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
-
-  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
-  if (op->padding()->size() == 2) {
-    std::array<uint32_t, 2> symPadding;
-    std::copy_n(op->padding()->begin(), 2, symPadding.begin());
-    padding = symPadding;
-  } else {
-    std::array<uint32_t, 4> asymPadding;
-    std::copy_n(op->padding()->begin(), 4, asymPadding.begin());
-    padding = asymPadding;
-  }
+  ::tt::target::ttnn::PrepareConv2dBiasOpT prepareConv2dBiasOpNative;
+  op->UnPackTo(&prepareConv2dBiasOpNative);
 
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
-  if (op->conv2d_slice_config()) {
-    sliceConfig = utils::createConv2dSliceConfig(op->conv2d_slice_config());
-  }
+  ttnn_op_invoke::PrepareConv2dBiasOpResult result =
+      ttnn_op_invoke::callPrepareConv2dBias(ttnn_op_invoke::CallType::EXECUTE,
+                                            prepareConv2dBiasOpNative,
+                                            &biasTensor, &targetDevice);
 
-  ::ttnn::Tensor out = ::ttnn::operations::conv::conv2d::prepare_conv_bias(
-      weightTensor, *inputMemoryConfig,
-      ::ttnn_op_invoke::operations::utils::toTTNNLayout(
-          op->input_tensor_layout()),
-      op->in_channels(), op->out_channels(), op->batch_size(),
-      op->input_height(), op->input_width(), kernelSize, stride, padding,
-      dilation, op->groups(), &targetDevice, inputDtype, outputDtype,
-      conv2dConfig, computeConfig, sliceConfig);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callPrepareConv2dBias execution");
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/conv/prepare_conv2d_weights.cpp
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv2d_weights.cpp
@@ -3,85 +3,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/conv/prepare_conv2d_weights.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-
-#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dWeightsOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::conv {
+
 void run(const ::tt::target::ttnn::PrepareConv2dWeightsOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &weightTensor =
       tensorPool.getTTNNTensorAndValidate(op->weight_tensor());
 
-  std::optional<::ttnn::MemoryConfig> inputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->input_memory_config());
-  LOG_ASSERT(inputMemoryConfig.has_value(),
-             "Input memory expected to have a value");
-
-  LOG_ASSERT(op->kernel_size()->size() == 2,
-             "Kernel size expected to have 2 elements");
-  LOG_ASSERT(op->stride()->size() == 2, "Stride expected to have 2 elements");
-  LOG_ASSERT(op->padding()->size() == 2 || op->padding()->size() == 4,
-             "Padding expected to have 2 or 4 elements");
-  LOG_ASSERT(op->dilation()->size() == 2,
-             "Dilation expected to have 2 elements");
-
-  std::array<uint32_t, 2> kernelSize, stride, dilation;
-  std::copy_n(op->kernel_size()->begin(), 2, kernelSize.begin());
-  std::copy_n(op->stride()->begin(), 2, stride.begin());
-  std::copy_n(op->dilation()->begin(), 2, dilation.begin());
-
-  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
-  if (op->padding()->size() == 2) {
-    std::array<uint32_t, 2> symPadding;
-    std::copy_n(op->padding()->begin(), 2, symPadding.begin());
-    padding = symPadding;
-  } else {
-    std::array<uint32_t, 4> asymPadding;
-    std::copy_n(op->padding()->begin(), 4, asymPadding.begin());
-    padding = asymPadding;
-  }
-
-  ::ttnn::DataType inputDtype =
-      ttnn_op_invoke::operations::utils::toTTNNDataType(op->input_dtype());
-
-  std::optional<::ttnn::DataType> outputDtype;
-  if (op->output_dtype()) {
-    outputDtype = ttnn_op_invoke::operations::utils::toTTNNDataType(
-        *(op->output_dtype()));
-  }
-
-  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
-  if (op->conv2d_config()) {
-    conv2dConfig = utils::createConv2dConfig(op->conv2d_config());
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ::tt::target::ttnn::PrepareConv2dWeightsOpT prepareConv2dWeightsOpNative;
+  op->UnPackTo(&prepareConv2dWeightsOpNative);
 
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
-  if (op->conv2d_slice_config()) {
-    sliceConfig = utils::createConv2dSliceConfig(op->conv2d_slice_config());
-  }
+  ttnn_op_invoke::PrepareConv2dWeightsOpResult result =
+      ttnn_op_invoke::callPrepareConv2dWeights(
+          ttnn_op_invoke::CallType::EXECUTE, prepareConv2dWeightsOpNative,
+          &weightTensor, &targetDevice);
 
-  ::ttnn::Tensor out = ::ttnn::operations::conv::conv2d::prepare_conv_weights(
-      weightTensor, *inputMemoryConfig,
-      ::ttnn_op_invoke::operations::utils::toTTNNLayout(
-          op->input_tensor_layout()),
-      op->weights_format()->str(), op->in_channels(), op->out_channels(),
-      op->batch_size(), op->input_height(), op->input_width(), kernelSize,
-      stride, padding, dilation, op->has_bias(), op->groups(), &targetDevice,
-      inputDtype, outputDtype, conv2dConfig, computeConfig, sliceConfig);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callPrepareConv2dWeights execution");
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/conv/prepare_conv3d_weights.cpp
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv3d_weights.cpp
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/conv/prepare_conv3d_weights.h"
-
-#include "tt/runtime/detail/ttnn/ttnn.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConv3dWeightsOp.h"
 
 namespace tt::runtime::ttnn::operations::conv {
 void run(const ::tt::target::ttnn::PrepareConv3dWeightsOp *op,
@@ -13,12 +13,20 @@ void run(const ::tt::target::ttnn::PrepareConv3dWeightsOp *op,
   const ::ttnn::Tensor &weightTensor =
       tensorPool.getTTNNTensorAndValidate(op->weight_tensor());
 
+  ::tt::target::ttnn::PrepareConv3dWeightsOpT opNative;
+  op->UnPackTo(&opNative);
+
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
-  ::ttnn::Tensor out =
-      ::ttnn::operations::experimental::conv3d::prepare_conv3d_weights(
-          weightTensor, op->groups(), op->c_in_block(), op->alignment(),
+
+  ttnn_op_invoke::PrepareConv3dWeightsOpResult result =
+      ttnn_op_invoke::callPrepareConv3dWeights(
+          ttnn_op_invoke::CallType::EXECUTE, opNative, &weightTensor,
           &targetDevice);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callPrepareConv3dWeights execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/conv/prepare_conv_transpose2d_bias.cpp
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv_transpose2d_bias.cpp
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/conv/prepare_conv_transpose2d_bias.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-
-#include "ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dBiasOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::conv {
 void run(const ::tt::target::ttnn::PrepareConvTranspose2dBiasOp *op,
@@ -16,72 +14,22 @@ void run(const ::tt::target::ttnn::PrepareConvTranspose2dBiasOp *op,
   const ::ttnn::Tensor &biasTensor =
       tensorPool.getTTNNTensorAndValidate(op->bias_tensor());
 
-  std::optional<::ttnn::MemoryConfig> inputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->input_memory_config());
-  LOG_ASSERT(inputMemoryConfig.has_value(),
-             "Input memory expected to have a value");
-
-  LOG_ASSERT(op->kernel_size()->size() == 2,
-             "Kernel size expected to have 2 elements");
-  LOG_ASSERT(op->stride()->size() == 2, "Stride expected to have 2 elements");
-  LOG_ASSERT(op->padding()->size() == 2 || op->padding()->size() == 4,
-             "Padding expected to have 2 or 4 elements");
-  LOG_ASSERT(op->dilation()->size() == 2,
-             "Dilation expected to have 2 elements");
-
-  std::array<uint32_t, 2> kernelSize, stride, dilation;
-  std::copy_n(op->kernel_size()->begin(), 2, kernelSize.begin());
-  std::copy_n(op->stride()->begin(), 2, stride.begin());
-  std::copy_n(op->dilation()->begin(), 2, dilation.begin());
-
-  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
-  if (op->padding()->size() == 2) {
-    std::array<uint32_t, 2> symPadding;
-    std::copy_n(op->padding()->begin(), 2, symPadding.begin());
-    padding = symPadding;
-  } else {
-    std::array<uint32_t, 4> asymPadding;
-    std::copy_n(op->padding()->begin(), 4, asymPadding.begin());
-    padding = asymPadding;
-  }
-
-  ::ttnn::DataType inputDtype =
-      ttnn_op_invoke::operations::utils::toTTNNDataType(op->input_dtype());
-
-  std::optional<::ttnn::DataType> outputDtype;
-  if (op->output_dtype()) {
-    outputDtype = ttnn_op_invoke::operations::utils::toTTNNDataType(
-        *(op->output_dtype()));
-  }
-
-  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
-  if (op->conv2d_config()) {
-    conv2dConfig = utils::createConv2dConfig(op->conv2d_config());
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT
+      prepareConvTranspose2dBiasOpNative;
+  op->UnPackTo(&prepareConvTranspose2dBiasOpNative);
 
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
-  if (op->conv2d_slice_config()) {
-    sliceConfig = utils::createConv2dSliceConfig(op->conv2d_slice_config());
-  }
-  ::ttnn::Tensor out =
-      ::ttnn::operations::conv::conv_transpose2d::prepare_conv_transpose2d_bias(
-          biasTensor, *inputMemoryConfig,
-          ::ttnn_op_invoke::operations::utils::toTTNNLayout(
-              op->input_tensor_layout()),
-          op->in_channels(), op->out_channels(), op->batch_size(),
-          op->input_height(), op->input_width(), kernelSize, stride, padding,
-          dilation, op->groups(), &targetDevice, inputDtype, outputDtype,
-          conv2dConfig, computeConfig, sliceConfig);
+  ttnn_op_invoke::PrepareConvTranspose2dBiasOpResult result =
+      ttnn_op_invoke::callPrepareConvTranspose2dBias(
+          ttnn_op_invoke::CallType::EXECUTE, prepareConvTranspose2dBiasOpNative,
+          &biasTensor, &targetDevice);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callPrepareConvTranspose2dBias execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/conv/prepare_conv_transpose2d_weights.cpp
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv_transpose2d_weights.cpp
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/conv/prepare_conv_transpose2d_weights.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-
-#include "ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dWeightsOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::conv {
 void run(const ::tt::target::ttnn::PrepareConvTranspose2dWeightsOp *op,
@@ -16,76 +14,23 @@ void run(const ::tt::target::ttnn::PrepareConvTranspose2dWeightsOp *op,
   const ::ttnn::Tensor &weightTensor =
       tensorPool.getTTNNTensorAndValidate(op->weight_tensor());
 
-  std::optional<::ttnn::MemoryConfig> inputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->input_memory_config());
-  LOG_ASSERT(inputMemoryConfig.has_value(),
-             "Input memory expected to have a value");
-
-  LOG_ASSERT(op->kernel_size()->size() == 2,
-             "Kernel size expected to have 2 elements");
-  LOG_ASSERT(op->stride()->size() == 2, "Stride expected to have 2 elements");
-  LOG_ASSERT(op->padding()->size() == 2 || op->padding()->size() == 4,
-             "Padding expected to have 2 or 4 elements");
-  LOG_ASSERT(op->output_padding()->size() == 2,
-             "Output padding expected to have 2 elements");
-  LOG_ASSERT(op->dilation()->size() == 2,
-             "Dilation expected to have 2 elements");
-
-  std::array<uint32_t, 2> kernelSize, stride, outputPadding, dilation;
-  std::copy_n(op->kernel_size()->begin(), 2, kernelSize.begin());
-  std::copy_n(op->stride()->begin(), 2, stride.begin());
-  std::copy_n(op->output_padding()->begin(), 2, outputPadding.begin());
-  std::copy_n(op->dilation()->begin(), 2, dilation.begin());
-
-  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
-  if (op->padding()->size() == 2) {
-    std::array<uint32_t, 2> symPadding;
-    std::copy_n(op->padding()->begin(), 2, symPadding.begin());
-    padding = symPadding;
-  } else {
-    std::array<uint32_t, 4> asymPadding;
-    std::copy_n(op->padding()->begin(), 4, asymPadding.begin());
-    padding = asymPadding;
-  }
-
-  ::ttnn::DataType inputDtype =
-      ttnn_op_invoke::operations::utils::toTTNNDataType(op->input_dtype());
-
-  std::optional<::ttnn::DataType> outputDtype;
-  if (op->output_dtype()) {
-    outputDtype = ttnn_op_invoke::operations::utils::toTTNNDataType(
-        *(op->output_dtype()));
-  }
-
-  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
-  if (op->conv2d_config()) {
-    conv2dConfig = utils::createConv2dConfig(op->conv2d_config());
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT
+      prepareConvTranspose2dWeightsOpNative;
+  op->UnPackTo(&prepareConvTranspose2dWeightsOpNative);
 
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
-  if (op->conv2d_slice_config()) {
-    sliceConfig = utils::createConv2dSliceConfig(op->conv2d_slice_config());
-  }
-  ::ttnn::Tensor out = ::ttnn::operations::conv::conv_transpose2d::
-      prepare_conv_transpose2d_weights(
-          weightTensor, *inputMemoryConfig,
-          ::ttnn_op_invoke::operations::utils::toTTNNLayout(
-              op->input_tensor_layout()),
-          op->weights_format()->str(), op->in_channels(), op->out_channels(),
-          op->batch_size(), op->input_height(), op->input_width(), kernelSize,
-          stride, padding, outputPadding, dilation, op->has_bias(),
-          op->groups(), &targetDevice, inputDtype, outputDtype, conv2dConfig,
-          computeConfig, sliceConfig, op->mirror_kernel());
+  ttnn_op_invoke::PrepareConvTranspose2dWeightsOpResult result =
+      ttnn_op_invoke::callPrepareConvTranspose2dWeights(
+          ttnn_op_invoke::CallType::EXECUTE,
+          prepareConvTranspose2dWeightsOpNative, &weightTensor, &targetDevice);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(
+      std::holds_alternative<::ttnn::Tensor>(result),
+      "Expected Tensor from callPrepareConvTranspose2dWeights execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::conv

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
@@ -35,6 +35,46 @@ const mlir::tt::ttcore::DataTypeAttr bf16DtypeAttr =
     mlir::tt::ttcore::DataTypeAttr::get(getContext(),
                                         mlir::tt::ttcore::DataType::BFloat16);
 
+const mlir::tt::ttnn::Conv2dConfigAttr nonDefaultConv2dConfigAttr =
+    mlir::tt::ttnn::Conv2dConfigAttr::get(
+        getContext(),
+        /*weights_dtype=*/mlir::tt::ttcore::DataType::BFloat16,
+        /*activation=*/mlir::tt::ttnn::UnaryWithParamAttr(),
+        /*deallocate_activation=*/mlir::BoolAttr::get(getContext(), false),
+        /*reallocate_halo_output=*/mlir::BoolAttr::get(getContext(), true),
+        /*act_block_h_override=*/0, /*act_block_w_div=*/1,
+        /*reshard_if_not_optimal=*/mlir::BoolAttr::get(getContext(), false),
+        /*override_sharding_config=*/mlir::BoolAttr::get(getContext(), false),
+        /*shard_layout=*/std::nullopt,
+        /*core_grid=*/mlir::tt::ttnn::CoreRangeSetAttr(),
+        /*transpose_shards=*/mlir::BoolAttr::get(getContext(), false),
+        /*output_layout=*/mlir::tt::ttnn::Layout::Tile,
+        /*enable_act_double_buffer=*/mlir::BoolAttr::get(getContext(), true),
+        /*enable_weights_double_buffer=*/
+        mlir::BoolAttr::get(getContext(), true),
+        /*enable_kernel_stride_folding=*/
+        mlir::BoolAttr::get(getContext(), false),
+        /*config_tensors_in_dram=*/mlir::BoolAttr());
+
+const mlir::tt::ttnn::DeviceComputeKernelConfigAttr
+    nonDefaultDeviceComputeKernelConfigAttr =
+        mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
+            getContext(), mlir::tt::ttnn::MathFidelity::HiFi2,
+            mlir::BoolAttr::get(getContext(), false),
+            mlir::BoolAttr::get(getContext(), true),
+            mlir::BoolAttr::get(getContext(), true),
+            mlir::BoolAttr::get(getContext(), false));
+
+const mlir::tt::ttnn::Conv2dSliceConfigAttr nonDefaultConv2dSliceConfigAttr =
+    mlir::tt::ttnn::Conv2dSliceConfigAttr::get(
+        getContext(), mlir::tt::ttnn::Conv2dSliceType::DramHeight, 4);
+
+const mlir::tt::ttnn::MemoryConfigAttr nonDefaultInputMemoryConfigAttr =
+    mlir::tt::ttnn::MemoryConfigAttr::Builder(
+        mlir::tt::ttnn::MemoryConfigAttr::get(
+            createTiledL1InterleavedLayout({32, 32})))
+        .setBufferType(mlir::tt::ttnn::BufferType::DRAM);
+
 namespace {
 
 void resetUnusedFields(::tt::target::ttnn::MatmulOpT &opNativeOpModel,
@@ -288,47 +328,15 @@ TEST_P(Conv2dOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
 const std::initializer_list<mlir::tt::ttnn::Conv2dOp> conv2dOpList = {
     buildTestConv2dOp(),
     buildTestConv2dOp(/*withBias=*/true),
-    buildTestConv2dOp(/*withBias=*/false,
-                      /*outputDtype=*/bf16DtypeAttr),
-    buildTestConv2dOp(
-        /*withBias=*/false, /*outputDtype=*/{},
-        /*conv2dConfig=*/
-        mlir::tt::ttnn::Conv2dConfigAttr::get(
-            getContext(),
-            /*weights_dtype=*/mlir::tt::ttcore::DataType::BFloat16,
-            /*activation=*/mlir::tt::ttnn::UnaryWithParamAttr(),
-            /*deallocate_activation=*/mlir::BoolAttr::get(getContext(), false),
-            /*reallocate_halo_output=*/mlir::BoolAttr::get(getContext(), true),
-            /*act_block_h_override=*/0, /*act_block_w_div=*/1,
-            /*reshard_if_not_optimal=*/mlir::BoolAttr::get(getContext(), false),
-            /*override_sharding_config=*/
-            mlir::BoolAttr::get(getContext(), false),
-            /*shard_layout=*/std::nullopt,
-            /*core_grid=*/mlir::tt::ttnn::CoreRangeSetAttr(),
-            /*transpose_shards=*/mlir::BoolAttr::get(getContext(), false),
-            /*output_layout=*/mlir::tt::ttnn::Layout::Tile,
-            /*enable_act_double_buffer=*/
-            mlir::BoolAttr::get(getContext(), true),
-            /*enable_weights_double_buffer=*/
-            mlir::BoolAttr::get(getContext(), true),
-            /*enable_kernel_stride_folding=*/
-            mlir::BoolAttr::get(getContext(), false),
-            /*config_tensors_in_dram=*/mlir::BoolAttr())),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/bf16DtypeAttr),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/nonDefaultConv2dConfigAttr),
     buildTestConv2dOp(
         /*withBias=*/false, /*outputDtype=*/{}, /*conv2dConfig=*/{},
-        /*computeKernelConfig=*/
-        mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
-            getContext(), mlir::tt::ttnn::MathFidelity::HiFi2,
-            mlir::BoolAttr::get(getContext(), false),
-            mlir::BoolAttr::get(getContext(), true),
-            mlir::BoolAttr::get(getContext(), true),
-            mlir::BoolAttr::get(getContext(), false))),
-    buildTestConv2dOp(
-        /*withBias=*/false, /*outputDtype=*/{}, /*conv2dConfig=*/{},
-        /*computeKernelConfig=*/{},
-        /*conv2dSliceConfig=*/
-        mlir::tt::ttnn::Conv2dSliceConfigAttr::get(
-            getContext(), mlir::tt::ttnn::Conv2dSliceType::DramHeight, 4)),
+        /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+    buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr),
     buildTestConv2dOp(/*withBias=*/false, /*outputDtype=*/{},
                       /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
                       /*conv2dSliceConfig=*/{}, /*inChannels=*/64u),
@@ -384,49 +392,1425 @@ const std::initializer_list<mlir::tt::ttnn::Conv2dOp> conv2dOpList = {
                       /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
                       /*padding=*/{3, 3}, /*dilation=*/{1, 1},
                       /*groups=*/3u),
-    buildTestConv2dOp(
-        /*withBias=*/true,
-        /*outputDtype=*/bf16DtypeAttr,
-        /*conv2dConfig=*/
-        mlir::tt::ttnn::Conv2dConfigAttr::get(
-            getContext(),
-            /*weights_dtype=*/mlir::tt::ttcore::DataType::BFloat16,
-            /*activation=*/mlir::tt::ttnn::UnaryWithParamAttr(),
-            /*deallocate_activation=*/mlir::BoolAttr::get(getContext(), true),
-            /*reallocate_halo_output=*/mlir::BoolAttr::get(getContext(), false),
-            /*act_block_h_override=*/32, /*act_block_w_div=*/1,
-            /*reshard_if_not_optimal=*/mlir::BoolAttr::get(getContext(), false),
-            /*override_sharding_config=*/
-            mlir::BoolAttr::get(getContext(), false),
-            /*shard_layout=*/std::nullopt,
-            /*core_grid=*/mlir::tt::ttnn::CoreRangeSetAttr(),
-            /*transpose_shards=*/mlir::BoolAttr::get(getContext(), false),
-            /*output_layout=*/mlir::tt::ttnn::Layout::Tile,
-            /*enable_act_double_buffer=*/
-            mlir::BoolAttr::get(getContext(), true),
-            /*enable_weights_double_buffer=*/
-            mlir::BoolAttr::get(getContext(), false),
-            /*enable_kernel_stride_folding=*/
-            mlir::BoolAttr::get(getContext(), false),
-            /*config_tensors_in_dram=*/mlir::BoolAttr()),
-        /*computeKernelConfig=*/
-        mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
-            getContext(), mlir::tt::ttnn::MathFidelity::HiFi3,
-            mlir::BoolAttr::get(getContext(), false),
-            mlir::BoolAttr::get(getContext(), false),
-            mlir::BoolAttr::get(getContext(), true),
-            mlir::BoolAttr::get(getContext(), true)),
-        /*conv2dSliceConfig=*/
-        mlir::tt::ttnn::Conv2dSliceConfigAttr::get(
-            getContext(), mlir::tt::ttnn::Conv2dSliceType::DramHeight, 2),
-        /*inChannels=*/16u, /*outChannels=*/32u, /*batchSize=*/2u,
-        /*inputHeight=*/112u, /*inputWidth=*/112u,
-        /*kernelSize=*/{3, 3}, /*stride=*/{1, 1}, /*padding=*/{1, 1},
-        /*dilation=*/{1, 1}, /*groups=*/1u),
+    buildTestConv2dOp(/*withBias=*/true, /*outputDtype=*/bf16DtypeAttr,
+                      /*conv2dConfig=*/nonDefaultConv2dConfigAttr,
+                      /*computeKernelConfig=*/
+                      nonDefaultDeviceComputeKernelConfigAttr,
+                      /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr,
+                      /*inChannels=*/64u, /*outChannels=*/128u,
+                      /*batchSize=*/8u, /*inputHeight=*/56u,
+                      /*inputWidth=*/56u, /*kernelSize=*/{3, 3},
+                      /*stride=*/{1, 1}, /*padding=*/{1, 1},
+                      /*dilation=*/{2, 2}, /*groups=*/2u),
 };
 
 INSTANTIATE_TEST_SUITE_P(Conv2dOpTPathParityTest, Conv2dOpTPathParityTest,
                          ::testing::ValuesIn(conv2dOpList));
+
+//===----------------------------------------------------------------------===//
+// Conv3dOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+const mlir::tt::ttnn::Conv3dConfigAttr nonDefaultConv3dConfigAttr =
+    mlir::tt::ttnn::Conv3dConfigAttr::get(
+        getContext(),
+        /*weights_dtype=*/mlir::tt::ttcore::DataType::BFloat16,
+        /*t_out_block=*/1u,
+        /*w_out_block=*/2u,
+        /*h_out_block=*/2u,
+        /*c_out_block=*/16u,
+        /*c_in_block=*/16u,
+        /*compute_with_storage_grid_size=*/
+        mlir::tt::ttcore::GridAttr::get(getContext(),
+                                        llvm::ArrayRef<int64_t>{8, 8}));
+
+void resetUnusedFields(::tt::target::ttnn::Conv3dOpT &opNativeOpModel,
+                       ::tt::target::ttnn::Conv3dOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::Conv3dOpT &op) {
+    op.input.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.device.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::Conv3dOp buildTestConv3dOp(
+    bool withBias = false, mlir::tt::ttcore::DataTypeAttr outputDtype = {},
+    mlir::tt::ttnn::Conv3dConfigAttr conv3dConfig = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeKernelConfig = {},
+    uint32_t inChannels = 32, uint32_t outChannels = 64, uint32_t batchSize = 1,
+    uint32_t inputDepth = 8, uint32_t inputHeight = 8, uint32_t inputWidth = 8,
+    llvm::ArrayRef<int32_t> kernelSize = {3, 3, 3},
+    llvm::ArrayRef<int32_t> stride = {1, 1, 1},
+    llvm::ArrayRef<int32_t> padding = {0, 0, 0},
+    llvm::StringRef paddingMode = "zeros", uint32_t groups = 1) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto weightType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value weight =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{weightType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value bias = nullptr;
+  if (withBias) {
+    auto biasType = tiledL1BF16Type(defaultShape);
+    bias = e.builder
+               .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{biasType},
+                                               mlir::ValueRange{})
+               .getResult();
+  }
+
+  mlir::Value device =
+      e.builder
+          .create<mlir::tt::ttnn::GetDeviceOp>(
+              loc, e.builder.getType<mlir::tt::ttnn::DeviceType>(),
+              mlir::tt::ttnn::MeshShapeAttr::get(&e.context, 1, 1),
+              mlir::tt::ttnn::MeshOffsetAttr::get(&e.context, 0, 0))
+          .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::Conv3dOp>(
+      loc, outputType, input, weight, bias, device, inChannels, outChannels,
+      batchSize, inputDepth, inputHeight, inputWidth, kernelSize, stride,
+      padding, paddingMode, groups, conv3dConfig, computeKernelConfig);
+}
+
+} // namespace
+
+using Conv3dOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::Conv3dOp>;
+
+TEST_P(Conv3dOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::Conv3dOp conv3dOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::Conv3dOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildConv3dOpTFromMLIR(
+          conv3dOp.getInChannels(), conv3dOp.getOutChannels(),
+          conv3dOp.getBatchSize(), conv3dOp.getInputDepth(),
+          conv3dOp.getInputHeight(), conv3dOp.getInputWidth(),
+          conv3dOp.getKernelSize(), conv3dOp.getStride(), conv3dOp.getPadding(),
+          conv3dOp.getPaddingMode(), conv3dOp.getGroups(),
+          conv3dOp.getDtypeAttr(), conv3dOp.getConv3dConfig(),
+          conv3dOp.getComputeConfig(), resolveOutputLayout(conv3dOp));
+
+  // Path B: FB serialization round-trip.
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, conv3dOp.getInput(),
+                               conv3dOp.getWeight());
+  if (conv3dOp.getBias()) {
+    prepopulateOperandTensorRefs(cache, conv3dOp.getBias());
+  }
+  cache.getOrCreate(conv3dOp.getDevice(), mlir::tt::ttnn::createDeviceRef);
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, conv3dOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::Conv3dOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::Conv3dOp> conv3dOpList = {
+    buildTestConv3dOp(),
+    buildTestConv3dOp(/*withBias=*/true),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/bf16DtypeAttr),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/nonDefaultConv3dConfigAttr),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{},
+                      /*computeKernelConfig=*/
+                      nonDefaultDeviceComputeKernelConfigAttr),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/64u),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/128u),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/64u,
+                      /*batchSize=*/4u),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/64u,
+                      /*batchSize=*/1u, /*inputDepth=*/16u),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/64u,
+                      /*batchSize=*/1u, /*inputDepth=*/8u,
+                      /*inputHeight=*/16u),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/64u,
+                      /*batchSize=*/1u, /*inputDepth=*/8u,
+                      /*inputHeight=*/8u, /*inputWidth=*/16u),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/64u,
+                      /*batchSize=*/1u, /*inputDepth=*/8u,
+                      /*inputHeight=*/8u, /*inputWidth=*/8u,
+                      /*kernelSize=*/{2, 2, 2}),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/64u,
+                      /*batchSize=*/1u, /*inputDepth=*/8u,
+                      /*inputHeight=*/8u, /*inputWidth=*/8u,
+                      /*kernelSize=*/{3, 3, 3}, /*stride=*/{2, 2, 2}),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/64u,
+                      /*batchSize=*/1u, /*inputDepth=*/8u,
+                      /*inputHeight=*/8u, /*inputWidth=*/8u,
+                      /*kernelSize=*/{3, 3, 3}, /*stride=*/{1, 1, 1},
+                      /*padding=*/{1, 1, 1}),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/64u,
+                      /*batchSize=*/1u, /*inputDepth=*/8u,
+                      /*inputHeight=*/8u, /*inputWidth=*/8u,
+                      /*kernelSize=*/{3, 3, 3}, /*stride=*/{1, 1, 1},
+                      /*padding=*/{0, 0, 0},
+                      /*paddingMode=*/"replicate"),
+    buildTestConv3dOp(/*withBias=*/false, /*outputDtype=*/{},
+                      /*conv3dConfig=*/{}, /*computeKernelConfig=*/{},
+                      /*inChannels=*/32u, /*outChannels=*/64u,
+                      /*batchSize=*/1u, /*inputDepth=*/8u,
+                      /*inputHeight=*/8u, /*inputWidth=*/8u,
+                      /*kernelSize=*/{3, 3, 3}, /*stride=*/{1, 1, 1},
+                      /*padding=*/{0, 0, 0}, /*paddingMode=*/"zeros",
+                      /*groups=*/4u),
+    buildTestConv3dOp(/*withBias=*/true, /*outputDtype=*/bf16DtypeAttr,
+                      /*conv3dConfig=*/nonDefaultConv3dConfigAttr,
+                      /*computeKernelConfig=*/
+                      nonDefaultDeviceComputeKernelConfigAttr,
+                      /*inChannels=*/64u, /*outChannels=*/128u,
+                      /*batchSize=*/4u, /*inputDepth=*/16u,
+                      /*inputHeight=*/16u, /*inputWidth=*/16u,
+                      /*kernelSize=*/{2, 2, 2}, /*stride=*/{2, 2, 2},
+                      /*padding=*/{1, 1, 1}, /*paddingMode=*/"replicate",
+                      /*groups=*/2u),
+};
+
+INSTANTIATE_TEST_SUITE_P(Conv3dOpTPathParityTest, Conv3dOpTPathParityTest,
+                         ::testing::ValuesIn(conv3dOpList));
+
+//===----------------------------------------------------------------------===//
+// ConvTranspose2dOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::ConvTranspose2dOpT &opNativeOpModel,
+                       ::tt::target::ttnn::ConvTranspose2dOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ConvTranspose2dOpT &op) {
+    op.input.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.device.reset();
+    op.out.reset();
+    op.output_dtype.reset();
+    op.memory_config.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::ConvTranspose2dOp buildTestConvTranspose2dOp(
+    bool withBias = false, mlir::tt::ttcore::DataTypeAttr outputDtype = {},
+    mlir::tt::ttnn::Conv2dConfigAttr conv2dConfig = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeKernelConfig = {},
+    mlir::tt::ttnn::Conv2dSliceConfigAttr conv2dSliceConfig = {},
+    mlir::tt::ttnn::MemoryConfigAttr memoryConfig = {},
+    uint32_t inChannels = 64, uint32_t outChannels = 32, uint32_t batchSize = 1,
+    uint32_t inputHeight = 28, uint32_t inputWidth = 28,
+    llvm::ArrayRef<int32_t> kernelSize = {3, 3},
+    llvm::ArrayRef<int32_t> stride = {2, 2},
+    llvm::ArrayRef<int32_t> padding = {1, 1},
+    llvm::ArrayRef<int32_t> outputPadding = {0, 0},
+    llvm::ArrayRef<int32_t> dilation = {1, 1}, uint32_t groups = 1) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto weightType = tiledL1BF16Type(defaultShape);
+  auto outputType =
+      memoryConfig ? tiledBF16TypeFromMemoryConfig(defaultShape, memoryConfig)
+                   : tiledL1BF16Type(defaultShape);
+
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value weight =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{weightType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value bias = nullptr;
+  if (withBias) {
+    auto biasType = tiledL1BF16Type(defaultShape);
+    bias = e.builder
+               .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{biasType},
+                                               mlir::ValueRange{})
+               .getResult();
+  }
+
+  mlir::Value device =
+      e.builder
+          .create<mlir::tt::ttnn::GetDeviceOp>(
+              loc, e.builder.getType<mlir::tt::ttnn::DeviceType>(),
+              mlir::tt::ttnn::MeshShapeAttr::get(&e.context, 1, 1),
+              mlir::tt::ttnn::MeshOffsetAttr::get(&e.context, 0, 0))
+          .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::ConvTranspose2dOp>(
+      loc, outputType, input, weight, bias, device, inChannels, outChannels,
+      batchSize, inputHeight, inputWidth, kernelSize, stride, padding,
+      outputPadding, dilation, groups, conv2dConfig, computeKernelConfig,
+      conv2dSliceConfig);
+}
+
+} // namespace
+
+using ConvTranspose2dOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ConvTranspose2dOp>;
+
+TEST_P(ConvTranspose2dOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::ConvTranspose2dOp convTranspose2dOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ConvTranspose2dOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildConvTranspose2dOpTFromMLIR(
+          convTranspose2dOp.getInChannels(), convTranspose2dOp.getOutChannels(),
+          convTranspose2dOp.getBatchSize(), convTranspose2dOp.getInputHeight(),
+          convTranspose2dOp.getInputWidth(), convTranspose2dOp.getKernelSize(),
+          convTranspose2dOp.getStride(), convTranspose2dOp.getPadding(),
+          convTranspose2dOp.getOutputPadding(), convTranspose2dOp.getDilation(),
+          convTranspose2dOp.getGroups(), convTranspose2dOp.getConv2dConfig(),
+          convTranspose2dOp.getConv2dSliceConfig(),
+          convTranspose2dOp.getComputeConfig(),
+          resolveOutputLayout(convTranspose2dOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, convTranspose2dOp.getInput(),
+                               convTranspose2dOp.getWeight());
+  if (convTranspose2dOp.getBias()) {
+    prepopulateOperandTensorRefs(cache, convTranspose2dOp.getBias());
+  }
+  cache.getOrCreate(convTranspose2dOp.getDevice(),
+                    mlir::tt::ttnn::createDeviceRef);
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, convTranspose2dOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ConvTranspose2dOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::ConvTranspose2dOp>
+    convTranspose2dOpList = {
+        buildTestConvTranspose2dOp(),
+        buildTestConvTranspose2dOp(/*withBias=*/true),
+        buildTestConvTranspose2dOp(/*withBias=*/false,
+                                   /*outputDtype=*/bf16DtypeAttr),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/nonDefaultConv2dConfigAttr),
+        buildTestConvTranspose2dOp(
+            /*withBias=*/false, /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestConvTranspose2dOp(
+            /*withBias=*/false, /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/
+                                   nonDefaultInputMemoryConfigAttr),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/128u),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/64u),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/32u,
+                                   /*batchSize=*/4u),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/32u,
+                                   /*batchSize=*/1u, /*inputHeight=*/14u),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/32u,
+                                   /*batchSize=*/1u, /*inputHeight=*/28u,
+                                   /*inputWidth=*/14u),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/32u,
+                                   /*batchSize=*/1u, /*inputHeight=*/28u,
+                                   /*inputWidth=*/28u, /*kernelSize=*/{4, 4}),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/32u,
+                                   /*batchSize=*/1u, /*inputHeight=*/28u,
+                                   /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+                                   /*stride=*/{1, 1}),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/32u,
+                                   /*batchSize=*/1u, /*inputHeight=*/28u,
+                                   /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+                                   /*stride=*/{2, 2}, /*padding=*/{0, 0}),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/32u,
+                                   /*batchSize=*/1u, /*inputHeight=*/28u,
+                                   /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+                                   /*stride=*/{2, 2}, /*padding=*/{1, 1},
+                                   /*outputPadding=*/{1, 1}),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/32u,
+                                   /*batchSize=*/1u, /*inputHeight=*/28u,
+                                   /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+                                   /*stride=*/{2, 2}, /*padding=*/{1, 1},
+                                   /*outputPadding=*/{0, 0},
+                                   /*dilation=*/{2, 2}),
+        buildTestConvTranspose2dOp(/*withBias=*/false, /*outputDtype=*/{},
+                                   /*conv2dConfig=*/{},
+                                   /*computeKernelConfig=*/{},
+                                   /*conv2dSliceConfig=*/{},
+                                   /*memoryConfig=*/{},
+                                   /*inChannels=*/64u, /*outChannels=*/32u,
+                                   /*batchSize=*/1u, /*inputHeight=*/28u,
+                                   /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+                                   /*stride=*/{2, 2}, /*padding=*/{1, 1},
+                                   /*outputPadding=*/{0, 0},
+                                   /*dilation=*/{1, 1}, /*groups=*/4u),
+        buildTestConvTranspose2dOp(
+            /*withBias=*/true, /*outputDtype=*/bf16DtypeAttr,
+            /*conv2dConfig=*/nonDefaultConv2dConfigAttr,
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr,
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr,
+            /*memoryConfig=*/nonDefaultInputMemoryConfigAttr,
+            /*inChannels=*/128u, /*outChannels=*/64u, /*batchSize=*/4u,
+            /*inputHeight=*/14u, /*inputWidth=*/14u, /*kernelSize=*/{4, 4},
+            /*stride=*/{1, 1}, /*padding=*/{0, 0}, /*outputPadding=*/{1, 1},
+            /*dilation=*/{2, 2}, /*groups=*/2u),
+};
+
+INSTANTIATE_TEST_SUITE_P(ConvTranspose2dOpTPathParityTest,
+                         ConvTranspose2dOpTPathParityTest,
+                         ::testing::ValuesIn(convTranspose2dOpList));
+
+//===----------------------------------------------------------------------===//
+// PrepareConv2dBiasOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::PrepareConv2dBiasOpT &opNativeOpModel,
+    ::tt::target::ttnn::PrepareConv2dBiasOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::PrepareConv2dBiasOpT &op) {
+    op.bias_tensor.reset();
+    op.device.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PrepareConv2dBiasOp buildTestPrepareConv2dBiasOp(
+    mlir::tt::ttcore::DataTypeAttr outputDtype = {},
+    mlir::tt::ttnn::Conv2dConfigAttr conv2dConfig = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeKernelConfig = {},
+    mlir::tt::ttnn::Conv2dSliceConfigAttr conv2dSliceConfig = {},
+    uint32_t inChannels = 3, uint32_t outChannels = 64, uint32_t batchSize = 1,
+    uint32_t inputHeight = 224, uint32_t inputWidth = 224,
+    llvm::ArrayRef<int32_t> kernelSize = {7, 7},
+    llvm::ArrayRef<int32_t> stride = {2, 2},
+    llvm::ArrayRef<int32_t> padding = {3, 3},
+    llvm::ArrayRef<int32_t> dilation = {1, 1}, uint32_t groups = 1,
+    mlir::tt::ttnn::MemoryConfigAttr inputMemoryConfig = {},
+    mlir::tt::ttnn::Layout inputTensorLayout = mlir::tt::ttnn::Layout::Tile,
+    mlir::tt::ttcore::DataType inputDtype =
+        mlir::tt::ttcore::DataType::BFloat16) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  llvm::SmallVector<int64_t, 4> biasShape = {1, 1, 1,
+                                             static_cast<int64_t>(outChannels)};
+  auto biasType = tiledL1BF16Type(biasShape);
+  auto outputType = tiledL1BF16Type(biasShape);
+
+  mlir::Value bias = e.builder
+                         .create<mlir::tt::ttnn::OnesOp>(
+                             loc, mlir::TypeRange{biasType}, mlir::ValueRange{})
+                         .getResult();
+
+  mlir::Value device =
+      e.builder
+          .create<mlir::tt::ttnn::GetDeviceOp>(
+              loc, e.builder.getType<mlir::tt::ttnn::DeviceType>(),
+              mlir::tt::ttnn::MeshShapeAttr::get(&e.context, 1, 1),
+              mlir::tt::ttnn::MeshOffsetAttr::get(&e.context, 0, 0))
+          .getResult();
+
+  if (!inputMemoryConfig) {
+    auto biasLayout = mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+        mlir::cast<mlir::RankedTensorType>(biasType).getEncoding());
+    inputMemoryConfig = mlir::tt::ttnn::MemoryConfigAttr::get(biasLayout);
+  }
+
+  return e.builder.create<mlir::tt::ttnn::PrepareConv2dBiasOp>(
+      loc, outputType, bias, inputMemoryConfig, inputTensorLayout, inChannels,
+      outChannels, batchSize, inputHeight, inputWidth, kernelSize, stride,
+      padding, dilation, groups, device, inputDtype, outputDtype, conv2dConfig,
+      computeKernelConfig, conv2dSliceConfig);
+}
+
+} // namespace
+
+using PrepareConv2dBiasOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::PrepareConv2dBiasOp>;
+
+TEST_P(PrepareConv2dBiasOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PrepareConv2dBiasOp prepareOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::PrepareConv2dBiasOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildPrepareConv2dBiasOpTFromMLIR(
+          prepareOp.getInputMemoryConfig(), prepareOp.getInputTensorLayout(),
+          prepareOp.getInChannels(), prepareOp.getOutChannels(),
+          prepareOp.getBatchSize(), prepareOp.getInputHeight(),
+          prepareOp.getInputWidth(), prepareOp.getKernelSize(),
+          prepareOp.getStride(), prepareOp.getPadding(),
+          prepareOp.getDilation(), prepareOp.getGroups(),
+          prepareOp.getInputDtype(), prepareOp.getOutputDtype(),
+          prepareOp.getConv2dConfig(), prepareOp.getConv2dSliceConfig(),
+          prepareOp.getComputeConfig(), resolveOutputLayout(prepareOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, prepareOp.getBiasTensor());
+  cache.getOrCreate(prepareOp.getDevice(), mlir::tt::ttnn::createDeviceRef);
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, prepareOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PrepareConv2dBiasOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::PrepareConv2dBiasOp>
+    prepareConv2dBiasOpList = {
+        buildTestPrepareConv2dBiasOp(),
+        buildTestPrepareConv2dBiasOp(/*outputDtype=*/bf16DtypeAttr),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/nonDefaultConv2dConfigAttr),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr),
+        buildTestPrepareConv2dBiasOp(/*outputDtype=*/{}, /*conv2dConfig=*/{},
+                                     /*computeKernelConfig=*/{},
+                                     /*conv2dSliceConfig=*/{},
+                                     /*inChannels=*/64u),
+        buildTestPrepareConv2dBiasOp(/*outputDtype=*/{}, /*conv2dConfig=*/{},
+                                     /*computeKernelConfig=*/{},
+                                     /*conv2dSliceConfig=*/{},
+                                     /*inChannels=*/3u,
+                                     /*outChannels=*/128u),
+        buildTestPrepareConv2dBiasOp(/*outputDtype=*/{}, /*conv2dConfig=*/{},
+                                     /*computeKernelConfig=*/{},
+                                     /*conv2dSliceConfig=*/{},
+                                     /*inChannels=*/3u, /*outChannels=*/64u,
+                                     /*batchSize=*/8u),
+        buildTestPrepareConv2dBiasOp(/*outputDtype=*/{}, /*conv2dConfig=*/{},
+                                     /*computeKernelConfig=*/{},
+                                     /*conv2dSliceConfig=*/{},
+                                     /*inChannels=*/3u, /*outChannels=*/64u,
+                                     /*batchSize=*/1u, /*inputHeight=*/56u),
+        buildTestPrepareConv2dBiasOp(/*outputDtype=*/{}, /*conv2dConfig=*/{},
+                                     /*computeKernelConfig=*/{},
+                                     /*conv2dSliceConfig=*/{},
+                                     /*inChannels=*/3u, /*outChannels=*/64u,
+                                     /*batchSize=*/1u, /*inputHeight=*/224u,
+                                     /*inputWidth=*/56u),
+        buildTestPrepareConv2dBiasOp(/*outputDtype=*/{}, /*conv2dConfig=*/{},
+                                     /*computeKernelConfig=*/{},
+                                     /*conv2dSliceConfig=*/{},
+                                     /*inChannels=*/3u, /*outChannels=*/64u,
+                                     /*batchSize=*/1u, /*inputHeight=*/224u,
+                                     /*inputWidth=*/224u,
+                                     /*kernelSize=*/{3, 3}),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/{}, /*inChannels=*/3u, /*outChannels=*/64u,
+            /*batchSize=*/1u, /*inputHeight=*/224u, /*inputWidth=*/224u,
+            /*kernelSize=*/{7, 7}, /*stride=*/{1, 1}),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/{}, /*inChannels=*/3u, /*outChannels=*/64u,
+            /*batchSize=*/1u, /*inputHeight=*/224u, /*inputWidth=*/224u,
+            /*kernelSize=*/{7, 7}, /*stride=*/{2, 2}, /*padding=*/{1, 1}),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/{}, /*inChannels=*/3u, /*outChannels=*/64u,
+            /*batchSize=*/1u, /*inputHeight=*/224u, /*inputWidth=*/224u,
+            /*kernelSize=*/{7, 7}, /*stride=*/{2, 2}, /*padding=*/{3, 3},
+            /*dilation=*/{2, 2}),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/{}, /*inChannels=*/3u, /*outChannels=*/64u,
+            /*batchSize=*/1u, /*inputHeight=*/224u, /*inputWidth=*/224u,
+            /*kernelSize=*/{7, 7}, /*stride=*/{2, 2}, /*padding=*/{3, 3},
+            /*dilation=*/{1, 1}, /*groups=*/3u),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/{}, /*inChannels=*/3u, /*outChannels=*/64u,
+            /*batchSize=*/1u, /*inputHeight=*/224u, /*inputWidth=*/224u,
+            /*kernelSize=*/{7, 7}, /*stride=*/{2, 2}, /*padding=*/{3, 3},
+            /*dilation=*/{1, 1}, /*groups=*/1u,
+            /*inputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/{}, /*inChannels=*/3u, /*outChannels=*/64u,
+            /*batchSize=*/1u, /*inputHeight=*/224u, /*inputWidth=*/224u,
+            /*kernelSize=*/{7, 7}, /*stride=*/{2, 2}, /*padding=*/{3, 3},
+            /*dilation=*/{1, 1}, /*groups=*/1u,
+            /*inputMemoryConfig=*/{},
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::RowMajor),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{}, /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/{}, /*inChannels=*/3u, /*outChannels=*/64u,
+            /*batchSize=*/1u, /*inputHeight=*/224u, /*inputWidth=*/224u,
+            /*kernelSize=*/{7, 7}, /*stride=*/{2, 2}, /*padding=*/{3, 3},
+            /*dilation=*/{1, 1}, /*groups=*/1u,
+            /*inputMemoryConfig=*/{},
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::Tile,
+            /*inputDtype=*/mlir::tt::ttcore::DataType::Float32),
+        buildTestPrepareConv2dBiasOp(
+            /*outputDtype=*/bf16DtypeAttr,
+            /*conv2dConfig=*/nonDefaultConv2dConfigAttr,
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr,
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr,
+            /*inChannels=*/64u, /*outChannels=*/128u, /*batchSize=*/8u,
+            /*inputHeight=*/56u, /*inputWidth=*/56u, /*kernelSize=*/{3, 3},
+            /*stride=*/{1, 1}, /*padding=*/{1, 1}, /*dilation=*/{2, 2},
+            /*groups=*/2u,
+            /*inputMemoryConfig=*/nonDefaultInputMemoryConfigAttr,
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::RowMajor,
+            /*inputDtype=*/mlir::tt::ttcore::DataType::Float32),
+};
+
+INSTANTIATE_TEST_SUITE_P(PrepareConv2dBiasOpTPathParityTest,
+                         PrepareConv2dBiasOpTPathParityTest,
+                         ::testing::ValuesIn(prepareConv2dBiasOpList));
+
+//===----------------------------------------------------------------------===//
+// PrepareConv2dWeightsOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::PrepareConv2dWeightsOpT &opNativeOpModel,
+    ::tt::target::ttnn::PrepareConv2dWeightsOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::PrepareConv2dWeightsOpT &op) {
+    op.weight_tensor.reset();
+    op.device.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PrepareConv2dWeightsOp buildTestPrepareConv2dWeightsOp(
+    mlir::tt::ttcore::DataTypeAttr outputDtype = {},
+    mlir::tt::ttnn::Conv2dConfigAttr conv2dConfig = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeKernelConfig = {},
+    mlir::tt::ttnn::Conv2dSliceConfigAttr conv2dSliceConfig = {},
+    llvm::StringRef weightsFormat = "OIHW", bool hasBias = false,
+    uint32_t inChannels = 3, uint32_t outChannels = 64, uint32_t batchSize = 1,
+    uint32_t inputHeight = 224, uint32_t inputWidth = 224,
+    llvm::ArrayRef<int32_t> kernelSize = {7, 7},
+    llvm::ArrayRef<int32_t> stride = {2, 2},
+    llvm::ArrayRef<int32_t> padding = {3, 3},
+    llvm::ArrayRef<int32_t> dilation = {1, 1}, uint32_t groups = 1,
+    mlir::tt::ttnn::MemoryConfigAttr inputMemoryConfig = {},
+    mlir::tt::ttnn::Layout inputTensorLayout = mlir::tt::ttnn::Layout::Tile,
+    mlir::tt::ttcore::DataType inputDtype =
+        mlir::tt::ttcore::DataType::BFloat16) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  llvm::SmallVector<int64_t, 4> weightShape = {
+      static_cast<int64_t>(outChannels),
+      static_cast<int64_t>(inChannels / groups),
+      static_cast<int64_t>(kernelSize[0]), static_cast<int64_t>(kernelSize[1])};
+  auto weightType = tiledL1BF16Type(weightShape);
+  auto outputType = tiledL1BF16Type(weightShape);
+
+  mlir::Value weight =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{weightType},
+                                          mlir::ValueRange{})
+          .getResult();
+
+  mlir::Value device =
+      e.builder
+          .create<mlir::tt::ttnn::GetDeviceOp>(
+              loc, e.builder.getType<mlir::tt::ttnn::DeviceType>(),
+              mlir::tt::ttnn::MeshShapeAttr::get(&e.context, 1, 1),
+              mlir::tt::ttnn::MeshOffsetAttr::get(&e.context, 0, 0))
+          .getResult();
+
+  if (!inputMemoryConfig) {
+    auto weightLayout = mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+        mlir::cast<mlir::RankedTensorType>(weightType).getEncoding());
+    inputMemoryConfig = mlir::tt::ttnn::MemoryConfigAttr::get(weightLayout);
+  }
+
+  return e.builder.create<mlir::tt::ttnn::PrepareConv2dWeightsOp>(
+      loc, outputType, weight, inputMemoryConfig, inputTensorLayout,
+      weightsFormat, inChannels, outChannels, batchSize, inputHeight,
+      inputWidth, kernelSize, stride, padding, dilation, hasBias, groups,
+      device, inputDtype, outputDtype, conv2dConfig, computeKernelConfig,
+      conv2dSliceConfig);
+}
+
+} // namespace
+
+using PrepareConv2dWeightsOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::PrepareConv2dWeightsOp>;
+
+TEST_P(PrepareConv2dWeightsOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PrepareConv2dWeightsOp prepareOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::PrepareConv2dWeightsOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildPrepareConv2dWeightsOpTFromMLIR(
+          prepareOp.getInputMemoryConfig(), prepareOp.getInputTensorLayout(),
+          prepareOp.getWeightsFormat(), prepareOp.getInChannels(),
+          prepareOp.getOutChannels(), prepareOp.getBatchSize(),
+          prepareOp.getInputHeight(), prepareOp.getInputWidth(),
+          prepareOp.getKernelSize(), prepareOp.getStride(),
+          prepareOp.getPadding(), prepareOp.getDilation(),
+          prepareOp.getHasBias(), prepareOp.getGroups(),
+          prepareOp.getInputDtype(), prepareOp.getOutputDtype(),
+          prepareOp.getConv2dConfig(), prepareOp.getComputeConfig(),
+          prepareOp.getConv2dSliceConfig(), resolveOutputLayout(prepareOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, prepareOp.getWeightTensor());
+  cache.getOrCreate(prepareOp.getDevice(), mlir::tt::ttnn::createDeviceRef);
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, prepareOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PrepareConv2dWeightsOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::PrepareConv2dWeightsOp>
+    prepareConv2dWeightsOpList = {
+        buildTestPrepareConv2dWeightsOp(),
+        buildTestPrepareConv2dWeightsOp(/*outputDtype=*/bf16DtypeAttr),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{},
+            /*conv2dConfig=*/nonDefaultConv2dConfigAttr),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"IOHW"),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/true),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/64u),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/128u),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/8u),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/56u),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/224u,
+            /*inputWidth=*/56u),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/224u,
+            /*inputWidth=*/224u, /*kernelSize=*/{3, 3}),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/224u,
+            /*inputWidth=*/224u, /*kernelSize=*/{7, 7}, /*stride=*/{1, 1}),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/224u,
+            /*inputWidth=*/224u, /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
+            /*padding=*/{1, 1}),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/224u,
+            /*inputWidth=*/224u, /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
+            /*padding=*/{3, 3}, /*dilation=*/{2, 2}),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/224u,
+            /*inputWidth=*/224u, /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
+            /*padding=*/{3, 3}, /*dilation=*/{1, 1}, /*groups=*/3u),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/224u,
+            /*inputWidth=*/224u, /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
+            /*padding=*/{3, 3}, /*dilation=*/{1, 1}, /*groups=*/1u,
+            /*inputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/224u,
+            /*inputWidth=*/224u, /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
+            /*padding=*/{3, 3}, /*dilation=*/{1, 1}, /*groups=*/1u,
+            /*inputMemoryConfig=*/{},
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::RowMajor),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false, /*inChannels=*/3u,
+            /*outChannels=*/64u, /*batchSize=*/1u, /*inputHeight=*/224u,
+            /*inputWidth=*/224u, /*kernelSize=*/{7, 7}, /*stride=*/{2, 2},
+            /*padding=*/{3, 3}, /*dilation=*/{1, 1}, /*groups=*/1u,
+            /*inputMemoryConfig=*/{},
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::Tile,
+            /*inputDtype=*/mlir::tt::ttcore::DataType::Float32),
+        buildTestPrepareConv2dWeightsOp(
+            /*outputDtype=*/bf16DtypeAttr,
+            /*conv2dConfig=*/nonDefaultConv2dConfigAttr,
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr,
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr,
+            /*weightsFormat=*/"IOHW", /*hasBias=*/true,
+            /*inChannels=*/64u, /*outChannels=*/128u, /*batchSize=*/8u,
+            /*inputHeight=*/56u, /*inputWidth=*/56u, /*kernelSize=*/{3, 3},
+            /*stride=*/{1, 1}, /*padding=*/{1, 1}, /*dilation=*/{2, 2},
+            /*groups=*/2u,
+            /*inputMemoryConfig=*/nonDefaultInputMemoryConfigAttr,
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::RowMajor,
+            /*inputDtype=*/mlir::tt::ttcore::DataType::Float32),
+};
+
+INSTANTIATE_TEST_SUITE_P(PrepareConv2dWeightsOpTPathParityTest,
+                         PrepareConv2dWeightsOpTPathParityTest,
+                         ::testing::ValuesIn(prepareConv2dWeightsOpList));
+
+//===----------------------------------------------------------------------===//
+// PrepareConvTranspose2dBiasOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT &opNativeOpModel,
+    ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::PrepareConvTranspose2dBiasOpT &op) {
+    op.bias_tensor.reset();
+    op.device.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PrepareConvTranspose2dBiasOp
+buildTestPrepareConvTranspose2dBiasOp(
+    mlir::tt::ttcore::DataTypeAttr outputDtype = {},
+    mlir::tt::ttnn::Conv2dConfigAttr conv2dConfig = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeKernelConfig = {},
+    mlir::tt::ttnn::Conv2dSliceConfigAttr conv2dSliceConfig = {},
+    uint32_t inChannels = 64, uint32_t outChannels = 32, uint32_t batchSize = 1,
+    uint32_t inputHeight = 28, uint32_t inputWidth = 28,
+    llvm::ArrayRef<int32_t> kernelSize = {3, 3},
+    llvm::ArrayRef<int32_t> stride = {2, 2},
+    llvm::ArrayRef<int32_t> padding = {1, 1},
+    llvm::ArrayRef<int32_t> dilation = {1, 1}, uint32_t groups = 1,
+    mlir::tt::ttnn::MemoryConfigAttr inputMemoryConfig = {},
+    mlir::tt::ttnn::Layout inputTensorLayout = mlir::tt::ttnn::Layout::Tile,
+    mlir::tt::ttcore::DataType inputDtype =
+        mlir::tt::ttcore::DataType::BFloat16) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  llvm::SmallVector<int64_t, 4> biasShape = {1, 1, 1,
+                                             static_cast<int64_t>(outChannels)};
+  auto biasType = tiledL1BF16Type(biasShape);
+  auto outputType = tiledL1BF16Type(biasShape);
+
+  mlir::Value bias = e.builder
+                         .create<mlir::tt::ttnn::OnesOp>(
+                             loc, mlir::TypeRange{biasType}, mlir::ValueRange{})
+                         .getResult();
+
+  mlir::Value device =
+      e.builder
+          .create<mlir::tt::ttnn::GetDeviceOp>(
+              loc, e.builder.getType<mlir::tt::ttnn::DeviceType>(),
+              mlir::tt::ttnn::MeshShapeAttr::get(&e.context, 1, 1),
+              mlir::tt::ttnn::MeshOffsetAttr::get(&e.context, 0, 0))
+          .getResult();
+
+  if (!inputMemoryConfig) {
+    auto biasLayout = mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+        mlir::cast<mlir::RankedTensorType>(biasType).getEncoding());
+    inputMemoryConfig = mlir::tt::ttnn::MemoryConfigAttr::get(biasLayout);
+  }
+
+  return e.builder.create<mlir::tt::ttnn::PrepareConvTranspose2dBiasOp>(
+      loc, outputType, bias, inputMemoryConfig, inputTensorLayout, inChannels,
+      outChannels, batchSize, inputHeight, inputWidth, kernelSize, stride,
+      padding, dilation, groups, device, inputDtype, outputDtype, conv2dConfig,
+      computeKernelConfig, conv2dSliceConfig);
+}
+
+} // namespace
+
+using PrepareConvTranspose2dBiasOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::PrepareConvTranspose2dBiasOp>;
+
+TEST_P(PrepareConvTranspose2dBiasOpTPathParityTest,
+       BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PrepareConvTranspose2dBiasOp prepareOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildPrepareConvTranspose2dBiasOpTFromMLIR(
+          prepareOp.getInputMemoryConfig(), prepareOp.getInputTensorLayout(),
+          prepareOp.getInChannels(), prepareOp.getOutChannels(),
+          prepareOp.getBatchSize(), prepareOp.getInputHeight(),
+          prepareOp.getInputWidth(), prepareOp.getKernelSize(),
+          prepareOp.getStride(), prepareOp.getPadding(),
+          prepareOp.getDilation(), prepareOp.getGroups(),
+          prepareOp.getInputDtype(), prepareOp.getOutputDtype(),
+          prepareOp.getConv2dConfig(), prepareOp.getComputeConfig(),
+          prepareOp.getConv2dSliceConfig(), resolveOutputLayout(prepareOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, prepareOp.getBiasTensor());
+  cache.getOrCreate(prepareOp.getDevice(), mlir::tt::ttnn::createDeviceRef);
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, prepareOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PrepareConvTranspose2dBiasOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::PrepareConvTranspose2dBiasOp>
+    prepareConvTranspose2dBiasOpList = {
+        buildTestPrepareConvTranspose2dBiasOp(),
+        buildTestPrepareConvTranspose2dBiasOp(/*outputDtype=*/bf16DtypeAttr),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{},
+            /*conv2dConfig=*/nonDefaultConv2dConfigAttr),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/128u),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/64u),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/4u),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/14u),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/28u, /*inputWidth=*/14u),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/28u, /*inputWidth=*/28u, /*kernelSize=*/{4, 4}),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/28u, /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+            /*stride=*/{1, 1}),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/28u, /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+            /*stride=*/{2, 2}, /*padding=*/{0, 0}),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/28u, /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+            /*stride=*/{2, 2}, /*padding=*/{1, 1}, /*dilation=*/{2, 2}),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/28u, /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+            /*stride=*/{2, 2}, /*padding=*/{1, 1}, /*dilation=*/{1, 1},
+            /*groups=*/4u),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/28u, /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+            /*stride=*/{2, 2}, /*padding=*/{1, 1}, /*dilation=*/{1, 1},
+            /*groups=*/1u,
+            /*inputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/28u, /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+            /*stride=*/{2, 2}, /*padding=*/{1, 1}, /*dilation=*/{1, 1},
+            /*groups=*/1u, /*inputMemoryConfig=*/{},
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::RowMajor),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*inChannels=*/64u, /*outChannels=*/32u, /*batchSize=*/1u,
+            /*inputHeight=*/28u, /*inputWidth=*/28u, /*kernelSize=*/{3, 3},
+            /*stride=*/{2, 2}, /*padding=*/{1, 1}, /*dilation=*/{1, 1},
+            /*groups=*/1u, /*inputMemoryConfig=*/{},
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::Tile,
+            /*inputDtype=*/mlir::tt::ttcore::DataType::Float32),
+        buildTestPrepareConvTranspose2dBiasOp(
+            /*outputDtype=*/bf16DtypeAttr,
+            /*conv2dConfig=*/nonDefaultConv2dConfigAttr,
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr,
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr,
+            /*inChannels=*/128u, /*outChannels=*/64u, /*batchSize=*/4u,
+            /*inputHeight=*/14u, /*inputWidth=*/14u, /*kernelSize=*/{4, 4},
+            /*stride=*/{1, 1}, /*padding=*/{0, 0}, /*dilation=*/{2, 2},
+            /*groups=*/2u,
+            /*inputMemoryConfig=*/nonDefaultInputMemoryConfigAttr,
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::RowMajor,
+            /*inputDtype=*/mlir::tt::ttcore::DataType::Float32),
+};
+
+INSTANTIATE_TEST_SUITE_P(PrepareConvTranspose2dBiasOpTPathParityTest,
+                         PrepareConvTranspose2dBiasOpTPathParityTest,
+                         ::testing::ValuesIn(prepareConvTranspose2dBiasOpList));
+
+//===----------------------------------------------------------------------===//
+// PrepareConvTranspose2dWeightsOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT &opNativeOpModel,
+    ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT &op) {
+    op.weight_tensor.reset();
+    op.device.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PrepareConvTranspose2dWeightsOp
+buildTestPrepareConvTranspose2dWeightsOp(
+    mlir::tt::ttcore::DataTypeAttr outputDtype = {},
+    mlir::tt::ttnn::Conv2dConfigAttr conv2dConfig = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeKernelConfig = {},
+    mlir::tt::ttnn::Conv2dSliceConfigAttr conv2dSliceConfig = {},
+    llvm::StringRef weightsFormat = "OIHW", bool hasBias = false,
+    bool mirrorKernel = true, uint32_t inChannels = 64,
+    uint32_t outChannels = 32, uint32_t batchSize = 1,
+    uint32_t inputHeight = 28, uint32_t inputWidth = 28,
+    llvm::ArrayRef<int32_t> kernelSize = {3, 3},
+    llvm::ArrayRef<int32_t> stride = {2, 2},
+    llvm::ArrayRef<int32_t> padding = {1, 1},
+    llvm::ArrayRef<int32_t> outputPadding = {1, 1},
+    llvm::ArrayRef<int32_t> dilation = {1, 1}, uint32_t groups = 1,
+    mlir::tt::ttnn::MemoryConfigAttr inputMemoryConfig = {},
+    mlir::tt::ttnn::Layout inputTensorLayout = mlir::tt::ttnn::Layout::Tile,
+    mlir::tt::ttcore::DataType inputDtype =
+        mlir::tt::ttcore::DataType::BFloat16) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  llvm::SmallVector<int64_t, 4> weightShape = {
+      static_cast<int64_t>(inChannels),
+      static_cast<int64_t>(outChannels / groups),
+      static_cast<int64_t>(kernelSize[0]), static_cast<int64_t>(kernelSize[1])};
+  auto weightType = tiledL1BF16Type(weightShape);
+  auto outputType = tiledL1BF16Type(weightShape);
+
+  mlir::Value weight =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{weightType},
+                                          mlir::ValueRange{})
+          .getResult();
+
+  mlir::Value device =
+      e.builder
+          .create<mlir::tt::ttnn::GetDeviceOp>(
+              loc, e.builder.getType<mlir::tt::ttnn::DeviceType>(),
+              mlir::tt::ttnn::MeshShapeAttr::get(&e.context, 1, 1),
+              mlir::tt::ttnn::MeshOffsetAttr::get(&e.context, 0, 0))
+          .getResult();
+
+  if (!inputMemoryConfig) {
+    auto weightLayout = mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+        mlir::cast<mlir::RankedTensorType>(weightType).getEncoding());
+    inputMemoryConfig = mlir::tt::ttnn::MemoryConfigAttr::get(weightLayout);
+  }
+
+  return e.builder.create<mlir::tt::ttnn::PrepareConvTranspose2dWeightsOp>(
+      loc, outputType, weight, inputMemoryConfig, inputTensorLayout,
+      weightsFormat, inChannels, outChannels, batchSize, inputHeight,
+      inputWidth, kernelSize, stride, padding, outputPadding, dilation, hasBias,
+      groups, device, inputDtype, outputDtype, conv2dConfig,
+      computeKernelConfig, conv2dSliceConfig, mirrorKernel);
+}
+
+} // namespace
+
+using PrepareConvTranspose2dWeightsOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::PrepareConvTranspose2dWeightsOp>;
+
+TEST_P(PrepareConvTranspose2dWeightsOpTPathParityTest,
+       BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PrepareConvTranspose2dWeightsOp prepareOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildPrepareConvTranspose2dWeightsOpTFromMLIR(
+          prepareOp.getInputMemoryConfig(), prepareOp.getInputTensorLayout(),
+          prepareOp.getWeightsFormat(), prepareOp.getInChannels(),
+          prepareOp.getOutChannels(), prepareOp.getBatchSize(),
+          prepareOp.getInputHeight(), prepareOp.getInputWidth(),
+          prepareOp.getKernelSize(), prepareOp.getStride(),
+          prepareOp.getPadding(), prepareOp.getOutputPadding(),
+          prepareOp.getDilation(), prepareOp.getHasBias(),
+          prepareOp.getGroups(), prepareOp.getInputDtype(),
+          prepareOp.getOutputDtype(), prepareOp.getConv2dConfig(),
+          prepareOp.getComputeConfig(), prepareOp.getConv2dSliceConfig(),
+          prepareOp.getMirrorKernel(), resolveOutputLayout(prepareOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, prepareOp.getWeightTensor());
+  cache.getOrCreate(prepareOp.getDevice(), mlir::tt::ttnn::createDeviceRef);
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, prepareOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PrepareConvTranspose2dWeightsOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::PrepareConvTranspose2dWeightsOp>
+    prepareConvTranspose2dWeightsOpList = {
+        buildTestPrepareConvTranspose2dWeightsOp(),
+        buildTestPrepareConvTranspose2dWeightsOp(/*outputDtype=*/bf16DtypeAttr),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{},
+            /*conv2dConfig=*/nonDefaultConv2dConfigAttr),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{},
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"IOHW"),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/true),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/false),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/128u),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/64u),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/4u),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/14u),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/14u),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/28u,
+            /*kernelSize=*/{4, 4}),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/28u,
+            /*kernelSize=*/{3, 3}, /*stride=*/{1, 1}),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/28u,
+            /*kernelSize=*/{3, 3}, /*stride=*/{2, 2}, /*padding=*/{0, 0}),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/28u,
+            /*kernelSize=*/{3, 3}, /*stride=*/{2, 2}, /*padding=*/{1, 1},
+            /*outputPadding=*/
+            {1, 1}),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/28u,
+            /*kernelSize=*/{3, 3}, /*stride=*/{2, 2}, /*padding=*/{1, 1},
+            /*outputPadding=*/
+            {1, 1},
+            /*dilation=*/{2, 2}),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/28u,
+            /*kernelSize=*/{3, 3}, /*stride=*/{2, 2},
+            /*padding=*/{1, 1}, /*outputPadding=*/{1, 1},
+            /*dilation=*/{1, 1}, /*groups=*/4u),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/28u,
+            /*kernelSize=*/{3, 3}, /*stride=*/{2, 2}, /*padding=*/{1, 1},
+            /*outputPadding=*/{1, 1},
+            /*dilation=*/{1, 1}, /*groups=*/1u,
+            /*inputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/28u,
+            /*kernelSize=*/{3, 3}, /*stride=*/{2, 2}, /*padding=*/{1, 1},
+            /*outputPadding=*/{1, 1},
+            /*dilation=*/{1, 1}, /*groups=*/1u, /*inputMemoryConfig=*/{},
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::RowMajor),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/{}, /*conv2dConfig=*/{},
+            /*computeKernelConfig=*/{}, /*conv2dSliceConfig=*/{},
+            /*weightsFormat=*/"OIHW", /*hasBias=*/false,
+            /*mirrorKernel=*/true, /*inChannels=*/64u, /*outChannels=*/32u,
+            /*batchSize=*/1u, /*inputHeight=*/28u, /*inputWidth=*/28u,
+            /*kernelSize=*/{3, 3}, /*stride=*/{2, 2}, /*padding=*/{1, 1},
+            /*outputPadding=*/{1, 1},
+            /*dilation=*/{1, 1}, /*groups=*/1u, /*inputMemoryConfig=*/{},
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::Tile,
+            /*inputDtype=*/mlir::tt::ttcore::DataType::Float32),
+        buildTestPrepareConvTranspose2dWeightsOp(
+            /*outputDtype=*/bf16DtypeAttr,
+            /*conv2dConfig=*/nonDefaultConv2dConfigAttr,
+            /*computeKernelConfig=*/nonDefaultDeviceComputeKernelConfigAttr,
+            /*conv2dSliceConfig=*/nonDefaultConv2dSliceConfigAttr,
+            /*weightsFormat=*/"IOHW", /*hasBias=*/true, /*mirrorKernel=*/false,
+            /*inChannels=*/128u, /*outChannels=*/64u, /*batchSize=*/4u,
+            /*inputHeight=*/14u, /*inputWidth=*/14u, /*kernelSize=*/{4, 4},
+            /*stride=*/{1, 1}, /*padding=*/{0, 0}, /*outputPadding=*/{0, 0},
+            /*dilation=*/{2, 2},
+            /*groups=*/2u,
+            /*inputMemoryConfig=*/nonDefaultInputMemoryConfigAttr,
+            /*inputTensorLayout=*/mlir::tt::ttnn::Layout::RowMajor,
+            /*inputDtype=*/mlir::tt::ttcore::DataType::Float32),
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    PrepareConvTranspose2dWeightsOpTPathParityTest,
+    PrepareConvTranspose2dWeightsOpTPathParityTest,
+    ::testing::ValuesIn(prepareConvTranspose2dWeightsOpList));
 
 //===----------------------------------------------------------------------===//
 // LinearOpTPathParity

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.h
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.h
@@ -72,6 +72,28 @@ inline mlir::RankedTensorType tiledL1BF16Type(llvm::ArrayRef<int64_t> shape) {
                                      createTiledL1InterleavedLayout(shape));
 }
 
+inline mlir::tt::ttnn::TTNNLayoutAttr createTiledBF16LayoutFromMemoryConfig(
+    llvm::ArrayRef<int64_t> shape,
+    mlir::tt::ttnn::MemoryConfigAttr memoryConfig) {
+  auto &e = env();
+  auto device = mlir::tt::ttcore::lookupDevice(e.module.get());
+  auto tileType = mlir::tt::ttcore::TileType::get(e.builder.getBF16Type());
+  llvm::SmallVector<int64_t> gridShape = {1, 1, 32, 32};
+  return mlir::tt::ttnn::TTNNLayoutAttr::Builder(&e.context, shape, tileType)
+      .setBufferType(memoryConfig.getBufferType().getValue())
+      .setMemoryLayout(memoryConfig.getTensorMemoryLayout().getValue())
+      .setGridShape(gridShape)
+      .buildWithCanonicalCorePlacement(device);
+}
+
+inline mlir::RankedTensorType
+tiledBF16TypeFromMemoryConfig(llvm::ArrayRef<int64_t> shape,
+                              mlir::tt::ttnn::MemoryConfigAttr memoryConfig) {
+  return mlir::RankedTensorType::get(
+      shape, env().builder.getBF16Type(),
+      createTiledBF16LayoutFromMemoryConfig(shape, memoryConfig));
+}
+
 template <typename OpT>
 inline mlir::tt::ttnn::TTNNLayoutAttr resolveOutputLayout(OpT op) {
   return mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -2865,11 +2865,19 @@ TEST_P(OpModelConvTranspose2dParam, ConvTranspose2d) {
   const TTNNLayoutAttr outputLayout = CreateTiledLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
+          /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+          /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+          /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+          /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
+
   auto constraintsExp = OpModel<ConvTranspose2dOp>::getOpConstraints(
       inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
       std::nullopt, in_channels, out_channels, batch_size, input_height,
       input_width, kernel_size, stride, padding, output_padding, dilation,
-      groups, std::nullopt, std::nullopt, outputLayout);
+      groups, std::nullopt, std::nullopt, deviceConfig, outputLayout);
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -2888,7 +2896,7 @@ TEST_P(OpModelConvTranspose2dParam, ConvTranspose2d) {
       inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
       std::nullopt, in_channels, out_channels, batch_size, input_height,
       input_width, kernel_size, stride, padding, output_padding, dilation,
-      groups, std::nullopt, std::nullopt, outputLayout);
+      groups, std::nullopt, std::nullopt, deviceConfig, outputLayout);
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
@@ -4036,12 +4044,19 @@ TEST_P(OpModelPrepareConv2dBiasParam, PrepareConv2dBias) {
   //  issues an error. See conv2d_op_program_factory_common.cpp in tt-metal.
   Conv2dConfigAttr conv2dConfig = Conv2dConfigAttr::get(&context);
   conv2dConfig = conv2dConfig.withWeightsDtype(ttcore::DataType::Float32);
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
+          /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+          /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+          /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+          /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
 
   auto constraintsExp = OpModel<PrepareConv2dBiasOp>::getOpConstraints(
       biasLayout, biasShape, inputMemConfig, inputTensorLayout, in_channels,
       out_channels, batch_size, input_height, input_width, kernel_size, stride,
       padding, dilation, groups, ttcore::DataType::Float32, std::nullopt,
-      conv2dConfig, std::nullopt, outputLayout);
+      conv2dConfig, std::nullopt, deviceConfig, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.

### What's changed
This is eighth PR in TTNNOpInvokeLib series. It introduces shared dispatch for the remaining convolution operations across OpModel and Runtime: conv3d, conv_transpose2d, and the weight/bias preparation ops (prepare_conv2d_weights, prepare_conv2d_bias, prepare_conv3d_weights, prepare_conv_transpose2d_weights, prepare_conv_transpose2d_bias).

### Checklist
- [ ] New/Existing tests provide coverage for changes
