### PR TITLE
[d2m] remove unused vars

### DIFF
--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -325,6 +325,20 @@ def ConvertTTKernelToEmitC : Pass<"convert-ttkernel-to-emitc", "::mlir::ModuleOp
                            "mlir::tt::ttkernel::TTKernelDialect"];
 }
 
+def RemoveDeadEmitCExpressions : Pass<"remove-dead-emitc-expressions", "::mlir::ModuleOp"> {
+  let summary = "Remove unused side-effect-free EmitC operations.";
+  let description = [{
+    Remove unused EmitC operations that implement CExpressionInterface or wrap
+    expression bodies in emitc.expression and report no side effects. Also
+    remove EmitC variables whose only uses are writes, together with the dead
+    assignments. This covers pure C expression fragments and write-only locals
+    that MLIR's generic DCE cannot see because EmitC models expression effects
+    through CExpressionInterface and variables carry memory effects.
+  }];
+  let constructor = "createRemoveDeadEmitCExpressionsPass()";
+  let dependentDialects = ["mlir::emitc::EmitCDialect"];
+}
+
 def ConvertSFPIToEmitC : Pass<"convert-sfpi-to-emitc", "::mlir::ModuleOp"> {
   let summary = "Convert SFPI dialect to EmitC dialect using GCC RISC-V Tenstorrent builtins.";
   let description = [{

--- a/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
+++ b/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
@@ -15,6 +15,8 @@
 namespace mlir::tt {
 #define GEN_PASS_DECL_CONVERTTTKERNELTOEMITC
 #include "ttmlir/Conversion/Passes.h.inc"
+
+std::unique_ptr<OperationPass<ModuleOp>> createRemoveDeadEmitCExpressionsPass();
 } // namespace mlir::tt
 
 #endif

--- a/lib/Conversion/TTKernelToEmitC/CMakeLists.txt
+++ b/lib/Conversion/TTKernelToEmitC/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_conversion_library(TTMLIRTTKernelToEmitC
+  RemoveDeadEmitCExpressions.cpp
   TTKernelToEmitC.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/TTKernelToEmitC/RemoveDeadEmitCExpressions.cpp
+++ b/lib/Conversion/TTKernelToEmitC/RemoveDeadEmitCExpressions.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir::tt {
+
+#define GEN_PASS_DEF_REMOVEDEADEMITCEXPRESSIONS
+#include "ttmlir/Conversion/Passes.h.inc"
+
+namespace {
+
+static bool hasNoUses(Operation *op) {
+  return op->getNumResults() > 0 &&
+         llvm::all_of(op->getResults(),
+                      [](OpResult result) { return result.use_empty(); });
+}
+
+static bool hasOnlyDeadAssignUses(emitc::VariableOp op) {
+  return llvm::all_of(op.getResult().getUses(), [](OpOperand &use) {
+    return use.getOperandNumber() == 0 && isa<emitc::AssignOp>(use.getOwner());
+  });
+}
+
+static bool isDeadEmitCExpression(Operation *op) {
+  auto expression = dyn_cast<emitc::CExpressionInterface>(op);
+  if (expression) {
+    return hasNoUses(op) && !expression.hasSideEffects();
+  }
+  auto expressionOp = dyn_cast<emitc::ExpressionOp>(op);
+  return expressionOp && hasNoUses(op) && !expressionOp.hasSideEffects();
+}
+
+static bool isDeadEmitCVariable(Operation *op) {
+  auto variable = dyn_cast<emitc::VariableOp>(op);
+  return variable && hasOnlyDeadAssignUses(variable);
+}
+
+static bool isDeadEmitCOp(Operation *op) {
+  return isDeadEmitCExpression(op) || isDeadEmitCVariable(op);
+}
+
+static void enqueueIfDead(Operation *op, SmallVectorImpl<Operation *> &worklist,
+                          DenseSet<Operation *> &queued) {
+  if (op && !queued.contains(op) && isDeadEmitCOp(op)) {
+    worklist.push_back(op);
+    queued.insert(op);
+  }
+}
+
+static void eraseDeadExpression(Operation *op,
+                                SmallVectorImpl<Operation *> &worklist,
+                                DenseSet<Operation *> &queued) {
+  SmallVector<Operation *> definingOps;
+  for (Value operand : op->getOperands()) {
+    if (Operation *definingOp = operand.getDefiningOp()) {
+      definingOps.push_back(definingOp);
+    }
+  }
+
+  op->erase();
+  for (Operation *definingOp : definingOps) {
+    enqueueIfDead(definingOp, worklist, queued);
+  }
+}
+
+static void eraseDeadVariable(emitc::VariableOp variable,
+                              SmallVectorImpl<Operation *> &worklist,
+                              DenseSet<Operation *> &queued) {
+  SmallVector<emitc::AssignOp> assignOps;
+  SmallVector<Operation *> valueDefiningOps;
+  for (OpOperand &use : variable.getResult().getUses()) {
+    auto assign = cast<emitc::AssignOp>(use.getOwner());
+    assignOps.push_back(assign);
+    if (Operation *definingOp = assign.getValue().getDefiningOp()) {
+      valueDefiningOps.push_back(definingOp);
+    }
+  }
+
+  for (emitc::AssignOp assign : assignOps) {
+    assign.erase();
+  }
+  variable.erase();
+  for (Operation *definingOp : valueDefiningOps) {
+    enqueueIfDead(definingOp, worklist, queued);
+  }
+}
+
+class RemoveDeadEmitCExpressions
+    : public impl::RemoveDeadEmitCExpressionsBase<RemoveDeadEmitCExpressions> {
+public:
+  using impl::RemoveDeadEmitCExpressionsBase<
+      RemoveDeadEmitCExpressions>::RemoveDeadEmitCExpressionsBase;
+
+  void runOnOperation() final {
+    SmallVector<Operation *> worklist;
+    DenseSet<Operation *> queued;
+    getOperation()->walk<WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
+      if (!isDeadEmitCOp(op)) {
+        return WalkResult::advance();
+      }
+      worklist.push_back(op);
+      queued.insert(op);
+      return WalkResult::skip();
+    });
+
+    for (unsigned index = 0; index < worklist.size(); ++index) {
+      Operation *op = worklist[index];
+      queued.erase(op);
+      if (!isDeadEmitCOp(op)) {
+        continue;
+      }
+
+      if (auto variable = dyn_cast<emitc::VariableOp>(op)) {
+        eraseDeadVariable(variable, worklist, queued);
+      } else {
+        eraseDeadExpression(op, worklist, queued);
+      }
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createRemoveDeadEmitCExpressionsPass() {
+  return std::make_unique<RemoveDeadEmitCExpressions>();
+}
+
+} // namespace mlir::tt

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -297,6 +297,7 @@ void createD2MEmitCPipeline(OpPassManager &pm,
                             const D2MPipelineOptions &options) {
   pm.addPass(createConvertTTKernelToEmitC());
   pm.addPass(createCanonicalizerPassWithOptions(options));
+  pm.addPass(createRemoveDeadEmitCExpressionsPass());
   pm.addPass(mlir::emitc::createFormExpressionsPass());
 }
 

--- a/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
+++ b/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
@@ -23,6 +23,8 @@ void createPyKernelCompilePipeline(
     pm.addPass(mlir::createCanonicalizerPass());
   }
 
+  pm.addPass(mlir::tt::createRemoveDeadEmitCExpressionsPass());
+
   if (options.enableFormExpressions) {
     pm.addPass(mlir::emitc::createFormExpressionsPass());
   }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/d2m_emitc_pipeline_removes_dead_expressions.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/d2m_emitc_pipeline_removes_dead_expressions.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --d2m-emitc-pipeline %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @pipeline_erases_dead_arith
+  // CHECK-NOT: emitc.expression
+  // CHECK-NOT: emitc.constant
+  // CHECK-NOT: emitc.add
+  // CHECK: return
+  func.func @pipeline_erases_dead_arith() attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+    %0 = arith.constant 1 : i32
+    %1 = arith.constant 2 : i32
+    %2 = arith.addi %0, %1 : i32
+    return
+  }
+}

--- a/test/ttmlir/Conversion/TTKernelToEmitC/remove_dead_emitc_expressions.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/remove_dead_emitc_expressions.mlir
@@ -1,0 +1,114 @@
+// RUN: ttmlir-opt --remove-dead-emitc-expressions %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @erase_dead_chain
+  // CHECK-NOT: emitc.constant
+  // CHECK-NOT: emitc.add
+  // CHECK-NOT: emitc.cast
+  // CHECK: return
+  func.func @erase_dead_chain(%arg0: i32) {
+    %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+    %1 = emitc.add %arg0, %0 : (i32, i32) -> i32
+    %2 = emitc.cast %1 : i32 to ui32
+    return
+  }
+
+  // CHECK-LABEL: func.func @erase_dead_expression
+  // CHECK-NOT: emitc.expression
+  // CHECK: return
+  func.func @erase_dead_expression() {
+    %0 = emitc.expression  : () -> i32 {
+      %1 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+      %2 = emitc.add %1, %1 : (i32, i32) -> i32
+      emitc.yield %2 : i32
+    }
+    return
+  }
+
+  // CHECK-LABEL: func.func @erase_expression_after_consumer
+  // CHECK-NOT: emitc.expression
+  // CHECK-NOT: emitc.constant
+  // CHECK-NOT: emitc.add
+  // CHECK: return
+  func.func @erase_expression_after_consumer(%arg0: i32) {
+    %0 = emitc.expression  : () -> i32 {
+      %1 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+      emitc.yield %1 : i32
+    }
+    %2 = emitc.add %arg0, %0 : (i32, i32) -> i32
+    return
+  }
+
+  // CHECK-LABEL: func.func @erase_dead_variable_assign
+  // CHECK-NOT: emitc.variable
+  // CHECK-NOT: emitc.assign
+  // CHECK-NOT: emitc.add
+  // CHECK: return
+  func.func @erase_dead_variable_assign(%arg0: i32) {
+    %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
+    %1 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+    %2 = emitc.add %arg0, %1 : (i32, i32) -> i32
+    emitc.assign %2 : i32 to %0 : !emitc.lvalue<i32>
+    return
+  }
+
+  // CHECK-LABEL: func.func @keep_read_variable
+  // CHECK: emitc.variable
+  // CHECK: emitc.load
+  // CHECK: return
+  func.func @keep_read_variable() -> i32 {
+    %0 = "emitc.variable"() <{value = 1 : i32}> : () -> !emitc.lvalue<i32>
+    %1 = emitc.load %0 : !emitc.lvalue<i32>
+    return %1 : i32
+  }
+
+  // CHECK-LABEL: func.func @keep_side_effectful_assign_rhs
+  // CHECK-NOT: emitc.variable
+  // CHECK-NOT: emitc.assign
+  // CHECK: emitc.call_opaque "foo"
+  // CHECK: return
+  func.func @keep_side_effectful_assign_rhs() {
+    %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
+    %1 = emitc.call_opaque "foo"() : () -> i32
+    emitc.assign %1 : i32 to %0 : !emitc.lvalue<i32>
+    return
+  }
+
+  // CHECK-LABEL: func.func @keep_used
+  // CHECK: %[[CST:.*]] = "emitc.constant"
+  // CHECK: %[[SUM:.*]] = emitc.add %arg0, %[[CST]]
+  // CHECK: return %[[SUM]]
+  func.func @keep_used(%arg0: i32) -> i32 {
+    %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+    %1 = emitc.add %arg0, %0 : (i32, i32) -> i32
+    return %1 : i32
+  }
+
+  // CHECK-LABEL: func.func @keep_side_effectful_call
+  // CHECK: emitc.call_opaque "foo"
+  // CHECK: return
+  func.func @keep_side_effectful_call(%arg0: i32) {
+    %0 = emitc.call_opaque "foo"(%arg0) : (i32) -> i32
+    return
+  }
+
+  // CHECK-LABEL: func.func @keep_side_effectful_expression
+  // CHECK: emitc.expression
+  // CHECK: call_opaque "foo"
+  // CHECK: return
+  func.func @keep_side_effectful_expression() {
+    %0 = emitc.expression  : () -> i32 {
+      %1 = emitc.call_opaque "foo"() : () -> i32
+      emitc.yield %1 : i32
+    }
+    return
+  }
+
+  // CHECK-LABEL: func.func @keep_opaque_constant
+  // CHECK: "emitc.constant"
+  // CHECK: return
+  func.func @keep_opaque_constant() {
+    %0 = "emitc.constant"() <{value = #emitc.opaque<"FOO">}> : () -> !emitc.opaque<"int">
+    return
+  }
+}


### PR DESCRIPTION
### Problem description
Emitc would generate a bunch of unused vars which would bloat kernels and produce sfpi/gcc unused warnings. Regular Canonicalizer/DCE doesn't remove these because these EmitC ops do not expose purity through the generic MLIR memory-effect interface in the way it expects and has its own interface emitc::CExpressionInterface::hasSideEffects()

### What's changed
- Added a new compiler pass `remove-dead-emitc-expressions` that removes unused, side-effect-free EmitC ops
- Wired the pass into the TTKernel/D2M EmitC flow
- The pass scales well using a worklist instead of repeatedly scanning the whole module only rechecking producers whose users were just erased. 10k dead EmitC chain took 0.139s and 50k dead EmitC chain took 0.611s
- Added lit tests and verified unused temps like int32_t v1 = 1; get removed

### Checklist
- [ ] New/Existing tests provide coverage for changes
