### PR TITLE
Fixup for exp attributes.

### DIFF
--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -620,7 +620,7 @@ public:
   }
 
   static bool hasNonDefaultExpTileScale(IntegerAttr scaleAttr) {
-    constexpr uint32_t defaultScale = 0x3F80u; // 1.0 encoded for exp_tile().
+    constexpr uint32_t defaultScale = 0x3F800000u; // 1.0 encoded as fp32.
     return scaleAttr &&
            static_cast<uint32_t>(scaleAttr.getInt()) != defaultScale;
   }
@@ -899,11 +899,15 @@ public:
       }
       SmallVector<Attribute, 3> args;
       args.push_back(builder.getIndexAttr(0)); // idst (operand 0)
+      args.push_back(emitc::OpaqueAttr::get(op.getContext(), "VectorMode::RC"));
+      // The exp_tile runtime scale arg is uint16_t and must be the FP16b
+      // (bfloat16) encoding of the scale, i.e. the top 16 bits of the fp32 bit
+      // pattern. (exp_tile_init's scale template param is the full uint32 fp32
+      // bits, so that emission is handled separately.)
+      uint16_t scaleFp16b = static_cast<uint16_t>(
+          static_cast<uint32_t>(scaleAttr.getInt()) >> 16);
       args.push_back(
-          emitc::OpaqueAttr::get(op.getContext(), "(int)VectorMode::RC"));
-      args.push_back(emitc::OpaqueAttr::get(
-          op.getContext(),
-          std::to_string(static_cast<uint32_t>(scaleAttr.getInt()))));
+          emitc::OpaqueAttr::get(op.getContext(), std::to_string(scaleFp16b)));
       return ArrayAttr::get(op.getContext(), args);
     }
     return ArrayAttr();

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -932,9 +932,9 @@ module {
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
       %dst_index = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "exp_tile"(%[[DST_INDEX]])
-      // CHECK-SAME: args = [0 : index, #emitc.opaque<"(int)VectorMode::RC">, #emitc.opaque<"16384">]
+      // CHECK-SAME: args = [0 : index, #emitc.opaque<"VectorMode::RC">, #emitc.opaque<"16384">]
       // CHECK-SAME: template_args = [#emitc.opaque<"true">, #emitc.opaque<"true">, #emitc.opaque<"InputClamping::None">]
-      "ttkernel.exp_tile"(%dst_index) <{approx = true, input_clamping = #ttkernel.input_clamping<none>, scale = 16384 : i32}> : (i32) -> ()
+      "ttkernel.exp_tile"(%dst_index) <{approx = true, input_clamping = #ttkernel.input_clamping<none>, scale = 1073741824 : i32}> : (i32) -> ()
       return
     }
 
@@ -945,7 +945,7 @@ module {
       // CHECK: emitc.call_opaque "exp_tile"(%[[DST_INDEX]])
       // CHECK-NOT: args =
       // CHECK-NOT: template_args
-      "ttkernel.exp_tile"(%dst_index) <{scale = 16256 : i32}> : (i32) -> ()
+      "ttkernel.exp_tile"(%dst_index) <{scale = 1065353216 : i32}> : (i32) -> ()
       return
     }
 


### PR DESCRIPTION
### Ticket
None.
This is a follow-up of https://github.com/tenstorrent/tt-mlir/pull/8796 (commit d1358c902cc7a44e17c5e2e704d189c8f6415b74)

### Problem description
Previous commit used outdated the outdated exp_tile prototype.

### What's changed

1. `VectorMode::RC` is not casted to `int` any more;
2. Use Bf16 data type for scale;

### Checklist
- [ ] New/Existing tests provide coverage for changes
