### PR TITLE
Normalization ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Normalization/BatchNormOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Normalization/BatchNormOp.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_NORMALIZATION_BATCHNORMOP_H
+#define TTMLIR_OPINVOKE_TTNN_NORMALIZATION_BATCHNORMOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/normalization_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/normalization/batch_norm/batch_norm.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using BatchNormOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct BatchNormResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+};
+
+BatchNormResolvedParams resolveBatchNormInferenceParams(
+    const ::tt::target::ttnn::BatchNormInferenceOpT &op);
+
+BatchNormResolvedParams resolveBatchNormTrainingParams(
+    const ::tt::target::ttnn::BatchNormTrainingOpT &op);
+
+BatchNormOpResult callBatchNormInference(
+    CallType callType, const ::tt::target::ttnn::BatchNormInferenceOpT &op,
+    TensorArg input, std::optional<TensorArg> runningMean,
+    std::optional<TensorArg> runningVar, std::optional<TensorArg> weight,
+    std::optional<TensorArg> bias, ::ttnn::MeshDevice *device);
+
+BatchNormOpResult callBatchNormTraining(
+    CallType callType, const ::tt::target::ttnn::BatchNormTrainingOpT &op,
+    TensorArg input, std::optional<TensorArg> runningMean,
+    std::optional<TensorArg> runningVar, std::optional<TensorArg> weight,
+    std::optional<TensorArg> bias, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_NORMALIZATION_BATCHNORMOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Normalization/DistributedRMSNormOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Normalization/DistributedRMSNormOp.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_NORMALIZATION_DISTRIBUTEDRMSNORMOP_H
+#define TTMLIR_OPINVOKE_TTNN_NORMALIZATION_DISTRIBUTEDRMSNORMOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/normalization_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/experimental/ccl/rms_allgather/rms_allgather.hpp"
+#include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using DistributedRMSNormOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct DistributedRMSNormResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  ::ttnn::prim::LayerNormProgramConfig programConfig;
+  std::optional<::tt::tt_metal::SubDeviceId> subDeviceId;
+  std::optional<size_t> numLinks;
+  ::ttnn::ccl::Topology topology = ::ttnn::ccl::Topology::Linear;
+  std::optional<ttnn::DataType> dtype;
+  bool useNoc1Only = false;
+};
+
+DistributedRMSNormResolvedParams resolveDistributedRMSNormParams(
+    const ::tt::target::ttnn::DistributedRMSNormOpT &op);
+
+DistributedRMSNormOpResult callDistributedRMSNorm(
+    CallType callType, const ::tt::target::ttnn::DistributedRMSNormOpT &op,
+    TensorArg input, std::optional<TensorArg> residual_input_tensor,
+    std::optional<TensorArg> weight, std::optional<TensorArg> stats,
+    const ::ttnn::GlobalSemaphore &semaphore, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_NORMALIZATION_DISTRIBUTEDRMSNORMOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Normalization/GroupNormOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Normalization/GroupNormOp.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_NORMALIZATION_GROUPNORMOP_H
+#define TTMLIR_OPINVOKE_TTNN_NORMALIZATION_GROUPNORMOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/normalization_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/normalization/groupnorm/groupnorm.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using GroupNormOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct GroupNormResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+GroupNormResolvedParams
+resolveGroupNormParams(const ::tt::target::ttnn::GroupNormOpT &op,
+                       CallType callType);
+
+GroupNormOpResult
+callGroupNorm(CallType callType, const ::tt::target::ttnn::GroupNormOpT &op,
+              TensorArg input, std::optional<TensorArg> inputMask,
+              std::optional<TensorArg> weight, std::optional<TensorArg> bias,
+              ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_NORMALIZATION_GROUPNORMOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Normalization/LayerNormOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Normalization/LayerNormOp.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_NORMALIZATION_LAYERNORMOP_H
+#define TTMLIR_OPINVOKE_TTNN_NORMALIZATION_LAYERNORMOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/normalization_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/normalization/layernorm/layernorm.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using LayerNormOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct LayerNormResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+LayerNormResolvedParams
+resolveLayerNormParams(const ::tt::target::ttnn::LayerNormOpT &op);
+
+LayerNormOpResult
+callLayerNorm(CallType callType, const ::tt::target::ttnn::LayerNormOpT &op,
+              TensorArg input, std::optional<TensorArg> weight,
+              std::optional<TensorArg> bias, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_NORMALIZATION_LAYERNORMOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Normalization/LayerNormPostAllGatherOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Normalization/LayerNormPostAllGatherOp.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_NORMALIZATION_LAYERNORMPOSTALLGATHEROP_H
+#define TTMLIR_OPINVOKE_TTNN_NORMALIZATION_LAYERNORMPOSTALLGATHEROP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/normalization_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using LayerNormPostAllGatherOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct LayerNormPostAllGatherResolvedParams {
+  std::optional<::ttnn::DataType> outputDtype;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::prim::LayerNormProgramConfig> programConfig;
+};
+
+LayerNormPostAllGatherResolvedParams resolveLayerNormPostAllGatherParams(
+    const ::tt::target::ttnn::LayerNormPostAllGatherOpT &op);
+
+LayerNormPostAllGatherOpResult callLayerNormPostAllGather(
+    CallType callType, const ::tt::target::ttnn::LayerNormPostAllGatherOpT &op,
+    TensorArg input, TensorArg stats, std::optional<TensorArg> weight,
+    std::optional<TensorArg> bias, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_NORMALIZATION_LAYERNORMPOSTALLGATHEROP_H

--- a/include/ttmlir/OpInvoke/TTNN/Normalization/LayerNormPreAllGatherOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Normalization/LayerNormPreAllGatherOp.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_NORMALIZATION_LAYERNORMPREALLGATHEROP_H
+#define TTMLIR_OPINVOKE_TTNN_NORMALIZATION_LAYERNORMPREALLGATHEROP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/normalization_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using LayerNormPreAllGatherOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct LayerNormPreAllGatherResolvedParams {
+  ::ttnn::DataType dtype;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::prim::LayerNormProgramConfig> programConfig;
+};
+
+LayerNormPreAllGatherResolvedParams resolveLayerNormPreAllGatherParams(
+    const ::tt::target::ttnn::LayerNormPreAllGatherOpT &op);
+
+LayerNormPreAllGatherOpResult callLayerNormPreAllGather(
+    CallType callType, const ::tt::target::ttnn::LayerNormPreAllGatherOpT &op,
+    TensorArg input, std::optional<TensorArg> residualInput,
+    std::optional<TensorArg> recip, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_NORMALIZATION_LAYERNORMPREALLGATHEROP_H

--- a/include/ttmlir/OpInvoke/TTNN/Normalization/RMSNormOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Normalization/RMSNormOp.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_NORMALIZATION_RMSNORMOP_H
+#define TTMLIR_OPINVOKE_TTNN_NORMALIZATION_RMSNORMOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/normalization_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/normalization/rmsnorm/rmsnorm.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using RMSNormOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct RMSNormResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+};
+
+RMSNormResolvedParams
+resolveRMSNormParams(const ::tt::target::ttnn::RMSNormOpT &op);
+
+RMSNormOpResult callRMSNorm(CallType callType,
+                            const ::tt::target::ttnn::RMSNormOpT &op,
+                            TensorArg input, std::optional<TensorArg> weight,
+                            std::optional<TensorArg> bias,
+                            ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_NORMALIZATION_RMSNORMOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Normalization/RMSNormPreAllGatherOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Normalization/RMSNormPreAllGatherOp.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_NORMALIZATION_RMSNORMPREALLGATHEROP_H
+#define TTMLIR_OPINVOKE_TTNN_NORMALIZATION_RMSNORMPREALLGATHEROP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/normalization_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using RMSNormPreAllGatherOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct RMSNormPreAllGatherResolvedParams {
+  ::ttnn::DataType dtype;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::prim::LayerNormProgramConfig> programConfig;
+  std::optional<bool> use2DCoreGrid;
+};
+
+RMSNormPreAllGatherResolvedParams resolveRMSNormPreAllGatherParams(
+    const ::tt::target::ttnn::RMSNormPreAllGatherOpT &op);
+
+RMSNormPreAllGatherOpResult
+callRMSNormPreAllGather(CallType callType,
+                        const ::tt::target::ttnn::RMSNormPreAllGatherOpT &op,
+                        TensorArg input, std::optional<TensorArg> residual,
+                        ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_NORMALIZATION_RMSNORMPREALLGATHEROP_H

--- a/include/ttmlir/OpInvoke/TTNN/Normalization/SoftmaxOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Normalization/SoftmaxOp.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_NORMALIZATION_SOFTMAXOP_H
+#define TTMLIR_OPINVOKE_TTNN_NORMALIZATION_SOFTMAXOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/normalization_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/normalization/softmax/softmax.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using SoftmaxOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct SoftmaxResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+};
+
+SoftmaxResolvedParams
+resolveSoftmaxParams(const ::tt::target::ttnn::SoftmaxOpT &op);
+
+SoftmaxOpResult callSoftmax(CallType callType,
+                            const ::tt::target::ttnn::SoftmaxOpT &op,
+                            TensorArg input, ::ttnn::MeshDevice *device);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_NORMALIZATION_SOFTMAXOP_H

--- a/include/ttmlir/OpInvoke/TTNN/utils/utils.h
+++ b/include/ttmlir/OpInvoke/TTNN/utils/utils.h
@@ -163,6 +163,12 @@ createConv2dSliceConfig(const ::tt::target::ttnn::Conv2dSliceConfigT &config);
 ::ttnn::operations::transformer::SDPAProgramConfig
 createSDPAProgramConfig(const ::tt::target::ttnn::SDPAConfigT &config);
 
+::ttnn::prim::LayerNormProgramConfig
+createLayerNormShardedMultiCoreProgramConfig(
+    const ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfigT &config);
+
+::tt::tt_fabric::Topology toMetalTopology(::tt::target::Topology topology);
+
 } // namespace ttnn_op_invoke::operations::utils
 
 #endif // TTMLIR_OPINVOKE_TTNN_UTILS_UTILS_H

--- a/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
+++ b/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
@@ -226,6 +226,51 @@ buildSplitQueryKeyValueAndSplitHeadsOpTFromMLIR(
 buildNLPConcatHeadsDecodeOpTFromMLIR(uint32_t numHeads,
                                      TTNNLayoutAttr outputLayout);
 
+::tt::target::ttnn::BatchNormInferenceOpT buildBatchNormInferenceOpTFromMLIR(
+    llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::BatchNormTrainingOpT buildBatchNormTrainingOpTFromMLIR(
+    llvm::APFloat epsilon, llvm::APFloat momentum,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::GroupNormOpT
+buildGroupNormOpTFromMLIR(int64_t numGroups, llvm::APFloat epsilon,
+                          TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::LayerNormPostAllGatherOpT
+buildLayerNormPostAllGatherOpTFromMLIR(
+    llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::LayerNormPreAllGatherOpT
+buildLayerNormPreAllGatherOpTFromMLIR(
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::LayerNormOpT
+buildLayerNormOpTFromMLIR(llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::RMSNormPreAllGatherOpT buildRMSNormPreAllGatherOpTFromMLIR(
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    std::optional<bool> use2DCoreGrid, TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::RMSNormOpT buildRMSNormOpTFromMLIR(
+    llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::SoftmaxOpT buildSoftmaxOpTFromMLIR(
+    int32_t dimension, bool numericStable,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout);
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -509,16 +509,17 @@ struct OpModel<RequantizeOp> {
 
 template <>
 struct OpModel<SoftmaxOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, const int dimArg,
-                   bool numericStable, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      const int dimArg, bool numericStable,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-                                             TTNNLayoutAttr inputLayout,
-                                             const int dimArg,
-                                             bool numericStable,
-                                             TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               const int dimArg, bool numericStable,
+               std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1604,18 +1605,18 @@ struct OpModel<GlobalAvgPool2dOp> {
 
 template <>
 struct OpModel<BatchNormInferenceOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout,
-                   std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
-                   std::optional<TTNNLayoutAttr> runningMeanLayout,
-                   std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
-                   std::optional<TTNNLayoutAttr> runningVarLayout,
-                   std::optional<llvm::ArrayRef<int64_t>> weightShape,
-                   std::optional<TTNNLayoutAttr> weightLayout,
-                   std::optional<llvm::ArrayRef<int64_t>> biasShape,
-                   std::optional<TTNNLayoutAttr> biasLayout,
-                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
+      std::optional<TTNNLayoutAttr> runningMeanLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
+      std::optional<TTNNLayoutAttr> runningVarLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1627,6 +1628,7 @@ struct OpModel<BatchNormInferenceOp> {
                std::optional<TTNNLayoutAttr> weightLayout,
                std::optional<llvm::ArrayRef<int64_t>> biasShape,
                std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+               std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
                TTNNLayoutAttr outputLayout);
 };
 
@@ -1646,7 +1648,9 @@ struct OpModel<BatchNormTrainingOp> {
       std::optional<TTNNLayoutAttr> weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-      llvm::APFloat momentum, TTNNLayoutAttr outputLayout);
+      llvm::APFloat momentum,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1658,7 +1662,9 @@ struct OpModel<BatchNormTrainingOp> {
                std::optional<TTNNLayoutAttr> weightLayout,
                std::optional<llvm::ArrayRef<int64_t>> biasShape,
                std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-               llvm::APFloat momentum, TTNNLayoutAttr outputLayout);
+               llvm::APFloat momentum,
+               std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1699,14 +1705,18 @@ struct OpModel<RMSNormPreAllGatherOp> {
       std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
       std::optional<TTNNLayoutAttr> residualInputLayout,
       std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
       TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-               std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
-               std::optional<TTNNLayoutAttr> residualInputLayout,
-               std::optional<ttcore::DataType> dtype,
-               std::optional<bool> use2DCoreGrid, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+      std::optional<TTNNLayoutAttr> residualInputLayout,
+      std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1745,16 +1755,21 @@ struct OpModel<LayerNormPreAllGatherOp> {
       std::optional<TTNNLayoutAttr> residualInputLayout,
       std::optional<llvm::ArrayRef<int64_t>> recipShape,
       std::optional<TTNNLayoutAttr> recipLayout,
-      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
+      std::optional<ttcore::DataType> dtype,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-               std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
-               std::optional<TTNNLayoutAttr> residualInputLayout,
-               std::optional<llvm::ArrayRef<int64_t>> recipShape,
-               std::optional<TTNNLayoutAttr> recipLayout,
-               std::optional<ttcore::DataType> dtype,
-               TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+      std::optional<TTNNLayoutAttr> residualInputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> recipShape,
+      std::optional<TTNNLayoutAttr> recipLayout,
+      std::optional<ttcore::DataType> dtype,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1770,16 +1785,20 @@ struct OpModel<LayerNormPostAllGatherOp> {
       std::optional<TTNNLayoutAttr> weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
       TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-               llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
-               std::optional<llvm::ArrayRef<int64_t>> weightShape,
-               std::optional<TTNNLayoutAttr> weightLayout,
-               std::optional<llvm::ArrayRef<int64_t>> biasShape,
-               std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-               TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
+++ b/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
@@ -151,6 +151,33 @@ createOp(::mlir::tt::FlatbufferObjectCache &cache,
 ::flatbuffers::Offset<::tt::target::ttnn::NLPConcatHeadsDecodeOp>
 createOp(::mlir::tt::FlatbufferObjectCache &cache, NLPConcatHeadsDecodeOp op);
 
+::flatbuffers::Offset<::tt::target::ttnn::BatchNormInferenceOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, BatchNormInferenceOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::BatchNormTrainingOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, BatchNormTrainingOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::GroupNormOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, GroupNormOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::LayerNormPostAllGatherOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, LayerNormPostAllGatherOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::LayerNormPreAllGatherOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, LayerNormPreAllGatherOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::LayerNormOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, LayerNormOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::RMSNormPreAllGatherOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, RMSNormPreAllGatherOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::RMSNormOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, RMSNormOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::SoftmaxOp>
+createSoftmaxOp(::mlir::tt::FlatbufferObjectCache &cache, SoftmaxOp op);
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_TARGET_TTNN_TTNNTOFLATBUFFER_H

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -972,15 +972,26 @@ toFlatbuffer(FlatbufferObjectCache &cache,
   return ::tt::target::ttnn::SDPAConfig::Pack(*cache.fbb, &t);
 }
 
+inline ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfigT
+toNative(ttnn::LayerNormShardedMultiCoreProgramConfigAttr configAttr) {
+  ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfigT config;
+  config.compute_with_storage_grid_size =
+      std::make_unique<::tt::target::ttnn::CoreCoord>(
+          toNative(configAttr.getComputeWithStorageGridSize()));
+  config.subblock_w = configAttr.getSubblockW();
+  config.block_h = configAttr.getBlockH();
+  config.block_w = configAttr.getBlockW();
+  config.inplace = configAttr.getInplace();
+  return config;
+}
+
 inline ::flatbuffers::Offset<
     ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfig>
 toFlatbuffer(FlatbufferObjectCache &cache,
              ttnn::LayerNormShardedMultiCoreProgramConfigAttr configAttr) {
-  ::tt::target::ttnn::CoreCoord computeWithStorageGridSize =
-      toFlatbuffer(cache, configAttr.getComputeWithStorageGridSize());
-  return ::tt::target::ttnn::CreateLayerNormShardedMultiCoreProgramConfig(
-      *cache.fbb, &computeWithStorageGridSize, configAttr.getSubblockW(),
-      configAttr.getBlockH(), configAttr.getBlockW(), configAttr.getInplace());
+  auto t = toNative(configAttr);
+  return ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfig::Pack(
+      *cache.fbb, &t);
 }
 
 inline ::tt::target::ttnn::Conv2dConfigT
@@ -1419,8 +1430,7 @@ toFlatbuffer(FlatbufferObjectCache &cache,
   return fbMathFidelity;
 }
 
-inline ::tt::target::Topology toFlatbuffer(FlatbufferObjectCache &cache,
-                                           ttcore::Topology topology) {
+inline ::tt::target::Topology toNative(ttcore::Topology topology) {
   ::tt::target::Topology fbTopology;
   switch (topology) {
   case ttcore::Topology::Ring:
@@ -1439,6 +1449,11 @@ inline ::tt::target::Topology toFlatbuffer(FlatbufferObjectCache &cache,
     llvm_unreachable("Disabled topology cannot be serialized to flatbuffer");
   }
   return fbTopology;
+}
+
+inline ::tt::target::Topology toFlatbuffer(FlatbufferObjectCache &,
+                                           ttcore::Topology topology) {
+  return toNative(topology);
 }
 
 inline ::tt::target::MoEActivationFunction

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1513,7 +1513,8 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SoftmaxOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDimension(), getNumericStable(), opConfig.outputLayout);
+      inputs[0], getDimension(), getNumericStable(), getComputeConfig(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1525,7 +1526,8 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<SoftmaxOp>::getOpRuntime, *this, inputShape, inputs[0],
-      getDimension(), getNumericStable(), opConfig.outputLayout);
+      getDimension(), getNumericStable(), getComputeConfig(),
+      opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3832,6 +3834,8 @@ struct BatchNormOptionalArgs {
   std::optional<TTNNLayoutAttr> weightLayout = std::nullopt;
   std::optional<llvm::ArrayRef<int64_t>> biasShape = std::nullopt;
   std::optional<TTNNLayoutAttr> biasLayout = std::nullopt;
+  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+      std::nullopt;
 };
 
 template <typename BatchNormOpType>
@@ -3848,6 +3852,7 @@ unpackBatchNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
     ret.runningVarLayout = inputs[2];
     ret.weightLayout = inputs[3];
     ret.biasLayout = inputs[4];
+    ret.computeKernelConfig = op.getComputeConfig();
   }
   return ret;
 }
@@ -3869,7 +3874,8 @@ llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
       optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+      optionalArgs.biasLayout, getEpsilon(), optionalArgs.computeKernelConfig,
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3890,7 +3896,7 @@ BatchNormInferenceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       optionalArgs.runningVarShape, optionalArgs.runningVarLayout,
       optionalArgs.weightShape, optionalArgs.weightLayout,
       optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
-      opConfig.outputLayout);
+      optionalArgs.computeKernelConfig, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3919,7 +3925,7 @@ BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
       optionalArgs.biasLayout, getEpsilon(), getMomentum(),
-      opConfig.outputLayout);
+      optionalArgs.computeKernelConfig, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3943,7 +3949,7 @@ BatchNormTrainingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       optionalArgs.runningVarShape, optionalArgs.runningVarLayout,
       optionalArgs.weightShape, optionalArgs.weightLayout,
       optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
-      getMomentum(), opConfig.outputLayout);
+      getMomentum(), optionalArgs.computeKernelConfig, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -4024,6 +4030,10 @@ RMSNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 struct RMSNormPreAllGatherOptionalArgs {
   std::optional<llvm::ArrayRef<int64_t>> residualInputShape = std::nullopt;
   std::optional<TTNNLayoutAttr> residualInputLayout = std::nullopt;
+  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+      std::nullopt;
+  std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig =
+      std::nullopt;
 };
 
 static RMSNormPreAllGatherOptionalArgs
@@ -4037,6 +4047,13 @@ unpackRMSNormPreAllGatherOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
     if (idx < inputs.size()) {
       ret.residualInputLayout = inputs[idx++];
     }
+  }
+
+  if (op.getComputeConfig()) {
+    ret.computeKernelConfig = op.getComputeConfig();
+  }
+  if (op.getProgramConfig()) {
+    ret.programConfig = op.getProgramConfig();
   }
 
   return ret;
@@ -4054,7 +4071,8 @@ llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
       op_model::OpModel<RMSNormPreAllGatherOp>::getOpConstraints, *this,
       inputShape, inputs[0], optionalArgs.residualInputShape,
       optionalArgs.residualInputLayout, dataTypeAttrToOptional(getDtypeAttr()),
-      getUse_2dCoreGrid(), opConfig.outputLayout);
+      getUse_2dCoreGrid(), optionalArgs.computeKernelConfig,
+      optionalArgs.programConfig, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4069,7 +4087,8 @@ RMSNormPreAllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<RMSNormPreAllGatherOp>::getOpRuntime, *this, inputShape,
       inputs[0], optionalArgs.residualInputShape,
       optionalArgs.residualInputLayout, dataTypeAttrToOptional(getDtypeAttr()),
-      getUse_2dCoreGrid(), opConfig.outputLayout);
+      getUse_2dCoreGrid(), optionalArgs.computeKernelConfig,
+      optionalArgs.programConfig, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -4144,6 +4163,10 @@ struct LayerNormPreAllGatherOptionalArgs {
   std::optional<TTNNLayoutAttr> residualInputLayout = std::nullopt;
   std::optional<llvm::ArrayRef<int64_t>> recipShape = std::nullopt;
   std::optional<TTNNLayoutAttr> recipLayout = std::nullopt;
+  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+      std::nullopt;
+  std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig =
+      std::nullopt;
 };
 
 static LayerNormPreAllGatherOptionalArgs
@@ -4164,6 +4187,12 @@ unpackLayerNormPreAllGatherOptionalArgs(
       ret.recipLayout = inputs[idx++];
     }
   }
+  if (op.getComputeConfig()) {
+    ret.computeKernelConfig = op.getComputeConfig();
+  }
+  if (op.getProgramConfig()) {
+    ret.programConfig = op.getProgramConfig();
+  }
   return ret;
 }
 
@@ -4181,6 +4210,7 @@ LayerNormPreAllGatherOp::getOpConstraints(
       inputShape, inputs[0], optionalArgs.residualInputShape,
       optionalArgs.residualInputLayout, optionalArgs.recipShape,
       optionalArgs.recipLayout, dataTypeAttrToOptional(getDtypeAttr()),
+      optionalArgs.computeKernelConfig, optionalArgs.programConfig,
       opConfig.outputLayout);
 }
 
@@ -4197,6 +4227,7 @@ LayerNormPreAllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       inputShape, inputs[0], optionalArgs.residualInputShape,
       optionalArgs.residualInputLayout, optionalArgs.recipShape,
       optionalArgs.recipLayout, dataTypeAttrToOptional(getDtypeAttr()),
+      optionalArgs.computeKernelConfig, optionalArgs.programConfig,
       opConfig.outputLayout);
 }
 
@@ -4209,6 +4240,10 @@ struct LayerNormPostAllGatherOptionalArgs {
   std::optional<TTNNLayoutAttr> weightLayout = std::nullopt;
   std::optional<llvm::ArrayRef<int64_t>> biasShape = std::nullopt;
   std::optional<TTNNLayoutAttr> biasLayout = std::nullopt;
+  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+      std::nullopt;
+  std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig =
+      std::nullopt;
 };
 
 static LayerNormPostAllGatherOptionalArgs
@@ -4229,6 +4264,12 @@ unpackLayerNormPostAllGatherOptionalArgs(
       ret.biasLayout = inputs[idx++];
     }
   }
+  if (op.getComputeConfig()) {
+    ret.computeKernelConfig = op.getComputeConfig();
+  }
+  if (op.getProgramConfig()) {
+    ret.programConfig = op.getProgramConfig();
+  }
   return ret;
 }
 
@@ -4246,7 +4287,8 @@ LayerNormPostAllGatherOp::getOpConstraints(
       op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraints, *this,
       inputShape, inputs[0], statsShape, inputs[1], optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+      optionalArgs.biasLayout, getEpsilon(), optionalArgs.computeKernelConfig,
+      optionalArgs.programConfig, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> LayerNormPostAllGatherOp::getOpRuntime(
@@ -4261,7 +4303,8 @@ llvm::Expected<size_t> LayerNormPostAllGatherOp::getOpRuntime(
       op_model::OpModel<LayerNormPostAllGatherOp>::getOpRuntime, *this,
       inputShape, inputs[0], statsShape, inputs[1], optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+      optionalArgs.biasLayout, getEpsilon(), optionalArgs.computeKernelConfig,
+      optionalArgs.programConfig, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -15,6 +15,15 @@ add_library(TTNNOpInvokeLib STATIC
   Eltwise/Unary/EltwiseUnaryCompositeOp.cpp
   Eltwise/Unary/EltwiseUnaryOp.cpp
   Matmul/MatmulOp.cpp
+  Normalization/BatchNormOp.cpp
+  Normalization/DistributedRMSNormOp.cpp
+  Normalization/GroupNormOp.cpp
+  Normalization/LayerNormOp.cpp
+  Normalization/LayerNormPostAllGatherOp.cpp
+  Normalization/LayerNormPreAllGatherOp.cpp
+  Normalization/RMSNormOp.cpp
+  Normalization/RMSNormPreAllGatherOp.cpp
+  Normalization/SoftmaxOp.cpp
   Transformer/ConcatenateHeadsOp.cpp
   Transformer/NLPConcatHeadsDecodeOp.cpp
   Transformer/NLPConcatHeadsOp.cpp

--- a/lib/OpInvoke/TTNN/Normalization/BatchNormOp.cpp
+++ b/lib/OpInvoke/TTNN/Normalization/BatchNormOp.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Normalization/BatchNormOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/normalization/batch_norm/batch_norm.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+BatchNormResolvedParams resolveBatchNormInferenceParams(
+    const ::tt::target::ttnn::BatchNormInferenceOpT &op) {
+  BatchNormResolvedParams params;
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+BatchNormResolvedParams resolveBatchNormTrainingParams(
+    const ::tt::target::ttnn::BatchNormTrainingOpT &op) {
+  BatchNormResolvedParams params;
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createBatchNormInferenceTuple(
+    Tag tag, const ::tt::target::ttnn::BatchNormInferenceOpT &op,
+    TensorArg input, std::optional<TensorArg> runningMean,
+    std::optional<TensorArg> runningVar, std::optional<TensorArg> weight,
+    std::optional<TensorArg> bias, const BatchNormResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag),
+      runningMean ? std::make_optional(resolveTensorArg(*runningMean, tag))
+                  : std::nullopt,
+      runningVar ? std::make_optional(resolveTensorArg(*runningVar, tag))
+                 : std::nullopt,
+      /*training=*/false, op.epsilon, /*momentum=*/0.1f,
+      weight ? std::make_optional(resolveTensorArg(*weight, tag))
+             : std::nullopt,
+      bias ? std::make_optional(resolveTensorArg(*bias, tag)) : std::nullopt,
+      std::optional<::ttnn::Tensor>(std::nullopt), params.outputMemoryConfig,
+      params.computeConfig);
+}
+
+template <typename Tag>
+auto createBatchNormTrainingTuple(
+    Tag tag, const ::tt::target::ttnn::BatchNormTrainingOpT &op,
+    TensorArg input, std::optional<TensorArg> runningMean,
+    std::optional<TensorArg> runningVar, std::optional<TensorArg> weight,
+    std::optional<TensorArg> bias, const BatchNormResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag),
+      runningMean ? std::make_optional(resolveTensorArg(*runningMean, tag))
+                  : std::nullopt,
+      runningVar ? std::make_optional(resolveTensorArg(*runningVar, tag))
+                 : std::nullopt,
+      /*training=*/true, op.epsilon, op.momentum,
+      weight ? std::make_optional(resolveTensorArg(*weight, tag))
+             : std::nullopt,
+      bias ? std::make_optional(resolveTensorArg(*bias, tag)) : std::nullopt,
+      std::optional<::ttnn::Tensor>(std::nullopt), params.outputMemoryConfig,
+      params.computeConfig);
+}
+
+BatchNormOpResult callBatchNormInference(
+    CallType callType, const ::tt::target::ttnn::BatchNormInferenceOpT &op,
+    TensorArg input, std::optional<TensorArg> runningMean,
+    std::optional<TensorArg> runningVar, std::optional<TensorArg> weight,
+    std::optional<TensorArg> bias, ::ttnn::MeshDevice *device) {
+  BatchNormResolvedParams params = resolveBatchNormInferenceParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createBatchNormInferenceTuple(tag, op, input, runningMean,
+                                         runningVar, weight, bias, params);
+  };
+
+  return callOp<BatchNormOpResult>(WRAP_OP(::ttnn::batch_norm), callType,
+                                   makeTuple, device);
+}
+
+BatchNormOpResult callBatchNormTraining(
+    CallType callType, const ::tt::target::ttnn::BatchNormTrainingOpT &op,
+    TensorArg input, std::optional<TensorArg> runningMean,
+    std::optional<TensorArg> runningVar, std::optional<TensorArg> weight,
+    std::optional<TensorArg> bias, ::ttnn::MeshDevice *device) {
+  BatchNormResolvedParams params = resolveBatchNormTrainingParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createBatchNormTrainingTuple(tag, op, input, runningMean, runningVar,
+                                        weight, bias, params);
+  };
+
+  return callOp<BatchNormOpResult>(WRAP_OP(::ttnn::batch_norm), callType,
+                                   makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Normalization/DistributedRMSNormOp.cpp
+++ b/lib/OpInvoke/TTNN/Normalization/DistributedRMSNormOp.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Normalization/DistributedRMSNormOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+#include <functional>
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+DistributedRMSNormResolvedParams resolveDistributedRMSNormParams(
+    const ::tt::target::ttnn::DistributedRMSNormOpT &op) {
+  DistributedRMSNormResolvedParams params;
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+  if (op.program_config) {
+    params.programConfig =
+        operations::utils::createLayerNormShardedMultiCoreProgramConfig(
+            *op.program_config);
+  }
+  if (op.sub_device_id.has_value()) {
+    params.subDeviceId = std::make_optional<::tt::tt_metal::SubDeviceId>(
+        op.sub_device_id.value());
+  }
+  if (op.num_links.has_value()) {
+    params.numLinks = static_cast<size_t>(op.num_links.value());
+  }
+  if (op.topology.has_value()) {
+    params.topology = static_cast<::ttnn::ccl::Topology>(
+        operations::utils::toMetalTopology(op.topology.value()));
+  }
+  params.dtype = std::nullopt;
+  params.useNoc1Only = false;
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createDistributedRMSNormTuple(
+    Tag tag, const ::tt::target::ttnn::DistributedRMSNormOpT &op,
+    TensorArg input, std::optional<TensorArg> residual_input_tensor,
+    std::optional<TensorArg> weight, std::optional<TensorArg> stats,
+    ::ttnn::MeshDevice *device, const ::ttnn::GlobalSemaphore &semaphore,
+    const DistributedRMSNormResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), params.programConfig, op.cluster_axis,
+      std::cref(*device), semaphore,
+      /*persistent_output_tensor=*/std::nullopt, params.numLinks,
+      params.topology, params.subDeviceId, params.dtype, params.computeConfig,
+      params.outputMemoryConfig,
+      residual_input_tensor
+          ? std::make_optional(resolveTensorArg(*residual_input_tensor, tag))
+          : std::nullopt,
+      op.epsilon,
+      weight ? std::make_optional(resolveTensorArg(*weight, tag))
+             : std::nullopt,
+      stats ? std::make_optional(resolveTensorArg(*stats, tag)) : std::nullopt,
+      params.useNoc1Only);
+}
+
+DistributedRMSNormOpResult callDistributedRMSNorm(
+    CallType callType, const ::tt::target::ttnn::DistributedRMSNormOpT &op,
+    TensorArg input, std::optional<TensorArg> residual_input_tensor,
+    std::optional<TensorArg> weight, std::optional<TensorArg> stats,
+    const ::ttnn::GlobalSemaphore &semaphore, ::ttnn::MeshDevice *device) {
+  DistributedRMSNormResolvedParams params = resolveDistributedRMSNormParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createDistributedRMSNormTuple(tag, op, input, residual_input_tensor,
+                                         weight, stats, device, semaphore,
+                                         params);
+  };
+
+  return callOp<DistributedRMSNormOpResult, false, false>(
+      WRAP_OP(::ttnn::fused_rms_minimal), callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Normalization/GroupNormOp.cpp
+++ b/lib/OpInvoke/TTNN/Normalization/GroupNormOp.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Normalization/GroupNormOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/normalization/groupnorm/groupnorm.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+GroupNormResolvedParams
+resolveGroupNormParams(const ::tt::target::ttnn::GroupNormOpT &op) {
+  GroupNormResolvedParams params;
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createGroupNormTuple(Tag tag, const ::tt::target::ttnn::GroupNormOpT &op,
+                          TensorArg input, std::optional<TensorArg> inputMask,
+                          std::optional<TensorArg> weight,
+                          std::optional<TensorArg> bias,
+                          const GroupNormResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), static_cast<int>(op.num_groups), op.epsilon,
+      inputMask ? std::make_optional(resolveTensorArg(*inputMask, tag))
+                : std::nullopt,
+      weight ? std::make_optional(resolveTensorArg(*weight, tag))
+             : std::nullopt,
+      bias ? std::make_optional(resolveTensorArg(*bias, tag)) : std::nullopt,
+      /*reciprocals=*/std::nullopt, params.outputMemoryConfig,
+      /*dtype=*/std::nullopt, /*core_grid=*/std::nullopt,
+      /*inplace=*/std::nullopt, /*output_layout=*/std::nullopt,
+      /*num_out_blocks=*/std::nullopt, /*compute_kernel_config=*/std::nullopt,
+      /*negative_mask=*/std::nullopt, /*use_welford=*/false);
+}
+
+GroupNormOpResult
+callGroupNorm(CallType callType, const ::tt::target::ttnn::GroupNormOpT &op,
+              TensorArg input, std::optional<TensorArg> inputMask,
+              std::optional<TensorArg> weight, std::optional<TensorArg> bias,
+              ::ttnn::MeshDevice *device) {
+  GroupNormResolvedParams params = resolveGroupNormParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createGroupNormTuple(tag, op, input, inputMask, weight, bias,
+                                params);
+  };
+
+  return callOp<GroupNormOpResult>(WRAP_OP(::ttnn::group_norm), callType,
+                                   makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Normalization/LayerNormOp.cpp
+++ b/lib/OpInvoke/TTNN/Normalization/LayerNormOp.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Normalization/LayerNormOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/normalization/layernorm/layernorm.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+LayerNormResolvedParams
+resolveLayerNormParams(const ::tt::target::ttnn::LayerNormOpT &op) {
+  LayerNormResolvedParams params;
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createLayerNormTuple(Tag tag, const ::tt::target::ttnn::LayerNormOpT &op,
+                          TensorArg input, std::optional<TensorArg> weight,
+                          std::optional<TensorArg> bias,
+                          const LayerNormResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), op.epsilon,
+      weight ? std::make_optional(resolveTensorArg(*weight, tag))
+             : std::nullopt,
+      bias ? std::make_optional(resolveTensorArg(*bias, tag)) : std::nullopt,
+      /*residual_input_tensor=*/std::nullopt, params.outputMemoryConfig,
+      /*program_config=*/std::nullopt,
+      /*compute_kernel_config=*/std::nullopt,
+      /*recip_tensor=*/std::nullopt);
+}
+
+LayerNormOpResult
+callLayerNorm(CallType callType, const ::tt::target::ttnn::LayerNormOpT &op,
+              TensorArg input, std::optional<TensorArg> weight,
+              std::optional<TensorArg> bias, ::ttnn::MeshDevice *device) {
+  LayerNormResolvedParams params = resolveLayerNormParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createLayerNormTuple(tag, op, input, weight, bias, params);
+  };
+
+  return callOp<LayerNormOpResult>(WRAP_OP(::ttnn::layer_norm), callType,
+                                   makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Normalization/LayerNormPostAllGatherOp.cpp
+++ b/lib/OpInvoke/TTNN/Normalization/LayerNormPostAllGatherOp.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Normalization/LayerNormPostAllGatherOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+LayerNormPostAllGatherResolvedParams resolveLayerNormPostAllGatherParams(
+    const ::tt::target::ttnn::LayerNormPostAllGatherOpT &op) {
+  LayerNormPostAllGatherResolvedParams params;
+  if (op.out) {
+    params.outputDtype = operations::utils::getDataType(*op.out);
+  }
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+  if (op.program_config) {
+    params.programConfig =
+        operations::utils::createLayerNormShardedMultiCoreProgramConfig(
+            *op.program_config);
+  }
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createLayerNormPostAllGatherTuple(
+    Tag tag, const ::tt::target::ttnn::LayerNormPostAllGatherOpT &op,
+    TensorArg input, TensorArg stats, std::optional<TensorArg> weight,
+    std::optional<TensorArg> bias,
+    const LayerNormPostAllGatherResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), resolveTensorArg(stats, tag), op.epsilon,
+      weight ? std::make_optional(resolveTensorArg(*weight, tag))
+             : std::nullopt,
+      bias ? std::make_optional(resolveTensorArg(*bias, tag)) : std::nullopt,
+      params.outputMemoryConfig, params.computeConfig, params.programConfig,
+      params.outputDtype);
+}
+
+LayerNormPostAllGatherOpResult callLayerNormPostAllGather(
+    CallType callType, const ::tt::target::ttnn::LayerNormPostAllGatherOpT &op,
+    TensorArg input, TensorArg stats, std::optional<TensorArg> weight,
+    std::optional<TensorArg> bias, ::ttnn::MeshDevice *device) {
+  LayerNormPostAllGatherResolvedParams params =
+      resolveLayerNormPostAllGatherParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createLayerNormPostAllGatherTuple(tag, op, input, stats, weight,
+                                             bias, params);
+  };
+
+  return callOp<LayerNormPostAllGatherOpResult>(
+      WRAP_OP(::ttnn::layer_norm_post_all_gather), callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Normalization/LayerNormPreAllGatherOp.cpp
+++ b/lib/OpInvoke/TTNN/Normalization/LayerNormPreAllGatherOp.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Normalization/LayerNormPreAllGatherOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp"
+
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+LayerNormPreAllGatherResolvedParams resolveLayerNormPreAllGatherParams(
+    const ::tt::target::ttnn::LayerNormPreAllGatherOpT &op) {
+  LayerNormPreAllGatherResolvedParams params;
+  if (op.out) {
+    params.dtype = operations::utils::getDataType(*op.out);
+  } else {
+    params.dtype = ttnn::DataType::BFLOAT16;
+  }
+
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+  if (op.program_config) {
+    params.programConfig =
+        operations::utils::createLayerNormShardedMultiCoreProgramConfig(
+            *op.program_config);
+  }
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createLayerNormPreAllGatherTuple(
+    Tag tag, const ::tt::target::ttnn::LayerNormPreAllGatherOpT & /*op*/,
+    TensorArg input, std::optional<TensorArg> residualInput,
+    std::optional<TensorArg> recip,
+    const LayerNormPreAllGatherResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), params.dtype,
+      residualInput ? std::make_optional(resolveTensorArg(*residualInput, tag))
+                    : std::nullopt,
+      params.computeConfig, params.programConfig, params.outputMemoryConfig,
+      recip ? std::make_optional(resolveTensorArg(*recip, tag)) : std::nullopt);
+}
+
+LayerNormPreAllGatherOpResult callLayerNormPreAllGather(
+    CallType callType, const ::tt::target::ttnn::LayerNormPreAllGatherOpT &op,
+    TensorArg input, std::optional<TensorArg> residualInput,
+    std::optional<TensorArg> recip, ::ttnn::MeshDevice *device) {
+  LayerNormPreAllGatherResolvedParams params =
+      resolveLayerNormPreAllGatherParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createLayerNormPreAllGatherTuple(tag, op, input, residualInput,
+                                            recip, params);
+  };
+
+  return callOp<LayerNormPreAllGatherOpResult>(
+      WRAP_OP(::ttnn::layer_norm_pre_all_gather), callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Normalization/RMSNormOp.cpp
+++ b/lib/OpInvoke/TTNN/Normalization/RMSNormOp.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Normalization/RMSNormOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/normalization/rmsnorm/rmsnorm.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+RMSNormResolvedParams
+resolveRMSNormParams(const ::tt::target::ttnn::RMSNormOpT &op) {
+  RMSNormResolvedParams params;
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createRMSNormTuple(Tag tag, const ::tt::target::ttnn::RMSNormOpT &op,
+                        TensorArg input, std::optional<TensorArg> weight,
+                        std::optional<TensorArg> bias,
+                        const RMSNormResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), op.epsilon,
+      weight ? std::make_optional(resolveTensorArg(*weight, tag))
+             : std::nullopt,
+      bias ? std::make_optional(resolveTensorArg(*bias, tag)) : std::nullopt,
+      /*residual_input_tensor=*/std::nullopt, params.outputMemoryConfig,
+      /*program_config=*/std::nullopt, params.computeConfig);
+}
+
+RMSNormOpResult callRMSNorm(CallType callType,
+                            const ::tt::target::ttnn::RMSNormOpT &op,
+                            TensorArg input, std::optional<TensorArg> weight,
+                            std::optional<TensorArg> bias,
+                            ::ttnn::MeshDevice *device) {
+  RMSNormResolvedParams params = resolveRMSNormParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createRMSNormTuple(tag, op, input, weight, bias, params);
+  };
+
+  return callOp<RMSNormOpResult>(WRAP_OP(::ttnn::rms_norm), callType, makeTuple,
+                                 device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Normalization/RMSNormPreAllGatherOp.cpp
+++ b/lib/OpInvoke/TTNN/Normalization/RMSNormPreAllGatherOp.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Normalization/RMSNormPreAllGatherOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp"
+
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+RMSNormPreAllGatherResolvedParams resolveRMSNormPreAllGatherParams(
+    const ::tt::target::ttnn::RMSNormPreAllGatherOpT &op) {
+  RMSNormPreAllGatherResolvedParams params;
+  if (op.out) {
+    params.dtype = operations::utils::getDataType(*op.out);
+  }
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+  if (op.program_config) {
+    params.programConfig =
+        operations::utils::createLayerNormShardedMultiCoreProgramConfig(
+            *op.program_config);
+  }
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  params.use2DCoreGrid = std::make_optional(op.use_2d_core_grid);
+  return params;
+}
+
+template <typename Tag>
+auto createRMSNormPreAllGatherTuple(
+    Tag tag, const ::tt::target::ttnn::RMSNormPreAllGatherOpT & /*op*/,
+    TensorArg input, std::optional<TensorArg> residual,
+    const RMSNormPreAllGatherResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), params.dtype,
+      residual ? std::make_optional(resolveTensorArg(*residual, tag))
+               : std::nullopt,
+      params.computeConfig, params.programConfig, params.outputMemoryConfig,
+      params.use2DCoreGrid);
+}
+
+RMSNormPreAllGatherOpResult
+callRMSNormPreAllGather(CallType callType,
+                        const ::tt::target::ttnn::RMSNormPreAllGatherOpT &op,
+                        TensorArg input, std::optional<TensorArg> residual,
+                        ::ttnn::MeshDevice *device) {
+  RMSNormPreAllGatherResolvedParams params =
+      resolveRMSNormPreAllGatherParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createRMSNormPreAllGatherTuple(tag, op, input, residual, params);
+  };
+
+  return callOp<RMSNormPreAllGatherOpResult>(
+      WRAP_OP(::ttnn::rms_norm_pre_all_gather), callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Normalization/SoftmaxOp.cpp
+++ b/lib/OpInvoke/TTNN/Normalization/SoftmaxOp.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Normalization/SoftmaxOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/normalization/softmax/softmax.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+SoftmaxResolvedParams
+resolveSoftmaxParams(const ::tt::target::ttnn::SoftmaxOpT &op) {
+  SoftmaxResolvedParams params;
+  if (op.compute_config) {
+    params.computeConfig =
+        operations::utils::createDeviceComputeKernelConfig(*op.compute_config);
+  }
+  if (op.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+  return params;
+}
+
+template <typename Tag>
+auto createSoftmaxTuple(Tag tag, const ::tt::target::ttnn::SoftmaxOpT &op,
+                        TensorArg input, const SoftmaxResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), op.dimension,
+                         params.outputMemoryConfig, params.computeConfig,
+                         op.numeric_stable);
+}
+
+SoftmaxOpResult callSoftmax(CallType callType,
+                            const ::tt::target::ttnn::SoftmaxOpT &op,
+                            TensorArg input, ::ttnn::MeshDevice *device) {
+  SoftmaxResolvedParams params = resolveSoftmaxParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createSoftmaxTuple(tag, op, input, params);
+  };
+
+  return callOp<SoftmaxOpResult>(WRAP_OP(::ttnn::softmax), callType, makeTuple,
+                                 device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/utils/utils.cpp
+++ b/lib/OpInvoke/TTNN/utils/utils.cpp
@@ -584,4 +584,33 @@ createSDPAProgramConfig(const ::tt::target::ttnn::SDPAConfigT &config) {
   return sdpaConfig;
 }
 
+::ttnn::prim::LayerNormProgramConfig
+createLayerNormShardedMultiCoreProgramConfig(
+    const ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfigT &config) {
+  ::ttnn::prim::LayerNormShardedMultiCoreProgramConfig layerNormConfig;
+
+  layerNormConfig.compute_with_storage_grid_size =
+      toTTNNCoreCoord(*config.compute_with_storage_grid_size);
+  layerNormConfig.subblock_w = config.subblock_w;
+  layerNormConfig.block_h = config.block_h;
+  layerNormConfig.block_w = config.block_w;
+  layerNormConfig.inplace = config.inplace;
+
+  return layerNormConfig;
+}
+
+::tt::tt_fabric::Topology toMetalTopology(::tt::target::Topology topology) {
+  switch (topology) {
+  case ::tt::target::Topology::Ring:
+    return ::tt::tt_fabric::Topology::Ring;
+  case ::tt::target::Topology::Linear:
+    return ::tt::tt_fabric::Topology::Linear;
+  case ::tt::target::Topology::Mesh:
+    return ::tt::tt_fabric::Topology::Mesh;
+  case ::tt::target::Topology::Torus:
+    return ::tt::tt_fabric::Topology::Torus;
+  }
+  llvm_unreachable("Unknown tt::target::Topology value");
+}
+
 } // namespace ttnn_op_invoke::operations::utils

--- a/lib/OpModel/TTNN/NativeFromMLIR.cpp
+++ b/lib/OpModel/TTNN/NativeFromMLIR.cpp
@@ -1006,6 +1006,151 @@ buildNLPConcatHeadsDecodeOpTFromMLIR(uint32_t numHeads,
   return nlpConcatHeadsDecodeOp;
 }
 
+::tt::target::ttnn::SoftmaxOpT buildSoftmaxOpTFromMLIR(
+    int32_t dimension, bool numericStable,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::SoftmaxOpT softmaxOp;
+  softmaxOp.dimension = dimension;
+  softmaxOp.numeric_stable = numericStable;
+  softmaxOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+  softmaxOp.out = detail::getOutputTensorRefT(outputLayout);
+  return softmaxOp;
+}
+
+::tt::target::ttnn::BatchNormInferenceOpT buildBatchNormInferenceOpTFromMLIR(
+    llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::BatchNormInferenceOpT batchNormInferenceOp;
+  batchNormInferenceOp.epsilon = epsilon.convertToFloat();
+  batchNormInferenceOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+  batchNormInferenceOp.out = detail::getOutputTensorRefT(outputLayout);
+  return batchNormInferenceOp;
+}
+
+::tt::target::ttnn::BatchNormTrainingOpT buildBatchNormTrainingOpTFromMLIR(
+    llvm::APFloat epsilon, llvm::APFloat momentum,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::BatchNormTrainingOpT batchNormTrainingOp;
+  batchNormTrainingOp.epsilon = epsilon.convertToFloat();
+  batchNormTrainingOp.momentum = momentum.convertToFloat();
+  batchNormTrainingOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+  batchNormTrainingOp.out = detail::getOutputTensorRefT(outputLayout);
+  return batchNormTrainingOp;
+}
+
+::tt::target::ttnn::RMSNormOpT buildRMSNormOpTFromMLIR(
+    llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::RMSNormOpT rmsNormOp;
+  rmsNormOp.epsilon = epsilon.convertToFloat();
+  rmsNormOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+  rmsNormOp.out = detail::getOutputTensorRefT(outputLayout);
+  return rmsNormOp;
+}
+
+::tt::target::ttnn::RMSNormPreAllGatherOpT buildRMSNormPreAllGatherOpTFromMLIR(
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    std::optional<bool> use2DCoreGrid, TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::RMSNormPreAllGatherOpT rmsNormPreAllGatherOp;
+  rmsNormPreAllGatherOp.use_2d_core_grid = use2DCoreGrid.value_or(false);
+  rmsNormPreAllGatherOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+  rmsNormPreAllGatherOp.program_config =
+      (programConfig.has_value() && *programConfig)
+          ? std::make_unique<
+                ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfigT>(
+                toNative(*programConfig))
+          : nullptr;
+  rmsNormPreAllGatherOp.out = detail::getOutputTensorRefT(outputLayout);
+  return rmsNormPreAllGatherOp;
+}
+
+::tt::target::ttnn::LayerNormOpT
+buildLayerNormOpTFromMLIR(llvm::APFloat epsilon, TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::LayerNormOpT layerNormOp;
+  layerNormOp.epsilon = epsilon.convertToFloat();
+  layerNormOp.out = detail::getOutputTensorRefT(outputLayout);
+  return layerNormOp;
+}
+
+::tt::target::ttnn::LayerNormPreAllGatherOpT
+buildLayerNormPreAllGatherOpTFromMLIR(
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::LayerNormPreAllGatherOpT layerNormPreAllGatherOp;
+  layerNormPreAllGatherOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+  layerNormPreAllGatherOp.program_config =
+      (programConfig.has_value() && *programConfig)
+          ? std::make_unique<
+                ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfigT>(
+                toNative(*programConfig))
+          : nullptr;
+  layerNormPreAllGatherOp.out = detail::getOutputTensorRefT(outputLayout);
+  return layerNormPreAllGatherOp;
+}
+
+::tt::target::ttnn::LayerNormPostAllGatherOpT
+buildLayerNormPostAllGatherOpTFromMLIR(
+    llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::LayerNormPostAllGatherOpT layerNormPostAllGatherOp;
+  layerNormPostAllGatherOp.epsilon = epsilon.convertToFloat();
+  layerNormPostAllGatherOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+  layerNormPostAllGatherOp.program_config =
+      (programConfig.has_value() && *programConfig)
+          ? std::make_unique<
+                ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfigT>(
+                toNative(*programConfig))
+          : nullptr;
+  layerNormPostAllGatherOp.out = detail::getOutputTensorRefT(outputLayout);
+  return layerNormPostAllGatherOp;
+}
+
+::tt::target::ttnn::GroupNormOpT
+buildGroupNormOpTFromMLIR(int64_t numGroups, llvm::APFloat epsilon,
+                          TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::GroupNormOpT groupNormOp;
+  groupNormOp.num_groups = numGroups;
+  groupNormOp.epsilon = epsilon.convertToFloat();
+  groupNormOp.out = detail::getOutputTensorRefT(outputLayout);
+  return groupNormOp;
+}
+
 } // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -25,6 +25,14 @@
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/BatchNormOp.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/GroupNormOp.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/LayerNormOp.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/LayerNormPostAllGatherOp.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/LayerNormPreAllGatherOp.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/RMSNormOp.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/RMSNormPreAllGatherOp.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/SoftmaxOp.h"
 #include "ttmlir/OpInvoke/TTNN/Transformer/ConcatenateHeadsOp.h"
 #include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsDecodeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsOp.h"
@@ -2110,9 +2118,12 @@ template struct NamedFullOpModel<OnesOp>;
 //===----------------------------------------------------------------------===//
 // SoftmaxOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    const int dimArg, bool numericStable, TTNNLayoutAttr outputLayout) {
+    const int dimArg, bool numericStable,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2121,12 +2132,19 @@ llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::SoftmaxOpT softmaxOpNative = buildSoftmaxOpTFromMLIR(
+      dimArg, numericStable, computeKernelConfig, outputLayout);
+
   auto softmaxOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::softmax, device, inputSpec, dimArg,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                std::nullopt, // compute_kernel_config,
-                                numericStable);
+    ttnn_op_invoke::SoftmaxOpResult result = ttnn_op_invoke::callSoftmax(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, softmaxOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected SoftmaxOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), softmaxOpQuery);
@@ -2137,7 +2155,9 @@ llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
 
 llvm::Expected<size_t> OpModel<SoftmaxOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    const int dimArg, bool numericStable, TTNNLayoutAttr outputLayout) {
+    const int dimArg, bool numericStable,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2146,12 +2166,18 @@ llvm::Expected<size_t> OpModel<SoftmaxOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::SoftmaxOpT softmaxOpNative = buildSoftmaxOpTFromMLIR(
+      dimArg, numericStable, computeKernelConfig, outputLayout);
+
   auto softmaxOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::softmax, device, inputSpec, dimArg,
-                            detail::getNullableMemoryConfig(outputLayout),
-                            std::nullopt, // compute_kernel_config,
-                            numericStable);
+    ttnn_op_invoke::SoftmaxOpResult result =
+        ttnn_op_invoke::callSoftmax(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                    softmaxOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected SoftmaxOp runtime query to return RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(softmaxOpQuery);
@@ -6468,6 +6494,7 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6487,22 +6514,23 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
-  // The following arguments are received by the invoke method of batch norm but
-  // they don't exist in the op's definition in TTNNOps.td:
-  std::optional<::ttnn::TensorSpec> outputSpec = std::nullopt;
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeKernelConfig =
-      std::nullopt;
 
-  // For inference, training is false and momentum is 0.1 (default)
-  bool training = false;
-  float momentum = 0.1f;
+  ::tt::target::ttnn::BatchNormInferenceOpT batchNormInferenceOpNative =
+      buildBatchNormInferenceOpTFromMLIR(epsilon, computeKernelConfig,
+                                         outputLayout);
 
   auto batchNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::batch_norm, device, inputSpec, runningMeanSpec, runningVarSpec,
-        training, epsilon.convertToFloat(), momentum, weightSpec, biasSpec,
-        outputSpec, detail::getNullableMemoryConfig(outputLayout),
-        computeKernelConfig);
+    ttnn_op_invoke::BatchNormOpResult result =
+        ttnn_op_invoke::callBatchNormInference(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            batchNormInferenceOpNative, inputSpec, runningMeanSpec,
+            runningVarSpec, weightSpec, biasSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected BatchNormInferenceOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), batchNormQuery);
@@ -6521,6 +6549,7 @@ llvm::Expected<size_t> OpModel<BatchNormInferenceOp>::getOpRuntime(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6540,23 +6569,23 @@ llvm::Expected<size_t> OpModel<BatchNormInferenceOp>::getOpRuntime(
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
-  // The following arguments are received by the invoke method of batch norm but
-  // they don't exist in the op's definition in TTNNOps.td:
-  std::optional<::ttnn::TensorSpec> outputSpec = std::nullopt;
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeKernelConfig =
-      std::nullopt;
 
-  // For inference, training is false and momentum is 0.1 (default)
-  bool training = false;
-  float momentum = 0.1f;
+  ::tt::target::ttnn::BatchNormInferenceOpT batchNormInferenceOpNative =
+      buildBatchNormInferenceOpTFromMLIR(epsilon, computeKernelConfig,
+                                         outputLayout);
 
-  // Create query closure
   auto batchNormQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::batch_norm, device, inputSpec, runningMeanSpec, runningVarSpec,
-        training, epsilon.convertToFloat(), momentum, weightSpec, biasSpec,
-        outputSpec, detail::getNullableMemoryConfig(outputLayout),
-        computeKernelConfig);
+    ttnn_op_invoke::BatchNormOpResult result =
+        ttnn_op_invoke::callBatchNormInference(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            batchNormInferenceOpNative, inputSpec, runningMeanSpec,
+            runningVarSpec, weightSpec, biasSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected BatchNormInferenceOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(batchNormQuery);
@@ -6579,7 +6608,9 @@ llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-    llvm::APFloat momentum, TTNNLayoutAttr outputLayout) {
+    llvm::APFloat momentum,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6598,21 +6629,23 @@ llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
-  // The following arguments are received by the invoke method of batch norm but
-  // they don't exist in the op's definition in TTNNOps.td:
-  std::optional<::ttnn::TensorSpec> outputSpec = std::nullopt;
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeKernelConfig =
-      std::nullopt;
 
-  // For training mode
-  bool training = true;
+  ::tt::target::ttnn::BatchNormTrainingOpT batchNormTrainingOpNative =
+      buildBatchNormTrainingOpTFromMLIR(epsilon, momentum, computeKernelConfig,
+                                        outputLayout);
 
   auto batchNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::batch_norm, device, inputSpec, runningMeanSpec, runningVarSpec,
-        training, epsilon.convertToFloat(), momentum.convertToFloat(),
-        weightSpec, biasSpec, outputSpec,
-        detail::getNullableMemoryConfig(outputLayout), computeKernelConfig);
+    ttnn_op_invoke::BatchNormOpResult result =
+        ttnn_op_invoke::callBatchNormTraining(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            batchNormTrainingOpNative, inputSpec, runningMeanSpec,
+            runningVarSpec, weightSpec, biasSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected BatchNormTrainingOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), batchNormQuery);
@@ -6631,7 +6664,9 @@ llvm::Expected<size_t> OpModel<BatchNormTrainingOp>::getOpRuntime(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-    llvm::APFloat momentum, TTNNLayoutAttr outputLayout) {
+    llvm::APFloat momentum,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6650,22 +6685,23 @@ llvm::Expected<size_t> OpModel<BatchNormTrainingOp>::getOpRuntime(
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
-  // The following arguments are received by the invoke method of batch norm but
-  // they don't exist in the op's definition in TTNNOps.td:
-  std::optional<::ttnn::TensorSpec> outputSpec = std::nullopt;
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeKernelConfig =
-      std::nullopt;
 
-  // For training mode
-  bool training = true;
+  ::tt::target::ttnn::BatchNormTrainingOpT batchNormTrainingOpNative =
+      buildBatchNormTrainingOpTFromMLIR(epsilon, momentum, computeKernelConfig,
+                                        outputLayout);
 
-  // Create query closure
   auto batchNormQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::batch_norm, device, inputSpec, runningMeanSpec, runningVarSpec,
-        training, epsilon.convertToFloat(), momentum.convertToFloat(),
-        weightSpec, biasSpec, outputSpec,
-        detail::getNullableMemoryConfig(outputLayout), computeKernelConfig);
+    ttnn_op_invoke::BatchNormOpResult result =
+        ttnn_op_invoke::callBatchNormTraining(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            batchNormTrainingOpNative, inputSpec, runningMeanSpec,
+            runningVarSpec, weightSpec, biasSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected BatchNormTrainingOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(batchNormQuery);
@@ -6699,20 +6735,19 @@ llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
-  // This information is not available in the op's definition in TTNNOps.td:
-  std::optional<::ttnn::TensorSpec> residualInputSpec = std::nullopt;
+  ::tt::target::ttnn::RMSNormOpT rmsNormOpNative =
+      buildRMSNormOpTFromMLIR(epsilon, computeKernelConfig, outputLayout);
 
-  std::optional<::ttnn::DeviceComputeKernelConfig>
-      computeKernelConfigConverted =
-          conversion::getDeviceComputeKernelConfig(computeKernelConfig);
-
-  // Create query closure
   auto rmsNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::rms_norm, device, inputSpec, epsilon.convertToFloat(),
-        weightSpec, biasSpec, residualInputSpec,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt, computeKernelConfigConverted);
+    ttnn_op_invoke::RMSNormOpResult result = ttnn_op_invoke::callRMSNorm(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, rmsNormOpNative,
+        inputSpec, weightSpec, biasSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected RMSNormOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), rmsNormQuery);
@@ -6742,20 +6777,18 @@ llvm::Expected<size_t> OpModel<RMSNormOp>::getOpRuntime(
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
-  // This information is not available in the op's definition in TTNNOps.td:
-  std::optional<::ttnn::TensorSpec> residualInputSpec = std::nullopt;
+  ::tt::target::ttnn::RMSNormOpT rmsNormOpNative =
+      buildRMSNormOpTFromMLIR(epsilon, computeKernelConfig, outputLayout);
 
-  std::optional<::ttnn::DeviceComputeKernelConfig>
-      computeKernelConfigConverted =
-          conversion::getDeviceComputeKernelConfig(computeKernelConfig);
-
-  // Create query closure
   auto rmsNormQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::rms_norm, device, inputSpec, epsilon.convertToFloat(),
-        weightSpec, biasSpec, residualInputSpec,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt, computeKernelConfigConverted);
+    ttnn_op_invoke::RMSNormOpResult result = ttnn_op_invoke::callRMSNorm(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, rmsNormOpNative, inputSpec,
+        weightSpec, biasSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RMSNormOp runtime query to return RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(rmsNormQuery);
@@ -6773,6 +6806,8 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
     std::optional<TTNNLayoutAttr> residualInputLayout,
     std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6786,24 +6821,24 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
       detail::convertToOptionalTensorSpec(device, residualInputShape,
                                           residualInputLayout);
 
-  ::ttnn::DataType metalDtype = ::ttnn::DataType::BFLOAT16;
-  if (dtype.has_value()) {
-    metalDtype = conversion::getDataType(dtype.value());
-  }
+  ::tt::target::ttnn::RMSNormPreAllGatherOpT rmsNormPreAllGatherOpNative =
+      buildRMSNormPreAllGatherOpTFromMLIR(computeKernelConfig, programConfig,
+                                          use2DCoreGrid, outputLayout);
 
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        ::ttnn::rms_norm_pre_all_gather, device, inputSpec,
-        /*dtype=*/metalDtype,
-        /*residual_input_tensor=*/residualInputSpec,
-        /*compute_kernel_config=*/std::nullopt,
-        /*program_config=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*use_2d_core_grid=*/use2DCoreGrid);
+    ttnn_op_invoke::RMSNormPreAllGatherOpResult result =
+        ttnn_op_invoke::callRMSNormPreAllGather(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            rmsNormPreAllGatherOpNative, inputSpec, residualInputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected RMSNormPreAllGatherOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), query);
-
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6814,6 +6849,8 @@ llvm::Expected<size_t> OpModel<RMSNormPreAllGatherOp>::getOpRuntime(
     std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
     std::optional<TTNNLayoutAttr> residualInputLayout,
     std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6827,21 +6864,23 @@ llvm::Expected<size_t> OpModel<RMSNormPreAllGatherOp>::getOpRuntime(
       detail::convertToOptionalTensorSpec(device, residualInputShape,
                                           residualInputLayout);
 
-  ::ttnn::DataType metalDtype = ::ttnn::DataType::BFLOAT16;
-  if (dtype.has_value()) {
-    metalDtype = conversion::getDataType(dtype.value());
-  }
+  ::tt::target::ttnn::RMSNormPreAllGatherOpT rmsNormPreAllGatherOpNative =
+      buildRMSNormPreAllGatherOpTFromMLIR(computeKernelConfig, programConfig,
+                                          use2DCoreGrid, outputLayout);
 
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        ::ttnn::rms_norm_pre_all_gather, device, inputSpec,
-        /*dtype=*/metalDtype,
-        /*residual_input_tensor=*/residualInputSpec,
-        /*compute_kernel_config=*/std::nullopt,
-        /*program_config=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*use_2d_core_grid=*/use2DCoreGrid);
+    ttnn_op_invoke::RMSNormPreAllGatherOpResult result =
+        ttnn_op_invoke::callRMSNormPreAllGather(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            rmsNormPreAllGatherOpNative, inputSpec, residualInputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RMSNormPreAllGatherOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
+
   return operation::getOpRuntime(query);
 #else
   return llvm::createStringError("Not Implemented");
@@ -6872,15 +6911,19 @@ llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
-  std::optional<::ttnn::TensorSpec> residualInputSpec = std::nullopt;
+  ::tt::target::ttnn::LayerNormOpT layerNormOpNative =
+      buildLayerNormOpTFromMLIR(epsilon, outputLayout);
 
   auto layerNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::layer_norm, device, inputSpec, epsilon.convertToFloat(),
-        weightSpec, biasSpec, residualInputSpec,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
-        /*compute_kernel_config=*/std::nullopt, /*recip_tensor=*/std::nullopt);
+    ttnn_op_invoke::LayerNormOpResult result = ttnn_op_invoke::callLayerNorm(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, layerNormOpNative,
+        inputSpec, weightSpec, biasSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected LayerNormOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), layerNormQuery);
@@ -6909,16 +6952,18 @@ llvm::Expected<size_t> OpModel<LayerNormOp>::getOpRuntime(
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
-  std::optional<::ttnn::TensorSpec> residualInputSpec = std::nullopt;
+  ::tt::target::ttnn::LayerNormOpT layerNormOpNative =
+      buildLayerNormOpTFromMLIR(epsilon, outputLayout);
 
-  // Create query closure
   auto layerNormQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::layer_norm, device, inputSpec, epsilon.convertToFloat(),
-        weightSpec, biasSpec, residualInputSpec,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
-        /*compute_kernel_config=*/std::nullopt, /*recip_tensor=*/std::nullopt);
+    ttnn_op_invoke::LayerNormOpResult result = ttnn_op_invoke::callLayerNorm(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, layerNormOpNative,
+        inputSpec, weightSpec, biasSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected LayerNormOp runtime query to return RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(layerNormQuery);
@@ -6938,7 +6983,10 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> residualInputLayout,
     std::optional<llvm::ArrayRef<int64_t>> recipShape,
     std::optional<TTNNLayoutAttr> recipLayout,
-    std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout) {
+    std::optional<ttcore::DataType> dtype,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6953,20 +7001,22 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
   std::optional<::ttnn::TensorSpec> recipSpec =
       detail::convertToOptionalTensorSpec(device, recipShape, recipLayout);
 
-  ::ttnn::DataType metalDtype = ::ttnn::DataType::BFLOAT16;
-  if (dtype.has_value()) {
-    metalDtype = conversion::getDataType(dtype.value());
-  }
+  ::tt::target::ttnn::LayerNormPreAllGatherOpT layerNormPreAllGatherOpNative =
+      buildLayerNormPreAllGatherOpTFromMLIR(computeKernelConfig, programConfig,
+                                            outputLayout);
 
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        ::ttnn::layer_norm_pre_all_gather, device, inputSpec,
-        /*dtype=*/metalDtype,
-        /*residual_input_tensor=*/residualInputSpec,
-        /*compute_kernel_config=*/std::nullopt,
-        /*program_config=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*recip_tensor=*/recipSpec);
+    ttnn_op_invoke::LayerNormPreAllGatherOpResult result =
+        ttnn_op_invoke::callLayerNormPreAllGather(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            layerNormPreAllGatherOpNative, inputSpec, residualInputSpec,
+            recipSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected LayerNormPreAllGatherOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), query);
@@ -6981,7 +7031,10 @@ llvm::Expected<size_t> OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
     std::optional<TTNNLayoutAttr> residualInputLayout,
     std::optional<llvm::ArrayRef<int64_t>> recipShape,
     std::optional<TTNNLayoutAttr> recipLayout,
-    std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout) {
+    std::optional<ttcore::DataType> dtype,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6996,20 +7049,22 @@ llvm::Expected<size_t> OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
   std::optional<::ttnn::TensorSpec> recipSpec =
       detail::convertToOptionalTensorSpec(device, recipShape, recipLayout);
 
-  ::ttnn::DataType metalDtype = ::ttnn::DataType::BFLOAT16;
-  if (dtype.has_value()) {
-    metalDtype = conversion::getDataType(dtype.value());
-  }
+  ::tt::target::ttnn::LayerNormPreAllGatherOpT layerNormPreAllGatherOpNative =
+      buildLayerNormPreAllGatherOpTFromMLIR(computeKernelConfig, programConfig,
+                                            outputLayout);
 
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        ::ttnn::layer_norm_pre_all_gather, device, inputSpec,
-        /*dtype=*/metalDtype,
-        /*residual_input_tensor=*/residualInputSpec,
-        /*compute_kernel_config=*/std::nullopt,
-        /*program_config=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*recip_tensor=*/recipSpec);
+    ttnn_op_invoke::LayerNormPreAllGatherOpResult result =
+        ttnn_op_invoke::callLayerNormPreAllGather(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            layerNormPreAllGatherOpNative, inputSpec, residualInputSpec,
+            recipSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected LayerNormPreAllGatherOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(query);
@@ -7030,6 +7085,8 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7048,14 +7105,22 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
+  ::tt::target::ttnn::LayerNormPostAllGatherOpT layerNormPostAllGatherOpNative =
+      buildLayerNormPostAllGatherOpTFromMLIR(epsilon, computeKernelConfig,
+                                             programConfig, outputLayout);
+
   auto query = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::layer_norm_post_all_gather, device,
-                                inputSpec, statsSpec, epsilon.convertToFloat(),
-                                weightSpec, biasSpec,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*compute_kernel_config=*/std::nullopt,
-                                /*program_config=*/std::nullopt,
-                                /*dtype=*/std::nullopt);
+    ttnn_op_invoke::LayerNormPostAllGatherOpResult result =
+        ttnn_op_invoke::callLayerNormPostAllGather(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            layerNormPostAllGatherOpNative, inputSpec, statsSpec, weightSpec,
+            biasSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected LayerNormPostAllGatherOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), query);
@@ -7071,6 +7136,8 @@ llvm::Expected<size_t> OpModel<LayerNormPostAllGatherOp>::getOpRuntime(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7089,14 +7156,22 @@ llvm::Expected<size_t> OpModel<LayerNormPostAllGatherOp>::getOpRuntime(
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
+  ::tt::target::ttnn::LayerNormPostAllGatherOpT layerNormPostAllGatherOpNative =
+      buildLayerNormPostAllGatherOpTFromMLIR(epsilon, computeKernelConfig,
+                                             programConfig, outputLayout);
+
   auto query = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::layer_norm_post_all_gather, device,
-                            inputSpec, statsSpec, epsilon.convertToFloat(),
-                            weightSpec, biasSpec,
-                            detail::getNullableMemoryConfig(outputLayout),
-                            /*compute_kernel_config=*/std::nullopt,
-                            /*program_config=*/std::nullopt,
-                            /*dtype=*/std::nullopt);
+    ttnn_op_invoke::LayerNormPostAllGatherOpResult result =
+        ttnn_op_invoke::callLayerNormPostAllGather(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            layerNormPostAllGatherOpNative, inputSpec, statsSpec, weightSpec,
+            biasSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected LayerNormPostAllGatherOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(query);
@@ -7134,23 +7209,19 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
-  int numGroupsInt = static_cast<int>(numGroups);
-  float epsilonFloat = epsilon.convertToFloat();
+  ::tt::target::ttnn::GroupNormOpT groupNormOpNative =
+      buildGroupNormOpTFromMLIR(numGroups, epsilon, outputLayout);
 
   auto groupNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::group_norm, device, inputSpec,
-                                numGroupsInt, epsilonFloat, inputMaskSpec,
-                                weightSpec, biasSpec,
-                                /*reciprocals=*/std::nullopt,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*dtype=*/std::nullopt,
-                                /*core_grid=*/std::nullopt,
-                                /*inplace=*/std::nullopt,
-                                /*output_layout=*/std::nullopt,
-                                /*num_out_blocks=*/std::nullopt,
-                                /*compute_kernel_config=*/std::nullopt,
-                                /*negative_mask=*/std::nullopt,
-                                /*use_welford=*/false);
+    ttnn_op_invoke::GroupNormOpResult result = ttnn_op_invoke::callGroupNorm(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, groupNormOpNative,
+        inputSpec, inputMaskSpec, weightSpec, biasSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected GroupNormOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), groupNormQuery);
@@ -7184,22 +7255,19 @@ llvm::Expected<size_t> OpModel<GroupNormOp>::getOpRuntime(
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
-  int numGroupsInt = static_cast<int>(numGroups);
-  float epsilonFloat = epsilon.convertToFloat();
+  ::tt::target::ttnn::GroupNormOpT groupNormOpNative =
+      buildGroupNormOpTFromMLIR(numGroups, epsilon, outputLayout);
 
   auto groupNormQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::group_norm, device, inputSpec, numGroupsInt,
-                            epsilonFloat, inputMaskSpec, weightSpec, biasSpec,
-                            /*reciprocals=*/std::nullopt,
-                            detail::getNullableMemoryConfig(outputLayout),
-                            /*dtype=*/std::nullopt,
-                            /*core_grid=*/std::nullopt,
-                            /*inplace=*/std::nullopt,
-                            /*output_layout=*/std::nullopt,
-                            /*num_out_blocks=*/std::nullopt,
-                            /*compute_kernel_config=*/std::nullopt,
-                            /*negative_mask=*/std::nullopt,
-                            /*use_welford=*/false);
+    ttnn_op_invoke::GroupNormOpResult result = ttnn_op_invoke::callGroupNorm(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, groupNormOpNative,
+        inputSpec, inputMaskSpec, weightSpec, biasSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected GroupNormOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(groupNormQuery);

--- a/runtime/include/tt/runtime/detail/common/common.h
+++ b/runtime/include/tt/runtime/detail/common/common.h
@@ -5,6 +5,7 @@
 #ifndef TT_RUNTIME_DETAIL_COMMON_COMMON_H
 #define TT_RUNTIME_DETAIL_COMMON_COMMON_H
 
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
 #include <optional>
 #include <vector>
 
@@ -170,17 +171,7 @@ createFullMeshDevice(
 
 inline ::tt::tt_fabric::Topology
 toMetalTopology(::tt::target::Topology topology) {
-  switch (topology) {
-  case ::tt::target::Topology::Ring:
-    return ::tt::tt_fabric::Topology::Ring;
-  case ::tt::target::Topology::Linear:
-    return ::tt::tt_fabric::Topology::Linear;
-  case ::tt::target::Topology::Mesh:
-    return ::tt::tt_fabric::Topology::Mesh;
-  case ::tt::target::Topology::Torus:
-    return ::tt::tt_fabric::Topology::Torus;
-  }
-  LOG_FATAL("Unknown tt::target::Topology value");
+  return ttnn_op_invoke::operations::utils::toMetalTopology(topology);
 }
 
 } // namespace tt::runtime::common

--- a/runtime/lib/ttnn/operations/normalization/batch_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/batch_norm.cpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/normalization/batch_norm.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/BatchNormOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::batch_norm {
 void run(const ::tt::target::ttnn::BatchNormInferenceOp *op,
@@ -20,19 +22,20 @@ void run(const ::tt::target::ttnn::BatchNormInferenceOp *op,
       tensorPool.getTTNNTensorAndValidate(op->weight());
   const ::ttnn::Tensor &bias = tensorPool.getTTNNTensorAndValidate(op->bias());
 
-  float epsilon = op->epsilon();
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ::tt::target::ttnn::BatchNormInferenceOpT batchNormInferenceOpNative;
+  op->UnPackTo(&batchNormInferenceOpNative);
 
-  // For inference: training=false, momentum=0.1 (default, not used in
-  // inference)
-  ::ttnn::Tensor output = ::ttnn::batch_norm(
-      input, runningMean, runningVar, false, epsilon, 0.1f, weight, bias,
-      /*output=*/std::nullopt, /*memory_config=*/std::nullopt, computeConfig);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
+  ttnn_op_invoke::BatchNormOpResult result =
+      ttnn_op_invoke::callBatchNormInference(
+          ttnn_op_invoke::CallType::EXECUTE, batchNormInferenceOpNative, &input,
+          &runningMean, &runningVar, &weight, &bias, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callBatchNormInference execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
@@ -50,20 +53,20 @@ void run(const ::tt::target::ttnn::BatchNormTrainingOp *op,
       tensorPool.getTTNNTensorAndValidate(op->weight());
   const ::ttnn::Tensor &bias = tensorPool.getTTNNTensorAndValidate(op->bias());
 
-  float epsilon = op->epsilon();
-  float momentum = op->momentum();
+  ::tt::target::ttnn::BatchNormTrainingOpT batchNormTrainingOpNative;
+  op->UnPackTo(&batchNormTrainingOpNative);
 
-  // For training: training=true
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::Tensor output = ::ttnn::batch_norm(
-      input, runningMean, runningVar, true, epsilon, momentum, weight, bias,
-      /*output=*/std::nullopt, /*memory_config=*/std::nullopt, computeConfig);
+  ttnn_op_invoke::BatchNormOpResult result =
+      ttnn_op_invoke::callBatchNormTraining(
+          ttnn_op_invoke::CallType::EXECUTE, batchNormTrainingOpNative, &input,
+          &runningMean, &runningVar, &weight, &bias, &targetDevice);
 
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callBatchNormTraining execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::batch_norm

--- a/runtime/lib/ttnn/operations/normalization/distributed_rms_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/distributed_rms_norm.cpp
@@ -3,13 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/normalization/distributed_rms_norm.h"
-#include "tt/runtime/detail/common/common.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-
-#include "ttnn/global_semaphore.hpp"
-#include "ttnn/operations/experimental/ccl/rms_allgather/rms_allgather.hpp"
-#include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/DistributedRMSNormOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::distributed_rms_norm {
 void run(const ::tt::target::ttnn::DistributedRMSNormOp *op,
@@ -28,60 +24,38 @@ void run(const ::tt::target::ttnn::DistributedRMSNormOp *op,
     residual = tensorPool.getTTNNTensorAndValidate(op->residual());
   }
 
-  uint32_t clusterAxis = op->cluster_axis();
-  float epsilon = op->epsilon();
-
-  std::optional<::tt::tt_metal::SubDeviceId> subDeviceId =
-      op->sub_device_id() ? std::make_optional<::tt::tt_metal::SubDeviceId>(
-                                op->sub_device_id().value())
-                          : std::nullopt;
-
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-
-  std::optional<size_t> numLinks = std::nullopt;
-  if (op->num_links()) {
-    numLinks = static_cast<size_t>(op->num_links().value());
-  }
-
-  ::ttnn::ccl::Topology topology = ::ttnn::ccl::Topology::Linear;
-  if (op->topology()) {
-    topology = static_cast<::ttnn::ccl::Topology>(
-        ::tt::runtime::common::toMetalTopology(op->topology().value()));
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
+  std::optional<::ttnn::Tensor> stats = std::nullopt;
+  if (op->stats()) {
+    stats = tensorPool.getTTNNTensorAndValidate(op->stats());
   }
 
   ::ttnn::MeshDevice &meshDevice = context.getMeshDevice();
-
-  ::ttnn::prim::LayerNormProgramConfig programConfig;
-  if (op->program_config()) {
-    programConfig = utils::createLayerNormShardedMultiCoreProgramConfig(
-        op->program_config());
-  }
-
   LOG_ASSERT(op->semaphore(),
              "DistributedRMSNormOp expects an explicit global semaphore");
   ::ttnn::GlobalSemaphore semaphore =
       context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
           op->semaphore());
 
-  ::ttnn::Tensor &statsTensor =
-      tensorPool.getTTNNTensorAndValidate(op->stats());
+  ::tt::target::ttnn::DistributedRMSNormOpT distributedRmsNormOpNative;
+  op->UnPackTo(&distributedRmsNormOpNative);
 
-  ::ttnn::Tensor output = ::ttnn::fused_rms_minimal(
-      input, programConfig, clusterAxis, meshDevice, semaphore,
-      /*persistent_output_tensor=*/std::nullopt, numLinks, topology,
-      subDeviceId,
-      /*dtype=*/std::nullopt, computeConfig, memoryConfig, residual, epsilon,
-      weight, statsTensor,
-      /*use_noc1_only=*/false);
+  ttnn_op_invoke::DistributedRMSNormOpResult result =
+      ttnn_op_invoke::callDistributedRMSNorm(
+          ttnn_op_invoke::CallType::EXECUTE, distributedRmsNormOpNative, &input,
+          residual.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*residual)
+              : std::nullopt,
+          weight.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*weight)
+              : std::nullopt,
+          stats.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*stats)
+                            : std::nullopt,
+          semaphore, &meshDevice);
 
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callDistributedRMSNorm execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::distributed_rms_norm

--- a/runtime/lib/ttnn/operations/normalization/group_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/group_norm.cpp
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/normalization/group_norm.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/GroupNormOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::group_norm {
 void run(const ::tt::target::ttnn::GroupNormOp *op, ProgramContext &context) {
@@ -27,26 +28,26 @@ void run(const ::tt::target::ttnn::GroupNormOp *op, ProgramContext &context) {
     bias = tensorPool.getTTNNTensorAndValidate(op->bias());
   }
 
-  float epsilon = op->epsilon();
+  ::tt::target::ttnn::GroupNormOpT groupNormOpNative;
+  op->UnPackTo(&groupNormOpNative);
 
-  int num_groups = static_cast<int>(op->num_groups());
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  // Handle optional memory config
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+  ttnn_op_invoke::GroupNormOpResult result = ttnn_op_invoke::callGroupNorm(
+      ttnn_op_invoke::CallType::EXECUTE, groupNormOpNative, &input,
+      input_mask.has_value()
+          ? std::optional<ttnn_op_invoke::TensorArg>(&*input_mask)
+          : std::nullopt,
+      weight.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*weight)
+                         : std::nullopt,
+      bias.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*bias)
+                       : std::nullopt,
+      &targetDevice);
 
-  // Call TTNN group norm operation
-  ::ttnn::Tensor output = ::ttnn::group_norm(
-      input, num_groups, epsilon, input_mask, weight, bias,
-      /*reciprocals=*/std::nullopt, memoryConfig,
-      /*dtype=*/std::nullopt, /*core_grid=*/std::nullopt,
-      /*inplace=*/std::nullopt, /*output_layout=*/std::nullopt,
-      /*num_out_blocks=*/std::nullopt,
-      /*compute_kernel_config=*/std::nullopt,
-      /*negative_mask=*/std::nullopt,
-      /*use_welford=*/false);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callGroupNorm execution");
 
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::group_norm

--- a/runtime/lib/ttnn/operations/normalization/layer_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/layer_norm.cpp
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/normalization/layer_norm.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/LayerNormOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::layer_norm {
 void run(const ::tt::target::ttnn::LayerNormOp *op, ProgramContext &context) {
@@ -23,19 +24,23 @@ void run(const ::tt::target::ttnn::LayerNormOp *op, ProgramContext &context) {
     bias = tensorPool.getTTNNTensorAndValidate(op->bias());
   }
 
-  float epsilon = op->epsilon();
+  ::tt::target::ttnn::LayerNormOpT layerNormOpNative;
+  op->UnPackTo(&layerNormOpNative);
 
-  // Handle optional memory config
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  // Call TTNN layer norm operation
-  ::ttnn::Tensor output =
-      ::ttnn::layer_norm(input, epsilon, weight, bias,
-                         /*residual_input_tensor=*/std::nullopt, memoryConfig,
-                         /*program_config=*/std::nullopt);
+  ttnn_op_invoke::LayerNormOpResult result = ttnn_op_invoke::callLayerNorm(
+      ttnn_op_invoke::CallType::EXECUTE, layerNormOpNative, &input,
+      weight.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*weight)
+                         : std::nullopt,
+      bias.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*bias)
+                       : std::nullopt,
+      &targetDevice);
 
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callLayerNorm execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::layer_norm

--- a/runtime/lib/ttnn/operations/normalization/layer_norm_post_all_gather.cpp
+++ b/runtime/lib/ttnn/operations/normalization/layer_norm_post_all_gather.cpp
@@ -3,10 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/normalization/layer_norm_post_all_gather.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-
-#include "ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/LayerNormPostAllGatherOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::layer_norm_post_all_gather {
 void run(const ::tt::target::ttnn::LayerNormPostAllGatherOp *op,
@@ -15,8 +14,6 @@ void run(const ::tt::target::ttnn::LayerNormPostAllGatherOp *op,
 
   ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->input());
   ::ttnn::Tensor &stats = tensorPool.getTTNNTensorAndValidate(op->stats());
-
-  float epsilon = op->epsilon();
 
   std::optional<::ttnn::Tensor> weight = std::nullopt;
   if (op->weight()) {
@@ -28,32 +25,26 @@ void run(const ::tt::target::ttnn::LayerNormPostAllGatherOp *op,
     bias = tensorPool.getTTNNTensorAndValidate(op->bias());
   }
 
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+  ::tt::target::ttnn::LayerNormPostAllGatherOpT layerNormPostAllGatherOpNative;
+  op->UnPackTo(&layerNormPostAllGatherOpNative);
 
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::prim::LayerNormProgramConfig> programConfig =
-      std::nullopt;
-  if (op->program_config()) {
-    programConfig = utils::createLayerNormShardedMultiCoreProgramConfig(
-        op->program_config());
-  }
+  ttnn_op_invoke::LayerNormPostAllGatherOpResult result =
+      ttnn_op_invoke::callLayerNormPostAllGather(
+          ttnn_op_invoke::CallType::EXECUTE, layerNormPostAllGatherOpNative,
+          &input, &stats,
+          weight.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*weight)
+              : std::nullopt,
+          bias.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*bias)
+                           : std::nullopt,
+          &targetDevice);
 
-  std::optional<::ttnn::DataType> dtype = std::nullopt;
-  if (op->dtype()) {
-    dtype = ttnn_op_invoke::operations::utils::toTTNNDataType(*op->dtype());
-  }
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callLayerNormPostAllGather execution");
 
-  ::ttnn::Tensor output = ::ttnn::layer_norm_post_all_gather(
-      input, stats, epsilon, weight, bias, memoryConfig, computeConfig,
-      programConfig, dtype);
-
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::layer_norm_post_all_gather

--- a/runtime/lib/ttnn/operations/normalization/layer_norm_pre_all_gather.cpp
+++ b/runtime/lib/ttnn/operations/normalization/layer_norm_pre_all_gather.cpp
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/normalization/layer_norm_pre_all_gather.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-#include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
-#include "ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/LayerNormPreAllGatherOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::layer_norm_pre_all_gather {
 void run(const ::tt::target::ttnn::LayerNormPreAllGatherOp *op,
@@ -21,35 +19,31 @@ void run(const ::tt::target::ttnn::LayerNormPreAllGatherOp *op,
     residualInput = tensorPool.getTTNNTensorAndValidate(op->residual_input());
   }
 
-  ::ttnn::DataType dtype =
-      ttnn_op_invoke::operations::utils::toTTNNDataType(op->dtype());
-
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
-
-  std::optional<::ttnn::prim::LayerNormProgramConfig> programConfig =
-      std::nullopt;
-  if (op->program_config()) {
-    programConfig = utils::createLayerNormShardedMultiCoreProgramConfig(
-        op->program_config());
-  }
-
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-
   std::optional<::ttnn::Tensor> recip = std::nullopt;
   if (op->recip()) {
     recip = tensorPool.getTTNNTensorAndValidate(op->recip());
   }
 
-  ::ttnn::Tensor output = ::ttnn::layer_norm_pre_all_gather(
-      input, dtype, residualInput, computeConfig, programConfig, memoryConfig,
-      recip);
+  ::tt::target::ttnn::LayerNormPreAllGatherOpT layerNormPreAllGatherOpNative;
+  op->UnPackTo(&layerNormPreAllGatherOpNative);
 
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::LayerNormPreAllGatherOpResult result =
+      ttnn_op_invoke::callLayerNormPreAllGather(
+          ttnn_op_invoke::CallType::EXECUTE, layerNormPreAllGatherOpNative,
+          &input,
+          residualInput.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*residualInput)
+              : std::nullopt,
+          recip.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*recip)
+                            : std::nullopt,
+          &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callLayerNormPreAllGather execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::layer_norm_pre_all_gather

--- a/runtime/lib/ttnn/operations/normalization/rms_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/rms_norm.cpp
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/normalization/rms_norm.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/RMSNormOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::rms_norm {
 void run(const ::tt::target::ttnn::RMSNormOp *op, ProgramContext &context) {
@@ -23,28 +24,23 @@ void run(const ::tt::target::ttnn::RMSNormOp *op, ProgramContext &context) {
     bias = tensorPool.getTTNNTensorAndValidate(op->bias());
   }
 
-  float epsilon = op->epsilon();
+  ::tt::target::ttnn::RMSNormOpT rmsNormOpNative;
+  op->UnPackTo(&rmsNormOpNative);
 
-  // Handle optional memory config
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ttnn_op_invoke::RMSNormOpResult result = ttnn_op_invoke::callRMSNorm(
+      ttnn_op_invoke::CallType::EXECUTE, rmsNormOpNative, &input,
+      weight.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*weight)
+                         : std::nullopt,
+      bias.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*bias)
+                       : std::nullopt,
+      &targetDevice);
 
-  // Call TTNN RMS norm operation
-  ::ttnn::Tensor output = ::ttnn::rms_norm(
-      input, epsilon, weight, bias,
-      /*residual_input_tensor=*/std::nullopt, // Not used in our implementation
-      memoryConfig,
-      /*program_config=*/std::nullopt,        // Use default
-      /*compute_kernel_config=*/computeConfig // Use default
-  );
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callRMSNorm execution");
 
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::rms_norm

--- a/runtime/lib/ttnn/operations/normalization/rms_norm_pre_all_gather.cpp
+++ b/runtime/lib/ttnn/operations/normalization/rms_norm_pre_all_gather.cpp
@@ -3,51 +3,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/normalization/rms_norm_pre_all_gather.h"
-#include "tt/runtime/detail/common/common.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-
-#include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
-#include "ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/RMSNormPreAllGatherOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::rms_norm_pre_all_gather {
+
 void run(const ::tt::target::ttnn::RMSNormPreAllGatherOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
   ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->input());
 
-  std::optional<::ttnn::Tensor> residual = std::nullopt;
+  std::optional<::ttnn::Tensor> residual;
   if (op->residual()) {
-    residual = tensorPool.getTTNNTensorAndValidate(op->residual());
+    residual.emplace(tensorPool.getTTNNTensorAndValidate(op->residual()));
   }
 
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+  ::tt::target::ttnn::RMSNormPreAllGatherOpT rmsNormPreAllGatherOpNative;
+  op->UnPackTo(&rmsNormPreAllGatherOpNative);
 
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::prim::LayerNormProgramConfig programConfig;
-  if (op->program_config()) {
-    programConfig = utils::createLayerNormShardedMultiCoreProgramConfig(
-        op->program_config());
-  }
+  ttnn_op_invoke::RMSNormPreAllGatherOpResult result =
+      ttnn_op_invoke::callRMSNormPreAllGather(
+          ttnn_op_invoke::CallType::EXECUTE, rmsNormPreAllGatherOpNative,
+          &input,
+          residual.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*residual)
+              : std::nullopt,
+          &targetDevice);
 
-  bool use2DCoreGrid = op->use_2d_core_grid();
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callRMSNormPreAllGather execution");
 
-  ::ttnn::DataType dtype =
-      ttnn_op_invoke::operations::utils::toTTNNDataType(op->dtype());
-
-  // Call TTNN RMS Norm Pre all-gather Op
-  ::ttnn::Tensor output = ::ttnn::rms_norm_pre_all_gather(
-      input, dtype, residual, computeConfig, programConfig, memoryConfig,
-      use2DCoreGrid);
-
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
+
 } // namespace tt::runtime::ttnn::operations::rms_norm_pre_all_gather

--- a/runtime/lib/ttnn/operations/normalization/softmax.cpp
+++ b/runtime/lib/ttnn/operations/normalization/softmax.cpp
@@ -4,34 +4,26 @@
 
 #include "operations/normalization/softmax.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Normalization/SoftmaxOp.h"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::normalization {
 void run(const ::tt::target::ttnn::SoftmaxOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  int32_t dimension = op->dimension();
-  bool numericStable = op->numeric_stable();
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  ::tt::target::ttnn::SoftmaxOpT softmaxOpNative;
+  op->UnPackTo(&softmaxOpNative);
 
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::Tensor out = ::ttnn::softmax(in, dimension, outputMemoryConfig,
-                                       computeConfig, numericStable);
+  ttnn_op_invoke::SoftmaxOpResult result = ttnn_op_invoke::callSoftmax(
+      ttnn_op_invoke::CallType::EXECUTE, softmaxOpNative, &in, &targetDevice);
 
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callSoftmax execution");
+
+  ::ttnn::Tensor out = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::normalization

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -105,14 +105,11 @@ createSDPAProgramConfig(const ::tt::target::ttnn::SDPAConfig *config) {
 ::ttnn::prim::LayerNormProgramConfig
 createLayerNormShardedMultiCoreProgramConfig(
     const ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfig *config) {
-  const auto *gridSize = config->compute_with_storage_grid_size();
-  return ::ttnn::prim::LayerNormShardedMultiCoreProgramConfig{
-      .compute_with_storage_grid_size = {gridSize->x(), gridSize->y()},
-      .subblock_w = config->subblock_w(),
-      .block_h = config->block_h(),
-      .block_w = config->block_w(),
-      .inplace = config->inplace(),
-  };
+  ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfigT
+      layerNormConfigNative;
+  config->UnPackTo(&layerNormConfigNative);
+  return ttnn_op_invoke::operations::utils::
+      createLayerNormShardedMultiCoreProgramConfig(layerNormConfigNative);
 }
 
 template <typename T>

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
@@ -4071,4 +4071,970 @@ INSTANTIATE_TEST_SUITE_P(NLPConcatHeadsDecodeOpTPathParityTest,
                          NLPConcatHeadsDecodeOpTPathParityTest,
                          ::testing::ValuesIn(nlpConcatHeadsDecodeOpList));
 
+//===----------------------------------------------------------------------===//
+// BatchNormInferenceOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::BatchNormInferenceOpT &opNativeOpModel,
+    ::tt::target::ttnn::BatchNormInferenceOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::BatchNormInferenceOpT &op) {
+    op.input.reset();
+    op.running_mean.reset();
+    op.running_var.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.out.reset();
+    op.memory_config.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::BatchNormInferenceOp buildTestBatchNormInferenceOp(
+    mlir::FloatAttr epsilon = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value input = makeOnes();
+  mlir::Value runningMean = makeOnes();
+  mlir::Value runningVar = makeOnes();
+  mlir::Value weight = makeOnes();
+  mlir::Value bias = makeOnes();
+
+  llvm::APFloat epsilonVal(1e-5f);
+  if (epsilon) {
+    epsilonVal = epsilon.getValue();
+  }
+
+  return e.builder.create<mlir::tt::ttnn::BatchNormInferenceOp>(
+      loc, tensorType, input, runningMean, runningVar, epsilonVal, weight, bias,
+      computeConfig);
+}
+
+} // namespace
+
+using BatchNormInferenceOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::BatchNormInferenceOp>;
+
+TEST_P(BatchNormInferenceOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::BatchNormInferenceOp bnOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::BatchNormInferenceOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildBatchNormInferenceOpTFromMLIR(
+          bnOp.getEpsilon(), bnOp.getComputeConfig(),
+          resolveOutputLayout(bnOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, bnOp.getInput(), bnOp.getRunningMean(),
+                               bnOp.getRunningVar(), bnOp.getWeight(),
+                               bnOp.getBias());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, bnOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::BatchNormInferenceOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::BatchNormInferenceOp>
+    batchNormInferenceOpList = {
+        buildTestBatchNormInferenceOp(),
+        buildTestBatchNormInferenceOp(
+            /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-3f)),
+        buildTestBatchNormInferenceOp(
+            /*epsilon=*/{},
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestBatchNormInferenceOp(
+            /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-3f),
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(BatchNormInferenceOpTPathParityTest,
+                         BatchNormInferenceOpTPathParityTest,
+                         ::testing::ValuesIn(batchNormInferenceOpList));
+
+//===----------------------------------------------------------------------===//
+// BatchNormTrainingOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::BatchNormTrainingOpT &opNativeOpModel,
+    ::tt::target::ttnn::BatchNormTrainingOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::BatchNormTrainingOpT &op) {
+    op.input.reset();
+    op.running_mean.reset();
+    op.running_var.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.out.reset();
+    op.memory_config.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::BatchNormTrainingOp buildTestBatchNormTrainingOp(
+    mlir::FloatAttr epsilon = {}, mlir::FloatAttr momentum = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value input = makeOnes();
+  mlir::Value runningMean = makeOnes();
+  mlir::Value runningVar = makeOnes();
+  mlir::Value weight = makeOnes();
+  mlir::Value bias = makeOnes();
+
+  llvm::APFloat epsilonVal(1e-5f);
+  if (epsilon) {
+    epsilonVal = epsilon.getValue();
+  }
+  llvm::APFloat momentumVal(0.1f);
+  if (momentum) {
+    momentumVal = momentum.getValue();
+  }
+
+  return e.builder.create<mlir::tt::ttnn::BatchNormTrainingOp>(
+      loc, tensorType, input, runningMean, runningVar, epsilonVal, momentumVal,
+      weight, bias, computeConfig);
+}
+
+} // namespace
+
+using BatchNormTrainingOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::BatchNormTrainingOp>;
+
+TEST_P(BatchNormTrainingOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::BatchNormTrainingOp bnOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::BatchNormTrainingOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildBatchNormTrainingOpTFromMLIR(
+          bnOp.getEpsilon(), bnOp.getMomentum(), bnOp.getComputeConfig(),
+          resolveOutputLayout(bnOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, bnOp.getInput(), bnOp.getRunningMean(),
+                               bnOp.getRunningVar(), bnOp.getWeight(),
+                               bnOp.getBias());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, bnOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::BatchNormTrainingOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::BatchNormTrainingOp>
+    batchNormTrainingOpList = {
+        buildTestBatchNormTrainingOp(),
+        buildTestBatchNormTrainingOp(
+            /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-3f)),
+        buildTestBatchNormTrainingOp(
+            /*epsilon=*/{},
+            /*momentum=*/mlir::Builder(getContext()).getF32FloatAttr(0.01f)),
+        buildTestBatchNormTrainingOp(
+            /*epsilon=*/{}, /*momentum=*/{},
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestBatchNormTrainingOp(
+            /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-3f),
+            /*momentum=*/mlir::Builder(getContext()).getF32FloatAttr(0.01f),
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(BatchNormTrainingOpTPathParityTest,
+                         BatchNormTrainingOpTPathParityTest,
+                         ::testing::ValuesIn(batchNormTrainingOpList));
+
+//===----------------------------------------------------------------------===//
+// GroupNormOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::GroupNormOpT &opNativeOpModel,
+                       ::tt::target::ttnn::GroupNormOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::GroupNormOpT &op) {
+    op.input.reset();
+    op.input_mask.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.out.reset();
+    op.memory_config.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::GroupNormOp buildTestGroupNormOp(bool withInputMask = false,
+                                                 bool withWeight = false,
+                                                 bool withBias = false,
+                                                 uint64_t numGroups = 4u,
+                                                 mlir::FloatAttr epsilon = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value input = makeOnes();
+  mlir::Value inputMask = withInputMask ? makeOnes() : mlir::Value();
+  mlir::Value weight = withWeight ? makeOnes() : mlir::Value();
+  mlir::Value bias = withBias ? makeOnes() : mlir::Value();
+
+  llvm::APFloat epsilonVal(1e-12f);
+  if (epsilon) {
+    epsilonVal = epsilon.getValue();
+  }
+
+  return e.builder.create<mlir::tt::ttnn::GroupNormOp>(
+      loc, tensorType, input, inputMask, weight, bias, numGroups, epsilonVal);
+}
+
+} // namespace
+
+using GroupNormOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::GroupNormOp>;
+
+TEST_P(GroupNormOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::GroupNormOp gnOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::GroupNormOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildGroupNormOpTFromMLIR(
+          static_cast<int64_t>(gnOp.getNumGroups()), gnOp.getEpsilon(),
+          resolveOutputLayout(gnOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, gnOp.getInput());
+  if (gnOp.getInputMask()) {
+    prepopulateOperandTensorRefs(cache, gnOp.getInputMask());
+  }
+  if (gnOp.getWeight()) {
+    prepopulateOperandTensorRefs(cache, gnOp.getWeight());
+  }
+  if (gnOp.getBias()) {
+    prepopulateOperandTensorRefs(cache, gnOp.getBias());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, gnOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::GroupNormOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::GroupNormOp> groupNormOpList = {
+    buildTestGroupNormOp(),
+    buildTestGroupNormOp(/*withInputMask=*/true),
+    buildTestGroupNormOp(/*withInputMask=*/false, /*withWeight=*/true),
+    buildTestGroupNormOp(/*withInputMask=*/false, /*withWeight=*/false,
+                         /*withBias=*/true),
+    buildTestGroupNormOp(/*withInputMask=*/false, /*withWeight=*/false,
+                         /*withBias=*/false, /*numGroups=*/8u),
+    buildTestGroupNormOp(
+        /*withInputMask=*/false, /*withWeight=*/false, /*withBias=*/false,
+        /*numGroups=*/4u,
+        /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-6f)),
+    buildTestGroupNormOp(
+        /*withInputMask=*/true, /*withWeight=*/true, /*withBias=*/true,
+        /*numGroups=*/8u,
+        /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-6f)),
+};
+
+INSTANTIATE_TEST_SUITE_P(GroupNormOpTPathParityTest, GroupNormOpTPathParityTest,
+                         ::testing::ValuesIn(groupNormOpList));
+
+//===----------------------------------------------------------------------===//
+// LayerNormPostAllGatherOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+const mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr
+    nonDefaultLayerNormProgramConfigAttr =
+        mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr::get(
+            getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(getContext(), 8, 8),
+            /*subblock_w=*/1u, /*block_h=*/4u, /*block_w=*/4u,
+            /*inplace=*/false);
+
+void resetUnusedFields(
+    ::tt::target::ttnn::LayerNormPostAllGatherOpT &opNativeOpModel,
+    ::tt::target::ttnn::LayerNormPostAllGatherOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::LayerNormPostAllGatherOpT &op) {
+    op.input.reset();
+    op.stats.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.out.reset();
+    op.memory_config.reset();
+    op.dtype.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::LayerNormPostAllGatherOp buildTestLayerNormPostAllGatherOp(
+    bool withWeight = false, bool withBias = false,
+    mlir::FloatAttr epsilon = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {},
+    mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr programConfig =
+        {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value input = makeOnes();
+  mlir::Value stats = makeOnes();
+  mlir::Value weight = withWeight ? makeOnes() : mlir::Value();
+  mlir::Value bias = withBias ? makeOnes() : mlir::Value();
+
+  llvm::APFloat epsilonVal(1e-12f);
+  if (epsilon) {
+    epsilonVal = epsilon.getValue();
+  }
+
+  return e.builder.create<mlir::tt::ttnn::LayerNormPostAllGatherOp>(
+      loc, tensorType, input, stats, weight, bias, epsilonVal, computeConfig,
+      programConfig);
+}
+
+} // namespace
+
+using LayerNormPostAllGatherOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::LayerNormPostAllGatherOp>;
+
+TEST_P(LayerNormPostAllGatherOpTPathParityTest,
+       BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::LayerNormPostAllGatherOp lnOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::LayerNormPostAllGatherOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildLayerNormPostAllGatherOpTFromMLIR(
+          lnOp.getEpsilon(), lnOp.getComputeConfig(), lnOp.getProgramConfig(),
+          resolveOutputLayout(lnOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, lnOp.getInput(), lnOp.getStats());
+  if (lnOp.getWeight()) {
+    prepopulateOperandTensorRefs(cache, lnOp.getWeight());
+  }
+  if (lnOp.getBias()) {
+    prepopulateOperandTensorRefs(cache, lnOp.getBias());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, lnOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::LayerNormPostAllGatherOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::LayerNormPostAllGatherOp>
+    layerNormPostAllGatherOpList = {
+        buildTestLayerNormPostAllGatherOp(),
+        buildTestLayerNormPostAllGatherOp(/*withWeight=*/true),
+        buildTestLayerNormPostAllGatherOp(/*withWeight=*/false,
+                                          /*withBias=*/true),
+        buildTestLayerNormPostAllGatherOp(
+            /*withWeight=*/false, /*withBias=*/false,
+            /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-6f)),
+        buildTestLayerNormPostAllGatherOp(
+            /*withWeight=*/false, /*withBias=*/false, /*epsilon=*/{},
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestLayerNormPostAllGatherOp(
+            /*withWeight=*/false, /*withBias=*/false, /*epsilon=*/{},
+            /*computeConfig=*/{},
+            /*programConfig=*/nonDefaultLayerNormProgramConfigAttr),
+        buildTestLayerNormPostAllGatherOp(
+            /*withWeight=*/true, /*withBias=*/true,
+            /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-6f),
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr,
+            /*programConfig=*/nonDefaultLayerNormProgramConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(LayerNormPostAllGatherOpTPathParityTest,
+                         LayerNormPostAllGatherOpTPathParityTest,
+                         ::testing::ValuesIn(layerNormPostAllGatherOpList));
+
+//===----------------------------------------------------------------------===//
+// LayerNormPreAllGatherOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::LayerNormPreAllGatherOpT &opNativeOpModel,
+    ::tt::target::ttnn::LayerNormPreAllGatherOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::LayerNormPreAllGatherOpT &op) {
+    op.input.reset();
+    op.residual_input.reset();
+    op.recip.reset();
+    op.out.reset();
+    op.memory_config.reset();
+    op.dtype = tt::target::DataType::BFloat16;
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::LayerNormPreAllGatherOp buildTestLayerNormPreAllGatherOp(
+    bool withResidualInput = false, bool withRecip = false,
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {},
+    mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr programConfig =
+        {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value input = makeOnes();
+  mlir::Value residualInput = withResidualInput ? makeOnes() : mlir::Value();
+  mlir::Value recip = withRecip ? makeOnes() : mlir::Value();
+
+  return e.builder.create<mlir::tt::ttnn::LayerNormPreAllGatherOp>(
+      loc, tensorType, input, residualInput, recip, computeConfig,
+      programConfig);
+}
+
+} // namespace
+
+using LayerNormPreAllGatherOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::LayerNormPreAllGatherOp>;
+
+TEST_P(LayerNormPreAllGatherOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::LayerNormPreAllGatherOp lnOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::LayerNormPreAllGatherOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildLayerNormPreAllGatherOpTFromMLIR(
+          lnOp.getComputeConfig(), lnOp.getProgramConfig(),
+          resolveOutputLayout(lnOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, lnOp.getInput());
+  if (lnOp.getResidualInput()) {
+    prepopulateOperandTensorRefs(cache, lnOp.getResidualInput());
+  }
+  if (lnOp.getRecip()) {
+    prepopulateOperandTensorRefs(cache, lnOp.getRecip());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, lnOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::LayerNormPreAllGatherOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::LayerNormPreAllGatherOp>
+    layerNormPreAllGatherOpList = {
+        buildTestLayerNormPreAllGatherOp(),
+        buildTestLayerNormPreAllGatherOp(/*withResidualInput=*/true),
+        buildTestLayerNormPreAllGatherOp(/*withResidualInput=*/false,
+                                         /*withRecip=*/true),
+        buildTestLayerNormPreAllGatherOp(
+            /*withResidualInput=*/false, /*withRecip=*/false,
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestLayerNormPreAllGatherOp(
+            /*withResidualInput=*/false, /*withRecip=*/false,
+            /*computeConfig=*/{},
+            /*programConfig=*/nonDefaultLayerNormProgramConfigAttr),
+        buildTestLayerNormPreAllGatherOp(
+            /*withResidualInput=*/true, /*withRecip=*/true,
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr,
+            /*programConfig=*/nonDefaultLayerNormProgramConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(LayerNormPreAllGatherOpTPathParityTest,
+                         LayerNormPreAllGatherOpTPathParityTest,
+                         ::testing::ValuesIn(layerNormPreAllGatherOpList));
+
+//===----------------------------------------------------------------------===//
+// LayerNormOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::LayerNormOpT &opNativeOpModel,
+                       ::tt::target::ttnn::LayerNormOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::LayerNormOpT &op) {
+    op.input.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.out.reset();
+    op.memory_config.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::LayerNormOp buildTestLayerNormOp(bool withWeight = false,
+                                                 bool withBias = false,
+                                                 mlir::FloatAttr epsilon = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value input = makeOnes();
+  mlir::Value weight = withWeight ? makeOnes() : mlir::Value();
+  mlir::Value bias = withBias ? makeOnes() : mlir::Value();
+
+  llvm::APFloat epsilonVal(1e-12f);
+  if (epsilon) {
+    epsilonVal = epsilon.getValue();
+  }
+
+  return e.builder.create<mlir::tt::ttnn::LayerNormOp>(
+      loc, tensorType, input, weight, bias, epsilonVal);
+}
+
+} // namespace
+
+using LayerNormOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::LayerNormOp>;
+
+TEST_P(LayerNormOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::LayerNormOp lnOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::LayerNormOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildLayerNormOpTFromMLIR(
+          lnOp.getEpsilon(), resolveOutputLayout(lnOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, lnOp.getInput());
+  if (lnOp.getWeight()) {
+    prepopulateOperandTensorRefs(cache, lnOp.getWeight());
+  }
+  if (lnOp.getBias()) {
+    prepopulateOperandTensorRefs(cache, lnOp.getBias());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, lnOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::LayerNormOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::LayerNormOp> layerNormOpList = {
+    buildTestLayerNormOp(),
+    buildTestLayerNormOp(/*withWeight=*/true),
+    buildTestLayerNormOp(/*withWeight=*/false, /*withBias=*/true),
+    buildTestLayerNormOp(
+        /*withWeight=*/false, /*withBias=*/false,
+        /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-6f)),
+    buildTestLayerNormOp(
+        /*withWeight=*/true, /*withBias=*/true,
+        /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-6f)),
+};
+
+INSTANTIATE_TEST_SUITE_P(LayerNormOpTPathParityTest, LayerNormOpTPathParityTest,
+                         ::testing::ValuesIn(layerNormOpList));
+
+//===----------------------------------------------------------------------===//
+// RMSNormPreAllGatherOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::RMSNormPreAllGatherOpT &opNativeOpModel,
+    ::tt::target::ttnn::RMSNormPreAllGatherOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::RMSNormPreAllGatherOpT &op) {
+    op.input.reset();
+    op.residual.reset();
+    op.out.reset();
+    op.memory_config.reset();
+    op.dtype = ::tt::target::DataType::Float32;
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::RMSNormPreAllGatherOp buildTestRMSNormPreAllGatherOp(
+    bool withResidual = false,
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {},
+    mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr programConfig =
+        {},
+    mlir::BoolAttr use2dCoreGrid = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value input = makeOnes();
+  mlir::Value residual = withResidual ? makeOnes() : mlir::Value();
+
+  return e.builder.create<mlir::tt::ttnn::RMSNormPreAllGatherOp>(
+      loc, tensorType, input, residual, computeConfig, programConfig,
+      use2dCoreGrid);
+}
+
+} // namespace
+
+using RMSNormPreAllGatherOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::RMSNormPreAllGatherOp>;
+
+TEST_P(RMSNormPreAllGatherOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::RMSNormPreAllGatherOp rmsOp = GetParam();
+
+  std::optional<bool> use2dCoreGridOpt;
+  if (rmsOp.getUse_2dCoreGrid().has_value()) {
+    use2dCoreGridOpt = rmsOp.getUse_2dCoreGrid().value();
+  }
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::RMSNormPreAllGatherOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildRMSNormPreAllGatherOpTFromMLIR(
+          rmsOp.getComputeConfig(), rmsOp.getProgramConfig(), use2dCoreGridOpt,
+          resolveOutputLayout(rmsOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, rmsOp.getInput());
+  if (rmsOp.getResidual()) {
+    prepopulateOperandTensorRefs(cache, rmsOp.getResidual());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, rmsOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::RMSNormPreAllGatherOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::RMSNormPreAllGatherOp>
+    rmsNormPreAllGatherOpList = {
+        buildTestRMSNormPreAllGatherOp(),
+        buildTestRMSNormPreAllGatherOp(/*withResidual=*/true),
+        buildTestRMSNormPreAllGatherOp(
+            /*withResidual=*/false,
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+        buildTestRMSNormPreAllGatherOp(
+            /*withResidual=*/false, /*computeConfig=*/{},
+            /*programConfig=*/nonDefaultLayerNormProgramConfigAttr),
+        buildTestRMSNormPreAllGatherOp(
+            /*withResidual=*/false, /*computeConfig=*/{}, /*programConfig=*/{},
+            /*use2dCoreGrid=*/mlir::BoolAttr::get(getContext(), true)),
+        buildTestRMSNormPreAllGatherOp(
+            /*withResidual=*/true,
+            /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr,
+            /*programConfig=*/nonDefaultLayerNormProgramConfigAttr,
+            /*use2dCoreGrid=*/mlir::BoolAttr::get(getContext(), true)),
+};
+
+INSTANTIATE_TEST_SUITE_P(RMSNormPreAllGatherOpTPathParityTest,
+                         RMSNormPreAllGatherOpTPathParityTest,
+                         ::testing::ValuesIn(rmsNormPreAllGatherOpList));
+
+//===----------------------------------------------------------------------===//
+// RMSNormOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::RMSNormOpT &opNativeOpModel,
+                       ::tt::target::ttnn::RMSNormOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::RMSNormOpT &op) {
+    op.input.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.out.reset();
+    op.memory_config.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::RMSNormOp buildTestRMSNormOp(
+    bool withWeight = false, bool withBias = false,
+    mlir::FloatAttr epsilon = {},
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value input = makeOnes();
+  mlir::Value weight = withWeight ? makeOnes() : mlir::Value();
+  mlir::Value bias = withBias ? makeOnes() : mlir::Value();
+
+  llvm::APFloat epsilonVal(1e-12f);
+  if (epsilon) {
+    epsilonVal = epsilon.getValue();
+  }
+
+  return e.builder.create<mlir::tt::ttnn::RMSNormOp>(
+      loc, tensorType, input, weight, bias, epsilonVal, computeConfig);
+}
+
+} // namespace
+
+using RMSNormOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::RMSNormOp>;
+
+TEST_P(RMSNormOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::RMSNormOp rmsOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::RMSNormOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildRMSNormOpTFromMLIR(
+          rmsOp.getEpsilon(), rmsOp.getComputeConfig(),
+          resolveOutputLayout(rmsOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, rmsOp.getInput());
+  if (rmsOp.getWeight()) {
+    prepopulateOperandTensorRefs(cache, rmsOp.getWeight());
+  }
+  if (rmsOp.getBias()) {
+    prepopulateOperandTensorRefs(cache, rmsOp.getBias());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, rmsOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::RMSNormOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::RMSNormOp> rmsNormOpList = {
+    buildTestRMSNormOp(),
+    buildTestRMSNormOp(/*withWeight=*/true),
+    buildTestRMSNormOp(/*withWeight=*/false, /*withBias=*/true),
+    buildTestRMSNormOp(
+        /*withWeight=*/false, /*withBias=*/false,
+        /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-6f)),
+    buildTestRMSNormOp(
+        /*withWeight=*/false, /*withBias=*/false, /*epsilon=*/{},
+        /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+    buildTestRMSNormOp(
+        /*withWeight=*/true, /*withBias=*/true,
+        /*epsilon=*/mlir::Builder(getContext()).getF32FloatAttr(1e-6f),
+        /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(RMSNormOpTPathParityTest, RMSNormOpTPathParityTest,
+                         ::testing::ValuesIn(rmsNormOpList));
+
+//===----------------------------------------------------------------------===//
+// SoftmaxOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::SoftmaxOpT &opNativeOpModel,
+                       ::tt::target::ttnn::SoftmaxOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::SoftmaxOpT &op) {
+    op.in.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::SoftmaxOp buildTestSoftmaxOp(
+    int32_t dimension = -1, bool numericStable = false,
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  mlir::Value input =
+      e.builder
+          .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                          mlir::ValueRange{})
+          .getResult();
+
+  return e.builder.create<mlir::tt::ttnn::SoftmaxOp>(
+      loc, tensorType, input, dimension, numericStable, computeConfig);
+}
+
+} // namespace
+
+using SoftmaxOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::SoftmaxOp>;
+
+TEST_P(SoftmaxOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::SoftmaxOp smOp = GetParam();
+
+  std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr> computeConfig =
+      smOp.getComputeConfigAttr()
+          ? std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr>(
+                smOp.getComputeConfigAttr())
+          : std::nullopt;
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::SoftmaxOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildSoftmaxOpTFromMLIR(
+          smOp.getDimension(), smOp.getNumericStable(), computeConfig,
+          resolveOutputLayout(smOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, smOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createSoftmaxOp(cache, smOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::SoftmaxOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::SoftmaxOp> softmaxOpList = {
+    buildTestSoftmaxOp(),
+    buildTestSoftmaxOp(/*dimension=*/-2),
+    buildTestSoftmaxOp(/*dimension=*/-1, /*numericStable=*/true),
+    buildTestSoftmaxOp(
+        /*dimension=*/-1, /*numericStable=*/false,
+        /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+    buildTestSoftmaxOp(
+        /*dimension=*/-2, /*numericStable=*/true,
+        /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(SoftmaxOpTPathParityTest, SoftmaxOpTPathParityTest,
+                         ::testing::ValuesIn(softmaxOpList));
+
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/test/unittests/MLIRAttrToFBNative/ToNativeConsistency.cpp
+++ b/test/unittests/MLIRAttrToFBNative/ToNativeConsistency.cpp
@@ -711,3 +711,41 @@ const std::initializer_list<mlir::tt::ttnn::SDPAProgramConfigAttr>
 
 INSTANTIATE_TEST_SUITE_P(SDPAProgramConfigTest, SDPAProgramConfigTest,
                          ::testing::ValuesIn(sdpaProgramConfigAttrList));
+
+//===----------------------------------------------------------------------===//
+// LayerNormShardedMultiCoreProgramConfig
+//===----------------------------------------------------------------------===//
+
+class LayerNormShardedMultiCoreProgramConfigTest
+    : public ToNativeConsistencyTest<
+          mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr,
+          ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfigT> {};
+
+TEST_P(LayerNormShardedMultiCoreProgramConfigTest,
+       LayerNormShardedMultiCoreProgramConfig) {
+  RunTest(GetParam());
+}
+
+const std::initializer_list<
+    mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr>
+    layerNormShardedMultiCoreProgramConfigAttrList = {
+        mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr::get(
+            LayerNormShardedMultiCoreProgramConfigTest::getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(
+                LayerNormShardedMultiCoreProgramConfigTest::getContext(), 8, 8),
+            1, 4, 4, false),
+        mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr::get(
+            LayerNormShardedMultiCoreProgramConfigTest::getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(
+                LayerNormShardedMultiCoreProgramConfigTest::getContext(), 4, 4),
+            1, 2, 8, true),
+        mlir::tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr::get(
+            LayerNormShardedMultiCoreProgramConfigTest::getContext(),
+            mlir::tt::ttnn::CoreCoordAttr::get(
+                LayerNormShardedMultiCoreProgramConfigTest::getContext(), 1, 1),
+            1, 1, 1, false)};
+
+INSTANTIATE_TEST_SUITE_P(
+    LayerNormShardedMultiCoreProgramConfigTest,
+    LayerNormShardedMultiCoreProgramConfigTest,
+    ::testing::ValuesIn(layerNormShardedMultiCoreProgramConfigAttrList));

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -545,8 +545,16 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   const TTNNLayoutAttr inputLayout_l1 = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
+          /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+          /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+          /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+          /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
+
   auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      tensorShape, inputLayout_dram, -1, false, inputLayout_dram);
+      tensorShape, inputLayout_dram, -1, false, deviceConfig, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
       constraintsExp.get();
@@ -555,7 +563,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   EXPECT_EQ(l1PeakSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      tensorShape, inputLayout_dram, -1, false, inputLayout_l1);
+      tensorShape, inputLayout_dram, -1, false, deviceConfig, inputLayout_l1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -563,7 +571,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      tensorShape, inputLayout_l1, -1, false, inputLayout_dram);
+      tensorShape, inputLayout_l1, -1, false, deviceConfig, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -571,7 +579,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      tensorShape, inputLayout_l1, -1, false, inputLayout_l1);
+      tensorShape, inputLayout_l1, -1, false, deviceConfig, inputLayout_l1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -579,7 +587,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      tensorShape, inputLayout_dram, -1, false, inputLayout_dram);
+      tensorShape, inputLayout_dram, -1, false, deviceConfig, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -593,7 +601,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
        {inputLayout_l1, inputLayout_l1}};
   for (const auto &[input_layout, output_layout] : layout_combinations) {
     auto runtimeExp = OpModel<SoftmaxOp>::getOpRuntime(
-        tensorShape, input_layout, -1, false, output_layout);
+        tensorShape, input_layout, -1, false, deviceConfig, output_layout);
     EXPECT_TRUE(static_cast<bool>(runtimeExp));
     EXPECT_TRUE(runtimeExp.get() > 0);
   }
@@ -604,12 +612,20 @@ TEST_F(OpModelTest, SoftmaxNumericStable) {
   const TTNNLayoutAttr inputLayout_dram = CreateTiledLayout(
       tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
+          /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+          /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+          /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+          /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
+
   auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      tensorShape, inputLayout_dram, -1, true, inputLayout_dram);
+      tensorShape, inputLayout_dram, -1, true, deviceConfig, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
 
   auto runtimeExp = OpModel<SoftmaxOp>::getOpRuntime(
-      tensorShape, inputLayout_dram, -1, true, inputLayout_dram);
+      tensorShape, inputLayout_dram, -1, true, deviceConfig, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
@@ -1627,8 +1643,17 @@ TEST_F(OpModelTest, SoftmaxSharded) {
   const TTNNLayoutAttr inputLayout_l1_i = CreateTiledLayout(
       tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
+          /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+          /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+          /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+          /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
+
   auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      tensorShape, inputLayout_l1_hs, -2, false, inputLayout_l1_hs);
+      tensorShape, inputLayout_l1_hs, -2, false, deviceConfig,
+      inputLayout_l1_hs);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1636,7 +1661,8 @@ TEST_F(OpModelTest, SoftmaxSharded) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      tensorShape, inputLayout_l1_hs, -2, false, inputLayout_l1_i);
+      tensorShape, inputLayout_l1_hs, -2, false, deviceConfig,
+      inputLayout_l1_i);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -1644,15 +1670,17 @@ TEST_F(OpModelTest, SoftmaxSharded) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
-      tensorShape, inputLayout_l1_i, -2, false, inputLayout_l1_hs);
+      tensorShape, inputLayout_l1_i, -2, false, deviceConfig,
+      inputLayout_l1_hs);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
   EXPECT_GE(opCstr.tensorL1PeakSize, 0);
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
-  auto runtimeExp = OpModel<SoftmaxOp>::getOpRuntime(
-      tensorShape, inputLayout_l1_i, -2, false, inputLayout_l1_hs);
+  auto runtimeExp =
+      OpModel<SoftmaxOp>::getOpRuntime(tensorShape, inputLayout_l1_i, -2, false,
+                                       deviceConfig, inputLayout_l1_hs);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
@@ -4188,17 +4216,26 @@ TEST_P(OpModelBatchNormParam, BatchNormParam) {
     biasLayout = CreateTiledLayout(shape, bufferType, layout, virtualGrid);
   }
 
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
+          /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+          /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+          /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+          /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
+
   // Test getOpConstraints
   llvm::Expected<OpConstraints> constraintsExp =
       training
           ? op_model::OpModel<BatchNormTrainingOp>::getOpConstraints(
                 inputShape, inputLayout, runningMeanShape, runningMeanLayout,
                 runningVarShape, runningVarLayout, weightShape, weightLayout,
-                biasShape, biasLayout, epsilon, momentum, outputLayout)
+                biasShape, biasLayout, epsilon, momentum, deviceConfig,
+                outputLayout)
           : op_model::OpModel<BatchNormInferenceOp>::getOpConstraints(
                 inputShape, inputLayout, runningMeanShape, runningMeanLayout,
                 runningVarShape, runningVarLayout, weightShape, weightLayout,
-                biasShape, biasLayout, epsilon, outputLayout);
+                biasShape, biasLayout, epsilon, deviceConfig, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -4218,11 +4255,12 @@ TEST_P(OpModelBatchNormParam, BatchNormParam) {
           ? op_model::OpModel<BatchNormTrainingOp>::getOpRuntime(
                 inputShape, inputLayout, runningMeanShape, runningMeanLayout,
                 runningVarShape, runningVarLayout, weightShape, weightLayout,
-                biasShape, biasLayout, epsilon, momentum, outputLayout)
+                biasShape, biasLayout, epsilon, momentum, deviceConfig,
+                outputLayout)
           : op_model::OpModel<BatchNormInferenceOp>::getOpRuntime(
                 inputShape, inputLayout, runningMeanShape, runningMeanLayout,
                 runningVarShape, runningVarLayout, weightShape, weightLayout,
-                biasShape, biasLayout, epsilon, outputLayout);
+                biasShape, biasLayout, epsilon, deviceConfig, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {
@@ -4495,11 +4533,25 @@ TEST_P(OpModelRMSNormPreAllGatherParam, RMSNormPreAllGatherParam) {
         CreateTiledLayout(shape, bufferType, layout, virtualGrid);
   }
 
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
+          /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+          /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+          /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+          /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
+
+  LayerNormShardedMultiCoreProgramConfigAttr programConfig =
+      LayerNormShardedMultiCoreProgramConfigAttr::get(
+          &context, CoreCoordAttr::get(&context, 8, 8),
+          /*subblock_w=*/1u, /*block_h=*/1u, /*block_w=*/4u,
+          /*inplace=*/false);
+
   // Test Constraints
   auto constraintsExp =
       op_model::OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
           inputShape, inputLayout, residualInputShape, residualInputLayout,
-          dtype, use_2d_core_grid, outputLayout);
+          dtype, use_2d_core_grid, deviceConfig, programConfig, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -4516,7 +4568,7 @@ TEST_P(OpModelRMSNormPreAllGatherParam, RMSNormPreAllGatherParam) {
   // Test Op Runtime
   auto runtimeExp = op_model::OpModel<RMSNormPreAllGatherOp>::getOpRuntime(
       inputShape, inputLayout, residualInputShape, residualInputLayout, dtype,
-      use_2d_core_grid, outputLayout);
+      use_2d_core_grid, deviceConfig, programConfig, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {
@@ -4755,11 +4807,26 @@ TEST_P(OpModelLayerNormPreAllGatherParam, LayerNormPreAllGatherParam) {
     recipLayout = CreateTiledLayout(shape, bufferType, layout, virtualGrid);
   }
 
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
+          /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+          /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+          /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+          /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
+
+  LayerNormShardedMultiCoreProgramConfigAttr programConfig =
+      LayerNormShardedMultiCoreProgramConfigAttr::get(
+          &context, CoreCoordAttr::get(&context, 8, 8),
+          /*subblock_w=*/1u, /*block_h=*/1u, /*block_w=*/4u,
+          /*inplace=*/false);
+
   // Test getOpConstraints
   auto constraintsExp =
       op_model::OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
           inputShape, inputLayout, residualInputShape, residualInputLayout,
-          recipShape, recipLayout, dtype, outputLayout);
+          recipShape, recipLayout, dtype, deviceConfig, programConfig,
+          outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -4776,7 +4843,8 @@ TEST_P(OpModelLayerNormPreAllGatherParam, LayerNormPreAllGatherParam) {
   // Test getOpRuntime
   auto runtimeExp = op_model::OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
       inputShape, inputLayout, residualInputShape, residualInputLayout,
-      recipShape, recipLayout, dtype, outputLayout);
+      recipShape, recipLayout, dtype, deviceConfig, programConfig,
+      outputLayout);
 
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {
@@ -4883,10 +4951,25 @@ TEST_P(OpModelLayerNormPostAllGatherParam, LayerNormPostAllGatherParam) {
     biasLayout = CreateTiledLayout(shape, bufferType, layout, virtualGrid);
   }
 
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
+          /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+          /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+          /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+          /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
+
+  LayerNormShardedMultiCoreProgramConfigAttr programConfig =
+      LayerNormShardedMultiCoreProgramConfigAttr::get(
+          &context, CoreCoordAttr::get(&context, 8, 8),
+          /*subblock_w=*/1u, /*block_h=*/1u, /*block_w=*/4u,
+          /*inplace=*/false);
+
   auto constraintsExp =
       op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
           inputShape, inputLayout, statsShape, statsLayout, weightShape,
-          weightLayout, biasShape, biasLayout, epsilon, outputLayout);
+          weightLayout, biasShape, biasLayout, epsilon, deviceConfig,
+          programConfig, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -4902,7 +4985,8 @@ TEST_P(OpModelLayerNormPostAllGatherParam, LayerNormPostAllGatherParam) {
 
   auto runtimeExp = op_model::OpModel<LayerNormPostAllGatherOp>::getOpRuntime(
       inputShape, inputLayout, statsShape, statsLayout, weightShape,
-      weightLayout, biasShape, biasLayout, epsilon, outputLayout);
+      weightLayout, biasShape, biasLayout, epsilon, deviceConfig, programConfig,
+      outputLayout);
 
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.

### What's changed
This is the tenth PR in the TTNNOpInvokeLib series. It introduces shared dispatch for the normalization operations across OpModel and Runtime: batch_norm, group_norm, layer_norm, layer_norm_pre_all_gather, layer_norm_post_all_gather, rms_norm, rms_norm_pre_all_gather, distributed_rms_norm, and softmax.

### Checklist
- [ ] New/Existing tests provide coverage for changes
