### PR TITLE
Uplift third_party/tt-metal to 7f6364a June 15

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=1efd27cafdb43765593130b72b78084999eb8f45
+ARG TT_METAL_DEPENDENCIES_COMMIT=7f6364a11dafadf141b6c87358073d9e3d1dd22f
 
 # Install dependencies
 RUN <<EOT

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_pack_untilize_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_pack_untilize_llks.h
@@ -39,7 +39,7 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t ocb,
             icb, r * block_col_tiles + b * cols_per_dst_pass + c)));
         MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE,
                                               BroadcastType::NONE,
-                                              UnpackToDestEn>(c)));
+                                              UnpackToDestEn>(c, icb)));
       }
 
       MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_tilize_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_tilize_llks.h
@@ -60,7 +60,7 @@ ALWI void tilize_block(uint32_t icb, uint32_t ocb, uint32_t block_r,
       MATH(
           (llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE,
                                            BroadcastType::NONE, UnpackToDestEn>(
-              0 /*dst index*/)));
+              0 /*dst index*/, icb /*operand*/)));
       PACK((llk_pack<false, false>(0 /*tile index*/, ocb)));
 
       // Release dest

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_untilize_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_untilize_llks.h
@@ -41,7 +41,7 @@ ALWI void untilize_block(uint32_t icb, uint32_t ocb, uint32_t block_r,
 
       // Datacopy
       MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE,
-                                            BroadcastType::NONE>(0)));
+                                            BroadcastType::NONE>(0, icb)));
 
       MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "1efd27cafdb43765593130b72b78084999eb8f45")
+set(TT_METAL_VERSION "7f6364a11dafadf141b6c87358073d9e3d1dd22f")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
uplift pin to 7f6364a

Note Dockerfile.base is modified due to dependency updates. 

### Checklist

 - Frontend CI links

   - [tt-xla(full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): (passing) https://github.com/tenstorrent/tt-xla/actions/runs/27642360881
        - Note that the test branch is based on 
        - 464a5f341908d5a3f790e697be5ffa6fd3fb6f32 (latest tt-xla->tt-mlir pin) +
        - https://github.com/tenstorrent/tt-mlir/pull/8728 (uplift) +
        - https://github.com/tenstorrent/tt-mlir/pull/8797 (uplift) +
        - This change
   -  [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): (passing) https://github.com/tenstorrent/tt-forge-onnx/actions/runs/27636776238

 - Follow-up Actions

- [ ]  Issues filed to follow up on incomplete changes (if any):
- [ ]  Frontend fix PRs ready (if needed by this uplift):