### PR TITLE
[d2m] add flag for turning ct args to rt args

### DIFF
--- a/include/ttmlir/Conversion/D2MToTTKernel/D2MToTTKernel.h
+++ b/include/ttmlir/Conversion/D2MToTTKernel/D2MToTTKernel.h
@@ -20,7 +20,8 @@ namespace mlir::tt {
 
 void populateD2MToTTKernelPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
-    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode);
+    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode,
+    bool hitKernelCache);
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertD2MToTTKernelPass();
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -183,7 +183,9 @@ def ConvertD2MToTTKernel: Pass<"convert-d2m-to-ttkernel", "::mlir::ModuleOp"> {
   let constructor = "createConvertD2MToTTKernelPass()";
   let dependentDialects = ["mlir::tt::d2m::D2MDialect", "mlir::tt::ttmetal::TTMetalDialect", "mlir::tt::ttkernel::TTKernelDialect", "mlir::arith::ArithDialect"];
   let options = [
-    Option<"ttnnMode", "ttnn-mode", "bool", /*default=*/"false", "Enable TTNN mode">
+    Option<"ttnnMode", "ttnn-mode", "bool", /*default=*/"false", "Enable TTNN mode">,
+    Option<"hitKernelCache", "hit-kernel-cache", "bool", /*default=*/"false",
+           "Prefer TT-Metal kernel-cache hits by canonicalizing generated kernel source and lowering non-structural kernel inputs as runtime args when legal.">
   ];
 }
 

--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -191,6 +191,13 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
                         llvm::cl::desc("D2M/TTNN integration mode."),
                         llvm::cl::init(false)};
 
+  Option<bool> hitKernelCache{
+      *this, "hit-kernel-cache",
+      llvm::cl::desc("Prefer TT-Metal kernel-cache hits by canonicalizing "
+                     "generated kernel source and lowering non-structural "
+                     "kernel inputs as runtime args when legal."),
+      llvm::cl::init(false)};
+
   // Option to set the target data format for the global data format conversion
   // pass.
   Option<std::string> globalDataFormatTarget{

--- a/include/ttmlir/Target/TTKernel/TTKernelToCpp.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelToCpp.h
@@ -18,13 +18,15 @@ namespace mlir::tt::ttkernel {
 // Translates a top level TTKernel func op (already converted to EmitC) to C++
 // and writes it to the given stream.
 LogicalResult translateKernelFuncToCpp(func::FuncOp entry,
-                                       llvm::raw_ostream &os);
+                                       llvm::raw_ostream &os,
+                                       bool includeOriginalSymbolName = true);
 
 // Translates a top level TTKernel func op (already converted to EmitC) to C++
 // for the given symbol name and writes it to the given stream.
-LogicalResult translateTopLevelKernelToCpp(ModuleOp moduleOp,
-                                           llvm::raw_ostream &os,
-                                           StringRef symbolName);
+LogicalResult
+translateTopLevelKernelToCpp(ModuleOp moduleOp, llvm::raw_ostream &os,
+                             StringRef symbolName,
+                             bool includeOriginalSymbolName = true);
 
 // Walks over all top level TTKernel func ops (already converted to EmitC) in
 // the given module and writes them to the given stream.

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2892,9 +2892,9 @@ namespace {
 class D2MGetArgRewriter : public OpConversionPattern<d2m::GetArgOp> {
 public:
   D2MGetArgRewriter(TypeConverter &typeConverter, MLIRContext *context,
-                    bool ttnnMode)
+                    bool ttnnMode, bool hitKernelCache)
       : OpConversionPattern<d2m::GetArgOp>(typeConverter, context),
-        ttnnMode(ttnnMode) {}
+        ttnnMode(ttnnMode), hitKernelCache(hitKernelCache) {}
 
   LogicalResult
   matchAndRewrite(d2m::GetArgOp op, d2m::GetArgOpAdaptor adaptor,
@@ -2941,27 +2941,38 @@ public:
       return success();
     } else if (mlir::isa<IndexType, IntegerType, FloatType>(
                    op.getResult().getType())) {
-      // Scalar additional args are always stored as ui32 in the CT arg slot.
-      // If the declared type differs from ui32, a ReinterpretCastOp recovers
-      // the correct type.
+      // Scalar additional args are stored as ui32. If the declared type differs
+      // from ui32, a BitcastOp recovers the correct type.
       Type scalarType = op.getResult().getType();
       Type ui32Type =
           IntegerType::get(op.getContext(), 32, IntegerType::Unsigned);
 
       ArgAttr scalarArg =
           rewriter.getAttr<ArgAttr>(ArgType::Scalar, op.getOperandIndex());
-      size_t ctArgIdx;
+      size_t argIdx;
       rewriter.modifyOpInPlace(entry, [&]() {
-        ctArgIdx = ArgSpecAttr::appendCompileTimeArg(entry, scalarArg);
+        argIdx = shouldUseRuntimeArgs()
+                     ? ArgSpecAttr::appendRuntimeArg(entry, scalarArg)
+                     : ArgSpecAttr::appendCompileTimeArg(entry, scalarArg);
       });
 
-      Value ctArg = rewriter.create<ttkernel::GetCompileArgValOp>(
-          op.getLoc(), ui32Type, static_cast<int32_t>(ctArgIdx));
+      Value scalarArgValue =
+          shouldUseRuntimeArgs()
+              ? rewriter
+                    .create<ttkernel::GetArgValOp>(
+                        op.getLoc(), ui32Type,
+                        index(rewriter, op->getLoc(), argIdx))
+                    .getResult()
+              : rewriter
+                    .create<ttkernel::GetCompileArgValOp>(
+                        op.getLoc(), ui32Type, static_cast<int32_t>(argIdx))
+                    .getResult();
 
       if (scalarType == ui32Type) {
-        rewriter.replaceOp(op, ctArg);
+        rewriter.replaceOp(op, scalarArgValue);
       } else {
-        rewriter.replaceOpWithNewOp<ttkernel::BitcastOp>(op, scalarType, ctArg);
+        rewriter.replaceOpWithNewOp<ttkernel::BitcastOp>(op, scalarType,
+                                                         scalarArgValue);
       }
       return success();
     } else {
@@ -2975,6 +2986,13 @@ public:
       rewriter.replaceOpWithNewOp<ttkernel::GetCommonArgValOp>(
           op, argResultType, index(rewriter, op->getLoc(), argIndex));
 
+    } else if (hitKernelCache) {
+      rewriter.modifyOpInPlace(entry, [&]() {
+        argIndex = ArgSpecAttr::appendRuntimeArg(entry, arg);
+      });
+      rewriter.replaceOpWithNewOp<ttkernel::GetArgValOp>(
+          op, argResultType, index(rewriter, op->getLoc(), argIndex));
+
     } else {
       rewriter.modifyOpInPlace(entry, [&]() {
         argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg);
@@ -2986,7 +3004,10 @@ public:
   }
 
 private:
+  bool shouldUseRuntimeArgs() const { return hitKernelCache && !ttnnMode; }
+
   bool ttnnMode;
+  bool hitKernelCache;
 };
 
 class D2MGetCBRewriter : public OpConversionPattern<d2m::GetCBOp> {
@@ -3356,7 +3377,8 @@ namespace mlir::tt {
 
 void populateD2MToTTKernelPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
-    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode) {
+    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode,
+    bool hitKernelCache) {
   // clang-format off
   patterns.add<ttkernel::D2MKernelFunctionArgsRewriter,
                ttkernel::PassthroughRewriter<memref::CastOp>,
@@ -3478,8 +3500,8 @@ void populateD2MToTTKernelPatterns(
                ttkernel::D2MSemaphoreWaitRewriter,
                ttkernel::D2MDeviceSynchronizeRewriter>(typeConverter, ctx);
 
-  patterns.add<ttkernel::D2MGetArgRewriter>(typeConverter, ctx,
-                                                      ttnnMode);
+  patterns.add<ttkernel::D2MGetArgRewriter>(typeConverter, ctx, ttnnMode,
+                                            hitKernelCache);
   patterns.add<ttkernel::D2MGetCBRewriter>(typeConverter, ctx);
   patterns.add<ttkernel::D2MDMAReadRewriter>(typeConverter, ctx, &cbProducerConsumer);
   patterns.add<ttkernel::D2MDMAWriteRewriter>(typeConverter, ctx, &cbProducerConsumer);

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -56,6 +56,7 @@ struct ConvertD2MToTTKernel
     // Workaround: Passes are required to be copy-constructible but autogen'ed
     // base class copy constructors ignore Pass option fields.
     this->ttnnMode = rhs.ttnnMode;
+    this->hitKernelCache = rhs.hitKernelCache;
   }
 
   void runOnOperation() final {
@@ -174,11 +175,16 @@ struct ConvertD2MToTTKernel
     d2m::CBProducerConsumer cbProducerConsumer =
         getAnalysis<d2m::CBProducerConsumer>();
 
+    if (hitKernelCache) {
+      moduleOp->setAttr("ttkernel.hit_kernel_cache",
+                        UnitAttr::get(&getContext()));
+    }
+
     RewritePatternSet patterns(&getContext());
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
         patterns, typeConverter);
     populateD2MToTTKernelPatterns(&getContext(), patterns, typeConverter,
-                                  cbProducerConsumer, ttnnMode);
+                                  cbProducerConsumer, ttnnMode, hitKernelCache);
     scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter,
                                                          patterns, target);
 

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -285,9 +285,12 @@ void createD2MToTTNNPipeline(OpPassManager &pm,
 // selection). Callers are responsible for adding them at the right point.
 void createD2MToTTKernelPreEmitCPipeline(OpPassManager &pm,
                                          const D2MPipelineOptions &options) {
-  d2m::ConvertD2MToTTKernelOptions D2MToTTKernelOptions;
-  { D2MToTTKernelOptions.ttnnMode = options.ttnnMode; }
-  pm.addPass(tt::createConvertD2MToTTKernelPass(D2MToTTKernelOptions));
+  d2m::ConvertD2MToTTKernelOptions d2mToTTKernelOptions;
+  {
+    d2mToTTKernelOptions.ttnnMode = options.ttnnMode;
+    d2mToTTKernelOptions.hitKernelCache = options.hitKernelCache;
+  }
+  pm.addPass(tt::createConvertD2MToTTKernelPass(d2mToTTKernelOptions));
   pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(ttkernel::createTTKernelControlDstSection());
   createOptimizationPasses(pm, options);

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -308,7 +308,8 @@ private:
 } // namespace
 
 static FailureOr<mlir::ModuleOp>
-cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType) {
+cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType,
+                               bool includeOriginalSymbolName) {
   auto *ctx = origEntry.getContext();
   mlir::DialectRegistry registry;
   registry.insert<mlir::emitc::EmitCDialect>();
@@ -326,8 +327,10 @@ cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType) {
 
   Region *kernelMainRegion;
   {
+    StringRef originalSymbolName =
+        includeOriginalSymbolName ? origEntry.getName() : StringRef();
     ScopedModuleHelper threadConfigHelper(&builder, loc, region, threadType,
-                                          origEntry.getName());
+                                          originalSymbolName);
 
     // Clone 'region' into a new func op nested inside 'moduleWrapper':
     auto kernelMain = builder.create<func::FuncOp>(
@@ -342,15 +345,16 @@ cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType) {
 }
 
 LogicalResult translateKernelFuncToCpp(func::FuncOp entry,
-                                       llvm::raw_ostream &os) {
+                                       llvm::raw_ostream &os,
+                                       bool includeOriginalSymbolName) {
   if (!entry->hasAttr(ThreadTypeAttr::name)) {
     return failure();
   }
 
   ThreadType threadType =
       entry->getAttrOfType<ThreadTypeAttr>(ThreadTypeAttr::name).getValue();
-  FailureOr<mlir::ModuleOp> kernelModule =
-      cloneEntryIntoStandaloneModule(entry, threadType);
+  FailureOr<mlir::ModuleOp> kernelModule = cloneEntryIntoStandaloneModule(
+      entry, threadType, includeOriginalSymbolName);
   if (failed(kernelModule)) {
     return failure();
   }
@@ -360,13 +364,14 @@ LogicalResult translateKernelFuncToCpp(func::FuncOp entry,
 
 LogicalResult translateTopLevelKernelToCpp(ModuleOp moduleOp,
                                            llvm::raw_ostream &os,
-                                           StringRef symbolName) {
+                                           StringRef symbolName,
+                                           bool includeOriginalSymbolName) {
   SymbolTable symbolTable(moduleOp);
   auto entry = symbolTable.lookup<func::FuncOp>(symbolName);
   if (!entry) {
     return failure();
   }
-  return translateKernelFuncToCpp(entry, os);
+  return translateKernelFuncToCpp(entry, os, includeOriginalSymbolName);
 }
 
 LogicalResult translateTopLevelKernelsToCpp(ModuleOp moduleOp,

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -960,8 +960,11 @@ kernelConfigToFlatbuffer(FlatbufferObjectCache &cache,
   assert(kernelEntry);
   std::string source;
   llvm::raw_string_ostream stream(source);
-  LogicalResult result =
-      ttkernel::translateKernelFuncToCpp(kernelEntry, stream);
+  bool includeOriginalSymbolName =
+      !kernelEntry->getParentOfType<ModuleOp>()->hasAttr(
+          "ttkernel.hit_kernel_cache");
+  LogicalResult result = ttkernel::translateKernelFuncToCpp(
+      kernelEntry, stream, includeOriginalSymbolName);
   assert(result.succeeded());
   assert(source.size() > 0 && "empty kernel source");
 

--- a/test/ttmlir/Conversion/D2MToTTKernel/hit_kernel_cache_args.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/hit_kernel_cache_args.mlir
@@ -1,0 +1,31 @@
+// RUN: ttmlir-opt --ttcore-register-device --convert-d2m-to-ttkernel %s | FileCheck %s --check-prefix=DEFAULT
+// RUN: ttmlir-opt --ttcore-register-device --convert-d2m-to-ttkernel="hit-kernel-cache=true" %s | FileCheck %s --check-prefix=HIT
+// RUN: ttmlir-opt --ttcore-register-device --d2m-to-ttkernel-pre-emitc-pipeline="hit-kernel-cache=true" %s | FileCheck %s --check-prefix=PIPELINE
+
+#l1 = #ttcore.memory_space<l1>
+
+module {
+  func.func private @kernel() attributes {d2m.thread = #d2m.thread<datamovement, dm_core = 1>} {
+    %addr = d2m.get_arg(0) : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %scalar = d2m.get_arg(1) : i32
+    %gsem = d2m.get_arg(2) : !d2m.global_semaphore
+    %cb = d2m.get_arg(3) : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1>
+    %lsem = d2m.get_arg(4) : !d2m.local_semaphore
+    return
+  }
+}
+
+// DEFAULT-LABEL: func.func private @kernel
+// DEFAULT-SAME: ttkernel.arg_spec< ct_args = [<arg_type = buffer_address, operand_index = 0>, <arg_type = scalar, operand_index = 1>, <arg_type = global_semaphore, operand_index = 2>, <arg_type = cb_port, operand_index = 3>, <arg_type = local_semaphore, operand_index = 4>]>
+// DEFAULT-COUNT-5: ttkernel.get_compile_time_arg_val
+// DEFAULT-NOT: ttkernel.get_arg_val
+
+// HIT: module attributes {{.*}}ttkernel.hit_kernel_cache
+// HIT-LABEL: func.func private @kernel
+// HIT-SAME: ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>, <arg_type = scalar, operand_index = 1>, <arg_type = global_semaphore, operand_index = 2>] ct_args = [<arg_type = cb_port, operand_index = 3>, <arg_type = local_semaphore, operand_index = 4>]>
+// HIT-COUNT-3: ttkernel.get_arg_val
+// HIT-COUNT-2: ttkernel.get_compile_time_arg_val
+
+// PIPELINE: module attributes {{.*}}ttkernel.hit_kernel_cache
+// PIPELINE-LABEL: func.func private @kernel
+// PIPELINE-SAME: ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>, <arg_type = scalar, operand_index = 1>, <arg_type = global_semaphore, operand_index = 2>] ct_args = [<arg_type = cb_port, operand_index = 3>, <arg_type = local_semaphore, operand_index = 4>]>


### PR DESCRIPTION
### Problem description
Qwen model on device kernel compilation takes 2.5+ hours for cold kernel cache. Untestable like this so we need to turn some ct args to rt to get better kernel cache

### What's changed
- Added hit-kernel-cache plumbing for the D2M to TTKernel/TTMetal pipeline so TTMetal JIT cache-friendly lowering can be enabled from ttir-to-ttmetal-pipeline
- When enabled, non-structural kernel inputs such as buffer addresses, scalars, and global semaphores are lowered as runtime args instead of compile-time args, while structural args like CB ports and local semaphores remain compile-time args
- Canonicalized generated TTKernel source used for TTMetal flatbuffer generation by omitting per-kernel original symbol comments in cache-hit mode, improving JIT kernel cache reuse
- Added lit coverage for default vs hit-kernel-cache=true arg lowering, including pipeline option propagation through d2m-to-ttkernel-pre-emitc-pipeline

Total flatbuffer runtime with cold cache (includes kernel compilation) for 26,007 kernels went down from 162 mins to 8 mins on the second run and 3 mins to 2 mins on subsequent runs with warm cache

### Checklist
- [ ] New/Existing tests provide coverage for changes
