### PR TITLE
KV cache ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/KVCache/FillCacheOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/KVCache/FillCacheOp.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_KVCACHE_FILLCACHEOP_H
+#define TTMLIR_OPINVOKE_TTNN_KVCACHE_FILLCACHEOP_H
+
+#include "operations/kv_cache/kv_cache.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn_op_invoke {
+
+using FillCacheOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct FillCacheResolvedParams {};
+
+FillCacheResolvedParams
+resolveFillCacheParams(const ::tt::target::ttnn::FillCacheOpT &op);
+
+FillCacheOpResult callFillCache(CallType callType,
+                                const ::tt::target::ttnn::FillCacheOpT &op,
+                                TensorArg cache, TensorArg input,
+                                ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_KVCACHE_FILLCACHEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/KVCache/PagedFillCacheOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/KVCache/PagedFillCacheOp.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_KVCACHE_PAGEDFILLCACHEOP_H
+#define TTMLIR_OPINVOKE_TTNN_KVCACHE_PAGEDFILLCACHEOP_H
+
+#include "operations/experimental/paged_cache/paged_cache.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PagedFillCacheOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PagedFillCacheResolvedParams {
+  std::optional<std::set<::ttnn::MeshCoordinate>> meshCoords;
+};
+
+PagedFillCacheResolvedParams
+resolvePagedFillCacheParams(const ::tt::target::ttnn::PagedFillCacheOpT &op,
+                            CallType callType, TensorArg cache);
+
+PagedFillCacheOpResult
+callPagedFillCache(CallType callType,
+                   const ::tt::target::ttnn::PagedFillCacheOpT &op,
+                   TensorArg cache, TensorArg input, TensorArg pageTable,
+                   std::optional<TensorArg> batchIdxTensor,
+                   ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_KVCACHE_PAGEDFILLCACHEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/KVCache/PagedUpdateCacheOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/KVCache/PagedUpdateCacheOp.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_KVCACHE_PAGEDUPDATECACHEOP_H
+#define TTMLIR_OPINVOKE_TTNN_KVCACHE_PAGEDUPDATECACHEOP_H
+
+#include "operations/experimental/paged_cache/paged_cache.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using PagedUpdateCacheOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct PagedUpdateCacheResolvedParams {
+  std::vector<uint32_t> update_idxs;
+  std::optional<std::set<::ttnn::MeshCoordinate>> meshCoords;
+};
+
+PagedUpdateCacheResolvedParams
+resolvePagedUpdateCacheParams(const ::tt::target::ttnn::PagedUpdateCacheOpT &op,
+                              CallType callType, TensorArg cache);
+
+PagedUpdateCacheOpResult callPagedUpdateCache(
+    CallType callType, const ::tt::target::ttnn::PagedUpdateCacheOpT &op,
+    TensorArg cache, TensorArg input, std::optional<TensorArg> updateIndex,
+    std::optional<TensorArg> pageTable, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_KVCACHE_PAGEDUPDATECACHEOP_H

--- a/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
+++ b/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
@@ -342,6 +342,14 @@ buildTopKRouterGptOpTFromMLIR(uint32_t k, uint32_t numExperts,
                                                  bool largest, bool sorted,
                                                  TTNNLayoutAttr outputLayout);
 
+::tt::target::ttnn::FillCacheOpT
+buildFillCacheOpTFromMLIR(uint32_t batchOffset);
+
+::tt::target::ttnn::PagedFillCacheOpT buildPagedFillCacheOpTFromMLIR();
+
+::tt::target::ttnn::PagedUpdateCacheOpT
+buildPagedUpdateCacheOpTFromMLIR(bool shareCache);
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL
 

--- a/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
+++ b/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
@@ -239,6 +239,15 @@ createOp(::mlir::tt::FlatbufferObjectCache &cache, TopKRouterGptOp op);
 ::flatbuffers::Offset<::tt::target::ttnn::TopKOp>
 createOp(::mlir::tt::FlatbufferObjectCache &cache, TopKOp op);
 
+::flatbuffers::Offset<::tt::target::ttnn::FillCacheOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, FillCacheOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::PagedFillCacheOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, PagedFillCacheOp op);
+
+::flatbuffers::Offset<::tt::target::ttnn::PagedUpdateCacheOp>
+createOp(::mlir::tt::FlatbufferObjectCache &cache, PagedUpdateCacheOp op);
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_TARGET_TTNN_TTNNTOFLATBUFFER_H

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -27,6 +27,9 @@ add_library(TTNNOpInvokeLib STATIC
   Eltwise/Ternary/EltwiseTernaryOp.cpp
   Eltwise/Unary/EltwiseUnaryCompositeOp.cpp
   Eltwise/Unary/EltwiseUnaryOp.cpp
+  KVCache/FillCacheOp.cpp
+  KVCache/PagedFillCacheOp.cpp
+  KVCache/PagedUpdateCacheOp.cpp
   Matmul/MatmulOp.cpp
   Normalization/BatchNormOp.cpp
   Normalization/DistributedRMSNormOp.cpp

--- a/lib/OpInvoke/TTNN/KVCache/FillCacheOp.cpp
+++ b/lib/OpInvoke/TTNN/KVCache/FillCacheOp.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/KVCache/FillCacheOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+FillCacheResolvedParams
+resolveFillCacheParams(const ::tt::target::ttnn::FillCacheOpT &op) {
+  FillCacheResolvedParams params;
+
+  return params;
+}
+
+template <typename Tag>
+auto createFillCacheTuple(Tag tag,
+                          const ::tt::target::ttnn::FillCacheOpT &fillCacheOp,
+                          TensorArg cache, TensorArg input,
+                          const FillCacheResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(cache, tag),
+                         resolveTensorArg(input, tag),
+                         fillCacheOp.batch_offset);
+}
+
+FillCacheOpResult callFillCache(CallType callType,
+                                const ::tt::target::ttnn::FillCacheOpT &op,
+                                TensorArg cache, TensorArg input,
+                                ::ttnn::MeshDevice *device) {
+  FillCacheResolvedParams params = resolveFillCacheParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createFillCacheTuple(tag, op, cache, input, params);
+  };
+
+  return callOp<FillCacheOpResult>(WRAP_OP(::ttnn::fill_cache), callType,
+                                   makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/KVCache/PagedFillCacheOp.cpp
+++ b/lib/OpInvoke/TTNN/KVCache/PagedFillCacheOp.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/KVCache/PagedFillCacheOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+PagedFillCacheResolvedParams
+resolvePagedFillCacheParams(const ::tt::target::ttnn::PagedFillCacheOpT &op,
+                            CallType callType, TensorArg cache) {
+  PagedFillCacheResolvedParams params;
+
+  // TODO: This branching on callType should be removed.
+  if (callType == CallType::EXECUTE) {
+    // Force the MeshWorkloadFactory by passing the cache tensor's full set of
+    // mesh coordinates. With std::nullopt, the device op selects the
+    // single-program factory, which under DP partitioning runs the kernel on
+    // the mesh root only - so per-rank cache writes from non-root devices are
+    // silently dropped. Per-rank divergent updates require one program per
+    // mesh coordinate, which is what the MeshWorkloadFactory provides.
+    //
+    // TODO(#47955): ttnn could infer these coords from the cache tensor (it is
+    // already an op input) and select the MeshWorkloadFactory by default,
+    // letting us drop this explicit pass. Tracked in
+    // tenstorrent/tt-metal#47955.
+    ::ttnn::Tensor cacheTensor = *std::get<const ::ttnn::Tensor *>(cache);
+    const auto &coordVec = cacheTensor.tensor_topology().mesh_coords();
+    std::set<::ttnn::MeshCoordinate> meshCoords(coordVec.begin(),
+                                                coordVec.end());
+    params.meshCoords = std::make_optional(meshCoords);
+  } else {
+    params.meshCoords = std::nullopt;
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPagedFillCacheTuple(Tag tag,
+                               const ::tt::target::ttnn::PagedFillCacheOpT &op,
+                               TensorArg cache, TensorArg input,
+                               TensorArg pageTable,
+                               std::optional<TensorArg> batchIdxTensor,
+                               const PagedFillCacheResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(cache, tag), resolveTensorArg(input, tag),
+      resolveTensorArg(pageTable, tag),
+      batchIdxTensor
+          ? std::make_optional(resolveTensorArg(*batchIdxTensor, tag))
+          : std::nullopt,
+      /*batch_idx=*/0,
+      /*compute_kernel_config=*/std::nullopt,
+      /*mesh_coords=*/params.meshCoords);
+}
+
+PagedFillCacheOpResult callPagedFillCache(
+    CallType callType, const ::tt::target::ttnn::PagedFillCacheOpT &op,
+    TensorArg cache, TensorArg input, TensorArg pageTable,
+    std::optional<TensorArg> batchIdxTensor, ::ttnn::MeshDevice *device) {
+  PagedFillCacheResolvedParams params =
+      resolvePagedFillCacheParams(op, callType, cache);
+
+  auto makeTuple = [&](auto tag) {
+    return createPagedFillCacheTuple(tag, op, cache, input, pageTable,
+                                     batchIdxTensor, params);
+  };
+
+  return callOp<PagedFillCacheOpResult>(
+      WRAP_OP(::ttnn::experimental::paged_fill_cache), callType, makeTuple,
+      device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/KVCache/PagedUpdateCacheOp.cpp
+++ b/lib/OpInvoke/TTNN/KVCache/PagedUpdateCacheOp.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/KVCache/PagedUpdateCacheOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+PagedUpdateCacheResolvedParams
+resolvePagedUpdateCacheParams(const ::tt::target::ttnn::PagedUpdateCacheOpT &op,
+                              CallType callType, TensorArg cache) {
+  PagedUpdateCacheResolvedParams params;
+
+  params.update_idxs = {};
+
+  // TODO: This branching on callType should be removed.
+  if (callType == CallType::EXECUTE) {
+    // Force the MeshWorkloadFactory by passing the cache tensor's full set of
+    // mesh coordinates. With std::nullopt, the device op selects the
+    // single-program factory, which under DP partitioning runs the kernel on
+    // the mesh root only - so per-rank cache writes from non-root devices are
+    // silently dropped. Per-rank divergent updates require one program per
+    // mesh coordinate, which is what the MeshWorkloadFactory provides.
+    //
+    // TODO(#47955): ttnn could infer these coords from the cache tensor (it is
+    // already an op input) and select the MeshWorkloadFactory by default,
+    // letting us drop this explicit pass. Tracked in
+    // tenstorrent/tt-metal#47955.
+    ::ttnn::Tensor cacheTensor = *std::get<const ::ttnn::Tensor *>(cache);
+    const auto &coordVec = cacheTensor.tensor_topology().mesh_coords();
+    std::set<::ttnn::MeshCoordinate> meshCoords(coordVec.begin(),
+                                                coordVec.end());
+    params.meshCoords = std::make_optional(meshCoords);
+  } else {
+    params.meshCoords = std::nullopt;
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createPagedUpdateCacheTuple(
+    Tag tag, const ::tt::target::ttnn::PagedUpdateCacheOpT &op, TensorArg cache,
+    TensorArg input, std::optional<TensorArg> updateIndex,
+    std::optional<TensorArg> pageTable,
+    const PagedUpdateCacheResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(cache, tag), resolveTensorArg(input, tag),
+      params.update_idxs,
+      updateIndex ? std::make_optional(resolveTensorArg(*updateIndex, tag))
+                  : std::nullopt,
+      op.share_cache,
+      pageTable ? std::make_optional(resolveTensorArg(*pageTable, tag))
+                : std::nullopt,
+      /*batch_offset=*/0,
+      /*compute_kernel_config=*/std::nullopt,
+      /*mesh_coords=*/params.meshCoords);
+}
+
+PagedUpdateCacheOpResult callPagedUpdateCache(
+    CallType callType, const ::tt::target::ttnn::PagedUpdateCacheOpT &op,
+    TensorArg cache, TensorArg input, std::optional<TensorArg> updateIndex,
+    std::optional<TensorArg> pageTable, ::ttnn::MeshDevice *device) {
+  PagedUpdateCacheResolvedParams params =
+      resolvePagedUpdateCacheParams(op, callType, cache);
+
+  auto makeTuple = [&](auto tag) {
+    return createPagedUpdateCacheTuple(tag, op, cache, input, updateIndex,
+                                       pageTable, params);
+  };
+
+  return callOp<PagedUpdateCacheOpResult>(
+      WRAP_OP(::ttnn::experimental::paged_update_cache), callType, makeTuple,
+      device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpModel/TTNN/NativeFromMLIR.cpp
+++ b/lib/OpModel/TTNN/NativeFromMLIR.cpp
@@ -1348,6 +1348,26 @@ buildProdOpTFromMLIR(std::optional<int64_t> dimArg, bool keepDim,
   return topKOp;
 }
 
+::tt::target::ttnn::FillCacheOpT
+buildFillCacheOpTFromMLIR(uint32_t batchOffset) {
+  ::tt::target::ttnn::FillCacheOpT fillCacheOp;
+  fillCacheOp.batch_offset = batchOffset;
+  return fillCacheOp;
+}
+
+::tt::target::ttnn::PagedUpdateCacheOpT
+buildPagedUpdateCacheOpTFromMLIR(bool shareCache) {
+  ::tt::target::ttnn::PagedUpdateCacheOpT op;
+  op.share_cache = shareCache;
+  return op;
+}
+
+::tt::target::ttnn::PagedFillCacheOpT buildPagedFillCacheOpTFromMLIR() {
+  ::tt::target::ttnn::PagedFillCacheOpT pagedFillCacheOp;
+
+  return pagedFillCacheOp;
+}
+
 } // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -36,6 +36,9 @@
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Ternary/EltwiseTernaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h"
+#include "ttmlir/OpInvoke/TTNN/KVCache/FillCacheOp.h"
+#include "ttmlir/OpInvoke/TTNN/KVCache/PagedFillCacheOp.h"
+#include "ttmlir/OpInvoke/TTNN/KVCache/PagedUpdateCacheOp.h"
 #include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
 #include "ttmlir/OpInvoke/TTNN/Normalization/BatchNormOp.h"
 #include "ttmlir/OpInvoke/TTNN/Normalization/GroupNormOp.h"
@@ -5259,9 +5262,19 @@ llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  ::tt::target::ttnn::FillCacheOpT fillCacheOpNative =
+      buildFillCacheOpTFromMLIR(batchOffset);
+
   auto fillCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::fill_cache, device, cacheSpec,
-                                inputSpec, batchOffset);
+    ttnn_op_invoke::FillCacheOpResult result = ttnn_op_invoke::callFillCache(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, fillCacheOpNative,
+        cacheSpec, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from FillCacheOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(cacheLayout.getContext(),
@@ -5287,9 +5300,19 @@ llvm::Expected<size_t> OpModel<FillCacheOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  ::tt::target::ttnn::FillCacheOpT fillCacheOpNative =
+      buildFillCacheOpTFromMLIR(batchOffset);
+
   auto fillCacheOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::fill_cache, device, cacheSpec, inputSpec,
-                            batchOffset);
+    ttnn_op_invoke::FillCacheOpResult result = ttnn_op_invoke::callFillCache(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, fillCacheOpNative,
+        cacheSpec, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from FillCacheOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(fillCacheOpQuery);
@@ -5384,6 +5407,7 @@ llvm::Expected<size_t> OpModel<UpdateCacheOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // PagedUpdateCacheOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -5414,13 +5438,25 @@ llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
         detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout));
   }
 
-  std::vector<uint32_t> emptyUpdateIndex = {};
+  ::tt::target::ttnn::PagedUpdateCacheOpT pagedUpdateCacheOpNative =
+      buildPagedUpdateCacheOpTFromMLIR(shareCache);
+
   auto pagedUpdateCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::paged_update_cache, device, cacheSpec, inputSpec,
-        emptyUpdateIndex, updateIndexSpec, shareCache, pageTableSpec,
-        /*batch_offset=*/0,
-        /*compute_kernel_config=*/std::nullopt, /*mesh_coords=*/std::nullopt);
+    ttnn_op_invoke::PagedUpdateCacheOpResult result =
+        ttnn_op_invoke::callPagedUpdateCache(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            pagedUpdateCacheOpNative, cacheSpec, inputSpec,
+            std::optional<ttnn_op_invoke::TensorArg>(updateIndexSpec),
+            pageTableSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*pageTableSpec)
+                : std::nullopt,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from PagedUpdateCacheOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(cacheLayout.getContext(),
@@ -5460,12 +5496,30 @@ llvm::Expected<size_t> OpModel<PagedUpdateCacheOp>::getOpRuntime(
         detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout));
   }
 
-  std::vector<uint32_t> emptyUpdateIndex = {};
+  ::tt::target::ttnn::PagedUpdateCacheOpT pagedUpdateCacheOpNative =
+      buildPagedUpdateCacheOpTFromMLIR(shareCache);
+
+  std::optional<ttnn_op_invoke::TensorArg> pageTableArg;
+  if (pageTableSpec) {
+    pageTableArg = *pageTableSpec;
+  }
+
   auto pagedUpdateCacheOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::experimental::paged_update_cache, device,
-                            cacheSpec, inputSpec, emptyUpdateIndex,
-                            updateIndexSpec, shareCache, pageTableSpec, 0,
-                            std::nullopt, std::nullopt);
+    ttnn_op_invoke::PagedUpdateCacheOpResult result =
+        ttnn_op_invoke::callPagedUpdateCache(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            pagedUpdateCacheOpNative, cacheSpec, inputSpec,
+            std::optional<ttnn_op_invoke::TensorArg>(updateIndexSpec),
+            pageTableSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*pageTableSpec)
+                : std::nullopt,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from PagedUpdateCacheOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(pagedUpdateCacheOpQuery);
@@ -5506,12 +5560,24 @@ llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
         detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout));
   }
 
+  ::tt::target::ttnn::PagedFillCacheOpT pagedFillCacheOpNative =
+      buildPagedFillCacheOpTFromMLIR();
+
   auto pagedFillCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::paged_fill_cache, device, cacheSpec, inputSpec,
-        pageTableSpec, batchIdxSpec,
-        /*batch_offset=*/0,
-        /*compute_kernel_config=*/std::nullopt, /*mesh_coords=*/std::nullopt);
+    ttnn_op_invoke::PagedFillCacheOpResult result =
+        ttnn_op_invoke::callPagedFillCache(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            pagedFillCacheOpNative, cacheSpec, inputSpec, pageTableSpec,
+            batchIdxSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*batchIdxSpec)
+                : std::nullopt,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from PagedFillCacheOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(cacheLayout.getContext(),
@@ -5549,12 +5615,24 @@ llvm::Expected<size_t> OpModel<PagedFillCacheOp>::getOpRuntime(
         detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout));
   }
 
+  ::tt::target::ttnn::PagedFillCacheOpT pagedFillCacheOpNative =
+      buildPagedFillCacheOpTFromMLIR();
+
   auto pagedFillCacheOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::experimental::paged_fill_cache, device,
-                            cacheSpec, inputSpec, pageTableSpec, batchIdxSpec,
-                            /*batch_offset=*/0,
-                            /*compute_kernel_config=*/std::nullopt,
-                            /*mesh_coords=*/std::nullopt);
+    ttnn_op_invoke::PagedFillCacheOpResult result =
+        ttnn_op_invoke::callPagedFillCache(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, pagedFillCacheOpNative,
+            cacheSpec, inputSpec, pageTableSpec,
+            batchIdxSpec.has_value()
+                ? std::optional<ttnn_op_invoke::TensorArg>(*batchIdxSpec)
+                : std::nullopt,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from PagedFillCacheOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(pagedFillCacheOpQuery);

--- a/runtime/lib/ttnn/operations/kv_cache/fill_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/fill_cache.cpp
@@ -4,16 +4,26 @@
 
 #include "operations/kv_cache/fill_cache.h"
 #include "tt/runtime/detail/common/logger.h"
+#include "ttmlir/OpInvoke/TTNN/KVCache/FillCacheOp.h"
 
 namespace tt::runtime::ttnn::operations::kv_cache {
 void run(const ::tt::target::ttnn::FillCacheOp *op, ProgramContext &context) {
-
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &cache =
       tensorPool.getTTNNTensorAndValidate(op->cache());
   const ::ttnn::Tensor &input =
       tensorPool.getTTNNTensorAndValidate(op->input());
 
-  ::ttnn::fill_cache(cache, input, op->batch_offset());
+  ::tt::target::ttnn::FillCacheOpT fillCacheOpNative;
+  op->UnPackTo(&fillCacheOpNative);
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::FillCacheOpResult result = ttnn_op_invoke::callFillCache(
+      ttnn_op_invoke::CallType::EXECUTE, fillCacheOpNative, &cache, &input,
+      &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callFillCache execution");
 }
 } // namespace tt::runtime::ttnn::operations::kv_cache

--- a/runtime/lib/ttnn/operations/kv_cache/paged_fill_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/paged_fill_cache.cpp
@@ -3,46 +3,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/kv_cache/paged_fill_cache.h"
-
 #include "tt/runtime/detail/common/logger.h"
-
-#include "tt/runtime/workarounds.h"
-#include "ttnn/distributed/api.hpp"
-#include "ttnn/distributed/distributed_tensor.hpp"
+#include "ttmlir/OpInvoke/TTNN/KVCache/PagedFillCacheOp.h"
 
 namespace tt::runtime::ttnn::operations::kv_cache {
 void run(const ::tt::target::ttnn::PagedFillCacheOp *op,
          ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  const ::ttnn::Tensor &cacheTensor =
-      context.getTensorPool().getTTNNTensorAndValidate(op->cache());
-  const ::ttnn::Tensor &inputTensor =
-      context.getTensorPool().getTTNNTensorAndValidate(op->input());
-  const ::ttnn::Tensor &pageTableTensor =
-      context.getTensorPool().getTTNNTensorAndValidate(op->page_table());
+  const ::ttnn::Tensor &cache =
+      tensorPool.getTTNNTensorAndValidate(op->cache());
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
+  const ::ttnn::Tensor &pageTable =
+      tensorPool.getTTNNTensorAndValidate(op->page_table());
 
-  const std::optional<::ttnn::Tensor> &batchIdxTensor =
-      op->batch_idx_tensor()
-          ? std::make_optional(context.getTensorPool().getTTNNTensorAndValidate(
-                op->batch_idx_tensor()))
-          : std::nullopt;
+  std::optional<::ttnn::Tensor> batchIdxTensor;
+  if (op->batch_idx_tensor()) {
+    batchIdxTensor =
+        tensorPool.getTTNNTensorAndValidate(op->batch_idx_tensor());
+  }
 
-  // Force the MeshWorkloadFactory by passing the cache tensor's full set of
-  // mesh coordinates. With std::nullopt, the device op selects the
-  // single-program factory, which under DP partitioning runs the kernel on
-  // the mesh root only - so per-rank cache writes from non-root devices are
-  // silently dropped.
-  //
-  // TODO(#47955): ttnn could infer these coords from the cache tensor (it is
-  // already an op input) and select the MeshWorkloadFactory by default, letting
-  // us drop this explicit pass. Tracked in tenstorrent/tt-metal#47955.
-  const auto &coordVec = cacheTensor.tensor_topology().mesh_coords();
-  std::set<::ttnn::MeshCoordinate> meshCoords(coordVec.begin(), coordVec.end());
+  ::tt::target::ttnn::PagedFillCacheOpT opNative;
+  op->UnPackTo(&opNative);
 
-  ::ttnn::experimental::paged_fill_cache(cacheTensor, inputTensor,
-                                         pageTableTensor, batchIdxTensor,
-                                         /*batch_offset=*/0,
-                                         /*compute_kernel_config*/ std::nullopt,
-                                         /*mesh_coords*/ meshCoords);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  ttnn_op_invoke::PagedFillCacheOpResult result =
+      ttnn_op_invoke::callPagedFillCache(
+          ttnn_op_invoke::CallType::EXECUTE, opNative, &cache, &input,
+          &pageTable,
+          batchIdxTensor.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*batchIdxTensor)
+              : std::nullopt,
+          &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callPagedFillCache execution");
 }
 } // namespace tt::runtime::ttnn::operations::kv_cache

--- a/runtime/lib/ttnn/operations/kv_cache/paged_update_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/paged_update_cache.cpp
@@ -3,53 +3,47 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/kv_cache/paged_update_cache.h"
-
 #include "tt/runtime/detail/common/logger.h"
-
-#include "tt/runtime/workarounds.h"
-#include "ttnn/distributed/api.hpp"
-#include "ttnn/distributed/distributed_tensor.hpp"
+#include "ttmlir/OpInvoke/TTNN/KVCache/PagedUpdateCacheOp.h"
 
 namespace tt::runtime::ttnn::operations::kv_cache {
 void run(const ::tt::target::ttnn::PagedUpdateCacheOp *op,
          ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  const ::ttnn::Tensor &cacheTensor =
-      context.getTensorPool().getTTNNTensorAndValidate(op->cache());
-  const ::ttnn::Tensor &inputTensor =
-      context.getTensorPool().getTTNNTensorAndValidate(op->input());
+  const ::ttnn::Tensor &cache =
+      tensorPool.getTTNNTensorAndValidate(op->cache());
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
   const std::optional<::ttnn::Tensor> &updateIndexTensor =
       op->update_index()
           ? std::make_optional(context.getTensorPool().getTTNNTensorAndValidate(
                 op->update_index()))
           : std::nullopt;
-  const bool &shareCache = op->share_cache();
+
   const std::optional<::ttnn::Tensor> &pageTableTensor =
       op->page_table()
           ? std::make_optional(context.getTensorPool().getTTNNTensorAndValidate(
                 op->page_table()))
           : std::nullopt;
 
-  const std::vector<uint32_t> emptyUpdateIndex = {};
+  ::tt::target::ttnn::PagedUpdateCacheOpT opNative;
+  op->UnPackTo(&opNative);
 
-  // Force the MeshWorkloadFactory by passing the cache tensor's full set of
-  // mesh coordinates. With std::nullopt, the device op selects the
-  // single-program factory, which under DP partitioning runs the kernel on
-  // the mesh root only - so per-rank cache writes from non-root devices are
-  // silently dropped. Per-rank divergent updates require one program per
-  // mesh coordinate, which is what the MeshWorkloadFactory provides.
-  //
-  // TODO(#47955): ttnn could infer these coords from the cache tensor (it is
-  // already an op input) and select the MeshWorkloadFactory by default, letting
-  // us drop this explicit pass. Tracked in tenstorrent/tt-metal#47955.
-  const auto &coordVec = cacheTensor.tensor_topology().mesh_coords();
-  std::set<::ttnn::MeshCoordinate> meshCoords(coordVec.begin(), coordVec.end());
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::experimental::paged_update_cache(
-      cacheTensor, inputTensor, emptyUpdateIndex, updateIndexTensor, shareCache,
-      pageTableTensor,
-      /*batch_offset=*/0,
-      /*compute_kernel_config*/ std::nullopt,
-      /*mesh_coords*/ meshCoords);
+  ttnn_op_invoke::PagedUpdateCacheOpResult result =
+      ttnn_op_invoke::callPagedUpdateCache(
+          ttnn_op_invoke::CallType::EXECUTE, opNative, &cache, &input,
+          updateIndexTensor.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*updateIndexTensor)
+              : std::nullopt,
+          pageTableTensor.has_value()
+              ? std::optional<ttnn_op_invoke::TensorArg>(&*pageTableTensor)
+              : std::nullopt,
+          &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callPagedUpdateCache execution");
 }
 } // namespace tt::runtime::ttnn::operations::kv_cache

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
@@ -6742,4 +6742,251 @@ const std::initializer_list<mlir::tt::ttnn::TopKOp> topKOpList = {
 INSTANTIATE_TEST_SUITE_P(TopKOpTPathParityTest, TopKOpTPathParityTest,
                          ::testing::ValuesIn(topKOpList));
 
+//===----------------------------------------------------------------------===//
+// FillCacheOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::FillCacheOpT &opNativeOpModel,
+                       ::tt::target::ttnn::FillCacheOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::FillCacheOpT &op) {
+    op.cache.reset();
+    op.input.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::FillCacheOp buildTestFillCacheOp(int32_t batchOffset = 0) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  return e.builder.create<mlir::tt::ttnn::FillCacheOp>(
+      loc, makeOnes(), makeOnes(), e.builder.getI32IntegerAttr(batchOffset));
+}
+
+} // namespace
+
+using FillCacheOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::FillCacheOp>;
+
+TEST_P(FillCacheOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::FillCacheOp fillCacheOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::FillCacheOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildFillCacheOpTFromMLIR(
+          static_cast<uint32_t>(fillCacheOp.getBatchOffset()));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, fillCacheOp.getCache(),
+                               fillCacheOp.getInput());
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, fillCacheOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::FillCacheOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+}
+
+const std::initializer_list<mlir::tt::ttnn::FillCacheOp> fillCacheOpList = {
+    buildTestFillCacheOp(),
+    buildTestFillCacheOp(/*batchOffset=*/1),
+    buildTestFillCacheOp(/*batchOffset=*/1),
+};
+
+INSTANTIATE_TEST_SUITE_P(FillCacheOpTPathParityTest, FillCacheOpTPathParityTest,
+                         ::testing::ValuesIn(fillCacheOpList));
+
+//===----------------------------------------------------------------------===//
+// PagedFillCacheOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::PagedFillCacheOpT &opNativeOpModel,
+                       ::tt::target::ttnn::PagedFillCacheOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::PagedFillCacheOpT &op) {
+    op.cache.reset();
+    op.input.reset();
+    op.page_table.reset();
+    op.batch_idx_tensor.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PagedFillCacheOp
+buildTestPagedFillCacheOp(bool withBatchIdxTensor = false) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value batchIdxValue;
+  if (withBatchIdxTensor) {
+    batchIdxValue = makeOnes();
+  }
+
+  return e.builder.create<mlir::tt::ttnn::PagedFillCacheOp>(
+      loc, makeOnes(), makeOnes(), makeOnes(), batchIdxValue);
+}
+
+} // namespace
+
+using PagedFillCacheOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::PagedFillCacheOp>;
+
+TEST_P(PagedFillCacheOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PagedFillCacheOp pagedFillCacheOp = GetParam();
+
+  // Path A: OpModel-style construction (no scalar fields, no output TensorRef).
+  ::tt::target::ttnn::PagedFillCacheOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildPagedFillCacheOpTFromMLIR();
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, pagedFillCacheOp.getCache(),
+                               pagedFillCacheOp.getInput(),
+                               pagedFillCacheOp.getPageTable());
+  if (pagedFillCacheOp.getBatchIdxTensor()) {
+    prepopulateOperandTensorRefs(cache, pagedFillCacheOp.getBatchIdxTensor());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, pagedFillCacheOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PagedFillCacheOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+}
+
+const std::initializer_list<mlir::tt::ttnn::PagedFillCacheOp>
+    pagedFillCacheOpList = {
+        buildTestPagedFillCacheOp(),
+        buildTestPagedFillCacheOp(/*withBatchIdxTensor=*/true),
+};
+
+INSTANTIATE_TEST_SUITE_P(PagedFillCacheOpTPathParityTest,
+                         PagedFillCacheOpTPathParityTest,
+                         ::testing::ValuesIn(pagedFillCacheOpList));
+
+//===----------------------------------------------------------------------===//
+// PagedUpdateCacheOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(::tt::target::ttnn::PagedUpdateCacheOpT &opNativeOpModel,
+                       ::tt::target::ttnn::PagedUpdateCacheOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::PagedUpdateCacheOpT &op) {
+    op.cache.reset();
+    op.input.reset();
+    op.update_index.reset();
+    op.page_table.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::PagedUpdateCacheOp
+buildTestPagedUpdateCacheOp(bool shareCache = false,
+                            bool withPageTable = false) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  mlir::Value pageTableValue;
+  if (withPageTable) {
+    pageTableValue = makeOnes();
+  }
+
+  return e.builder.create<mlir::tt::ttnn::PagedUpdateCacheOp>(
+      loc, makeOnes(), makeOnes(), makeOnes(),
+      e.builder.getBoolAttr(shareCache), pageTableValue);
+}
+
+} // namespace
+
+using PagedUpdateCacheOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::PagedUpdateCacheOp>;
+
+TEST_P(PagedUpdateCacheOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::PagedUpdateCacheOp pagedUpdateCacheOp = GetParam();
+
+  // Path A: OpModel-style construction. Only share_cache survives the reset.
+  ::tt::target::ttnn::PagedUpdateCacheOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildPagedUpdateCacheOpTFromMLIR(
+          pagedUpdateCacheOp.getShareCache());
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, pagedUpdateCacheOp.getCache(),
+                               pagedUpdateCacheOp.getInput(),
+                               pagedUpdateCacheOp.getUpdateIndex());
+  if (pagedUpdateCacheOp.getPageTable()) {
+    prepopulateOperandTensorRefs(cache, pagedUpdateCacheOp.getPageTable());
+  }
+
+  auto fbOffset = mlir::tt::ttnn::createOp(cache, pagedUpdateCacheOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::PagedUpdateCacheOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+}
+
+const std::initializer_list<mlir::tt::ttnn::PagedUpdateCacheOp>
+    pagedUpdateCacheOpList = {
+        buildTestPagedUpdateCacheOp(),
+        buildTestPagedUpdateCacheOp(/*shareCache=*/true),
+        buildTestPagedUpdateCacheOp(/*shareCache=*/false,
+                                    /*withPageTable=*/true),
+        buildTestPagedUpdateCacheOp(/*shareCache=*/true,
+                                    /*withPageTable=*/true),
+};
+
+INSTANTIATE_TEST_SUITE_P(PagedUpdateCacheOpTPathParityTest,
+                         PagedUpdateCacheOpTPathParityTest,
+                         ::testing::ValuesIn(pagedUpdateCacheOpList));
+
 #endif // TTMLIR_ENABLE_OPMODEL


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.

### What's changed
This is the thirteenth PR in the TTNNOpInvokeLib series. It introduces shared dispatch for the KV cache operations across OpModel and Runtime: fill_cache, paged_fill_cache, and paged_update_cache.

### Checklist
- [ ] New/Existing tests provide coverage for changes
