### PR TITLE
[builder] Support presharded results in TTIRBuilder

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2975,28 +2975,22 @@ def test_presharded_arg(target, mesh_shape, request, device):
     def module(builder: TTIRBuilder):
         # (1, 1, 256, 512) is the logical (global) tensor shape.
         # After pre-sharding, each device will have a local shard of shape (1, 1, 256, 256).
+        # The result is presharded too, so each device keeps its local (1, 1, 256, 256)
+        # shard and no ShardToFull mesh_shard is emitted to gather the output.
         @builder.func(
             [(1, 1, 256, 512), (1, 1, 256, 512)],
             [torch.float32, torch.float32],
             presharded_args={0: (-1, 3), 1: (-1, 3)},
+            presharded_results={0: (-1, 3)},
         )
         def model(in0: Operand, in1: Operand, builder: TTIRBuilder):
-            # Goldens are set on the logical (global) tensors.
+            # Goldens are set on the logical (global) tensors; the builder shards
+            # them into per-device shards for both inputs and the result.
             torch_all_ones = torch.ones((1, 1, 256, 512), dtype=torch.float32)
             torch_all_twos = torch.full((1, 1, 256, 512), 2.0, dtype=torch.float32)
             builder.set_goldens({in0: torch_all_ones, in1: torch_all_twos}, {})
 
-            sum = builder.add(in0, in1)
-
-            # Performing a manual mesh_shard to collect the output shards, since presharded results
-            # aren't supported by the builder infrastructure yet.
-            result = builder.mesh_shard(
-                sum,
-                shard_direction=MeshShardDirection.ShardToFull.value,
-                shard_type=MeshShardType.Devices.value,
-                shard_shape=(1, 1, 1, 2),
-                shard_dims=(-1, 3),
-            )
+            result = builder.add(in0, in1)
 
             torch_all_threes = torch.full((1, 1, 256, 512), 3.0, dtype=torch.float32)
             builder.set_goldens({}, {result: torch_all_threes})

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2985,15 +2985,20 @@ def test_presharded_arg(target, mesh_shape, request, device):
         )
         def model(in0: Operand, in1: Operand, builder: TTIRBuilder):
             # Goldens are set on the logical (global) tensors; the builder shards
-            # them into per-device shards for both inputs and the result.
-            torch_all_ones = torch.ones((1, 1, 256, 512), dtype=torch.float32)
-            torch_all_twos = torch.full((1, 1, 256, 512), 2.0, dtype=torch.float32)
-            builder.set_goldens({in0: torch_all_ones, in1: torch_all_twos}, {})
+            # them into per-device shards for both inputs and the result. Use
+            # non-uniform values that vary along the sharded dim (3) so the
+            # per-device shards differ - this actually exercises the global ->
+            # per-device split rather than letting identical shards mask a bug.
+            torch_in0 = torch.arange(1 * 1 * 256 * 512, dtype=torch.float32).reshape(
+                1, 1, 256, 512
+            )
+            torch_in1 = torch_in0 * 2.0
+            builder.set_goldens({in0: torch_in0, in1: torch_in1}, {})
 
             result = builder.add(in0, in1)
 
-            torch_all_threes = torch.full((1, 1, 256, 512), 3.0, dtype=torch.float32)
-            builder.set_goldens({}, {result: torch_all_threes})
+            torch_sum = torch_in0 + torch_in1
+            builder.set_goldens({}, {result: torch_sum})
 
             return result
 

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2984,23 +2984,11 @@ def test_presharded_arg(target, mesh_shape, request, device):
             presharded_results={0: (-1, 3)},
         )
         def model(in0: Operand, in1: Operand, builder: TTIRBuilder):
-            # Goldens are set on the logical (global) tensors; the builder shards
-            # them into per-device shards for both inputs and the result. Use
-            # non-uniform values that vary along the sharded dim (3) so the
-            # per-device shards differ - this actually exercises the global ->
-            # per-device split rather than letting identical shards mask a bug.
-            torch_in0 = torch.arange(1 * 1 * 256 * 512, dtype=torch.float32).reshape(
-                1, 1, 256, 512
-            )
-            torch_in1 = torch_in0 * 2.0
-            builder.set_goldens({in0: torch_in0, in1: torch_in1}, {})
-
-            result = builder.add(in0, in1)
-
-            torch_sum = torch_in0 + torch_in1
-            builder.set_goldens({}, {result: torch_sum})
-
-            return result
+            # Rely on the builder's default (random) goldens: the global input
+            # goldens are sharded into per-device shards, and the result golden
+            # is checked per-device. Random non-uniform values vary across the
+            # sharded dim, so a wrong global -> per-device split would fail PCC.
+            return builder.add(in0, in1)
 
     compile_and_execute_ttir(
         module,

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2973,10 +2973,7 @@ def test_hoisted_concatenate_heads(
 @pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=shape_str)
 def test_presharded_arg(target, mesh_shape, request, device):
     def module(builder: TTIRBuilder):
-        # (1, 1, 256, 512) is the logical (global) tensor shape.
-        # After pre-sharding, each device will have a local shard of shape (1, 1, 256, 256).
-        # The result is presharded too, so each device keeps its local (1, 1, 256, 256)
-        # shard and no ShardToFull mesh_shard is emitted to gather the output.
+        # Global shape (1, 1, 256, 512); each device holds a (1, 1, 256, 256) shard.
         @builder.func(
             [(1, 1, 256, 512), (1, 1, 256, 512)],
             [torch.float32, torch.float32],
@@ -2984,11 +2981,12 @@ def test_presharded_arg(target, mesh_shape, request, device):
             presharded_results={0: (-1, 3)},
         )
         def model(in0: Operand, in1: Operand, builder: TTIRBuilder):
-            # Rely on the builder's default (random) goldens: the global input
-            # goldens are sharded into per-device shards, and the result golden
-            # is checked per-device. Random non-uniform values vary across the
-            # sharded dim, so a wrong global -> per-device split would fail PCC.
-            return builder.add(in0, in1)
+            summed = builder.add(in0, in1)
+            # Swap shards across devices so each device's output depends on the
+            # other device's input, validating physical shard placement.
+            return builder.collective_permute(
+                summed, source_target_pairs=[(0, 1), (1, 0)]
+            )
 
     compile_and_execute_ttir(
         module,

--- a/tools/builder/README.md
+++ b/tools/builder/README.md
@@ -1520,29 +1520,28 @@ module {
 }
 ```
 
-## build multi-device graphs with presharded args
+## build multi-device graphs with presharded args and results
+
+Pass `presharded_args` / `presharded_results` to `builder.func` to model tensors
+that are already sharded across the mesh, keyed by argument/result index and
+mapping to the `shard_dims` describing how the global tensor is split. The
+function signature then uses the per-device (local) shape, the arg/result is
+annotated `ttcore.shard_status<presharded>`, and no `mesh_shard` is emitted to
+scatter the inputs or gather the outputs. Goldens are still set on the logical
+(global) tensors; the builder shards them into per-device shards for comparison.
 
 ```python
 def module(builder: TTIRBuilder):
-    @builder.func([(1, 1, 256, 512)], [torch.float32])
-    def model(in0: Operand, builder: TTIRBuilder):
-        builder.preshard_arg(in0, shard_dims=(-1, 3))
-        in_shard = builder.mesh_shard(
-            in0,
-            shard_direction=MeshShardDirection.FullToShard.value,
-            shard_type=MeshShardType.Identity.value,
-            shard_shape=(1, 1, 1, 2),
-            shard_dims=(-1, 3),
-        )
-        exp = builder.exp(in_shard)
-        out_shard = builder.mesh_shard(
-            exp,
-            shard_direction=MeshShardDirection.ShardToFull.value,
-            shard_type=MeshShardType.Devices.value,
-            shard_shape=(1, 1, 1, 2),
-            shard_dims=(-1, 3),
-        )
-        return out_shard
+    # (1, 1, 256, 512) is the logical (global) shape. With a 1x2 mesh and
+    # shard_dims=(-1, 3), each device holds a local (1, 1, 256, 256) shard.
+    @builder.func(
+        [(1, 1, 256, 512), (1, 1, 256, 512)],
+        [torch.float32, torch.float32],
+        presharded_args={0: (-1, 3), 1: (-1, 3)},
+        presharded_results={0: (-1, 3)},
+    )
+    def model(in0: Operand, in1: Operand, builder: TTIRBuilder):
+        return builder.add(in0, in1)
 
 module, builder = build_module(module, "ttir", mesh_dict=OrderedDict([("x", 1), ("y", 2)]))
 print(module)
@@ -1550,11 +1549,9 @@ print(module)
 
 ```mlir
 module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x2>]>} {
-  func.func @model(%arg0: tensor<1x1x256x512xf32> {ttcore.shard_status = #ttcore.shard_status<presharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x1x256x256xf32>>}) -> tensor<1x1x256x512xf32> {
-    %0 = "ttir.mesh_shard"(%arg0) <{shard_dims = array<i64: -1, 3>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1x1x256x512xf32>) -> tensor<1x1x256x256xf32>
-    %1 = "ttir.exp"(%0) : (tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xf32>
-    %2 = "ttir.mesh_shard"(%1) <{shard_dims = array<i64: -1, 3>, shard_direction = #ttcore.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1x1x256x256xf32>) -> tensor<1x1x256x512xf32>
-    return %2 : tensor<1x1x256x512xf32>
+  func.func @model(%arg0: tensor<1x1x256x256xf32> {ttcore.shard_status = #ttcore.shard_status<presharded>}, %arg1: tensor<1x1x256x256xf32> {ttcore.shard_status = #ttcore.shard_status<presharded>}) -> (tensor<1x1x256x256xf32> {ttcore.shard_status = #ttcore.shard_status<presharded>}) {
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<1x1x256x256xf32>, tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xf32>
+    return %0 : tensor<1x1x256x256xf32>
   }
 }
 ```

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -741,7 +741,7 @@ class Builder(metaclass=BuilderMeta):
     def _set_golden_tensor(
         self,
         operand: Operand,
-        goldens: List[Union[GoldenMapTensor, str]],
+        goldens: Union[GoldenMapTensor, str],
     ):
         shard_dims = self._presharded_arg_shard_dims.get(
             operand

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -86,6 +86,13 @@ class Builder(metaclass=BuilderMeta):
         # at set-time. See builder.func(presharded_args=...).
         self._presharded_arg_shard_dims: Dict[BlockArgument, Tuple[int, ...]] = {}
 
+        # Mirror of the above for presharded results: the returned op's MLIR
+        # type is already the per-device (local) shape, and the func result is
+        # annotated ttcore.shard_status<presharded> (no ShardToFull mesh_shard).
+        # This dict lets the golden machinery shard the user-supplied global
+        # golden into per-device shards. See builder.func(presharded_results=...).
+        self._presharded_result_shard_dims: Dict[OpResult, Tuple[int, ...]] = {}
+
         # Map from operand to its location string.
         self._operand_to_loc: Dict[Operand, str] = {}
 
@@ -350,6 +357,33 @@ class Builder(metaclass=BuilderMeta):
 
         func_op.arg_attrs = ArrayAttr.get(new_arg_attr_list)
 
+    def set_result_attribute(
+        self,
+        func_op: func.FuncOp,
+        result_index: int,
+        new_attr_name: str,
+        new_attr: Attribute,
+    ):
+        num_results = len(func_op.type.results)
+        try:
+            existing = list(func_op.result_attrs)
+        except KeyError:
+            existing = []
+
+        new_result_attr_list = []
+        for index in range(num_results):
+            result_attrs = (
+                existing[index] if index < len(existing) else DictAttr.get({})
+            )
+            if index == result_index:
+                new_result_attr = {attr.name: attr.attr for attr in result_attrs}
+                new_result_attr[new_attr_name] = new_attr
+                new_result_attr_list.append(DictAttr.get(new_result_attr))
+            else:
+                new_result_attr_list.append(result_attrs)
+
+        func_op.result_attrs = ArrayAttr.get(new_result_attr_list)
+
     @staticmethod
     def _local_shape_for_shard_dims(
         global_shape: Tuple[int, ...],
@@ -373,6 +407,17 @@ class Builder(metaclass=BuilderMeta):
         self._presharded_arg_shard_dims[arg] = shard_dims
         self.set_arg_attribute(
             arg,
+            "ttcore.shard_status",
+            ttcore.ir.ShardStatusAttr.get(self._ctx, ttcore.ir.ShardStatus.Presharded),
+        )
+
+    def _mark_presharded_result(self, func_op: func.FuncOp, result_index: int):
+        # The returned op already carries the per-device (local) shape, so the
+        # func result type needs no rewrite; we only annotate it presharded so
+        # no ShardToFull mesh_shard is emitted and the runtime gathers shards.
+        self.set_result_attribute(
+            func_op,
+            result_index,
             "ttcore.shard_status",
             ttcore.ir.ShardStatusAttr.get(self._ctx, ttcore.ir.ShardStatus.Presharded),
         )
@@ -698,16 +743,16 @@ class Builder(metaclass=BuilderMeta):
         operand: Operand,
         goldens: List[Union[GoldenMapTensor, str]],
     ):
-        if (
-            isinstance(goldens, GoldenMapTensor)
-            and operand in self._presharded_arg_shard_dims
-        ):
+        shard_dims = self._presharded_arg_shard_dims.get(
+            operand
+        ) or self._presharded_result_shard_dims.get(operand)
+        if isinstance(goldens, GoldenMapTensor) and shard_dims is not None:
             local_shape = tuple(self._get_type(operand).shape)
             if tuple(goldens.shard_at(0).shape) != local_shape:
                 goldens = apply_sharding(
                     goldens,
                     self._mesh_shape,
-                    self._presharded_arg_shard_dims[operand],
+                    shard_dims,
                 )
         if isinstance(goldens, str):
             self._deallocated_goldens[operand] = goldens
@@ -1515,6 +1560,7 @@ class Builder(metaclass=BuilderMeta):
         ttnn_inputs: bool = False,
         custom_inputs: Optional[List[dict]] = None,
         presharded_args: Optional[Dict[int, Tuple[int, ...]]] = None,
+        presharded_results: Optional[Dict[int, Tuple[int, ...]]] = None,
     ):
         if ttnn_inputs or custom_inputs:
             encoding_fn = self._create_ttnn_tensor_encoding
@@ -1522,6 +1568,7 @@ class Builder(metaclass=BuilderMeta):
             encoding_fn = self.create_tensor_encoding
 
         presharded_args = presharded_args or {}
+        presharded_results = presharded_results or {}
         # Global shapes are needed to shard goldens later; the function
         # signature uses local shapes for presharded args.
         global_input_shapes = [tuple(s) for s in input_shapes]
@@ -1591,6 +1638,14 @@ class Builder(metaclass=BuilderMeta):
 
                 outputs = result if hasattr(result, "__iter__") else [result]
 
+                # Record the result shard dims before storing their goldens so the
+                # user-supplied global golden gets sharded into per-device shards
+                # (mirrors the presharded_args path). The IR result attribute is
+                # stamped in the wrapper below, after @func.func finalizes the
+                # result types (it would otherwise clobber res_attrs set here).
+                for idx, shard_dims in presharded_results.items():
+                    self._presharded_result_shard_dims[outputs[idx]] = tuple(shard_dims)
+
                 output_goldens: Dict[Operand, GoldenMapTensor] = {}
                 for op in outputs:
                     output_goldens[op] = self._get_golden_tensor(op)
@@ -1600,6 +1655,11 @@ class Builder(metaclass=BuilderMeta):
                 return process_multi_return_result(result)
 
             new_func_op = decorated_func.func_op
+            # Stamp presharded result attributes now that @func.func has finalized
+            # the result types. The returned op already carries the local shape,
+            # so no result-type rewrite (and no ShardToFull mesh_shard) is needed.
+            for idx in presharded_results:
+                self._mark_presharded_result(new_func_op, idx)
             self._func_ops_generated[new_func_op] = [ordered_inputs, ordered_outputs]
             self._func_name_to_op[new_func_op.name.value] = new_func_op
             return new_func_op


### PR DESCRIPTION
### Ticket
pre-requisite for #8795

### Problem description
The TTIRBuilder could model presharded **inputs** (`builder.func(..., presharded_args=...)`) but not presharded **results**. Tests had to gather the output with a manual `mesh_shard` ShardToFull. That gather's host `to_layout → system_memory` lands inside the trace region and trips `capture_or_execute_trace`'s "all output tensors must be on device" check — blocking a fully-presharded multi-device trace e2e.

### What's changed
Added `presharded_results: Optional[Dict[int, shard_dims]]` to `builder.func`. A declared result keeps its per-device local shape, the func result is annotated `ttcore.shard_status<presharded>`, and no ShardToFull `mesh_shard` is emitted — matching the IR the StableHLO frontend produces. The user-supplied global golden is sharded into per-device shards for PCC, mirroring the `presharded_args` path.

No C++ changes needed: `FuncOpToProgram.h` already serializes the result `ShardStatus`/`local_shape`, and the runtime already compares outputs per-device shard against the per-device golden.

`test_presharded_arg` now uses `presharded_results={0: (-1, 3)}` and drops the manual ShardToFull; verified passing on a 1×2 mesh.

### Checklist
- [x] New/Existing tests provide coverage for changes