### PR TITLE
[EmitPy] Fix fabricConfig emission

### DIFF
--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1047,6 +1047,30 @@ private:
     return "utils.DeviceGetter.get_device";
   }
 
+  // Emit a `fabric_config=...` keyword argument based on the
+  // device's `meshTopology`:
+  //   - Linear / Mesh  axes (no wraparound): `FABRIC_1D`.
+  //   - Ring   / Torus axes (wraparound):    `FABRIC_1D_RING`.
+  // Only 1D fabrics are set, matching the runtime classifier.
+  static std::optional<llvm::StringRef>
+  getFabricConfigExpression(mlir::Operation *op) {
+    auto deviceOp = ttcore::lookupDeviceOp(op);
+    if (!deviceOp) {
+      return std::nullopt;
+    }
+    auto deviceAttr = deviceOp.getDeviceAttr();
+    if (deviceAttr.getChipIds().size() <= 1) {
+      return llvm::StringRef("ttnn.FabricConfig.DISABLED");
+    }
+    bool anyAxisWraps =
+        llvm::any_of(deviceAttr.getMeshTopology(), [](ttcore::Topology t) {
+          return t == ttcore::Topology::Ring || t == ttcore::Topology::Torus;
+        });
+
+    return anyAxisWraps ? llvm::StringRef("ttnn.FabricConfig.FABRIC_1D_RING")
+                        : llvm::StringRef("ttnn.FabricConfig.FABRIC_1D");
+  }
+
 public:
   using TTNNToEmitPyBaseOpConversionPattern<
       mlir::tt::ttnn::GetDeviceOp>::TTNNToEmitPyBaseOpConversionPattern;
@@ -1061,6 +1085,11 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(getDeviceOp.getMeshShapeAttr()),
     };
+
+    if (auto fabricConfigExpr = getFabricConfigExpression(getDeviceOp)) {
+      args.push_back(
+          emitter.emitExpression(*fabricConfigExpr, "fabric_config"));
+    }
 
     emitter.replaceOp(*this, args);
 

--- a/test/ttmlir/EmitPy/get_device_fabric_config.mlir
+++ b/test/ttmlir/EmitPy/get_device_fabric_config.mlir
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Verifies that the EmitPy lowering of `ttnn.get_device` translates the correct
+// `fabric_config=...` kwarg on the generated `utils.DeviceGetter.get_device`
+// call.
+
+// 1. Both axes are ring -> FABRIC_1D_RING.
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline="mesh-shape=2,4 mesh-topology=ring,ring" %s \
+// RUN:   | ttmlir-translate --mlir-to-python \
+// RUN:   | FileCheck %s --check-prefix=RING-RING
+
+// 2. Only one axis is a ring -> still FABRIC_1D_RING (FABRIC_1D would not be
+//    able to route the ring axis).
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline="mesh-shape=2,4 mesh-topology=ring,linear" %s \
+// RUN:   | ttmlir-translate --mlir-to-python \
+// RUN:   | FileCheck %s --check-prefix=RING-LINEAR
+
+// 3. No ring axes on a multi-device mesh -> FABRIC_1D.
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline="mesh-shape=2,4 mesh-topology=linear,linear" %s \
+// RUN:   | ttmlir-translate --mlir-to-python \
+// RUN:   | FileCheck %s --check-prefix=LINEAR-LINEAR
+
+// 4. Unit mesh (prod(mesh_shape) == 1) -> DISABLED, regardless of topology.
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline="mesh-shape=1,1 mesh-topology=linear,linear" %s \
+// RUN:   | ttmlir-translate --mlir-to-python \
+// RUN:   | FileCheck %s --check-prefix=UNIT-MESH
+
+func.func @add(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %0 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+// RING-RING:     utils.DeviceGetter.get_device({{.*}}fabric_config=ttnn.FabricConfig.FABRIC_1D_RING)
+
+// RING-LINEAR:   utils.DeviceGetter.get_device({{.*}}fabric_config=ttnn.FabricConfig.FABRIC_1D_RING)
+
+// LINEAR-LINEAR: utils.DeviceGetter.get_device({{.*}}fabric_config=ttnn.FabricConfig.FABRIC_1D)
+
+// UNIT-MESH:     utils.DeviceGetter.get_device({{.*}}fabric_config=ttnn.FabricConfig.DISABLED)

--- a/tools/tt-alchemist/templates/python/local/utils.py
+++ b/tools/tt-alchemist/templates/python/local/utils.py
@@ -21,7 +21,7 @@ class DeviceGetter:
 
     @classmethod
     def get_device(cls, mesh_shape, fabric_config=None):
-        if cls._instance == None:
+        if cls._instance is None:
             if (
                 not isinstance(mesh_shape, (list, tuple))
                 or len(mesh_shape) == 0
@@ -42,8 +42,7 @@ class DeviceGetter:
                 )
             cls._fabric_config = fabric_config
 
-            if fabric_config != ttnn.FabricConfig.DISABLED:
-                ttnn.set_fabric_config(fabric_config)
+            ttnn.set_fabric_config(fabric_config)
             cls._instance = ttnn.open_mesh_device(
                 mesh_shape=ttnn.MeshShape(mesh_shape),
                 l1_small_size=cls.l1_small_size,

--- a/tools/tt-alchemist/templates/python/local/utils.py
+++ b/tools/tt-alchemist/templates/python/local/utils.py
@@ -8,6 +8,7 @@ import math
 class DeviceGetter:
     _instance = None
     _mesh_shape = None
+    _fabric_config = None
     l1_small_size = 1 << 15
 
     def __init__(self):
@@ -19,7 +20,7 @@ class DeviceGetter:
             ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
     @classmethod
-    def get_device(cls, mesh_shape):
+    def get_device(cls, mesh_shape, fabric_config=None):
         if cls._instance == None:
             if (
                 not isinstance(mesh_shape, (list, tuple))
@@ -31,8 +32,18 @@ class DeviceGetter:
                 )
             cls._mesh_shape = mesh_shape
 
-            if math.prod(mesh_shape) >= 2:
-                ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D)
+            # If the caller doesn't specify a fabric config, fallback to
+            # FABRIC_1D for multi-device meshes.
+            if fabric_config is None:
+                fabric_config = (
+                    ttnn.FabricConfig.FABRIC_1D
+                    if math.prod(mesh_shape) >= 2
+                    else ttnn.FabricConfig.DISABLED
+                )
+            cls._fabric_config = fabric_config
+
+            if fabric_config != ttnn.FabricConfig.DISABLED:
+                ttnn.set_fabric_config(fabric_config)
             cls._instance = ttnn.open_mesh_device(
                 mesh_shape=ttnn.MeshShape(mesh_shape),
                 l1_small_size=cls.l1_small_size,
@@ -43,6 +54,14 @@ class DeviceGetter:
         if tuple(cls._mesh_shape) != tuple(mesh_shape):
             raise ValueError(
                 f"Device already initialized with mesh_shape={cls._mesh_shape}, but got mesh_shape={mesh_shape}"
+            )
+
+        # Same for fabric_config: if the caller explicitly requests one, it
+        # must match the config the singleton was initialized with.
+        if fabric_config is not None and fabric_config != cls._fabric_config:
+            raise ValueError(
+                f"Device already initialized with fabric_config={cls._fabric_config}, "
+                f"but got fabric_config={fabric_config}"
             )
 
         return cls._instance


### PR DESCRIPTION
### Ticket
Closes #8013
### Problem description
Previously, `fabricConfig` was set by default to `FABRIC_1D` for the multi-device generated Python code. This caused LLMs on Galaxy, which use ring ccls on both axes, to break.
### What's changed
- `TTNNToEmitPy.cpp`: `GetDeviceOp` conversion now reads the `meshTopology` from the `deviceAttr` and sets the fabric config accordingly. 
- `utils.py`: multi-device `FABRIC_1D` default left as a fallback.

### Checklist
- [x] New/Existing tests provide coverage for changes
