### PR TITLE
Transformer ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Transformer/ConcatenateHeadsOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/ConcatenateHeadsOp.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_CONCATENATEHEADSOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_CONCATENATEHEADSOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using ConcatenateHeadsOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct ConcatenateHeadsResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+ConcatenateHeadsResolvedParams resolveConcatenateHeadsParams(
+    const ::tt::target::ttnn::ConcatenateHeadsOpT &op);
+
+ConcatenateHeadsOpResult
+callConcatenateHeads(CallType callType,
+                     const ::tt::target::ttnn::ConcatenateHeadsOpT &op,
+                     TensorArg input, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_CONCATENATEHEADSOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsDecodeOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsDecodeOp.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_NLPCONCATHEADSDECODEOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_NLPCONCATHEADSDECODEOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using NLPConcatHeadsDecodeOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct NLPConcatHeadsDecodeResolvedParams {
+  std::optional<::tt::tt_metal::CoreRangeSet> subCoreGrids;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+NLPConcatHeadsDecodeResolvedParams resolveNLPConcatHeadsDecodeParams(
+    const ::tt::target::ttnn::NLPConcatHeadsDecodeOpT &op, CallType callType,
+    TensorArg input);
+
+NLPConcatHeadsDecodeOpResult
+callNLPConcatHeadsDecode(CallType callType,
+                         const ::tt::target::ttnn::NLPConcatHeadsDecodeOpT &op,
+                         TensorArg input, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_NLPCONCATHEADSDECODEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsOp.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_NLPCONCATHEADSOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_NLPCONCATHEADSOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using NLPConcatHeadsOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct NLPConcatHeadsResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+NLPConcatHeadsResolvedParams
+resolveNLPConcatHeadsParams(const ::tt::target::ttnn::NLPConcatHeadsOpT &op);
+
+NLPConcatHeadsOpResult
+callNLPConcatHeads(CallType callType,
+                   const ::tt::target::ttnn::NLPConcatHeadsOpT &op,
+                   TensorArg input, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_NLPCONCATHEADSOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/NLPCreateQKVHeadsDecodeOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/NLPCreateQKVHeadsDecodeOp.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_NLPCREATEQKVHEADSDECODEOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_NLPCREATEQKVHEADSDECODEOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp"
+
+#include <optional>
+#include <tuple>
+
+namespace ttnn_op_invoke {
+
+using NLPCreateQKVHeadsDecodeOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse,
+                 std::tuple<::ttnn::Tensor, ::ttnn::Tensor, ::ttnn::Tensor>>;
+
+struct NLPCreateQKVHeadsDecodeResolvedParams {
+  std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+NLPCreateQKVHeadsDecodeResolvedParams resolveNLPCreateQKVHeadsDecodeParams(
+    const ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT &op);
+
+NLPCreateQKVHeadsDecodeOpResult callNLPCreateQKVHeadsDecode(
+    CallType callType, const ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT &op,
+    TensorArg input, std::optional<TensorArg> batchOffset,
+    ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_NLPCREATEQKVHEADSDECODEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/PagedFlashMultiLatentAttentionDecodeOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/PagedFlashMultiLatentAttentionDecodeOp.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_PAGEDFLASHMULTILATENTATTENTIONDECODEOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_PAGEDFLASHMULTILATENTATTENTIONDECODEOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PagedFlashMultiLatentAttentionDecodeOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PagedFlashMultiLatentAttentionDecodeResolvedParams {
+  std::optional<float> scale;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      programConfig;
+};
+
+PagedFlashMultiLatentAttentionDecodeResolvedParams
+resolvePagedFlashMultiLatentAttentionDecodeParams(
+    const ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT &op,
+    ::ttnn::MeshDevice *device);
+
+PagedFlashMultiLatentAttentionDecodeOpResult
+callPagedFlashMultiLatentAttentionDecode(
+    CallType callType,
+    const ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT &op,
+    TensorArg query, TensorArg key, std::optional<TensorArg> value,
+    TensorArg pageTable, std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> curPosTensor,
+    std::optional<TensorArg> attentionSink, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_PAGEDFLASHMULTILATENTATTENTIONDECODEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/PagedScaledDotProductAttentionDecodeOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/PagedScaledDotProductAttentionDecodeOp.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_PAGEDSCALEDDOTPRODUCTATTENTIONDECODEOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_PAGEDSCALEDDOTPRODUCTATTENTIONDECODEOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PagedScaledDotProductAttentionDecodeOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PagedScaledDotProductAttentionDecodeResolvedParams {
+  std::optional<float> scale;
+  std::optional<uint32_t> slidingWindowSize;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      programConfig;
+};
+
+PagedScaledDotProductAttentionDecodeResolvedParams
+resolvePagedScaledDotProductAttentionDecodeParams(
+    const ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT &op,
+    ::ttnn::MeshDevice *device);
+
+PagedScaledDotProductAttentionDecodeOpResult
+callPagedScaledDotProductAttentionDecode(
+    CallType callType,
+    const ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT &op,
+    TensorArg query, TensorArg key, TensorArg value, TensorArg pageTable,
+    std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> curPosTensor,
+    std::optional<TensorArg> attentionSink, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_PAGEDSCALEDDOTPRODUCTATTENTIONDECODEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingLlamaOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingLlamaOp.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_ROTARYEMBEDDINGLLAMAOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_ROTARYEMBEDDINGLLAMAOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using RotaryEmbeddingLlamaOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct RotaryEmbeddingLlamaResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+};
+
+RotaryEmbeddingLlamaResolvedParams resolveRotaryEmbeddingLlamaParams(
+    const ::tt::target::ttnn::RotaryEmbeddingLlamaOpT &op);
+
+RotaryEmbeddingLlamaOpResult callRotaryEmbeddingLlama(
+    CallType callType, const ::tt::target::ttnn::RotaryEmbeddingLlamaOpT &op,
+    TensorArg input, TensorArg cosCache, TensorArg sinCache, TensorArg transMat,
+    ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_ROTARYEMBEDDINGLLAMAOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingOp.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_ROTARYEMBEDDINGOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_ROTARYEMBEDDINGOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using RotaryEmbeddingOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct RotaryEmbeddingResolvedParams {
+  std::optional<uint32_t> tokenIndex;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+};
+
+RotaryEmbeddingResolvedParams
+resolveRotaryEmbeddingParams(const ::tt::target::ttnn::RotaryEmbeddingOpT &op);
+
+RotaryEmbeddingOpResult
+callRotaryEmbedding(CallType callType,
+                    const ::tt::target::ttnn::RotaryEmbeddingOpT &op,
+                    TensorArg input, TensorArg cosCache, TensorArg sinCache,
+                    ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_ROTARYEMBEDDINGOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionDecodeOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionDecodeOp.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_SCALEDDOTPRODUCTATTENTIONDECODEOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_SCALEDDOTPRODUCTATTENTIONDECODEOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using ScaledDotProductAttentionDecodeOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct ScaledDotProductAttentionDecodeResolvedParams {
+  std::vector<uint32_t> curPos;
+  std::optional<float> scale;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      programConfig;
+};
+
+ScaledDotProductAttentionDecodeResolvedParams
+resolveScaledDotProductAttentionDecodeParams(
+    const ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT &op);
+
+ScaledDotProductAttentionDecodeOpResult callScaledDotProductAttentionDecode(
+    CallType callType,
+    const ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT &op,
+    TensorArg query, TensorArg key, TensorArg value,
+    std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> curPosTensor,
+    std::optional<TensorArg> attentionSink, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_SCALEDDOTPRODUCTATTENTIONDECODEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionOp.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_SCALEDDOTPRODUCTATTENTIONOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_SCALEDDOTPRODUCTATTENTIONOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/transformer/sdpa/sdpa.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using ScaledDotProductAttentionOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct ScaledDotProductAttentionResolvedParams {
+  std::optional<float> scale;
+  std::optional<uint32_t> slidingWindowSize;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+ScaledDotProductAttentionResolvedParams resolveScaledDotProductAttentionParams(
+    const ::tt::target::ttnn::ScaledDotProductAttentionOpT &op);
+
+ScaledDotProductAttentionOpResult callScaledDotProductAttention(
+    CallType callType,
+    const ::tt::target::ttnn::ScaledDotProductAttentionOpT &op, TensorArg query,
+    TensorArg key, TensorArg value, std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> attentionSink, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_SCALEDDOTPRODUCTATTENTIONOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Transformer/SplitQueryKeyValueAndSplitHeadsOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Transformer/SplitQueryKeyValueAndSplitHeadsOp.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_TRANSFORMER_SPLITQUERYKEYVALUEANDSPLITHEADSOP_H
+#define TTMLIR_OPINVOKE_TTNN_TRANSFORMER_SPLITQUERYKEYVALUEANDSPLITHEADSOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/transformer_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp"
+
+#include <optional>
+#include <tuple>
+
+namespace ttnn_op_invoke {
+
+using SplitQueryKeyValueAndSplitHeadsOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse,
+                 std::tuple<::ttnn::Tensor, ::ttnn::Tensor, ::ttnn::Tensor>>;
+
+struct SplitQueryKeyValueAndSplitHeadsResolvedParams {
+  std::optional<uint32_t> numKVHeads;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+SplitQueryKeyValueAndSplitHeadsResolvedParams
+resolveSplitQueryKeyValueAndSplitHeadsParams(
+    const ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT &op);
+
+SplitQueryKeyValueAndSplitHeadsOpResult callSplitQueryKeyValueAndSplitHeads(
+    CallType callType,
+    const ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT &op,
+    TensorArg input, std::optional<TensorArg> kvInput,
+    ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_TRANSFORMER_SPLITQUERYKEYVALUEANDSPLITHEADSOP_H

--- a/include/ttmlir/OpInvoke/TTNN/utils/utils.h
+++ b/include/ttmlir/OpInvoke/TTNN/utils/utils.h
@@ -12,6 +12,7 @@
 #include "ttmlir/OpModel/TTNN/MetalHeaders.h"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/matmul/device/config/matmul_program_config_types.hpp"
+#include "ttnn/operations/transformer/sdpa_config.hpp"
 
 #include "llvm/Support/ErrorHandling.h"
 
@@ -158,6 +159,9 @@ createConv2dSliceConfig(const ::tt::target::ttnn::Conv2dSliceConfigT &config);
 
 ::ttnn::DeviceComputeKernelConfig createDeviceComputeKernelConfig(
     const ::tt::target::ttnn::DeviceComputeKernelConfigT &config);
+
+::ttnn::operations::transformer::SDPAProgramConfig
+createSDPAProgramConfig(const ::tt::target::ttnn::SDPAConfigT &config);
 
 } // namespace ttnn_op_invoke::operations::utils
 

--- a/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
+++ b/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
@@ -168,6 +168,64 @@ buildPrepareConvTranspose2dBiasOpTFromMLIR(
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout);
 
+::tt::target::ttnn::ConcatenateHeadsOpT
+buildConcatenateHeadsOpTFromMLIR(TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::NLPConcatHeadsOpT
+buildNLPConcatHeadsOpTFromMLIR(TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT
+buildNLPCreateQKVHeadsDecodeOpTFromMLIR(uint32_t numHeads,
+                                        std::optional<uint32_t> numKVHeads,
+                                        std::optional<bool> overlapQKCoregrid,
+                                        std::optional<uint32_t> sliceSize,
+                                        TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT
+buildPagedFlashMultiLatentAttentionDecodeOpTFromMLIR(
+    uint32_t headDimV, bool isCausal, std::optional<llvm::APFloat> scale,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT
+buildPagedScaledDotProductAttentionDecodeOpTFromMLIR(
+    bool isCausal, std::optional<llvm::APFloat> scale,
+    std::optional<uint32_t> slidingWindowSize,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::RotaryEmbeddingLlamaOpT
+buildRotaryEmbeddingLlamaOpTFromMLIR(
+    bool isDecodeMode,
+    std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+        deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::RotaryEmbeddingOpT buildRotaryEmbeddingOpTFromMLIR(
+    std::optional<uint32_t> tokenIndex,
+    std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+        deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT
+buildScaledDotProductAttentionDecodeOpTFromMLIR(
+    bool isCausal, std::optional<llvm::APFloat> scale,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::ScaledDotProductAttentionOpT
+buildScaledDotProductAttentionOpTFromMLIR(
+    bool isCausal, std::optional<llvm::APFloat> scale,
+    std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT
+buildSplitQueryKeyValueAndSplitHeadsOpTFromMLIR(
+    uint32_t numHeads, std::optional<uint32_t> numKVHeads, bool transposeKey,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::NLPConcatHeadsDecodeOpT
+buildNLPConcatHeadsDecodeOpTFromMLIR(uint32_t numHeads,
+                                     TTNNLayoutAttr outputLayout);
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -778,7 +778,9 @@ struct OpModel<ScaledDotProductAttentionDecodeOp> {
                std::optional<TTNNLayoutAttr> curPosTensorLayout,
                std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
                std::optional<TTNNLayoutAttr> attentionSinkLayout,
-               std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout);
+               std::optional<llvm::APFloat> scale,
+               std::optional<SDPAProgramConfigAttr> programConfig,
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -921,7 +923,10 @@ struct OpModel<RotaryEmbeddingLlamaOp> {
       llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
       llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
       llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
-      bool isDecodeMode, TTNNLayoutAttr outputLayout);
+      bool isDecodeMode,
+      std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+          deviceComputeKernelConfig,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -929,6 +934,8 @@ struct OpModel<RotaryEmbeddingLlamaOp> {
                llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
                llvm::ArrayRef<int64_t> transMatShape,
                TTNNLayoutAttr transMatLayout, bool isDecodeMode,
+               std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+                   deviceComputeKernelConfig,
                TTNNLayoutAttr outputLayout);
 };
 
@@ -938,18 +945,23 @@ struct OpModel<RotaryEmbeddingLlamaOp> {
 
 template <>
 struct OpModel<RotaryEmbeddingOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> cosShape,
-                   TTNNLayoutAttr cosLayout, llvm::ArrayRef<int64_t> sinShape,
-                   TTNNLayoutAttr sinLayout, std::optional<uint32_t> tokenIndex,
-                   TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+      llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+      std::optional<uint32_t> tokenIndex,
+      std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+          deviceComputeKernelConfig,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
                llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
-               std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout);
+               std::optional<uint32_t> tokenIndex,
+               std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+                   deviceComputeKernelConfig,
+               TTNNLayoutAttr outputLayout);
 };
 
 //===-----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
+++ b/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
@@ -109,6 +109,48 @@ template <typename EltwiseQuantizationOp>
 ::flatbuffers::Offset<::tt::target::ttnn::EltwiseQuantizationOp>
 createEltwiseQuantizationOp(::mlir::tt::FlatbufferObjectCache &cache,
                             EltwiseQuantizationOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::ConcatenateHeadsOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, ConcatenateHeadsOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::NLPConcatHeadsOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, NLPConcatHeadsOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::NLPCreateQKVHeadsDecodeOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache,
+         NLPCreateQKVHeadsDecodeOp op);
+
+::flatbuffers::Offset<
+    ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache,
+         PagedFlashMultiLatentAttentionDecodeOp op);
+
+::flatbuffers::Offset<
+    ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache,
+         PagedScaledDotProductAttentionDecodeOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::RotaryEmbeddingLlamaOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, RotaryEmbeddingLlamaOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::RotaryEmbeddingOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, RotaryEmbeddingOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::ScaledDotProductAttentionDecodeOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache,
+         ScaledDotProductAttentionDecodeOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::ScaledDotProductAttentionOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache,
+         ScaledDotProductAttentionOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache,
+         SplitQueryKeyValueAndSplitHeadsOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::NLPConcatHeadsDecodeOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, NLPConcatHeadsDecodeOp op);
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_TARGET_TTNN_TTNNTOFLATBUFFER_H

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -945,20 +945,31 @@ inline ::flatbuffers::Optional<bool> toFlatbuffer(FlatbufferObjectCache &cache,
   return toNative(attr);
 }
 
+inline ::tt::target::ttnn::SDPAConfigT
+toNative(ttnn::SDPAProgramConfigAttr sdpaConfigAttr) {
+  ::tt::target::ttnn::SDPAConfigT sdpaConfigT;
+  sdpaConfigT.compute_with_storage_grid_size =
+      std::make_unique<::tt::target::ttnn::CoreCoord>(
+          toNative(sdpaConfigAttr.getComputeWithStorageGridSize()));
+  if (sdpaConfigAttr.getSubCoreGrids()) {
+    sdpaConfigT.sub_core_grids =
+        std::make_unique<::tt::target::ttnn::CoreRangeSetT>(
+            toNative(sdpaConfigAttr.getSubCoreGrids()));
+  }
+  sdpaConfigT.q_chunk_size = sdpaConfigAttr.getQChunkSize();
+  sdpaConfigT.k_chunk_size = sdpaConfigAttr.getKChunkSize();
+  sdpaConfigT.exp_approx_mode = toNative(sdpaConfigAttr.getExpApproxMode());
+  if (auto maxCores = sdpaConfigAttr.getMaxCoresPerHeadBatch()) {
+    sdpaConfigT.max_cores_per_head_batch = *maxCores;
+  }
+  return sdpaConfigT;
+}
+
 inline ::flatbuffers::Offset<::tt::target::ttnn::SDPAConfig>
 toFlatbuffer(FlatbufferObjectCache &cache,
              ttnn::SDPAProgramConfigAttr sdpaConfigAttr) {
-  ::tt::target::ttnn::CoreCoord computeWithStorageGridSize =
-      toFlatbuffer(cache, sdpaConfigAttr.getComputeWithStorageGridSize());
-  ::flatbuffers::Offset<::tt::target::ttnn::CoreRangeSet> subCoreGrids;
-  if (sdpaConfigAttr.getSubCoreGrids()) {
-    subCoreGrids = toFlatbuffer(cache, sdpaConfigAttr.getSubCoreGrids());
-  }
-  return ::tt::target::ttnn::CreateSDPAConfig(
-      *cache.fbb, &computeWithStorageGridSize, subCoreGrids,
-      sdpaConfigAttr.getQChunkSize(), sdpaConfigAttr.getKChunkSize(),
-      toFlatbuffer(cache, sdpaConfigAttr.getExpApproxMode()),
-      toFlatbuffer(cache, sdpaConfigAttr.getMaxCoresPerHeadBatch()));
+  auto t = toNative(sdpaConfigAttr);
+  return ::tt::target::ttnn::SDPAConfig::Pack(*cache.fbb, &t);
 }
 
 inline ::flatbuffers::Offset<

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2075,7 +2075,8 @@ llvm::Expected<size_t> ScaledDotProductAttentionDecodeOp::getOpRuntime(
       sdpaArgs.isCausal, sdpaArgs.attentionMaskShape,
       sdpaArgs.attentionMaskLayout, sdpaArgs.curPosTensorShape,
       sdpaArgs.curPosTensorLayout, sdpaArgs.attentionSinkShape,
-      sdpaArgs.attentionSinkLayout, sdpaArgs.scale, opConfig.outputLayout);
+      sdpaArgs.attentionSinkLayout, sdpaArgs.scale, sdpaArgs.programConfig,
+      opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
@@ -2499,7 +2500,8 @@ RotaryEmbeddingLlamaOp::getOpConstraints(
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints, *this,
       inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
-      transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
+      transMatShape, inputs[3], isDecodeMode, getComputeConfig(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2516,7 +2518,8 @@ RotaryEmbeddingLlamaOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<RotaryEmbeddingLlamaOp>::getOpRuntime, *this,
       inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
-      transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
+      transMatShape, inputs[3], isDecodeMode, getComputeConfig(),
+      opConfig.outputLayout);
 }
 
 //===-----------------------------------------------------------------------===//
@@ -2536,7 +2539,7 @@ RotaryEmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RotaryEmbeddingOp>::getOpConstraints, *this, inputShape,
       inputs[0], cosShape, inputs[1], sinShape, inputs[2], tokenIndex,
-      opConfig.outputLayout);
+      getComputeConfig(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2552,7 +2555,7 @@ RotaryEmbeddingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<RotaryEmbeddingOp>::getOpRuntime, *this, inputShape,
       inputs[0], cosShape, inputs[1], sinShape, inputs[2], tokenIndex,
-      opConfig.outputLayout);
+      getComputeConfig(), opConfig.outputLayout);
 }
 
 //===-----------------------------------------------------------------------===//

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -15,6 +15,17 @@ add_library(TTNNOpInvokeLib STATIC
   Eltwise/Unary/EltwiseUnaryCompositeOp.cpp
   Eltwise/Unary/EltwiseUnaryOp.cpp
   Matmul/MatmulOp.cpp
+  Transformer/ConcatenateHeadsOp.cpp
+  Transformer/NLPConcatHeadsDecodeOp.cpp
+  Transformer/NLPConcatHeadsOp.cpp
+  Transformer/NLPCreateQKVHeadsDecodeOp.cpp
+  Transformer/PagedFlashMultiLatentAttentionDecodeOp.cpp
+  Transformer/PagedScaledDotProductAttentionDecodeOp.cpp
+  Transformer/RotaryEmbeddingLlamaOp.cpp
+  Transformer/RotaryEmbeddingOp.cpp
+  Transformer/ScaledDotProductAttentionDecodeOp.cpp
+  Transformer/ScaledDotProductAttentionOp.cpp
+  Transformer/SplitQueryKeyValueAndSplitHeadsOp.cpp
 )
 
 set_property(TARGET TTNNOpInvokeLib PROPERTY CXX_STANDARD 20)

--- a/lib/OpInvoke/TTNN/Transformer/ConcatenateHeadsOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/ConcatenateHeadsOp.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/ConcatenateHeadsOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+ConcatenateHeadsResolvedParams resolveConcatenateHeadsParams(
+    const ::tt::target::ttnn::ConcatenateHeadsOpT &op) {
+  ConcatenateHeadsResolvedParams params;
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createConcatenateHeadsTuple(
+    Tag tag, const ::tt::target::ttnn::ConcatenateHeadsOpT & /*op*/,
+    TensorArg input, const ConcatenateHeadsResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag),
+                         params.outputMemoryConfig);
+}
+
+ConcatenateHeadsOpResult
+callConcatenateHeads(CallType callType,
+                     const ::tt::target::ttnn::ConcatenateHeadsOpT &op,
+                     TensorArg input, ::ttnn::MeshDevice *device) {
+  ConcatenateHeadsResolvedParams params = resolveConcatenateHeadsParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createConcatenateHeadsTuple(tag, op, input, params);
+  };
+
+  return callOp<ConcatenateHeadsOpResult>(
+      WRAP_OP(::ttnn::transformer::concatenate_heads), callType, makeTuple,
+      device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/NLPConcatHeadsDecodeOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/NLPConcatHeadsDecodeOp.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+NLPConcatHeadsDecodeResolvedParams resolveNLPConcatHeadsDecodeParams(
+    const ::tt::target::ttnn::NLPConcatHeadsDecodeOpT &op, CallType callType,
+    TensorArg input) {
+  NLPConcatHeadsDecodeResolvedParams params;
+
+  // TODO: This branching on callType should be removed. Either add subCoreGrids
+  // as a fb schema field, or remove it entirely if the op doesn't need it.
+  if (callType == CallType::EXECUTE) {
+    const auto &in = *std::get<const ::ttnn::Tensor *>(input);
+    if (in.is_sharded() && in.shard_spec().has_value()) {
+      const auto &ranges = in.shard_spec().value().grid.ranges();
+      if (ranges.size() > 1 ||
+          !(ranges[0].start_coord == ::tt::tt_metal::CoreCoord{0, 0})) {
+        params.subCoreGrids = in.shard_spec().value().grid;
+      }
+    }
+  } else {
+    const auto &spec = std::get<::ttnn::TensorSpec>(input);
+    const auto &mc = spec.tensor_layout().get_memory_config();
+    if (mc.is_sharded() && mc.shard_spec().has_value()) {
+      const auto &ranges = mc.shard_spec().value().grid.ranges();
+      if (ranges.size() > 1 ||
+          !(ranges[0].start_coord == ::tt::tt_metal::CoreCoord{0, 0})) {
+        params.subCoreGrids = mc.shard_spec().value().grid;
+      }
+    }
+  }
+
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createNLPConcatHeadsDecodeTuple(
+    Tag tag, const ::tt::target::ttnn::NLPConcatHeadsDecodeOpT &op,
+    TensorArg input, const NLPConcatHeadsDecodeResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), op.num_heads, params.outputMemoryConfig,
+      /*optional_output_tensor=*/std::nullopt, params.subCoreGrids);
+}
+
+NLPConcatHeadsDecodeOpResult
+callNLPConcatHeadsDecode(CallType callType,
+                         const ::tt::target::ttnn::NLPConcatHeadsDecodeOpT &op,
+                         TensorArg input, ::ttnn::MeshDevice *device) {
+  NLPConcatHeadsDecodeResolvedParams params =
+      resolveNLPConcatHeadsDecodeParams(op, callType, input);
+
+  auto makeTuple = [&](auto tag) {
+    return createNLPConcatHeadsDecodeTuple(tag, op, input, params);
+  };
+
+  return callOp<NLPConcatHeadsDecodeOpResult>(
+      WRAP_OP(::ttnn::experimental::nlp_concat_heads_decode), callType,
+      makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/NLPConcatHeadsOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/NLPConcatHeadsOp.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+NLPConcatHeadsResolvedParams
+resolveNLPConcatHeadsParams(const ::tt::target::ttnn::NLPConcatHeadsOpT &op) {
+  NLPConcatHeadsResolvedParams params;
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createNLPConcatHeadsTuple(
+    Tag tag, const ::tt::target::ttnn::NLPConcatHeadsOpT & /*op*/,
+    TensorArg input, const NLPConcatHeadsResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag),
+                         params.outputMemoryConfig);
+}
+
+NLPConcatHeadsOpResult
+callNLPConcatHeads(CallType callType,
+                   const ::tt::target::ttnn::NLPConcatHeadsOpT &op,
+                   TensorArg input, ::ttnn::MeshDevice *device) {
+  NLPConcatHeadsResolvedParams params = resolveNLPConcatHeadsParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createNLPConcatHeadsTuple(tag, op, input, params);
+  };
+
+  return callOp<NLPConcatHeadsOpResult>(
+      WRAP_OP(::ttnn::experimental::nlp_concat_heads), callType, makeTuple,
+      device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/NLPCreateQKVHeadsDecodeOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/NLPCreateQKVHeadsDecodeOp.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/NLPCreateQKVHeadsDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <tuple>
+
+namespace ttnn_op_invoke {
+
+NLPCreateQKVHeadsDecodeResolvedParams resolveNLPCreateQKVHeadsDecodeParams(
+    const ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT &op) {
+  NLPCreateQKVHeadsDecodeResolvedParams params;
+  params.optionalOutputTensors = std::nullopt;
+
+  if (op.memcfg) {
+    params.outputMemoryConfig =
+        operations::utils::createMemoryConfigIfNeeded(*op.memcfg);
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createNLPCreateQKVHeadsDecodeTuple(
+    Tag tag, const ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT &op,
+    TensorArg input, std::optional<TensorArg> batchOffset,
+    const NLPCreateQKVHeadsDecodeResolvedParams &params) {
+  std::optional<const uint32_t> numKVHeads =
+      op.num_kv_heads.has_value()
+          ? std::optional<const uint32_t>(*op.num_kv_heads)
+          : std::nullopt;
+  std::optional<const bool> overlapQKCoregrid =
+      op.overlap_qk_coregrid.has_value()
+          ? std::optional<const bool>(*op.overlap_qk_coregrid)
+          : std::nullopt;
+  std::optional<const uint32_t> sliceSize =
+      op.slice_size.has_value() ? std::optional<const uint32_t>(*op.slice_size)
+                                : std::nullopt;
+  return std::make_tuple(
+      resolveTensorArg(input, tag), op.num_heads, numKVHeads,
+      params.optionalOutputTensors, overlapQKCoregrid,
+      batchOffset ? std::make_optional(resolveTensorArg(*batchOffset, tag))
+                  : std::nullopt,
+      sliceSize, params.outputMemoryConfig);
+}
+
+NLPCreateQKVHeadsDecodeOpResult callNLPCreateQKVHeadsDecode(
+    CallType callType, const ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT &op,
+    TensorArg input, std::optional<TensorArg> batchOffset,
+    ::ttnn::MeshDevice *device) {
+  NLPCreateQKVHeadsDecodeResolvedParams params =
+      resolveNLPCreateQKVHeadsDecodeParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createNLPCreateQKVHeadsDecodeTuple(tag, op, input, batchOffset,
+                                              params);
+  };
+
+  return callOp<NLPCreateQKVHeadsDecodeOpResult>(
+      WRAP_OP(::ttnn::experimental::nlp_create_qkv_heads_decode), callType,
+      makeTuple, device);
+}
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/PagedFlashMultiLatentAttentionDecodeOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/PagedFlashMultiLatentAttentionDecodeOp.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/PagedFlashMultiLatentAttentionDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/transformer/sdpa_config.hpp"
+#include "ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+PagedFlashMultiLatentAttentionDecodeResolvedParams
+resolvePagedFlashMultiLatentAttentionDecodeParams(
+    const ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT &op,
+    ::ttnn::MeshDevice *device) {
+  PagedFlashMultiLatentAttentionDecodeResolvedParams params;
+
+  if (op.scale.has_value()) {
+    params.scale = *op.scale;
+  }
+
+  if (!op.is_causal) {
+    params.programConfig = std::make_optional<
+        ::ttnn::operations::transformer::SDPAProgramConfig>();
+    params.programConfig->k_chunk_size = 32;
+    params.programConfig->compute_with_storage_grid_size =
+        device->compute_with_storage_grid_size();
+  }
+
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPagedFlashMultiLatentAttentionDecodeTuple(
+    Tag tag,
+    const ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT &op,
+    TensorArg query, TensorArg key, std::optional<TensorArg> value,
+    TensorArg pageTable, std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> curPosTensor,
+    std::optional<TensorArg> attentionSink,
+    const PagedFlashMultiLatentAttentionDecodeResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(query, tag), resolveTensorArg(key, tag),
+      value ? std::make_optional(resolveTensorArg(*value, tag)) : std::nullopt,
+      op.head_dim_v, resolveTensorArg(pageTable, tag), op.is_causal,
+      attentionMask ? std::make_optional(resolveTensorArg(*attentionMask, tag))
+                    : std::nullopt,
+      curPosTensor ? std::make_optional(resolveTensorArg(*curPosTensor, tag))
+                   : std::nullopt,
+      attentionSink ? std::make_optional(resolveTensorArg(*attentionSink, tag))
+                    : std::nullopt,
+      params.scale, /*sliding_window_size=*/std::nullopt,
+      params.outputMemoryConfig, params.programConfig,
+      /*compute_kernel_config=*/std::nullopt);
+}
+
+PagedFlashMultiLatentAttentionDecodeOpResult
+callPagedFlashMultiLatentAttentionDecode(
+    CallType callType,
+    const ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT &op,
+    TensorArg query, TensorArg key, std::optional<TensorArg> value,
+    TensorArg pageTable, std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> curPosTensor,
+    std::optional<TensorArg> attentionSink, ::ttnn::MeshDevice *device) {
+  PagedFlashMultiLatentAttentionDecodeResolvedParams params =
+      resolvePagedFlashMultiLatentAttentionDecodeParams(op, device);
+
+  auto makeTuple = [&](auto tag) {
+    return createPagedFlashMultiLatentAttentionDecodeTuple(
+        tag, op, query, key, value, pageTable, attentionMask, curPosTensor,
+        attentionSink, params);
+  };
+
+  return callOp<PagedFlashMultiLatentAttentionDecodeOpResult>(
+      WRAP_OP(::ttnn::transformer::paged_flash_multi_latent_attention_decode),
+      callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/PagedScaledDotProductAttentionDecodeOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/PagedScaledDotProductAttentionDecodeOp.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/PagedScaledDotProductAttentionDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+PagedScaledDotProductAttentionDecodeResolvedParams
+resolvePagedScaledDotProductAttentionDecodeParams(
+    const ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT &op,
+    ::ttnn::MeshDevice *device) {
+  PagedScaledDotProductAttentionDecodeResolvedParams params;
+
+  if (op.scale.has_value()) {
+    params.scale = *op.scale;
+  }
+  if (op.sliding_window_size.has_value()) {
+    params.slidingWindowSize = *op.sliding_window_size;
+  }
+
+  const auto computeGrid = device->compute_with_storage_grid_size();
+  if (op.program_config) {
+    params.programConfig =
+        operations::utils::createSDPAProgramConfig(*op.program_config);
+  } else if (!op.is_causal) {
+    params.programConfig.emplace();
+    params.programConfig->k_chunk_size = 32; // Required for non-causal
+    params.programConfig->compute_with_storage_grid_size = computeGrid;
+  } else if (device->arch() == ::tt::ARCH::BLACKHOLE) {
+    params.programConfig.emplace();
+    params.programConfig->q_chunk_size = 0;
+    params.programConfig->k_chunk_size = 0;
+    params.programConfig->compute_with_storage_grid_size = computeGrid;
+    params.programConfig->max_cores_per_head_batch =
+        computeGrid.x * computeGrid.y;
+  }
+
+  // Blackhole's SDPA decode default approx-exp path fails SFPI compile
+  // (tt-metal #40301).
+  if (params.programConfig.has_value() &&
+      device->arch() == ::tt::ARCH::BLACKHOLE) {
+    params.programConfig->exp_approx_mode = false;
+  }
+
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPagedScaledDotProductAttentionDecodeTuple(
+    Tag tag,
+    const ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT &op,
+    TensorArg query, TensorArg key, TensorArg value, TensorArg pageTable,
+    std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> curPosTensor,
+    std::optional<TensorArg> attentionSink,
+    const PagedScaledDotProductAttentionDecodeResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(query, tag), resolveTensorArg(key, tag),
+      resolveTensorArg(value, tag), resolveTensorArg(pageTable, tag),
+      op.is_causal,
+      attentionMask ? std::make_optional(resolveTensorArg(*attentionMask, tag))
+                    : std::nullopt,
+      curPosTensor ? std::make_optional(resolveTensorArg(*curPosTensor, tag))
+                   : std::nullopt,
+      attentionSink ? std::make_optional(resolveTensorArg(*attentionSink, tag))
+                    : std::nullopt,
+      params.scale, params.slidingWindowSize, params.outputMemoryConfig,
+      params.programConfig,
+      /*compute_kernel_config=*/std::nullopt,
+      /*block_size_override=*/std::nullopt);
+}
+
+PagedScaledDotProductAttentionDecodeOpResult
+callPagedScaledDotProductAttentionDecode(
+    CallType callType,
+    const ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT &op,
+    TensorArg query, TensorArg key, TensorArg value, TensorArg pageTable,
+    std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> curPosTensor,
+    std::optional<TensorArg> attentionSink, ::ttnn::MeshDevice *device) {
+  PagedScaledDotProductAttentionDecodeResolvedParams params =
+      resolvePagedScaledDotProductAttentionDecodeParams(op, device);
+
+  auto makeTuple = [&](auto tag) {
+    return createPagedScaledDotProductAttentionDecodeTuple(
+        tag, op, query, key, value, pageTable, attentionMask, curPosTensor,
+        attentionSink, params);
+  };
+
+  return callOp<PagedScaledDotProductAttentionDecodeOpResult>(
+      WRAP_OP(::ttnn::transformer::paged_scaled_dot_product_attention_decode),
+      callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/RotaryEmbeddingLlamaOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/RotaryEmbeddingLlamaOp.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingLlamaOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+RotaryEmbeddingLlamaResolvedParams resolveRotaryEmbeddingLlamaParams(
+    const ::tt::target::ttnn::RotaryEmbeddingLlamaOpT &op) {
+  RotaryEmbeddingLlamaResolvedParams params;
+
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createRotaryEmbeddingLlamaTuple(
+    Tag tag, const ::tt::target::ttnn::RotaryEmbeddingLlamaOpT &op,
+    TensorArg input, TensorArg cosCache, TensorArg sinCache, TensorArg transMat,
+    const RotaryEmbeddingLlamaResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), resolveTensorArg(cosCache, tag),
+      resolveTensorArg(sinCache, tag), resolveTensorArg(transMat, tag),
+      op.is_decode_mode, params.outputMemoryConfig, params.computeConfig);
+}
+
+RotaryEmbeddingLlamaOpResult callRotaryEmbeddingLlama(
+    CallType callType, const ::tt::target::ttnn::RotaryEmbeddingLlamaOpT &op,
+    TensorArg input, TensorArg cosCache, TensorArg sinCache, TensorArg transMat,
+    ::ttnn::MeshDevice *device) {
+  RotaryEmbeddingLlamaResolvedParams params =
+      resolveRotaryEmbeddingLlamaParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createRotaryEmbeddingLlamaTuple(tag, op, input, cosCache, sinCache,
+                                           transMat, params);
+  };
+
+  return callOp<RotaryEmbeddingLlamaOpResult>(
+      WRAP_OP(::ttnn::experimental::rotary_embedding_llama), callType,
+      makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/RotaryEmbeddingOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/RotaryEmbeddingOp.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+RotaryEmbeddingResolvedParams
+resolveRotaryEmbeddingParams(const ::tt::target::ttnn::RotaryEmbeddingOpT &op) {
+  RotaryEmbeddingResolvedParams params;
+
+  if (op.token_index.has_value()) {
+    params.tokenIndex = *op.token_index;
+  }
+
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createRotaryEmbeddingTuple(
+    Tag tag, const ::tt::target::ttnn::RotaryEmbeddingOpT &op, TensorArg input,
+    TensorArg cosCache, TensorArg sinCache,
+    const RotaryEmbeddingResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag),
+                         resolveTensorArg(cosCache, tag),
+                         resolveTensorArg(sinCache, tag), params.tokenIndex,
+                         params.outputMemoryConfig, params.computeConfig);
+}
+
+RotaryEmbeddingOpResult
+callRotaryEmbedding(CallType callType,
+                    const ::tt::target::ttnn::RotaryEmbeddingOpT &op,
+                    TensorArg input, TensorArg cosCache, TensorArg sinCache,
+                    ::ttnn::MeshDevice *device) {
+  RotaryEmbeddingResolvedParams params = resolveRotaryEmbeddingParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createRotaryEmbeddingTuple(tag, op, input, cosCache, sinCache,
+                                      params);
+  };
+
+  return callOp<RotaryEmbeddingOpResult>(
+      WRAP_OP(::ttnn::experimental::rotary_embedding), callType, makeTuple,
+      device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionDecodeOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionDecodeOp.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/transformer/sdpa_config.hpp"
+#include "ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp"
+
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace ttnn_op_invoke {
+
+ScaledDotProductAttentionDecodeResolvedParams
+resolveScaledDotProductAttentionDecodeParams(
+    const ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT &op) {
+  ScaledDotProductAttentionDecodeResolvedParams params;
+
+  // The current position information is required for this op. It can either be
+  // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
+  // std::optional so we must pass an empty vector.
+  params.curPos = {};
+
+  if (op.scale.has_value()) {
+    params.scale = *op.scale;
+  }
+  if (op.program_config) {
+    params.programConfig =
+        operations::utils::createSDPAProgramConfig(*op.program_config);
+  }
+
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createScaledDotProductAttentionDecodeTuple(
+    Tag tag, const ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT &op,
+    TensorArg query, TensorArg key, TensorArg value,
+    std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> curPosTensor,
+    std::optional<TensorArg> attentionSink,
+    const ScaledDotProductAttentionDecodeResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(query, tag), resolveTensorArg(key, tag),
+      resolveTensorArg(value, tag), op.is_causal,
+      attentionMask ? std::make_optional(resolveTensorArg(*attentionMask, tag))
+                    : std::nullopt,
+      params.curPos,
+      curPosTensor ? std::make_optional(resolveTensorArg(*curPosTensor, tag))
+                   : std::nullopt,
+      attentionSink ? std::make_optional(resolveTensorArg(*attentionSink, tag))
+                    : std::nullopt,
+      params.scale, /*sliding_window_size=*/std::nullopt,
+      params.outputMemoryConfig, params.programConfig,
+      /*compute_kernel_config=*/std::nullopt,
+      /*share_cache=*/std::nullopt);
+}
+
+ScaledDotProductAttentionDecodeOpResult callScaledDotProductAttentionDecode(
+    CallType callType,
+    const ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT &op,
+    TensorArg query, TensorArg key, TensorArg value,
+    std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> curPosTensor,
+    std::optional<TensorArg> attentionSink, ::ttnn::MeshDevice *device) {
+  ScaledDotProductAttentionDecodeResolvedParams params =
+      resolveScaledDotProductAttentionDecodeParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createScaledDotProductAttentionDecodeTuple(
+        tag, op, query, key, value, attentionMask, curPosTensor, attentionSink,
+        params);
+  };
+
+  return callOp<ScaledDotProductAttentionDecodeOpResult>(
+      WRAP_OP(::ttnn::transformer::scaled_dot_product_attention_decode),
+      callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionOp.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/transformer/sdpa/sdpa.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+ScaledDotProductAttentionResolvedParams resolveScaledDotProductAttentionParams(
+    const ::tt::target::ttnn::ScaledDotProductAttentionOpT &op) {
+  ScaledDotProductAttentionResolvedParams params;
+  if (op.scale.has_value()) {
+    params.scale = *op.scale;
+  }
+  if (op.sliding_window_size.has_value()) {
+    params.slidingWindowSize = *op.sliding_window_size;
+  }
+
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createScaledDotProductAttentionTuple(
+    Tag tag, const ::tt::target::ttnn::ScaledDotProductAttentionOpT &op,
+    TensorArg query, TensorArg key, TensorArg value,
+    std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> attentionSink,
+    const ScaledDotProductAttentionResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(query, tag), resolveTensorArg(key, tag),
+      resolveTensorArg(value, tag),
+      attentionMask ? std::make_optional(resolveTensorArg(*attentionMask, tag))
+                    : std::nullopt,
+      op.is_causal, params.scale, params.slidingWindowSize,
+      params.outputMemoryConfig,
+      /*program_config=*/std::nullopt,
+      /*compute_kernel_config=*/std::nullopt,
+      attentionSink ? std::make_optional(resolveTensorArg(*attentionSink, tag))
+                    : std::nullopt);
+}
+
+ScaledDotProductAttentionOpResult callScaledDotProductAttention(
+    CallType callType,
+    const ::tt::target::ttnn::ScaledDotProductAttentionOpT &op, TensorArg query,
+    TensorArg key, TensorArg value, std::optional<TensorArg> attentionMask,
+    std::optional<TensorArg> attentionSink, ::ttnn::MeshDevice *device) {
+  ScaledDotProductAttentionResolvedParams params =
+      resolveScaledDotProductAttentionParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createScaledDotProductAttentionTuple(
+        tag, op, query, key, value, attentionMask, attentionSink, params);
+  };
+
+  return callOp<ScaledDotProductAttentionOpResult>(
+      WRAP_OP(::ttnn::transformer::scaled_dot_product_attention), callType,
+      makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Transformer/SplitQueryKeyValueAndSplitHeadsOp.cpp
+++ b/lib/OpInvoke/TTNN/Transformer/SplitQueryKeyValueAndSplitHeadsOp.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Transformer/SplitQueryKeyValueAndSplitHeadsOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp"
+
+#include <optional>
+#include <tuple>
+
+namespace ttnn_op_invoke {
+
+SplitQueryKeyValueAndSplitHeadsResolvedParams
+resolveSplitQueryKeyValueAndSplitHeadsParams(
+    const ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT &op) {
+  SplitQueryKeyValueAndSplitHeadsResolvedParams params;
+  if (op.num_kv_heads.has_value()) {
+    params.numKVHeads = *op.num_kv_heads;
+  }
+
+  // The output memory config is passed through q_out
+  if (op.q_out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.q_out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.q_out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createSplitQueryKeyValueAndSplitHeadsTuple(
+    Tag tag, const ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT &op,
+    TensorArg input, std::optional<TensorArg> kvInput,
+    const SplitQueryKeyValueAndSplitHeadsResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag),
+      kvInput ? std::make_optional(resolveTensorArg(*kvInput, tag))
+              : std::nullopt,
+      op.num_heads, params.numKVHeads, op.transpose_key,
+      params.outputMemoryConfig);
+}
+
+SplitQueryKeyValueAndSplitHeadsOpResult callSplitQueryKeyValueAndSplitHeads(
+    CallType callType,
+    const ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT &op,
+    TensorArg input, std::optional<TensorArg> kvInput,
+    ::ttnn::MeshDevice *device) {
+  SplitQueryKeyValueAndSplitHeadsResolvedParams params =
+      resolveSplitQueryKeyValueAndSplitHeadsParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createSplitQueryKeyValueAndSplitHeadsTuple(tag, op, input, kvInput,
+                                                      params);
+  };
+
+  return callOp<SplitQueryKeyValueAndSplitHeadsOpResult>(
+      WRAP_OP(::ttnn::transformer::split_query_key_value_and_split_heads),
+      callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/utils/utils.cpp
+++ b/lib/OpInvoke/TTNN/utils/utils.cpp
@@ -559,4 +559,29 @@ createConv2dSliceConfig(const ::tt::target::ttnn::Conv2dSliceConfigT &config) {
   return computeKernelConfig;
 }
 
+::ttnn::operations::transformer::SDPAProgramConfig
+createSDPAProgramConfig(const ::tt::target::ttnn::SDPAConfigT &config) {
+  ::ttnn::operations::transformer::SDPAProgramConfig sdpaConfig;
+
+  sdpaConfig.compute_with_storage_grid_size =
+      toTTNNCoreCoord(*config.compute_with_storage_grid_size);
+
+  if (config.sub_core_grids) {
+    sdpaConfig.sub_core_grids = toTTNNCoreRangeSet(*config.sub_core_grids);
+  }
+
+  sdpaConfig.q_chunk_size = config.q_chunk_size;
+  sdpaConfig.k_chunk_size = config.k_chunk_size;
+
+  if (config.exp_approx_mode.has_value()) {
+    sdpaConfig.exp_approx_mode = *config.exp_approx_mode;
+  }
+
+  if (config.max_cores_per_head_batch.has_value()) {
+    sdpaConfig.max_cores_per_head_batch = *config.max_cores_per_head_batch;
+  }
+
+  return sdpaConfig;
+}
+
 } // namespace ttnn_op_invoke::operations::utils

--- a/lib/OpModel/TTNN/NativeFromMLIR.cpp
+++ b/lib/OpModel/TTNN/NativeFromMLIR.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/WithColor.h"
 
 #include <array>
 #include <cassert>
@@ -818,6 +819,191 @@ buildPrepareConvTranspose2dBiasOpTFromMLIR(
   prepareConvTranspose2dBiasOp.out = detail::getOutputTensorRefT(outputLayout);
 
   return prepareConvTranspose2dBiasOp;
+}
+
+::tt::target::ttnn::ConcatenateHeadsOpT
+buildConcatenateHeadsOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ConcatenateHeadsOpT concatenateHeadsOp;
+  concatenateHeadsOp.out = detail::getOutputTensorRefT(outputLayout);
+  return concatenateHeadsOp;
+}
+
+::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT
+buildScaledDotProductAttentionDecodeOpTFromMLIR(
+    bool isCausal, std::optional<llvm::APFloat> scale,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT
+      scaledDotProductAttentionDecodeOp;
+  scaledDotProductAttentionDecodeOp.is_causal = isCausal;
+  if (scale.has_value()) {
+    scaledDotProductAttentionDecodeOp.scale = scale->convertToFloat();
+  }
+  if (programConfig.has_value() && *programConfig) {
+    scaledDotProductAttentionDecodeOp.program_config =
+        std::make_unique<::tt::target::ttnn::SDPAConfigT>(
+            toNative(*programConfig));
+  }
+  scaledDotProductAttentionDecodeOp.out =
+      detail::getOutputTensorRefT(outputLayout);
+  return scaledDotProductAttentionDecodeOp;
+}
+
+::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT
+buildPagedScaledDotProductAttentionDecodeOpTFromMLIR(
+    bool isCausal, std::optional<llvm::APFloat> scale,
+    std::optional<uint32_t> slidingWindowSize,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT
+      pagedScaledDotProductAttentionDecodeOp;
+  pagedScaledDotProductAttentionDecodeOp.is_causal = isCausal;
+  if (scale.has_value()) {
+    pagedScaledDotProductAttentionDecodeOp.scale =
+        scale.value().convertToFloat();
+  }
+  if (slidingWindowSize.has_value()) {
+    pagedScaledDotProductAttentionDecodeOp.sliding_window_size =
+        *slidingWindowSize;
+  }
+  if (programConfig.has_value() && *programConfig) {
+    pagedScaledDotProductAttentionDecodeOp.program_config =
+        std::make_unique<::tt::target::ttnn::SDPAConfigT>(
+            toNative(*programConfig));
+  }
+  pagedScaledDotProductAttentionDecodeOp.out =
+      detail::getOutputTensorRefT(outputLayout);
+  return pagedScaledDotProductAttentionDecodeOp;
+}
+
+::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT
+buildPagedFlashMultiLatentAttentionDecodeOpTFromMLIR(
+    uint32_t headDimV, bool isCausal, std::optional<llvm::APFloat> scale,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT
+      pagedFlashMultiLatentAttentionDecodeOp;
+  pagedFlashMultiLatentAttentionDecodeOp.head_dim_v = headDimV;
+  pagedFlashMultiLatentAttentionDecodeOp.is_causal = isCausal;
+  if (scale.has_value()) {
+    pagedFlashMultiLatentAttentionDecodeOp.scale =
+        scale.value().convertToFloat();
+  }
+  pagedFlashMultiLatentAttentionDecodeOp.out =
+      detail::getOutputTensorRefT(outputLayout);
+  return pagedFlashMultiLatentAttentionDecodeOp;
+}
+
+::tt::target::ttnn::ScaledDotProductAttentionOpT
+buildScaledDotProductAttentionOpTFromMLIR(
+    bool isCausal, std::optional<llvm::APFloat> scale,
+    std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ScaledDotProductAttentionOpT scaledDotProductAttentionOp;
+  scaledDotProductAttentionOp.is_causal = isCausal;
+  if (scale.has_value()) {
+    scaledDotProductAttentionOp.scale = scale->convertToFloat();
+  }
+  if (slidingWindowSize.has_value()) {
+    scaledDotProductAttentionOp.sliding_window_size = *slidingWindowSize;
+  }
+  scaledDotProductAttentionOp.out = detail::getOutputTensorRefT(outputLayout);
+  return scaledDotProductAttentionOp;
+}
+
+::tt::target::ttnn::RotaryEmbeddingLlamaOpT
+buildRotaryEmbeddingLlamaOpTFromMLIR(
+    bool isDecodeMode,
+    std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+        deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::RotaryEmbeddingLlamaOpT rotaryEmbeddingLlamaOp;
+  rotaryEmbeddingLlamaOp.is_decode_mode = isDecodeMode;
+  rotaryEmbeddingLlamaOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  rotaryEmbeddingLlamaOp.out = detail::getOutputTensorRefT(outputLayout);
+  return rotaryEmbeddingLlamaOp;
+}
+
+::tt::target::ttnn::RotaryEmbeddingOpT buildRotaryEmbeddingOpTFromMLIR(
+    std::optional<uint32_t> tokenIndex,
+    std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+        deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::RotaryEmbeddingOpT rotaryEmbeddingOp;
+  if (tokenIndex.has_value()) {
+    rotaryEmbeddingOp.token_index = *tokenIndex;
+  }
+  rotaryEmbeddingOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  rotaryEmbeddingOp.out = detail::getOutputTensorRefT(outputLayout);
+  return rotaryEmbeddingOp;
+}
+
+::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT
+buildNLPCreateQKVHeadsDecodeOpTFromMLIR(uint32_t numHeads,
+                                        std::optional<uint32_t> numKVHeads,
+                                        std::optional<bool> overlapQKCoregrid,
+                                        std::optional<uint32_t> sliceSize,
+                                        TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT nlpCreateQkvHeadsDecodeOp;
+  nlpCreateQkvHeadsDecodeOp.num_heads = numHeads;
+  if (numKVHeads.has_value()) {
+    nlpCreateQkvHeadsDecodeOp.num_kv_heads = *numKVHeads;
+  }
+  if (overlapQKCoregrid.has_value()) {
+    nlpCreateQkvHeadsDecodeOp.overlap_qk_coregrid = *overlapQKCoregrid;
+  }
+  if (sliceSize.has_value()) {
+    nlpCreateQkvHeadsDecodeOp.slice_size = *sliceSize;
+  }
+  auto memory_config = detail::getNullableMemoryConfigT(outputLayout);
+  if (memory_config.has_value()) {
+    nlpCreateQkvHeadsDecodeOp.memcfg =
+        std::make_unique<::tt::target::ttnn::MemoryConfigT>(
+            memory_config.value());
+    if (nlpCreateQkvHeadsDecodeOp.memcfg) {
+      llvm::WithColor::warning()
+          << "Memory config should be set to nullptr to match runtime";
+    }
+  }
+  return nlpCreateQkvHeadsDecodeOp;
+}
+
+::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT
+buildSplitQueryKeyValueAndSplitHeadsOpTFromMLIR(
+    uint32_t numHeads, std::optional<uint32_t> numKVHeads, bool transposeKey,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT
+      splitQueryKeyValueAndSplitHeadsOp;
+  splitQueryKeyValueAndSplitHeadsOp.num_heads = numHeads;
+  if (numKVHeads.has_value()) {
+    splitQueryKeyValueAndSplitHeadsOp.num_kv_heads = *numKVHeads;
+  }
+  splitQueryKeyValueAndSplitHeadsOp.transpose_key = transposeKey;
+  splitQueryKeyValueAndSplitHeadsOp.q_out =
+      detail::getOutputTensorRefT(outputLayout);
+  return splitQueryKeyValueAndSplitHeadsOp;
+}
+
+::tt::target::ttnn::NLPConcatHeadsOpT
+buildNLPConcatHeadsOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::NLPConcatHeadsOpT nlpConcatHeadsOp;
+  nlpConcatHeadsOp.out = detail::getOutputTensorRefT(outputLayout);
+  return nlpConcatHeadsOp;
+}
+
+::tt::target::ttnn::NLPConcatHeadsDecodeOpT
+buildNLPConcatHeadsDecodeOpTFromMLIR(uint32_t numHeads,
+                                     TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::NLPConcatHeadsDecodeOpT nlpConcatHeadsDecodeOp;
+  nlpConcatHeadsDecodeOp.num_heads = numHeads;
+  nlpConcatHeadsDecodeOp.out = detail::getOutputTensorRefT(outputLayout);
+  return nlpConcatHeadsDecodeOp;
 }
 
 } // namespace mlir::tt::ttnn::op_model

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -25,6 +25,17 @@
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/ConcatenateHeadsOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/NLPCreateQKVHeadsDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/PagedFlashMultiLatentAttentionDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/PagedScaledDotProductAttentionDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingLlamaOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionDecodeOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionOp.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/SplitQueryKeyValueAndSplitHeadsOp.h"
 #include "ttmlir/OpInvoke/TTNN/utils/utils.h"
 #include "ttmlir/OpModel/TTNN/Conversion.h"
 #include "ttmlir/OpModel/TTNN/NativeFromMLIR.h"
@@ -2936,11 +2947,20 @@ llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::ConcatenateHeadsOpT concatenateHeadsOpNative =
+      buildConcatenateHeadsOpTFromMLIR(outputLayout);
+
   auto concatenateHeadsOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::transformer::concatenate_heads, device,
-                                inputSpec,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::ConcatenateHeadsOpResult result =
+        ttnn_op_invoke::callConcatenateHeads(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            concatenateHeadsOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConcatenateHeadsOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -2962,11 +2982,20 @@ OpModel<ConcatenateHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::ConcatenateHeadsOpT concatenateHeadsOpNative =
+      buildConcatenateHeadsOpTFromMLIR(outputLayout);
+
   auto concatenateHeadsOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::transformer::concatenate_heads, device,
-                            inputSpec,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::ConcatenateHeadsOpResult result =
+        ttnn_op_invoke::callConcatenateHeads(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            concatenateHeadsOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected ConcatenateHeadsOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(concatenateHeadsOpQuery);
@@ -2978,6 +3007,7 @@ OpModel<ConcatenateHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 // ScaledDotProductAttentionDecodeOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints>
 OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -3016,26 +3046,24 @@ OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
       detail::convertToOptionalTensorSpec(device, attentionSinkShape,
                                           attentionSinkLayout);
 
-  std::optional<float> scaleFloat =
-      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
-  std::optional<uint32_t> slidingWindowSize = std::nullopt;
-
-  // The current position information is required for this op. It can either be
-  // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
-  // std::optional so we must pass an empty vector.
-  const std::vector<uint32_t> curPosEmpty = {};
-
-  auto sdpaProgramConfigConverted =
-      conversion::getSDPAProgramConfig(programConfig);
+  ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT
+      scaledDotProductAttentionDecodeOpNative =
+          buildScaledDotProductAttentionDecodeOpTFromMLIR(
+              isCausal, scale, programConfig, outputLayout);
 
   auto scaledDotProductAttentionDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::transformer::scaled_dot_product_attention_decode, device,
-        querySpec, keySpec, valueSpec, isCausal, attentionMaskSpec, curPosEmpty,
-        curPosTensorSpec, attentionSinkSpec, scaleFloat, slidingWindowSize,
-        detail::getNullableMemoryConfig(outputLayout),
-        sdpaProgramConfigConverted,
-        /*compute_kernel_config=*/std::nullopt);
+    ttnn_op_invoke::ScaledDotProductAttentionDecodeOpResult result =
+        ttnn_op_invoke::callScaledDotProductAttentionDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            scaledDotProductAttentionDecodeOpNative, querySpec, keySpec,
+            valueSpec, attentionMaskSpec, curPosTensorSpec, attentionSinkSpec,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ScaledDotProductAttentionDecodeOp constraints query to "
+           "return ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(queryLayout.getContext(),
@@ -3055,7 +3083,9 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionDecodeOp>::getOpRuntime(
     std::optional<TTNNLayoutAttr> curPosTensorLayout,
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
-    std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
+    std::optional<llvm::APFloat> scale,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -3080,22 +3110,24 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionDecodeOp>::getOpRuntime(
       detail::convertToOptionalTensorSpec(device, attentionSinkShape,
                                           attentionSinkLayout);
 
-  std::optional<float> scaleFloat =
-      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT
+      scaledDotProductAttentionDecodeOpNative =
+          buildScaledDotProductAttentionDecodeOpTFromMLIR(
+              isCausal, scale, programConfig, outputLayout);
 
-  // The current position information is required for this op. It can either be
-  // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
-  // std::optional so we must pass an empty vector.
-  const std::vector<uint32_t> curPosEmpty = {};
   auto scaledDotProductAttentionDecodeOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::transformer::scaled_dot_product_attention_decode, device,
-        querySpec, keySpec, valueSpec, isCausal, attentionMaskSpec, curPosEmpty,
-        curPosTensorSpec, attentionSinkSpec, scaleFloat,
-        /*slidingWindowSize=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
-        /*compute_kernel_config=*/std::nullopt);
+    ttnn_op_invoke::ScaledDotProductAttentionDecodeOpResult result =
+        ttnn_op_invoke::callScaledDotProductAttentionDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            scaledDotProductAttentionDecodeOpNative, querySpec, keySpec,
+            valueSpec, attentionMaskSpec, curPosTensorSpec, attentionSinkSpec,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected ScaledDotProductAttentionDecodeOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(scaledDotProductAttentionDecodeOpQuery);
@@ -3152,19 +3184,33 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
       detail::convertToOptionalTensorSpec(device, attentionSinkShape,
                                           attentionSinkLayout);
 
-  std::optional<float> scaleFloat =
-      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
-  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
-      sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
+  ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT
+      pagedScaledDotProductAttentionDecodeOpNative =
+          buildPagedScaledDotProductAttentionDecodeOpTFromMLIR(
+              isCausal, scale, slidingWindowSize, programConfig, outputLayout);
 
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::transformer::paged_scaled_dot_product_attention_decode, device,
-        querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
-        attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
-        slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
-        sdpaProgramConfig,
-        /*compute_kernel_config=*/std::nullopt);
+    ttnn_op_invoke::PagedScaledDotProductAttentionDecodeOpResult result =
+        ttnn_op_invoke::callPagedScaledDotProductAttentionDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            pagedScaledDotProductAttentionDecodeOpNative, querySpec, keySpec,
+            valueSpec, pageTableSpec,
+            attentionMaskSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*attentionMaskSpec)
+                : std::nullopt,
+            curPosTensorSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*curPosTensorSpec)
+                : std::nullopt,
+            attentionSinkSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*attentionSinkSpec)
+                : std::nullopt,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected PagedScaledDotProductAttentionDecodeOp constraints query "
+           "to return ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(
@@ -3218,20 +3264,33 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
       detail::convertToOptionalTensorSpec(device, attentionSinkShape,
                                           attentionSinkLayout);
 
-  std::optional<float> scaleFloat =
-      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
-
-  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
-      sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
+  ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT
+      pagedScaledDotProductAttentionDecodeOpNative =
+          buildPagedScaledDotProductAttentionDecodeOpTFromMLIR(
+              isCausal, scale, slidingWindowSize, programConfig, outputLayout);
 
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::transformer::paged_scaled_dot_product_attention_decode, device,
-        querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
-        attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
-        slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
-        sdpaProgramConfig,
-        /*compute_kernel_config=*/std::nullopt);
+    ttnn_op_invoke::PagedScaledDotProductAttentionDecodeOpResult result =
+        ttnn_op_invoke::callPagedScaledDotProductAttentionDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            pagedScaledDotProductAttentionDecodeOpNative, querySpec, keySpec,
+            valueSpec, pageTableSpec,
+            attentionMaskSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*attentionMaskSpec)
+                : std::nullopt,
+            curPosTensorSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*curPosTensorSpec)
+                : std::nullopt,
+            attentionSinkSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*attentionSinkSpec)
+                : std::nullopt,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected PagedScaledDotProductAttentionDecodeOp runtime query to "
+        "return RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(pagedScaledDotProductAttentionDecodeOpQuery);
@@ -3283,18 +3342,36 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
       detail::convertToOptionalTensorSpec(device, attentionSinkShape,
                                           attentionSinkLayout);
 
-  std::optional<float> scaleFloat =
-      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT
+      pagedFlashMultiLatentAttentionDecodeOpNative =
+          buildPagedFlashMultiLatentAttentionDecodeOpTFromMLIR(
+              headDimV, isCausal, scale, outputLayout);
 
   auto pagedFlashMlaDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::transformer::paged_flash_multi_latent_attention_decode, device,
-        querySpec, keySpec, valueSpec, headDimV, pageTableSpec, isCausal,
-        attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
-        /*slidingWindowSize=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
-        /*compute_kernel_config=*/std::nullopt);
+    ttnn_op_invoke::PagedFlashMultiLatentAttentionDecodeOpResult result =
+        ttnn_op_invoke::callPagedFlashMultiLatentAttentionDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            pagedFlashMultiLatentAttentionDecodeOpNative, querySpec, keySpec,
+            valueSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*valueSpec)
+                : std::nullopt,
+            pageTableSpec,
+            attentionMaskSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*attentionMaskSpec)
+                : std::nullopt,
+            curPosTensorSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*curPosTensorSpec)
+                : std::nullopt,
+            attentionSinkSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*attentionSinkSpec)
+                : std::nullopt,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected PagedFlashMultiLatentAttentionDecodeOp constraints query "
+           "to return ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(queryLayout.getContext(),
@@ -3343,18 +3420,36 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpRuntime(
       detail::convertToOptionalTensorSpec(device, attentionSinkShape,
                                           attentionSinkLayout);
 
-  std::optional<float> scaleFloat =
-      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT
+      pagedFlashMultiLatentAttentionDecodeOpNative =
+          buildPagedFlashMultiLatentAttentionDecodeOpTFromMLIR(
+              headDimV, isCausal, scale, outputLayout);
 
   auto pagedFlashMlaDecodeOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::transformer::paged_flash_multi_latent_attention_decode, device,
-        querySpec, keySpec, valueSpec, headDimV, pageTableSpec, isCausal,
-        attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
-        /*slidingWindowSize=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
-        /*compute_kernel_config=*/std::nullopt);
+    ttnn_op_invoke::PagedFlashMultiLatentAttentionDecodeOpResult result =
+        ttnn_op_invoke::callPagedFlashMultiLatentAttentionDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            pagedFlashMultiLatentAttentionDecodeOpNative, querySpec, keySpec,
+            valueSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*valueSpec)
+                : std::nullopt,
+            pageTableSpec,
+            attentionMaskSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*attentionMaskSpec)
+                : std::nullopt,
+            curPosTensorSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*curPosTensorSpec)
+                : std::nullopt,
+            attentionSinkSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*attentionSinkSpec)
+                : std::nullopt,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected PagedFlashMultiLatentAttentionDecodeOp runtime query to "
+        "return RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(pagedFlashMlaDecodeOpQuery);
@@ -3398,16 +3493,23 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
       detail::convertToOptionalTensorSpec(device, attentionSinkShape,
                                           attentionSinkLayout);
 
-  std::optional<float> scaleFloat =
-      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  ::tt::target::ttnn::ScaledDotProductAttentionOpT
+      scaledDotProductAttentionOpNative =
+          buildScaledDotProductAttentionOpTFromMLIR(
+              isCausal, scale, slidingWindowSize, outputLayout);
 
   auto scaledDotProductAttentionOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::transformer::scaled_dot_product_attention, device, querySpec,
-        keySpec, valueSpec, attentionMaskSpec, isCausal, scaleFloat,
-        slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
-        /*compute_kernel_config=*/std::nullopt, attentionSinkSpec);
+    ttnn_op_invoke::ScaledDotProductAttentionOpResult result =
+        ttnn_op_invoke::callScaledDotProductAttention(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            scaledDotProductAttentionOpNative, querySpec, keySpec, valueSpec,
+            attentionMaskSpec, attentionSinkSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ScaledDotProductAttentionOp constraints query to "
+           "return ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(queryLayout.getContext(),
@@ -3448,16 +3550,23 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionOp>::getOpRuntime(
       detail::convertToOptionalTensorSpec(device, attentionSinkShape,
                                           attentionSinkLayout);
 
-  std::optional<float> scaleFloat =
-      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  ::tt::target::ttnn::ScaledDotProductAttentionOpT
+      scaledDotProductAttentionOpNative =
+          buildScaledDotProductAttentionOpTFromMLIR(
+              isCausal, scale, slidingWindowSize, outputLayout);
 
   auto scaledDotProductAttentionOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::transformer::scaled_dot_product_attention, device, querySpec,
-        keySpec, valueSpec, attentionMaskSpec, isCausal, scaleFloat,
-        slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
-        /*compute_kernel_config=*/std::nullopt, attentionSinkSpec);
+    ttnn_op_invoke::ScaledDotProductAttentionOpResult result =
+        ttnn_op_invoke::callScaledDotProductAttention(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            scaledDotProductAttentionOpNative, querySpec, keySpec, valueSpec,
+            attentionMaskSpec, attentionSinkSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected ScaledDotProductAttentionOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(scaledDotProductAttentionOpQuery);
@@ -3560,12 +3669,16 @@ llvm::Expected<size_t> OpModel<FlashMlaPrefillOp>::getOpRuntime(
 //===-----------------------------------------------------------------------===//
 // RotaryEmbeddingLlamaOp
 // ===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
     llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
-    bool isDecodeMode, TTNNLayoutAttr outputLayout) {
+    bool isDecodeMode,
+    std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+        deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3581,11 +3694,22 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
       ::ttnn::TensorSpec transMatSpec,
       detail::convertToTensorSpec(device, transMatShape, transMatLayout));
 
+  ::tt::target::ttnn::RotaryEmbeddingLlamaOpT rotaryEmbeddingLlamaOpNative =
+      buildRotaryEmbeddingLlamaOpTFromMLIR(
+          isDecodeMode, deviceComputeKernelConfig, outputLayout);
+
   auto rotaryEmbeddingLlamaOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding_llama,
-                                device, inputSpec, cosSpec, sinSpec,
-                                transMatSpec, isDecodeMode,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::RotaryEmbeddingLlamaOpResult result =
+        ttnn_op_invoke::callRotaryEmbeddingLlama(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            rotaryEmbeddingLlamaOpNative, inputSpec, cosSpec, sinSpec,
+            transMatSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected RotaryEmbeddingLlamaOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -3600,7 +3724,10 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingLlamaOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
     llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
-    bool isDecodeMode, TTNNLayoutAttr outputLayout) {
+    bool isDecodeMode,
+    std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+        deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3616,12 +3743,22 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingLlamaOp>::getOpRuntime(
       ::ttnn::TensorSpec transMatSpec,
       detail::convertToTensorSpec(device, transMatShape, transMatLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::RotaryEmbeddingLlamaOpT rotaryEmbeddingLlamaOpNative =
+      buildRotaryEmbeddingLlamaOpTFromMLIR(
+          isDecodeMode, deviceComputeKernelConfig, outputLayout);
+
   auto rotaryEmbeddingLlamaOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::experimental::rotary_embedding_llama,
-                            device, inputSpec, cosSpec, sinSpec, transMatSpec,
-                            isDecodeMode,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::RotaryEmbeddingLlamaOpResult result =
+        ttnn_op_invoke::callRotaryEmbeddingLlama(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            rotaryEmbeddingLlamaOpNative, inputSpec, cosSpec, sinSpec,
+            transMatSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RotaryEmbeddingLlamaOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(rotaryEmbeddingLlamaOpQuery);
@@ -3638,7 +3775,10 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
-    std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout) {
+    std::optional<uint32_t> tokenIndex,
+    std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+        deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3651,10 +3791,21 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
                    detail::convertToTensorSpec(device, sinShape, sinLayout));
 
+  ::tt::target::ttnn::RotaryEmbeddingOpT rotaryEmbeddingOpNative =
+      buildRotaryEmbeddingOpTFromMLIR(tokenIndex, deviceComputeKernelConfig,
+                                      outputLayout);
+
   auto rotaryEmbeddingOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding, device,
-                                inputSpec, cosSpec, sinSpec, tokenIndex,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::RotaryEmbeddingOpResult result =
+        ttnn_op_invoke::callRotaryEmbedding(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            rotaryEmbeddingOpNative, inputSpec, cosSpec, sinSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected RotaryEmbeddingOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -3668,7 +3819,10 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
-    std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout) {
+    std::optional<uint32_t> tokenIndex,
+    std::optional<::mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
+        deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3681,11 +3835,21 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingOp>::getOpRuntime(
   ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
                    detail::convertToTensorSpec(device, sinShape, sinLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::RotaryEmbeddingOpT rotaryEmbeddingOpNative =
+      buildRotaryEmbeddingOpTFromMLIR(tokenIndex, deviceComputeKernelConfig,
+                                      outputLayout);
+
   auto rotaryEmbeddingOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::experimental::rotary_embedding, device,
-                            inputSpec, cosSpec, sinSpec, tokenIndex,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::RotaryEmbeddingOpResult result =
+        ttnn_op_invoke::callRotaryEmbedding(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, rotaryEmbeddingOpNative,
+            inputSpec, cosSpec, sinSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RotaryEmbeddingOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(rotaryEmbeddingOpQuery);
@@ -3697,6 +3861,7 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // NLPCreateQKVHeadsDecodeOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<op_model::OpConstraints>
 OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -3718,15 +3883,25 @@ OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
-  std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors =
-      std::nullopt;
-  auto nlpCreateQKVHeadsDecode = [&]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::nlp_create_qkv_heads_decode, device, inputSpec,
-        numHeads, numKVHeads, optionalOutputTensors,
-        std::optional<const bool>(overlapQKCoregrid), batchOffsetSpec,
-        sliceSize, detail::getNullableMemoryConfig(outputLayout));
+  ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT
+      nlpCreateQkvHeadsDecodeOpNative = buildNLPCreateQKVHeadsDecodeOpTFromMLIR(
+          numHeads, numKVHeads, overlapQKCoregrid, sliceSize, outputLayout);
+
+  auto nlpCreateQKVHeadsDecode = [=]() {
+    ttnn_op_invoke::NLPCreateQKVHeadsDecodeOpResult result =
+        ttnn_op_invoke::callNLPCreateQKVHeadsDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            nlpCreateQkvHeadsDecodeOpNative, inputSpec,
+            batchOffsetSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*batchOffsetSpec)
+                : std::nullopt,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected NLPCreateQKVHeadsDecodeOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -3757,15 +3932,25 @@ llvm::Expected<size_t> OpModel<NLPCreateQKVHeadsDecodeOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
-  std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors =
-      std::nullopt;
+  ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT
+      nlpCreateQkvHeadsDecodeOpNative = buildNLPCreateQKVHeadsDecodeOpTFromMLIR(
+          numHeads, numKVHeads, overlapQKCoregrid, sliceSize, outputLayout);
+
   auto nlpCreateQKVHeadsDecode = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::experimental::nlp_create_qkv_heads_decode, device, inputSpec,
-        numHeads, numKVHeads, optionalOutputTensors,
-        std::optional<const bool>(overlapQKCoregrid), batchOffsetSpec,
-        sliceSize, detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::NLPCreateQKVHeadsDecodeOpResult result =
+        ttnn_op_invoke::callNLPCreateQKVHeadsDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            nlpCreateQkvHeadsDecodeOpNative, inputSpec,
+            batchOffsetSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*batchOffsetSpec)
+                : std::nullopt,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected NLPCreateQKVHeadsDecodeOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(nlpCreateQKVHeadsDecode);
@@ -3777,6 +3962,7 @@ llvm::Expected<size_t> OpModel<NLPCreateQKVHeadsDecodeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // SplitQueryKeyValueAndSplitHeadsOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints>
 OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -3799,12 +3985,23 @@ OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
                                                  inputKVLayout.value()));
   }
 
-  // Create query closure
+  ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT
+      splitQueryKeyValueAndSplitHeadsOpNative =
+          buildSplitQueryKeyValueAndSplitHeadsOpTFromMLIR(
+              numHeads, numKVHeads, transposeKey, outputLayout);
+
   auto splitQueryKeyValueAndSplitHeadsOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::transformer::split_query_key_value_and_split_heads, device,
-        inputSpec, inputKVSpec, numHeads, numKVHeads, transposeKey,
-        detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::SplitQueryKeyValueAndSplitHeadsOpResult result =
+        ttnn_op_invoke::callSplitQueryKeyValueAndSplitHeads(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            splitQueryKeyValueAndSplitHeadsOpNative, inputSpec, inputKVSpec,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected SplitQueryKeyValueAndSplitHeadsOp constraints query "
+           "to return ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -3835,12 +4032,23 @@ llvm::Expected<size_t> OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpRuntime(
                                                  inputKVLayout.value()));
   }
 
-  // Create query closure
+  ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT
+      splitQueryKeyValueAndSplitHeadsOpNative =
+          buildSplitQueryKeyValueAndSplitHeadsOpTFromMLIR(
+              numHeads, numKVHeads, transposeKey, outputLayout);
+
   auto splitQueryKeyValueAndSplitHeadsOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::transformer::split_query_key_value_and_split_heads, device,
-        inputSpec, inputKVSpec, numHeads, numKVHeads, transposeKey,
-        detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::SplitQueryKeyValueAndSplitHeadsOpResult result =
+        ttnn_op_invoke::callSplitQueryKeyValueAndSplitHeads(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            splitQueryKeyValueAndSplitHeadsOpNative, inputSpec, inputKVSpec,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected SplitQueryKeyValueAndSplitHeadsOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(splitQueryKeyValueAndSplitHeadsOpQuery);
@@ -3852,6 +4060,7 @@ llvm::Expected<size_t> OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // NLPConcatHeadsOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints>
 OpModel<NLPConcatHeadsOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                                             TTNNLayoutAttr inputLayout,
@@ -3864,11 +4073,20 @@ OpModel<NLPConcatHeadsOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::NLPConcatHeadsOpT nlpConcatHeadsOpNative =
+      buildNLPConcatHeadsOpTFromMLIR(outputLayout);
+
   auto nlpConcatHeadsOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::nlp_concat_heads, device,
-                                inputSpec,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::NLPConcatHeadsOpResult result =
+        ttnn_op_invoke::callNLPConcatHeads(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            nlpConcatHeadsOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected NLPConcatHeadsOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -3890,11 +4108,20 @@ OpModel<NLPConcatHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::NLPConcatHeadsOpT nlpConcatHeadsOpNative =
+      buildNLPConcatHeadsOpTFromMLIR(outputLayout);
+
   auto nlpConcatHeadsOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::experimental::nlp_concat_heads, device,
-                            inputSpec,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::NLPConcatHeadsOpResult result =
+        ttnn_op_invoke::callNLPConcatHeads(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, nlpConcatHeadsOpNative,
+            inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected NLPConcatHeadsOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(nlpConcatHeadsOpQuery);
@@ -3906,6 +4133,7 @@ OpModel<NLPConcatHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 // NLPConcatHeadsDecodeOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     uint32_t numHeads, TTNNLayoutAttr outputLayout) {
@@ -3917,28 +4145,20 @@ llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // tt-metal's nlp_concat_heads_decode infers on_subcoregrids from the input
-  // shard grid: if the CoreRangeSet has multiple ranges or doesn't start at
-  // (0,0), it sets on_subcoregrids=true and requires sub_core_grids.
-  // Compute sub_core_grids from the input layout so the subcoregrids path
-  // doesn't crash on a nullopt dereference in compute_output_specs.
-  std::optional<::tt::tt_metal::CoreRangeSet> subCoreGrids = std::nullopt;
-  if (inputLayout.hasL1BufferType() && inputLayout.getMemLayout() &&
-      isShardedMemoryLayout(inputLayout.getMemLayout().getValue())) {
-    auto coreRangeSet = conversion::getCoreRangeSet(inputLayout);
-    auto ranges = coreRangeSet.ranges();
-    if (ranges.size() != 1 ||
-        ranges[0].start_coord != ::tt::tt_metal::CoreCoord{0, 0}) {
-      subCoreGrids = coreRangeSet;
-    }
-  }
+  ::tt::target::ttnn::NLPConcatHeadsDecodeOpT nlpConcatHeadsDecodeOpNative =
+      buildNLPConcatHeadsDecodeOpTFromMLIR(numHeads, outputLayout);
 
-  // Create query closure
   auto nlpConcatHeadsDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::nlp_concat_heads_decode, device, inputSpec,
-        numHeads, detail::getNullableMemoryConfig(outputLayout),
-        std::optional<::tt::tt_metal::Tensor>(std::nullopt), subCoreGrids);
+    ttnn_op_invoke::NLPConcatHeadsDecodeOpResult result =
+        ttnn_op_invoke::callNLPConcatHeadsDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            nlpConcatHeadsDecodeOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected NLPConcatHeadsDecodeOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -3959,25 +4179,20 @@ llvm::Expected<size_t> OpModel<NLPConcatHeadsDecodeOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Pass sub_core_grids when the input shard grid would trigger subcoregrids
-  // (see getOpConstraints above for rationale).
-  std::optional<::tt::tt_metal::CoreRangeSet> subCoreGrids = std::nullopt;
-  if (inputLayout.hasL1BufferType() && inputLayout.getMemLayout() &&
-      isShardedMemoryLayout(inputLayout.getMemLayout().getValue())) {
-    auto coreRangeSet = conversion::getCoreRangeSet(inputLayout);
-    auto ranges = coreRangeSet.ranges();
-    if (ranges.size() != 1 ||
-        ranges[0].start_coord != ::tt::tt_metal::CoreCoord{0, 0}) {
-      subCoreGrids = coreRangeSet;
-    }
-  }
+  ::tt::target::ttnn::NLPConcatHeadsDecodeOpT nlpConcatHeadsDecodeOpNative =
+      buildNLPConcatHeadsDecodeOpTFromMLIR(numHeads, outputLayout);
 
-  // Create query closure
   auto nlpConcatHeadsDecodeOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::experimental::nlp_concat_heads_decode, device, inputSpec,
-        numHeads, detail::getNullableMemoryConfig(outputLayout),
-        std::optional<::tt::tt_metal::Tensor>(std::nullopt), subCoreGrids);
+    ttnn_op_invoke::NLPConcatHeadsDecodeOpResult result =
+        ttnn_op_invoke::callNLPConcatHeadsDecode(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            nlpConcatHeadsDecodeOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected NLPConcatHeadsDecodeOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(nlpConcatHeadsDecodeOpQuery);
@@ -3985,6 +4200,8 @@ llvm::Expected<size_t> OpModel<NLPConcatHeadsDecodeOp>::getOpRuntime(
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
 }
+
+//===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
 // RepeatInterleaveOp

--- a/runtime/lib/ttnn/operations/transformer/concatenate_heads.cpp
+++ b/runtime/lib/ttnn/operations/transformer/concatenate_heads.cpp
@@ -4,28 +4,37 @@
 
 #include "operations/transformer/concatenate_heads.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/ConcatenateHeadsOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 static void
 runConcatenateHeadsOp(const ::tt::target::ttnn::ConcatenateHeadsOp *op,
-                      ProgramTensorPool &tensorPool) {
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+                      ProgramTensorPool &tensorPool, ProgramContext &context) {
+  const ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
-  ::ttnn::Tensor out =
-      ::ttnn::transformer::concatenate_heads(in, outputMemoryConfig);
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::tt::target::ttnn::ConcatenateHeadsOpT concatenateHeadsOpNative;
+  op->UnPackTo(&concatenateHeadsOpNative);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::ConcatenateHeadsOpResult result =
+      ttnn_op_invoke::callConcatenateHeads(ttnn_op_invoke::CallType::EXECUTE,
+                                           concatenateHeadsOpNative, &input,
+                                           &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callConcatenateHeads execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::ConcatenateHeadsOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runConcatenateHeadsOp(op, tensorPool);
+  runConcatenateHeadsOp(op, tensorPool, context);
 }
 
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/nlp_concat_heads.cpp
+++ b/runtime/lib/ttnn/operations/transformer/nlp_concat_heads.cpp
@@ -4,27 +4,37 @@
 
 #include "operations/transformer/nlp_concat_heads.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 static void runNLPConcatHeadsOp(const ::tt::target::ttnn::NLPConcatHeadsOp *op,
-                                ProgramTensorPool &tensorPool) {
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+                                ProgramTensorPool &tensorPool,
+                                ProgramContext &context) {
+  const ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
-  ::ttnn::Tensor out =
-      ::ttnn::experimental::nlp_concat_heads(in, outputMemoryConfig);
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::tt::target::ttnn::NLPConcatHeadsOpT nlpConcatHeadsOpNative;
+  op->UnPackTo(&nlpConcatHeadsOpNative);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::NLPConcatHeadsOpResult result =
+      ttnn_op_invoke::callNLPConcatHeads(ttnn_op_invoke::CallType::EXECUTE,
+                                         nlpConcatHeadsOpNative, &input,
+                                         &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callNLPConcatHeads execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::NLPConcatHeadsOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runNLPConcatHeadsOp(op, tensorPool);
+  runNLPConcatHeadsOp(op, tensorPool, context);
 }
 
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/nlp_concat_heads_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/nlp_concat_heads_decode.cpp
@@ -2,34 +2,34 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp"
-
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "operations/transformer/nlp_concat_heads_decode.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsDecodeOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 
 void run(const ::tt::target::ttnn::NLPConcatHeadsDecodeOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
-
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  // Pass in sub_core_grids when metal would infer it is required
-  std::optional<::tt::tt_metal::CoreRangeSet> subCoreGrids = std::nullopt;
-  if (in.is_sharded() && in.shard_spec().has_value()) {
-    const auto &inputCoreRanges = in.shard_spec().value().grid.ranges();
-    if (inputCoreRanges.size() > 1 ||
-        !(inputCoreRanges[0].start_coord == ::tt::tt_metal::CoreCoord{0, 0})) {
-      subCoreGrids = in.shard_spec().value().grid;
-    }
-  }
+  ::tt::target::ttnn::NLPConcatHeadsDecodeOpT nlpConcatHeadsDecodeOpNative;
+  op->UnPackTo(&nlpConcatHeadsDecodeOpNative);
 
-  ::ttnn::Tensor out = ::ttnn::experimental::nlp_concat_heads_decode(
-      in, op->num_heads(), outputMemoryConfig, std::nullopt, subCoreGrids);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::NLPConcatHeadsDecodeOpResult result =
+      ttnn_op_invoke::callNLPConcatHeadsDecode(
+          ttnn_op_invoke::CallType::EXECUTE, nlpConcatHeadsDecodeOpNative, &in,
+          &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callNLPConcatHeadsDecode execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/nlp_create_qkv_heads_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/nlp_create_qkv_heads_decode.cpp
@@ -2,35 +2,46 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp"
-
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "operations/transformer/nlp_create_qkv_heads_decode.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/NLPCreateQKVHeadsDecodeOp.h"
+#include <tuple>
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 
 void run(const ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
-
   const ::ttnn::Tensor &input =
       tensorPool.getTTNNTensorAndValidate(op->input());
-  std::optional<::ttnn::Tensor> batch_offset = std::nullopt;
+
+  std::optional<::ttnn::Tensor> batchOffset;
   if (op->batch_offset()) {
-    batch_offset = tensorPool.getTTNNTensorAndValidate(op->batch_offset());
+    batchOffset = tensorPool.getTTNNTensorAndValidate(op->batch_offset());
   }
 
-  uint32_t numHeads = op->num_heads();
-  std::optional<const uint32_t> numKVHeads = op->num_kv_heads();
-  std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors =
-      std::nullopt;
-  std::optional<const bool> overlapQKCoregrid(op->overlap_qk_coregrid());
-  std::optional<const uint32_t> sliceSize = op->slice_size();
+  ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT
+      nlpCreateQkvHeadsDecodeOpNative;
+  op->UnPackTo(&nlpCreateQkvHeadsDecodeOpNative);
 
-  auto [q, k, v] = ::ttnn::experimental::nlp_create_qkv_heads_decode(
-      input, numHeads, numKVHeads, optionalOutputTensors, overlapQKCoregrid,
-      batch_offset, sliceSize, outputMemoryConfig);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::NLPCreateQKVHeadsDecodeOpResult result =
+      ttnn_op_invoke::callNLPCreateQKVHeadsDecode(
+          ttnn_op_invoke::CallType::EXECUTE, nlpCreateQkvHeadsDecodeOpNative,
+          &input,
+          batchOffset.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*batchOffset)
+              : std::nullopt,
+          &targetDevice);
+
+  using QKVTuple = std::tuple<::ttnn::Tensor, ::ttnn::Tensor, ::ttnn::Tensor>;
+  LOG_ASSERT(
+      std::holds_alternative<QKVTuple>(result),
+      "Expected Tensor tuple from callNLPCreateQKVHeadsDecode execution");
+
+  auto &[q, k, v] = std::get<QKVTuple>(result);
 
   tensorPool.insertTTNNTensorAndValidate(op->q_out(), q);
   tensorPool.insertTTNNTensorAndValidate(op->k_out(), k);

--- a/runtime/lib/ttnn/operations/transformer/paged_flash_multi_latent_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/paged_flash_multi_latent_attention_decode.cpp
@@ -3,16 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/transformer/paged_flash_multi_latent_attention_decode.h"
-
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/PagedFlashMultiLatentAttentionDecodeOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 static void runPagedFlashMultiLatentAttentionDecodeOp(
     const ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOp *op,
-    ProgramTensorPool &tensorPool) {
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
-
+    ProgramTensorPool &tensorPool, ProgramContext &context) {
   const ::ttnn::Tensor &query =
       tensorPool.getTTNNTensorAndValidate(op->query());
   const ::ttnn::Tensor &key = tensorPool.getTTNNTensorAndValidate(op->key());
@@ -22,11 +20,8 @@ static void runPagedFlashMultiLatentAttentionDecodeOp(
     value.emplace(tensorPool.getTTNNTensorAndValidate(op->value()));
   }
 
-  uint32_t headDimV = op->head_dim_v();
-
   const ::ttnn::Tensor &pageTable =
       tensorPool.getTTNNTensorAndValidate(op->page_table());
-  bool isCausal = op->is_causal();
 
   std::optional<::ttnn::Tensor> attentionMask = std::nullopt;
   if (op->attention_mask()) {
@@ -46,29 +41,42 @@ static void runPagedFlashMultiLatentAttentionDecodeOp(
         tensorPool.getTTNNTensorAndValidate(op->attention_sink()));
   }
 
-  std::optional<float> scale = op->scale();
-  std::optional<uint32_t> slidingWindowSize = std::nullopt;
+  ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT
+      pagedFlashMultiLatentAttentionDecodeOpNative;
+  op->UnPackTo(&pagedFlashMultiLatentAttentionDecodeOpNative);
 
-  auto programConfig =
-      std::make_optional<::ttnn::operations::transformer::SDPAProgramConfig>();
-  programConfig->k_chunk_size = 32;
-  programConfig->compute_with_storage_grid_size =
-      query.device()->compute_with_storage_grid_size();
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::Tensor out =
-      ::ttnn::transformer::paged_flash_multi_latent_attention_decode(
-          query, key, value, headDimV, pageTable, isCausal, attentionMask,
-          curPosTensor, attentionSink, scale, slidingWindowSize,
-          outputMemoryConfig,
-          /*program_config=*/programConfig,
-          /*compute_kernel_config=*/std::nullopt);
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::PagedFlashMultiLatentAttentionDecodeOpResult result =
+      ttnn_op_invoke::callPagedFlashMultiLatentAttentionDecode(
+          ttnn_op_invoke::CallType::EXECUTE,
+          pagedFlashMultiLatentAttentionDecodeOpNative, &query, &key,
+          value.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*value)
+                            : std::nullopt,
+          &pageTable,
+          attentionMask.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*attentionMask)
+              : std::nullopt,
+          curPosTensor.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*curPosTensor)
+              : std::nullopt,
+          attentionSink.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*attentionSink)
+              : std::nullopt,
+          &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from "
+             "callPagedFlashMultiLatentAttentionDecode execution");
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(),
+                                         std::get<::ttnn::Tensor>(result));
 }
 
 void run(const ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runPagedFlashMultiLatentAttentionDecodeOp(op, tensorPool);
+  runPagedFlashMultiLatentAttentionDecodeOp(op, tensorPool, context);
 }
 
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
@@ -3,17 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/transformer/paged_scaled_dot_product_attention_decode.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/PagedScaledDotProductAttentionDecodeOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 static void runPagedScaledDotProductAttentionDecodeOp(
     const ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOp *op,
-    ProgramTensorPool &tensorPool) {
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
-
+    ProgramTensorPool &tensorPool, ProgramContext &context) {
   const ::ttnn::Tensor &query =
       tensorPool.getTTNNTensorAndValidate(op->query());
   const ::ttnn::Tensor &key = tensorPool.getTTNNTensorAndValidate(op->key());
@@ -21,7 +18,6 @@ static void runPagedScaledDotProductAttentionDecodeOp(
       tensorPool.getTTNNTensorAndValidate(op->value());
   const ::ttnn::Tensor &pageTable =
       tensorPool.getTTNNTensorAndValidate(op->page_table());
-  bool isCausal = op->is_causal();
 
   std::optional<::ttnn::Tensor> attentionMask = std::nullopt;
   if (op->attention_mask()) {
@@ -41,46 +37,40 @@ static void runPagedScaledDotProductAttentionDecodeOp(
         tensorPool.getTTNNTensorAndValidate(op->attention_sink()));
   }
 
-  std::optional<float> scale = op->scale();
-  std::optional<uint32_t> slidingWindowSize = op->sliding_window_size();
-  const auto computeGrid = query.device()->compute_with_storage_grid_size();
+  ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT
+      pagedScaledDotProductAttentionDecodeOpNative;
+  op->UnPackTo(&pagedScaledDotProductAttentionDecodeOpNative);
 
-  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
-      programConfig = std::nullopt;
-  if (op->program_config()) {
-    programConfig = utils::createSDPAProgramConfig(op->program_config());
-  } else if (!isCausal) {
-    programConfig.emplace();
-    programConfig->k_chunk_size = 32; // Required for non-causal
-    programConfig->compute_with_storage_grid_size = computeGrid;
-  } else if (query.device()->arch() == ::tt::ARCH::BLACKHOLE) {
-    programConfig.emplace();
-    programConfig->q_chunk_size = 0;
-    programConfig->k_chunk_size = 0;
-    programConfig->compute_with_storage_grid_size = computeGrid;
-    programConfig->max_cores_per_head_batch = computeGrid.x * computeGrid.y;
-  }
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  // Blackhole's SDPA decode default approx-exp path fails SFPI compile
-  // (tt-metal #40301).
-  if (programConfig.has_value() &&
-      query.device()->arch() == ::tt::ARCH::BLACKHOLE) {
-    programConfig->exp_approx_mode = false;
-  }
+  ttnn_op_invoke::PagedScaledDotProductAttentionDecodeOpResult result =
+      ttnn_op_invoke::callPagedScaledDotProductAttentionDecode(
+          ttnn_op_invoke::CallType::EXECUTE,
+          pagedScaledDotProductAttentionDecodeOpNative, &query, &key, &value,
+          &pageTable,
+          attentionMask.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*attentionMask)
+              : std::nullopt,
+          curPosTensor.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*curPosTensor)
+              : std::nullopt,
+          attentionSink.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*attentionSink)
+              : std::nullopt,
+          &targetDevice);
 
-  ::ttnn::Tensor out =
-      ::ttnn::transformer::paged_scaled_dot_product_attention_decode(
-          query, key, value, pageTable, isCausal, attentionMask, curPosTensor,
-          attentionSink, scale, slidingWindowSize, outputMemoryConfig,
-          /*program_config=*/programConfig,
-          /*compute_kernel_config=*/std::nullopt);
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from "
+             "callPagedScaledDotProductAttentionDecode execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runPagedScaledDotProductAttentionDecodeOp(op, tensorPool);
+  runPagedScaledDotProductAttentionDecodeOp(op, tensorPool, context);
 }
 
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/rotary_embedding.cpp
+++ b/runtime/lib/ttnn/operations/transformer/rotary_embedding.cpp
@@ -3,36 +3,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/transformer/rotary_embedding.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 static void runRotaryEmbedding(const ::tt::target::ttnn::RotaryEmbeddingOp *op,
-                               ProgramTensorPool &tensorPool) {
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
-
-  const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->input());
+                               ProgramTensorPool &tensorPool,
+                               ProgramContext &context) {
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
   const ::ttnn::Tensor &cosCache =
       tensorPool.getTTNNTensorAndValidate(op->cos_cache());
   const ::ttnn::Tensor &sinCache =
       tensorPool.getTTNNTensorAndValidate(op->sin_cache());
-  std::optional<uint32_t> tokenIndex = op->token_index();
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
 
-  ::ttnn::Tensor out = ::ttnn::experimental::rotary_embedding(
-      in, cosCache, sinCache, tokenIndex, outputMemoryConfig, computeConfig);
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::tt::target::ttnn::RotaryEmbeddingOpT rotaryEmbeddingOpNative;
+  op->UnPackTo(&rotaryEmbeddingOpNative);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::RotaryEmbeddingOpResult result =
+      ttnn_op_invoke::callRotaryEmbedding(ttnn_op_invoke::CallType::EXECUTE,
+                                          rotaryEmbeddingOpNative, &input,
+                                          &cosCache, &sinCache, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callRotaryEmbedding execution");
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::RotaryEmbeddingOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runRotaryEmbedding(op, tensorPool);
+  runRotaryEmbedding(op, tensorPool, context);
 }
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/rotary_embedding_llama.cpp
+++ b/runtime/lib/ttnn/operations/transformer/rotary_embedding_llama.cpp
@@ -3,40 +3,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/transformer/rotary_embedding_llama.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/RotaryEmbeddingLlamaOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 static void
 runRotaryEmbeddingLlama(const ::tt::target::ttnn::RotaryEmbeddingLlamaOp *op,
-                        ProgramTensorPool &tensorPool) {
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
-
-  const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->input());
+                        ProgramTensorPool &tensorPool,
+                        ProgramContext &context) {
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
   const ::ttnn::Tensor &cosCache =
       tensorPool.getTTNNTensorAndValidate(op->cos_cache());
   const ::ttnn::Tensor &sinCache =
       tensorPool.getTTNNTensorAndValidate(op->sin_cache());
   const ::ttnn::Tensor &transMat =
       tensorPool.getTTNNTensorAndValidate(op->trans_mat());
-  bool isDecodeMode = op->is_decode_mode();
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
-  ::ttnn::Tensor out = ::ttnn::experimental::rotary_embedding_llama(
-      in, cosCache, sinCache, transMat, isDecodeMode, outputMemoryConfig,
-      computeConfig);
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+
+  ::tt::target::ttnn::RotaryEmbeddingLlamaOpT rotaryEmbeddingLlamaOpNative;
+  op->UnPackTo(&rotaryEmbeddingLlamaOpNative);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::RotaryEmbeddingLlamaOpResult result =
+      ttnn_op_invoke::callRotaryEmbeddingLlama(
+          ttnn_op_invoke::CallType::EXECUTE, rotaryEmbeddingLlamaOpNative,
+          &input, &cosCache, &sinCache, &transMat, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callRotaryEmbeddingLlama execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::RotaryEmbeddingLlamaOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runRotaryEmbeddingLlama(op, tensorPool);
+  runRotaryEmbeddingLlama(op, tensorPool, context);
 }
 
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.cpp
+++ b/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.cpp
@@ -4,52 +4,60 @@
 
 #include "operations/transformer/scaled_dot_product_attention.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 static void runScaledDotProductAttentionOp(
     const ::tt::target::ttnn::ScaledDotProductAttentionOp *op,
-    ProgramTensorPool &tensorPool) {
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
-
+    ProgramTensorPool &tensorPool, ProgramContext &context) {
   const ::ttnn::Tensor &query =
       tensorPool.getTTNNTensorAndValidate(op->query());
   const ::ttnn::Tensor &key = tensorPool.getTTNNTensorAndValidate(op->key());
   const ::ttnn::Tensor &value =
       tensorPool.getTTNNTensorAndValidate(op->value());
-  bool isCausal = op->is_causal();
 
-  const std::optional<::ttnn::Tensor> &attentionMask =
-      op->attention_mask()
-          ? std::make_optional(
-                tensorPool.getTTNNTensorAndValidate(op->attention_mask()))
-          : std::nullopt;
+  std::optional<::ttnn::Tensor> attentionMask = std::nullopt;
+  if (op->attention_mask()) {
+    attentionMask.emplace(
+        tensorPool.getTTNNTensorAndValidate(op->attention_mask()));
+  }
 
-  std::optional<float> scale = op->scale();
-  std::optional<uint32_t> slidingWindowSize = op->sliding_window_size();
+  std::optional<::ttnn::Tensor> attentionSink = std::nullopt;
+  if (op->attention_sink()) {
+    attentionSink.emplace(
+        tensorPool.getTTNNTensorAndValidate(op->attention_sink()));
+  }
 
-  const std::optional<::ttnn::Tensor> &attentionSink =
-      op->attention_sink()
-          ? std::make_optional(
-                tensorPool.getTTNNTensorAndValidate(op->attention_sink()))
-          : std::nullopt;
+  ::tt::target::ttnn::ScaledDotProductAttentionOpT
+      scaledDotProductAttentionOpNative;
+  op->UnPackTo(&scaledDotProductAttentionOpNative);
 
-  ::ttnn::Tensor out = ::ttnn::transformer::scaled_dot_product_attention(
-      query, key, value, attentionMask, isCausal, scale, slidingWindowSize,
-      outputMemoryConfig,
-      /*program_config=*/std::nullopt,
-      /*compute_kernel_config=*/std::nullopt, attentionSink);
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::ScaledDotProductAttentionOpResult result =
+      ttnn_op_invoke::callScaledDotProductAttention(
+          ttnn_op_invoke::CallType::EXECUTE, scaledDotProductAttentionOpNative,
+          &query, &key, &value,
+          attentionMask.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*attentionMask)
+              : std::nullopt,
+          attentionSink.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*attentionSink)
+              : std::nullopt,
+          &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callScaledDotProductAttention execution");
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::ScaledDotProductAttentionOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runScaledDotProductAttentionOp(op, tensorPool);
+  runScaledDotProductAttentionOp(op, tensorPool, context);
 }
 
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention_decode.cpp
@@ -4,35 +4,29 @@
 
 #include "operations/transformer/scaled_dot_product_attention_decode.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/ScaledDotProductAttentionDecodeOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 static void runScaledDotProductAttentionDecodeOp(
     const ::tt::target::ttnn::ScaledDotProductAttentionDecodeOp *op,
-    ProgramTensorPool &tensorPool) {
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
-
+    ProgramTensorPool &tensorPool, ProgramContext &context) {
   const ::ttnn::Tensor &query =
       tensorPool.getTTNNTensorAndValidate(op->query());
   const ::ttnn::Tensor &key = tensorPool.getTTNNTensorAndValidate(op->key());
   const ::ttnn::Tensor &value =
       tensorPool.getTTNNTensorAndValidate(op->value());
-  bool isCausal = op->is_causal();
-
-  std::optional<::ttnn::Tensor> curPosTensor = std::nullopt;
-  if (op->cur_pos_tensor()) {
-    curPosTensor.emplace(
-        tensorPool.getTTNNTensorAndValidate(op->cur_pos_tensor()));
-  }
 
   std::optional<::ttnn::Tensor> attentionMask = std::nullopt;
   if (op->attention_mask()) {
     attentionMask.emplace(
         tensorPool.getTTNNTensorAndValidate(op->attention_mask()));
+  }
+
+  std::optional<::ttnn::Tensor> curPosTensor = std::nullopt;
+  if (op->cur_pos_tensor()) {
+    curPosTensor.emplace(
+        tensorPool.getTTNNTensorAndValidate(op->cur_pos_tensor()));
   }
 
   std::optional<::ttnn::Tensor> attentionSink = std::nullopt;
@@ -41,31 +35,40 @@ static void runScaledDotProductAttentionDecodeOp(
         tensorPool.getTTNNTensorAndValidate(op->attention_sink()));
   }
 
-  std::optional<float> scale = op->scale();
-  std::optional<uint32_t> slidingWindowSize = std::nullopt;
+  ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT
+      scaledDotProductAttentionDecodeOpNative;
+  op->UnPackTo(&scaledDotProductAttentionDecodeOpNative);
 
-  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
-      programConfig;
-  if (op->program_config()) {
-    programConfig = utils::createSDPAProgramConfig(op->program_config());
-  }
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  // The current position information is required for this op. It can either be
-  // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
-  // std::optional so we must pass an empty vector.
-  const std::vector<uint32_t> curPosEmpty = {};
-  ::ttnn::Tensor out = ::ttnn::transformer::scaled_dot_product_attention_decode(
-      query, key, value, isCausal, attentionMask, curPosEmpty, curPosTensor,
-      attentionSink, scale, slidingWindowSize, outputMemoryConfig,
-      programConfig,
-      /*compute_kernel_config=*/std::nullopt);
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::ScaledDotProductAttentionDecodeOpResult result =
+      ttnn_op_invoke::callScaledDotProductAttentionDecode(
+          ttnn_op_invoke::CallType::EXECUTE,
+          scaledDotProductAttentionDecodeOpNative, &query, &key, &value,
+          attentionMask.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*attentionMask)
+              : std::nullopt,
+          curPosTensor.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*curPosTensor)
+              : std::nullopt,
+          attentionSink.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*attentionSink)
+              : std::nullopt,
+          &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callScaledDotProductAttentionDecode "
+             "execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::ScaledDotProductAttentionDecodeOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runScaledDotProductAttentionDecodeOp(op, tensorPool);
+  runScaledDotProductAttentionDecodeOp(op, tensorPool, context);
 }
 
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/split_query_key_value_and_split_heads.cpp
+++ b/runtime/lib/ttnn/operations/transformer/split_query_key_value_and_split_heads.cpp
@@ -4,34 +4,42 @@
 
 #include "operations/transformer/split_query_key_value_and_split_heads.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Transformer/SplitQueryKeyValueAndSplitHeadsOp.h"
+#include <tuple>
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::transformer {
 static void runSplitQueryKeyValueAndSplitHeadsOp(
     const ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOp *op,
-    ProgramTensorPool &tensorPool) {
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
-
-  uint32_t numHeads = op->num_heads();
-  std::optional<uint32_t> numKVHeads;
-  if (op->num_kv_heads()) {
-    numKVHeads = op->num_kv_heads();
-  }
-  std::optional<::ttnn::Tensor> kvInputTensor =
-      op->kv_input() ? std::make_optional(
-                           tensorPool.getTTNNTensorAndValidate(op->kv_input()))
-                     : std::nullopt;
-
+    ProgramTensorPool &tensorPool, ProgramContext &context) {
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
-  bool transposeKey = op->transpose_key();
 
-  auto [q, k, v] = ::ttnn::transformer::split_query_key_value_and_split_heads(
-      in, kvInputTensor, numHeads, numKVHeads, transposeKey,
-      outputMemoryConfig);
+  std::optional<::ttnn::Tensor> kvInput;
+  if (op->kv_input()) {
+    kvInput.emplace(tensorPool.getTTNNTensorAndValidate(op->kv_input()));
+  }
+
+  ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT
+      splitQueryKeyValueAndSplitHeadsOpNative;
+  op->UnPackTo(&splitQueryKeyValueAndSplitHeadsOpNative);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::SplitQueryKeyValueAndSplitHeadsOpResult result =
+      ttnn_op_invoke::callSplitQueryKeyValueAndSplitHeads(
+          ttnn_op_invoke::CallType::EXECUTE,
+          splitQueryKeyValueAndSplitHeadsOpNative, &in,
+          kvInput.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*kvInput)
+              : std::nullopt,
+          &targetDevice);
+
+  using QKVTuple = std::tuple<::ttnn::Tensor, ::ttnn::Tensor, ::ttnn::Tensor>;
+  LOG_ASSERT(std::holds_alternative<QKVTuple>(result),
+             "Expected Tensor tuple from callSplitQueryKeyValueAndSplitHeads "
+             "execution");
+
+  auto &[q, k, v] = std::get<QKVTuple>(result);
 
   tensorPool.insertTTNNTensorAndValidate(op->q_out(), q);
   tensorPool.insertTTNNTensorAndValidate(op->k_out(), k);
@@ -41,6 +49,6 @@ static void runSplitQueryKeyValueAndSplitHeadsOp(
 void run(const ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runSplitQueryKeyValueAndSplitHeadsOp(op, tensorPool);
+  runSplitQueryKeyValueAndSplitHeadsOp(op, tensorPool, context);
 }
 } // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -96,29 +96,10 @@ createConv2dSliceConfig(const ::tt::target::ttnn::Conv2dSliceConfig *config) {
 
 ::ttnn::operations::transformer::SDPAProgramConfig
 createSDPAProgramConfig(const ::tt::target::ttnn::SDPAConfig *config) {
-  ::ttnn::operations::transformer::SDPAProgramConfig sdpaConfig;
-
-  sdpaConfig.compute_with_storage_grid_size =
-      ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
-          *config->compute_with_storage_grid_size());
-
-  if (config->sub_core_grids()) {
-    sdpaConfig.sub_core_grids = ::tt::runtime::ttnn::utils::toTTNNCoreRangeSet(
-        *config->sub_core_grids());
-  }
-
-  sdpaConfig.q_chunk_size = config->q_chunk_size();
-  sdpaConfig.k_chunk_size = config->k_chunk_size();
-
-  if (config->exp_approx_mode()) {
-    sdpaConfig.exp_approx_mode = *config->exp_approx_mode();
-  }
-
-  if (config->max_cores_per_head_batch()) {
-    sdpaConfig.max_cores_per_head_batch = *config->max_cores_per_head_batch();
-  }
-
-  return sdpaConfig;
+  ::tt::target::ttnn::SDPAConfigT sdpaConfigNative;
+  config->UnPackTo(&sdpaConfigNative);
+  return ttnn_op_invoke::operations::utils::createSDPAProgramConfig(
+      sdpaConfigNative);
 }
 
 ::ttnn::prim::LayerNormProgramConfig

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
@@ -2757,4 +2757,1318 @@ INSTANTIATE_TEST_SUITE_P(RequantizeOpTPathParityTest,
                          RequantizeOpTPathParityTest,
                          ::testing::ValuesIn(requantizeOpList));
 
+// ConcatenateHeadsOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::ConcatenateHeadsOpT &opNativeOpModel,
+                       ::tt::target::ttnn::ConcatenateHeadsOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ConcatenateHeadsOpT &op) {
+    op.in.reset();
+    op.out.reset();
+    op.memcfg.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::ConcatenateHeadsOp buildTestConcatenateHeadsOp(
+    mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::ConcatenateHeadsOp>(loc, outputType,
+                                                              input);
+}
+
+} // namespace
+
+using ConcatenateHeadsOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ConcatenateHeadsOp>;
+
+TEST_P(ConcatenateHeadsOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::ConcatenateHeadsOp concatOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ConcatenateHeadsOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildConcatenateHeadsOpTFromMLIR(
+          resolveOutputLayout(concatOp));
+
+  // Path B: FB serialization round-trip.
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, concatOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, concatOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ConcatenateHeadsOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::ConcatenateHeadsOp>
+    concatenateHeadsOpList = {
+        buildTestConcatenateHeadsOp(),
+        buildTestConcatenateHeadsOp(
+            /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(ConcatenateHeadsOpTPathParityTest,
+                         ConcatenateHeadsOpTPathParityTest,
+                         ::testing::ValuesIn(concatenateHeadsOpList));
+
+//===----------------------------------------------------------------------===//
+// NLPConcatHeadsOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::NLPConcatHeadsOpT &opNativeOpModel,
+                       ::tt::target::ttnn::NLPConcatHeadsOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::NLPConcatHeadsOpT &op) {
+    op.in.reset();
+    op.out.reset();
+    op.memcfg.reset();
+  };
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::NLPConcatHeadsOp buildTestNLPConcatHeadsOp(
+    mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::NLPConcatHeadsOp>(loc, outputType,
+                                                            input);
+}
+
+} // namespace
+
+using NLPConcatHeadsOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::NLPConcatHeadsOp>;
+
+TEST_P(NLPConcatHeadsOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::NLPConcatHeadsOp nlpConcatOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::NLPConcatHeadsOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildNLPConcatHeadsOpTFromMLIR(
+          resolveOutputLayout(nlpConcatOp));
+
+  // Path B: FB serialization round-trip.
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, nlpConcatOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, nlpConcatOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::NLPConcatHeadsOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::NLPConcatHeadsOp>
+    nlpConcatHeadsOpList = {
+        buildTestNLPConcatHeadsOp(),
+        buildTestNLPConcatHeadsOp(
+            /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(NLPConcatHeadsOpTPathParityTest,
+                         NLPConcatHeadsOpTPathParityTest,
+                         ::testing::ValuesIn(nlpConcatHeadsOpList));
+
+//===----------------------------------------------------------------------===//
+// NLPCreateQKVHeadsDecodeOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT &opNativeOpModel,
+    ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT &op) {
+    op.input.reset();
+    op.batch_offset.reset();
+    op.q_out.reset();
+    op.k_out.reset();
+    op.v_out.reset();
+  };
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::NLPCreateQKVHeadsDecodeOp buildTestNLPCreateQKVHeadsDecodeOp(
+    bool withBatchOffset = false, uint32_t numHeads = 8,
+    std::optional<uint32_t> numKVHeads = std::nullopt,
+    std::optional<bool> overlapQKCoregrid = std::nullopt,
+    std::optional<uint32_t> sliceSize = std::nullopt) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value batchOffset = nullptr;
+  if (withBatchOffset) {
+    auto batchOffsetType = tiledL1BF16Type(defaultShape);
+    batchOffset =
+        e.builder
+            .create<mlir::tt::ttnn::OnesOp>(
+                loc, mlir::TypeRange{batchOffsetType}, mlir::ValueRange{})
+            .getResult();
+  }
+
+  mlir::IntegerAttr numKVHeadsAttr;
+  if (numKVHeads.has_value()) {
+    numKVHeadsAttr = mlir::IntegerAttr::get(
+        mlir::IntegerType::get(getContext(), 32, mlir::IntegerType::Unsigned),
+        *numKVHeads);
+  }
+  mlir::BoolAttr overlapQKCoregridAttr;
+  if (overlapQKCoregrid.has_value()) {
+    overlapQKCoregridAttr =
+        mlir::BoolAttr::get(getContext(), *overlapQKCoregrid);
+  }
+  mlir::IntegerAttr sliceSizeAttr;
+  if (sliceSize.has_value()) {
+    sliceSizeAttr = mlir::IntegerAttr::get(
+        mlir::IntegerType::get(getContext(), 32, mlir::IntegerType::Unsigned),
+        *sliceSize);
+  }
+
+  return e.builder.create<mlir::tt::ttnn::NLPCreateQKVHeadsDecodeOp>(
+      loc, /*query=*/outputType, /*key=*/outputType, /*value=*/outputType,
+      input, batchOffset, numHeads, numKVHeadsAttr, overlapQKCoregridAttr,
+      sliceSizeAttr);
+}
+
+} // namespace
+
+using NLPCreateQKVHeadsDecodeOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::NLPCreateQKVHeadsDecodeOp>;
+
+TEST_P(NLPCreateQKVHeadsDecodeOpTPathParityTest,
+       BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::NLPCreateQKVHeadsDecodeOp qkvOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildNLPCreateQKVHeadsDecodeOpTFromMLIR(
+          qkvOp.getNumHeads(), qkvOp.getNumKvHeads(),
+          qkvOp.getOverlapQkCoregrid(), qkvOp.getSliceSize(), nullptr);
+
+  // Path B: FB serialization round-trip.
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, qkvOp.getInput());
+  if (qkvOp.getBatchOffset()) {
+    prepopulateOperandTensorRefs(cache, qkvOp.getBatchOffset());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, qkvOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.q_out, opNativeFB.q_out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::NLPCreateQKVHeadsDecodeOp>
+    nlpCreateQKVHeadsDecodeOpList = {
+        buildTestNLPCreateQKVHeadsDecodeOp(),
+        buildTestNLPCreateQKVHeadsDecodeOp(/*withBatchOffset=*/true),
+        buildTestNLPCreateQKVHeadsDecodeOp(/*withBatchOffset=*/false,
+                                           /*numHeads=*/16u),
+        buildTestNLPCreateQKVHeadsDecodeOp(
+            /*withBatchOffset=*/false, /*numHeads=*/8u,
+            /*numKVHeads=*/std::optional<uint32_t>(4u)),
+        buildTestNLPCreateQKVHeadsDecodeOp(
+            /*withBatchOffset=*/false, /*numHeads=*/8u,
+            /*numKVHeads=*/std::nullopt,
+            /*overlapQKCoregrid=*/std::optional<bool>(true)),
+        buildTestNLPCreateQKVHeadsDecodeOp(
+            /*withBatchOffset=*/false, /*numHeads=*/8u,
+            /*numKVHeads=*/std::nullopt,
+            /*overlapQKCoregrid=*/std::nullopt,
+            /*sliceSize=*/std::optional<uint32_t>(32u)),
+        buildTestNLPCreateQKVHeadsDecodeOp(
+            /*withBatchOffset=*/true, /*numHeads=*/16u,
+            /*numKVHeads=*/std::optional<uint32_t>(4u),
+            /*overlapQKCoregrid=*/std::optional<bool>(false),
+            /*sliceSize=*/std::optional<uint32_t>(64u)),
+};
+
+INSTANTIATE_TEST_SUITE_P(NLPCreateQKVHeadsDecodeOpTPathParityTest,
+                         NLPCreateQKVHeadsDecodeOpTPathParityTest,
+                         ::testing::ValuesIn(nlpCreateQKVHeadsDecodeOpList));
+
+TEST_F(NLPCreateQKVHeadsDecodeOpTPathParityTest, NonDefaultMemoryConfig) {
+  mlir::tt::ttnn::NLPCreateQKVHeadsDecodeOp qkvOp =
+      buildTestNLPCreateQKVHeadsDecodeOp(
+          /*withBatchOffset=*/true, /*numHeads=*/16u,
+          /*numKVHeads=*/std::optional<uint32_t>(4u),
+          /*overlapQKCoregrid=*/std::optional<bool>(false),
+          /*sliceSize=*/std::optional<uint32_t>(64u));
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildNLPCreateQKVHeadsDecodeOpTFromMLIR(
+          qkvOp.getNumHeads(), qkvOp.getNumKvHeads(),
+          qkvOp.getOverlapQkCoregrid(), qkvOp.getSliceSize(),
+          mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+              mlir::cast<mlir::RankedTensorType>(qkvOp.getQuery().getType())
+                  .getEncoding()));
+
+  // Path B: FB serialization round-trip.
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, qkvOp.getInput());
+  if (qkvOp.getBatchOffset()) {
+    prepopulateOperandTensorRefs(cache, qkvOp.getBatchOffset());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, qkvOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::NLPCreateQKVHeadsDecodeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_NE(opNativeOpModel, opNativeFB);
+  EXPECT_NE(opNativeOpModel.memcfg, opNativeFB.memcfg);
+  EXPECT_NE(opNativeOpModel.memcfg, nullptr);
+  EXPECT_EQ(opNativeFB.memcfg, nullptr);
+  opNativeOpModel.memcfg.reset();
+  opNativeFB.memcfg.reset();
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+}
+
+//===----------------------------------------------------------------------===//
+// PagedFlashMultiLatentAttentionDecodeOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT
+        &opNativeOpModel,
+    ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT &opNativeFB) {
+  auto helper =
+      [](::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT &op) {
+        op.query.reset();
+        op.key.reset();
+        op.value.reset();
+        op.page_table.reset();
+        op.attention_mask.reset();
+        op.cur_pos_tensor.reset();
+        op.attention_sink.reset();
+        op.out.reset();
+        op.memcfg.reset();
+      };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PagedFlashMultiLatentAttentionDecodeOp
+buildTestPagedFlashMultiLatentAttentionDecodeOp(
+    bool withValue = false, uint32_t headDimV = 64, bool isCausal = true,
+    bool withAttentionMask = false, bool withCurPosTensor = false,
+    bool withAttentionSink = false, mlir::FloatAttr scale = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value query = makeOnes();
+  mlir::Value key = makeOnes();
+  mlir::Value value = withValue ? makeOnes() : mlir::Value();
+  mlir::Value pageTable = makeOnes();
+  mlir::Value attentionMask = withAttentionMask ? makeOnes() : mlir::Value();
+  mlir::Value curPosTensor = withCurPosTensor ? makeOnes() : mlir::Value();
+  mlir::Value attentionSink = withAttentionSink ? makeOnes() : mlir::Value();
+
+  return e.builder
+      .create<mlir::tt::ttnn::PagedFlashMultiLatentAttentionDecodeOp>(
+          loc, tensorType, query, key, value, headDimV, pageTable, isCausal,
+          attentionMask, curPosTensor, attentionSink, scale);
+}
+
+} // namespace
+
+using PagedFlashMultiLatentAttentionDecodeOpTPathParityTest =
+    ::testing::TestWithParam<
+        mlir::tt::ttnn::PagedFlashMultiLatentAttentionDecodeOp>;
+
+TEST_P(PagedFlashMultiLatentAttentionDecodeOpTPathParityTest,
+       BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PagedFlashMultiLatentAttentionDecodeOp mlaOp = GetParam();
+
+  std::optional<llvm::APFloat> scaleOpt;
+  if (auto scaleAttr = mlaOp.getScaleAttr()) {
+    scaleOpt = scaleAttr.getValue();
+  }
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::
+          buildPagedFlashMultiLatentAttentionDecodeOpTFromMLIR(
+              mlaOp.getHeadDimV(), mlaOp.getIsCausal(), scaleOpt,
+              resolveOutputLayout(mlaOp));
+
+  // Path B: FB serialization round-trip.
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, mlaOp.getQuery(), mlaOp.getKey(),
+                               mlaOp.getPageTable());
+  if (mlaOp.getValue()) {
+    prepopulateOperandTensorRefs(cache, mlaOp.getValue());
+  }
+  if (mlaOp.getAttentionMask()) {
+    prepopulateOperandTensorRefs(cache, mlaOp.getAttentionMask());
+  }
+  if (mlaOp.getCurPosTensor()) {
+    prepopulateOperandTensorRefs(cache, mlaOp.getCurPosTensor());
+  }
+  if (mlaOp.getAttentionSink()) {
+    prepopulateOperandTensorRefs(cache, mlaOp.getAttentionSink());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, mlaOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PagedFlashMultiLatentAttentionDecodeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<
+    mlir::tt::ttnn::PagedFlashMultiLatentAttentionDecodeOp>
+    pagedFlashMlaDecodeOpList = {
+        buildTestPagedFlashMultiLatentAttentionDecodeOp(),
+        buildTestPagedFlashMultiLatentAttentionDecodeOp(/*withValue=*/true),
+        buildTestPagedFlashMultiLatentAttentionDecodeOp(/*withValue=*/false,
+                                                        /*headDimV=*/128u),
+        buildTestPagedFlashMultiLatentAttentionDecodeOp(/*withValue=*/false,
+                                                        /*headDimV=*/64u,
+                                                        /*isCausal=*/false),
+        buildTestPagedFlashMultiLatentAttentionDecodeOp(
+            /*withValue=*/false, /*headDimV=*/64u, /*isCausal=*/true,
+            /*withAttentionMask=*/true),
+        buildTestPagedFlashMultiLatentAttentionDecodeOp(
+            /*withValue=*/false, /*headDimV=*/64u, /*isCausal=*/true,
+            /*withAttentionMask=*/false, /*withCurPosTensor=*/true),
+        buildTestPagedFlashMultiLatentAttentionDecodeOp(
+            /*withValue=*/false, /*headDimV=*/64u, /*isCausal=*/true,
+            /*withAttentionMask=*/false, /*withCurPosTensor=*/false,
+            /*withAttentionSink=*/true),
+        buildTestPagedFlashMultiLatentAttentionDecodeOp(
+            /*withValue=*/false, /*headDimV=*/64u, /*isCausal=*/true,
+            /*withAttentionMask=*/false, /*withCurPosTensor=*/false,
+            /*withAttentionSink=*/false,
+            /*scale=*/mlir::Builder(getContext()).getF32FloatAttr(0.125f)),
+        buildTestPagedFlashMultiLatentAttentionDecodeOp(
+            /*withValue=*/true, /*headDimV=*/128u, /*isCausal=*/false,
+            /*withAttentionMask=*/true, /*withCurPosTensor=*/true,
+            /*withAttentionSink=*/true,
+            /*scale=*/mlir::Builder(getContext()).getF32FloatAttr(0.25f)),
+};
+
+INSTANTIATE_TEST_SUITE_P(PagedFlashMultiLatentAttentionDecodeOpTPathParityTest,
+                         PagedFlashMultiLatentAttentionDecodeOpTPathParityTest,
+                         ::testing::ValuesIn(pagedFlashMlaDecodeOpList));
+
+//===----------------------------------------------------------------------===//
+// PagedScaledDotProductAttentionDecodeOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+const mlir::tt::ttnn::SDPAProgramConfigAttr nonDefaultSDPAProgramConfigAttr =
+    mlir::tt::ttnn::SDPAProgramConfigAttr::get(
+        getContext(),
+        /*computeWithStorageGridSize=*/
+        mlir::tt::ttnn::CoreCoordAttr::get(getContext(), 8, 8),
+        /*subCoreGrids=*/mlir::tt::ttnn::CoreRangeSetAttr(),
+        /*qChunkSize=*/64, /*kChunkSize=*/64,
+        /*expApproxMode=*/mlir::BoolAttr::get(getContext(), false),
+        /*maxCoresPerHeadBatch=*/64);
+
+void resetUnusedFields(
+    ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT
+        &opNativeOpModel,
+    ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT &opNativeFB) {
+  auto helper =
+      [](::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT &op) {
+        op.query.reset();
+        op.key.reset();
+        op.value.reset();
+        op.page_table.reset();
+        op.attention_mask.reset();
+        op.cur_pos_tensor.reset();
+        op.attention_sink.reset();
+        op.out.reset();
+        op.memcfg.reset();
+      };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp
+buildTestPagedScaledDotProductAttentionDecodeOp(
+    bool isCausal = true, bool withAttentionMask = false,
+    bool withCurPosTensor = false, bool withAttentionSink = false,
+    mlir::FloatAttr scale = {}, mlir::IntegerAttr slidingWindowSize = {},
+    mlir::tt::ttnn::SDPAProgramConfigAttr programConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value query = makeOnes();
+  mlir::Value key = makeOnes();
+  mlir::Value value = makeOnes();
+  mlir::Value pageTable = makeOnes();
+  mlir::Value attentionMask = withAttentionMask ? makeOnes() : mlir::Value();
+  mlir::Value curPosTensor = withCurPosTensor ? makeOnes() : mlir::Value();
+  mlir::Value attentionSink = withAttentionSink ? makeOnes() : mlir::Value();
+
+  return e.builder
+      .create<mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp>(
+          loc, tensorType, query, key, value, pageTable, isCausal,
+          attentionMask, curPosTensor, attentionSink, scale, slidingWindowSize,
+          programConfig);
+}
+
+} // namespace
+
+using PagedScaledDotProductAttentionDecodeOpTPathParityTest =
+    ::testing::TestWithParam<
+        mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp>;
+
+TEST_P(PagedScaledDotProductAttentionDecodeOpTPathParityTest,
+       BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp sdpaOp = GetParam();
+
+  std::optional<llvm::APFloat> scaleOpt;
+  if (auto scaleAttr = sdpaOp.getScaleAttr()) {
+    scaleOpt = scaleAttr.getValue();
+  }
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::
+          buildPagedScaledDotProductAttentionDecodeOpTFromMLIR(
+              sdpaOp.getIsCausal(), scaleOpt, sdpaOp.getSlidingWindowSize(),
+              sdpaOp.getProgramConfig(), resolveOutputLayout(sdpaOp));
+
+  // Path B: FB serialization round-trip.
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, sdpaOp.getQuery(), sdpaOp.getKey(),
+                               sdpaOp.getValue(), sdpaOp.getPageTable());
+  if (sdpaOp.getAttentionMask()) {
+    prepopulateOperandTensorRefs(cache, sdpaOp.getAttentionMask());
+  }
+  if (sdpaOp.getCurPosTensor()) {
+    prepopulateOperandTensorRefs(cache, sdpaOp.getCurPosTensor());
+  }
+  if (sdpaOp.getAttentionSink()) {
+    prepopulateOperandTensorRefs(cache, sdpaOp.getAttentionSink());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, sdpaOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PagedScaledDotProductAttentionDecodeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<
+    mlir::tt::ttnn::PagedScaledDotProductAttentionDecodeOp>
+    pagedScaledDotProductAttentionDecodeOpList = {
+        buildTestPagedScaledDotProductAttentionDecodeOp(),
+        buildTestPagedScaledDotProductAttentionDecodeOp(/*isCausal=*/false),
+        buildTestPagedScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/true),
+        buildTestPagedScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*withCurPosTensor=*/true),
+        buildTestPagedScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*withCurPosTensor=*/false, /*withAttentionSink=*/true),
+        buildTestPagedScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*withCurPosTensor=*/false, /*withAttentionSink=*/false,
+            /*scale=*/mlir::Builder(getContext()).getF32FloatAttr(0.125f)),
+        buildTestPagedScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*withCurPosTensor=*/false, /*withAttentionSink=*/false,
+            /*scale=*/{},
+            /*slidingWindowSize=*/
+            mlir::IntegerAttr::get(
+                mlir::IntegerType::get(getContext(), 32,
+                                       mlir::IntegerType::Unsigned),
+                128u)),
+        buildTestPagedScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*withCurPosTensor=*/false, /*withAttentionSink=*/false,
+            /*scale=*/{}, /*slidingWindowSize=*/{},
+            /*programConfig=*/nonDefaultSDPAProgramConfigAttr),
+        buildTestPagedScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/false, /*withAttentionMask=*/true,
+            /*withCurPosTensor=*/true, /*withAttentionSink=*/true,
+            /*scale=*/mlir::Builder(getContext()).getF32FloatAttr(0.25f),
+            /*slidingWindowSize=*/
+            mlir::IntegerAttr::get(
+                mlir::IntegerType::get(getContext(), 32,
+                                       mlir::IntegerType::Unsigned),
+                256u),
+            /*programConfig=*/nonDefaultSDPAProgramConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    PagedScaledDotProductAttentionDecodeOpTPathParityTest,
+    PagedScaledDotProductAttentionDecodeOpTPathParityTest,
+    ::testing::ValuesIn(pagedScaledDotProductAttentionDecodeOpList));
+
+//===----------------------------------------------------------------------===//
+// RotaryEmbeddingLlamaOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::RotaryEmbeddingLlamaOpT &opNativeOpModel,
+    ::tt::target::ttnn::RotaryEmbeddingLlamaOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::RotaryEmbeddingLlamaOpT &op) {
+    op.input.reset();
+    op.cos_cache.reset();
+    op.sin_cache.reset();
+    op.trans_mat.reset();
+    op.out.reset();
+    op.memcfg.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::RotaryEmbeddingLlamaOp buildTestRotaryEmbeddingLlamaOp(
+    bool isDecodeMode = false,
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto cosCacheType = tiledL1BF16Type(defaultShape);
+  auto sinCacheType = tiledL1BF16Type(defaultShape);
+  auto transMatType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value cosCache =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{cosCacheType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value sinCache =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{sinCacheType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value transMat =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{transMatType},
+                                          mlir::ValueRange{})
+          .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::RotaryEmbeddingLlamaOp>(
+      loc, outputType, input, cosCache, sinCache, transMat, isDecodeMode,
+      computeConfig);
+}
+
+} // namespace
+
+using RotaryEmbeddingLlamaOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::RotaryEmbeddingLlamaOp>;
+
+TEST_P(RotaryEmbeddingLlamaOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::RotaryEmbeddingLlamaOp rotaryOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::RotaryEmbeddingLlamaOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildRotaryEmbeddingLlamaOpTFromMLIR(
+          rotaryOp.getIsDecodeMode(), rotaryOp.getComputeConfig(),
+          resolveOutputLayout(rotaryOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, rotaryOp.getInput(),
+                               rotaryOp.getCosCache(), rotaryOp.getSinCache(),
+                               rotaryOp.getTransMat());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, rotaryOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::RotaryEmbeddingLlamaOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::RotaryEmbeddingLlamaOp>
+    rotaryEmbeddingLlamaOpList = {
+        buildTestRotaryEmbeddingLlamaOp(),
+        buildTestRotaryEmbeddingLlamaOp(/*isDecodeMode=*/true),
+        buildTestRotaryEmbeddingLlamaOp(
+            /*isDecodeMode=*/false,
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestRotaryEmbeddingLlamaOp(
+            /*isDecodeMode=*/true,
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(RotaryEmbeddingLlamaOpTPathParityTest,
+                         RotaryEmbeddingLlamaOpTPathParityTest,
+                         ::testing::ValuesIn(rotaryEmbeddingLlamaOpList));
+
+//===----------------------------------------------------------------------===//
+// RotaryEmbeddingOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::RotaryEmbeddingOpT &opNativeOpModel,
+                       ::tt::target::ttnn::RotaryEmbeddingOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::RotaryEmbeddingOpT &op) {
+    op.input.reset();
+    op.cos_cache.reset();
+    op.sin_cache.reset();
+    op.out.reset();
+    op.memcfg.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::RotaryEmbeddingOp buildTestRotaryEmbeddingOp(
+    mlir::IntegerAttr tokenIndex = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto cosCacheType = tiledL1BF16Type(defaultShape);
+  auto sinCacheType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value cosCache =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{cosCacheType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value sinCache =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{sinCacheType},
+                                          mlir::ValueRange{})
+          .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::RotaryEmbeddingOp>(
+      loc, outputType, input, cosCache, sinCache, tokenIndex, computeConfig);
+}
+
+} // namespace
+
+using RotaryEmbeddingOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::RotaryEmbeddingOp>;
+
+TEST_P(RotaryEmbeddingOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::RotaryEmbeddingOp rotaryOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::RotaryEmbeddingOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildRotaryEmbeddingOpTFromMLIR(
+          rotaryOp.getTokenIndex(), rotaryOp.getComputeConfig(),
+          resolveOutputLayout(rotaryOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, rotaryOp.getInput(),
+                               rotaryOp.getCosCache(), rotaryOp.getSinCache());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, rotaryOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::RotaryEmbeddingOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::RotaryEmbeddingOp>
+    rotaryEmbeddingOpList = {
+        buildTestRotaryEmbeddingOp(),
+        buildTestRotaryEmbeddingOp(
+            /*tokenIndex=*/mlir::IntegerAttr::get(
+                mlir::IntegerType::get(getContext(), 32,
+                                       mlir::IntegerType::Unsigned),
+                42u)),
+        buildTestRotaryEmbeddingOp(
+            /*tokenIndex=*/{},
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestRotaryEmbeddingOp(
+            /*tokenIndex=*/
+            mlir::IntegerAttr::get(
+                mlir::IntegerType::get(getContext(), 32,
+                                       mlir::IntegerType::Unsigned),
+                42u),
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(RotaryEmbeddingOpTPathParityTest,
+                         RotaryEmbeddingOpTPathParityTest,
+                         ::testing::ValuesIn(rotaryEmbeddingOpList));
+
+//===----------------------------------------------------------------------===//
+// ScaledDotProductAttentionDecodeOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT &opNativeOpModel,
+    ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT &op) {
+    op.query.reset();
+    op.key.reset();
+    op.value.reset();
+    op.attention_mask.reset();
+    op.cur_pos_tensor.reset();
+    op.attention_sink.reset();
+    op.out.reset();
+    op.memcfg.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp
+buildTestScaledDotProductAttentionDecodeOp(
+    bool isCausal = true, bool withAttentionMask = false,
+    bool withCurPosTensor = false, bool withAttentionSink = false,
+    mlir::FloatAttr scale = {},
+    mlir::tt::ttnn::SDPAProgramConfigAttr programConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value query = makeOnes();
+  mlir::Value key = makeOnes();
+  mlir::Value value = makeOnes();
+  mlir::Value attentionMask = withAttentionMask ? makeOnes() : mlir::Value();
+  mlir::Value curPosTensor = withCurPosTensor ? makeOnes() : mlir::Value();
+  mlir::Value attentionSink = withAttentionSink ? makeOnes() : mlir::Value();
+
+  return e.builder.create<mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp>(
+      loc, tensorType, query, key, value, isCausal, attentionMask, curPosTensor,
+      attentionSink, scale, programConfig);
+}
+
+} // namespace
+
+using ScaledDotProductAttentionDecodeOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp>;
+
+TEST_P(ScaledDotProductAttentionDecodeOpTPathParityTest,
+       BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp sdpaOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildScaledDotProductAttentionDecodeOpTFromMLIR(
+          sdpaOp.getIsCausal(), sdpaOp.getScale(),
+          sdpaOp.getProgramConfigAttr(), resolveOutputLayout(sdpaOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, sdpaOp.getQuery(), sdpaOp.getKey(),
+                               sdpaOp.getValue());
+  if (sdpaOp.getAttentionMask()) {
+    prepopulateOperandTensorRefs(cache, sdpaOp.getAttentionMask());
+  }
+  if (sdpaOp.getCurPosTensor()) {
+    prepopulateOperandTensorRefs(cache, sdpaOp.getCurPosTensor());
+  }
+  if (sdpaOp.getAttentionSink()) {
+    prepopulateOperandTensorRefs(cache, sdpaOp.getAttentionSink());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, sdpaOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ScaledDotProductAttentionDecodeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp>
+    scaledDotProductAttentionDecodeOpList = {
+        buildTestScaledDotProductAttentionDecodeOp(),
+        buildTestScaledDotProductAttentionDecodeOp(/*isCausal=*/false),
+        buildTestScaledDotProductAttentionDecodeOp(/*isCausal=*/true,
+                                                   /*withAttentionMask=*/true),
+        buildTestScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*withCurPosTensor=*/true),
+        buildTestScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*withCurPosTensor=*/false, /*withAttentionSink=*/true),
+        buildTestScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*withCurPosTensor=*/false, /*withAttentionSink=*/false,
+            /*scale=*/mlir::Builder(getContext()).getF32FloatAttr(0.125f)),
+        buildTestScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*withCurPosTensor=*/false, /*withAttentionSink=*/false,
+            /*scale=*/{},
+            /*programConfig=*/nonDefaultSDPAProgramConfigAttr),
+        buildTestScaledDotProductAttentionDecodeOp(
+            /*isCausal=*/false, /*withAttentionMask=*/true,
+            /*withCurPosTensor=*/true, /*withAttentionSink=*/true,
+            /*scale=*/mlir::Builder(getContext()).getF32FloatAttr(0.125f),
+            /*programConfig=*/nonDefaultSDPAProgramConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    ScaledDotProductAttentionDecodeOpTPathParityTest,
+    ScaledDotProductAttentionDecodeOpTPathParityTest,
+    ::testing::ValuesIn(scaledDotProductAttentionDecodeOpList));
+
+//===----------------------------------------------------------------------===//
+// ScaledDotProductAttentionOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::ScaledDotProductAttentionOpT &opNativeOpModel,
+    ::tt::target::ttnn::ScaledDotProductAttentionOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ScaledDotProductAttentionOpT &op) {
+    op.query.reset();
+    op.key.reset();
+    op.value.reset();
+    op.attention_mask.reset();
+    op.attention_sink.reset();
+    op.out.reset();
+    op.memcfg.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::ScaledDotProductAttentionOp
+buildTestScaledDotProductAttentionOp(bool isCausal = true,
+                                     bool withAttentionMask = false,
+                                     mlir::FloatAttr scale = {},
+                                     mlir::IntegerAttr slidingWindowSize = {},
+                                     bool withAttentionSink = false) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value query = makeOnes();
+  mlir::Value key = makeOnes();
+  mlir::Value value = makeOnes();
+  mlir::Value attentionMask = withAttentionMask ? makeOnes() : mlir::Value();
+  mlir::Value attentionSink = withAttentionSink ? makeOnes() : mlir::Value();
+
+  return e.builder.create<mlir::tt::ttnn::ScaledDotProductAttentionOp>(
+      loc, tensorType, query, key, value, attentionMask, isCausal, scale,
+      slidingWindowSize, attentionSink);
+}
+
+} // namespace
+
+using ScaledDotProductAttentionOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ScaledDotProductAttentionOp>;
+
+TEST_P(ScaledDotProductAttentionOpTPathParityTest,
+       BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::ScaledDotProductAttentionOp sdpaOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ScaledDotProductAttentionOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildScaledDotProductAttentionOpTFromMLIR(
+          sdpaOp.getIsCausal(), sdpaOp.getScale(),
+          sdpaOp.getSlidingWindowSize(), resolveOutputLayout(sdpaOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, sdpaOp.getQuery(), sdpaOp.getKey(),
+                               sdpaOp.getValue());
+  if (sdpaOp.getAttentionMask()) {
+    prepopulateOperandTensorRefs(cache, sdpaOp.getAttentionMask());
+  }
+  if (sdpaOp.getAttentionSink()) {
+    prepopulateOperandTensorRefs(cache, sdpaOp.getAttentionSink());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, sdpaOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ScaledDotProductAttentionOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::ScaledDotProductAttentionOp>
+    scaledDotProductAttentionOpList = {
+        buildTestScaledDotProductAttentionOp(),
+        buildTestScaledDotProductAttentionOp(/*isCausal=*/false),
+        buildTestScaledDotProductAttentionOp(/*isCausal=*/true,
+                                             /*withAttentionMask=*/true),
+        buildTestScaledDotProductAttentionOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false,
+            /*scale=*/mlir::Builder(getContext()).getF32FloatAttr(0.125f)),
+        buildTestScaledDotProductAttentionOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false, /*scale=*/{},
+            /*slidingWindowSize=*/
+            mlir::IntegerAttr::get(
+                mlir::IntegerType::get(getContext(), 32,
+                                       mlir::IntegerType::Unsigned),
+                128u)),
+        buildTestScaledDotProductAttentionOp(
+            /*isCausal=*/true, /*withAttentionMask=*/false, /*scale=*/{},
+            /*slidingWindowSize=*/{},
+            /*withAttentionSink=*/true),
+        buildTestScaledDotProductAttentionOp(
+            /*isCausal=*/false, /*withAttentionMask=*/true,
+            /*scale=*/mlir::Builder(getContext()).getF32FloatAttr(0.125f),
+            /*slidingWindowSize=*/
+            mlir::IntegerAttr::get(
+                mlir::IntegerType::get(getContext(), 32,
+                                       mlir::IntegerType::Unsigned),
+                128u),
+            /*withAttentionSink=*/true),
+};
+
+INSTANTIATE_TEST_SUITE_P(ScaledDotProductAttentionOpTPathParityTest,
+                         ScaledDotProductAttentionOpTPathParityTest,
+                         ::testing::ValuesIn(scaledDotProductAttentionOpList));
+
+//===----------------------------------------------------------------------===//
+// SplitQueryKeyValueAndSplitHeadsOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT &opNativeOpModel,
+    ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT &op) {
+    op.in.reset();
+    op.kv_input.reset();
+    op.memcfg.reset();
+    op.q_out.reset();
+    op.k_out.reset();
+    op.v_out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::SplitQueryKeyValueAndSplitHeadsOp
+buildTestSplitQueryKeyValueAndSplitHeadsOp(bool withKvInputTensor = false,
+                                           uint32_t numHeads = 4u,
+                                           mlir::IntegerAttr numKvHeads = {},
+                                           bool transposeKey = false) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  mlir::Value inputTensor =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                          mlir::ValueRange{})
+          .getResult();
+  mlir::Value kvInputTensor =
+      withKvInputTensor
+          ? e.builder
+                .create<mlir::tt::ttnn::OnesOp>(
+                    loc, mlir::TypeRange{tensorType}, mlir::ValueRange{})
+                .getResult()
+          : mlir::Value();
+
+  return e.builder.create<mlir::tt::ttnn::SplitQueryKeyValueAndSplitHeadsOp>(
+      loc, mlir::TypeRange{tensorType, tensorType, tensorType}, inputTensor,
+      kvInputTensor, numHeads, numKvHeads, transposeKey);
+}
+
+} // namespace
+
+using SplitQueryKeyValueAndSplitHeadsOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::SplitQueryKeyValueAndSplitHeadsOp>;
+
+TEST_P(SplitQueryKeyValueAndSplitHeadsOpTPathParityTest,
+       BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::SplitQueryKeyValueAndSplitHeadsOp sqkvOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildSplitQueryKeyValueAndSplitHeadsOpTFromMLIR(
+          sqkvOp.getNumHeads(), sqkvOp.getNumKvHeads(),
+          sqkvOp.getTransposeKey(),
+          mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+              mlir::cast<mlir::RankedTensorType>(sqkvOp.getQuery().getType())
+                  .getEncoding()));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, sqkvOp.getInputTensor());
+  if (sqkvOp.getKvInputTensor()) {
+    prepopulateOperandTensorRefs(cache, sqkvOp.getKvInputTensor());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, sqkvOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::SplitQueryKeyValueAndSplitHeadsOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.q_out, opNativeFB.q_out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::SplitQueryKeyValueAndSplitHeadsOp>
+    splitQueryKeyValueAndSplitHeadsOpList = {
+        buildTestSplitQueryKeyValueAndSplitHeadsOp(),
+        buildTestSplitQueryKeyValueAndSplitHeadsOp(/*withKvInputTensor=*/true),
+        buildTestSplitQueryKeyValueAndSplitHeadsOp(/*withKvInputTensor=*/false,
+                                                   /*numHeads=*/8u),
+        buildTestSplitQueryKeyValueAndSplitHeadsOp(
+            /*withKvInputTensor=*/false, /*numHeads=*/4u,
+            /*numKvHeads=*/
+            mlir::IntegerAttr::get(
+                mlir::IntegerType::get(getContext(), 32,
+                                       mlir::IntegerType::Unsigned),
+                2u)),
+        buildTestSplitQueryKeyValueAndSplitHeadsOp(
+            /*withKvInputTensor=*/false, /*numHeads=*/4u, /*numKvHeads=*/{},
+            /*transposeKey=*/true),
+        buildTestSplitQueryKeyValueAndSplitHeadsOp(
+            /*withKvInputTensor=*/true, /*numHeads=*/8u,
+            /*numKvHeads=*/
+            mlir::IntegerAttr::get(
+                mlir::IntegerType::get(getContext(), 32,
+                                       mlir::IntegerType::Unsigned),
+                2u),
+            /*transposeKey=*/true),
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    SplitQueryKeyValueAndSplitHeadsOpTPathParityTest,
+    SplitQueryKeyValueAndSplitHeadsOpTPathParityTest,
+    ::testing::ValuesIn(splitQueryKeyValueAndSplitHeadsOpList));
+
+//===----------------------------------------------------------------------===//
+// NLPConcatHeadsDecodeOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::NLPConcatHeadsDecodeOpT &opNativeOpModel,
+    ::tt::target::ttnn::NLPConcatHeadsDecodeOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::NLPConcatHeadsDecodeOpT &op) {
+    op.in.reset();
+    op.out.reset();
+    op.memcfg.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::NLPConcatHeadsDecodeOp
+buildTestNLPConcatHeadsDecodeOp(uint32_t numHeads = 4u) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                          mlir::ValueRange{})
+          .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::NLPConcatHeadsDecodeOp>(
+      loc, outputType, input, numHeads);
+}
+
+} // namespace
+
+using NLPConcatHeadsDecodeOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::NLPConcatHeadsDecodeOp>;
+
+TEST_P(NLPConcatHeadsDecodeOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::NLPConcatHeadsDecodeOp nlpOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::NLPConcatHeadsDecodeOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildNLPConcatHeadsDecodeOpTFromMLIR(
+          nlpOp.getNumHeads(), resolveOutputLayout(nlpOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, nlpOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, nlpOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::NLPConcatHeadsDecodeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::NLPConcatHeadsDecodeOp>
+    nlpConcatHeadsDecodeOpList = {
+        buildTestNLPConcatHeadsDecodeOp(),
+        buildTestNLPConcatHeadsDecodeOp(/*numHeads=*/8u),
+};
+
+INSTANTIATE_TEST_SUITE_P(NLPConcatHeadsDecodeOpTPathParityTest,
+                         NLPConcatHeadsDecodeOpTPathParityTest,
+                         ::testing::ValuesIn(nlpConcatHeadsDecodeOpList));
+
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/test/unittests/MLIRAttrToFBNative/ToNativeConsistency.cpp
+++ b/test/unittests/MLIRAttrToFBNative/ToNativeConsistency.cpp
@@ -666,3 +666,48 @@ INSTANTIATE_TEST_SUITE_P(
     MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigTest,
     MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigTest,
     ::testing::ValuesIn(matmulDRAMShardedAttrList));
+
+//===----------------------------------------------------------------------===//
+// SDPAProgramConfig
+//===----------------------------------------------------------------------===//
+
+class SDPAProgramConfigTest
+    : public ToNativeConsistencyTest<mlir::tt::ttnn::SDPAProgramConfigAttr,
+                                     ::tt::target::ttnn::SDPAConfigT> {};
+
+TEST_P(SDPAProgramConfigTest, SDPAProgramConfig) { RunTest(GetParam()); }
+
+const std::initializer_list<mlir::tt::ttnn::SDPAProgramConfigAttr>
+    sdpaProgramConfigAttrList = {
+        mlir::tt::ttnn::SDPAProgramConfigAttr::get(
+            SDPAProgramConfigTest::getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(
+                SDPAProgramConfigTest::getContext(), 8, 8),
+            mlir::tt::ttnn::CoreRangeSetAttr(), 128, 128,
+            mlir::BoolAttr::get(SDPAProgramConfigTest::getContext(), true),
+            std::nullopt),
+        mlir::tt::ttnn::SDPAProgramConfigAttr::get(
+            SDPAProgramConfigTest::getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(
+                SDPAProgramConfigTest::getContext(), 4, 8),
+            mlir::tt::ttnn::CoreRangeSetAttr::get(
+                SDPAProgramConfigTest::getContext(),
+                llvm::ArrayRef<mlir::tt::ttnn::CoreRangeAttr>(
+                    {mlir::tt::ttnn::CoreRangeAttr::get(
+                        SDPAProgramConfigTest::getContext(),
+                        mlir::tt::ttnn::CoreCoordAttr::get(
+                            SDPAProgramConfigTest::getContext(), 0, 0),
+                        mlir::tt::ttnn::CoreCoordAttr::get(
+                            SDPAProgramConfigTest::getContext(), 3, 7))})),
+            64, 64,
+            mlir::BoolAttr::get(SDPAProgramConfigTest::getContext(), false),
+            16u),
+        mlir::tt::ttnn::SDPAProgramConfigAttr::get(
+            SDPAProgramConfigTest::getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(
+                SDPAProgramConfigTest::getContext(), 8, 8),
+            mlir::tt::ttnn::CoreRangeSetAttr(), 32, 64, mlir::BoolAttr(),
+            std::nullopt)};
+
+INSTANTIATE_TEST_SUITE_P(SDPAProgramConfigTest, SDPAProgramConfigTest,
+                         ::testing::ValuesIn(sdpaProgramConfigAttrList));


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.

### What's changed
This is the ninth PR in the TTNNOpInvokeLib series. It introduces shared dispatch for the transformer operations across OpModel and Runtime: concatenate_heads, nlp_concat_head, nlp_concat_heads_decode, nlp_create_qkv_heads_decode, paged_flash_multi_latent_attention_decode, paged_scaled_dot_product_attention_decode, rotary_embedding, rotary_embedding_llama, scaled_dot_product_attention, scaled_dot_product_attention_decode, and split_query_key_value_and_split_heads.

### Checklist
- [ ] New/Existing tests provide coverage for changes
