### PR TITLE
Add SymbolDCE pass after TTNNResolveComposites

### DIFF
--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -395,6 +395,8 @@ void createTTIRToTTNNCommonPipeline(
     // Run TTNN lowering passes on Device module.
     createTTNNPipelineLoweringPasses(devicePm, options.removeDeadValuesEnabled);
     createTTNNResolveCompositesPass(devicePm, options);
+    // Add pass to clean up the leftover unreferenced symbols.
+    devicePm.addPass(mlir::createSymbolDCEPass());
     createTTNNFusingPass(devicePm, options);
 
     // Create TTNN decomposition pass, optionally with op-model validation.


### PR DESCRIPTION
### Ticket
N/A
### Problem description
After the `TTNNResolveComposites` pass runs, leftover const-eval functions can
remain in the IR even though they are no longer referenced.

**Example: `test_flash_mla_prefill_causal_with_value`**

Before `TTNNResolveComposites` pass:
```
...
func.func @flash_mla_prefill_causal_with_value(%arg0: tensor<1x8x32x128xbf16, #ttnn_layout> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x8x32x128xbf16>>, ttcore.shard_status = #ttcore.shard_status<unsharded>}, %arg1: tensor<1x8x32x128xbf16, #ttnn_layout> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x8x32x128xbf16>>, ttcore.shard_status = #ttcore.shard_status<unsharded>}, %arg2: tensor<1x8x32x64xbf16, #ttnn_layout1> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x8x32x64xbf16>>, ttcore.shard_status = #ttcore.shard_status<unsharded>}) -> (tensor<1x8x32x64xbf16, #ttnn_layout1> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x8x32x64xbf16>>, ttcore.shard_status = #ttcore.shard_status<unsharded>}) attributes {tt.function_type = "forward_device"} {
        %0 = "ttcore.composite"(%arg0, %arg1, %arg2) <{composite_attributes = {has_attention_mask = false, has_value = true, head_dim_v = 64 : ui32, is_causal = true, scale = 0.0883883461 : f32}, composite_name = "flash_mla_prefill", decomposition = @flash_mla_prefill_decomp}> : (tensor<1x8x32x128xbf16, #ttnn_layout>, tensor<1x8x32x128xbf16, #ttnn_layout>, tensor<1x8x32x64xbf16, #ttnn_layout1>) -> tensor<1x8x32x64xbf16, #ttnn_layout1>
        return %0 : tensor<1x8x32x64xbf16, #ttnn_layout1>
      }
...
func.func private @flash_mla_prefill_decomp_const_eval_0() -> tensor<1x1x32x32xbf16, #ttnn_layout2> attributes {tt.function_type = "const_eval"} {
       
        ...
      }
func.func private @flash_mla_prefill_decomp(%arg0: tensor<1x8x32x128xbf16, #ttnn_layout>, %arg1: tensor<1x8x32x128xbf16, #ttnn_layout>, %arg2: tensor<1x8x32x64xbf16, #ttnn_layout1>) -> tensor<1x8x32x64xbf16, #ttnn_layout1> {
        %0 = ttcore.load_cached(@flash_mla_prefill_decomp_const_eval_0, []) : () -> tensor<1x1x32x32xbf16, #ttnn_layout2>
        ...
      }
...
```
After `TTNNResolveComposites` pass (the composite is resolved to `ttnn.flash_mla_prefill` and so `@flash_mla_prefill_decomp` is removed, but `@flash_mla_prefill_decomp_const_eval_0` is left behind even though nothing references it anymore):
```
...
func.func @flash_mla_prefill_causal_with_value(%arg0: tensor<1x8x32x128xbf16, #ttnn_layout> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x8x32x128xbf16>>, ttcore.shard_status = #ttcore.shard_status<unsharded>}, %arg1: tensor<1x8x32x128xbf16, #ttnn_layout> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x8x32x128xbf16>>, ttcore.shard_status = #ttcore.shard_status<unsharded>}, %arg2: tensor<1x8x32x64xbf16, #ttnn_layout1> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x8x32x64xbf16>>, ttcore.shard_status = #ttcore.shard_status<unsharded>}) -> (tensor<1x8x32x64xbf16, #ttnn_layout1> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x8x32x64xbf16>>, ttcore.shard_status = #ttcore.shard_status<unsharded>}) attributes {tt.function_type = "forward_device"} {
        %0 = "ttnn.flash_mla_prefill"(%arg0, %arg1, %arg2) <{head_dim_v = 64 : ui32, is_causal = true, operandSegmentSizes = array<i32: 1, 1, 1, 0>, scale = 0.0883883461 : f32}> : (tensor<1x8x32x128xbf16, #ttnn_layout>, tensor<1x8x32x128xbf16, #ttnn_layout>, tensor<1x8x32x64xbf16, #ttnn_layout1>) -> tensor<1x8x32x64xbf16, #ttnn_layout1>
        return %0 : tensor<1x8x32x64xbf16, #ttnn_layout1>
      }
...
func.func private @flash_mla_prefill_decomp_const_eval_0() -> tensor<1x1x32x32xbf16, #ttnn_layout2> attributes {tt.function_type = "const_eval"} {
      
        ...
      }
...
```
### What's changed
Added a `SymbolDCE` pass after `TTNNResolveComposite` to clean up the leftover unreferenced symbols.

### Checklist
- [ ] New/Existing tests provide coverage for changes
