### PR TITLE
Embedding ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Embedding/EmbeddingBackwardOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Embedding/EmbeddingBackwardOp.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_EMBEDDING_EMBEDDINGBACKWARDOP_H
+#define TTMLIR_OPINVOKE_TTNN_EMBEDDING_EMBEDDINGBACKWARDOP_H
+
+#include "operations/embedding_backward/embedding_backward.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using EmbeddingBackwardOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct EmbeddingBackwardResolvedParams {
+  std::optional<::ttnn::DataType> dtype;
+  std::optional<::ttnn::MemoryConfig> memoryConfig;
+};
+
+EmbeddingBackwardResolvedParams resolveEmbeddingBackwardParams(
+    const ::tt::target::ttnn::EmbeddingBackwardOpT &op);
+
+EmbeddingBackwardOpResult
+callEmbeddingBackward(CallType callType,
+                      const ::tt::target::ttnn::EmbeddingBackwardOpT &op,
+                      TensorArg input, TensorArg weight, TensorArg inGradient,
+                      ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_EMBEDDING_EMBEDDINGBACKWARDOP_H

--- a/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
+++ b/include/ttmlir/OpModel/TTNN/NativeFromMLIR.h
@@ -350,6 +350,9 @@ buildFillCacheOpTFromMLIR(uint32_t batchOffset);
 ::tt::target::ttnn::PagedUpdateCacheOpT
 buildPagedUpdateCacheOpTFromMLIR(bool shareCache);
 
+::tt::target::ttnn::EmbeddingBackwardOpT
+buildEmbeddingBackwardOpTFromMLIR(TTNNLayoutAttr outputLayout);
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL
 

--- a/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
+++ b/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
@@ -248,6 +248,11 @@ createOp(::mlir::tt::FlatbufferObjectCache &cache, PagedFillCacheOp op);
 ::flatbuffers::Offset<::tt::target::ttnn::PagedUpdateCacheOp>
 createOp(::mlir::tt::FlatbufferObjectCache &cache, PagedUpdateCacheOp op);
 
+template <typename EmbeddingBackwardOpTy>
+::flatbuffers::Offset<::tt::target::ttnn::EmbeddingBackwardOp>
+createEmbeddingBackwardOp(::mlir::tt::FlatbufferObjectCache &cache,
+                          EmbeddingBackwardOpTy op);
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_TARGET_TTNN_TTNNTOFLATBUFFER_H

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(TTNNOpInvokeLib STATIC
   Eltwise/Ternary/EltwiseTernaryOp.cpp
   Eltwise/Unary/EltwiseUnaryCompositeOp.cpp
   Eltwise/Unary/EltwiseUnaryOp.cpp
+  Embedding/EmbeddingBackwardOp.cpp
   KVCache/FillCacheOp.cpp
   KVCache/PagedFillCacheOp.cpp
   KVCache/PagedUpdateCacheOp.cpp

--- a/lib/OpInvoke/TTNN/Embedding/EmbeddingBackwardOp.cpp
+++ b/lib/OpInvoke/TTNN/Embedding/EmbeddingBackwardOp.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Embedding/EmbeddingBackwardOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+namespace ttnn_op_invoke {
+
+EmbeddingBackwardResolvedParams resolveEmbeddingBackwardParams(
+    const ::tt::target::ttnn::EmbeddingBackwardOpT &op) {
+  EmbeddingBackwardResolvedParams params;
+
+  if (op.out) {
+    params.dtype = operations::utils::getDataType(*op.out);
+  }
+
+  if (op.out) {
+    params.memoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*op.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*op.out) ||
+                         params.memoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createEmbeddingBackwardTuple(
+    Tag tag, const ::tt::target::ttnn::EmbeddingBackwardOpT &op,
+    TensorArg input, TensorArg weight, TensorArg inGradient,
+    const EmbeddingBackwardResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), resolveTensorArg(weight, tag),
+      resolveTensorArg(inGradient, tag), params.dtype, params.memoryConfig);
+}
+
+EmbeddingBackwardOpResult
+callEmbeddingBackward(CallType callType,
+                      const ::tt::target::ttnn::EmbeddingBackwardOpT &op,
+                      TensorArg input, TensorArg weight, TensorArg inGradient,
+                      ::ttnn::MeshDevice *device) {
+  EmbeddingBackwardResolvedParams params = resolveEmbeddingBackwardParams(op);
+
+  auto makeTuple = [&](auto tag) {
+    return createEmbeddingBackwardTuple(tag, op, input, weight, inGradient,
+                                        params);
+  };
+
+  return callOp<EmbeddingBackwardOpResult>(WRAP_OP(::ttnn::embedding_bw),
+                                           callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpModel/TTNN/NativeFromMLIR.cpp
+++ b/lib/OpModel/TTNN/NativeFromMLIR.cpp
@@ -1368,6 +1368,13 @@ buildPagedUpdateCacheOpTFromMLIR(bool shareCache) {
   return pagedFillCacheOp;
 }
 
+::tt::target::ttnn::EmbeddingBackwardOpT
+buildEmbeddingBackwardOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EmbeddingBackwardOpT op;
+  op.out = detail::getOutputTensorRefT(outputLayout);
+  return op;
+}
+
 } // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -36,6 +36,7 @@
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Ternary/EltwiseTernaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h"
+#include "ttmlir/OpInvoke/TTNN/Embedding/EmbeddingBackwardOp.h"
 #include "ttmlir/OpInvoke/TTNN/KVCache/FillCacheOp.h"
 #include "ttmlir/OpInvoke/TTNN/KVCache/PagedFillCacheOp.h"
 #include "ttmlir/OpInvoke/TTNN/KVCache/PagedUpdateCacheOp.h"
@@ -7972,11 +7973,21 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
       ::ttnn::TensorSpec inGradientSpec,
       detail::convertToTensorSpec(device, inGradientShape, inGradientLayout));
 
+  ::tt::target::ttnn::EmbeddingBackwardOpT embeddingBackwardOpNative =
+      buildEmbeddingBackwardOpTFromMLIR(outputLayout);
+
   auto embeddingBackwardOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::embedding_bw, device, inputSpec, weightSpec, inGradientSpec,
-        /*dtype*/ std::nullopt, detail::getNullableMemoryConfig(outputLayout),
-        /*optional_output_tensor*/ std::nullopt);
+    ttnn_op_invoke::EmbeddingBackwardOpResult result =
+        ttnn_op_invoke::callEmbeddingBackward(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            embeddingBackwardOpNative, inputSpec, weightSpec, inGradientSpec,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from EmbeddingBackwardOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -8008,11 +8019,21 @@ OpModel<mlir::tt::ttnn::EmbeddingBackwardOp>::getOpRuntime(
       ::ttnn::TensorSpec inGradientSpec,
       detail::convertToTensorSpec(device, inGradientShape, inGradientLayout));
 
+  ::tt::target::ttnn::EmbeddingBackwardOpT embeddingBackwardOpNative =
+      buildEmbeddingBackwardOpTFromMLIR(outputLayout);
+
   auto embeddingBackwardOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::embedding_bw, device, inputSpec, weightSpec, inGradientSpec,
-        /*dtype*/ std::nullopt, detail::getNullableMemoryConfig(outputLayout),
-        /*optional_output_tensor*/ std::nullopt);
+    ttnn_op_invoke::EmbeddingBackwardOpResult result =
+        ttnn_op_invoke::callEmbeddingBackward(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            embeddingBackwardOpNative, inputSpec, weightSpec, inGradientSpec,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EmbeddingBackwardOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(embeddingBackwardOpQuery);

--- a/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
+++ b/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
@@ -4,13 +4,7 @@
 
 #include "operations/embedding/embedding_backward.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
-#include "ttmlir/Target/TTNN/program_generated.h"
-#include "ttnn/operations/embedding_backward/embedding_backward.hpp"
-#include "ttnn/tensor/tensor.hpp"
+#include "ttmlir/OpInvoke/TTNN/Embedding/EmbeddingBackwardOp.h"
 
 namespace tt::runtime::ttnn::operations::embedding_backward {
 void run(const ::tt::target::ttnn::EmbeddingBackwardOp *op,
@@ -24,16 +18,20 @@ void run(const ::tt::target::ttnn::EmbeddingBackwardOp *op,
   const ::ttnn::Tensor &inGrad =
       tensorPool.getTTNNTensorAndValidate(op->in_grad());
 
-  std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+  ::tt::target::ttnn::EmbeddingBackwardOpT opNative;
+  op->UnPackTo(&opNative);
 
-  std::optional<::ttnn::DataType> dtype = std::nullopt;
-  if (op->dtype()) {
-    dtype = ttnn_op_invoke::operations::utils::toTTNNDataType(*(op->dtype()));
-  }
-  ::ttnn::Tensor out =
-      ::ttnn::embedding_bw(input, weight, inGrad, dtype, memoryConfig);
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::EmbeddingBackwardOpResult result =
+      ttnn_op_invoke::callEmbeddingBackward(ttnn_op_invoke::CallType::EXECUTE,
+                                            opNative, &input, &weight, &inGrad,
+                                            &targetDevice);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected Tensor from callEmbeddingBackward execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::embedding_backward

--- a/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
+++ b/test/unittests/MLIRAttrToFBNative/OpTPathParity.cpp
@@ -6989,4 +6989,95 @@ INSTANTIATE_TEST_SUITE_P(PagedUpdateCacheOpTPathParityTest,
                          PagedUpdateCacheOpTPathParityTest,
                          ::testing::ValuesIn(pagedUpdateCacheOpList));
 
+//===----------------------------------------------------------------------===//
+// EmbeddingBackwardOpTPathParity
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+void resetUnusedFields(
+    ::tt::target::ttnn::EmbeddingBackwardOpT &opNativeOpModel,
+    ::tt::target::ttnn::EmbeddingBackwardOpT &opNativeFB) {
+  auto helper = [](::tt::target::ttnn::EmbeddingBackwardOpT &op) {
+    op.input.reset();
+    op.weight.reset();
+    op.in_grad.reset();
+    op.dtype.reset();
+    op.memcfg.reset();
+    op.out.reset();
+  };
+
+  helper(opNativeOpModel);
+  helper(opNativeFB);
+}
+
+mlir::tt::ttnn::EmbeddingBackwardOp buildTestEmbeddingBackwardOp(
+    mlir::tt::ttnn::MemoryConfigAttr outputMemoryConfig = {}) {
+  auto &e = env();
+  auto loc = e.builder.getUnknownLoc();
+
+  auto tensorType = tiledL1BF16Type(defaultShape);
+
+  auto makeOnes = [&]() {
+    return e.builder
+        .create<mlir::tt::ttnn::OnesOp>(loc, mlir::TypeRange{tensorType},
+                                        mlir::ValueRange{})
+        .getResult();
+  };
+
+  auto outputType =
+      outputMemoryConfig
+          ? tiledBF16TypeFromMemoryConfig(defaultShape, outputMemoryConfig)
+          : tiledL1BF16Type(defaultShape);
+
+  return e.builder.create<mlir::tt::ttnn::EmbeddingBackwardOp>(
+      loc, outputType, mlir::ValueRange{makeOnes(), makeOnes(), makeOnes()});
+}
+
+} // namespace
+
+using EmbeddingBackwardOpTPathParityTest =
+    ::testing::TestWithParam<mlir::tt::ttnn::EmbeddingBackwardOp>;
+
+TEST_P(EmbeddingBackwardOpTPathParityTest, BuildEqualsFlatbufferRoundTrip) {
+  mlir::tt::ttnn::EmbeddingBackwardOp embeddingBackwardOp = GetParam();
+
+  // Path A: OpModel-style construction.
+  ::tt::target::ttnn::EmbeddingBackwardOpT opNativeOpModel =
+      mlir::tt::ttnn::op_model::buildEmbeddingBackwardOpTFromMLIR(
+          resolveOutputLayout(embeddingBackwardOp));
+
+  // Path B: FB serialization round-trip (what runtime sees).
+  ::flatbuffers::FlatBufferBuilder fbb;
+  mlir::tt::FlatbufferObjectCache cache(&fbb);
+  prepopulateOperandTensorRefs(cache, embeddingBackwardOp.getInput(),
+                               embeddingBackwardOp.getWeight(),
+                               embeddingBackwardOp.getInGradient());
+
+  auto fbOffset =
+      mlir::tt::ttnn::createEmbeddingBackwardOp(cache, embeddingBackwardOp);
+  fbb.Finish(fbOffset);
+  auto *r = ::flatbuffers::GetTemporaryPointer(fbb, fbOffset);
+  ::tt::target::ttnn::EmbeddingBackwardOpT opNativeFB;
+  r->UnPackTo(&opNativeFB);
+
+  resetUnusedFields(opNativeOpModel, opNativeFB);
+
+  EXPECT_EQ(opNativeOpModel, opNativeFB);
+  compareOutputTensorRefT(opNativeOpModel.out, opNativeFB.out);
+}
+
+const std::initializer_list<mlir::tt::ttnn::EmbeddingBackwardOp>
+    embeddingBackwardOpList = {
+        buildTestEmbeddingBackwardOp(),
+        buildTestEmbeddingBackwardOp(
+            /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+        buildTestEmbeddingBackwardOp(
+            /*outputMemoryConfig=*/nonDefaultInputMemoryConfigAttr),
+};
+
+INSTANTIATE_TEST_SUITE_P(EmbeddingBackwardOpTPathParityTest,
+                         EmbeddingBackwardOpTPathParityTest,
+                         ::testing::ValuesIn(embeddingBackwardOpList));
+
 #endif // TTMLIR_ENABLE_OPMODEL


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.

### What's changed
This is the fourteenth PR in the TTNNOpInvokeLib series. It introduces shared dispatch for the embedding operations across OpModel and Runtime: embedding and embedding_backward.

### Checklist
- [ ] New/Existing tests provide coverage for changes
