### PR TITLE
[d2m] update codegen to remove warnings

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -753,12 +753,16 @@ def TTKernel_CopyDestValuesOp : TTKernel_SFPUOp<"copy_dest_values", [TTKernel_Bi
       register buffer. Performs element-wise copy: DST[idst_out] <- DST[idst_in].
       The DST register buffer must be in acquired state via *tile_regs_acquire* call.
       This call is blocking and is only available on the compute engine.
+
+      Lowers to: copy_dest_values<DataFormat>(idst_in, idst_out).
     }];
 
-    let arguments = (ins IndexLike:$idst_in, IndexLike:$idst_out);
+    let arguments = (ins IndexLike:$idst_in,
+                         IndexLike:$idst_out,
+                         TTCore_DataTypeAttr:$data_format);
 
     let assemblyFormat = [{
-      `(` $idst_in `,` $idst_out `)` attr-dict `:` functional-type(operands, results)
+      `(` $idst_in `,` $idst_out `,` $data_format `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_pack_untilize_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_pack_untilize_llks.h
@@ -18,8 +18,8 @@ ALWI void llk_pack_untilize(uint32_t output, uint32_t num_col_tiles_in_pass,
   const uint32_t offset = start_tile_row * total_col_tiles * page_size;
 
   get_local_cb_interface(output_id).fifo_wr_ptr += offset;
-  ::llk_pack_untilize<cols_per_dst_pass, total_col_tiles>(1, output, FACE_R_DIM,
-                                                          4, block_c_index, 0);
+  ::llk_pack_untilize<cols_per_dst_pass, total_col_tiles>(1, output,
+                                                          block_c_index, 0);
   get_local_cb_interface(output_id).fifo_wr_ptr -= offset;
 }
 #endif // TRISC_PACK

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1706,15 +1706,18 @@ private:
     Value cb;
     Value cbTileIdx;
     Value dstOperandIdx;
+    Type dstOperandType;
     if (reuseType == BinaryDestReuseType::DestToSrcA) {
       // LHS from Dst, RHS from Cb
       cb = getCB(rewriter, op.getRhs());
       cbTileIdx = adaptor.getRhs();
       dstOperandIdx = adaptor.getLhs();
+      dstOperandType = op.getLhs().getType();
     } else {
       cb = getCB(rewriter, op.getLhs());
       cbTileIdx = adaptor.getLhs();
       dstOperandIdx = adaptor.getRhs();
+      dstOperandType = op.getRhs().getType();
     }
 
     auto outCB = getOutCB(rewriter, op);
@@ -1734,8 +1737,11 @@ private:
     // binary_dest_reuse is an in-place operation. If the DST
     // operand comes from a different slot, copy it first to the output slot.
     if (dstOperandIdx != dstIdx) {
+      const auto dataFormat =
+          mlir::cast<ttcore::TileType>(dstOperandType).getDataType();
       rewriter.create<ttkernel::CopyDestValuesInitOp>(loc);
-      rewriter.create<ttkernel::CopyDestValuesOp>(loc, dstOperandIdx, dstIdx);
+      rewriter.create<ttkernel::CopyDestValuesOp>(loc, dstOperandIdx, dstIdx,
+                                                  dataFormat);
     }
 
     rewriter.create<ttkernel::BinaryDestReuseTilesInitOp>(loc, cb, eltwiseType,

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1436,18 +1436,15 @@ public:
   using OpConversionPattern<
       ttkernel::GetDeviceIdFromLogicalMeshPositionOp>::OpConversionPattern;
 
-  // helper function thats like call opaque inintializer list
-  Value callOpaqueInitializerList(ConversionPatternRewriter &rewriter,
-                                  Location loc, emitc::OpaqueType type,
-                                  std::string callee,
-                                  SmallVector<Value> initializerList) const {
-    // Create the variable
-    auto var = rewriter.create<emitc::VariableOp>(
-        loc, emitc::LValueType::get(type),
-        emitc::OpaqueAttr::get(rewriter.getContext(), ""));
-
-    // Initialize it via VerbatimOp
-    std::string initStr = "{} = " + callee;
+  // Creates a named value for an opaque initializer list.
+  Value
+  callOpaqueInitializerList(ConversionPatternRewriter &rewriter,
+                            ttkernel::GetDeviceIdFromLogicalMeshPositionOp op,
+                            emitc::OpaqueType type, std::string callee,
+                            SmallVector<Value> initializerList) const {
+    std::string varName =
+        getResultVariableName(op.getResult(), "logical_mesh_position_");
+    std::string initStr = callee + " " + varName + " = " + callee;
     initStr += "{{";
     for (size_t i = 0; i < initializerList.size(); ++i) {
       if (i > 0) {
@@ -1456,25 +1453,27 @@ public:
       initStr += "{}";
     }
     initStr += "};";
-    initializerList.insert(initializerList.begin(), var.getResult());
-    rewriter.create<emitc::VerbatimOp>(loc, initStr, initializerList);
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), initStr, initializerList);
 
-    // Load the value from the variable
-    auto loadOp = rewriter.create<emitc::LoadOp>(loc, type, var);
-    return loadOp.getResult();
+    return rewriter.create<emitc::LiteralOp>(op.getLoc(), type, varName)
+        .getResult();
   }
 
   LogicalResult
   matchAndRewrite(ttkernel::GetDeviceIdFromLogicalMeshPositionOp op,
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    if (op.getResult().use_empty()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
     // Call std::array constructor to create an array out of the indices
     auto arrTypeStr = "std::array<uint32_t, " +
                       std::to_string(adaptor.getPositionIndices().size()) + ">";
     auto arrType = emitc::OpaqueType::get(op.getContext(), arrTypeStr);
-    Value meshPositionArray =
-        callOpaqueInitializerList(rewriter, op.getLoc(), arrType, arrTypeStr,
-                                  adaptor.getPositionIndices());
+    Value meshPositionArray = callOpaqueInitializerList(
+        rewriter, op, arrType, arrTypeStr, adaptor.getPositionIndices());
 
     // Call get_device_id_from_logical_mesh_position
     auto opName = op.getOperation()->getName().getStringRef().drop_front(9);
@@ -1643,47 +1642,35 @@ public:
   LogicalResult
   matchAndRewrite(Op op, ttkernel::GetInterleavedAddrGenFastOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    if (op.getResult().getUses().empty()) {
+    if (op.getResult().use_empty()) {
       rewriter.eraseOp(op);
-    } else {
-      mlir::Type opaqueStructType =
-          this->getTypeConverter()->convertType(op->getResultTypes()[0]);
-
-      mlir::Type lvalueType = emitc::LValueType::get(opaqueStructType);
-
-      // Declare the struct variable and then assign to its members
-      auto varOp = rewriter.create<emitc::VariableOp>(
-          op->getLoc(), lvalueType,
-          emitc::OpaqueAttr::get(op.getContext(), ""));
-
-      // Create an lvalue for all struct field accesses
-      auto lvalueBankBaseAddr = rewriter.create<emitc::MemberOp>(
-          op->getLoc(),
-          emitc::LValueType::get(adaptor.getBankBaseAddress().getType()),
-          "bank_base_address", varOp);
-      auto lvaluePageSize = rewriter.create<emitc::MemberOp>(
-          op->getLoc(), emitc::LValueType::get(adaptor.getPageSize().getType()),
-          "page_size", varOp);
-      auto lvalueDataFormat = rewriter.create<emitc::MemberOp>(
-          op->getLoc(),
-          emitc::LValueType::get(adaptor.getDataFormat().getType()),
-          "data_format", varOp);
-
-      // Assign corresponding values to the struct members
-      rewriter.create<emitc::AssignOp>(op->getLoc(), lvalueBankBaseAddr,
-                                       adaptor.getBankBaseAddress());
-      rewriter.create<emitc::AssignOp>(op->getLoc(), lvaluePageSize,
-                                       adaptor.getPageSize());
-      rewriter.create<emitc::AssignOp>(op->getLoc(), lvalueDataFormat,
-                                       adaptor.getDataFormat());
-
-      // Load the value from the lvalue variable
-      auto loadOp =
-          rewriter.create<emitc::LoadOp>(op->getLoc(), opaqueStructType, varOp);
-
-      // Replace the original operation with the loaded value so it can be used.
-      rewriter.replaceOp(op, loadOp.getResult());
+      return success();
     }
+
+    mlir::Type opaqueStructType =
+        this->getTypeConverter()->convertType(op->getResultTypes()[0]);
+    if (!opaqueStructType) {
+      return rewriter.notifyMatchFailure(op, "Failed to convert result type");
+    }
+
+    std::string varName =
+        getResultVariableName(op.getResult(), "interleaved_addr_gen_");
+    rewriter.create<emitc::VerbatimOp>(
+        op.getLoc(), "InterleavedAddrGenFast<true> " + varName + ";");
+    rewriter.create<emitc::VerbatimOp>(
+        op.getLoc(), varName + ".bank_base_address = {};",
+        ValueRange{adaptor.getBankBaseAddress()});
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(),
+                                       varName + ".page_size = {};",
+                                       ValueRange{adaptor.getPageSize()});
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(),
+                                       varName + ".data_format = {};",
+                                       ValueRange{adaptor.getDataFormat()});
+
+    rewriter.replaceOp(op, rewriter
+                               .create<emitc::LiteralOp>(
+                                   op.getLoc(), opaqueStructType, varName)
+                               .getResult());
     return success();
   }
 };
@@ -1702,7 +1689,7 @@ public:
   LogicalResult
   matchAndRewrite(Op op, ttkernel::TensorAccessorArgsOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    if (op.getResult().getUses().empty()) {
+    if (op.getResult().use_empty()) {
       rewriter.eraseOp(op);
       return success();
     }
@@ -1770,24 +1757,25 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
     if (op.getResult().getUses().empty()) {
       rewriter.eraseOp(op);
-    } else {
-      mlir::Type opaqueStructType =
-          this->getTypeConverter()->convertType(op->getResultTypes()[0]);
-
-      mlir::Type lvalueType = emitc::LValueType::get(opaqueStructType);
-
-      // Declare the struct variable
-      auto varOp = rewriter.create<emitc::VariableOp>(
-          op->getLoc(), lvalueType,
-          emitc::OpaqueAttr::get(op.getContext(), ""));
-
-      // Load the value from the lvalue variable
-      auto loadOp =
-          rewriter.create<emitc::LoadOp>(op->getLoc(), opaqueStructType, varOp);
-
-      // Replace the original operation with the loaded value so it can be used.
-      rewriter.replaceOp(op, loadOp.getResult());
+      return success();
     }
+
+    mlir::Type opaqueStructType =
+        this->getTypeConverter()->convertType(op->getResultTypes()[0]);
+    auto opaqueType =
+        mlir::dyn_cast_if_present<emitc::OpaqueType>(opaqueStructType);
+    if (!opaqueType) {
+      return rewriter.notifyMatchFailure(op, "Failed to convert result type");
+    }
+
+    std::string varName =
+        getResultVariableName(op.getResult(), "fabric_connection_manager_");
+    rewriter.create<emitc::VerbatimOp>(
+        op.getLoc(), (opaqueType.getValue() + " " + varName + ";").str());
+    rewriter.replaceOp(op, rewriter
+                               .create<emitc::LiteralOp>(
+                                   op.getLoc(), opaqueStructType, varName)
+                               .getResult());
     return success();
   }
 };

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -685,6 +685,11 @@ public:
       template_args.push_back(emitc::OpaqueAttr::get(
           op.getContext(), getReduceDim(op.getReduceDim())));
       return ArrayAttr::get(op.getContext(), template_args);
+    } else if constexpr (std::is_same_v<SourceOp, ttkernel::CopyDestValuesOp>) {
+      SmallVector<Attribute, 1> template_args;
+      template_args.push_back(
+          datatypeToDataformatEnumNameOpaqueAttr(builder, op.getDataFormat()));
+      return ArrayAttr::get(op.getContext(), template_args);
     } else if constexpr (std::is_same_v<SourceOp, ttkernel::UnaryBcastInitOp> ||
                          std::is_same_v<SourceOp, ttkernel::UnaryBcastTileOp>) {
       SmallVector<Attribute, 1> template_args;

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1920,6 +1920,38 @@ public:
   }
 };
 
+// Boolean arith.andi / arith.ori represent logical operations. Lowering them to
+// bitwise EmitC ops emits C++ expressions like `(a != b) | (c != d)`, which GCC
+// warns about as an ambiguous mix of comparisons and bitwise operators.
+template <typename SourceOp, typename EmitCOp>
+class ArithBoolBinaryRewriter : public OpConversionPattern<SourceOp> {
+public:
+  ArithBoolBinaryRewriter(const TypeConverter &typeConverter,
+                          MLIRContext *context,
+                          PatternBenefit benefit = PatternBenefit(2))
+      : OpConversionPattern<SourceOp>(typeConverter, context, benefit) {}
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto resultType = dyn_cast<IntegerType>(op.getResult().getType());
+    if (!resultType || resultType.getWidth() != 1) {
+      return failure();
+    }
+
+    Type convertedType =
+        this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!convertedType) {
+      return failure();
+    }
+
+    ValueRange operands = adaptor.getOperands();
+    rewriter.replaceOpWithNewOp<EmitCOp>(op, convertedType, operands[0],
+                                         operands[1]);
+    return success();
+  }
+};
+
 // Rewriter for scalar unary tile ops (add_unary_tile, mul_unary_tile, etc).
 // These ops take a tile index and a scalar parameter. The custom GCC may not
 // see the data dependency between the scalar value and the SFPU intrinsic,
@@ -2515,7 +2547,9 @@ public:
 
     patterns
         .add<ArithFloorDivRewriter, ArithBitcastRewriter, ArithMaxUIRewriter,
-             ArithMinUIRewriter, ArithMaxSIRewriter, ArithMinSIRewriter>(
+             ArithMinUIRewriter, ArithMaxSIRewriter, ArithMinSIRewriter,
+             ArithBoolBinaryRewriter<arith::AndIOp, emitc::LogicalAndOp>,
+             ArithBoolBinaryRewriter<arith::OrIOp, emitc::LogicalOrOp>>(
             typeConverter, funcOp.getContext());
 
     return applyFullConversion(funcOp, target, std::move(patterns));

--- a/test/ttmlir/Conversion/D2MToTTKernel/binary_dest_reuse_dst_index_mismatch.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/binary_dest_reuse_dst_index_mismatch.mlir
@@ -38,7 +38,7 @@ module {
 
     // CHECK: ttkernel.unary_bcast({{.*}}, {{.*}}, <row>)
     // CHECK: ttkernel.copy_dest_values_init
-    // CHECK: ttkernel.copy_dest_values(%[[DST_SRC:.*]], %[[DST_OUT:.*]]) : (index, index) -> ()
+    // CHECK: ttkernel.copy_dest_values(%[[DST_SRC:.*]], %[[DST_OUT:.*]], <f32>) : (index, index) -> ()
     // CHECK: ttkernel.binary_dest_reuse_tiles_init({{.*}}, <mul>, <dest_to_srcb>)
     // CHECK: ttkernel.binary_dest_reuse_tiles({{.*}}, {{.*}}, %[[DST_OUT]], <mul>, <dest_to_srcb>)
     return

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2565,14 +2565,11 @@ module {
       %temp_addr = arith.constant 262400 : i32
       %tile_size = arith.constant 8 : i32
       %tile = arith.constant 1 : i32
-      // CHECK: %[[VAR:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"InterleavedAddrGenFast<true>">>
-      // CHECK: "emitc.member"(%[[VAR]]) <{member = "bank_base_address"}>
-      // CHECK: "emitc.member"(%[[VAR]]) <{member = "page_size"}>
-      // CHECK: "emitc.member"(%[[VAR]]) <{member = "data_format"}>
-      // CHECK: emitc.assign %[[TEMP_ADDR]]
-      // CHECK: emitc.assign %[[TILE_SIZE]]
-      // CHECK: emitc.assign %[[DATA_FORMAT]]
-      // CHECK: %[[ADDR_GEN:.*]] = emitc.load %[[VAR]] : <!emitc.opaque<"InterleavedAddrGenFast<true>">>
+      // CHECK: emitc.verbatim "InterleavedAddrGenFast<true> [[ADDR_GEN_VAR:interleaved_addr_gen_[0-9]+]];"
+      // CHECK: emitc.verbatim "[[ADDR_GEN_VAR]].bank_base_address = {};" args %[[TEMP_ADDR]]
+      // CHECK: emitc.verbatim "[[ADDR_GEN_VAR]].page_size = {};" args %[[TILE_SIZE]]
+      // CHECK: emitc.verbatim "[[ADDR_GEN_VAR]].data_format = {};" args %[[DATA_FORMAT]]
+      // CHECK: %[[ADDR_GEN:.*]] = emitc.literal "[[ADDR_GEN_VAR]]" : !emitc.opaque<"InterleavedAddrGenFast<true>">
       %s = "ttkernel.get_interleaved_addr_gen_fast"(%is_dram, %temp_addr, %tile_size, %data_format) : (i1, i32, i32, !ttkernel.DataFormat) -> !ttkernel.interleaved_addr_gen_fast
       // CHECK: emitc.call_opaque "noc_async_write_tile"(%[[TILE]], %[[ADDR_GEN]], %[[TEMP_ADDR]])
       "ttkernel.noc_async_write_tile"(%tile, %s, %temp_addr) : (i32, !ttkernel.interleaved_addr_gen_fast, i32) -> ()
@@ -2938,6 +2935,33 @@ module {
       // CHECK: %[[LOADED:.*]] = emitc.load %[[SUBSCRIPT]] : <{{.*}}>
       // CHECK: emitc.cast %[[LOADED]] : !emitc.opaque<"tt_l1_ptr uint32_t"> to i32
       %val = ttkernel.load_from_l1(%ptr, %offset) : (!ttkernel.l1_addr_ptr, i32) -> i32
+      return
+    }
+
+    // CHECK-LABEL: func @fabric_connection_manager
+    func.func @fabric_connection_manager() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: emitc.verbatim "experimental::FabricConnectionManager [[FCM:fabric_connection_manager_[0-9]+]];"
+      // CHECK: %[[FCM_LIT:.*]] = emitc.literal "[[FCM]]" : !emitc.opaque<"experimental::FabricConnectionManager">
+      %fcm = "ttkernel.experimental::create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
+      // CHECK: emitc.call_opaque "experimental::setup_fabric_connections"(%[[FCM_LIT]])
+      "ttkernel.experimental::setup_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
+
+      %bank_id = arith.constant 0 : i32
+      %addr_offset = arith.constant 0 : i32
+      %noc_addr = ttkernel.get_noc_addr_from_bank_id(%bank_id, %addr_offset) : (i32, i32) -> !ttkernel.noc_addr
+      %l1_addr = arith.constant 1024 : i32
+      %size = arith.constant 16 : i32
+      %src_dev = arith.constant 0 : i16
+      %mesh_y = arith.constant 0 : index
+      %mesh_x = arith.constant 1 : index
+      // CHECK: emitc.verbatim "std::array<uint32_t, 2> [[POS:logical_mesh_position_[0-9]+]] = std::array<uint32_t, 2>{{.*}};" args
+      // CHECK: %[[POS_LIT:.*]] = emitc.literal "[[POS]]" : !emitc.opaque<"std::array<uint32_t, 2>">
+      // CHECK: call_opaque "experimental::get_device_id_from_logical_mesh_position"(%[[FCM_LIT]], %[[POS_LIT]])
+      %device_id = "ttkernel.experimental::get_device_id_from_logical_mesh_position"(%fcm, %mesh_y, %mesh_x) : (!ttkernel.fabric_connection_manager, index, index) -> i16
+      // CHECK: emitc.call_opaque "experimental::fabric_fast_write_any_len"(%[[FCM_LIT]]
+      "ttkernel.experimental::fabric_fast_write_any_len"(%fcm, %src_dev, %device_id, %noc_addr, %l1_addr, %size) : (!ttkernel.fabric_connection_manager, i16, i16, !ttkernel.noc_addr, i32, i32) -> ()
+      // CHECK: emitc.call_opaque "experimental::close_fabric_connections"(%[[FCM_LIT]])
+      "ttkernel.experimental::close_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
       return
     }
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2968,6 +2968,34 @@ module {
   } // module
 
   //===----------------------------------------------------------------------===//
+  // TTKernel Arith operations
+  //===----------------------------------------------------------------------===//
+
+  module @ttkernel_arith_operations {
+
+    // CHECK-LABEL: func @bool_logical_andi_ori
+    func.func @bool_logical_andi_ori() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = scalar, operand_index = 0>, <arg_type = scalar, operand_index = 1>, <arg_type = scalar, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+      %arg0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> i32
+      %arg1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> i32
+      %arg2 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 2 : i32}> : () -> i32
+      // CHECK: %[[LHS:.*]] = emitc.cmp ne
+      %lhs = arith.cmpi ne, %arg0, %arg1 : i32
+      // CHECK: %[[RHS:.*]] = emitc.cmp eq
+      %rhs = arith.cmpi eq, %arg0, %arg2 : i32
+      // CHECK: emitc.logical_or %[[LHS]], %[[RHS]]
+      %logical_or = arith.ori %lhs, %rhs : i1
+      // CHECK: emitc.logical_and %[[LHS]], %[[RHS]]
+      %logical_and = arith.andi %lhs, %rhs : i1
+      // CHECK: emitc.bitwise_or
+      %bitwise_or = arith.ori %arg0, %arg1 : i32
+      // CHECK: emitc.bitwise_and
+      %bitwise_and = arith.andi %arg0, %arg2 : i32
+      return
+    }
+
+  } // module
+
+  //===----------------------------------------------------------------------===//
   // TTKernel Numeric operations
   //===----------------------------------------------------------------------===//
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -698,8 +698,8 @@ module {
       %c1 = arith.constant 1 : index
       // CHECK: %[[DST0_INDEX:.*]] = "emitc.constant"
       // CHECK: %[[DST1_INDEX:.*]] = "emitc.constant"
-      // CHECK: emitc.call_opaque "copy_dest_values"(%[[DST0_INDEX]], %[[DST1_INDEX]])
-      "ttkernel.copy_dest_values"(%c0, %c1) : (index, index) -> ()
+      // CHECK: emitc.call_opaque "copy_dest_values"(%[[DST0_INDEX]], %[[DST1_INDEX]]) {template_args = [#emitc.opaque<"DataFormat::Float16_b">]}
+      "ttkernel.copy_dest_values"(%c0, %c1) <{data_format = #ttcore.supportedDataTypes<bf16>}> : (index, index) -> ()
       return
     }
 

--- a/test/ttmlir/Dialect/TTKernel/ops.mlir
+++ b/test/ttmlir/Dialect/TTKernel/ops.mlir
@@ -95,8 +95,8 @@ func.func @test_copy_dest_values_init() -> () {
 // CHECK-LABEL: func.func @test_copy_dest_values
 func.func @test_copy_dest_values() -> () {
   %c0 = arith.constant 0 : index
-  ttkernel.copy_dest_values(%c0, %c0) : (index, index) -> ()
-  // CHECK: ttkernel.copy_dest_values(%{{.*}}, %{{.*}}) : (index, index) -> ()
+  ttkernel.copy_dest_values(%c0, %c0, <f32>) : (index, index) -> ()
+  // CHECK: ttkernel.copy_dest_values(%{{.*}}, %{{.*}}, <f32>) : (index, index) -> ()
   return
 }
 


### PR DESCRIPTION
### Problem description
After recent uplifts, d2m kernels codgenned produce a lot of warnings from sfpi compiler

### What's changed
- Updated experimental_pack_untilize_llks.h to call the newer 4-argument llk_pack_untilize overload, removing the deprecated explicit face-geometry arguments FACE_R_DIM, 4
- Cleaned up generated EmitC for opaque helper objects so we emit named C++ variables/literals instead of temporary load/member patterns that produced unused-variable-style warnings
- Added/updated TTKernelToEmitC tests for the named generated objects, including fabric connection manager and interleaved address generator paths
- Added a TTKernelToEmitC rewrite for boolean arith.andi/arith.ori
- Boolean i1 ops now lower to emitc.logical_and / emitc.logical_or, producing C++ && / ||
- Non-boolean integer ops still lower to emitc.bitwise_and / emitc.bitwise_or, producing & / |
- Added lit coverage for both boolean and integer paths

### Checklist
- [ ] New/Existing tests provide coverage for changes
