### PR TITLE
Data movement ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/AssignOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/AssignOp.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_ASSIGN_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_ASSIGN_OP_H
+
+#include "operations/data_movement/copy/copy.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using AssignOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct AssignResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::tt::tt_metal::DataType> outputDtype;
+};
+
+AssignResolvedParams
+resolveAssignParams(const ::tt::target::ttnn::AssignOpT &assignOp);
+
+AssignOpResult callAssign(CallType callType,
+                          const ::tt::target::ttnn::AssignOpT &assignOp,
+                          TensorArg input,
+                          ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_ASSIGN_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/ConcatOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/ConcatOp.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_CONCAT_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_CONCAT_OP_H
+
+#include "operations/data_movement/concat/concat.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+#include <vector>
+
+namespace ttnn_op_invoke {
+
+using ConcatOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct ConcatResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+ConcatResolvedParams
+resolveConcatParams(const ::tt::target::ttnn::ConcatOpT &concatOp);
+
+ConcatOpResult callConcat(CallType callType,
+                          const ::tt::target::ttnn::ConcatOpT &concatOp,
+                          std::vector<TensorArg> inputs,
+                          ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_CONCAT_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/GatherOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/GatherOp.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_GATHER_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_GATHER_OP_H
+
+#include "operations/data_movement/gather/gather.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using GatherOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct GatherResolvedParams {
+  int8_t dim;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+GatherResolvedParams
+resolveGatherParams(const ::tt::target::ttnn::GatherOpT &gatherOp);
+
+GatherOpResult callGather(CallType callType,
+                          const ::tt::target::ttnn::GatherOpT &gatherOp,
+                          TensorArg input, TensorArg index,
+                          ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_GATHER_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/PadOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/PadOp.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_PAD_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_PAD_OP_H
+
+#include "operations/data_movement/pad/pad.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PadOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PadResolvedParams {
+  ::ttsl::SmallVector<::ttnn::operations::data_movement::PadSpecDim> padding;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+PadResolvedParams resolvePadParams(const ::tt::target::ttnn::PadOpT &padOp);
+
+PadOpResult callPad(CallType callType, const ::tt::target::ttnn::PadOpT &padOp,
+                    TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_PAD_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/PermuteOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/PermuteOp.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_PERMUTE_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_PERMUTE_OP_H
+
+#include "operations/data_movement/permute/permute.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PermuteOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PermuteResolvedParams {
+  ::ttsl::SmallVector<int64_t> dims;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+PermuteResolvedParams
+resolvePermuteParams(const ::tt::target::ttnn::PermuteOpT &permuteOp);
+
+PermuteOpResult callPermute(CallType callType,
+                            const ::tt::target::ttnn::PermuteOpT &permuteOp,
+                            TensorArg input,
+                            ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_PERMUTE_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/RepeatInterleaveOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/RepeatInterleaveOp.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_REPEAT_INTERLEAVE_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_REPEAT_INTERLEAVE_OP_H
+
+#include "operations/data_movement/repeat_interleave/repeat_interleave.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using RepeatInterleaveOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct RepeatInterleaveResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+RepeatInterleaveResolvedParams resolveRepeatInterleaveParams(
+    const ::tt::target::ttnn::RepeatInterleaveOpT &repeatInterleaveOp);
+
+RepeatInterleaveOpResult callRepeatInterleave(
+    CallType callType,
+    const ::tt::target::ttnn::RepeatInterleaveOpT &repeatInterleaveOp,
+    TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_REPEAT_INTERLEAVE_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/RepeatOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/RepeatOp.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_REPEAT_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_REPEAT_OP_H
+
+#include "operations/data_movement/repeat/repeat.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using RepeatOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct RepeatResolvedParams {
+  ::ttsl::SmallVector<uint32_t> repeatDims;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+RepeatResolvedParams
+resolveRepeatParams(const ::tt::target::ttnn::RepeatOpT &repeatOp);
+
+RepeatOpResult callRepeat(CallType callType,
+                          const ::tt::target::ttnn::RepeatOpT &repeatOp,
+                          TensorArg input,
+                          ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_REPEAT_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/ReshapeOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/ReshapeOp.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_RESHAPE_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_RESHAPE_OP_H
+
+#include "operations/data_movement/reshape_view/reshape.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using ReshapeOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct ReshapeResolvedParams {
+  std::vector<int32_t> shape;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+ReshapeResolvedParams
+resolveReshapeParams(const ::tt::target::ttnn::ReshapeOpT &reshapeOp);
+
+ReshapeOpResult callReshape(CallType callType,
+                            const ::tt::target::ttnn::ReshapeOpT &reshapeOp,
+                            TensorArg input,
+                            ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_RESHAPE_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/ScatterOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/ScatterOp.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_SCATTER_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_SCATTER_OP_H
+
+#include "operations/data_movement/scatter/scatter.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+#include <string>
+
+namespace ttnn_op_invoke {
+
+using ScatterOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct ScatterResolvedParams {
+  std::optional<std::string> optReductionString;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+ScatterResolvedParams
+resolveScatterParams(const ::tt::target::ttnn::ScatterOpT &scatterOp);
+
+ScatterOpResult callScatter(CallType callType,
+                            const ::tt::target::ttnn::ScatterOpT &scatterOp,
+                            TensorArg input, TensorArg index, TensorArg source,
+                            ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_SCATTER_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/SliceOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/SliceOp.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATAMOVEMENT_SLICEOP_H
+#define TTNN_OP_INVOKE_DATAMOVEMENT_SLICEOP_H
+
+#include "operations/data_movement/slice/slice.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using SliceOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct SliceStaticResolvedParams {
+  ::ttsl::SmallVector<int32_t> begins;
+  ::ttsl::SmallVector<int32_t> ends;
+  ::ttsl::SmallVector<int32_t> step;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+SliceStaticResolvedParams
+resolveSliceStaticParams(const ::tt::target::ttnn::SliceOpT &sliceOp);
+
+SliceOpResult callSliceStatic(CallType callType,
+                              const ::tt::target::ttnn::SliceOpT &sliceOp,
+                              TensorArg input,
+                              ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATAMOVEMENT_SLICEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/SortOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/SortOp.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_SORT_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_SORT_OP_H
+
+#include "operations/data_movement/sort/sort.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+#include <vector>
+
+namespace ttnn_op_invoke {
+
+using SortOpResult = std::variant<::ttnn::graph::ConstraintQueryResponse,
+                                  ::ttnn::graph::RuntimeQueryResponse,
+                                  std::vector<::ttnn::Tensor>>;
+
+struct SortResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+SortResolvedParams resolveSortParams(const ::tt::target::ttnn::SortOpT &sortOp);
+
+SortOpResult callSort(CallType callType,
+                      const ::tt::target::ttnn::SortOpT &sortOp,
+                      TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_SORT_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/TransposeOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/TransposeOp.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_TRANSPOSE_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_TRANSPOSE_OP_H
+
+#include "operations/data_movement/transpose/transpose.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using TransposeOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct TransposeResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+TransposeResolvedParams
+resolveTransposeParams(const ::tt::target::ttnn::TransposeOpT &transposeOp);
+
+TransposeOpResult
+callTranspose(CallType callType,
+              const ::tt::target::ttnn::TransposeOpT &transposeOp,
+              TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_TRANSPOSE_OP_H

--- a/include/ttmlir/OpInvoke/TTNN/DataMovement/WriteTensorOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/DataMovement/WriteTensorOp.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_OP_INVOKE_DATA_MOVEMENT_WRITE_TENSOR_OP_H
+#define TTNN_OP_INVOKE_DATA_MOVEMENT_WRITE_TENSOR_OP_H
+
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+using WriteTensorOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, std::monostate>;
+
+struct WriteTensorResolvedParams {
+  ttnn::QueueId cq_id;
+};
+
+WriteTensorResolvedParams resolveWriteTensorParams(
+    const ::tt::target::ttnn::WriteTensorOpT &writeTensorOp);
+
+WriteTensorOpResult
+callWriteTensor(CallType callType,
+                const ::tt::target::ttnn::WriteTensorOpT &writeTensorOp,
+                TensorArg hostTensor, TensorArg deviceTensor,
+                ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTNN_OP_INVOKE_DATA_MOVEMENT_WRITE_TENSOR_OP_H

--- a/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
+++ b/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
@@ -271,6 +271,52 @@ buildLayerNormOpTFromMLIR(llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
     std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
     TTNNLayoutAttr outputLayout);
 
+::tt::target::ttnn::AssignOpT
+buildAssignOpTFromMLIR(TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::ConcatOpT
+buildConcatOpTFromMLIR(int32_t dim, TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::GatherOpT
+buildGatherOpTFromMLIR(int32_t dim, TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::PadOpT buildPadOpTFromMLIR(llvm::ArrayRef<int32_t> padding,
+                                               llvm::APFloat padValue,
+                                               bool useMulticore,
+                                               TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::PermuteOpT
+buildPermuteOpTFromMLIR(llvm::ArrayRef<int64_t> permutation,
+                        llvm::APFloat padValue, TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::RepeatInterleaveOpT
+buildRepeatInterleaveOpTFromMLIR(const unsigned int repeats, const int dim,
+                                 TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::RepeatOpT
+buildRepeatOpTFromMLIR(llvm::ArrayRef<int64_t> repeatDims,
+                       TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::ReshapeOpT
+buildReshapeOpTFromMLIR(llvm::ArrayRef<int64_t> outputShape,
+                        TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::ScatterOpT
+buildScatterOpTFromMLIR(int32_t dim, mlir::tt::ttcore::ReduceType reduceType,
+                        TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::SliceOpT buildSliceStaticOpTFromMLIR(
+    llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
+    llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::SortOpT buildSortOpTFromMLIR(int dim, bool descending,
+                                                 bool stable,
+                                                 TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::TransposeOpT
+buildTransposeOpTFromMLIR(int32_t dim0, int32_t dim1,
+                          TTNNLayoutAttr outputLayout);
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -532,14 +532,14 @@ struct OpModel<ScatterOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
       llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
-      int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
+      int32_t dim, mlir::tt::ttcore::ReduceType reduceType,
       TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
                llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
-               int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
+               int32_t dim, mlir::tt::ttcore::ReduceType reduceType,
                TTNNLayoutAttr outputLayout);
 };
 
@@ -2059,11 +2059,13 @@ struct OpModel<mlir::tt::ttnn::AssignOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
-                   std::optional<mlir::tt::ttcore::DataType> outputDtype);
+                   std::optional<mlir::tt::ttcore::DataType> outputDtype,
+                   TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-               std::optional<mlir::tt::ttcore::DataType> outputDtype);
+               std::optional<mlir::tt::ttcore::DataType> outputDtype,
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
+++ b/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
@@ -178,6 +178,45 @@ createOp(::mlir::tt::FlatbufferObjectCache &cache, RMSNormOp op);
 ::flatbuffers::Offset<::tt::target::ttnn::SoftmaxOp>
 createSoftmaxOp(::mlir::tt::FlatbufferObjectCache &cache, SoftmaxOp op);
 
+::flatbuffers::Offset<::tt::target::ttnn::AssignOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, AssignOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::ConcatOp>
+createConcatOp(::mlir::tt::FlatbufferObjectCache &cache, ConcatOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::GatherOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, GatherOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::PadOp>
+createPadOp(::mlir::tt::FlatbufferObjectCache &cache, PadOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::PermuteOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, PermuteOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::RepeatInterleaveOp>
+createRepeatInterleaveOp(::mlir::tt::FlatbufferObjectCache &cache,
+                         RepeatInterleaveOp op);
+
+template <typename RepeatOp>
+::flatbuffers::Offset<::tt::target::ttnn::RepeatOp>
+createRepeatOp(::mlir::tt::FlatbufferObjectCache &cache, RepeatOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::ReshapeOp>
+createReshapeOp(::mlir::tt::FlatbufferObjectCache &cache, ReshapeOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::ScatterOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, ScatterOp op);
+
+template <typename SliceOpT>
+::flatbuffers::Offset<::tt::target::ttnn::SliceOp>
+createSliceOp(::mlir::tt::FlatbufferObjectCache &cache, SliceOpT op);
+
+::flatbuffers::Offset<::tt::target::ttnn::SortOp>
+createSortOp(::mlir::tt::FlatbufferObjectCache &cache, SortOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::TransposeOp>
+createTransposeOp(::mlir::tt::FlatbufferObjectCache &cache, TransposeOp op);
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_TARGET_TTNN_TTNNTOFLATBUFFER_H

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -341,6 +341,32 @@ toFlatbuffer(FlatbufferObjectCache &,
   return toNative(shardDistributionStrategy);
 }
 
+inline ::tt::target::ttnn::ScatterReduceType
+toNative(ttcore::ReduceType reduceType) {
+  switch (reduceType) {
+  case ttcore::ReduceType::Sum:
+    return ::tt::target::ttnn::ScatterReduceType::Sum;
+  case ttcore::ReduceType::Max:
+    return ::tt::target::ttnn::ScatterReduceType::Max;
+  case ttcore::ReduceType::Min:
+    return ::tt::target::ttnn::ScatterReduceType::Min;
+  case ttcore::ReduceType::Prod:
+    return ::tt::target::ttnn::ScatterReduceType::Prod;
+  case ttcore::ReduceType::Invalid:
+    return ::tt::target::ttnn::ScatterReduceType::Invalid;
+  default:
+    llvm_unreachable("Unhandled reduce type");
+  }
+}
+
+// Convert ttcore::ReduceType to tt::target::ttnn::ScatterReduceType
+// Sum, Max, Min, Prod - applied reduction type to source tensor
+// Invalid - copy source to output tensor
+inline ::tt::target::ttnn::ScatterReduceType
+toFlatbuffer(ttcore::ReduceType reduceType) {
+  return toNative(reduceType);
+}
+
 inline ::tt::target::Arch toFlatbuffer(FlatbufferObjectCache &,
                                        ttcore::ArchAttr arch) {
   switch (arch.getValue()) {

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1082,17 +1082,10 @@ ScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto indexShape = getIndex().getType().getShape();
   const auto sourceShape = getSource().getType().getShape();
 
-  std::optional<ttcore::ReduceTypeAttr> reduceType =
-      ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
-  if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
-    reduceType =
-        ttcore::ReduceTypeAttr::get(getContext(), getScatterReduceType());
-  }
-
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ScatterOp>::getOpConstraints, *this, inputShape,
       inputs[0], indexShape, inputs[1], sourceShape, inputs[2], getDim(),
-      reduceType, opConfig.outputLayout);
+      getScatterReduceType(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1104,17 +1097,10 @@ ScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto indexShape = getIndex().getType().getShape();
   const auto sourceShape = getSource().getType().getShape();
 
-  std::optional<ttcore::ReduceTypeAttr> reduceType =
-      ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
-  if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
-    reduceType =
-        ttcore::ReduceTypeAttr::get(getContext(), getScatterReduceType());
-  }
-
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<ScatterOp>::getOpRuntime, *this, inputShape, inputs[0],
-      indexShape, inputs[1], sourceShape, inputs[2], getDim(), reduceType,
-      opConfig.outputLayout);
+      indexShape, inputs[1], sourceShape, inputs[2], getDim(),
+      getScatterReduceType(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -4823,7 +4809,8 @@ AssignOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::AssignOp>::getOpConstraints, *this,
-      inputShape, inputs[0], dataTypeAttrToOptional(getDtypeAttr()));
+      inputShape, inputs[0], dataTypeAttrToOptional(getDtypeAttr()),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4834,7 +4821,8 @@ AssignOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime, *this,
-      inputShape, inputs[0], dataTypeAttrToOptional(getDtypeAttr()));
+      inputShape, inputs[0], dataTypeAttrToOptional(getDtypeAttr()),
+      opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -8,6 +8,19 @@ add_library(TTNNOpInvokeLib STATIC
   Conv/PrepareConv3dWeightsOp.cpp
   Conv/PrepareConvTranspose2dBiasOp.cpp
   Conv/PrepareConvTranspose2dWeightsOp.cpp
+  DataMovement/AssignOp.cpp
+  DataMovement/ConcatOp.cpp
+  DataMovement/GatherOp.cpp
+  DataMovement/PadOp.cpp
+  DataMovement/PermuteOp.cpp
+  DataMovement/RepeatInterleaveOp.cpp
+  DataMovement/RepeatOp.cpp
+  DataMovement/ReshapeOp.cpp
+  DataMovement/ScatterOp.cpp
+  DataMovement/SliceOp.cpp
+  DataMovement/SortOp.cpp
+  DataMovement/TransposeOp.cpp
+  DataMovement/WriteTensorOp.cpp
   Eltwise/Binary/EltwiseBinaryCompositeOp.cpp
   Eltwise/Binary/EltwiseBinaryOp.cpp
   Eltwise/Quantization/EltwiseQuantizationOp.cpp

--- a/lib/OpInvoke/TTNN/DataMovement/AssignOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/AssignOp.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/AssignOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+AssignResolvedParams
+resolveAssignParams(const ::tt::target::ttnn::AssignOpT &assignOp) {
+  AssignResolvedParams params;
+
+  if (assignOp.output) {
+    params.outputDtype = operations::utils::getDataType(*assignOp.output);
+  }
+
+  if (assignOp.output) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*assignOp.output));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*assignOp.output) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  if (!params.outputMemoryConfig) {
+    params.outputMemoryConfig = ::ttnn::MemoryConfig{
+        ::ttnn::TensorMemoryLayout::INTERLEAVED, ::ttnn::BufferType::DRAM};
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createAssignTuple(Tag tag, const ::tt::target::ttnn::AssignOpT &assignOp,
+                       TensorArg input, const AssignResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag),
+                         params.outputMemoryConfig.value(), params.outputDtype,
+                         /*optional_output_tensor=*/std::nullopt);
+}
+
+AssignOpResult callAssign(CallType callType,
+                          const ::tt::target::ttnn::AssignOpT &assignOp,
+                          TensorArg input, ::ttnn::MeshDevice *device) {
+  AssignResolvedParams params = resolveAssignParams(assignOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createAssignTuple(tag, assignOp, input, params);
+  };
+
+  return callOp<AssignOpResult>(WRAP_OP(::ttnn::assign), callType, makeTuple,
+                                device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/ConcatOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/ConcatOp.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/ConcatOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+ConcatResolvedParams
+resolveConcatParams(const ::tt::target::ttnn::ConcatOpT &concatOp) {
+  ConcatResolvedParams params;
+
+  if (concatOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*concatOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*concatOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+inline auto resolveTensorArgVector(const std::vector<TensorArg> &args,
+                                   Tag callType) {
+  using ElemT = decltype(resolveTensorArg(std::declval<TensorArg>(), callType));
+  std::vector<ElemT> result;
+  for (const auto &arg : args) {
+    result.push_back(resolveTensorArg(arg, callType));
+  }
+  return result;
+}
+
+template <typename Tag>
+auto createConcatTuple(Tag tag, const ::tt::target::ttnn::ConcatOpT &concatOp,
+                       const std::vector<TensorArg> &inputs,
+                       const ConcatResolvedParams &params) {
+  return std::make_tuple(resolveTensorArgVector(inputs, tag), concatOp.dim,
+                         params.outputMemoryConfig);
+}
+
+ConcatOpResult callConcat(CallType callType,
+                          const ::tt::target::ttnn::ConcatOpT &concatOp,
+                          std::vector<TensorArg> inputs,
+                          ::ttnn::MeshDevice *device) {
+  ConcatResolvedParams params = resolveConcatParams(concatOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createConcatTuple(tag, concatOp, inputs, params);
+  };
+
+  return callOp<ConcatOpResult>(WRAP_OP(::ttnn::concat), callType, makeTuple,
+                                device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/GatherOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/GatherOp.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/GatherOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+GatherResolvedParams
+resolveGatherParams(const ::tt::target::ttnn::GatherOpT &gatherOp) {
+  GatherResolvedParams params;
+
+  params.dim = static_cast<int8_t>(gatherOp.dim);
+
+  if (gatherOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*gatherOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*gatherOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createGatherTuple(Tag tag, const ::tt::target::ttnn::GatherOpT &gatherOp,
+                       TensorArg input, TensorArg index,
+                       const GatherResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), params.dim,
+                         resolveTensorArg(index, tag),
+                         /*sparse_grad=*/false, params.outputMemoryConfig);
+}
+
+GatherOpResult callGather(CallType callType,
+                          const ::tt::target::ttnn::GatherOpT &gatherOp,
+                          TensorArg input, TensorArg index,
+                          ::ttnn::MeshDevice *device) {
+  GatherResolvedParams params = resolveGatherParams(gatherOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createGatherTuple(tag, gatherOp, input, index, params);
+  };
+
+  return callOp<GatherOpResult>(WRAP_OP(::ttnn::gather), callType, makeTuple,
+                                device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/PadOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/PadOp.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/PadOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+PadResolvedParams resolvePadParams(const ::tt::target::ttnn::PadOpT &padOp) {
+  PadResolvedParams params;
+
+  for (uint32_t i = 0; i + 1 < padOp.padding.size(); i += 2) {
+    params.padding.emplace_back(padOp.padding[i], padOp.padding[i + 1]);
+  }
+
+  if (padOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*padOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*padOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPadTuple(Tag tag, const ::tt::target::ttnn::PadOpT &padOp,
+                    TensorArg input, const PadResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), params.padding,
+                         padOp.value, padOp.use_multicore,
+                         params.outputMemoryConfig);
+}
+
+PadOpResult callPad(CallType callType, const ::tt::target::ttnn::PadOpT &padOp,
+                    TensorArg input, ::ttnn::MeshDevice *device) {
+  PadResolvedParams params = resolvePadParams(padOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createPadTuple(tag, padOp, input, params);
+  };
+
+  return callOp<PadOpResult>(WRAP_OP(::ttnn::pad), callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/PermuteOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/PermuteOp.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/PermuteOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+PermuteResolvedParams
+resolvePermuteParams(const ::tt::target::ttnn::PermuteOpT &permuteOp) {
+  PermuteResolvedParams params;
+
+  params.dims = {permuteOp.permutation.begin(), permuteOp.permutation.end()};
+
+  if (permuteOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*permuteOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*permuteOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPermuteTuple(Tag tag,
+                        const ::tt::target::ttnn::PermuteOpT &permuteOp,
+                        TensorArg input, const PermuteResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), params.dims,
+                         params.outputMemoryConfig, permuteOp.pad_value);
+}
+
+PermuteOpResult callPermute(CallType callType,
+                            const ::tt::target::ttnn::PermuteOpT &permuteOp,
+                            TensorArg input, ::ttnn::MeshDevice *device) {
+  PermuteResolvedParams params = resolvePermuteParams(permuteOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createPermuteTuple(tag, permuteOp, input, params);
+  };
+
+  return callOp<PermuteOpResult>(WRAP_OP(::ttnn::permute), callType, makeTuple,
+                                 device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/RepeatInterleaveOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/RepeatInterleaveOp.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/RepeatInterleaveOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+RepeatInterleaveResolvedParams resolveRepeatInterleaveParams(
+    const ::tt::target::ttnn::RepeatInterleaveOpT &repeatInterleaveOp) {
+  RepeatInterleaveResolvedParams params;
+
+  if (repeatInterleaveOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*repeatInterleaveOp.out));
+    TT_INVOKE_ASSERT(
+        operations::utils::inSystemMemory(*repeatInterleaveOp.out) ||
+            params.outputMemoryConfig.has_value(),
+        "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createRepeatInterleaveTuple(
+    Tag tag, const ::tt::target::ttnn::RepeatInterleaveOpT &repeatInterleaveOp,
+    TensorArg input, const RepeatInterleaveResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag),
+                         repeatInterleaveOp.repeats, repeatInterleaveOp.dim,
+                         params.outputMemoryConfig);
+}
+
+RepeatInterleaveOpResult callRepeatInterleave(
+    CallType callType,
+    const ::tt::target::ttnn::RepeatInterleaveOpT &repeatInterleaveOp,
+    TensorArg input, ::ttnn::MeshDevice *device) {
+  RepeatInterleaveResolvedParams params =
+      resolveRepeatInterleaveParams(repeatInterleaveOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createRepeatInterleaveTuple(tag, repeatInterleaveOp, input, params);
+  };
+
+  return callOp<RepeatInterleaveOpResult>(WRAP_OP(::ttnn::repeat_interleave),
+                                          callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/RepeatOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/RepeatOp.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/RepeatOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+RepeatResolvedParams
+resolveRepeatParams(const ::tt::target::ttnn::RepeatOpT &repeatOp) {
+  RepeatResolvedParams params;
+
+  params.repeatDims = {repeatOp.repeat_dims.begin(),
+                       repeatOp.repeat_dims.end()};
+
+  if (repeatOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*repeatOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*repeatOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createRepeatTuple(Tag tag, TensorArg input,
+                       const RepeatResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), params.repeatDims,
+                         params.outputMemoryConfig);
+}
+
+RepeatOpResult callRepeat(CallType callType,
+                          const ::tt::target::ttnn::RepeatOpT &repeatOp,
+                          TensorArg input, ::ttnn::MeshDevice *device) {
+  RepeatResolvedParams params = resolveRepeatParams(repeatOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createRepeatTuple(tag, input, params);
+  };
+
+  return callOp<RepeatOpResult>(WRAP_OP(::ttnn::repeat), callType, makeTuple,
+                                device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/ReshapeOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/ReshapeOp.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/ReshapeOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+ReshapeResolvedParams
+resolveReshapeParams(const ::tt::target::ttnn::ReshapeOpT &reshapeOp) {
+  ReshapeResolvedParams params;
+
+  params.shape = {reshapeOp.shape.begin(), reshapeOp.shape.end()};
+
+  if (reshapeOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*reshapeOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*reshapeOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createReshapeTuple(Tag tag, TensorArg input,
+                        const ReshapeResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), params.shape,
+                         params.outputMemoryConfig);
+}
+
+ReshapeOpResult callReshape(CallType callType,
+                            const ::tt::target::ttnn::ReshapeOpT &reshapeOp,
+                            TensorArg input, ::ttnn::MeshDevice *device) {
+  ReshapeResolvedParams params = resolveReshapeParams(reshapeOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createReshapeTuple(tag, input, params);
+  };
+
+  return callOp<ReshapeOpResult>(WRAP_OP(::ttnn::reshape), callType, makeTuple,
+                                 device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/ScatterOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/ScatterOp.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/ScatterOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+ScatterResolvedParams
+resolveScatterParams(const ::tt::target::ttnn::ScatterOpT &scatterOp) {
+  ScatterResolvedParams params;
+
+  switch (scatterOp.scatter_reduce_type) {
+  case ::tt::target::ttnn::ScatterReduceType::Sum: // Sum -> add
+    params.optReductionString = "add";
+    break;
+  case ::tt::target::ttnn::ScatterReduceType::Prod: // Prod -> multiply
+    params.optReductionString = "multiply";
+    break;
+  case ::tt::target::ttnn::ScatterReduceType::Min: // Min -> amin
+    params.optReductionString = "amin";
+    break;
+  case ::tt::target::ttnn::ScatterReduceType::Max: // Max -> amax
+    params.optReductionString = "amax";
+    break;
+  case ::tt::target::ttnn::ScatterReduceType::Invalid: // Invalid -> no
+                                                       // reduction
+    params.optReductionString = std::nullopt;
+    break;
+  }
+
+  if (scatterOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*scatterOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*scatterOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createScatterTuple(Tag tag,
+                        const ::tt::target::ttnn::ScatterOpT &scatterOp,
+                        TensorArg input, TensorArg index, TensorArg source,
+                        const ScatterResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), scatterOp.dim,
+                         resolveTensorArg(index, tag),
+                         resolveTensorArg(source, tag),
+                         params.outputMemoryConfig, params.optReductionString,
+                         /*sub_core_grid=*/std::nullopt);
+}
+
+ScatterOpResult callScatter(CallType callType,
+                            const ::tt::target::ttnn::ScatterOpT &scatterOp,
+                            TensorArg input, TensorArg index, TensorArg source,
+                            ::ttnn::MeshDevice *device) {
+  ScatterResolvedParams params = resolveScatterParams(scatterOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createScatterTuple(tag, scatterOp, input, index, source, params);
+  };
+
+  return callOp<ScatterOpResult>(WRAP_OP(::ttnn::scatter), callType, makeTuple,
+                                 device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/SliceOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/SliceOp.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/SliceOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+SliceStaticResolvedParams
+resolveSliceStaticParams(const ::tt::target::ttnn::SliceOpT &sliceOp) {
+  SliceStaticResolvedParams params;
+
+  const tt::target::ttnn::SliceStaticOpParamsT *staticParams =
+      sliceOp.params.AsSliceStaticOpParams();
+  TT_INVOKE_ASSERT(staticParams != nullptr,
+                   "Expected SliceStaticOpParams for static slice");
+
+  params.begins = {staticParams->begins.begin(), staticParams->begins.end()};
+  params.ends = {staticParams->ends.begin(), staticParams->ends.end()};
+  params.step = {sliceOp.step.begin(), sliceOp.step.end()};
+
+  if (sliceOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*sliceOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*sliceOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createSliceStaticTuple(Tag tag,
+                            const ::tt::target::ttnn::SliceOpT &sliceOp,
+                            TensorArg input,
+                            const SliceStaticResolvedParams &params) {
+  auto beginsSpan = ::ttsl::make_const_span(params.begins);
+  auto endsSpan = ::ttsl::make_const_span(params.ends);
+  auto stepSpan = ::ttsl::make_const_span(params.step);
+  return std::make_tuple(resolveTensorArg(input, tag), beginsSpan, endsSpan,
+                         stepSpan, params.outputMemoryConfig);
+}
+
+SliceOpResult callSliceStatic(CallType callType,
+                              const ::tt::target::ttnn::SliceOpT &sliceOp,
+                              TensorArg input, ::ttnn::MeshDevice *device) {
+  SliceStaticResolvedParams params = resolveSliceStaticParams(sliceOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createSliceStaticTuple(tag, sliceOp, input, params);
+  };
+
+  return callOp<SliceOpResult>(WRAP_OP(::ttnn::slice), callType, makeTuple,
+                               device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/SortOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/SortOp.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/SortOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+SortResolvedParams
+resolveSortParams(const ::tt::target::ttnn::SortOpT &sortOp) {
+  SortResolvedParams params;
+
+  if (!sortOp.outputs.empty() && sortOp.outputs[0]) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*sortOp.outputs[0]));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*sortOp.outputs[0]) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createSortTuple(Tag tag, const ::tt::target::ttnn::SortOpT &sortOp,
+                     TensorArg input, const SortResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), sortOp.dim,
+                         sortOp.descending, sortOp.stable,
+                         params.outputMemoryConfig,
+                         /*optional_output_tensors=*/std::nullopt);
+}
+
+SortOpResult callSort(CallType callType,
+                      const ::tt::target::ttnn::SortOpT &sortOp,
+                      TensorArg input, ::ttnn::MeshDevice *device) {
+  SortResolvedParams params = resolveSortParams(sortOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createSortTuple(tag, sortOp, input, params);
+  };
+
+  return callOp<SortOpResult>(WRAP_OP(::ttnn::sort), callType, makeTuple,
+                              device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/TransposeOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/TransposeOp.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/TransposeOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+TransposeResolvedParams
+resolveTransposeParams(const ::tt::target::ttnn::TransposeOpT &transposeOp) {
+  TransposeResolvedParams params;
+
+  if (transposeOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*transposeOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*transposeOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createTransposeTuple(Tag tag,
+                          const ::tt::target::ttnn::TransposeOpT &transposeOp,
+                          TensorArg input,
+                          const TransposeResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), transposeOp.dim0,
+                         transposeOp.dim1, params.outputMemoryConfig);
+}
+
+TransposeOpResult
+callTranspose(CallType callType,
+              const ::tt::target::ttnn::TransposeOpT &transposeOp,
+              TensorArg input, ::ttnn::MeshDevice *device) {
+  TransposeResolvedParams params = resolveTransposeParams(transposeOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createTransposeTuple(tag, transposeOp, input, params);
+  };
+
+  return callOp<TransposeOpResult>(WRAP_OP(::ttnn::transpose), callType,
+                                   makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/DataMovement/WriteTensorOp.cpp
+++ b/lib/OpInvoke/TTNN/DataMovement/WriteTensorOp.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/DataMovement/WriteTensorOp.h"
+#include "ttnn/common/queue_id.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+WriteTensorResolvedParams resolveWriteTensorParams(
+    const ::tt::target::ttnn::WriteTensorOpT &writeTensorOp) {
+  WriteTensorResolvedParams params;
+  params.cq_id = ::ttnn::QueueId(writeTensorOp.cq_id);
+  return params;
+}
+
+template <typename Tag>
+auto createWriteTensorTuple(
+    Tag tag, const ::tt::target::ttnn::WriteTensorOpT &writeTensorOp,
+    TensorArg hostTensor, TensorArg deviceTensor,
+    const WriteTensorResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(hostTensor, tag),
+                         resolveTensorArg(deviceTensor, tag),
+                         std::make_optional(params.cq_id));
+}
+
+WriteTensorOpResult callWriteTensor(
+    CallType callType, const ::tt::target::ttnn::WriteTensorOpT &writeTensorOp,
+    TensorArg hostTensor, TensorArg deviceTensor, ::ttnn::MeshDevice *device) {
+  WriteTensorResolvedParams params = resolveWriteTensorParams(writeTensorOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createWriteTensorTuple(tag, writeTensorOp, hostTensor, deviceTensor,
+                                  params);
+  };
+
+  // Note: copy_to_device replaced write_tensor and does not have a blocking
+  // parameter. The operation is always blocking.
+  return callOp<WriteTensorOpResult, false, false>(
+      [&](auto &&...args) {
+        ::tt::tt_metal::copy_to_device(std::forward<decltype(args)>(args)...);
+        return std::monostate{};
+      },
+      callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpModel/TTNN/NativeFromMLIR.cpp
+++ b/lib/OpModel/TTNN/NativeFromMLIR.cpp
@@ -1151,6 +1151,126 @@ buildGroupNormOpTFromMLIR(int64_t numGroups, llvm::APFloat epsilon,
   return groupNormOp;
 }
 
+::tt::target::ttnn::AssignOpT
+buildAssignOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::AssignOpT assignOp;
+  assignOp.output = detail::getOutputTensorRefT(outputLayout);
+  return assignOp;
+}
+
+::tt::target::ttnn::ScatterOpT
+buildScatterOpTFromMLIR(int32_t dim, mlir::tt::ttcore::ReduceType reduceType,
+                        TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ScatterOpT scatterOp;
+  scatterOp.dim = dim;
+  scatterOp.scatter_reduce_type = toNative(reduceType);
+  scatterOp.out = detail::getOutputTensorRefT(outputLayout);
+  return scatterOp;
+}
+
+::tt::target::ttnn::ReshapeOpT
+buildReshapeOpTFromMLIR(llvm::ArrayRef<int64_t> outputShape,
+                        TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ReshapeOpT reshapeOp;
+  reshapeOp.shape = {outputShape.begin(), outputShape.end()};
+  reshapeOp.out = detail::getOutputTensorRefT(outputLayout);
+  return reshapeOp;
+}
+
+::tt::target::ttnn::SliceOpT buildSliceStaticOpTFromMLIR(
+    llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
+    llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::SliceOpT sliceOp;
+  sliceOp.type = ::tt::target::ttnn::SliceOpType::SliceStaticOp;
+  sliceOp.step = {step.begin(), step.end()};
+  sliceOp.out = detail::getOutputTensorRefT(outputLayout);
+  ::tt::target::ttnn::SliceStaticOpParamsT staticParams;
+  staticParams.begins = {begins.begin(), begins.end()};
+  staticParams.ends = {ends.begin(), ends.end()};
+  sliceOp.params.Set(staticParams);
+  return sliceOp;
+}
+
+::tt::target::ttnn::ConcatOpT
+buildConcatOpTFromMLIR(int32_t dim, TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ConcatOpT concatOp;
+  concatOp.dim = dim;
+  concatOp.out = detail::getOutputTensorRefT(outputLayout);
+  return concatOp;
+}
+
+::tt::target::ttnn::TransposeOpT
+buildTransposeOpTFromMLIR(int32_t dim0, int32_t dim1,
+                          TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::TransposeOpT transposeOp;
+  transposeOp.dim0 = dim0;
+  transposeOp.dim1 = dim1;
+  transposeOp.out = detail::getOutputTensorRefT(outputLayout);
+  return transposeOp;
+}
+
+::tt::target::ttnn::RepeatInterleaveOpT
+buildRepeatInterleaveOpTFromMLIR(const unsigned int repeats, const int dim,
+                                 TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::RepeatInterleaveOpT repeatInterleaveOp;
+  repeatInterleaveOp.repeats = repeats;
+  repeatInterleaveOp.dim = dim;
+  repeatInterleaveOp.out = detail::getOutputTensorRefT(outputLayout);
+  return repeatInterleaveOp;
+}
+
+::tt::target::ttnn::RepeatOpT
+buildRepeatOpTFromMLIR(llvm::ArrayRef<int64_t> repeatDims,
+                       TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::RepeatOpT repeatOp;
+  repeatOp.repeat_dims = {repeatDims.begin(), repeatDims.end()};
+  repeatOp.out = detail::getOutputTensorRefT(outputLayout);
+  return repeatOp;
+}
+
+::tt::target::ttnn::PadOpT buildPadOpTFromMLIR(llvm::ArrayRef<int32_t> padding,
+                                               llvm::APFloat padValue,
+                                               bool useMulticore,
+                                               TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::PadOpT padOp;
+  for (int32_t p : padding) {
+    padOp.padding.push_back(static_cast<uint32_t>(p));
+  }
+  padOp.value = padValue.convertToFloat();
+  padOp.use_multicore = useMulticore;
+  padOp.out = detail::getOutputTensorRefT(outputLayout);
+  return padOp;
+}
+
+::tt::target::ttnn::SortOpT buildSortOpTFromMLIR(int dim, bool descending,
+                                                 bool stable,
+                                                 TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::SortOpT sortOp;
+  sortOp.dim = static_cast<int8_t>(dim);
+  sortOp.descending = descending;
+  sortOp.stable = stable;
+  sortOp.outputs.push_back(detail::getOutputTensorRefT(outputLayout));
+  return sortOp;
+}
+
+::tt::target::ttnn::PermuteOpT
+buildPermuteOpTFromMLIR(llvm::ArrayRef<int64_t> permutation,
+                        llvm::APFloat padValue, TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::PermuteOpT permuteOp;
+  permuteOp.permutation = {permutation.begin(), permutation.end()};
+  permuteOp.pad_value = padValue.convertToFloat();
+  permuteOp.out = detail::getOutputTensorRefT(outputLayout);
+  return permuteOp;
+}
+
+::tt::target::ttnn::GatherOpT
+buildGatherOpTFromMLIR(int32_t dim, TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::GatherOpT gatherOp;
+  gatherOp.dim = dim;
+  gatherOp.out = detail::getOutputTensorRefT(outputLayout);
+  return gatherOp;
+}
+
 } // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -18,6 +18,18 @@
 #include "ttmlir/OpInvoke/TTNN/Conv/PrepareConv2dWeightsOp.h"
 #include "ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dBiasOp.h"
 #include "ttmlir/OpInvoke/TTNN/Conv/PrepareConvTranspose2dWeightsOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/AssignOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/ConcatOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/GatherOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/PadOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/PermuteOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/RepeatInterleaveOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/RepeatOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/ReshapeOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/ScatterOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/SliceOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/SortOp.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/TransposeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Quantization/EltwiseQuantizationOp.h"
@@ -2189,11 +2201,12 @@ llvm::Expected<size_t> OpModel<SoftmaxOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ScatterOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
     llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
-    int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
+    int32_t dim, mlir::tt::ttcore::ReduceType reduceType,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2211,15 +2224,19 @@ llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
       ::ttnn::TensorSpec sourceSpec,
       detail::convertToTensorSpec(device, sourceShape, sourceLayout));
 
-  // Convert optReduction to ScatterReductionType enum
-  auto optReductionType = conversion::getScatterReductionType(optReduction);
+  ::tt::target::ttnn::ScatterOpT scatterOpNative =
+      buildScatterOpTFromMLIR(dim, reduceType, outputLayout);
 
-  //  Create query closure
   auto scatterOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::scatter, device, inputSpec, dim, indexSpec, sourceSpec,
-        detail::getNullableMemoryConfig(outputLayout), optReductionType,
-        /* sub_core_grid */ std::nullopt);
+    ttnn_op_invoke::ScatterOpResult result = ttnn_op_invoke::callScatter(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, scatterOpNative,
+        inputSpec, indexSpec, sourceSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from ScatterOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), scatterOpQuery);
@@ -2232,7 +2249,7 @@ llvm::Expected<size_t> OpModel<ScatterOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
     llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
-    int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
+    int32_t dim, mlir::tt::ttcore::ReduceType reduceType,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2250,17 +2267,22 @@ llvm::Expected<size_t> OpModel<ScatterOp>::getOpRuntime(
       ::ttnn::TensorSpec sourceSpec,
       detail::convertToTensorSpec(device, sourceShape, sourceLayout));
 
-  auto optReductionType = conversion::getScatterReductionType(optReduction);
+  ::tt::target::ttnn::ScatterOpT scatterOpNative =
+      buildScatterOpTFromMLIR(dim, reduceType, outputLayout);
 
-  //  Create query closure
-  auto scatterOpRuntimeQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::scatter, device, inputSpec, dim, indexSpec, sourceSpec,
-        detail::getNullableMemoryConfig(outputLayout), optReductionType,
-        /* sub_core_grid */ std::nullopt);
+  auto scatterOpQuery = [=]() {
+    ttnn_op_invoke::ScatterOpResult result = ttnn_op_invoke::callScatter(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, scatterOpNative, inputSpec,
+        indexSpec, sourceSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from ScatterOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
-  return operation::getOpRuntime(scatterOpRuntimeQuery);
+  return operation::getOpRuntime(scatterOpQuery);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2269,6 +2291,7 @@ llvm::Expected<size_t> OpModel<ScatterOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ReshapeOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout) {
@@ -2280,11 +2303,19 @@ llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::ReshapeOpT reshapeOpNative =
+      buildReshapeOpTFromMLIR(outputShape, outputLayout);
+
   auto reshapeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::reshape, device, inputSpec,
-                                conversion::getShape(outputShape),
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::ReshapeOpResult result = ttnn_op_invoke::callReshape(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, reshapeOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from ReshapeOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), reshapeOpQuery);
@@ -2304,11 +2335,19 @@ llvm::Expected<size_t> OpModel<ReshapeOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::ReshapeOpT reshapeOpNative =
+      buildReshapeOpTFromMLIR(outputShape, outputLayout);
+
   auto reshapeOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::reshape, device, inputSpec,
-                            conversion::getShape(outputShape),
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::ReshapeOpResult result =
+        ttnn_op_invoke::callReshape(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                    reshapeOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from ReshapeOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(reshapeOpQuery);
@@ -2320,6 +2359,7 @@ llvm::Expected<size_t> OpModel<ReshapeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // SliceStaticOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
@@ -2332,24 +2372,19 @@ llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // convert arrays
-  ::ttsl::SmallVector<int> beginsVec =
-      conversion::convertLLVMSmallVecToTTNNSmallVec(begins);
-  ::ttsl::SmallVector<int> endsVec =
-      conversion::convertLLVMSmallVecToTTNNSmallVec(ends);
-  ::ttsl::SmallVector<int> stepVec =
-      conversion::convertLLVMSmallVecToTTNNSmallVec(step);
+  ::tt::target::ttnn::SliceOpT sliceOpNative =
+      buildSliceStaticOpTFromMLIR(begins, ends, step, outputLayout);
 
-  ttsl::Span<const int> beginsSpan = ::ttsl::make_const_span(beginsVec);
-  ttsl::Span<const int> endsSpan = ::ttsl::make_const_span(endsVec);
-  ttsl::Span<const int> stepSpan = ::ttsl::make_const_span(stepVec);
-
-  // Create query closure
   auto sliceOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::slice, device, inputSpec, beginsSpan,
-                                endsSpan, stepSpan,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                std::nullopt, std::nullopt);
+    ttnn_op_invoke::SliceOpResult result = ttnn_op_invoke::callSliceStatic(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, sliceOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from SliceStaticOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), sliceOpQuery);
@@ -2370,24 +2405,19 @@ llvm::Expected<size_t> OpModel<SliceStaticOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Convert arrays
-  ::ttsl::SmallVector<int> beginsVec =
-      conversion::convertLLVMSmallVecToTTNNSmallVec(begins);
-  ::ttsl::SmallVector<int> endsVec =
-      conversion::convertLLVMSmallVecToTTNNSmallVec(ends);
-  ::ttsl::SmallVector<int> stepVec =
-      conversion::convertLLVMSmallVecToTTNNSmallVec(step);
+  ::tt::target::ttnn::SliceOpT sliceOpNative =
+      buildSliceStaticOpTFromMLIR(begins, ends, step, outputLayout);
 
-  ttsl::Span<const int> beginsSpan = ::ttsl::make_const_span(beginsVec);
-  ttsl::Span<const int> endsSpan = ::ttsl::make_const_span(endsVec);
-  ttsl::Span<const int> stepSpan = ::ttsl::make_const_span(stepVec);
-
-  // Create query closure
   auto sliceOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::slice, device, inputSpec, beginsSpan,
-                            endsSpan, stepSpan,
-                            detail::getNullableMemoryConfig(outputLayout),
-                            std::nullopt, std::nullopt);
+    ttnn_op_invoke::SliceOpResult result = ttnn_op_invoke::callSliceStatic(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, sliceOpNative, inputSpec,
+        device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from SliceStaticOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(sliceOpQuery);
@@ -2713,6 +2743,7 @@ OpModel<ToMemoryConfigOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 // ConcatOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
     std::vector<llvm::ArrayRef<int64_t>> inputShapes,
     std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
@@ -2732,10 +2763,22 @@ llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
     inputSpecs.push_back(std::move(_push_tmp));
   }
 
-  // Create query closure
+  ::tt::target::ttnn::ConcatOpT concatOpNative =
+      buildConcatOpTFromMLIR(dim, outputLayout);
+
+  std::vector<ttnn_op_invoke::TensorArg> inputArgs(inputSpecs.begin(),
+                                                   inputSpecs.end());
+
   auto concatOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::concat, device, inputSpecs, dim,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::ConcatOpResult result = ttnn_op_invoke::callConcat(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, concatOpNative,
+        inputArgs, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from ConcatOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayouts[0].getContext(),
@@ -2764,10 +2807,22 @@ llvm::Expected<size_t> OpModel<ConcatOp>::getOpRuntime(
     inputSpecs.push_back(std::move(_push_tmp));
   }
 
-  // Create query closure
+  ::tt::target::ttnn::ConcatOpT concatOpNative =
+      buildConcatOpTFromMLIR(dim, outputLayout);
+
+  std::vector<ttnn_op_invoke::TensorArg> inputArgs(inputSpecs.begin(),
+                                                   inputSpecs.end());
+
   auto concatOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::concat, device, inputSpecs, dim,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::ConcatOpResult result =
+        ttnn_op_invoke::callConcat(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                   concatOpNative, inputArgs, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from ConcatOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(concatOpQuery);
@@ -2779,6 +2834,7 @@ llvm::Expected<size_t> OpModel<ConcatOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // TransposeOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int dim0, const int dim1, TTNNLayoutAttr outputLayout) {
@@ -2790,12 +2846,19 @@ llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::TransposeOpT transposeOpNative =
+      buildTransposeOpTFromMLIR(dim0, dim1, outputLayout);
+
   auto transposeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::transpose, device, inputSpec,
-                                static_cast<int64_t>(dim0),
-                                static_cast<int64_t>(dim1),
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::TransposeOpResult result = ttnn_op_invoke::callTranspose(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, transposeOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from TransposeOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -2816,12 +2879,19 @@ llvm::Expected<size_t> OpModel<TransposeOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::TransposeOpT transposeOpNative =
+      buildTransposeOpTFromMLIR(dim0, dim1, outputLayout);
+
   auto transposeOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::transpose, device, inputSpec,
-                            static_cast<int64_t>(dim0),
-                            static_cast<int64_t>(dim1),
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::TransposeOpResult result = ttnn_op_invoke::callTranspose(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, transposeOpNative,
+        inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from TransposeOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(transposeOpQuery);
@@ -4232,6 +4302,7 @@ llvm::Expected<size_t> OpModel<NLPConcatHeadsDecodeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // RepeatInterleaveOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout) {
@@ -4243,11 +4314,20 @@ llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::RepeatInterleaveOpT repeatInterleaveOpNative =
+      buildRepeatInterleaveOpTFromMLIR(repeats, dim, outputLayout);
+
   auto repeatInterleaveOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::repeat_interleave, device, inputSpec,
-                                repeats, dim,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::RepeatInterleaveOpResult result =
+        ttnn_op_invoke::callRepeatInterleave(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            repeatInterleaveOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from RepeatInterleaveOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -4268,11 +4348,20 @@ llvm::Expected<size_t> OpModel<RepeatInterleaveOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::RepeatInterleaveOpT repeatInterleaveOpNative =
+      buildRepeatInterleaveOpTFromMLIR(repeats, dim, outputLayout);
+
   auto repeatInterleaveOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::repeat_interleave, device, inputSpec,
-                            repeats, dim,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::RepeatInterleaveOpResult result =
+        ttnn_op_invoke::callRepeatInterleave(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            repeatInterleaveOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from RepeatInterleaveOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(repeatInterleaveOpQuery);
@@ -4284,6 +4373,7 @@ llvm::Expected<size_t> OpModel<RepeatInterleaveOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // RepeatOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout) {
@@ -4295,21 +4385,19 @@ llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Convert repeats to ttnn::Shape
-  ::ttnn::Shape repeatShape = conversion::getShape(repeats);
+  ::tt::target::ttnn::RepeatOpT repeatOpNative =
+      buildRepeatOpTFromMLIR(repeats, outputLayout);
 
-  // Convert output layout to memory config
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
-
-  // Convert Shape to SmallVector<uint32_t> to use overload with memory_config
-  ::ttsl::SmallVector<uint32_t> repeatVec(repeatShape.cbegin(),
-                                          repeatShape.cend());
-
-  // Create query closure
   auto repeatOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::repeat, device, inputSpec, repeatVec,
-                                outputMemoryConfig);
+    ttnn_op_invoke::RepeatOpResult result = ttnn_op_invoke::callRepeat(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, repeatOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from RepeatOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), repeatOpQuery);
@@ -4329,21 +4417,19 @@ llvm::Expected<size_t> OpModel<RepeatOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Convert repeats to SmallVector<uint32_t> to use overload with memory_config
-  ::ttsl::SmallVector<uint32_t> repeatVec;
-  repeatVec.reserve(repeats.size());
-  for (int64_t r : repeats) {
-    repeatVec.push_back(static_cast<uint32_t>(r));
-  }
+  ::tt::target::ttnn::RepeatOpT repeatOpNative =
+      buildRepeatOpTFromMLIR(repeats, outputLayout);
 
-  // Convert output layout to memory config
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
-
-  // Create query closure
   auto repeatOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::repeat, device, inputSpec, repeatVec,
-                            outputMemoryConfig);
+    ttnn_op_invoke::RepeatOpResult result =
+        ttnn_op_invoke::callRepeat(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                   repeatOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from RepeatOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(repeatOpQuery);
@@ -4355,34 +4441,6 @@ llvm::Expected<size_t> OpModel<RepeatOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // PadOp
 //===----------------------------------------------------------------------===//
-
-#ifdef TTMLIR_ENABLE_OPMODEL
-/**
- * @brief Converts padding array to PadSpecDim format for TTNN operations.
- *
- * @param padding Array of padding values in [before0, after0, before1, after1,
- * ...] format
- * @return SmallVector of PadSpecDim objects
- */
-static ttsl::SmallVector<::ttnn::operations::data_movement::PadSpecDim>
-convertPadding(llvm::ArrayRef<int32_t> padding) {
-  ttsl::SmallVector<::ttnn::operations::data_movement::PadSpecDim> paddingSpec;
-  // Reserve space to avoid memory reallocations
-  paddingSpec.reserve((padding.size() + 1) / 2);
-
-  constexpr int32_t defaultPadValue = 0;
-  for (size_t i = 0; i < padding.size(); i += 2) {
-    int32_t before = padding[i];
-    int32_t after = (i + 1 < padding.size()) ? padding[i + 1] : defaultPadValue;
-
-    assert(before >= 0 && after >= 0 && "Padding values must be non-negative");
-
-    paddingSpec.emplace_back(static_cast<uint32_t>(before),
-                             static_cast<uint32_t>(after));
-  }
-  return paddingSpec;
-}
-#endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -4396,14 +4454,19 @@ llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Convert padding to PadSpecDim format
-  auto paddingSpec = convertPadding(padding);
+  ::tt::target::ttnn::PadOpT padOpNative =
+      buildPadOpTFromMLIR(padding, padValue, multicore, outputLayout);
 
-  // Create query closure
   auto padOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::pad, device, inputSpec, paddingSpec,
-                                padValue.convertToFloat(), multicore,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::PadOpResult result =
+        ttnn_op_invoke::callPad(ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+                                padOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from PadOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), padOpQuery);
@@ -4424,14 +4487,19 @@ llvm::Expected<size_t> OpModel<PadOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Convert padding to PadSpecDim format
-  auto paddingSpec = convertPadding(padding);
+  ::tt::target::ttnn::PadOpT padOpNative =
+      buildPadOpTFromMLIR(padding, padValue, multicore, outputLayout);
 
-  // Create query closure
   auto padOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::pad, device, inputSpec, paddingSpec,
-                            padValue.convertToFloat(), multicore,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::PadOpResult result =
+        ttnn_op_invoke::callPad(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                padOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from PadOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(padOpQuery);
@@ -4443,6 +4511,7 @@ llvm::Expected<size_t> OpModel<PadOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // SortOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
     bool descending, bool stable, TTNNLayoutAttr outputLayout) {
@@ -4454,11 +4523,19 @@ llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::SortOpT sortOpNative =
+      buildSortOpTFromMLIR(dim, descending, stable, outputLayout);
+
   auto sortOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::sort, device, inputSpec, dim,
-                                descending, stable,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::SortOpResult result =
+        ttnn_op_invoke::callSort(ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+                                 sortOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from SortOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), sortOpQuery);
@@ -4478,11 +4555,19 @@ llvm::Expected<size_t> OpModel<SortOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::SortOpT sortOpNative =
+      buildSortOpTFromMLIR(dim, descending, stable, outputLayout);
+
   auto sortOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::sort, device, inputSpec,
-                            static_cast<int8_t>(dim), descending, stable,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::SortOpResult result =
+        ttnn_op_invoke::callSort(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                 sortOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from SortOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(sortOpQuery);
@@ -7443,6 +7528,7 @@ llvm::Expected<size_t> OpModel<ClampTensorOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Permute
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
@@ -7451,21 +7537,23 @@ llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  // Convert permutations of TTNN_PermuteOp to dims of ttnn::permute
-  ::ttsl::SmallVector<int64_t> dims(permutation.size());
-  std::copy(permutation.begin(), permutation.end(), dims.begin());
-
-  float defaultedPadValue = padValue.convertToFloat();
-
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::PermuteOpT permuteOpNative =
+      buildPermuteOpTFromMLIR(permutation, padValue, outputLayout);
+
   auto permuteQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::permute, device, inputSpec, dims,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                defaultedPadValue);
+    ttnn_op_invoke::PermuteOpResult result = ttnn_op_invoke::callPermute(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, permuteOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from PermuteOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), permuteQuery);
@@ -7482,22 +7570,23 @@ llvm::Expected<size_t> OpModel<PermuteOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  // Convert permutations of TTNN_PermuteOp to dims of ttnn::permute
-  ::ttsl::SmallVector<int64_t> dims(permutation.size());
-  std::copy(permutation.begin(), permutation.end(), dims.begin());
-
-  // Convert float
-  float defaultedPadValue = padValue.convertToFloat();
-
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::PermuteOpT permuteOpNative =
+      buildPermuteOpTFromMLIR(permutation, padValue, outputLayout);
+
   auto permuteQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::permute, device, inputSpec, dims,
-                            detail::getNullableMemoryConfig(outputLayout),
-                            defaultedPadValue);
+    ttnn_op_invoke::PermuteOpResult result =
+        ttnn_op_invoke::callPermute(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                    permuteOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from PermuteOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(permuteQuery);
@@ -7801,12 +7890,19 @@ llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
       ::ttnn::TensorSpec indexSpec,
       detail::convertToTensorSpec(device, indexShape, indexLayout));
 
+  ::tt::target::ttnn::GatherOpT gatherOpNative =
+      buildGatherOpTFromMLIR(dim, outputLayout);
+
   auto gatherOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::gather, device, inputSpec, static_cast<int8_t>(dim), indexSpec,
-        /*sparse_grad=*/false, detail::getNullableMemoryConfig(outputLayout),
-        /*optional_output_tensor=*/std::nullopt,
-        /*sub_core_grids=*/std::nullopt);
+    ttnn_op_invoke::GatherOpResult result = ttnn_op_invoke::callGather(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, gatherOpNative,
+        inputSpec, indexSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from GatherOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), gatherOpQuery);
@@ -7830,12 +7926,19 @@ llvm::Expected<size_t> OpModel<GatherOp>::getOpRuntime(
       ::ttnn::TensorSpec indexSpec,
       detail::convertToTensorSpec(device, indexShape, indexLayout));
 
+  ::tt::target::ttnn::GatherOpT gatherOpNative =
+      buildGatherOpTFromMLIR(dim, outputLayout);
+
   auto gatherOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::gather, device, inputSpec, static_cast<int8_t>(dim), indexSpec,
-        /*sparse_grad=*/false, detail::getNullableMemoryConfig(outputLayout),
-        /*optional_output_tensor=*/std::nullopt,
-        /*sub_core_grids=*/std::nullopt);
+    ttnn_op_invoke::GatherOpResult result = ttnn_op_invoke::callGather(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, gatherOpNative, inputSpec,
+        indexSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from GatherOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(gatherOpQuery);
@@ -8200,29 +8303,29 @@ OpModel<ConstantOp>::getOpConstraints(mlir::ElementsAttr value,
 llvm::Expected<OpConstraints>
 OpModel<mlir::tt::ttnn::AssignOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<mlir::tt::ttcore::DataType> outputDtype) {
+    std::optional<mlir::tt::ttcore::DataType> dtype,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  // Convert input tensor to TensorSpec
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  ::tt::tt_metal::MemoryConfig metalMemConfig =
-      conversion::getMemoryConfig(MemoryConfigAttr::get(inputLayout));
+  ::tt::target::ttnn::AssignOpT assignOpNative =
+      buildAssignOpTFromMLIR(outputLayout);
 
-  // Convert optional output dtype
-  std::optional<::tt::tt_metal::DataType> metalOutputDtype = std::nullopt;
-  if (outputDtype.has_value()) {
-    metalOutputDtype = conversion::getDataType(outputDtype.value());
-  }
-  // Create query closure
   auto assignOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::assign, device, inputSpec,
-                                metalMemConfig, metalOutputDtype,
-                                std::nullopt /*optionalOutputTensor*/);
+    ttnn_op_invoke::AssignOpResult result = ttnn_op_invoke::callAssign(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, assignOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from AssignOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), assignOpQuery);
@@ -8233,30 +8336,29 @@ OpModel<mlir::tt::ttnn::AssignOp>::getOpConstraints(
 
 llvm::Expected<size_t> OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<mlir::tt::ttcore::DataType> outputDtype) {
+    std::optional<mlir::tt::ttcore::DataType> dtype,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  // Convert input tensor to TensorSpec
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  ::tt::tt_metal::MemoryConfig metalMemConfig =
-      conversion::getMemoryConfig(inputLayout);
+  ::tt::target::ttnn::AssignOpT assignOpNative =
+      buildAssignOpTFromMLIR(outputLayout);
 
-  // Convert optional output dtype
-  std::optional<::tt::tt_metal::DataType> metalOutputDtype = std::nullopt;
-  if (outputDtype.has_value()) {
-    metalOutputDtype = conversion::getDataType(outputDtype.value());
-  }
-
-  // Create query closure
   auto assignOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::assign, device, inputSpec, metalMemConfig,
-                            metalOutputDtype,
-                            std::nullopt /*optionalOutputTensor*/);
+    ttnn_op_invoke::AssignOpResult result =
+        ttnn_op_invoke::callAssign(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                   assignOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from AssignOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(assignOpQuery);

--- a/runtime/lib/ttnn/operations/data_movement/assign.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/assign.cpp
@@ -4,9 +4,7 @@
 
 #include "operations/data_movement/assign.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/AssignOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::AssignOp *op, ProgramContext &context) {
@@ -14,26 +12,18 @@ void run(const ::tt::target::ttnn::AssignOp *op, ProgramContext &context) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->input());
 
-  std::optional<::ttnn::MemoryConfig> memoryConfigOpt =
-      op->output_memory_config() == 0
-          ? ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-                ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(
-                    op->output()))
-          : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-                op->output_memory_config());
+  ::tt::target::ttnn::AssignOpT assignOpNative;
+  op->UnPackTo(&assignOpNative);
 
-  ::ttnn::MemoryConfig memoryConfig =
-      memoryConfigOpt.value_or(::ttnn::MemoryConfig{
-          ::ttnn::TensorMemoryLayout::INTERLEAVED, ::ttnn::BufferType::DRAM});
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::DataType> outputDtype = std::nullopt;
-  if (op->output_dtype()) {
-    outputDtype =
-        ttnn_op_invoke::operations::utils::toTTNNDataType(*op->output_dtype());
-  }
+  ttnn_op_invoke::AssignOpResult result = ttnn_op_invoke::callAssign(
+      ttnn_op_invoke::CallType::EXECUTE, assignOpNative, &in, &targetDevice);
 
-  ::ttnn::Tensor output = ::ttnn::assign(in, memoryConfig, outputDtype,
-                                         std::nullopt /*optionalOutputTensor*/);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callAssign execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
   tensorPool.insertTTNNTensorAndValidate(op->output(), output);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/concat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/concat.cpp
@@ -4,28 +4,31 @@
 
 #include "operations/data_movement/concat.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/ConcatOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::ConcatOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  std::vector<::ttnn::Tensor> inputs;
+
+  std::vector<ttnn_op_invoke::TensorArg> inputArgs;
   for (const auto &input : *op->inputs()) {
     const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(input);
-    inputs.push_back(in);
+    inputArgs.push_back(&in);
   }
-  int32_t dim = op->dim();
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      op->memory_config() == 0
-          ? ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-                ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()))
-          : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-                op->memory_config());
-  ::ttnn::Tensor out = ::ttnn::concat(inputs, dim, memoryConfig);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::tt::target::ttnn::ConcatOpT concatOpNative;
+  op->UnPackTo(&concatOpNative);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::ConcatOpResult result = ttnn_op_invoke::callConcat(
+      ttnn_op_invoke::CallType::EXECUTE, concatOpNative, std::move(inputArgs),
+      &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callConcat execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/gather.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/gather.cpp
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/data_movement/gather.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/GatherOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 
@@ -15,17 +14,21 @@ void run(const ::tt::target::ttnn::GatherOp *op, ProgramContext &context) {
       tensorPool.getTTNNTensorAndValidate(op->input());
   const ::ttnn::Tensor &index =
       tensorPool.getTTNNTensorAndValidate(op->index());
-  int32_t dim = op->dim();
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+  ::tt::target::ttnn::GatherOpT gatherOpNative;
+  op->UnPackTo(&gatherOpNative);
 
-  ::ttnn::Tensor out =
-      ::ttnn::gather(input, dim, index, /*sparse_grad=*/false,
-                     outputMemoryConfig, std::nullopt, std::nullopt);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::GatherOpResult result =
+      ttnn_op_invoke::callGather(ttnn_op_invoke::CallType::EXECUTE,
+                                 gatherOpNative, &input, &index, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callGather execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/pad.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/pad.cpp
@@ -4,13 +4,7 @@
 
 #include "operations/data_movement/pad.h"
 #include "tt/runtime/detail/common/logger.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-#include "tt/runtime/workarounds.h"
-#include "tt_stl/span.hpp"
-
-#include <optional>
+#include "ttmlir/OpInvoke/TTNN/DataMovement/PadOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
@@ -18,21 +12,18 @@ void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  float padValue = op->value();
+  ::tt::target::ttnn::PadOpT padOpNative;
+  op->UnPackTo(&padOpNative);
 
-  ::ttnn::Tensor out;
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttsl::SmallVector<::ttnn::operations::data_movement::PadSpecDim> padding;
-  for (uint32_t i = 0; i < op->padding()->size(); i += 2) {
-    padding.emplace_back(op->padding()->Get(i), op->padding()->Get(i + 1));
-  }
+  ttnn_op_invoke::PadOpResult result = ttnn_op_invoke::callPad(
+      ttnn_op_invoke::CallType::EXECUTE, padOpNative, &in, &targetDevice);
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callPad execution");
 
-  out = ::ttnn::pad(in, padding, padValue, op->use_multicore(),
-                    outputMemoryConfig);
-
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -3,12 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/data_movement/permute.h"
-
 #include "tt/runtime/detail/common/logger.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-#include <vector>
+#include "ttmlir/OpInvoke/TTNN/DataMovement/PermuteOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
@@ -16,15 +12,18 @@ void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  ::ttsl::SmallVector<int64_t> permutation(op->permutation()->begin(),
-                                           op->permutation()->end());
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  float padValue = op->pad_value();
+  ::tt::target::ttnn::PermuteOpT permuteOpNative;
+  op->UnPackTo(&permuteOpNative);
 
-  ::ttnn::Tensor out = ::ttnn::permute(in, permutation, memoryConfig, padValue);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::PermuteOpResult result = ttnn_op_invoke::callPermute(
+      ttnn_op_invoke::CallType::EXECUTE, permuteOpNative, &in, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callPermute execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/repeat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/repeat.cpp
@@ -4,9 +4,7 @@
 
 #include "operations/data_movement/repeat.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/RepeatOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::RepeatOp *op, ProgramContext &context) {
@@ -14,15 +12,18 @@ void run(const ::tt::target::ttnn::RepeatOp *op, ProgramContext &context) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  const auto *fbShape = op->repeat_dims();
-  const ::ttsl::SmallVector<uint32_t> repeatDims(fbShape->begin(),
-                                                 fbShape->end());
+  ::tt::target::ttnn::RepeatOpT repeatOpNative;
+  op->UnPackTo(&repeatOpNative);
 
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::Tensor out = ::ttnn::repeat(in, repeatDims, memoryConfig);
+  ttnn_op_invoke::RepeatOpResult result = ttnn_op_invoke::callRepeat(
+      ttnn_op_invoke::CallType::EXECUTE, repeatOpNative, &in, &targetDevice);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callRepeat execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/repeat_interleave.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/repeat_interleave.cpp
@@ -3,11 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/data_movement/repeat_interleave.h"
-
 #include "tt/runtime/detail/common/logger.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/RepeatInterleaveOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::RepeatInterleaveOp *op,
@@ -17,15 +14,20 @@ void run(const ::tt::target::ttnn::RepeatInterleaveOp *op,
   const ::ttnn::Tensor &input =
       tensorPool.getTTNNTensorAndValidate(op->input());
 
-  uint32_t repeats = op->repeats();
-  int32_t dim = op->dim();
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+  ::tt::target::ttnn::RepeatInterleaveOpT repeatInterleaveOpNative;
+  op->UnPackTo(&repeatInterleaveOpNative);
 
-  ::ttnn::Tensor out =
-      ::ttnn::repeat_interleave(input, repeats, dim, memoryConfig);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::RepeatInterleaveOpResult result =
+      ttnn_op_invoke::callRepeatInterleave(ttnn_op_invoke::CallType::EXECUTE,
+                                           repeatInterleaveOpNative, &input,
+                                           &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callRepeatInterleave execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/reshape.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/reshape.cpp
@@ -4,9 +4,7 @@
 
 #include "operations/data_movement/reshape.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/ReshapeOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
@@ -14,15 +12,18 @@ void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  const auto *fbShape = op->shape();
-  std::vector<int32_t> shape(fbShape->begin(), fbShape->end());
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      op->memory_config() == 0
-          ? ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-                ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()))
-          : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-                op->memory_config());
-  ::ttnn::Tensor out = ::ttnn::reshape(in, shape, memoryConfig);
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::tt::target::ttnn::ReshapeOpT reshapeOpNative;
+  op->UnPackTo(&reshapeOpNative);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::ReshapeOpResult result = ttnn_op_invoke::callReshape(
+      ttnn_op_invoke::CallType::EXECUTE, reshapeOpNative, &in, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callReshape execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/scatter.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/scatter.cpp
@@ -4,9 +4,7 @@
 
 #include "operations/data_movement/scatter.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/ScatterOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 
@@ -18,40 +16,21 @@ void run(const ::tt::target::ttnn::ScatterOp *op, ProgramContext &context) {
       tensorPool.getTTNNTensorAndValidate(op->index());
   const ::ttnn::Tensor &source =
       tensorPool.getTTNNTensorAndValidate(op->source());
-  int32_t dim = op->dim();
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  // TT Metal currently only supports the following scatter reduction types:
-  // SUM, MULTIPLY, AMIN, AMAX - applied reduction to source tensor
-  // INVALID - copy source to output tensor and apply no reduction(pass
-  // std::nullopt)
-  std::optional<std::string> scatterReduceTypeString;
-  switch (op->scatter_reduce_type()) {
-  case ::tt::target::ttnn::ScatterReduceType::Sum: // Sum -> add
-    scatterReduceTypeString = "add";
-    break;
-  case ::tt::target::ttnn::ScatterReduceType::Prod: // Prod -> multiply
-    scatterReduceTypeString = "multiply";
-    break;
-  case ::tt::target::ttnn::ScatterReduceType::Min: // Min -> amin
-    scatterReduceTypeString = "amin";
-    break;
-  case ::tt::target::ttnn::ScatterReduceType::Max: // Max -> amax
-    scatterReduceTypeString = "amax";
-    break;
-  case ::tt::target::ttnn::ScatterReduceType::Invalid: // Invalid -> no
-                                                       // reduction
-    scatterReduceTypeString = std::nullopt;
-    break;
-  }
+  ::tt::target::ttnn::ScatterOpT scatterOpNative;
+  op->UnPackTo(&scatterOpNative);
 
-  ::ttnn::Tensor out =
-      ::ttnn::scatter(input, dim, index, source, outputMemoryConfig,
-                      scatterReduceTypeString, std::nullopt);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::ScatterOpResult result = ttnn_op_invoke::callScatter(
+      ttnn_op_invoke::CallType::EXECUTE, scatterOpNative, &input, &index,
+      &source, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callScatter execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/slice.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/slice.cpp
@@ -6,36 +6,28 @@
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
-
+#include "ttmlir/OpInvoke/TTNN/DataMovement/SliceOp.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include <cstdint>
 
 namespace tt::runtime::ttnn::operations::data_movement {
 static void runSliceStaticOp(const ::tt::target::ttnn::SliceOp *op,
-                             ProgramTensorPool &tensorPool) {
+                             ProgramTensorPool &tensorPool,
+                             ::ttnn::MeshDevice &targetDevice) {
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  ::ttsl::SmallVector<int32_t> begins(
-      op->params_as<target::ttnn::SliceStaticOpParams>()->begins()->begin(),
-      op->params_as<target::ttnn::SliceStaticOpParams>()->begins()->end());
-  ::ttsl::SmallVector<int32_t> ends(
-      op->params_as<target::ttnn::SliceStaticOpParams>()->ends()->begin(),
-      op->params_as<target::ttnn::SliceStaticOpParams>()->ends()->end());
-  ::ttsl::SmallVector<int32_t> step(op->step()->begin(), op->step()->end());
+  ::tt::target::ttnn::SliceOpT sliceOpNative;
+  op->UnPackTo(&sliceOpNative);
 
-  ttsl::Span<const int32_t> beginsSpan(begins.data(), begins.size());
-  ttsl::Span<const int32_t> endsSpan(ends.data(), ends.size());
-  ttsl::Span<const int32_t> stepSpan(step.data(), step.size());
+  ttnn_op_invoke::SliceOpResult result = ttnn_op_invoke::callSliceStatic(
+      ttnn_op_invoke::CallType::EXECUTE, sliceOpNative, &in, &targetDevice);
 
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callSliceStatic execution");
 
-  ::ttnn::Tensor out =
-      ::ttnn::slice(in, beginsSpan, endsSpan, stepSpan, memoryConfig);
-
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 static void runSliceDynamicOp(const ::tt::target::ttnn::SliceOp *op,
@@ -66,10 +58,11 @@ static void runSliceDynamicOp(const ::tt::target::ttnn::SliceOp *op,
 
 void run(const ::tt::target::ttnn::SliceOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
   switch (op->type()) {
   case ::tt::target::ttnn::SliceOpType::SliceStaticOp:
-    runSliceStaticOp(op, tensorPool);
+    runSliceStaticOp(op, tensorPool, targetDevice);
     break;
   case ::tt::target::ttnn::SliceOpType::SliceDynamicOp:
     runSliceDynamicOp(op, tensorPool);

--- a/runtime/lib/ttnn/operations/data_movement/sort.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/sort.cpp
@@ -3,26 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/data_movement/sort.h"
-
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-
-#include "ttmlir/Target/TTNN/program_generated.h"
-#include <optional>
-#include <vector>
+#include "ttmlir/OpInvoke/TTNN/DataMovement/SortOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::SortOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+  ::tt::target::ttnn::SortOpT sortOpNative;
+  op->UnPackTo(&sortOpNative);
 
-  std::vector<::ttnn::Tensor> outputs =
-      ::ttnn::sort(in, op->dim(), op->descending(), op->stable(),
-                   outputMemoryConfig, std::nullopt);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::SortOpResult result = ttnn_op_invoke::callSort(
+      ttnn_op_invoke::CallType::EXECUTE, sortOpNative, &in, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<std::vector<::ttnn::Tensor>>(result),
+             "Expected vector<Tensor> from callSort execution");
+
+  auto outputs = std::get<std::vector<::ttnn::Tensor>>(result);
 
   LOG_ASSERT(
       op->outputs()->size() == outputs.size(),

--- a/runtime/lib/ttnn/operations/data_movement/transpose.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/transpose.cpp
@@ -4,28 +4,25 @@
 
 #include "operations/data_movement/transpose.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/TransposeOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::TransposeOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  int32_t dim0 = op->dim0();
-  int32_t dim1 = op->dim1();
+  ::tt::target::ttnn::TransposeOpT transposeOpNative;
+  op->UnPackTo(&transposeOpNative);
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::Tensor out = ::ttnn::transpose(in, dim0, dim1, outputMemoryConfig);
+  ttnn_op_invoke::TransposeOpResult result = ttnn_op_invoke::callTranspose(
+      ttnn_op_invoke::CallType::EXECUTE, transposeOpNative, &in, &targetDevice);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callTranspose execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/write_tensor.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/write_tensor.cpp
@@ -4,10 +4,8 @@
 
 #include "operations/data_movement/write_tensor.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
-#include "ttnn/tensor/tensor_impl.hpp"
+#include "ttmlir/OpInvoke/TTNN/DataMovement/WriteTensorOp.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::WriteTensorOp *op, ProgramContext &context) {
@@ -21,10 +19,17 @@ void run(const ::tt::target::ttnn::WriteTensorOp *op, ProgramContext &context) {
       tensorPool.getTTNNTensorAndValidate(op->host_tensor());
   ::ttnn::Tensor &deviceTensor =
       tensorPool.getTTNNTensorAndValidate(op->device_tensor());
-  ::ttnn::QueueId ttnnCqId = ::ttnn::QueueId(op->cq_id());
 
-  // Note: copy_to_device replaced write_tensor and does not have a blocking
-  // parameter. The operation is always blocking.
-  ::tt::tt_metal::copy_to_device(hostTensor, deviceTensor, ttnnCqId);
+  ::tt::target::ttnn::WriteTensorOpT writeTensorOpNative;
+  op->UnPackTo(&writeTensorOpNative);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::WriteTensorOpResult result = ttnn_op_invoke::callWriteTensor(
+      ttnn_op_invoke::CallType::EXECUTE, writeTensorOpNative, &hostTensor,
+      &deviceTensor, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<std::monostate>(result),
+             "Expected std::monostate from callWriteTensor execution");
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
@@ -5037,4 +5037,1122 @@ const std::initializer_list<mlir::tt::ttnn::SoftmaxOp> softmaxOpList = {
 INSTANTIATE_TEST_SUITE_P(SoftmaxOpTPathParityTest, SoftmaxOpTPathParityTest,
                          ::testing::ValuesIn(softmaxOpList));
 
+//===----------------------------------------------------------------------===//
+// AssignOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+const mlir::tt::ttcore::DataTypeAttr f32DtypeAttr =
+    mlir::tt::ttcore::DataTypeAttr::get(getContext(),
+                                        mlir::tt::ttcore::DataType::Float32);
+
+void resetUnusedFields(::tt::target::ttnn::AssignOpT &opNativeOpModel,
+                       ::tt::target::ttnn::AssignOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::AssignOpT &op) {
+    op.input.reset();
+    op.output_memory_config.reset();
+    op.output_dtype.reset();
+    op.output.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::AssignOp
+buildTestAssignOp(mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::RankedTensorType outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  return e.builder.create<mlir::tt::ttnn::AssignOp>(loc, outputType,
+                                                    makeOnes());
+}
+
+} // namespace
+
+using AssignOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::AssignOp>;
+
+TEST_P(AssignOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::AssignOp assignOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::AssignOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildAssignOpTFromMLIR(
+          resolveOutputLayout(assignOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, assignOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, assignOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::AssignOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.output, opNativeFB.output);
+}
+
+const std::initializer_list<mlir::tt::ttnn::AssignOp> assignOpList = {
+    buildTestAssignOp(),
+    buildTestAssignOp(/*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(AssignOpTPathParityTest, AssignOpTPathParityTest,
+                         ::testing::ValuesIn(assignOpList));
+
+//===----------------------------------------------------------------------===//
+// ConcatOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::ConcatOpT &opNativeOpModel,
+                       ::tt::target::ttnn::ConcatOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ConcatOpT &op) {
+    op.inputs.clear();
+    op.memory_config.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::ConcatOp
+buildTestConcatOp(int32_t dim = 0,
+                  mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  llvm::SmallVector<int64_t> outputShape =
+      dim == 0 ? llvm::SmallVector<int64_t>{64, 32}
+               : llvm::SmallVector<int64_t>{32, 64};
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(outputShape, outputMemoryConfig)
+          : tiledL1BF16Type(outputShape);
+
+  mlir::Value input1 = makeOnes();
+  mlir::Value input2 = makeOnes();
+
+  return e.builder.create<mlir::tt::ttnn::ConcatOp>(
+      loc, outputType, mlir::ValueRange{input1, input2}, dim);
+}
+
+} // namespace
+
+using ConcatOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ConcatOp>;
+
+TEST_P(ConcatOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::ConcatOp concatOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ConcatOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildConcatOpTFromMLIR(
+          concatOp.getDim(), resolveOutputLayout(concatOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  for (mlir::Value input : concatOp.getInputs()) {
+    cache.getOrCreateNoSharding(mlir::tt::ttnn::getOperandThroughDPSOps(input),
+                                mlir::tt::ttnn::tensorValueToFlatbuffer,
+                                /*localShape=*/std::nullopt);
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createConcatOp(cache, concatOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ConcatOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::ConcatOp> concatOpList = {
+    buildTestConcatOp(),
+    buildTestConcatOp(/*dim=*/1),
+    buildTestConcatOp(/*dim=*/0,
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestConcatOp(/*dim=*/1,
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(ConcatOpTPathParityTest, ConcatOpTPathParityTest,
+                         ::testing::ValuesIn(concatOpList));
+
+//===----------------------------------------------------------------------===//
+// GatherOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::GatherOpT &opNativeOpModel,
+                       ::tt::target::ttnn::GatherOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::GatherOpT &op) {
+    op.input.reset();
+    op.index.reset();
+    op.memory_config.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::GatherOp
+buildTestGatherOp(int32_t dim = 0,
+                  mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  return e.builder.create<mlir::tt::ttnn::GatherOp>(loc, outputType, makeOnes(),
+                                                    makeOnes(), dim);
+}
+
+} // namespace
+
+using GatherOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::GatherOp>;
+
+TEST_P(GatherOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::GatherOp gatherOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::GatherOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildGatherOpTFromMLIR(
+          gatherOp.getDim(), resolveOutputLayout(gatherOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, gatherOp.getInput(), gatherOp.getIndex());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, gatherOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::GatherOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::GatherOp> gatherOpList = {
+    buildTestGatherOp(),
+    buildTestGatherOp(/*dim=*/1),
+    buildTestGatherOp(/*dim=*/0,
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestGatherOp(/*dim=*/1,
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(GatherOpTPathParityTest, GatherOpTPathParityTest,
+                         ::testing::ValuesIn(gatherOpList));
+
+//===----------------------------------------------------------------------===//
+// PadOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::PadOpT &opNativeOpModel,
+                       ::tt::target::ttnn::PadOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::PadOpT &op) {
+    op.in.reset();
+    op.memcfg.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PadOp
+buildTestPadOp(std::vector<int32_t> padding = {0, 0, 0, 0}, float value = 0.0f,
+               bool useMulticore = false,
+               mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  llvm::SmallVector<int64_t> outputShape;
+  for (size_t i = 0; i < defaultShape.size(); ++i) {
+    outputShape.push_back(defaultShape[i] + padding[2 * i] +
+                          padding[2 * i + 1]);
+  }
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(outputShape, outputMemoryConfig)
+          : tiledL1BF16Type(outputShape);
+
+  return e.builder.create<mlir::tt::ttnn::PadOp>(
+      loc, outputType, makeOnes(),
+      mlir::DenseI32ArrayAttr::get(&e.context, padding),
+      mlir::FloatAttr::get(e.builder.getF32Type(), static_cast<double>(value)),
+      mlir::BoolAttr::get(&e.context, useMulticore));
+}
+
+} // namespace
+
+using PadOpTPathParityTest = ::testing::TestWithParam<mlir::tt::ttnn::PadOp>;
+
+TEST_P(PadOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PadOp padOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::PadOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildPadOpTFromMLIR(
+          padOp.getPadding(), padOp.getValue(), padOp.getUseMulticore(),
+          resolveOutputLayout(padOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, padOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createPadOp(cache, padOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PadOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::PadOp> padOpList = {
+    buildTestPadOp(),
+    buildTestPadOp(/*padding=*/{0, 2, 0, 2}),
+    buildTestPadOp(/*padding=*/{0, 0, 0, 0}, /*value=*/1.0f),
+    buildTestPadOp(/*padding=*/{0, 0, 0, 0}, /*value=*/0.0f,
+                   /*useMulticore=*/true),
+    buildTestPadOp(/*padding=*/{0, 0, 0, 0}, /*value=*/0.0f,
+                   /*useMulticore=*/false,
+                   /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestPadOp(/*padding=*/{0, 2, 0, 2}, /*value=*/1.0f,
+                   /*useMulticore=*/true,
+                   /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(PadOpTPathParityTest, PadOpTPathParityTest,
+                         ::testing::ValuesIn(padOpList));
+
+//===----------------------------------------------------------------------===//
+// PermuteOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::PermuteOpT &opNativeOpModel,
+                       ::tt::target::ttnn::PermuteOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::PermuteOpT &op) {
+    op.in.reset();
+    op.memory_config.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PermuteOp
+buildTestPermuteOp(std::vector<int64_t> permutation = {1, 0},
+                   float padValue = 0.0f,
+                   mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  llvm::SmallVector<int64_t> outputShape(defaultShape.size());
+  for (size_t i = 0; i < permutation.size(); ++i) {
+    outputShape[i] = defaultShape[permutation[i]];
+  }
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(outputShape, outputMemoryConfig)
+          : tiledL1BF16Type(outputShape);
+
+  return e.builder.create<mlir::tt::ttnn::PermuteOp>(
+      loc, outputType, makeOnes(),
+      mlir::DenseI64ArrayAttr::get(&e.context, permutation),
+      mlir::FloatAttr::get(e.builder.getF32Type(),
+                           static_cast<double>(padValue)));
+}
+
+} // namespace
+
+using PermuteOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::PermuteOp>;
+
+TEST_P(PermuteOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PermuteOp permuteOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::PermuteOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildPermuteOpTFromMLIR(
+          permuteOp.getPermutation(), permuteOp.getPadValue(),
+          resolveOutputLayout(permuteOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, permuteOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, permuteOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PermuteOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::PermuteOp> permuteOpList = {
+    buildTestPermuteOp(),
+    buildTestPermuteOp(/*permutation=*/{0, 1}),
+    buildTestPermuteOp(/*permutation=*/{1, 0}, /*padValue=*/1.0f),
+    buildTestPermuteOp(/*permutation=*/{1, 0}, /*padValue=*/0.0f,
+                       /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestPermuteOp(/*permutation=*/{0, 1}, /*padValue=*/1.0f,
+                       /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(PermuteOpTPathParityTest, PermuteOpTPathParityTest,
+                         ::testing::ValuesIn(permuteOpList));
+
+//===----------------------------------------------------------------------===//
+// RepeatInterleaveOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::RepeatInterleaveOpT &opNativeOpModel,
+                       ::tt::target::ttnn::RepeatInterleaveOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::RepeatInterleaveOpT &op) {
+    op.input.reset();
+    op.memory_config.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::RepeatInterleaveOp buildTestRepeatInterleaveOp(
+    uint32_t repeats = 2, int32_t dim = 0,
+    mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  llvm::SmallVector<int64_t> outputShape(defaultShape.begin(),
+                                         defaultShape.end());
+  outputShape[dim] = defaultShape[dim] * static_cast<int64_t>(repeats);
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(outputShape, outputMemoryConfig)
+          : tiledL1BF16Type(outputShape);
+
+  return e.builder.create<mlir::tt::ttnn::RepeatInterleaveOp>(
+      loc, outputType, makeOnes(),
+      e.builder.getIntegerAttr(e.builder.getIntegerType(32, /*isSigned=*/false),
+                               repeats),
+      e.builder.getI32IntegerAttr(dim));
+}
+
+} // namespace
+
+using RepeatInterleaveOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::RepeatInterleaveOp>;
+
+TEST_P(RepeatInterleaveOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::RepeatInterleaveOp repeatInterleaveOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::RepeatInterleaveOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildRepeatInterleaveOpTFromMLIR(
+          repeatInterleaveOp.getRepeats(), repeatInterleaveOp.getDim(),
+          resolveOutputLayout(repeatInterleaveOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, repeatInterleaveOp.getInput());
+
+  auto fbOffset =
+      mlir::tt::ttnn::createRepeatInterleaveOp(cache, repeatInterleaveOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::RepeatInterleaveOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::RepeatInterleaveOp>
+    repeatInterleaveOpList = {
+        buildTestRepeatInterleaveOp(),
+        buildTestRepeatInterleaveOp(/*repeats=*/3),
+        buildTestRepeatInterleaveOp(/*repeats=*/2, /*dim=*/1),
+        buildTestRepeatInterleaveOp(
+            /*repeats=*/2, /*dim=*/0,
+            /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+        buildTestRepeatInterleaveOp(
+            /*repeats=*/3, /*dim=*/1,
+            /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(RepeatInterleaveOpTPathParityTest,
+                         RepeatInterleaveOpTPathParityTest,
+                         ::testing::ValuesIn(repeatInterleaveOpList));
+
+//===----------------------------------------------------------------------===//
+// RepeatOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::RepeatOpT &opNativeOpModel,
+                       ::tt::target::ttnn::RepeatOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::RepeatOpT &op) {
+    op.in.reset();
+    op.memcfg.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::RepeatOp
+buildTestRepeatOp(std::vector<int64_t> repeatDims = {1, 1},
+                  mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  llvm::SmallVector<int64_t> outputShape(defaultShape.size());
+  for (size_t i = 0; i < defaultShape.size(); ++i) {
+    outputShape[i] = defaultShape[i] * repeatDims[i];
+  }
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(outputShape, outputMemoryConfig)
+          : tiledL1BF16Type(outputShape);
+
+  auto repeatDimsAttr = mlir::tt::ttnn::ShapeAttr::get(&e.context, repeatDims);
+
+  return e.builder.create<mlir::tt::ttnn::RepeatOp>(loc, outputType, makeOnes(),
+                                                    repeatDimsAttr);
+}
+
+} // namespace
+
+using RepeatOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::RepeatOp>;
+
+TEST_P(RepeatOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::RepeatOp repeatOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::RepeatOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildRepeatOpTFromMLIR(
+          repeatOp.getRepeatDims().getShape(), resolveOutputLayout(repeatOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, repeatOp.getInput());
+
+  auto fbOffset =
+      mlir::tt::ttnn::createRepeatOp<mlir::tt::ttnn::RepeatOp>(cache, repeatOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::RepeatOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::RepeatOp> repeatOpList = {
+    buildTestRepeatOp(),
+    buildTestRepeatOp(/*repeatDims=*/{2, 1}),
+    buildTestRepeatOp(/*repeatDims=*/{1, 1},
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestRepeatOp(/*repeatDims=*/{2, 1},
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(RepeatOpTPathParityTest, RepeatOpTPathParityTest,
+                         ::testing::ValuesIn(repeatOpList));
+
+//===----------------------------------------------------------------------===//
+// ReshapeOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::ReshapeOpT &opNativeOpModel,
+                       ::tt::target::ttnn::ReshapeOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ReshapeOpT &op) {
+    op.in.reset();
+    op.memory_config.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::ReshapeOp
+buildTestReshapeOp(std::vector<int32_t> shape = {32, 32},
+                   mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  llvm::SmallVector<int64_t> outputShape(shape.begin(), shape.end());
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(outputShape, outputMemoryConfig)
+          : tiledL1BF16Type(outputShape);
+
+  return e.builder.create<mlir::tt::ttnn::ReshapeOp>(
+      loc, outputType, makeOnes(), e.builder.getI32ArrayAttr(shape));
+}
+
+} // namespace
+
+using ReshapeOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ReshapeOp>;
+
+TEST_P(ReshapeOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::ReshapeOp reshapeOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ReshapeOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildReshapeOpTFromMLIR(
+          reshapeOp.getResult().getType().getShape(),
+          resolveOutputLayout(reshapeOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, reshapeOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createReshapeOp(cache, reshapeOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ReshapeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::ReshapeOp> reshapeOpList = {
+    buildTestReshapeOp(),
+    buildTestReshapeOp(/*shape=*/{16, 64}),
+    buildTestReshapeOp(/*shape=*/{32, 32},
+                       /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestReshapeOp(/*shape=*/{16, 64},
+                       /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(ReshapeOpTPathParityTest, ReshapeOpTPathParityTest,
+                         ::testing::ValuesIn(reshapeOpList));
+
+//===----------------------------------------------------------------------===//
+// ScatterOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::ScatterOpT &opNativeOpModel,
+                       ::tt::target::ttnn::ScatterOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ScatterOpT &op) {
+    op.input.reset();
+    op.index.reset();
+    op.source.reset();
+    op.memory_config.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::ScatterOp
+buildTestScatterOp(int32_t dim = 0,
+                   mlir::tt::ttcore::ReduceType reduceType =
+                       mlir::tt::ttcore::ReduceType::Invalid,
+                   mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  auto reduceTypeAttr =
+      mlir::tt::ttcore::ReduceTypeAttr::get(&e.context, reduceType);
+
+  return e.builder.create<mlir::tt::ttnn::ScatterOp>(
+      loc, outputType, makeOnes(), makeOnes(), makeOnes(),
+      e.builder.getI32IntegerAttr(dim), reduceTypeAttr);
+}
+
+} // namespace
+
+using ScatterOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ScatterOp>;
+
+TEST_P(ScatterOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::ScatterOp scatterOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ScatterOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildScatterOpTFromMLIR(
+          scatterOp.getDim(), scatterOp.getScatterReduceType(),
+          resolveOutputLayout(scatterOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, scatterOp.getInput(),
+                               scatterOp.getIndex(), scatterOp.getSource());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, scatterOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ScatterOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::ScatterOp> scatterOpList = {
+    buildTestScatterOp(),
+    buildTestScatterOp(/*dim=*/1),
+    buildTestScatterOp(/*dim=*/0, mlir::tt::ttcore::ReduceType::Sum),
+    buildTestScatterOp(/*dim=*/0, mlir::tt::ttcore::ReduceType::Invalid,
+                       /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestScatterOp(/*dim=*/1, mlir::tt::ttcore::ReduceType::Max,
+                       /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(ScatterOpTPathParityTest, ScatterOpTPathParityTest,
+                         ::testing::ValuesIn(scatterOpList));
+
+//===----------------------------------------------------------------------===//
+// SliceStaticOpTPathParity
+//===----------------------------------------------------------------------===//
+namespace mlir::tt::ttnn::detail {
+llvm::SmallVector<int64_t>
+convertArrayAttrToSmallVec(mlir::ArrayAttr arrayAttr);
+} // namespace mlir::tt::ttnn::detail
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::SliceOpT &opNativeOpModel,
+                       ::tt::target::ttnn::SliceOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::SliceOpT &op) {
+    op.in.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::SliceStaticOp buildTestSliceStaticOp(
+    std::vector<int64_t> begins = {0, 0}, std::vector<int64_t> ends = {16, 16},
+    std::vector<int64_t> step = {1, 1},
+    mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  llvm::SmallVector<int64_t> outputShape;
+  for (size_t i = 0; i < begins.size(); ++i) {
+    int64_t dim = (ends[i] - begins[i] + step[i] - 1) / step[i];
+    outputShape.push_back(dim);
+  }
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(outputShape, outputMemoryConfig)
+          : tiledL1BF16Type(outputShape);
+
+  llvm::SmallVector<int32_t> begins32(begins.begin(), begins.end());
+  llvm::SmallVector<int32_t> ends32(ends.begin(), ends.end());
+  llvm::SmallVector<int32_t> step32(step.begin(), step.end());
+
+  return e.builder.create<mlir::tt::ttnn::SliceStaticOp>(
+      loc, outputType, makeOnes(), e.builder.getI32ArrayAttr(begins32),
+      e.builder.getI32ArrayAttr(ends32), e.builder.getI32ArrayAttr(step32));
+}
+
+} // namespace
+
+using SliceStaticOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::SliceStaticOp>;
+
+TEST_P(SliceStaticOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::SliceStaticOp sliceStaticOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::SliceOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildSliceStaticOpTFromMLIR(
+          mlir::tt::ttnn::detail::convertArrayAttrToSmallVec(
+              sliceStaticOp.getBegins()),
+          mlir::tt::ttnn::detail::convertArrayAttrToSmallVec(
+              sliceStaticOp.getEnds()),
+          mlir::tt::ttnn::detail::convertArrayAttrToSmallVec(
+              sliceStaticOp.getStep()),
+          resolveOutputLayout(sliceStaticOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, sliceStaticOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createSliceOp(cache, sliceStaticOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::SliceOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::SliceStaticOp> sliceStaticOpList = {
+    buildTestSliceStaticOp(),
+    buildTestSliceStaticOp(/*begins=*/{4, 4}, /*ends=*/{16, 16},
+                           /*step=*/{1, 1}),
+    buildTestSliceStaticOp(/*begins=*/{0, 0}, /*ends=*/{8, 8},
+                           /*step=*/{1, 1}),
+    buildTestSliceStaticOp(/*begins=*/{0, 0}, /*ends=*/{16, 16},
+                           /*step=*/{2, 2}),
+    buildTestSliceStaticOp(/*begins=*/{0, 0}, /*ends=*/{16, 16},
+                           /*step=*/{1, 1},
+                           /*outputMemoryConfig=*/
+                           nonDefaultInputMemoryConfigAttr),
+    buildTestSliceStaticOp(/*begins=*/{4, 4}, /*ends=*/{8, 8},
+                           /*step=*/{2, 2},
+                           /*outputMemoryConfig=*/
+                           nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(SliceStaticOpTPathParityTest,
+                         SliceStaticOpTPathParityTest,
+                         ::testing::ValuesIn(sliceStaticOpList));
+
+//===----------------------------------------------------------------------===//
+// SortOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::SortOpT &opNativeOpModel,
+                       ::tt::target::ttnn::SortOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::SortOpT &op) {
+    op.in.reset();
+    op.memcfg.reset();
+    if (!op.outputs.empty() && op.outputs[0]) {
+      op.outputs[0].reset();
+      op.outputs.resize(1);
+    }
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::SortOp
+buildTestSortOp(int dim = -1, bool descending = false, bool stable = false,
+                mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto valuesType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+  auto indicesType = tiledL1BF16Type(defaultShape);
+
+  return e.builder.create<mlir::tt::ttnn::SortOp>(
+      loc, mlir::TypeRange{valuesType, indicesType}, makeOnes(),
+      e.builder.getIntegerAttr(e.builder.getIntegerType(8, /*isSigned=*/true),
+                               dim),
+      e.builder.getBoolAttr(descending), e.builder.getBoolAttr(stable));
+}
+
+} // namespace
+
+using SortOpTPathParityTest = ::testing::TestWithParam<mlir::tt::ttnn::SortOp>;
+
+TEST_P(SortOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::SortOp sortOp = GetParam();
+
+  auto valuesLayout = mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+      mlir::cast<mlir::RankedTensorType>(sortOp.getValues().getType())
+          .getEncoding());
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::SortOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildSortOpTFromMLIR(
+          sortOp.getDim(), sortOp.getDescending(), sortOp.getStable(),
+          valuesLayout);
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, sortOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createSortOp(cache, sortOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::SortOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.outputs[0], opNativeFB.outputs[0]);
+}
+
+const std::initializer_list<mlir::tt::ttnn::SortOp> sortOpList = {
+    buildTestSortOp(),
+    buildTestSortOp(/*dim=*/0),
+    buildTestSortOp(/*dim=*/-1, /*descending=*/true),
+    buildTestSortOp(/*dim=*/-1, /*descending=*/false, /*stable=*/true),
+    buildTestSortOp(/*dim=*/-1, /*descending=*/false, /*stable=*/false,
+                    /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestSortOp(/*dim=*/0, /*descending=*/true, /*stable=*/true,
+                    /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(SortOpTPathParityTest, SortOpTPathParityTest,
+                         ::testing::ValuesIn(sortOpList));
+
+//===----------------------------------------------------------------------===//
+// TransposeOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::TransposeOpT &opNativeOpModel,
+                       ::tt::target::ttnn::TransposeOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::TransposeOpT &op) {
+    op.in.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::TransposeOp
+buildTestTransposeOp(int32_t dim0 = 0, int32_t dim1 = 1,
+                     mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  return e.builder.create<mlir::tt::ttnn::TransposeOp>(
+      loc, outputType, makeOnes(), e.builder.getI32IntegerAttr(dim0),
+      e.builder.getI32IntegerAttr(dim1));
+}
+
+} // namespace
+
+using TransposeOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::TransposeOp>;
+
+TEST_P(TransposeOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::TransposeOp transposeOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::TransposeOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildTransposeOpTFromMLIR(
+          transposeOp.getDim0(), transposeOp.getDim1(),
+          resolveOutputLayout(transposeOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, transposeOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createTransposeOp(cache, transposeOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::TransposeOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::TransposeOp> transposeOpList = {
+    buildTestTransposeOp(),
+    buildTestTransposeOp(/*dim0=*/1, /*dim1=*/0),
+    buildTestTransposeOp(/*dim0=*/0, /*dim1=*/-1),
+    buildTestTransposeOp(
+        /*dim0=*/0, /*dim1=*/1,
+        /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestTransposeOp(
+        /*dim0=*/1, /*dim1=*/0,
+        /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(TransposeOpTPathParityTest, TransposeOpTPathParityTest,
+                         ::testing::ValuesIn(transposeOpList));
+
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -636,6 +636,7 @@ TEST_F(OpModelTest, Scatter) {
   const int32_t dim = 0;
   const ttcore::ReduceTypeAttr reduceTypeAttr =
       ttcore::ReduceTypeAttr::get(&context, ttcore::ReduceType::Invalid);
+  const ttcore::ReduceType reduceType = reduceTypeAttr.getValue();
 
   const TTNNLayoutAttr inputLayoutDRAM = CreateTiledLayout(
       inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
@@ -653,7 +654,7 @@ TEST_F(OpModelTest, Scatter) {
   // DRAM layouts
   auto constraintsExp = OpModel<ScatterOp>::getOpConstraints(
       inputShape, inputLayoutDRAM, indexSourceShape, indexLayoutDRAM,
-      indexSourceShape, sourceLayoutDRAM, dim, reduceTypeAttr, inputLayoutDRAM);
+      indexSourceShape, sourceLayoutDRAM, dim, reduceType, inputLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -663,14 +664,14 @@ TEST_F(OpModelTest, Scatter) {
 
   auto runtimeExp = OpModel<ScatterOp>::getOpRuntime(
       inputShape, inputLayoutDRAM, indexSourceShape, indexLayoutDRAM,
-      indexSourceShape, sourceLayoutDRAM, dim, reduceTypeAttr, inputLayoutDRAM);
+      indexSourceShape, sourceLayoutDRAM, dim, reduceType, inputLayoutDRAM);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   // L1 layouts
   constraintsExp = OpModel<ScatterOp>::getOpConstraints(
       inputShape, inputLayoutL1, indexSourceShape, indexLayoutL1,
-      indexSourceShape, sourceLayoutL1, dim, reduceTypeAttr, inputLayoutL1);
+      indexSourceShape, sourceLayoutL1, dim, reduceType, inputLayoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -680,7 +681,7 @@ TEST_F(OpModelTest, Scatter) {
 
   runtimeExp = OpModel<ScatterOp>::getOpRuntime(
       inputShape, inputLayoutL1, indexSourceShape, indexLayoutL1,
-      indexSourceShape, sourceLayoutL1, dim, reduceTypeAttr, inputLayoutL1);
+      indexSourceShape, sourceLayoutL1, dim, reduceType, inputLayoutL1);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
@@ -6752,7 +6753,7 @@ TEST_F(OpModelTest, AssignOp) {
       std::nullopt, GetPhysicalGridSize(), builder.getF32Type());
   // Test AssignOp with DRAM output
   auto constraintsExp = OpModel<AssignOp>::getOpConstraints(
-      tensorShape, tensorLayoutDRAM_F32, std::nullopt);
+      tensorShape, tensorLayoutDRAM_F32, std::nullopt, tensorLayoutDRAM_F32);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -6760,7 +6761,7 @@ TEST_F(OpModelTest, AssignOp) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
   auto runtimeExp = OpModel<AssignOp>::getOpRuntime(
-      tensorShape, tensorLayoutDRAM_F32, std::nullopt);
+      tensorShape, tensorLayoutDRAM_F32, std::nullopt, tensorLayoutDRAM_F32);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
@@ -6769,15 +6770,15 @@ TEST_F(OpModelTest, AssignOp) {
       std::nullopt, GetPhysicalGridSize(), builder.getF32Type());
   // Test AssignOp with L1 output
   constraintsExp = OpModel<AssignOp>::getOpConstraints(
-      tensorShape, tensorLayoutL1_F32, std::nullopt);
+      tensorShape, tensorLayoutL1_F32, std::nullopt, tensorLayoutL1_F32);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
   EXPECT_GE(opCstr.tensorL1PeakSize, 0);
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
-  runtimeExp = OpModel<AssignOp>::getOpRuntime(tensorShape, tensorLayoutL1_F32,
-                                               std::nullopt);
+  runtimeExp = OpModel<AssignOp>::getOpRuntime(
+      tensorShape, tensorLayoutL1_F32, std::nullopt, tensorLayoutL1_F32);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
@@ -6786,7 +6787,7 @@ TEST_F(OpModelTest, AssignOp) {
 
   // Test AssignOp with output dtype
   constraintsExp = OpModel<AssignOp>::getOpConstraints(
-      tensorShape, tensorLayoutL1_F32, outputDtype);
+      tensorShape, tensorLayoutL1_F32, outputDtype, tensorLayoutL1_F32);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -6794,7 +6795,7 @@ TEST_F(OpModelTest, AssignOp) {
   EXPECT_GT(opCstr.outputL1BufferSize, 0);
 
   runtimeExp = OpModel<AssignOp>::getOpRuntime(tensorShape, tensorLayoutL1_F32,
-                                               outputDtype);
+                                               outputDtype, tensorLayoutL1_F32);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.

### What's changed
This is the eleventh PR in the TTNNOpInvokeLib series. It introduces shared dispatch for the data movement operations across OpModel and Runtime: assign, concat, gather, pad, permute, repeat, repeat_interleave, reshape, scatter, sort, transpose, and write_tensor.

### Checklist
- [ ] New/Existing tests provide coverage for changes
