### PR TITLE
Reduction ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Reduction/ArgMaxOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Reduction/ArgMaxOp.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_REDUCTION_ARGMAXOP_H
+#define TTMLIR_OPINVOKE_TTNN_REDUCTION_ARGMAXOP_H
+
+#include "operations/reduction/argmax/argmax.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using ArgMaxOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct ArgMaxResolvedParams {
+  std::optional<int> dim;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+ArgMaxResolvedParams
+resolveArgMaxParams(const ::tt::target::ttnn::ReductionArgMaxOpT &argMaxOp);
+
+ArgMaxOpResult
+callArgMax(CallType callType,
+           const ::tt::target::ttnn::ReductionArgMaxOpT &argMaxOp,
+           TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_REDUCTION_ARGMAXOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Reduction/CumSumOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Reduction/CumSumOp.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_REDUCTION_CUMSUMOP_H
+#define TTMLIR_OPINVOKE_TTNN_REDUCTION_CUMSUMOP_H
+
+#include "operations/reduction/accumulation/cumsum/cumsum.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using CumSumOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct CumSumResolvedParams {
+  std::optional<::ttnn::DataType> dtype;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+CumSumResolvedParams
+resolveCumSumParams(const ::tt::target::ttnn::CumSumOpT &cumSumOp);
+
+CumSumOpResult callCumSum(CallType callType,
+                          const ::tt::target::ttnn::CumSumOpT &cumSumOp,
+                          TensorArg input,
+                          ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_REDUCTION_CUMSUMOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Reduction/ProdOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Reduction/ProdOp.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_REDUCTION_PRODOP_H
+#define TTMLIR_OPINVOKE_TTNN_REDUCTION_PRODOP_H
+
+#include "operations/reduction/prod/prod.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using ProdOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct ProdResolvedParams {
+  std::optional<int64_t> dimArg;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+ProdResolvedParams
+resolveProdParams(const ::tt::target::ttnn::ReductionProdOpT &prodOp);
+
+ProdOpResult callProd(CallType callType,
+                      const ::tt::target::ttnn::ReductionProdOpT &prodOp,
+                      TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_REDUCTION_PRODOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Reduction/ReductionOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Reduction/ReductionOp.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_REDUCTION_REDUCTIONOP_H
+#define TTMLIR_OPINVOKE_TTNN_REDUCTION_REDUCTIONOP_H
+
+#include "operations/reduction/generic/generic_reductions.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using ReductionOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct ReductionResolvedParams {
+  std::optional<::ttsl::SmallVector<int>> dimArg;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+};
+
+ReductionResolvedParams
+resolveReductionParams(const ::tt::target::ttnn::ReductionOpT &reductionOp);
+
+ReductionOpResult
+callReduction(CallType callType,
+              const ::tt::target::ttnn::ReductionOpT &reductionOp,
+              TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_REDUCTION_REDUCTIONOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Reduction/TopKOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Reduction/TopKOp.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_REDUCTION_TOPKOP_H
+#define TTMLIR_OPINVOKE_TTNN_REDUCTION_TOPKOP_H
+
+#include "operations/reduction/topk/topk.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+#include <vector>
+
+namespace ttnn_op_invoke {
+
+using TopKOpResult = std::variant<::ttnn::graph::ConstraintQueryResponse,
+                                  ::ttnn::graph::RuntimeQueryResponse,
+                                  std::vector<::ttnn::Tensor>>;
+
+struct TopKResolvedParams {
+  uint32_t k;
+  int8_t dim;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+TopKResolvedParams resolveTopKParams(const ::tt::target::ttnn::TopKOpT &op);
+
+TopKOpResult callTopK(CallType callType, const ::tt::target::ttnn::TopKOpT &op,
+                      TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_REDUCTION_TOPKOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Reduction/TopKRouterGptOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Reduction/TopKRouterGptOp.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_REDUCTION_TOPKROUTERGPTOP_H
+#define TTMLIR_OPINVOKE_TTNN_REDUCTION_TOPKROUTERGPTOP_H
+
+#include "operations/experimental/topk_router_gpt/topk_router_gpt.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <tuple>
+
+namespace ttnn_op_invoke {
+
+using TopKRouterGptOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse,
+                 std::tuple<::ttnn::Tensor, ::ttnn::Tensor>>;
+
+struct TopKRouterGptResolvedParams {
+  uint32_t k;
+  uint32_t numExperts;
+};
+
+TopKRouterGptResolvedParams
+resolveTopKRouterGptParams(const ::tt::target::ttnn::TopKRouterGptOpT &op);
+
+TopKRouterGptOpResult
+callTopKRouterGpt(CallType callType,
+                  const ::tt::target::ttnn::TopKRouterGptOpT &op,
+                  TensorArg input, TensorArg weight, TensorArg bias,
+                  ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_REDUCTION_TOPKROUTERGPTOP_H

--- a/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
+++ b/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
@@ -317,6 +317,31 @@ buildScatterOpTFromMLIR(int32_t dim, mlir::tt::ttcore::ReduceType reduceType,
 buildTransposeOpTFromMLIR(int32_t dim0, int32_t dim1,
                           TTNNLayoutAttr outputLayout);
 
+::tt::target::ttnn::ReductionArgMaxOpT
+buildArgMaxOpTFromMLIR(std::optional<int32_t> dim, bool keepDim,
+                       TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::CumSumOpT
+buildCumSumOpTFromMLIR(int32_t dim, TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::ReductionProdOpT
+buildProdOpTFromMLIR(std::optional<int64_t> dimArg, bool keepDim,
+                     TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::ReductionOpT buildReductionOpTFromMLIR(
+    ::tt::target::ttnn::ReductionOpType type,
+    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+    std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr> computeConfig,
+    TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::TopKRouterGptOpT
+buildTopKRouterGptOpTFromMLIR(uint32_t k, uint32_t numExperts,
+                              TTNNLayoutAttr outputLayout);
+
+::tt::target::ttnn::TopKOpT buildTopKOpTFromMLIR(int32_t k, int32_t dim,
+                                                 bool largest, bool sorted,
+                                                 TTNNLayoutAttr outputLayout);
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -382,15 +382,16 @@ struct OpModel<WhereOp> : TernaryEltwiseOpModel<WhereOp> {};
 
 template <typename OpT>
 struct ReductionOpModel {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout,
-                   std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
-                   TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+               std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
                TTNNLayoutAttr outputLayout);
 };
 

--- a/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
+++ b/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
@@ -217,6 +217,28 @@ createSortOp(::mlir::tt::FlatbufferObjectCache &cache, SortOp op);
 ::flatbuffers::Offset<::tt::target::ttnn::TransposeOp>
 createTransposeOp(::mlir::tt::FlatbufferObjectCache &cache, TransposeOp op);
 
+template <typename ReductionOp>
+::flatbuffers::Offset<::tt::target::ttnn::ReductionArgMaxOp>
+createReductionArgMaxOp(::mlir::tt::FlatbufferObjectCache &cache,
+                        ReductionOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::CumSumOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, CumSumOp op);
+
+template <typename ReductionOp>
+::flatbuffers::Offset<::tt::target::ttnn::ReductionProdOp>
+createReductionProdOp(::mlir::tt::FlatbufferObjectCache &cache, ReductionOp op);
+
+template <typename ReductionOp>
+::flatbuffers::Offset<::tt::target::ttnn::ReductionOp>
+createReductionOp(::mlir::tt::FlatbufferObjectCache &cache, ReductionOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::TopKRouterGptOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, TopKRouterGptOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::TopKOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, TopKOp op);
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_TARGET_TTNN_TTNNTOFLATBUFFER_H

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -222,7 +222,7 @@ getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
       detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
-      op.getKeepDim(), opConfig.outputLayout);
+      op.getKeepDim(), op.getComputeConfig(), opConfig.outputLayout);
 }
 
 template <typename OpT>
@@ -234,7 +234,7 @@ getReductionOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<OpT>::getOpRuntime, op, inputShape, inputs[0],
       detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
-      op.getKeepDim(), opConfig.outputLayout);
+      op.getKeepDim(), op.getComputeConfig(), opConfig.outputLayout);
 }
 
 template <typename OpT>

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -37,6 +37,12 @@ add_library(TTNNOpInvokeLib STATIC
   Normalization/RMSNormOp.cpp
   Normalization/RMSNormPreAllGatherOp.cpp
   Normalization/SoftmaxOp.cpp
+  Reduction/ArgMaxOp.cpp
+  Reduction/CumSumOp.cpp
+  Reduction/ProdOp.cpp
+  Reduction/ReductionOp.cpp
+  Reduction/TopKOp.cpp
+  Reduction/TopKRouterGptOp.cpp
   Transformer/ConcatenateHeadsOp.cpp
   Transformer/NLPConcatHeadsDecodeOp.cpp
   Transformer/NLPConcatHeadsOp.cpp

--- a/lib/OpInvoke/TTNN/Reduction/ArgMaxOp.cpp
+++ b/lib/OpInvoke/TTNN/Reduction/ArgMaxOp.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Reduction/ArgMaxOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+ArgMaxResolvedParams
+resolveArgMaxParams(const ::tt::target::ttnn::ReductionArgMaxOpT &argMaxOp) {
+  ArgMaxResolvedParams params;
+
+  if (argMaxOp.dim.has_value()) {
+    params.dim = *argMaxOp.dim;
+  }
+
+  if (argMaxOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*argMaxOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*argMaxOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createArgMaxTuple(Tag tag,
+                       const ::tt::target::ttnn::ReductionArgMaxOpT &argMaxOp,
+                       TensorArg input, const ArgMaxResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), params.dim, argMaxOp.keep_dim,
+      /*sub_core_grids=*/std::nullopt, params.outputMemoryConfig,
+      /*optional_output_tensor=*/std::nullopt);
+}
+
+ArgMaxOpResult
+callArgMax(CallType callType,
+           const ::tt::target::ttnn::ReductionArgMaxOpT &argMaxOp,
+           TensorArg input, ::ttnn::MeshDevice *device) {
+  ArgMaxResolvedParams params = resolveArgMaxParams(argMaxOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createArgMaxTuple(tag, argMaxOp, input, params);
+  };
+
+  return callOp<ArgMaxOpResult>(WRAP_OP(::ttnn::argmax), callType, makeTuple,
+                                device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Reduction/CumSumOp.cpp
+++ b/lib/OpInvoke/TTNN/Reduction/CumSumOp.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Reduction/CumSumOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+CumSumResolvedParams
+resolveCumSumParams(const ::tt::target::ttnn::CumSumOpT &cumSumOp) {
+  CumSumResolvedParams params;
+
+  if (cumSumOp.dtype.has_value()) {
+    params.dtype = operations::utils::getDataType(*cumSumOp.out);
+  }
+
+  if (cumSumOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*cumSumOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*cumSumOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createCumSumTuple(Tag tag, const ::tt::target::ttnn::CumSumOpT &cumSumOp,
+                       TensorArg input, const CumSumResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), cumSumOp.dim, params.dtype,
+      /*reverse_order=*/false,
+      /*optional_out=*/std::nullopt, params.outputMemoryConfig);
+}
+
+CumSumOpResult callCumSum(CallType callType,
+                          const ::tt::target::ttnn::CumSumOpT &cumSumOp,
+                          TensorArg input, ::ttnn::MeshDevice *device) {
+  CumSumResolvedParams params = resolveCumSumParams(cumSumOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createCumSumTuple(tag, cumSumOp, input, params);
+  };
+
+  return callOp<CumSumOpResult>(WRAP_OP(::ttnn::cumsum), callType, makeTuple,
+                                device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Reduction/ProdOp.cpp
+++ b/lib/OpInvoke/TTNN/Reduction/ProdOp.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Reduction/ProdOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+ProdResolvedParams
+resolveProdParams(const ::tt::target::ttnn::ReductionProdOpT &prodOp) {
+  ProdResolvedParams params;
+
+  if (prodOp.dim_arg.has_value()) {
+    params.dimArg = *prodOp.dim_arg;
+  }
+
+  if (prodOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*prodOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*prodOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createProdTuple(Tag tag,
+                     const ::tt::target::ttnn::ReductionProdOpT &prodOp,
+                     TensorArg input, const ProdResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), params.dimArg,
+                         prodOp.keep_dim, params.outputMemoryConfig);
+}
+
+ProdOpResult callProd(CallType callType,
+                      const ::tt::target::ttnn::ReductionProdOpT &prodOp,
+                      TensorArg input, ::ttnn::MeshDevice *device) {
+  ProdResolvedParams params = resolveProdParams(prodOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createProdTuple(tag, prodOp, input, params);
+  };
+
+  return callOp<ProdOpResult, true, false>(WRAP_OP(::ttnn::prod), callType,
+                                           makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Reduction/ReductionOp.cpp
+++ b/lib/OpInvoke/TTNN/Reduction/ReductionOp.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Reduction/ReductionOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+ReductionResolvedParams
+resolveReductionParams(const ::tt::target::ttnn::ReductionOpT &reductionOp) {
+  ReductionResolvedParams params;
+
+  if (!reductionOp.dim_arg.empty()) {
+    params.dimArg = ::ttsl::SmallVector<int>(reductionOp.dim_arg.begin(),
+                                             reductionOp.dim_arg.end());
+  }
+
+  if (reductionOp.compute_config) {
+    params.computeConfig = operations::utils::createDeviceComputeKernelConfig(
+        *reductionOp.compute_config);
+  }
+
+  if (reductionOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*reductionOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*reductionOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createReductionTuple(Tag tag,
+                          const ::tt::target::ttnn::ReductionOpT &reductionOp,
+                          TensorArg input,
+                          const ReductionResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), params.dimArg,
+                         reductionOp.keep_dim, params.outputMemoryConfig,
+                         params.computeConfig,
+                         /*scalar=*/1.0f,
+                         /*correction=*/true,
+                         /*sub_core_grids=*/std::nullopt);
+}
+
+ReductionOpResult
+callReduction(CallType callType,
+              const ::tt::target::ttnn::ReductionOpT &reductionOp,
+              TensorArg input, ::ttnn::MeshDevice *device) {
+  ReductionResolvedParams params = resolveReductionParams(reductionOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createReductionTuple(tag, reductionOp, input, params);
+  };
+
+  auto invokeReduction = [&](auto op) {
+    return callOp<ReductionOpResult>(op, callType, makeTuple, device);
+  };
+
+  switch (reductionOp.type) {
+  case ::tt::target::ttnn::ReductionOpType::Sum:
+    return invokeReduction(WRAP_OP(::ttnn::sum));
+  case ::tt::target::ttnn::ReductionOpType::Mean:
+    return invokeReduction(WRAP_OP(::ttnn::mean));
+  case ::tt::target::ttnn::ReductionOpType::Max:
+    return invokeReduction(WRAP_OP(::ttnn::max));
+  case ::tt::target::ttnn::ReductionOpType::Min:
+    return invokeReduction(WRAP_OP(::ttnn::min));
+  }
+  llvm_unreachable("unhandled ReductionOpType");
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Reduction/TopKOp.cpp
+++ b/lib/OpInvoke/TTNN/Reduction/TopKOp.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Reduction/TopKOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+TopKResolvedParams resolveTopKParams(const ::tt::target::ttnn::TopKOpT &op) {
+  TopKResolvedParams params;
+
+  params.k = static_cast<uint32_t>(op.k);
+  params.dim = static_cast<int8_t>(op.dim);
+
+  if (!op.outputs.empty() && op.outputs[0]) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.outputs[0]));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.outputs[0]) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createTopKTuple(Tag tag, const ::tt::target::ttnn::TopKOpT &op,
+                     TensorArg input, const TopKResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag), params.k, params.dim,
+                         op.largest, op.sorted, params.outputMemoryConfig,
+                         /*sub_core_grids=*/std::nullopt,
+                         /*indices_tensor=*/std::nullopt,
+                         /*preallocated_output_tensors=*/std::nullopt);
+}
+
+TopKOpResult callTopK(CallType callType, const ::tt::target::ttnn::TopKOpT &op,
+                      TensorArg input, ::ttnn::MeshDevice *device) {
+  TopKResolvedParams params = resolveTopKParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createTopKTuple(tag, op, input, params);
+  };
+
+  return callOp<TopKOpResult>(WRAP_OP(::ttnn::topk), callType, makeTuple,
+                              device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Reduction/TopKRouterGptOp.cpp
+++ b/lib/OpInvoke/TTNN/Reduction/TopKRouterGptOp.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Reduction/TopKRouterGptOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+TopKRouterGptResolvedParams
+resolveTopKRouterGptParams(const ::tt::target::ttnn::TopKRouterGptOpT &op) {
+  TopKRouterGptResolvedParams params;
+  params.k = static_cast<uint32_t>(op.k);
+  params.numExperts = static_cast<uint32_t>(op.num_experts);
+  return params;
+}
+
+template <typename Tag>
+auto createTopKRouterGptTuple(
+    Tag tag, const ::tt::target::ttnn::TopKRouterGptOpT &topKRouterGptOp,
+    TensorArg input, TensorArg weight, TensorArg bias,
+    const TopKRouterGptResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), resolveTensorArg(weight, tag),
+      resolveTensorArg(bias, tag), params.k, params.numExperts);
+}
+
+TopKRouterGptOpResult
+callTopKRouterGpt(CallType callType,
+                  const ::tt::target::ttnn::TopKRouterGptOpT &op,
+                  TensorArg input, TensorArg weight, TensorArg bias,
+                  ::ttnn::MeshDevice *device) {
+  TopKRouterGptResolvedParams params = resolveTopKRouterGptParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createTopKRouterGptTuple(tag, op, input, weight, bias, params);
+  };
+
+  return callOp<TopKRouterGptOpResult>(
+      WRAP_OP(::ttnn::experimental::topk_router_gpt), callType, makeTuple,
+      device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpModel/TTNN/NativeFromMLIR.cpp
+++ b/lib/OpModel/TTNN/NativeFromMLIR.cpp
@@ -1271,6 +1271,83 @@ buildGatherOpTFromMLIR(int32_t dim, TTNNLayoutAttr outputLayout) {
   return gatherOp;
 }
 
+::tt::target::ttnn::ReductionOpT buildReductionOpTFromMLIR(
+    ::tt::target::ttnn::ReductionOpType type,
+    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ReductionOpT reductionOp;
+  reductionOp.type = type;
+  if (dimArg) {
+    for (int64_t v : *dimArg) {
+      reductionOp.dim_arg.push_back(static_cast<int32_t>(v));
+    }
+  }
+  reductionOp.keep_dim = keepDim;
+  reductionOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+  reductionOp.out = detail::getOutputTensorRefT(outputLayout);
+  return reductionOp;
+}
+
+::tt::target::ttnn::CumSumOpT
+buildCumSumOpTFromMLIR(int32_t dim, TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::CumSumOpT cumSumOp;
+  cumSumOp.dim = dim;
+  cumSumOp.out = detail::getOutputTensorRefT(outputLayout);
+  return cumSumOp;
+}
+
+::tt::target::ttnn::TopKRouterGptOpT
+buildTopKRouterGptOpTFromMLIR(uint32_t k, uint32_t numExperts,
+                              TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::TopKRouterGptOpT topKOp;
+  topKOp.k = static_cast<int32_t>(k);
+  topKOp.num_experts = static_cast<int32_t>(numExperts);
+  topKOp.expert_indices = detail::getOutputTensorRefT(outputLayout);
+  topKOp.expert_weights = detail::getOutputTensorRefT(outputLayout);
+  return topKOp;
+}
+
+::tt::target::ttnn::ReductionArgMaxOpT
+buildArgMaxOpTFromMLIR(std::optional<int32_t> dim, bool keepDim,
+                       TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ReductionArgMaxOpT argMaxOp;
+  if (dim.has_value()) {
+    argMaxOp.dim = *dim;
+  }
+  argMaxOp.keep_dim = keepDim;
+  argMaxOp.out = detail::getOutputTensorRefT(outputLayout);
+  return argMaxOp;
+}
+
+::tt::target::ttnn::ReductionProdOpT
+buildProdOpTFromMLIR(std::optional<int64_t> dimArg, bool keepDim,
+                     TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::ReductionProdOpT prodOp;
+  if (dimArg.has_value()) {
+    prodOp.dim_arg = *dimArg;
+  }
+  prodOp.keep_dim = keepDim;
+  prodOp.out = detail::getOutputTensorRefT(outputLayout);
+  return prodOp;
+}
+
+::tt::target::ttnn::TopKOpT buildTopKOpTFromMLIR(int32_t k, int32_t dim,
+                                                 bool largest, bool sorted,
+                                                 TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::TopKOpT topKOp;
+  topKOp.k = k;
+  topKOp.dim = dim;
+  topKOp.largest = largest;
+  topKOp.sorted = sorted;
+  topKOp.outputs.push_back(detail::getOutputTensorRefT(outputLayout));
+  return topKOp;
+}
+
 } // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -45,6 +45,12 @@
 #include "ttmlir/OpInvoke/TTNN/Normalization/RMSNormOp.h"
 #include "ttmlir/OpInvoke/TTNN/Normalization/RMSNormPreAllGatherOp.h"
 #include "ttmlir/OpInvoke/TTNN/Normalization/SoftmaxOp.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/ArgMaxOp.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/CumSumOp.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/ProdOp.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/ReductionOp.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/TopKOp.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/TopKRouterGptOp.h"
 #include "ttmlir/OpInvoke/TTNN/Transformer/ConcatenateHeadsOp.h"
 #include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsDecodeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Transformer/NLPConcatHeadsOp.h"
@@ -2002,10 +2008,27 @@ template struct TernaryEltwiseOpModel<WhereOp>;
 // Reduction Ops
 //===----------------------------------------------------------------------===//
 
+#ifdef TTMLIR_ENABLE_OPMODEL
+template <typename OpTy>
+static ::tt::target::ttnn::ReductionOpType getReductionOpType() {
+  if constexpr (std::is_same_v<OpTy, SumOp>) {
+    return ::tt::target::ttnn::ReductionOpType::Sum;
+  } else if constexpr (std::is_same_v<OpTy, MeanOp>) {
+    return ::tt::target::ttnn::ReductionOpType::Mean;
+  } else if constexpr (std::is_same_v<OpTy, MaxOp>) {
+    return ::tt::target::ttnn::ReductionOpType::Max;
+  } else if constexpr (std::is_same_v<OpTy, MinOp>) {
+    return ::tt::target::ttnn::ReductionOpType::Min;
+  }
+  llvm_unreachable("Unsupported reduction op type");
+}
+#endif // TTMLIR_ENABLE_OPMODEL
+
 template <typename OpTy>
 llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2015,22 +2038,20 @@ llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  std::optional<::ttsl::SmallVector<int>> dimArgConverted;
-  if (dimArg) {
-    dimArgConverted =
-        conversion::convertLLVMSmallVecToTTNNSmallVec(dimArg.value());
-  } else {
-    dimArgConverted = std::nullopt;
-  }
+  ::tt::target::ttnn::ReductionOpT reductionOpNative =
+      buildReductionOpTFromMLIR(getReductionOpType<OpTy>(), dimArg, keepDim,
+                                computeKernelConfig, outputLayout);
 
-  // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, dimArgConverted,
-        keepDim, detail::getNullableMemoryConfig(outputLayout),
-        /*compute_kernel_config=*/std::nullopt,
-        /*scalar=*/1.0f, /*correction=*/true,
-        /*sub_core_grids=*/std::nullopt);
+    ttnn_op_invoke::ReductionOpResult result = ttnn_op_invoke::callReduction(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, reductionOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from ReductionOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), query);
@@ -2043,6 +2064,7 @@ template <typename OpTy>
 llvm::Expected<size_t> ReductionOpModel<OpTy>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2052,22 +2074,20 @@ llvm::Expected<size_t> ReductionOpModel<OpTy>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  std::optional<::ttsl::SmallVector<int>> dimArgConverted;
-  if (dimArg) {
-    dimArgConverted =
-        conversion::convertLLVMSmallVecToTTNNSmallVec(dimArg.value());
-  } else {
-    dimArgConverted = std::nullopt;
-  }
+  ::tt::target::ttnn::ReductionOpT reductionOpNative =
+      buildReductionOpTFromMLIR(getReductionOpType<OpTy>(), dimArg, keepDim,
+                                computeKernelConfig, outputLayout);
 
-  // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, dimArgConverted,
-        keepDim, detail::getNullableMemoryConfig(outputLayout),
-        /*compute_kernel_config=*/std::nullopt,
-        /*scalar=*/1.0f, /*correction=*/true,
-        /*sub_core_grids=*/std::nullopt);
+    ttnn_op_invoke::ReductionOpResult result = ttnn_op_invoke::callReduction(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, reductionOpNative,
+        inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from ReductionOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(query);
@@ -2903,6 +2923,7 @@ llvm::Expected<size_t> OpModel<TransposeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // CumSumOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int32_t dim, std::optional<ttcore::DataType> dtype,
@@ -2915,16 +2936,19 @@ llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  std::optional<::ttnn::DataType> ttnnDtype = std::nullopt;
-  if (dtype) {
-    ttnnDtype = conversion::getDataType(*dtype);
-  }
+  ::tt::target::ttnn::CumSumOpT cumSumOpNative =
+      buildCumSumOpTFromMLIR(dim, outputLayout);
 
-  // Create query closure
   auto cumSumOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::cumsum, device, inputSpec, dim,
-                                ttnnDtype, false, std::nullopt,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::CumSumOpResult result = ttnn_op_invoke::callCumSum(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, cumSumOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from CumSumOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), cumSumOpQuery);
@@ -2946,16 +2970,19 @@ OpModel<CumSumOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  std::optional<::ttnn::DataType> ttnnDtype = std::nullopt;
-  if (dtype) {
-    ttnnDtype = conversion::getDataType(*dtype);
-  }
+  ::tt::target::ttnn::CumSumOpT cumSumOpNative =
+      buildCumSumOpTFromMLIR(dim, outputLayout);
 
-  // Create query closure
   auto cumSumOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::cumsum, device, inputSpec, dim, ttnnDtype,
-                            false, std::nullopt,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::CumSumOpResult result =
+        ttnn_op_invoke::callCumSum(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                   cumSumOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from CumSumOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(cumSumOpQuery);
@@ -4592,17 +4619,26 @@ llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
-
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec weightSpec,
       detail::convertToTensorSpec(device, weightShape, weightLayout));
-
   ASSIGN_OR_RETURN(::ttnn::TensorSpec biasSpec,
                    detail::convertToTensorSpec(device, biasShape, biasLayout));
 
+  ::tt::target::ttnn::TopKRouterGptOpT topKOpNative =
+      buildTopKRouterGptOpTFromMLIR(k, numExperts, outputLayout);
+
   auto topKRouterGptQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::topk_router_gpt, device,
-                                inputSpec, weightSpec, biasSpec, k, numExperts);
+    ttnn_op_invoke::TopKRouterGptOpResult result =
+        ttnn_op_invoke::callTopKRouterGpt(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, topKOpNative,
+            inputSpec, weightSpec, biasSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from TopKRouterGptOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -4624,17 +4660,26 @@ llvm::Expected<size_t> OpModel<TopKRouterGptOp>::getOpRuntime(
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
-
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec weightSpec,
       detail::convertToTensorSpec(device, weightShape, weightLayout));
-
   ASSIGN_OR_RETURN(::ttnn::TensorSpec biasSpec,
                    detail::convertToTensorSpec(device, biasShape, biasLayout));
 
+  ::tt::target::ttnn::TopKRouterGptOpT topKOpNative =
+      buildTopKRouterGptOpTFromMLIR(k, numExperts, outputLayout);
+
   auto topKRouterGptQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::experimental::topk_router_gpt, device,
-                            inputSpec, weightSpec, biasSpec, k, numExperts);
+    ttnn_op_invoke::TopKRouterGptOpResult result =
+        ttnn_op_invoke::callTopKRouterGpt(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, topKOpNative, inputSpec,
+            weightSpec, biasSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from TopKRouterGptOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(topKRouterGptQuery);
@@ -4646,6 +4691,7 @@ llvm::Expected<size_t> OpModel<TopKRouterGptOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ArgMaxOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
@@ -4657,11 +4703,19 @@ llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::ReductionArgMaxOpT argMaxOpNative =
+      buildArgMaxOpTFromMLIR(dim, keepDim, outputLayout);
+
   auto argMaxOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::argmax, device, inputSpec, dim, keepDim, std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout), std::nullopt);
+    ttnn_op_invoke::ArgMaxOpResult result = ttnn_op_invoke::callArgMax(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, argMaxOpNative,
+        inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from ArgMaxOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), argMaxOpQuery);
@@ -4681,11 +4735,19 @@ llvm::Expected<size_t> OpModel<ArgMaxOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::ReductionArgMaxOpT argMaxOpNative =
+      buildArgMaxOpTFromMLIR(dim, keepDim, outputLayout);
+
   auto argMaxOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::argmax, device, inputSpec, dim, keepDim, std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout), std::nullopt);
+    ttnn_op_invoke::ArgMaxOpResult result =
+        ttnn_op_invoke::callArgMax(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                   argMaxOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from ArgMaxOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(argMaxOpQuery);
@@ -4697,6 +4759,7 @@ llvm::Expected<size_t> OpModel<ArgMaxOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ProdOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
@@ -4708,10 +4771,19 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::ReductionProdOpT prodOpNative =
+      buildProdOpTFromMLIR(dim, keepDim, outputLayout);
+
   auto prodOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::prod, device, inputSpec, dim, keepDim,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::ProdOpResult result =
+        ttnn_op_invoke::callProd(ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+                                 prodOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from ProdOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), prodOpQuery);
@@ -8383,13 +8455,19 @@ llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::TopKOpT topKOpNative =
+      buildTopKOpTFromMLIR(k, dim, largest, sorted, outputLayout);
+
   auto topKQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::topk, device, inputSpec,
-                                static_cast<uint32_t>(k),
-                                static_cast<int8_t>(dim), largest, sorted,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                std::nullopt, std::nullopt, std::nullopt);
+    ttnn_op_invoke::TopKOpResult result =
+        ttnn_op_invoke::callTopK(ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+                                 topKOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from TopKOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), topKQuery);
@@ -8410,13 +8488,19 @@ llvm::Expected<size_t> OpModel<TopKOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Create query closure
+  ::tt::target::ttnn::TopKOpT topKOpNative =
+      buildTopKOpTFromMLIR(k, dim, largest, sorted, outputLayout);
+
   auto topKQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::topk, device, inputSpec,
-                            static_cast<uint32_t>(k), static_cast<int8_t>(dim),
-                            largest, sorted,
-                            detail::getNullableMemoryConfig(outputLayout),
-                            std::nullopt, std::nullopt, std::nullopt);
+    ttnn_op_invoke::TopKOpResult result =
+        ttnn_op_invoke::callTopK(ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+                                 topKOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from TopKOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(topKQuery);

--- a/runtime/lib/ttnn/operations/reduction/argmax.cpp
+++ b/runtime/lib/ttnn/operations/reduction/argmax.cpp
@@ -4,32 +4,33 @@
 
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/utils.h"
-#include <optional>
+#include "ttmlir/OpInvoke/TTNN/Reduction/ArgMaxOp.h"
 
 namespace tt::runtime::ttnn::operations::reduction {
 static void
 runReductionArgMaxOp(const ::tt::target::ttnn::ReductionArgMaxOp *op,
-                     ProgramTensorPool &tensorPool) {
+                     ProgramTensorPool &tensorPool, ProgramContext &context) {
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+  ::tt::target::ttnn::ReductionArgMaxOpT reductionArgMaxOpNative;
+  op->UnPackTo(&reductionArgMaxOpNative);
 
-  ::ttnn::Tensor out = ::ttnn::argmax(in, op->dim(),
-                                      /*keepdim=*/op->keep_dim(),
-                                      /*sub_core_grids=*/std::nullopt,
-                                      /*memory_config_arg=*/outputMemoryConfig,
-                                      /*optional_output_tensor=*/std::nullopt);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::ArgMaxOpResult result =
+      ttnn_op_invoke::callArgMax(ttnn_op_invoke::CallType::EXECUTE,
+                                 reductionArgMaxOpNative, &in, &targetDevice);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callArgMax execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::ReductionArgMaxOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runReductionArgMaxOp(op, tensorPool);
+  runReductionArgMaxOp(op, tensorPool, context);
 }
 } // namespace tt::runtime::ttnn::operations::reduction

--- a/runtime/lib/ttnn/operations/reduction/cumsum.cpp
+++ b/runtime/lib/ttnn/operations/reduction/cumsum.cpp
@@ -5,32 +5,25 @@
 #include "operations/reduction/cumsum.h"
 
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-#include "ttmlir/Target/TTNN/program_generated.h"
-#include "ttnn/operations/reduction/accumulation/cumsum/cumsum.hpp"
-
-#include <optional>
+#include "ttmlir/OpInvoke/TTNN/Reduction/CumSumOp.h"
 
 namespace tt::runtime::ttnn::operations::reduction::cumsum {
 void run(const ::tt::target::ttnn::CumSumOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+  ::tt::target::ttnn::CumSumOpT cumSumOpNative;
+  op->UnPackTo(&cumSumOpNative);
 
-  std::optional<::ttnn::DataType> dtype = std::nullopt;
-  if (op->dtype()) {
-    dtype = ttnn_op_invoke::operations::utils::toTTNNDataType(*op->dtype());
-  }
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::Tensor out =
-      ::ttnn::cumsum(in, op->dim(), dtype, /*reverseOrder=*/false,
-                     /*optionalOut=*/std::nullopt, outputMemoryConfig);
+  ttnn_op_invoke::CumSumOpResult result = ttnn_op_invoke::callCumSum(
+      ttnn_op_invoke::CallType::EXECUTE, cumSumOpNative, &in, &targetDevice);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callCumSum execution");
+
+  const ::ttnn::Tensor &output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::reduction::cumsum

--- a/runtime/lib/ttnn/operations/reduction/prod.cpp
+++ b/runtime/lib/ttnn/operations/reduction/prod.cpp
@@ -4,29 +4,33 @@
 
 #include "operations/reduction/prod.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/ProdOp.h"
 
 namespace tt::runtime::ttnn::operations::reduction {
 static void runReductionProdOp(const ::tt::target::ttnn::ReductionProdOp *op,
-                               ProgramTensorPool &tensorPool) {
-
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+                               ProgramTensorPool &tensorPool,
+                               ProgramContext &context) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  ::ttnn::Tensor out = ::ttnn::prod(in, op->dim_arg(), op->keep_dim(),
-                                    outputMemoryConfig /* memory_config_arg */);
+  ::tt::target::ttnn::ReductionProdOpT prodOpNative;
+  op->UnPackTo(&prodOpNative);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::ProdOpResult result = ttnn_op_invoke::callProd(
+      ttnn_op_invoke::CallType::EXECUTE, prodOpNative, &in, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callProd execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::ReductionProdOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runReductionProdOp(op, tensorPool);
+  runReductionProdOp(op, tensorPool, context);
 }
 } // namespace tt::runtime::ttnn::operations::reduction

--- a/runtime/lib/ttnn/operations/reduction/reduction.cpp
+++ b/runtime/lib/ttnn/operations/reduction/reduction.cpp
@@ -4,70 +4,25 @@
 
 #include "operations/reduction/reduction.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/ReductionOp.h"
 
 namespace tt::runtime::ttnn::operations::reduction {
-static void runReductionOp(
-    const ::tt::target::ttnn::ReductionOp *op, ProgramTensorPool &tensorPool,
-    const std::function<::ttnn::Tensor(
-        const ::ttnn::Tensor &,
-        const std::optional<
-            std::variant<int, int64_t, ::ttsl::SmallVector<int>>> &,
-        const bool, const std::optional<::ttnn::MemoryConfig> &,
-        const std::optional<::ttnn::DeviceComputeKernelConfig> &, float, bool,
-        const std::optional<::ttnn::CoreRangeSet> &)> &ttnnOp) {
-
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
-
-  const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
-
-  const auto *fbDimArg = op->dim_arg();
-  std::optional<::ttsl::SmallVector<int>> dimArg =
-      fbDimArg ? std::make_optional(::ttsl::SmallVector<int>(fbDimArg->begin(),
-                                                             fbDimArg->end()))
-               : std::nullopt;
-
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
-
-  ::ttnn::Tensor out = ttnnOp(
-      in, dimArg, op->keep_dim(), outputMemoryConfig /* memory_config_arg */,
-      computeConfig /* compute_kernel_config */, 1.0f /* scalar */,
-      true /* correction */, std::nullopt /* sub_core_grids */);
-
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
-}
-
 void run(const ::tt::target::ttnn::ReductionOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  switch (op->type()) {
-  case ::tt::target::ttnn::ReductionOpType::Sum: {
-    runReductionOp(op, tensorPool, ::ttnn::sum);
-    break;
-  }
-  case ::tt::target::ttnn::ReductionOpType::Mean: {
-    runReductionOp(op, tensorPool, ::ttnn::mean);
-    break;
-  }
-  case ::tt::target::ttnn::ReductionOpType::Max: {
-    runReductionOp(op, tensorPool, ::ttnn::max);
-    break;
-  }
-  case ::tt::target::ttnn::ReductionOpType::Min: {
-    runReductionOp(op, tensorPool, ::ttnn::min);
-    break;
-  }
-  }
+  const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
+
+  ::tt::target::ttnn::ReductionOpT reductionOpT;
+  op->UnPackTo(&reductionOpT);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  auto result = ttnn_op_invoke::callReduction(ttnn_op_invoke::CallType::EXECUTE,
+                                              reductionOpT, &in, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callReduction execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::reduction

--- a/runtime/lib/ttnn/operations/reduction/topk.cpp
+++ b/runtime/lib/ttnn/operations/reduction/topk.cpp
@@ -4,28 +4,28 @@
 
 #include "operations/reduction/topk.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/TopKOp.h"
 
 namespace tt::runtime::ttnn::operations::reduction::topk {
 static void runReductionTopKOp(const ::tt::target::ttnn::TopKOp *op,
-                               ProgramTensorPool &tensorPool) {
+                               ProgramTensorPool &tensorPool,
+                               ProgramContext &context) {
   const ::ttnn::Tensor &in =
       tensorPool.getTTNNTensorAndValidate(op->input_tensor());
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+  ::tt::target::ttnn::TopKOpT opNative;
+  op->UnPackTo(&opNative);
 
-  std::vector<::ttnn::Tensor> outputs =
-      ::ttnn::topk(in, op->k(), op->dim(),
-                   /*largest=*/op->largest(),
-                   /*sorted=*/op->sorted(),
-                   /*memory_config=*/outputMemoryConfig,
-                   /*sub_core_grids=*/std::nullopt,
-                   /*indices_tensor=*/std::nullopt,
-                   /*preallocated_output_tensors=*/std::nullopt);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::TopKOpResult result = ttnn_op_invoke::callTopK(
+      ttnn_op_invoke::CallType::EXECUTE, opNative, &in, &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<std::vector<::ttnn::Tensor>>(result),
+             "Expected vector of Tensors from callTopK execution");
+
+  const std::vector<::ttnn::Tensor> &outputs =
+      std::get<std::vector<::ttnn::Tensor>>(result);
 
   for (size_t i = 0; i < op->outputs()->size(); ++i) {
     tensorPool.insertTTNNTensorAndValidate(op->outputs()->Get(i), outputs[i]);
@@ -34,6 +34,6 @@ static void runReductionTopKOp(const ::tt::target::ttnn::TopKOp *op,
 
 void run(const ::tt::target::ttnn::TopKOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  runReductionTopKOp(op, tensorPool);
+  runReductionTopKOp(op, tensorPool, context);
 }
 } // namespace tt::runtime::ttnn::operations::reduction::topk

--- a/runtime/lib/ttnn/operations/reduction/topk_router_gpt.cpp
+++ b/runtime/lib/ttnn/operations/reduction/topk_router_gpt.cpp
@@ -4,9 +4,7 @@
 
 #include "operations/reduction/topk_router_gpt.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Reduction/TopKRouterGptOp.h"
 
 namespace tt::runtime::ttnn::operations::reduction::topk_router_gpt {
 
@@ -20,11 +18,21 @@ void run(const ::tt::target::ttnn::TopKRouterGptOp *op,
       tensorPool.getTTNNTensorAndValidate(op->weight());
   const ::ttnn::Tensor &bias = tensorPool.getTTNNTensorAndValidate(op->bias());
 
-  uint32_t k = static_cast<uint32_t>(op->k());
-  uint32_t numExperts = static_cast<uint32_t>(op->num_experts());
+  ::tt::target::ttnn::TopKRouterGptOpT opNative;
+  op->UnPackTo(&opNative);
 
-  auto [expertIndices, expertWeights] =
-      ::ttnn::experimental::topk_router_gpt(input, weight, bias, k, numExperts);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::TopKRouterGptOpResult result =
+      ttnn_op_invoke::callTopKRouterGpt(ttnn_op_invoke::CallType::EXECUTE,
+                                        opNative, &input, &weight, &bias,
+                                        &targetDevice);
+
+  using tensorTuple = std::tuple<::ttnn::Tensor, ::ttnn::Tensor>;
+  LOG_ASSERT(std::holds_alternative<tensorTuple>(result),
+             "Expected tuple of Tensors from callTopKRouterGpt execution");
+
+  auto [expertIndices, expertWeights] = std::get<tensorTuple>(result);
 
   tensorPool.insertTTNNTensorAndValidate(op->expert_indices(), expertIndices);
   tensorPool.insertTTNNTensorAndValidate(op->expert_weights(), expertWeights);

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
@@ -6155,4 +6155,591 @@ const std::initializer_list<mlir::tt::ttnn::TransposeOp> transposeOpList = {
 INSTANTIATE_TEST_SUITE_P(TransposeOpTPathParityTest, TransposeOpTPathParityTest,
                          ::testing::ValuesIn(transposeOpList));
 
+//===----------------------------------------------------------------------===//
+// ArgMaxOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::ReductionArgMaxOpT &opNativeOpModel,
+                       ::tt::target::ttnn::ReductionArgMaxOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ReductionArgMaxOpT &op) {
+    op.in.reset();
+    op.memcfg.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::ArgMaxOp
+buildTestArgMaxOp(std::optional<int32_t> dim = std::nullopt,
+                  bool keepDim = false, bool useMulticore = false,
+                  mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  mlir::IntegerAttr dimAttr =
+      dim.has_value() ? e.builder.getI32IntegerAttr(*dim) : mlir::IntegerAttr();
+
+  return e.builder.create<mlir::tt::ttnn::ArgMaxOp>(
+      loc, outputType, makeOnes(), dimAttr, e.builder.getBoolAttr(keepDim),
+      e.builder.getBoolAttr(useMulticore));
+}
+
+} // namespace
+
+using ArgMaxOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::ArgMaxOp>;
+
+TEST_P(ArgMaxOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::ArgMaxOp argMaxOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ReductionArgMaxOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildArgMaxOpTFromMLIR(
+          argMaxOp.getDim(), argMaxOp.getKeepDim(), argMaxOp.getUseMulticore(),
+          resolveOutputLayout(argMaxOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, argMaxOp.getInput());
+
+  auto fbOffset =
+      mlir::tt::ttnn::createReductionArgMaxOp<mlir::tt::ttnn::ArgMaxOp>(
+          cache, argMaxOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ReductionArgMaxOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::ArgMaxOp> argMaxOpList = {
+    buildTestArgMaxOp(),
+    buildTestArgMaxOp(/*dim=*/1),
+    buildTestArgMaxOp(/*dim=*/std::nullopt, /*keepDim=*/true),
+    buildTestArgMaxOp(/*dim=*/std::nullopt, /*keepDim=*/false,
+                      /*useMulticore=*/true),
+    buildTestArgMaxOp(/*dim=*/std::nullopt, /*keepDim=*/false,
+                      /*useMulticore=*/false,
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestArgMaxOp(/*dim=*/1, /*keepDim=*/true, /*useMulticore=*/true,
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(ArgMaxOpTPathParityTest, ArgMaxOpTPathParityTest,
+                         ::testing::ValuesIn(argMaxOpList));
+
+//===----------------------------------------------------------------------===//
+// CumSumOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::CumSumOpT &opNativeOpModel,
+                       ::tt::target::ttnn::CumSumOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::CumSumOpT &op) {
+    op.in.reset();
+    op.memcfg.reset();
+    op.dtype.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::CumSumOp
+buildTestCumSumOp(int32_t dim = 0, mlir::Type dtype = {},
+                  mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  return e.builder.create<mlir::tt::ttnn::CumSumOp>(
+      loc, outputType, makeOnes(), e.builder.getI32IntegerAttr(dim));
+}
+
+} // namespace
+
+using CumSumOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::CumSumOp>;
+
+TEST_P(CumSumOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::CumSumOp cumSumOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::CumSumOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildCumSumOpTFromMLIR(
+          cumSumOp.getDim(), resolveOutputLayout(cumSumOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, cumSumOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, cumSumOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::CumSumOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::CumSumOp> cumSumOpList = {
+    buildTestCumSumOp(),
+    buildTestCumSumOp(/*dim=*/1),
+    buildTestCumSumOp(/*dim=*/0, /*dtype=*/env().builder.getF32Type()),
+    buildTestCumSumOp(/*dim=*/0, /*dtype=*/{},
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestCumSumOp(/*dim=*/1, /*dtype=*/env().builder.getF32Type(),
+                      /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(CumSumOpTPathParityTest, CumSumOpTPathParityTest,
+                         ::testing::ValuesIn(cumSumOpList));
+
+//===----------------------------------------------------------------------===//
+// ProdOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::ReductionProdOpT &opNativeOpModel,
+                       ::tt::target::ttnn::ReductionProdOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ReductionProdOpT &op) {
+    op.in.reset();
+    op.memcfg.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::ProdOp
+buildTestProdOp(std::optional<int64_t> dimArg = std::nullopt,
+                bool keepDim = false,
+                mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  mlir::IntegerAttr dimArgAttr = dimArg.has_value()
+                                     ? e.builder.getI64IntegerAttr(*dimArg)
+                                     : mlir::IntegerAttr();
+
+  return e.builder.create<mlir::tt::ttnn::ProdOp>(
+      loc, outputType, makeOnes(), dimArgAttr, e.builder.getBoolAttr(keepDim));
+}
+
+} // namespace
+
+using ProdOpTPathParityTest = ::testing::TestWithParam<mlir::tt::ttnn::ProdOp>;
+
+TEST_P(ProdOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::ProdOp prodOp = GetParam();
+
+  std::optional<int64_t> dimArg;
+  if (auto v = prodOp.getDimArg()) {
+    dimArg = static_cast<int64_t>(*v);
+  }
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ReductionProdOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildProdOpTFromMLIR(
+          dimArg, prodOp.getKeepDim(), resolveOutputLayout(prodOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, prodOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createReductionProdOp<mlir::tt::ttnn::ProdOp>(
+      cache, prodOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ReductionProdOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::ProdOp> prodOpList = {
+    buildTestProdOp(),
+    buildTestProdOp(/*dimArg=*/int64_t{0}),
+    buildTestProdOp(/*dimArg=*/std::nullopt, /*keepDim=*/true),
+    buildTestProdOp(/*dimArg=*/std::nullopt, /*keepDim=*/false,
+                    /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+    buildTestProdOp(/*dimArg=*/int64_t{0}, /*keepDim=*/true,
+                    /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(ProdOpTPathParityTest, ProdOpTPathParityTest,
+                         ::testing::ValuesIn(prodOpList));
+
+//===----------------------------------------------------------------------===//
+// Reduction OpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::ReductionOpT &opNativeOpModel,
+                       ::tt::target::ttnn::ReductionOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::ReductionOpT &op) {
+    op.in.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+template <typename OpTy>
+void runReductionParityTest(OpTy op,
+                            ::tt::target::ttnn::ReductionOpType reductionType) {
+  llvm::SmallVector<int64_t> dimArgStorage;
+  if (auto dimArgAttr = op.getDimArg()) {
+    for (auto attr : *dimArgAttr) {
+      dimArgStorage.push_back(mlir::cast<mlir::IntegerAttr>(attr).getInt());
+    }
+  }
+  std::optional<llvm::ArrayRef<int64_t>> dimArgRef =
+      op.getDimArg() ? std::optional<llvm::ArrayRef<int64_t>>(dimArgStorage)
+                     : std::nullopt;
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::ReductionOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildReductionOpTFromMLIR(
+          reductionType, dimArgRef, op.getKeepDim(), op.getComputeConfig(),
+          resolveOutputLayout(op));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, op.getInput());
+
+  auto fbOffset = createReductionOp(cache, op);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::ReductionOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+template <typename OpTy>
+OpTy buildTestReductionOp(
+    mlir::ArrayAttr dimArgAttr = nullptr, bool keepDim = false,
+    mlir::tt::ttnn::DeviceComputeKernelConfigAttr computeConfig = {},
+    mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+  return e.builder.create<OpTy>(loc, outputType, makeOnes(),
+                                e.builder.getBoolAttr(keepDim), dimArgAttr,
+                                computeConfig);
+}
+
+} // namespace
+
+using SumOpTPathParityTest = ::testing::TestWithParam<mlir::tt::ttnn::SumOp>;
+using MeanOpTPathParityTest = ::testing::TestWithParam<mlir::tt::ttnn::MeanOp>;
+using MaxOpTPathParityTest = ::testing::TestWithParam<mlir::tt::ttnn::MaxOp>;
+using MinOpTPathParityTest = ::testing::TestWithParam<mlir::tt::ttnn::MinOp>;
+
+TEST_P(SumOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runReductionParityTest(GetParam(), ::tt::target::ttnn::ReductionOpType::Sum);
+}
+
+TEST_P(MeanOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runReductionParityTest(GetParam(), ::tt::target::ttnn::ReductionOpType::Mean);
+}
+
+TEST_P(MaxOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runReductionParityTest(GetParam(), ::tt::target::ttnn::ReductionOpType::Max);
+}
+
+TEST_P(MinOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  runReductionParityTest(GetParam(), ::tt::target::ttnn::ReductionOpType::Min);
+}
+
+#define REDUCTION_OP_LIST(OP)                                                  \
+  {                                                                            \
+      buildTestReductionOp<OP>(),                                              \
+      buildTestReductionOp<OP>(                                                \
+          /*dimArg=*/env().builder.getI32ArrayAttr({0, 1})),                   \
+      buildTestReductionOp<OP>(/*dimArg=*/nullptr, /*keepDim=*/true),          \
+      buildTestReductionOp<OP>(                                                \
+          /*dimArg=*/nullptr, /*keepDim=*/false,                               \
+          /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr),          \
+      buildTestReductionOp<OP>(                                                \
+          /*dimArg=*/nullptr, /*keepDim=*/false, /*computeConfig=*/{},         \
+          /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),             \
+      buildTestReductionOp<OP>(                                                \
+          /*dimArg=*/env().builder.getI32ArrayAttr({0, 1}), /*keepDim=*/true,  \
+          /*computeConfig=*/nonDefaultDeviceComputeKernelConfigAttr,           \
+          /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),             \
+  }
+
+INSTANTIATE_TEST_SUITE_P(
+    SumOpTPathParityTest, SumOpTPathParityTest,
+    ::testing::ValuesIn(REDUCTION_OP_LIST(mlir::tt::ttnn::SumOp)));
+INSTANTIATE_TEST_SUITE_P(
+    MeanOpTPathParityTest, MeanOpTPathParityTest,
+    ::testing::ValuesIn(REDUCTION_OP_LIST(mlir::tt::ttnn::MeanOp)));
+INSTANTIATE_TEST_SUITE_P(
+    MaxOpTPathParityTest, MaxOpTPathParityTest,
+    ::testing::ValuesIn(REDUCTION_OP_LIST(mlir::tt::ttnn::MaxOp)));
+INSTANTIATE_TEST_SUITE_P(
+    MinOpTPathParityTest, MinOpTPathParityTest,
+    ::testing::ValuesIn(REDUCTION_OP_LIST(mlir::tt::ttnn::MinOp)));
+
+//===----------------------------------------------------------------------===//
+// TopKRouterGptOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::TopKRouterGptOpT &opNativeOpModel,
+                       ::tt::target::ttnn::TopKRouterGptOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::TopKRouterGptOpT &op) {
+    op.input.reset();
+    op.weight.reset();
+    op.bias.reset();
+    op.expert_indices.reset();
+    op.expert_weights.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::TopKRouterGptOp
+buildTestTopKRouterGptOp(int32_t k = 4, int32_t numExperts = 128) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto weightType = tiledL1BF16Type(defaultShape);
+  auto biasType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&](mlir::RankedTensorType t) {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{t},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  return e.builder.create<mlir::tt::ttnn::TopKRouterGptOp>(
+      loc, mlir::TypeRange{outputType, outputType}, makeOnes(inputType),
+      makeOnes(weightType), makeOnes(biasType), e.builder.getI32IntegerAttr(k),
+      e.builder.getI32IntegerAttr(numExperts));
+}
+
+} // namespace
+
+using TopKRouterGptOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::TopKRouterGptOp>;
+
+TEST_P(TopKRouterGptOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::TopKRouterGptOp topKOp = GetParam();
+
+  auto outputLayout = mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+      mlir::cast<mlir::RankedTensorType>(topKOp.getResult(0).getType())
+          .getEncoding());
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::TopKRouterGptOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildTopKRouterGptOpTFromMLIR(
+          topKOp.getK(), topKOp.getNumExperts(), outputLayout);
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, topKOp.getInput(), topKOp.getWeight(),
+                               topKOp.getBias());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, topKOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::TopKRouterGptOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.expert_indices,
+                          opNativeFB.expert_indices);
+  compareOutputTensorRefT(opNativeOpModel.expert_weights,
+                          opNativeFB.expert_weights);
+}
+
+const std::initializer_list<mlir::tt::ttnn::TopKRouterGptOp>
+    topKRouterGptOpList = {
+        buildTestTopKRouterGptOp(),
+        buildTestTopKRouterGptOp(/*k=*/8),
+        buildTestTopKRouterGptOp(/*k=*/8, /*numExperts=*/128),
+};
+
+INSTANTIATE_TEST_SUITE_P(TopKRouterGptOpTPathParityTest,
+                         TopKRouterGptOpTPathParityTest,
+                         ::testing::ValuesIn(topKRouterGptOpList));
+
+//===----------------------------------------------------------------------===//
+// TopKOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::TopKOpT &opNativeOpModel,
+                       ::tt::target::ttnn::TopKOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::TopKOpT &op) {
+    op.input_tensor.reset();
+    op.memcfg.reset();
+    if (!op.outputs.empty() && op.outputs[0]) {
+      op.outputs[0].reset();
+      op.outputs.resize(1);
+    }
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::TopKOp buildTestTopKOp(int32_t k = 4, int32_t dim = -1,
+                                       bool largest = true,
+                                       bool sorted = false) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto inputType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{inputType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType = tiledL1BF16Type(defaultShape);
+
+  return e.builder.create<mlir::tt::ttnn::TopKOp>(
+      loc, mlir::TypeRange{outputType, outputType}, makeOnes(),
+      e.builder.getI32IntegerAttr(k), e.builder.getI32IntegerAttr(dim),
+      e.builder.getBoolAttr(largest), e.builder.getBoolAttr(sorted));
+}
+
+} // namespace
+
+using TopKOpTPathParityTest = ::testing::TestWithParam<mlir::tt::ttnn::TopKOp>;
+
+TEST_P(TopKOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::TopKOp topKOp = GetParam();
+
+  mlir::tt::ttnn::TTNNLayoutAttr outputLayout =
+      mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(
+          mlir::cast<mlir::RankedTensorType>(topKOp.getValues().getType())
+              .getEncoding());
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::TopKOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildTopKOpTFromMLIR(
+          topKOp.getK(), topKOp.getDim(), topKOp.getLargest(),
+          topKOp.getSorted(), outputLayout);
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, topKOp.getInputTensor());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, topKOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::TopKOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.outputs[0], opNativeFB.outputs[0]);
+}
+
+const std::initializer_list<mlir::tt::ttnn::TopKOp> topKOpList = {
+    buildTestTopKOp(),
+    buildTestTopKOp(/*k=*/8),
+    buildTestTopKOp(/*k=*/4, /*dim=*/0),
+    buildTestTopKOp(/*k=*/4, /*dim=*/-1, /*largest=*/false),
+    buildTestTopKOp(/*k=*/4, /*dim=*/-1, /*largest=*/true, /*sorted=*/true),
+    buildTestTopKOp(/*k=*/8, /*dim=*/0, /*largest=*/false, /*sorted=*/true),
+};
+
+INSTANTIATE_TEST_SUITE_P(TopKOpTPathParityTest, TopKOpTPathParityTest,
+                         ::testing::ValuesIn(topKOpList));
+
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -383,8 +383,16 @@ protected:
     const TTNNLayoutAttr outputLayout = CreateTiledLayout(
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
+    DeviceComputeKernelConfigAttr deviceConfig =
+        DeviceComputeKernelConfigAttr::get(
+            &context, /*mathFidelity=*/MathFidelity::LoFi,
+            /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
+            /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
+            /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
+            /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
+
     auto constraintsExp = OpModel<OpTy>::getOpConstraints(
-        inputShape, inputLayout, dimArg, keepDim, outputLayout);
+        inputShape, inputLayout, dimArg, keepDim, deviceConfig, outputLayout);
     // Manually cast to bool because EXPECT_TRUE requires a const bool operator
     // which llvm::Expected<T> does not have
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -400,7 +408,7 @@ protected:
       llvm::consumeError(constraintsExp.takeError());
     }
     auto runtimeExp = OpModel<OpTy>::getOpRuntime(
-        inputShape, inputLayout, dimArg, keepDim, outputLayout);
+        inputShape, inputLayout, dimArg, keepDim, deviceConfig, outputLayout);
     EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
     if (expectedLegal) {
       EXPECT_TRUE(runtimeExp.get() > 0);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.

### What's changed
This is the twelfth PR in the TTNNOpInvokeLib series. It introduces shared dispatch for the reduction operations across OpModel and Runtime: argmax, cumsum, prod, the generic reduction ops (sum, mean, max, min), topk, and topk_router_gpt.

### Checklist
- [ ] New/Existing tests provide coverage for changes
