### PR TITLE
[TTNN] Deshard L1-sharded input before untilize in decompose-layouts typecast path

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -899,6 +899,51 @@ private:
     op.getResult().replaceAllUsesWith(currentInput);
   }
 
+  // Untilize a device tensor on-device (optionally typecasting first), then
+  // move it to host if needed. Shared by handleDeviceInputLayoutNoTypecast and
+  // handleDeviceInputLayoutTypecast.
+  //
+  // The memory-config change is ordered relative to the untilize based on the
+  // input placement:
+  //   - L1-sharded, or L1 -> DRAM: change memory config *before* untilizing.
+  //     ttnn::untilize does support sharded I/O, but only when the input shard
+  //     is tile-aligned and the (row-major) output shard row size is aligned
+  //     to the allocator alignment. A width-sharded tensor whose per-core
+  //     shard isn't tile-aligned (e.g. 268 elements over 9 cores -> 30/core)
+  //     yields a row-major output shard (1, 30) that satisfies neither:
+  //     ttnn::to_layout first FATALs building its TILE spec from that shard,
+  //     and even past that a 30xui32 (120B) row isn't 16B-aligned. Deshard to
+  //     the target memory config first, then untilize the interleaved tensor.
+  //     For L1 -> DRAM, moving while still tiled keeps the row-major
+  //     intermediate from clashing with live L1 buffers. (tt-xla #5118)
+  //   - otherwise: untilize first, then change memory config.
+  //
+  // createDataTypeCastingOpIfNeeded / createToMemoryConfigOpIfNeeded are no-ops
+  // when their op isn't required, so this is safe for the no-typecast caller.
+  void untilizeOnDeviceThenFromHost(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                                    mlir::Value currentInput,
+                                    const OpCreationInfo &info) const {
+    const LayoutInfo &input = info.input;
+    const LayoutInfo &output = info.output;
+    currentInput =
+        this->createDataTypeCastingOpIfNeeded(op, rewriter, currentInput, info);
+    if (input.isL1Sharded() || (input.bufferType == ttnn::BufferType::L1 &&
+                                output.bufferType == ttnn::BufferType::DRAM)) {
+      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
+                                                          currentInput, info);
+      currentInput =
+          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
+    } else {
+      currentInput =
+          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
+      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
+                                                          currentInput, info);
+    }
+    currentInput =
+        this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
+    op.getResult().replaceAllUsesWith(currentInput);
+  }
+
   void handleDeviceInputLayoutNoTypecast(ttnn::ToLayoutOp op,
                                          IRRewriter &rewriter,
                                          mlir::Value currentInput,
@@ -923,32 +968,9 @@ private:
       return;
     }
 
-    // If we can untilize on device, untilize on device
-    // then move to host.
+    // If we can untilize on device, untilize on device then move to host.
     if (info.shouldUntilize() && canUntilizeOnDevice(input, output)) {
-      if (input.isL1Sharded() ||
-          (input.bufferType == ttnn::BufferType::L1 &&
-           output.bufferType == ttnn::BufferType::DRAM)) {
-        // Move to target memory first, then untilize.
-        // L1 sharded: unshard first since untilize doesn't support
-        // sharded input with sharded output.
-        // L1 interleaved → DRAM: move to DRAM while still tiled
-        // (compact), then untilize in DRAM. Untilizing in L1 creates a
-        // large row-major intermediate whose subsequent prim::copy CBs
-        // can clash with live L1 buffers.
-        currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                            currentInput, info);
-        currentInput =
-            this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      } else {
-        currentInput =
-            this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-        currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                            currentInput, info);
-      }
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
+      untilizeOnDeviceThenFromHost(op, rewriter, currentInput, info);
       return;
     }
 
@@ -1116,16 +1138,10 @@ private:
       return;
     }
 
-    // If we need to untilize and the output can be untilized on
-    // device typecast and untilize on device
+    // If we need to untilize and the output can be untilized on device,
+    // typecast and untilize on device.
     if (info.shouldUntilize() && canUntilizeOnDevice(input, output)) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
+      untilizeOnDeviceThenFromHost(op, rewriter, currentInput, info);
       return;
     }
 


### PR DESCRIPTION
## Problem

`TTNNDecomposeLayouts`'s `handleDeviceInputLayoutTypecast` untilize-on-device branch untilized an **L1-sharded** input directly:

```cpp
typecast -> to_layout(untilize)   // on the still-sharded tensor
```

`untilize` does not support a sharded input with a sharded output, and untilizing a sharded tensor whose per-core shard width isn't tile-aligned builds an **illegal row-major shard** that fails TILE shard-alignment at runtime inside `ttnn::to_layout`:

```
TT_FATAL: Physical shard shape (1, 30) must be tile {32, 32} sized!
```

The `(1, 30)` comes from a width-sharded 268-element index tensor (`max_cache_len 256 + seq_len`) split over a 1×9 core grid → `ceil(268/9) = 30` per core.

The sibling handler `handleDeviceInputLayoutNoTypecast` already handled this correctly by moving to the target memory config (deshard) **before** untilizing; the typecast variant had diverged and was missing that ordering (and the memory-config change in its non-sharded branch too).

## Fix

Commonize the untilize-on-device sequence into a shared `untilizeOnDeviceThenFromHost` helper used by both `handleDeviceInputLayout{NoTypecast,Typecast}`. For L1-sharded / L1→DRAM inputs it deshards before untilizing; otherwise it untilizes then changes memory config. The typecast/memory-config ops are no-ops when not required, so the helper is safe for both callers.

This removes the duplicated logic and closes the latent gap in the typecast path.

## Repro / root cause

Reproduced on Blackhole at `optimization_level=2` via the tt-forge-models runner (Ministral-8B / sliding-window attention). Localized with `ttmlir-opt --mlir-print-ir-after-all`: the `(1,30)` width-sharded layout first appears only after `TTNNDecomposeLayouts` — the optimizer correctly targets an interleaved output; the decompose pass was overriding it.

## Verification

- `ttmlir-opt` opt-2 run: `(1,30)` shard eliminated; embedding index → `<1x1>` DRAM interleaved.
- End-to-end opt-2 device run (Ministral-8B, 2-layer): `Physical shard shape (1, 30)` FATAL → **PASS**.

Fixes tenstorrent/tt-xla#5118

🤖 Generated with [Claude Code](https://claude.com/claude-code)