### PR TITLE
[d2m] fix ttkernel op mnemonic round trips

### DIFF
--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -583,7 +583,7 @@ func.func private @compute_kernel8() attributes {
     "ttkernel.mm_block_init_short"(%0, %1, %c0_i32, %c1_i32_1, %c1_i32, %c1_i32_0) : (!ttkernel.cb&lt;1, !ttcore.tile&lt;32x32, bf16>>, !ttkernel.cb&lt;1, !ttcore.tile&lt;32x32, bf16>>, i32, i32, i32, i32) -> ()
     %c0_7 = arith.constant 0 : index
     %c0_8 = arith.constant 0 : index
-    "ttkernel.experimental::matmul_block"(%0, %1, %c0_7, %c0_8, %c0, %c0_i32, %c1_i32_1, %c1_i32, %c1_i32_0, %c1_i32_2) : (!ttkernel.cb&lt;1, !ttcore.tile&lt;32x32, bf16>>, !ttkernel.cb&lt;1, !ttcore.tile&lt;32x32, bf16>>, index, index, index, i32, i32, i32, i32, i32) -> ()
+    "ttkernel.experimental.matmul_block"(%0, %1, %c0_7, %c0_8, %c0, %c0_i32, %c1_i32_1, %c1_i32, %c1_i32_0, %c1_i32_2) : (!ttkernel.cb&lt;1, !ttcore.tile&lt;32x32, bf16>>, !ttkernel.cb&lt;1, !ttcore.tile&lt;32x32, bf16>>, index, index, index, i32, i32, i32, i32, i32) -> ()
     ttkernel.pack_tile(%c0_3, %2, %c0_3, true) : (index, !ttkernel.cb&lt;1, !ttcore.tile&lt;32x32, bf16>>, index) -> ()
     ttkernel.cb_pop_front(%0, %c1_i32_4) : (!ttkernel.cb&lt;1, !ttcore.tile&lt;32x32, bf16>>, i32) -> ()
     ttkernel.cb_pop_front(%1, %c1_i32_5) : (!ttkernel.cb&lt;1, !ttcore.tile&lt;32x32, bf16>>, i32) -> ()

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -33,9 +33,7 @@ def TTKernel_ComputeKernelHWStartupOp : TTKernel_InitOp<"compute_kernel_hw_start
                          Optional<TTKernel_CB>:$icb1,
                          TTKernel_CB:$ocb);
 
-    let assemblyFormat = [{
-      `(` $icb0 (`,` $icb1^)? `,` $ocb `)` attr-dict `:` functional-type(operands, results)
-    }];
+    let hasCustomAssemblyFormat = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -43,7 +41,7 @@ def TTKernel_ComputeKernelHWStartupOp : TTKernel_InitOp<"compute_kernel_hw_start
 //===----------------------------------------------------------------------===//
 
 def TTKernel_UnpackStallOnPackOp
-    : TTKernel_Op<"experimental::unpack_stall_on_pack"> {
+    : TTKernel_Op<"experimental.unpack_stall_on_pack"> {
   let summary = "Stall UNPACK thread until previous PACK write is committed to L1.";
   let description = [{
     Issues a hardware semaphore wait on the MATH_PACK semaphore from the
@@ -405,7 +403,7 @@ def TTKernel_MatmulBlockOp : TTKernel_FPUOp<"matmul_block", [TTKernel_TernaryOpT
     }];
 }
 
-def TTKernel_ExperimentalMatmulBlockOp : TTKernel_FPUOp<"experimental::matmul_block", [TTKernel_TernaryOpTrait]> {
+def TTKernel_ExperimentalMatmulBlockOp : TTKernel_FPUOp<"experimental.matmul_block", [TTKernel_TernaryOpTrait]> {
     let summary = "Matmul tiles operation";
     let description = [{
       Performs block-sized matrix multiplication *C=A\*B* between the blocks in two
@@ -3196,7 +3194,7 @@ def TTKernel_TilizeBlockOp : TTKernel_Op<"tilize_block", [TTKernel_LayoutOpTrait
     }];
 }
 
-def TTKernel_ExperimentalTilizeBlockOp : TTKernel_Op<"experimental::tilize_block", [TTKernel_LayoutOpTrait]> {
+def TTKernel_ExperimentalTilizeBlockOp : TTKernel_Op<"experimental.tilize_block", [TTKernel_LayoutOpTrait]> {
     let summary = "Experimental TilizeBlockOp call.";
     let description = [{
       This is a custom tilize block LLK that takes the dimensions of the block, and properly tilizes each row.
@@ -3255,7 +3253,7 @@ def TTKernel_UntilizeBlockOp : TTKernel_Op<"untilize_block", [TTKernel_LayoutOpT
     }];
 }
 
-def TTKernel_ExperimentalUntilizeBlockOp : TTKernel_Op<"experimental::untilize_block", [TTKernel_LayoutOpTrait]> {
+def TTKernel_ExperimentalUntilizeBlockOp : TTKernel_Op<"experimental.untilize_block", [TTKernel_LayoutOpTrait]> {
     let summary = "Experimental UntilizeBlockOp call.";
     let description = [{
       This is a custom untilize block LLK that takes the dimensions of the block.
@@ -3283,7 +3281,7 @@ def TTKernel_PackUntilizeInitOp : TTKernel_InitOp<"pack_untilize_init", [TTKerne
       `cols_per_dst_pass` must fit
       in DST capacity for the target data type. Both default to 1.
       This op is expected to be paired with
-      `experimental::pack_untilize_block` and finalized by
+      `experimental.pack_untilize_block` and finalized by
       `pack_untilize_uninit`.
     }];
 
@@ -3312,7 +3310,7 @@ def TTKernel_PackUntilizeUninitOp : TTKernel_Op<"pack_untilize_uninit", [TTKerne
     }];
 }
 
-def TTKernel_ExperimentalPackUntilizeBlockOp : TTKernel_Op<"experimental::pack_untilize_block", [TTKernel_LayoutOpTrait]> {
+def TTKernel_ExperimentalPackUntilizeBlockOp : TTKernel_Op<"experimental.pack_untilize_block", [TTKernel_LayoutOpTrait]> {
     let summary = "Experimental PackUntilizeBlockOp call.";
     let description = [{
       Custom pack untilize block LLK that takes the dimensions of the block.
@@ -3326,7 +3324,7 @@ def TTKernel_ExperimentalPackUntilizeBlockOp : TTKernel_Op<"experimental::pack_u
       `cols_per_dst_pass` (the implementation processes
       `block_c / cols_per_dst_pass` column blocks).
       Use this op in the sequence:
-      `pack_untilize_init -> experimental::pack_untilize_block -> pack_untilize_uninit`.
+      `pack_untilize_init -> experimental.pack_untilize_block -> pack_untilize_uninit`.
     }];
 
     let arguments = (ins TTKernel_CB:$cbIn, TTKernel_CB:$cbOut, I32:$blockR, I32:$blockC,
@@ -3339,7 +3337,7 @@ def TTKernel_ExperimentalPackUntilizeBlockOp : TTKernel_Op<"experimental::pack_u
     }];
 }
 
-def TTKernel_ExperimentalWriteRowMaskTileOp : TTKernel_Op<"experimental::write_row_mask_tile"> {
+def TTKernel_ExperimentalWriteRowMaskTileOp : TTKernel_Op<"experimental.write_row_mask_tile"> {
     let summary = "Experimental Write Row Mask Tile Op";
     let description = [{
       Writes a row mask tile pattern to a CB, where element[i,j] = 1.0 if i < validRows, else 0.0.
@@ -3354,7 +3352,7 @@ def TTKernel_ExperimentalWriteRowMaskTileOp : TTKernel_Op<"experimental::write_r
     }];
 }
 
-def TTKernel_ExperimentalWriteColMaskTileOp : TTKernel_Op<"experimental::write_col_mask_tile"> {
+def TTKernel_ExperimentalWriteColMaskTileOp : TTKernel_Op<"experimental.write_col_mask_tile"> {
     let summary = "Experimental Write Col Mask Tile Op";
     let description = [{
       Writes a column mask tile pattern to a CB, where element[i,j] = 1.0 if j < validCols, else 0.0.
@@ -3370,7 +3368,7 @@ def TTKernel_ExperimentalWriteColMaskTileOp : TTKernel_Op<"experimental::write_c
 }
 
 
-def TTKernel_ExperimentalFillArangeTileOp : TTKernel_Op<"experimental::fill_arange_tile"> {
+def TTKernel_ExperimentalFillArangeTileOp : TTKernel_Op<"experimental.fill_arange_tile"> {
     let summary = "Experimental Write Full Linear Index Tile Op";
     let description = [{
       Writes a full linear index tile pattern to a CB, where element[i,j] = i * 32 + j
@@ -3884,7 +3882,7 @@ def TTKernel_NocInlineDwWriteOp : TTKernel_Op<"noc_inline_dw_write"> {
     }];
 }
 
-def TTKernel_SemaphoreWaitOp : TTKernel_Op<"experimental::semaphore_wait"> {
+def TTKernel_SemaphoreWaitOp : TTKernel_Op<"experimental.semaphore_wait"> {
     let summary = "SemaphoreWait";
     let description = [{
       A blocking call that waits until the value of a local L1 memory address on
@@ -3900,7 +3898,7 @@ def TTKernel_SemaphoreWaitOp : TTKernel_Op<"experimental::semaphore_wait"> {
     }];
 }
 
-def TTKernel_SemaphoreWaitMinOp : TTKernel_Op<"experimental::semaphore_wait_min"> {
+def TTKernel_SemaphoreWaitMinOp : TTKernel_Op<"experimental.semaphore_wait_min"> {
     let summary = "SemaphoreWaitMin";
     let description = [{
       A blocking call that waits until the value of a local L1 memory address on
@@ -3980,7 +3978,7 @@ def TTKernel_NocSemaphoreIncMulticastOp : TTKernel_Op<"noc_semaphore_inc_multica
       encoded in a uint64_t produced by *get_noc_multicast_addr* covering the
       NOC coordinate range (x_start, y_start, x_end, y_end) and the target L1
       address. Used for cumulative synchronization across multiple senders
-      sharing receivers, paired with *experimental::semaphore_wait_min*.
+      sharing receivers, paired with *experimental.semaphore_wait_min*.
 
       The sender must not be a member of the multicast destination set; for
       including the sender there is no corresponding loopback variant in
@@ -4089,7 +4087,7 @@ def TTKernel_BitcastOp : TTKernel_Op<"bitcast", [Pure]> {
     }];
 }
 
-def TTKernel_CastToL1PtrOp : TTKernel_Op<"reinterpret_cast<tt_l1_ptr uint32_t*>"> {
+def TTKernel_CastToL1PtrOp : TTKernel_Op<"reinterpret_cast"> {
     let summary = "CastToL1Ptr";
     let description = [{
       Cast specified addr to L1 pointer.
@@ -4218,7 +4216,7 @@ def TTKernel_MyLogicalYOp : TTKernel_Op<"my_logical_y_",
     }];
 }
 
-def TTKernel_ConvertLogicalXToTranslatedOp : TTKernel_Op<"experimental::convert_logical_x_to_translated", [Pure]> {
+def TTKernel_ConvertLogicalXToTranslatedOp : TTKernel_Op<"experimental.convert_logical_x_to_translated", [Pure]> {
   let summary = "ConvertLogicalToTranslatedX";
   let description = [{
     this converts the x coordinate from the LOGICAL coordinate system to TRANSLATED
@@ -4232,7 +4230,7 @@ def TTKernel_ConvertLogicalXToTranslatedOp : TTKernel_Op<"experimental::convert_
   }];
 }
 
-def TTKernel_ConvertLogicalYToTranslatedOp : TTKernel_Op<"experimental::convert_logical_y_to_translated", [Pure]> {
+def TTKernel_ConvertLogicalYToTranslatedOp : TTKernel_Op<"experimental.convert_logical_y_to_translated", [Pure]> {
   let summary = "ConvertLogicalToTranslatedY";
   let description = [{
     this converts the y coordinate from the LOGICAL coordinate system to TRANSLATED
@@ -4250,7 +4248,7 @@ def TTKernel_ConvertLogicalYToTranslatedOp : TTKernel_Op<"experimental::convert_
 // TTKernel Fabric API operations
 //===----------------------------------------------------------------------===//
 
-def TTKernel_GetMyDeviceIdOp : TTKernel_Op<"experimental::get_my_device_id", [Pure]> {
+def TTKernel_GetMyDeviceIdOp : TTKernel_Op<"experimental.get_my_device_id", [Pure]> {
   let summary = "GetMyDeviceId";
   let description = [{
     Get my device id. This is a 16 bit value.
@@ -4264,7 +4262,7 @@ def TTKernel_GetMyDeviceIdOp : TTKernel_Op<"experimental::get_my_device_id", [Pu
   }];
 }
 
-def TTKernel_FabricWriteOp : TTKernel_Op<"experimental::fabric_fast_write_any_len"> {
+def TTKernel_FabricWriteOp : TTKernel_Op<"experimental.fabric_fast_write_any_len"> {
   let summary = "FabricWriteOp";
   let description = [{
     FabricWriteOp
@@ -4278,7 +4276,7 @@ def TTKernel_FabricWriteOp : TTKernel_Op<"experimental::fabric_fast_write_any_le
   }];
 }
 
-def TTKernel_FabricMulticastWriteOp : TTKernel_Op<"experimental::fabric_mcast_fast_write_any_len"> {
+def TTKernel_FabricMulticastWriteOp : TTKernel_Op<"experimental.fabric_mcast_fast_write_any_len"> {
   let summary = "FabricMulticastWriteOp";
   let description = [{
     FabricMulticastWriteOp
@@ -4292,7 +4290,7 @@ def TTKernel_FabricMulticastWriteOp : TTKernel_Op<"experimental::fabric_mcast_fa
   }];
 }
 
-def TTKernel_FabricSemIncOp : TTKernel_Op<"experimental::fabric_sem_inc"> {
+def TTKernel_FabricSemIncOp : TTKernel_Op<"experimental.fabric_sem_inc"> {
   let summary = "FabricSemIncOp";
   let description = [{
     FabricSemIncOp. This operation increments a semaphore on a remote device.
@@ -4306,7 +4304,7 @@ def TTKernel_FabricSemIncOp : TTKernel_Op<"experimental::fabric_sem_inc"> {
   }];
 }
 
-def TTKernel_FabricMulticastSemIncOp : TTKernel_Op<"experimental::fabric_mcast_sem_inc"> {
+def TTKernel_FabricMulticastSemIncOp : TTKernel_Op<"experimental.fabric_mcast_sem_inc"> {
   let summary = "FabricMulticastSemIncOp";
   let description = [{
     FabricMulticastSemIncOp. This operation increments a semaphore on a range of remote devices.
@@ -4320,7 +4318,7 @@ def TTKernel_FabricMulticastSemIncOp : TTKernel_Op<"experimental::fabric_mcast_s
   }];
 }
 
-def TTKernel_CreateFabricConnectionManagerOp : TTKernel_Op<"experimental::create_fabric_connection_manager"> {
+def TTKernel_CreateFabricConnectionManagerOp : TTKernel_Op<"experimental.create_fabric_connection_manager"> {
   let summary = "CreateFabricConnectionManager";
   let description = [{
     Create fabric connection manager. The fabric connection manager is required for all fabric operations.
@@ -4334,7 +4332,7 @@ def TTKernel_CreateFabricConnectionManagerOp : TTKernel_Op<"experimental::create
   }];
 }
 
-def TTKernel_SetupFabricConnectionsOp : TTKernel_Op<"experimental::setup_fabric_connections"> {
+def TTKernel_SetupFabricConnectionsOp : TTKernel_Op<"experimental.setup_fabric_connections"> {
   let summary = "SetupFabricConnections";
   let description = [{
     Setup fabric connections for inter-device communication. The connection scheme
@@ -4359,7 +4357,7 @@ def TTKernel_SetupFabricConnectionsOp : TTKernel_Op<"experimental::setup_fabric_
   }];
 }
 
-def TTKernel_CloseFabricConnectionsOp : TTKernel_Op<"experimental::close_fabric_connections"> {
+def TTKernel_CloseFabricConnectionsOp : TTKernel_Op<"experimental.close_fabric_connections"> {
   let summary = "CloseFabricConnections";
   let description = [{
     Close fabric connections.
@@ -4377,7 +4375,7 @@ def TTKernel_CloseFabricConnectionsOp : TTKernel_Op<"experimental::close_fabric_
 // TTKernel Logical Mesh Position operations
 //===----------------------------------------------------------------------===//
 
-def TTKernel_GetMyLogicalMeshPositionOp : TTKernel_Op<"experimental::get_my_logical_mesh_position", [Pure]> {
+def TTKernel_GetMyLogicalMeshPositionOp : TTKernel_Op<"experimental.get_my_logical_mesh_position", [Pure]> {
   let summary = "GetMyLogicalMeshPosition";
   let description = [{
     Get the mesh position for the current device at the given dimension.
@@ -4391,7 +4389,7 @@ def TTKernel_GetMyLogicalMeshPositionOp : TTKernel_Op<"experimental::get_my_logi
   }];
 }
 
-def TTKernel_GetDeviceIdFromLogicalMeshPositionOp : TTKernel_Op<"experimental::get_device_id_from_logical_mesh_position", [Pure]> {
+def TTKernel_GetDeviceIdFromLogicalMeshPositionOp : TTKernel_Op<"experimental.get_device_id_from_logical_mesh_position", [Pure]> {
   let summary = "GetDeviceIdFromLogicalMeshPosition";
   let description = [{
     Get the device ID for a given logical mesh position.

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -92,11 +92,9 @@ static std::string datatypeToDataformatStr(ttcore::DataType dtype) {
 }
 
 static std::string getTTKernelCalleeName(llvm::StringRef opName) {
-  if (opName.starts_with("ttkernel.")) {
-    opName = opName.drop_front(9);
-  }
-  if (opName.starts_with("experimental.")) {
-    return ("experimental::" + opName.drop_front(13)).str();
+  opName.consume_front("ttkernel.");
+  if (opName.consume_front("experimental.")) {
+    return ("experimental::" + opName).str();
   }
   return opName.str();
 }

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -91,6 +91,16 @@ static std::string datatypeToDataformatStr(ttcore::DataType dtype) {
   return expression;
 }
 
+static std::string getTTKernelCalleeName(llvm::StringRef opName) {
+  if (opName.starts_with("ttkernel.")) {
+    opName = opName.drop_front(9);
+  }
+  if (opName.starts_with("experimental.")) {
+    return ("experimental::" + opName.drop_front(13)).str();
+  }
+  return opName.str();
+}
+
 static emitc::OpaqueAttr
 datatypeToDataformatEnumNameOpaqueAttr(Builder &builder,
                                        ttcore::DataType dtype) {
@@ -558,13 +568,10 @@ public:
                                 MLIRContext *ctx, std::string opName = "")
       : OpConversionPattern<SourceOp>(typeConverter, ctx), opName(opName) {}
 
-  StringRef getOpName(SourceOp op) const {
+  std::string getOpName(SourceOp op) const {
     auto name =
         opName.empty() ? op.getOperation()->getName().getStringRef() : opName;
-    if (name.starts_with("ttkernel.")) {
-      return name.drop_front(9);
-    }
-    return name;
+    return getTTKernelCalleeName(name);
   }
 
   StringRef getReduceType(ttkernel::ReduceType reduceType) const {
@@ -1022,12 +1029,9 @@ class TTKernelToEmitCArgValRewriter : public OpConversionPattern<SourceOp> {
 public:
   using OpConversionPattern<SourceOp>::OpConversionPattern;
 
-  StringRef getOpName(SourceOp op) const {
+  std::string getOpName(SourceOp op) const {
     auto name = op.getOperation()->getName().getStringRef();
-    if (name.starts_with("ttkernel.")) {
-      return name.drop_front(9);
-    }
-    return name;
+    return getTTKernelCalleeName(name);
   }
 
   ArrayAttr getTemplateArgs(Builder &builder, SourceOp op) const {
@@ -1424,7 +1428,8 @@ public:
                                std::to_string(op.getDim()))
                            .getResult());
 
-    auto opName = op.getOperation()->getName().getStringRef().drop_front(9);
+    std::string opName =
+        getTTKernelCalleeName(op.getOperation()->getName().getStringRef());
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         op, getTypeConverter()->convertType(op.getResult().getType()), opName,
         nullptr, nullptr, operands);
@@ -1481,7 +1486,8 @@ public:
         rewriter, op, arrType, arrTypeStr, adaptor.getPositionIndices());
 
     // Call get_device_id_from_logical_mesh_position
-    auto opName = op.getOperation()->getName().getStringRef().drop_front(9);
+    std::string opName =
+        getTTKernelCalleeName(op.getOperation()->getName().getStringRef());
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         op, getTypeConverter()->convertType(op.getResult().getType()), opName,
         nullptr, nullptr, ValueRange{adaptor.getFcm(), meshPositionArray});
@@ -1975,12 +1981,9 @@ public:
                                     MLIRContext *ctx)
       : OpConversionPattern<SourceOp>(typeConverter, ctx) {}
 
-  StringRef getOpName(SourceOp op) const {
+  std::string getOpName(SourceOp op) const {
     auto name = op.getOperation()->getName().getStringRef();
-    if (name.starts_with("ttkernel.")) {
-      return name.drop_front(9);
-    }
-    return name;
+    return getTTKernelCalleeName(name);
   }
 
   LogicalResult
@@ -2002,7 +2005,7 @@ public:
     // Emits: { volatile int32_t __s = <scalar>; <op>(<idx>, __s); }
     // Note that apparently "{{" produces "{" but "}" is not escaped in EmitC.
     std::string code =
-        "{{ volatile int32_t __s = {}; " + getOpName(op).str() + "({}, __s); }";
+        "{{ volatile int32_t __s = {}; " + getOpName(op) + "({}, __s); }";
     rewriter.create<emitc::VerbatimOp>(op->getLoc(),
                                        rewriter.getStringAttr(code),
                                        ValueRange{scalarParam, dstIndex});

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -21,6 +21,65 @@
 
 namespace mlir::tt::ttkernel {
 
+void ComputeKernelHWStartupOp::print(::mlir::OpAsmPrinter &printer) {
+  printer << "(" << getIcb0();
+  if (getIcb1()) {
+    printer << ", " << getIcb1();
+  }
+  printer << ", " << getOcb() << ")";
+  printer.printOptionalAttrDict((*this)->getAttrs());
+  printer << " : ";
+  printer.printFunctionalType(getOperation()->getOperandTypes(),
+                              getOperation()->getResultTypes());
+}
+
+::mlir::ParseResult
+ComputeKernelHWStartupOp::parse(::mlir::OpAsmParser &parser,
+                                ::mlir::OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand, 3> operands;
+  OpAsmParser::UnresolvedOperand operand;
+
+  if (parser.parseLParen() || parser.parseOperand(operand)) {
+    return failure();
+  }
+  operands.push_back(operand);
+
+  while (succeeded(parser.parseOptionalComma())) {
+    if (parser.parseOperand(operand)) {
+      return failure();
+    }
+    operands.push_back(operand);
+  }
+
+  if (operands.size() != 2 && operands.size() != 3) {
+    return parser.emitError(parser.getNameLoc()) << "expected 2 or 3 operands";
+  }
+
+  if (parser.parseRParen() || parser.parseOptionalAttrDict(result.attributes) ||
+      parser.parseColon()) {
+    return failure();
+  }
+
+  FunctionType functionType;
+  if (parser.parseType(functionType)) {
+    return failure();
+  }
+
+  ArrayRef<Type> operandTypes = functionType.getInputs();
+  if (operandTypes.size() != operands.size()) {
+    return parser.emitError(parser.getNameLoc())
+           << "expected " << operands.size() << " operand types";
+  }
+
+  result.addTypes(functionType.getResults());
+  if (parser.resolveOperands(operands, operandTypes, parser.getNameLoc(),
+                             result.operands)) {
+    return failure();
+  }
+
+  return success();
+}
+
 static bool insideEnqueueProgramOpRegion(mlir::Operation *op) {
   mlir::Operation *parentOp = op->getParentOp();
 

--- a/test/python/golden/d2m/fabric_api_snippets/test_fabric_mcast.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_fabric_mcast.mlir
@@ -19,8 +19,8 @@ module attributes {} {
 
   func.func private @datamovement_kernel0() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     // Setup fabric connections
-    %fabric_connection_manager = "ttkernel.experimental::create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
-    "ttkernel.experimental::setup_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
+    %fabric_connection_manager = "ttkernel.experimental.create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
+    "ttkernel.experimental.setup_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
 
     // Constants
     %len_bytes = arith.constant 2048 : i32
@@ -32,8 +32,8 @@ module attributes {} {
     // Get logical coordinates of current core and convert logical coords to translated coords
     %logical_x = ttkernel.my_logical_x_ : () -> index
     %logical_y = ttkernel.my_logical_y_ : () -> index
-    %translated_x = "ttkernel.experimental::convert_logical_x_to_translated"(%logical_x) : (index) -> index
-    %translated_y = "ttkernel.experimental::convert_logical_y_to_translated"(%logical_y) : (index) -> index
+    %translated_x = "ttkernel.experimental.convert_logical_x_to_translated"(%logical_x) : (index) -> index
+    %translated_y = "ttkernel.experimental.convert_logical_y_to_translated"(%logical_y) : (index) -> index
 
     // Get CB write pointers
     %cb0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<24, !ttcore.tile<32x32, bf16>>
@@ -43,17 +43,17 @@ module attributes {} {
     %noc_addr = ttkernel.get_noc_addr(%translated_x, %translated_y, %write_ptr) : (index, index, i32) -> !ttkernel.noc_addr
 
     // Get my device id
-    %my_device_id = "ttkernel.experimental::get_my_device_id"() : () -> i16
+    %my_device_id = "ttkernel.experimental.get_my_device_id"() : () -> i16
 
     // Check if device is 0 and send to device 1 if it is
     %is_device_0 = arith.cmpi eq, %my_device_id, %src_dev_id : i16
     scf.if %is_device_0 {
       // Device 0 sends to device 1
-      "ttkernel.experimental::fabric_mcast_fast_write_any_len"(%fabric_connection_manager, %dst_mesh_id, %dst_dev_id_start, %dst_dev_id_end, %noc_addr, %write_ptr, %len_bytes) : (!ttkernel.fabric_connection_manager, i16, i16, i16, !ttkernel.noc_addr, i32, i32) -> ()
+      "ttkernel.experimental.fabric_mcast_fast_write_any_len"(%fabric_connection_manager, %dst_mesh_id, %dst_dev_id_start, %dst_dev_id_end, %noc_addr, %write_ptr, %len_bytes) : (!ttkernel.fabric_connection_manager, i16, i16, i16, !ttkernel.noc_addr, i32, i32) -> ()
     }
 
     // Close fabric connections
-    "ttkernel.experimental::close_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
+    "ttkernel.experimental.close_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
 
     return
   }

--- a/test/python/golden/d2m/fabric_api_snippets/test_fabric_sem_inc.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_fabric_sem_inc.mlir
@@ -21,8 +21,8 @@ module attributes {} {
 
   func.func private @datamovement_kernel0() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = global_semaphore, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     // Setup fabric connections
-    %fabric_connection_manager = "ttkernel.experimental::create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
-    "ttkernel.experimental::setup_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
+    %fabric_connection_manager = "ttkernel.experimental.create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
+    "ttkernel.experimental.setup_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
 
     // Constants
     %len_bytes = arith.constant 2048 : i32
@@ -33,33 +33,33 @@ module attributes {} {
     // Get logical coordinates of current core and convert logical coords to translated coords
     %logical_x = ttkernel.my_logical_x_ : () -> index
     %logical_y = ttkernel.my_logical_y_ : () -> index
-    %translated_x = "ttkernel.experimental::convert_logical_x_to_translated"(%logical_x) : (index) -> index
-    %translated_y = "ttkernel.experimental::convert_logical_y_to_translated"(%logical_y) : (index) -> index
+    %translated_x = "ttkernel.experimental.convert_logical_x_to_translated"(%logical_x) : (index) -> index
+    %translated_y = "ttkernel.experimental.convert_logical_y_to_translated"(%logical_y) : (index) -> index
 
     // Get noc address
     %global_semaphore = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.l1_addr
-    %global_semaphore_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%global_semaphore) : (!ttkernel.l1_addr) -> !ttkernel.l1_addr_ptr
+    %global_semaphore_ptr = ttkernel.reinterpret_cast(%global_semaphore) : (!ttkernel.l1_addr) -> !ttkernel.l1_addr_ptr
     %global_semaphore_noc_addr = ttkernel.get_noc_addr(%translated_x, %translated_y, %global_semaphore) : (index, index, !ttkernel.l1_addr) -> !ttkernel.noc_addr
     %incr = arith.constant 1 : index
 
     // Get my device id
-    %my_device_id = "ttkernel.experimental::get_my_device_id"() : () -> i16
+    %my_device_id = "ttkernel.experimental.get_my_device_id"() : () -> i16
 
     // Check if device is 0 and send to device 1 if it is
     %is_device_0 = arith.cmpi eq, %my_device_id, %src_dev_id : i16
     scf.if %is_device_0 {
       // Device 0 sends to device 1
-      "ttkernel.experimental::fabric_sem_inc"(%fabric_connection_manager, %dst_mesh_id, %dst_dev_id, %global_semaphore_noc_addr, %incr) : (!ttkernel.fabric_connection_manager, i16, i16, !ttkernel.noc_addr, index) -> ()
+      "ttkernel.experimental.fabric_sem_inc"(%fabric_connection_manager, %dst_mesh_id, %dst_dev_id, %global_semaphore_noc_addr, %incr) : (!ttkernel.fabric_connection_manager, i16, i16, !ttkernel.noc_addr, index) -> ()
     }
 
     %is_dst_device = arith.cmpi eq, %my_device_id, %dst_dev_id : i16
     scf.if %is_dst_device {
       // Destination device waits for semaphore inc
-      "ttkernel.experimental::semaphore_wait"(%global_semaphore_ptr, %incr) : (!ttkernel.l1_addr_ptr, index) -> ()
+      "ttkernel.experimental.semaphore_wait"(%global_semaphore_ptr, %incr) : (!ttkernel.l1_addr_ptr, index) -> ()
     }
 
     // Close fabric connections
-    "ttkernel.experimental::close_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
+    "ttkernel.experimental.close_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
 
     return
   }

--- a/test/python/golden/d2m/fabric_api_snippets/test_fabric_unicast.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_fabric_unicast.mlir
@@ -19,8 +19,8 @@ module attributes {} {
 
   func.func private @datamovement_kernel0() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     // Setup fabric connections
-    %fabric_connection_manager = "ttkernel.experimental::create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
-    "ttkernel.experimental::setup_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
+    %fabric_connection_manager = "ttkernel.experimental.create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
+    "ttkernel.experimental.setup_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
 
     // Constants
     %len_bytes = arith.constant 2048 : i32
@@ -31,8 +31,8 @@ module attributes {} {
     // Get logical coordinates of current core and convert logical coords to translated coords
     %logical_x = ttkernel.my_logical_x_ : () -> index
     %logical_y = ttkernel.my_logical_y_ : () -> index
-    %translated_x = "ttkernel.experimental::convert_logical_x_to_translated"(%logical_x) : (index) -> index
-    %translated_y = "ttkernel.experimental::convert_logical_y_to_translated"(%logical_y) : (index) -> index
+    %translated_x = "ttkernel.experimental.convert_logical_x_to_translated"(%logical_x) : (index) -> index
+    %translated_y = "ttkernel.experimental.convert_logical_y_to_translated"(%logical_y) : (index) -> index
 
     // Get CB write pointers
     %cb0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<24, !ttcore.tile<32x32, bf16>>
@@ -42,17 +42,17 @@ module attributes {} {
     %noc_addr = ttkernel.get_noc_addr(%translated_x, %translated_y, %write_ptr) : (index, index, i32) -> !ttkernel.noc_addr
 
     // Get my device id
-    %my_device_id = "ttkernel.experimental::get_my_device_id"() : () -> i16
+    %my_device_id = "ttkernel.experimental.get_my_device_id"() : () -> i16
 
     // Check if device is 0 and send to device 1 if it is
     %is_device_0 = arith.cmpi eq, %my_device_id, %src_dev_id : i16
     scf.if %is_device_0 {
       // Device 0 sends to device 1
-      "ttkernel.experimental::fabric_fast_write_any_len"(%fabric_connection_manager, %dst_mesh_id, %dst_dev_id, %noc_addr, %write_ptr, %len_bytes) : (!ttkernel.fabric_connection_manager, i16, i16, !ttkernel.noc_addr, i32, i32) -> ()
+      "ttkernel.experimental.fabric_fast_write_any_len"(%fabric_connection_manager, %dst_mesh_id, %dst_dev_id, %noc_addr, %write_ptr, %len_bytes) : (!ttkernel.fabric_connection_manager, i16, i16, !ttkernel.noc_addr, i32, i32) -> ()
     }
 
     // Close fabric connections
-    "ttkernel.experimental::close_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
+    "ttkernel.experimental.close_fabric_connections"(%fabric_connection_manager) : (!ttkernel.fabric_connection_manager) -> ()
 
     return
   }

--- a/test/ttmlir/Conversion/D2MToTTKernel/dma_ops.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/dma_ops.mlir
@@ -17,7 +17,7 @@ module {
     // CHECK: %[[DRAM_OFFSET:[0-9]+]] = arith.index_cast {{.*}} : index to i32
     // CHECK: %[[DRAM_ADDR:[0-9]+]] = arith.addi %[[DRAM_BASE]], %[[DRAM_OFFSET]] : i32
     // CHECK: %[[NOC_ADDR:[0-9]+]] = ttkernel.get_noc_addr_from_bank_id(%[[BANK_ID]], %[[DRAM_ADDR]]) : (i32, i32) -> !ttkernel.noc_addr
-    // CHECK: ttkernel.experimental::fabric_fast_write_any_len({{.*}}, %[[NOC_ADDR]], {{.*}})
+    // CHECK: ttkernel.experimental.fabric_fast_write_any_len({{.*}}, %[[NOC_ADDR]], {{.*}})
     %tx = d2m.dma_write %src[%c0], %dst[%c0, %c0, %c0] startDevice[%c0, %c1], <1> : (memref<1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>) -> !d2m.mem_tx<write>
     d2m.dma_wait %tx : !d2m.mem_tx<write>
     return
@@ -33,8 +33,8 @@ module {
     // CHECK-LABEL: func.func private @local_dma_read_uses_translated_self_coords
     // CHECK: %[[MY_Y:[0-9]+]] = ttkernel.my_logical_y_
     // CHECK: %[[MY_X:[0-9]+]] = ttkernel.my_logical_x_
-    // CHECK: %[[VIRT_Y:[0-9]+]] = ttkernel.experimental::convert_logical_y_to_translated(%[[MY_Y]]) : (index) -> index
-    // CHECK: %[[VIRT_X:[0-9]+]] = ttkernel.experimental::convert_logical_x_to_translated(%[[MY_X]]) : (index) -> index
+    // CHECK: %[[VIRT_Y:[0-9]+]] = ttkernel.experimental.convert_logical_y_to_translated(%[[MY_Y]]) : (index) -> index
+    // CHECK: %[[VIRT_X:[0-9]+]] = ttkernel.experimental.convert_logical_x_to_translated(%[[MY_X]]) : (index) -> index
     // CHECK: ttkernel.noc_async_read core[%[[VIRT_X]], %[[VIRT_Y]]],
     %tx = d2m.dma_read %src[%c0], %dst[%c0], <1> : (memref<1x!ttcore.tile<32x32, f32>, #l1>, memref<1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
     d2m.dma_wait %tx : !d2m.mem_tx<read>
@@ -52,10 +52,10 @@ module {
     %c3 = arith.constant 3 : index
 
     // CHECK-LABEL: func.func private @local_mcast_dma_write_loopback_uses_direct_coords
-    // CHECK: %[[START_Y:[0-9]+]] = ttkernel.experimental::convert_logical_y_to_translated
-    // CHECK: %[[START_X:[0-9]+]] = ttkernel.experimental::convert_logical_x_to_translated
-    // CHECK: %[[END_Y:[0-9]+]] = ttkernel.experimental::convert_logical_y_to_translated
-    // CHECK: %[[END_X:[0-9]+]] = ttkernel.experimental::convert_logical_x_to_translated
+    // CHECK: %[[START_Y:[0-9]+]] = ttkernel.experimental.convert_logical_y_to_translated
+    // CHECK: %[[START_X:[0-9]+]] = ttkernel.experimental.convert_logical_x_to_translated
+    // CHECK: %[[END_Y:[0-9]+]] = ttkernel.experimental.convert_logical_y_to_translated
+    // CHECK: %[[END_X:[0-9]+]] = ttkernel.experimental.convert_logical_x_to_translated
     // CHECK: %[[NUM_DESTS:[0-9]+]] = arith.index_cast {{.*}} : index to i32
     // CHECK: ttkernel.noc_async_write_multicast_loopback_src({{.*}}, {{.*}}, %[[NUM_DESTS]], start_xy[%[[END_X]], %[[END_Y]]], end_xy[%[[START_X]], %[[START_Y]]], {{.*}}, noc %{{[a-zA-Z0-9_]+}}, linked true)
     %tx = d2m.dma_write %src[%c0], %dst[%c0] core[%c1, %c2] mcast[%c2, %c3], <1> : (memref<1x!ttcore.tile<32x32, f32>, #l1>, memref<1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<write>
@@ -75,8 +75,8 @@ module {
     // CHECK: %[[DST_ADDR:[0-9]+]] = ttkernel.get_write_ptr
     // CHECK: %[[MY_Y:[0-9]+]] = ttkernel.my_logical_y_
     // CHECK: %[[MY_X:[0-9]+]] = ttkernel.my_logical_x_
-    // CHECK: %[[VIRT_Y:[0-9]+]] = ttkernel.experimental::convert_logical_y_to_translated(%[[MY_Y]]) : (index) -> index
-    // CHECK: %[[VIRT_X:[0-9]+]] = ttkernel.experimental::convert_logical_x_to_translated(%[[MY_X]]) : (index) -> index
+    // CHECK: %[[VIRT_Y:[0-9]+]] = ttkernel.experimental.convert_logical_y_to_translated(%[[MY_Y]]) : (index) -> index
+    // CHECK: %[[VIRT_X:[0-9]+]] = ttkernel.experimental.convert_logical_x_to_translated(%[[MY_X]]) : (index) -> index
     // CHECK: ttkernel.noc_async_write %[[SRC_ADDR]], core[%[[VIRT_X]], %[[VIRT_Y]]], %[[DST_ADDR]],
     %tx = d2m.dma_write %src[%c0], %dst[%c0], <1> : (memref<1x!ttcore.tile<32x32, f32>, #l1>, memref<1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<write>
     d2m.dma_wait %tx : !d2m.mem_tx<write>

--- a/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
@@ -8,7 +8,7 @@ module {
     d2m.semaphore_set %sem0, %c1 : !d2m.local_semaphore
     // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
-    // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>(%[[SEM]])
+    // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast(%[[SEM]])
     // CHECK: ttkernel.noc_semaphore_set(%[[PTR]], %c1)
     return
   }
@@ -41,7 +41,7 @@ module {
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
     // CHECK: %[[NOC:[a-zA-Z0-9_]+]] = arith.constant 0 : i8
     // CHECK: %[[MADDR:[0-9]+]] = ttkernel.get_noc_multicast_addr({{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[SEM]], %[[NOC]])
-    // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>(%[[SEM]])
+    // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast(%[[SEM]])
     // CHECK: ttkernel.noc_semaphore_set(%[[PTR]], %c7)
     // CHECK: ttkernel.noc_semaphore_set_multicast(%[[SEM]], %[[MADDR]], {{.*}})
     return
@@ -59,10 +59,10 @@ module {
     d2m.semaphore_set %sem0, %c7, core[%y, %x] mcast[%h, %w] : !d2m.local_semaphore
     // CHECK-LABEL: func.func private @mcast_set_noc1
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore
-    // CHECK: %[[START_Y:[0-9]+]] = ttkernel.experimental::convert_logical_y_to_translated
-    // CHECK: %[[START_X:[0-9]+]] = ttkernel.experimental::convert_logical_x_to_translated
-    // CHECK: %[[END_Y:[0-9]+]] = ttkernel.experimental::convert_logical_y_to_translated
-    // CHECK: %[[END_X:[0-9]+]] = ttkernel.experimental::convert_logical_x_to_translated
+    // CHECK: %[[START_Y:[0-9]+]] = ttkernel.experimental.convert_logical_y_to_translated
+    // CHECK: %[[START_X:[0-9]+]] = ttkernel.experimental.convert_logical_x_to_translated
+    // CHECK: %[[END_Y:[0-9]+]] = ttkernel.experimental.convert_logical_y_to_translated
+    // CHECK: %[[END_X:[0-9]+]] = ttkernel.experimental.convert_logical_x_to_translated
     // CHECK: %[[NOC:[a-zA-Z0-9_]+]] = arith.constant 1 : i8
     // CHECK: ttkernel.get_noc_multicast_addr(%[[END_X]], %[[END_Y]], %[[START_X]], %[[START_Y]], %[[SEM]], %[[NOC]])
     return
@@ -75,8 +75,8 @@ module {
     d2m.semaphore_wait %sem0, %c2 : !d2m.local_semaphore
     // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
-    // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>(%[[SEM]])
-    // CHECK: ttkernel.experimental::semaphore_wait(%[[PTR]], %c2)
+    // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast(%[[SEM]])
+    // CHECK: ttkernel.experimental.semaphore_wait(%[[PTR]], %c2)
     return
   }
 
@@ -88,8 +88,8 @@ module {
     d2m.semaphore_wait %sem0, %c2 reset %c0 : !d2m.local_semaphore
     // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
-    // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>(%[[SEM]])
-    // CHECK: ttkernel.experimental::semaphore_wait(%[[PTR]], %c2)
+    // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast(%[[SEM]])
+    // CHECK: ttkernel.experimental.semaphore_wait(%[[PTR]], %c2)
     // CHECK: ttkernel.noc_semaphore_set(%[[PTR]], %c0)
     return
   }

--- a/test/ttmlir/Conversion/D2MToTTKernel/tilize_untilize.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/tilize_untilize.mlir
@@ -10,7 +10,7 @@ module {
     %arg1 = d2m.get_cb(1) : !d2m.cb<memref<4x6x!ttcore.tile<32x32, f32>, #l1_>>
     // CHECK-NOT: d2m.tile_tilize_block
     // CHECK: ttkernel.tilize_init
-    // CHECK: ttkernel.experimental::tilize_block
+    // CHECK: ttkernel.experimental.tilize_block
     %in = d2m.wait %arg0 : !d2m.cb<memref<128x192xf32, #l1_>> -> memref<128x192xf32, #l1_>
     %out = d2m.reserve %arg1 : !d2m.cb<memref<4x6x!ttcore.tile<32x32, f32>, #l1_>> -> memref<4x6x!ttcore.tile<32x32, f32>, #l1_>
     %result = "d2m.tile_tilize_block"(%in, %out) : (memref<128x192xf32, #l1_>, memref<4x6x!ttcore.tile<32x32, f32>, #l1_>) -> memref<4x6x!ttcore.tile<32x32, f32>, #l1_>
@@ -23,7 +23,7 @@ module {
     %arg1 = d2m.get_cb(1) : !d2m.cb<memref<128x192xf32, #l1_>>
     // CHECK-NOT: d2m.tile_untilize_block
     // CHECK: ttkernel.pack_untilize_init
-    // CHECK: ttkernel.experimental::pack_untilize_block
+    // CHECK: ttkernel.experimental.pack_untilize_block
     // CHECK: ttkernel.pack_untilize_uninit
     %in = d2m.wait %arg0 : !d2m.cb<memref<4x6x!ttcore.tile<32x32, f32>, #l1_>> -> memref<4x6x!ttcore.tile<32x32, f32>, #l1_>
     %out = d2m.reserve %arg1 : !d2m.cb<memref<128x192xf32, #l1_>> -> memref<128x192xf32, #l1_>
@@ -37,7 +37,7 @@ module {
     %arg1 = d2m.get_cb(1) : !d2m.cb<memref<4x6x!ttcore.tile<32x32, si32>, #l1_>>
     // CHECK-NOT: d2m.tile_tilize_block
     // CHECK: ttkernel.tilize_init
-    // CHECK: ttkernel.experimental::tilize_block
+    // CHECK: ttkernel.experimental.tilize_block
     %in = d2m.wait %arg0 : !d2m.cb<memref<128x192xi32, #l1_>> -> memref<128x192xi32, #l1_>
     %out = d2m.reserve %arg1 : !d2m.cb<memref<4x6x!ttcore.tile<32x32, si32>, #l1_>> -> memref<4x6x!ttcore.tile<32x32, si32>, #l1_>
     %result = "d2m.tile_tilize_block"(%in, %out) : (memref<128x192xi32, #l1_>, memref<4x6x!ttcore.tile<32x32, si32>, #l1_>) -> memref<4x6x!ttcore.tile<32x32, si32>, #l1_>
@@ -50,7 +50,7 @@ module {
     %arg1 = d2m.get_cb(1) : !d2m.cb<memref<128x192xi32, #l1_>>
     // CHECK-NOT: d2m.tile_untilize_block
     // CHECK: ttkernel.pack_untilize_init
-    // CHECK: ttkernel.experimental::pack_untilize_block
+    // CHECK: ttkernel.experimental.pack_untilize_block
     // CHECK: ttkernel.pack_untilize_uninit
     %in = d2m.wait %arg0 : !d2m.cb<memref<4x6x!ttcore.tile<32x32, si32>, #l1_>> -> memref<4x6x!ttcore.tile<32x32, si32>, #l1_>
     %out = d2m.reserve %arg1 : !d2m.cb<memref<128x192xi32, #l1_>> -> memref<128x192xi32, #l1_>

--- a/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_false.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_false.mlir
@@ -13,9 +13,9 @@ module {
     // CHECK-NOT: ttir.matmul
     // CHECK-NOT: matmul_tiles
     // CHECK-DAG: emitc.verbatim "Noc noc0(0);"
-    // CHECK: noc0.async_write_multicast
+    // CHECK-DAG: noc0.async_write_multicast
     // CHECK-DAG: emitc.verbatim "Noc noc1(1);"
-    // CHECK: noc1.async_write_multicast
+    // CHECK-DAG: noc1.async_write_multicast
     // CHECK-NOT: noc_async_write_barrier
     // CHECK: mm_block_init
     // CHECK: mm_block_init_short

--- a/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_true.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_true.mlir
@@ -13,9 +13,9 @@ module {
     // CHECK-NOT: ttir.matmul
     // CHECK-NOT: matmul_block
     // CHECK-DAG: emitc.verbatim "Noc noc0(0);"
-    // CHECK: noc0.async_write_multicast
+    // CHECK-DAG: noc0.async_write_multicast
     // CHECK-DAG: emitc.verbatim "Noc noc1(1);"
-    // CHECK: noc1.async_write_multicast
+    // CHECK-DAG: noc1.async_write_multicast
     // CHECK-NOT: noc_async_write_barrier
     // CHECK: mm_init
     // CHECK: mm_init_short

--- a/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
@@ -94,7 +94,7 @@ func.func @trid_barrier_default_noc() -> () attributes {ttkernel.thread = #ttker
 func.func @trid_barrier_dynamic_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
   %noc_arg = arith.constant 262400 : i32
-  %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+  %noc_ptr = ttkernel.reinterpret_cast(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
   %noc_offset = arith.constant 0 : i32
   %noc = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
   "ttkernel.noc_async_read_barrier_with_trid"(%trid, %noc) : (i32, i8) -> ()

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -490,7 +490,7 @@ module {
       %kt_dim = arith.constant 2 : i32
       %in1_k_stride = arith.constant 2 : i32
       // CHECK: emitc.call_opaque "experimental::matmul_block"(%[[CB_A]], %[[CB_B]], %[[IN0_TILE_INDEX]], %[[IN1_TILE_INDEX]], %[[DST_TILE_INDEX]], %[[TRANSPOSE]], %[[CT_DIM]], %[[RT_DIM]], %[[KT_DIM]], %[[IN1_K_STRIDE]])
-      "ttkernel.experimental::matmul_block"(%cb_A, %cb_B, %in0_tile_index, %in1_tile_index, %dst_tile_index, %transpose, %ct_dim, %rt_dim, %kt_dim, %in1_k_stride) : (!cb0_tiles, !cb1_tiles, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
+      "ttkernel.experimental.matmul_block"(%cb_A, %cb_B, %in0_tile_index, %in1_tile_index, %dst_tile_index, %transpose, %ct_dim, %rt_dim, %kt_dim, %in1_k_stride) : (!cb0_tiles, !cb1_tiles, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
       return
     }
 
@@ -1960,7 +1960,7 @@ module {
     func.func @get_noc_addr_with_dynamic_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.verbatim "UnicastEndpoint unicast_ep;"
       %noc_arg = arith.constant 262400 : i32
-      %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+      %noc_ptr = ttkernel.reinterpret_cast(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
       %noc_offset = arith.constant 0 : i32
       %noc = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
       // CHECK: %[[NOC_ARG:.*]] = "emitc.constant"() <{value = 262400 : i32}>
@@ -2165,7 +2165,7 @@ module {
       %size = arith.constant 64 : i32
       %num_dests = arith.constant 4 : i32
       %noc_arg = arith.constant 262400 : i32
-      %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+      %noc_ptr = ttkernel.reinterpret_cast(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
       %noc_offset = arith.constant 0 : i32
       %noc = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
       // CHECK: %[[XS3:.*]] = "emitc.constant"() <{value = 0 : index}>
@@ -2368,7 +2368,7 @@ module {
     // CHECK-LABEL: func @noc_async_atomic_barrier_with_dynamic_noc_id
     func.func @noc_async_atomic_barrier_with_dynamic_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %noc_arg = arith.constant 262400 : i32
-      %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+      %noc_ptr = ttkernel.reinterpret_cast(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
       %noc_offset = arith.constant 0 : i32
       %noc_id = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
       // CHECK: %[[NOC_ARG:.*]] = "emitc.constant"() <{value = 262400 : i32}>
@@ -2386,7 +2386,7 @@ module {
     func.func @noc_semaphore_set() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast
       %temp = arith.constant 262400 : i32
-      %addr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr) // a dummy l1 addr ptr
+      %addr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr) // a dummy l1 addr ptr
       // CHECK: %[[VAL:.*]] = "emitc.constant"
       %val = arith.constant 123 : i32
       // CHECK: emitc.call_opaque "noc_semaphore_set"(%[[ADDR]], %[[VAL]])
@@ -2423,7 +2423,7 @@ module {
       // CHECK: %[[STAGING_ADDR:.*]] = emitc.cast %[[STAGING_ADDR_U32]] : ui32 to i32
       %staging_addr = arith.addi %staging_base, %staging_offset : i32
       // CHECK: %[[STAGING_PTR:.*]] = emitc.call_opaque "reinterpret_cast<tt_l1_ptr uint32_t*>"(%[[STAGING_BASE]]) : (i32) -> !emitc.ptr<!emitc.opaque<"tt_l1_ptr uint32_t">>
-      %staging_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%staging_base) : (i32) -> !ttkernel.l1_addr_ptr
+      %staging_ptr = ttkernel.reinterpret_cast(%staging_base) : (i32) -> !ttkernel.l1_addr_ptr
       %value = arith.constant 262400 : i32
       %word_offset = arith.constant 4 : i32
       // CHECK: %[[STAGING_SLOT:.*]] = emitc.subscript %[[STAGING_PTR]][%{{.*}}]
@@ -2493,11 +2493,11 @@ module {
     func.func @semaphore_wait() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast
       %temp = arith.constant 262400 : i32
-      %addr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr) // a dummy l1 addr ptr
+      %addr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr) // a dummy l1 addr ptr
       // CHECK: %[[VAL:.*]] = "emitc.constant"
       %val = arith.constant 123 : i32
       // CHECK: emitc.call_opaque "experimental::semaphore_wait"(%[[ADDR]], %[[VAL]])
-      "ttkernel.experimental::semaphore_wait"(%addr, %val) : (!ttkernel.l1_addr_ptr, i32) -> ()
+      "ttkernel.experimental.semaphore_wait"(%addr, %val) : (!ttkernel.l1_addr_ptr, i32) -> ()
       return
     }
 
@@ -2505,11 +2505,11 @@ module {
     func.func @semaphore_wait_min() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast
       %temp = arith.constant 262400 : i32
-      %addr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr) // a dummy l1 addr ptr
+      %addr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr) // a dummy l1 addr ptr
       // CHECK: %[[VAL:.*]] = "emitc.constant"
       %val = arith.constant 123 : i32
       // CHECK: emitc.call_opaque "experimental::semaphore_wait_min"(%[[ADDR]], %[[VAL]])
-      "ttkernel.experimental::semaphore_wait_min"(%addr, %val) : (!ttkernel.l1_addr_ptr, i32) -> ()
+      "ttkernel.experimental.semaphore_wait_min"(%addr, %val) : (!ttkernel.l1_addr_ptr, i32) -> ()
       return
     }
 
@@ -2849,7 +2849,7 @@ module {
     func.func @cast_to_l1_ptr_8() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %temp = arith.constant 262400 : i32
       // CHECK: emitc.call_opaque "reinterpret_cast<tt_l1_ptr uint8_t*>"
-      %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+      %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
       return
     }
 
@@ -2857,7 +2857,7 @@ module {
     func.func @cast_to_l1_ptr_16() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %temp = arith.constant 262400 : i32
       // CHECK: emitc.call_opaque "reinterpret_cast<tt_l1_ptr uint16_t*>"
-      %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<16>)
+      %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<16>)
       return
     }
 
@@ -2865,14 +2865,14 @@ module {
     func.func @cast_to_l1_ptr_32() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %temp = arith.constant 262400 : i32
       // CHECK: emitc.call_opaque "reinterpret_cast<tt_l1_ptr uint32_t*>"
-      %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr)
+      %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr)
       return
     }
 
     // CHECK-LABEL: func @store_to_l1_i8
     func.func @store_to_l1_i8() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %temp = arith.constant 262400 : i32
-      %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+      %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
       %offset = arith.constant 0 : i32
       %val = arith.constant 42 : i8
       // CHECK: emitc.cast %{{.*}} : i8 to !emitc.opaque<"tt_l1_ptr uint8_t">
@@ -2883,7 +2883,7 @@ module {
     // CHECK-LABEL: func @store_to_l1_i16
     func.func @store_to_l1_i16() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %temp = arith.constant 262400 : i32
-      %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<16>)
+      %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<16>)
       %offset = arith.constant 0 : i32
       %val = arith.constant 42 : i16
       // CHECK: emitc.cast %{{.*}} : i16 to !emitc.opaque<"tt_l1_ptr uint16_t">
@@ -2894,7 +2894,7 @@ module {
     // CHECK-LABEL: func @store_to_l1_i32
     func.func @store_to_l1_i32() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %temp = arith.constant 262400 : i32
-      %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr)
+      %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr)
       %offset = arith.constant 0 : i32
       %val = arith.constant 42 : i32
       // CHECK: emitc.cast %{{.*}} : i32 to !emitc.opaque<"tt_l1_ptr uint32_t">
@@ -2905,7 +2905,7 @@ module {
     // CHECK-LABEL: func @load_from_l1_i8
     func.func @load_from_l1_i8() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %temp = arith.constant 262400 : i32
-      %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+      %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
       %offset = arith.constant 0 : i32
       // CHECK: %[[SUBSCRIPT:.*]] = emitc.subscript %{{.*}}[%{{.*}}] : (!emitc.ptr<!emitc.opaque<"tt_l1_ptr uint8_t">>, i32) -> !emitc.lvalue<!emitc.opaque<"tt_l1_ptr uint8_t">>
       // CHECK: %[[LOADED:.*]] = emitc.load %[[SUBSCRIPT]] : <{{.*}}>
@@ -2917,7 +2917,7 @@ module {
     // CHECK-LABEL: func @load_from_l1_i16
     func.func @load_from_l1_i16() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %temp = arith.constant 262400 : i32
-      %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<16>)
+      %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr<16>)
       %offset = arith.constant 0 : i32
       // CHECK: %[[SUBSCRIPT:.*]] = emitc.subscript %{{.*}}[%{{.*}}] : (!emitc.ptr<!emitc.opaque<"tt_l1_ptr uint16_t">>, i32) -> !emitc.lvalue<!emitc.opaque<"tt_l1_ptr uint16_t">>
       // CHECK: %[[LOADED:.*]] = emitc.load %[[SUBSCRIPT]] : <{{.*}}>
@@ -2929,7 +2929,7 @@ module {
     // CHECK-LABEL: func @load_from_l1_i32
     func.func @load_from_l1_i32() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       %temp = arith.constant 262400 : i32
-      %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr)
+      %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> (!ttkernel.l1_addr_ptr)
       %offset = arith.constant 0 : i32
       // CHECK: %[[SUBSCRIPT:.*]] = emitc.subscript %{{.*}}[%{{.*}}] : (!emitc.ptr<!emitc.opaque<"tt_l1_ptr uint32_t">>, i32) -> !emitc.lvalue<!emitc.opaque<"tt_l1_ptr uint32_t">>
       // CHECK: %[[LOADED:.*]] = emitc.load %[[SUBSCRIPT]] : <{{.*}}>
@@ -2942,9 +2942,9 @@ module {
     func.func @fabric_connection_manager() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.verbatim "experimental::FabricConnectionManager [[FCM:fabric_connection_manager_[0-9]+]];"
       // CHECK: %[[FCM_LIT:.*]] = emitc.literal "[[FCM]]" : !emitc.opaque<"experimental::FabricConnectionManager">
-      %fcm = "ttkernel.experimental::create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
+      %fcm = "ttkernel.experimental.create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
       // CHECK: emitc.call_opaque "experimental::setup_fabric_connections"(%[[FCM_LIT]])
-      "ttkernel.experimental::setup_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
+      "ttkernel.experimental.setup_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
 
       %bank_id = arith.constant 0 : i32
       %addr_offset = arith.constant 0 : i32
@@ -2957,11 +2957,11 @@ module {
       // CHECK: emitc.verbatim "std::array<uint32_t, 2> [[POS:logical_mesh_position_[0-9]+]] = std::array<uint32_t, 2>{{.*}};" args
       // CHECK: %[[POS_LIT:.*]] = emitc.literal "[[POS]]" : !emitc.opaque<"std::array<uint32_t, 2>">
       // CHECK: call_opaque "experimental::get_device_id_from_logical_mesh_position"(%[[FCM_LIT]], %[[POS_LIT]])
-      %device_id = "ttkernel.experimental::get_device_id_from_logical_mesh_position"(%fcm, %mesh_y, %mesh_x) : (!ttkernel.fabric_connection_manager, index, index) -> i16
+      %device_id = "ttkernel.experimental.get_device_id_from_logical_mesh_position"(%fcm, %mesh_y, %mesh_x) : (!ttkernel.fabric_connection_manager, index, index) -> i16
       // CHECK: emitc.call_opaque "experimental::fabric_fast_write_any_len"(%[[FCM_LIT]]
-      "ttkernel.experimental::fabric_fast_write_any_len"(%fcm, %src_dev, %device_id, %noc_addr, %l1_addr, %size) : (!ttkernel.fabric_connection_manager, i16, i16, !ttkernel.noc_addr, i32, i32) -> ()
+      "ttkernel.experimental.fabric_fast_write_any_len"(%fcm, %src_dev, %device_id, %noc_addr, %l1_addr, %size) : (!ttkernel.fabric_connection_manager, i16, i16, !ttkernel.noc_addr, i32, i32) -> ()
       // CHECK: emitc.call_opaque "experimental::close_fabric_connections"(%[[FCM_LIT]])
-      "ttkernel.experimental::close_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
+      "ttkernel.experimental.close_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
       return
     }
 

--- a/test/ttmlir/Dialect/D2M/arguments/d2m_to_ttkernel_argument_lowering.mlir
+++ b/test/ttmlir/Dialect/D2M/arguments/d2m_to_ttkernel_argument_lowering.mlir
@@ -68,7 +68,7 @@ func.func private @datamovement_kernel1() attributes {d2m.thread = #d2m.thread<d
       d2m.pop %arg1 : <memref<2x2x!ttcore.tile<32x32, f32>, #l1>>
     }
   }
-  // CHECK: %2 = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>(%1) : (!ttkernel.l1_addr) -> !ttkernel.l1_addr_ptr
+  // CHECK: %2 = ttkernel.reinterpret_cast(%1) : (!ttkernel.l1_addr) -> !ttkernel.l1_addr_ptr
   d2m.semaphore_wait %arg3, %c1 : !d2m.global_semaphore
   return
 }
@@ -104,15 +104,15 @@ func.func private @datamovement_kernel4() attributes {d2m.thread = #d2m.thread<d
       %2 = d2m.get_arg(0) : memref<8x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
       %tx = d2m.dma_read %2[%core0, %arg7, %c0], %1[%c0], <1> : (memref<8x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
       d2m.dma_wait %tx : !d2m.mem_tx<read>
-      // CHECK: %19 = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>(%2) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
+      // CHECK: %19 = ttkernel.reinterpret_cast(%2) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
       d2m.semaphore_wait %arg5, %c7 reset %c0 : !d2m.local_semaphore
       %tx_0 = d2m.dma_write %1[%c0], %1[%c0] core[%core0, %c0] mcast[%c1, %c8], <1> : (memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<write>
       d2m.dma_wait %tx_0 : !d2m.mem_tx<write>
-      // CHECK: %45 = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>(%4) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
+      // CHECK: %45 = ttkernel.reinterpret_cast(%4) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
       d2m.semaphore_set %arg6, %c1, core[%core0, %c0] mcast[%c1, %c8] : !d2m.local_semaphore
     } else {
       d2m.semaphore_inc %arg5, %c1, core[%core0, %c0] : !d2m.local_semaphore
-      // CHECK: %13 = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>(%4) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
+      // CHECK: %13 = ttkernel.reinterpret_cast(%4) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
       d2m.semaphore_wait %arg6, %c1 reset %c0 : !d2m.local_semaphore
     }
     d2m.push %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>

--- a/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
+++ b/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
@@ -63,10 +63,10 @@ func.func @test_consecutive_write_barriers_different_noc(%noc0: i8, %noc1: i8) {
 
 // CHECK-LABEL: func.func @test_consecutive_unpack_stall_on_pack
 func.func @test_consecutive_unpack_stall_on_pack() {
-  // CHECK: ttkernel.experimental::unpack_stall_on_pack
-  "ttkernel.experimental::unpack_stall_on_pack"() : () -> ()
-  // CHECK-NOT: ttkernel.experimental::unpack_stall_on_pack
-  "ttkernel.experimental::unpack_stall_on_pack"() : () -> ()
+  // CHECK: ttkernel.experimental.unpack_stall_on_pack
+  "ttkernel.experimental.unpack_stall_on_pack"() : () -> ()
+  // CHECK-NOT: ttkernel.experimental.unpack_stall_on_pack
+  "ttkernel.experimental.unpack_stall_on_pack"() : () -> ()
   // CHECK: return
   return
 }

--- a/test/ttmlir/Dialect/TTKernel/l1_addr_ptr_types.mlir
+++ b/test/ttmlir/Dialect/TTKernel/l1_addr_ptr_types.mlir
@@ -5,7 +5,7 @@
 func.func @test_l1_addr_ptr_default() -> () {
   %temp = arith.constant 262400 : i32
   // CHECK: (i32) -> !ttkernel.l1_addr_ptr
-  %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> !ttkernel.l1_addr_ptr
+  %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> !ttkernel.l1_addr_ptr
   return
 }
 
@@ -13,7 +13,7 @@ func.func @test_l1_addr_ptr_default() -> () {
 func.func @test_l1_addr_ptr_8() -> () {
   %temp = arith.constant 262400 : i32
   // CHECK: (i32) -> !ttkernel.l1_addr_ptr<8>
-  %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> !ttkernel.l1_addr_ptr<8>
+  %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> !ttkernel.l1_addr_ptr<8>
   return
 }
 
@@ -21,14 +21,14 @@ func.func @test_l1_addr_ptr_8() -> () {
 func.func @test_l1_addr_ptr_16() -> () {
   %temp = arith.constant 262400 : i32
   // CHECK: (i32) -> !ttkernel.l1_addr_ptr<16>
-  %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> !ttkernel.l1_addr_ptr<16>
+  %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> !ttkernel.l1_addr_ptr<16>
   return
 }
 
 // CHECK-LABEL: func.func @test_load_from_l1_i32
 func.func @test_load_from_l1_i32() -> () {
   %temp = arith.constant 262400 : i32
-  %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> !ttkernel.l1_addr_ptr
+  %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> !ttkernel.l1_addr_ptr
   %offset = arith.constant 0 : i32
   // CHECK: ttkernel.load_from_l1(%{{.*}}, %{{.*}}) : (!ttkernel.l1_addr_ptr, i32) -> i32
   %val = ttkernel.load_from_l1(%ptr, %offset) : (!ttkernel.l1_addr_ptr, i32) -> i32
@@ -38,7 +38,7 @@ func.func @test_load_from_l1_i32() -> () {
 // CHECK-LABEL: func.func @test_load_from_l1_i16
 func.func @test_load_from_l1_i16() -> () {
   %temp = arith.constant 262400 : i32
-  %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> !ttkernel.l1_addr_ptr<16>
+  %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> !ttkernel.l1_addr_ptr<16>
   %offset = arith.constant 0 : i32
   // CHECK: ttkernel.load_from_l1(%{{.*}}, %{{.*}}) : (!ttkernel.l1_addr_ptr<16>, i32) -> i16
   %val = ttkernel.load_from_l1(%ptr, %offset) : (!ttkernel.l1_addr_ptr<16>, i32) -> i16
@@ -48,7 +48,7 @@ func.func @test_load_from_l1_i16() -> () {
 // CHECK-LABEL: func.func @test_load_from_l1_i8
 func.func @test_load_from_l1_i8() -> () {
   %temp = arith.constant 262400 : i32
-  %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> !ttkernel.l1_addr_ptr<8>
+  %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> !ttkernel.l1_addr_ptr<8>
   %offset = arith.constant 0 : i32
   // CHECK: ttkernel.load_from_l1(%{{.*}}, %{{.*}}) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
   %val = ttkernel.load_from_l1(%ptr, %offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8
@@ -58,7 +58,7 @@ func.func @test_load_from_l1_i8() -> () {
 // CHECK-LABEL: func.func @test_store_to_l1_i32
 func.func @test_store_to_l1_i32() -> () {
   %temp = arith.constant 262400 : i32
-  %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> !ttkernel.l1_addr_ptr
+  %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> !ttkernel.l1_addr_ptr
   %offset = arith.constant 0 : i32
   %val = arith.constant 42 : i32
   // CHECK: ttkernel.store_to_l1(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, !ttkernel.l1_addr_ptr, i32) -> ()
@@ -69,7 +69,7 @@ func.func @test_store_to_l1_i32() -> () {
 // CHECK-LABEL: func.func @test_store_to_l1_i16
 func.func @test_store_to_l1_i16() -> () {
   %temp = arith.constant 262400 : i32
-  %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> !ttkernel.l1_addr_ptr<16>
+  %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> !ttkernel.l1_addr_ptr<16>
   %offset = arith.constant 0 : i32
   %val = arith.constant 42 : i16
   // CHECK: ttkernel.store_to_l1(%{{.*}}, %{{.*}}, %{{.*}}) : (i16, !ttkernel.l1_addr_ptr<16>, i32) -> ()
@@ -80,7 +80,7 @@ func.func @test_store_to_l1_i16() -> () {
 // CHECK-LABEL: func.func @test_store_to_l1_i8
 func.func @test_store_to_l1_i8() -> () {
   %temp = arith.constant 262400 : i32
-  %ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%temp) : (i32) -> !ttkernel.l1_addr_ptr<8>
+  %ptr = ttkernel.reinterpret_cast(%temp) : (i32) -> !ttkernel.l1_addr_ptr<8>
   %offset = arith.constant 0 : i32
   %val = arith.constant 42 : i8
   // CHECK: ttkernel.store_to_l1(%{{.*}}, %{{.*}}, %{{.*}}) : (i8, !ttkernel.l1_addr_ptr<8>, i32) -> ()

--- a/test/ttmlir/Dialect/TTKernel/no_colon_mnemonics.mlir
+++ b/test/ttmlir/Dialect/TTKernel/no_colon_mnemonics.mlir
@@ -1,0 +1,6 @@
+// RUN: python -c 'import pathlib,re; text=pathlib.Path("%S/../../../../include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td").read_text(); bad=re.findall(r"TTKernel_(?:Op|FPUOp|SFPUOp|InitOp)<\"[^\"]*[<>::][^\"]*\"", text); assert not bad, bad[:5]'
+
+// TTKernel MLIR op mnemonics must not contain C++ spelling syntax. Bare custom
+// op printing treats these characters specially and can emit text that does not
+// parse back.
+// This file is intentionally not valid MLIR; it is a lit-only source check.

--- a/test/ttmlir/Dialect/TTKernel/no_colon_mnemonics.mlir
+++ b/test/ttmlir/Dialect/TTKernel/no_colon_mnemonics.mlir
@@ -1,4 +1,4 @@
-// RUN: python -c 'import pathlib,re; text=pathlib.Path("%S/../../../../include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td").read_text(); bad=re.findall(r"TTKernel_(?:Op|FPUOp|SFPUOp|InitOp)<\"[^\"]*[<>::][^\"]*\"", text); assert not bad, bad[:5]'
+// RUN: %python -c 'import pathlib,re; text=pathlib.Path("%S/../../../../include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td").read_text(); bad=re.findall(r"TTKernel_(?:Op|FPUOp|SFPUOp|InitOp)<\"[^\"]*[<>::][^\"]*\"", text); assert not bad, bad[:5]'
 
 // TTKernel MLIR op mnemonics must not contain C++ spelling syntax. Bare custom
 // op printing treats these characters specially and can emit text that does not

--- a/test/ttmlir/Dialect/TTKernel/ops.mlir
+++ b/test/ttmlir/Dialect/TTKernel/ops.mlir
@@ -1,7 +1,27 @@
 // RUN: ttmlir-opt -o %t %s
+// RUN: ttmlir-opt %s -o - | ttmlir-opt -o /dev/null
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>
+
+// CHECK-LABEL: func.func @test_compute_kernel_hw_startup_unary
+func.func @test_compute_kernel_hw_startup_unary() {
+  %icb = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1024, si32>
+  %ocb = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, si32>>
+  ttkernel.compute_kernel_hw_startup(%icb, %ocb) : (!ttkernel.cb<1024, si32>, !ttkernel.cb<1, !ttcore.tile<32x32, si32>>) -> ()
+  // CHECK: ttkernel.compute_kernel_hw_startup(%{{.*}}, %{{.*}}) : (!ttkernel.cb<1024, si32>, !ttkernel.cb<1, !ttcore.tile<32x32, si32>>) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @test_compute_kernel_hw_startup_binary
+func.func @test_compute_kernel_hw_startup_binary() {
+  %icb0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1024, si32>
+  %icb1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<1024, si32>
+  %ocb = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, si32>>
+  ttkernel.compute_kernel_hw_startup(%icb0, %icb1, %ocb) : (!ttkernel.cb<1024, si32>, !ttkernel.cb<1024, si32>, !ttkernel.cb<1, !ttcore.tile<32x32, si32>>) -> ()
+  // CHECK: ttkernel.compute_kernel_hw_startup(%{{.*}}, %{{.*}}, %{{.*}}) : (!ttkernel.cb<1024, si32>, !ttkernel.cb<1024, si32>, !ttkernel.cb<1, !ttcore.tile<32x32, si32>>) -> ()
+  return
+}
 
 // CHECK-LABEL: func.func @test_tilize_uninit
 func.func @test_tilize_uninit() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>} {
@@ -232,8 +252,8 @@ func.func @test_remote_mailbox_protocol_ops(%mailbox: !ttkernel.l1_addr) {
   %value = arith.constant 64 : i32
   // CHECK: %[[SEM:.*]] = ttkernel.get_semaphore
   %sem = ttkernel.get_semaphore(%zero) : (i32) -> !ttkernel.local_semaphore
-  // CHECK: %[[PTR:.*]] = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>
-  %sem_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%sem) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
+  // CHECK: %[[PTR:.*]] = ttkernel.reinterpret_cast
+  %sem_ptr = ttkernel.reinterpret_cast(%sem) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
   // CHECK: ttkernel.store_to_l1
   ttkernel.store_to_l1(%value, %sem_ptr, %zero) : (i32, !ttkernel.l1_addr_ptr, i32) -> ()
   // CHECK: ttkernel.load_from_l1

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc_dynamic_atomic.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc_dynamic_atomic.mlir
@@ -8,7 +8,7 @@
 func.func @ttkernel_dynamic_noc_atomic_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
   // CHECK: int32_t [[NOC_ARG:.*]] = 262400
   %noc_arg = arith.constant 262400 : i32
-  %noc_ptr = "ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>"(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
+  %noc_ptr = ttkernel.reinterpret_cast(%noc_arg) : (i32) -> (!ttkernel.l1_addr_ptr<8>)
   %noc_offset = arith.constant 0 : i32
   // CHECK: int8_t [[NOC:v[0-9]+]] = (int8_t)
   %noc = ttkernel.load_from_l1(%noc_ptr, %noc_offset) : (!ttkernel.l1_addr_ptr<8>, i32) -> i8


### PR DESCRIPTION
### Problem description
TTKernel experimental ops that use `::` would not be reparsed correctly if printed out

### What's changed
- Renames TTKernel MLIR op mnemonics that used C++ syntax into MLIR-safe names (ttkernel.experimental::foo -> ttkernel.experimental.foo), (ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*> -> ttkernel.reinterpret_cast)
- Updates TTKernelToEmitC so those MLIR-safe names still emit the correct C++ callee names (experimental.foo emits as experimental::foo) regular ttkernel. prefix stripping still works as before
- Adds custom parse/print support for ttkernel.compute_kernel_hw_startup so both unary and binary forms round-trip correctly
- Updates affected tests, goldens, and docs to use the new mnemonic spellings
- Adds test/ttmlir/Dialect/TTKernel/no_colon_mnemonics.mlir, a lit source check that prevents future TTKernel op mnemonics from containing <, >, or ::

### Checklist
- [ ] New/Existing tests provide coverage for changes
