### PR TITLE
[EmitPy] Fix flaky ExpressionOp verifier crash on zero-operand yield

### DIFF
--- a/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
+++ b/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
@@ -937,14 +937,13 @@ LogicalResult ExpressionOp::verify() {
     return emitOpError("must yield a value at termination");
   }
 
-  // Ensure the terminator is a yield op
-  auto yield = cast<YieldOp>(body.getTerminator());
-
-  // YieldOp's auto-generated operand-count invariant is checked only after
-  // this verifier runs (parent's verify() before children's invariants), so
-  // reading getResult() on a malformed zero-operand yield would be a UB OOB
-  // read into operand storage. Guard here.
-  if (yield->getNumOperands() != 1) {
+  // The SingleBlockImplicitTerminator trait's region-trait check runs in a
+  // separate verifyRegionInvariants hook called *after* this verifier, and
+  // YieldOp's own operand-count invariant runs only when children are
+  // descended into. So at this point the terminator may be a non-YieldOp or
+  // a malformed zero-operand YieldOp; guard both before reading the operand.
+  auto yield = dyn_cast<YieldOp>(body.getTerminator());
+  if (!yield || yield->getNumOperands() != 1) {
     return emitOpError("must yield a value at termination");
   }
 

--- a/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
+++ b/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
@@ -939,23 +939,21 @@ LogicalResult ExpressionOp::verify() {
 
   // Ensure the terminator is a yield op
   auto yield = cast<YieldOp>(body.getTerminator());
-  Value yieldResult = yield.getResult();
 
-  // Ensure the yield result is valid
-  if (!yieldResult) {
+  // YieldOp's auto-generated operand-count invariant is checked only after
+  // this verifier runs (parent's verify() before children's invariants), so
+  // reading getResult() on a malformed zero-operand yield would be a UB OOB
+  // read into operand storage. Guard here.
+  if (yield->getNumOperands() != 1) {
     return emitOpError("must yield a value at termination");
   }
 
+  Value yieldResult = yield.getResult();
   Operation *rootOp = yieldResult.getDefiningOp();
 
-  // Ensure the yield result is defined within the expression
+  // Ensure the yield result is defined within the expression (not a block arg)
   if (!rootOp) {
     return emitOpError("yielded value has no defining op");
-  }
-
-  // Check if the rootOp is in a block (required for getParentOp())
-  if (!rootOp->getBlock()) {
-    return emitOpError("yielded value's defining op is not in a block");
   }
 
   // Ensure the yield result op is defined within the expression

--- a/test/ttmlir/Dialect/EmitPy/expression_negative.mlir
+++ b/test/ttmlir/Dialect/EmitPy/expression_negative.mlir
@@ -25,6 +25,19 @@ func.func @test_expression_yield_no_value(%arg0: !emitpy.opaque<"float">) -> !em
 
 // -----
 
+// Test: Terminator must be emitpy.yield
+func.func @test_expression_wrong_terminator(%arg0: !emitpy.opaque<"int">) -> !emitpy.opaque<"int"> {
+  // expected-error @+1 {{must yield a value at termination}}
+  %0 = "emitpy.expression"(%arg0) ({
+  ^bb0(%a: !emitpy.opaque<"int">):
+    %1 = emitpy.call_opaque "relu"(%a) : (!emitpy.opaque<"int">) -> !emitpy.opaque<"int">
+    func.return %1 : !emitpy.opaque<"int">
+  }) : (!emitpy.opaque<"int">) -> !emitpy.opaque<"int">
+  return %0 : !emitpy.opaque<"int">
+}
+
+// -----
+
 // Test: Yielded value must have a defining op
 func.func @test_expression_yield_block_arg(%arg0: !emitpy.opaque<"int">) -> !emitpy.opaque<"int"> {
   // expected-error @+1 {{yielded value has no defining op}}

--- a/test/ttmlir/Dialect/EmitPy/expression_negative.mlir
+++ b/test/ttmlir/Dialect/EmitPy/expression_negative.mlir
@@ -13,9 +13,8 @@ func.func @test_expression_no_terminator(%arg0: !emitpy.opaque<"int">) -> !emitp
 // -----
 
 // Test: Yield must provide a value
-// Note: This test triggers compiler heap overflow since yield is defined within expression
 func.func @test_expression_yield_no_value(%arg0: !emitpy.opaque<"float">) -> !emitpy.opaque<"float"> {
-  // expected-error @+1 {{yielded value not defined within expression}}
+  // expected-error @+1 {{must yield a value at termination}}
   %0 = "emitpy.expression"(%arg0) ({
   ^bb0(%a: !emitpy.opaque<"float">):
     %1 = emitpy.call_opaque "relu"(%a) : (!emitpy.opaque<"float">) -> !emitpy.opaque<"float">


### PR DESCRIPTION
### Ticket
Fixes #8589

### Problem description
ExpressionOp::verify() called yield.getResult() before YieldOp's own operand-count invariant had a chance to run. MLIR verifies a parent op (including its custom verify()) before descending into its regions, so YieldOp's auto-generated invariants run *after* ExpressionOp::verify().

The auto-generated YieldOp::getResult() dereferences operand_begin() without a bounds check; on a malformed zero-operand yield this is an OOB read into the operand storage. The garbage Value occasionally survived the existing null guards and crashed later in rootOp->getParentOp() -> Block::getParentOp() on a bogus Block pointer, producing the flaky segfault tracked in #8589.

### What's changed

Guard the operand count explicitly before reading getResult(), and drop two now-unreachable checks (the !yieldResult guard and the !rootOp->getBlock() band-aid that didn't actually help because the garbage Block pointer was non-null). Update the second test case's expected error to match the (correct) new message.

Verified by 2000 stress runs with MALLOC_PERTURB_; previously 2-4 crashes per 1000, now 0.

### Checklist
- [x] New/Existing tests provide coverage for changes
