### PR TITLE
[D2M] improve kernel cache hit rate and deduplicate

### DIFF
--- a/include/ttmlir/Conversion/D2MToTTKernel/D2MToTTKernel.h
+++ b/include/ttmlir/Conversion/D2MToTTKernel/D2MToTTKernel.h
@@ -20,7 +20,8 @@ namespace mlir::tt {
 
 void populateD2MToTTKernelPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
-    const d2m::CBProducerConsumer &cbProducerConsumer);
+    const d2m::CBProducerConsumer &cbProducerConsumer,
+    bool forceCompileTimeArgs = false);
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertD2MToTTKernelPass();
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/include/ttmlir/Conversion/D2MToTTKernel/D2MToTTKernel.h
+++ b/include/ttmlir/Conversion/D2MToTTKernel/D2MToTTKernel.h
@@ -20,7 +20,7 @@ namespace mlir::tt {
 
 void populateD2MToTTKernelPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
-    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode);
+    const d2m::CBProducerConsumer &cbProducerConsumer);
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertD2MToTTKernelPass();
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -183,7 +183,9 @@ def ConvertD2MToTTKernel: Pass<"convert-d2m-to-ttkernel", "::mlir::ModuleOp"> {
   let constructor = "createConvertD2MToTTKernelPass()";
   let dependentDialects = ["mlir::tt::d2m::D2MDialect", "mlir::tt::ttmetal::TTMetalDialect", "mlir::tt::ttkernel::TTKernelDialect", "mlir::arith::ArithDialect"];
   let options = [
-    Option<"ttnnMode", "ttnn-mode", "bool", /*default=*/"false", "Enable TTNN mode">
+    Option<"ttnnMode", "ttnn-mode", "bool", /*default=*/"false", "Enable TTNN mode">,
+    Option<"forceCompileTimeArgs", "force-compile-time-args", "bool", /*default=*/"false",
+           "Force uniform D2M kernel arguments into compile-time args when legal for CRTA performance comparison.">
   ];
 }
 

--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -191,6 +191,13 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
                         llvm::cl::desc("D2M/TTNN integration mode."),
                         llvm::cl::init(false)};
 
+  // Evaluation knob for comparing the CRTA path against compile-time args.
+  Option<bool> forceCompileTimeArgs{
+      *this, "force-compile-time-args",
+      llvm::cl::desc("Force uniform D2M kernel arguments into compile-time "
+                     "args when legal for CRTA performance comparison."),
+      llvm::cl::init(false)};
+
   // Option to set the target data format for the global data format conversion
   // pass.
   Option<std::string> globalDataFormatTarget{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -176,6 +176,11 @@ def TTKernel_ArgSpecAttr : TTKernel_Attr<"ArgSpec", "arg_spec"> {
 
   let extraClassDeclaration = [{
     static ArgSpecAttr setArgSpec(func::FuncOp func, ArgSpecAttr argSpec);
+
+    // For args sorting.
+    static bool isSameArg(ArgAttr lhs, ArgAttr rhs);
+    static bool isLessArg(ArgAttr lhs, ArgAttr rhs);
+
     // Returns the appended argument index.
     static size_t appendCompileTimeArg(func::FuncOp func, ArgAttr arg);
     // Returns the appended argument index.

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOpsAttrs.td
@@ -55,12 +55,14 @@ def TTMetal_KernelArgAttr : TTMetal_Attr<"KernelArg", "kernel_arg"> {
 def TTMetal_KernelArgsAttr : TTMetal_Attr<"KernelArgs", "kernel_args"> {
   let summary = "TTMetal kernel arguments attribute.";
   let description = [{
-    Holds two lists of kernel arguments, one for runtime and one for compile time.
+    Holds kernel argument bindings for common runtime (CRTA), per-core runtime (RTA),
+    and compile-time (CTA) arguments.
   }];
 
-  let parameters = (ins OptionalArrayRefParameter<"KernelArgAttr">:$rt_args,
+  let parameters = (ins OptionalArrayRefParameter<"KernelArgAttr">:$common_rt_args,
+                        OptionalArrayRefParameter<"KernelArgAttr">:$rt_args,
                         OptionalArrayRefParameter<"KernelArgAttr">:$ct_args);
-  let assemblyFormat = "`<` (`rt_args` `=` `[` $rt_args^ `]`)? ` ` (`ct_args` `=` `[` $ct_args^ `]`)? `>`";
+  let assemblyFormat = "`<` (`common_rt_args` `=` `[` $common_rt_args^ `]`)? ` ` (`rt_args` `=` `[` $rt_args^ `]`)? ` ` (`ct_args` `=` `[` $ct_args^ `]`)? `>`";
 }
 
 

--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -100,6 +100,7 @@ table KernelArg {
 }
 
 table KernelArgs {
+  crt_args: [KernelArg];
   rt_args: [KernelArg];
   ct_args: [KernelArg];
 }

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2909,9 +2909,29 @@ static int64_t appendRuntimeArg(func::FuncOp entry, ArgAttr arg,
   llvm_unreachable("runtime arg missing from arg spec");
 }
 
-static void replaceOpWithRuntimeArg(Operation *op, Type resultType,
-                                    func::FuncOp entry, ArgAttr arg,
+static int64_t appendCompileTimeArg(func::FuncOp entry, ArgAttr arg,
                                     ConversionPatternRewriter &rewriter) {
+  size_t argIdx = 0;
+  rewriter.modifyOpInPlace(
+      entry, [&]() { argIdx = ArgSpecAttr::appendCompileTimeArg(entry, arg); });
+  return static_cast<int64_t>(argIdx);
+}
+
+static bool shouldUseCompileTimeArg(ArgAttr arg, bool forceCompileTimeArgs) {
+  return forceCompileTimeArgs && arg.getIsUniform();
+}
+
+static void replaceOpWithKernelArg(Operation *op, Type resultType,
+                                   func::FuncOp entry, ArgAttr arg,
+                                   bool forceCompileTimeArgs,
+                                   ConversionPatternRewriter &rewriter) {
+  if (shouldUseCompileTimeArg(arg, forceCompileTimeArgs)) {
+    const int64_t argIdx = appendCompileTimeArg(entry, arg, rewriter);
+    rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
+        op, resultType, static_cast<int32_t>(argIdx));
+    return;
+  }
+
   const int64_t argIdx = appendRuntimeArg(entry, arg, rewriter);
   Value indexValue = index(rewriter, op->getLoc(), argIdx);
   if (arg.getIsUniform()) {
@@ -2923,9 +2943,15 @@ static void replaceOpWithRuntimeArg(Operation *op, Type resultType,
                                                      indexValue);
 }
 
-static Value createRuntimeArg(Location loc, Type resultType, func::FuncOp entry,
-                              ArgAttr arg,
-                              ConversionPatternRewriter &rewriter) {
+static Value createKernelArg(Location loc, Type resultType, func::FuncOp entry,
+                             ArgAttr arg, bool forceCompileTimeArgs,
+                             ConversionPatternRewriter &rewriter) {
+  if (shouldUseCompileTimeArg(arg, forceCompileTimeArgs)) {
+    const int64_t argIdx = appendCompileTimeArg(entry, arg, rewriter);
+    return rewriter.create<ttkernel::GetCompileArgValOp>(
+        loc, resultType, static_cast<int32_t>(argIdx));
+  }
+
   const int64_t argIdx = appendRuntimeArg(entry, arg, rewriter);
   Value indexValue = index(rewriter, loc, argIdx);
   if (arg.getIsUniform()) {
@@ -2937,7 +2963,10 @@ static Value createRuntimeArg(Location loc, Type resultType, func::FuncOp entry,
 
 class D2MGetArgRewriter : public OpConversionPattern<d2m::GetArgOp> {
 public:
-  using OpConversionPattern<d2m::GetArgOp>::OpConversionPattern;
+  D2MGetArgRewriter(TypeConverter &typeConverter, MLIRContext *context,
+                    bool forceCompileTimeArgs)
+      : OpConversionPattern<d2m::GetArgOp>(typeConverter, context),
+        forceCompileTimeArgs(forceCompileTimeArgs) {}
 
   LogicalResult
   matchAndRewrite(d2m::GetArgOp op, d2m::GetArgOpAdaptor adaptor,
@@ -2951,12 +2980,12 @@ public:
       Type convertedType = getTypeConverter()->convertType(memrefType);
       if (mlir::isa<ttkernel::CBType>(convertedType)) {
         // CB-backed memref (e.g. scratch buffer with CBLayoutAttr).
-        // Handle identically to D2MGetCBRewriter: CBPort run-time arg.
+        // Handle identically to D2MGetCBRewriter: CBPort kernel arg.
         arg = rewriter.getAttr<ArgAttr>(ArgType::CBPort, op.getOperandIndex());
         argResultType = convertedType;
 
-        replaceOpWithRuntimeArg(op.getOperation(), argResultType, entry, arg,
-                                rewriter);
+        replaceOpWithKernelArg(op.getOperation(), argResultType, entry, arg,
+                               forceCompileTimeArgs, rewriter);
         return success();
       }
 
@@ -2970,8 +2999,9 @@ public:
     } else if (mlir::isa<d2m::LocalSemaphoreType>(op.getResult().getType())) {
       ArgAttr semArg = rewriter.getAttr<ArgAttr>(ArgType::LocalSemaphore,
                                                  op.getOperandIndex());
-      Value semaphoreIndex = createRuntimeArg(
-          op.getLoc(), rewriter.getI32Type(), entry, semArg, rewriter);
+      Value semaphoreIndex =
+          createKernelArg(op.getLoc(), rewriter.getI32Type(), entry, semArg,
+                          forceCompileTimeArgs, rewriter);
       rewriter.replaceOpWithNewOp<ttkernel::GetSemaphoreOp>(op, semaphoreIndex);
       return success();
     } else if (mlir::isa<IndexType, IntegerType, FloatType>(
@@ -2986,7 +3016,8 @@ public:
           rewriter.getAttr<ArgAttr>(ArgType::Scalar, op.getOperandIndex());
 
       Value scalarArgValue =
-          createRuntimeArg(op.getLoc(), ui32Type, entry, scalarArg, rewriter);
+          createKernelArg(op.getLoc(), ui32Type, entry, scalarArg,
+                          forceCompileTimeArgs, rewriter);
 
       if (scalarType == ui32Type) {
         rewriter.replaceOp(op, scalarArgValue);
@@ -2999,15 +3030,21 @@ public:
       llvm_unreachable("unexpected arg type to GetArgOp");
     }
 
-    replaceOpWithRuntimeArg(op.getOperation(), argResultType, entry, arg,
-                            rewriter);
+    replaceOpWithKernelArg(op.getOperation(), argResultType, entry, arg,
+                           forceCompileTimeArgs, rewriter);
     return success();
   }
+
+private:
+  bool forceCompileTimeArgs;
 };
 
 class D2MGetCBRewriter : public OpConversionPattern<d2m::GetCBOp> {
 public:
-  using OpConversionPattern<d2m::GetCBOp>::OpConversionPattern;
+  D2MGetCBRewriter(TypeConverter &typeConverter, MLIRContext *context,
+                   bool forceCompileTimeArgs)
+      : OpConversionPattern<d2m::GetCBOp>(typeConverter, context),
+        forceCompileTimeArgs(forceCompileTimeArgs) {}
 
   LogicalResult
   matchAndRewrite(d2m::GetCBOp op, d2m::GetCBOpAdaptor adaptor,
@@ -3019,9 +3056,13 @@ public:
         rewriter.getAttr<ArgAttr>(ArgType::CBPort, op.getCbOperandIdx());
     Type cbType = getTypeConverter()->convertType(op.getResult().getType());
 
-    replaceOpWithRuntimeArg(op.getOperation(), cbType, entry, cbArg, rewriter);
+    replaceOpWithKernelArg(op.getOperation(), cbType, entry, cbArg,
+                           forceCompileTimeArgs, rewriter);
     return success();
   }
+
+private:
+  bool forceCompileTimeArgs;
 };
 } // namespace
 
@@ -3059,7 +3100,10 @@ public:
 namespace {
 class D2MKernelFunctionArgsRewriter : public OpConversionPattern<func::FuncOp> {
 public:
-  using OpConversionPattern<func::FuncOp>::OpConversionPattern;
+  D2MKernelFunctionArgsRewriter(TypeConverter &typeConverter,
+                                MLIRContext *context, bool forceCompileTimeArgs)
+      : OpConversionPattern<func::FuncOp>(typeConverter, context),
+        forceCompileTimeArgs(forceCompileTimeArgs) {}
 
   static ThreadType getTTKernelThreadType(func::FuncOp op) {
     d2m::ThreadAttr threadAttr =
@@ -3101,12 +3145,21 @@ public:
     args.insert(it, arg);
   }
 
+  void insertKernelArg(SmallVectorImpl<ArgAttr> &rtArgs,
+                       SmallVectorImpl<ArgAttr> &ctArgs, ArgAttr arg) const {
+    if (shouldUseCompileTimeArg(arg, forceCompileTimeArgs)) {
+      insertSortedUnique(ctArgs, arg);
+      return;
+    }
+    insertSortedUnique(rtArgs, arg);
+  }
+
   void collectArgSpecs(Builder &builder, func::FuncOp op,
                        SmallVectorImpl<ArgAttr> &rtArgs,
                        SmallVectorImpl<ArgAttr> &ctArgs) const {
     op.walk([&](d2m::GetCBOp getCBOp) {
-      insertSortedUnique(
-          rtArgs,
+      insertKernelArg(
+          rtArgs, ctArgs,
           builder.getAttr<ArgAttr>(ArgType::CBPort, getCBOp.getCbOperandIdx()));
     });
 
@@ -3115,36 +3168,36 @@ public:
       if (auto memrefType = mlir::dyn_cast<MemRefType>(argType)) {
         Type convertedType = getTypeConverter()->convertType(memrefType);
         if (mlir::isa<ttkernel::CBType>(convertedType)) {
-          insertSortedUnique(
-              rtArgs, builder.getAttr<ArgAttr>(ArgType::CBPort,
-                                               getArgOp.getOperandIndex()));
+          insertKernelArg(rtArgs, ctArgs,
+                          builder.getAttr<ArgAttr>(ArgType::CBPort,
+                                                   getArgOp.getOperandIndex()));
           return;
         }
 
         ArgAttr arg = builder.getAttr<ArgAttr>(ArgType::BufferAddress,
                                                getArgOp.getOperandIndex());
-        insertSortedUnique(rtArgs, arg);
+        insertKernelArg(rtArgs, ctArgs, arg);
         return;
       }
 
       if (mlir::isa<d2m::GlobalSemaphoreType>(argType)) {
         ArgAttr arg = builder.getAttr<ArgAttr>(ArgType::GlobalSemaphore,
                                                getArgOp.getOperandIndex());
-        insertSortedUnique(rtArgs, arg);
+        insertKernelArg(rtArgs, ctArgs, arg);
         return;
       }
 
       if (mlir::isa<d2m::LocalSemaphoreType>(argType)) {
-        insertSortedUnique(
-            rtArgs, builder.getAttr<ArgAttr>(ArgType::LocalSemaphore,
-                                             getArgOp.getOperandIndex()));
+        insertKernelArg(rtArgs, ctArgs,
+                        builder.getAttr<ArgAttr>(ArgType::LocalSemaphore,
+                                                 getArgOp.getOperandIndex()));
         return;
       }
 
       if (mlir::isa<IndexType, IntegerType, FloatType>(argType)) {
         ArgAttr arg = builder.getAttr<ArgAttr>(ArgType::Scalar,
                                                getArgOp.getOperandIndex());
-        insertSortedUnique(rtArgs, arg);
+        insertKernelArg(rtArgs, ctArgs, arg);
       }
     });
   }
@@ -3167,6 +3220,9 @@ public:
     });
     return success();
   }
+
+private:
+  bool forceCompileTimeArgs;
 };
 } // namespace
 
@@ -3413,9 +3469,11 @@ namespace mlir::tt {
 
 void populateD2MToTTKernelPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
-    const d2m::CBProducerConsumer &cbProducerConsumer) {
+    const d2m::CBProducerConsumer &cbProducerConsumer,
+    bool forceCompileTimeArgs) {
   // clang-format off
-  patterns.add<ttkernel::D2MKernelFunctionArgsRewriter>(typeConverter, ctx);
+  patterns.add<ttkernel::D2MKernelFunctionArgsRewriter>(
+      typeConverter, ctx, forceCompileTimeArgs);
   patterns.add<ttkernel::PassthroughRewriter<memref::CastOp>,
                ttkernel::MemRefSubviewRewriter,
 
@@ -3535,8 +3593,10 @@ void populateD2MToTTKernelPatterns(
                ttkernel::D2MSemaphoreWaitRewriter,
                ttkernel::D2MDeviceSynchronizeRewriter>(typeConverter, ctx);
 
-  patterns.add<ttkernel::D2MGetArgRewriter>(typeConverter, ctx);
-  patterns.add<ttkernel::D2MGetCBRewriter>(typeConverter, ctx);
+  patterns.add<ttkernel::D2MGetArgRewriter>(typeConverter, ctx,
+                                            forceCompileTimeArgs);
+  patterns.add<ttkernel::D2MGetCBRewriter>(typeConverter, ctx,
+                                           forceCompileTimeArgs);
   patterns.add<ttkernel::D2MDMAReadRewriter>(typeConverter, ctx, &cbProducerConsumer);
   patterns.add<ttkernel::D2MDMAWriteRewriter>(typeConverter, ctx, &cbProducerConsumer);
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2889,19 +2889,61 @@ public:
 } // namespace
 
 namespace {
+static int64_t appendRuntimeArg(func::FuncOp entry, ArgAttr arg,
+                                ConversionPatternRewriter &rewriter) {
+  rewriter.modifyOpInPlace(
+      entry, [&]() { ArgSpecAttr::appendRuntimeArg(entry, arg); });
+
+  auto argSpec = entry->getAttrOfType<ArgSpecAttr>(ArgSpecAttr::name);
+
+  // RTA (non-uniform) and CRTA (uniform) are counted in their own index spaces.
+  int64_t index = 0;
+  for (ArgAttr existingArg : argSpec.getRtArgs()) {
+    if (existingArg.getIsUniform() == arg.getIsUniform()) {
+      if (ArgSpecAttr::isSameArg(existingArg, arg)) {
+        return index;
+      }
+      index++;
+    }
+  }
+  llvm_unreachable("runtime arg missing from arg spec");
+}
+
+static void replaceOpWithRuntimeArg(Operation *op, Type resultType,
+                                    func::FuncOp entry, ArgAttr arg,
+                                    ConversionPatternRewriter &rewriter) {
+  const int64_t argIdx = appendRuntimeArg(entry, arg, rewriter);
+  Value indexValue = index(rewriter, op->getLoc(), argIdx);
+  if (arg.getIsUniform()) {
+    rewriter.replaceOpWithNewOp<ttkernel::GetCommonArgValOp>(op, resultType,
+                                                             indexValue);
+    return;
+  }
+  rewriter.replaceOpWithNewOp<ttkernel::GetArgValOp>(op, resultType,
+                                                     indexValue);
+}
+
+static Value createRuntimeArg(Location loc, Type resultType, func::FuncOp entry,
+                              ArgAttr arg,
+                              ConversionPatternRewriter &rewriter) {
+  const int64_t argIdx = appendRuntimeArg(entry, arg, rewriter);
+  Value indexValue = index(rewriter, loc, argIdx);
+  if (arg.getIsUniform()) {
+    return rewriter.create<ttkernel::GetCommonArgValOp>(loc, resultType,
+                                                        indexValue);
+  }
+  return rewriter.create<ttkernel::GetArgValOp>(loc, resultType, indexValue);
+}
+
 class D2MGetArgRewriter : public OpConversionPattern<d2m::GetArgOp> {
 public:
-  D2MGetArgRewriter(TypeConverter &typeConverter, MLIRContext *context,
-                    bool ttnnMode)
-      : OpConversionPattern<d2m::GetArgOp>(typeConverter, context),
-        ttnnMode(ttnnMode) {}
+  using OpConversionPattern<d2m::GetArgOp>::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(d2m::GetArgOp op, d2m::GetArgOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     func::FuncOp entry = op->getParentOfType<func::FuncOp>();
     ArgAttr arg;
-    size_t argIndex;
     Type argResultType;
 
     if (auto memrefType =
@@ -2909,15 +2951,12 @@ public:
       Type convertedType = getTypeConverter()->convertType(memrefType);
       if (mlir::isa<ttkernel::CBType>(convertedType)) {
         // CB-backed memref (e.g. scratch buffer with CBLayoutAttr).
-        // Handle identically to D2MGetCBRewriter: CBPort compile-time arg.
+        // Handle identically to D2MGetCBRewriter: CBPort run-time arg.
         arg = rewriter.getAttr<ArgAttr>(ArgType::CBPort, op.getOperandIndex());
         argResultType = convertedType;
 
-        rewriter.modifyOpInPlace(entry, [&]() {
-          argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg);
-        });
-        rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
-            op, argResultType, static_cast<int32_t>(argIndex));
+        replaceOpWithRuntimeArg(op.getOperation(), argResultType, entry, arg,
+                                rewriter);
         return success();
       }
 
@@ -2931,62 +2970,39 @@ public:
     } else if (mlir::isa<d2m::LocalSemaphoreType>(op.getResult().getType())) {
       ArgAttr semArg = rewriter.getAttr<ArgAttr>(ArgType::LocalSemaphore,
                                                  op.getOperandIndex());
-      size_t ctArgIdx;
-      rewriter.modifyOpInPlace(entry, [&]() {
-        ctArgIdx = ArgSpecAttr::appendCompileTimeArg(entry, semArg);
-      });
-      auto semaphoreIndex = rewriter.create<ttkernel::GetCompileArgValOp>(
-          op.getLoc(), rewriter.getI32Type(), static_cast<int32_t>(ctArgIdx));
+      Value semaphoreIndex = createRuntimeArg(
+          op.getLoc(), rewriter.getI32Type(), entry, semArg, rewriter);
       rewriter.replaceOpWithNewOp<ttkernel::GetSemaphoreOp>(op, semaphoreIndex);
       return success();
     } else if (mlir::isa<IndexType, IntegerType, FloatType>(
                    op.getResult().getType())) {
-      // Scalar additional args are always stored as ui32 in the CT arg slot.
-      // If the declared type differs from ui32, a ReinterpretCastOp recovers
-      // the correct type.
+      // Scalar additional args are stored as ui32. If the declared type differs
+      // from ui32, a BitcastOp recovers the correct type.
       Type scalarType = op.getResult().getType();
       Type ui32Type =
           IntegerType::get(op.getContext(), 32, IntegerType::Unsigned);
 
       ArgAttr scalarArg =
           rewriter.getAttr<ArgAttr>(ArgType::Scalar, op.getOperandIndex());
-      size_t ctArgIdx;
-      rewriter.modifyOpInPlace(entry, [&]() {
-        ctArgIdx = ArgSpecAttr::appendCompileTimeArg(entry, scalarArg);
-      });
 
-      Value ctArg = rewriter.create<ttkernel::GetCompileArgValOp>(
-          op.getLoc(), ui32Type, static_cast<int32_t>(ctArgIdx));
+      Value scalarArgValue =
+          createRuntimeArg(op.getLoc(), ui32Type, entry, scalarArg, rewriter);
 
       if (scalarType == ui32Type) {
-        rewriter.replaceOp(op, ctArg);
+        rewriter.replaceOp(op, scalarArgValue);
       } else {
-        rewriter.replaceOpWithNewOp<ttkernel::BitcastOp>(op, scalarType, ctArg);
+        rewriter.replaceOpWithNewOp<ttkernel::BitcastOp>(op, scalarType,
+                                                         scalarArgValue);
       }
       return success();
     } else {
       llvm_unreachable("unexpected arg type to GetArgOp");
     }
 
-    if (ttnnMode) {
-      rewriter.modifyOpInPlace(entry, [&]() {
-        argIndex = ArgSpecAttr::appendRuntimeArg(entry, arg);
-      });
-      rewriter.replaceOpWithNewOp<ttkernel::GetCommonArgValOp>(
-          op, argResultType, index(rewriter, op->getLoc(), argIndex));
-
-    } else {
-      rewriter.modifyOpInPlace(entry, [&]() {
-        argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg);
-      });
-      rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
-          op, argResultType, argIndex);
-    }
+    replaceOpWithRuntimeArg(op.getOperation(), argResultType, entry, arg,
+                            rewriter);
     return success();
   }
-
-private:
-  bool ttnnMode;
 };
 
 class D2MGetCBRewriter : public OpConversionPattern<d2m::GetCBOp> {
@@ -2996,24 +3012,14 @@ public:
   LogicalResult
   matchAndRewrite(d2m::GetCBOp op, d2m::GetCBOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    // Append a CBPort entry to the parent function's ArgSpec so that
-    // D2MToTTNN can generate the corresponding cb_buffer_index in the
-    // kernel descriptor's ct_args.  The operand index tells the runtime
-    // which operand's buffer to associate with this CB.
+    // Append a CBPort entry to the parent function's ArgSpec. The operand index
+    // tells the runtime which operand's buffer to associate with this CB.
     func::FuncOp entry = op->getParentOfType<func::FuncOp>();
     ArgAttr cbArg =
         rewriter.getAttr<ArgAttr>(ArgType::CBPort, op.getCbOperandIdx());
-    size_t ctArgIndex;
-    rewriter.modifyOpInPlace(entry, [&]() {
-      ctArgIndex = ArgSpecAttr::appendCompileTimeArg(entry, cbArg);
-    });
-
-    // Emit a get_compile_time_arg_val that reads the port from ct_args at
-    // runtime. This allows the spatial op to remap CB ports per grid range
-    // by overriding compile-time arguments.
     Type cbType = getTypeConverter()->convertType(op.getResult().getType());
-    rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
-        op, cbType, static_cast<int32_t>(ctArgIndex));
+
+    replaceOpWithRuntimeArg(op.getOperation(), cbType, entry, cbArg, rewriter);
     return success();
   }
 };
@@ -3082,6 +3088,67 @@ public:
     ArgSpecAttr::setArgSpec(op, builder.getAttr<ArgSpecAttr>(rtArgs, ctArgs));
   }
 
+  static void insertSortedUnique(SmallVectorImpl<ArgAttr> &args, ArgAttr arg) {
+    if (llvm::any_of(args, [&](ArgAttr existing) {
+          return ArgSpecAttr::isSameArg(existing, arg);
+        })) {
+      return;
+    }
+    auto *it = std::lower_bound(args.begin(), args.end(), arg,
+                                [](ArgAttr lhs, ArgAttr rhs) {
+                                  return ArgSpecAttr::isLessArg(lhs, rhs);
+                                });
+    args.insert(it, arg);
+  }
+
+  void collectArgSpecs(Builder &builder, func::FuncOp op,
+                       SmallVectorImpl<ArgAttr> &rtArgs,
+                       SmallVectorImpl<ArgAttr> &ctArgs) const {
+    op.walk([&](d2m::GetCBOp getCBOp) {
+      insertSortedUnique(
+          rtArgs,
+          builder.getAttr<ArgAttr>(ArgType::CBPort, getCBOp.getCbOperandIdx()));
+    });
+
+    op.walk([&](d2m::GetArgOp getArgOp) {
+      Type argType = getArgOp.getResult().getType();
+      if (auto memrefType = mlir::dyn_cast<MemRefType>(argType)) {
+        Type convertedType = getTypeConverter()->convertType(memrefType);
+        if (mlir::isa<ttkernel::CBType>(convertedType)) {
+          insertSortedUnique(
+              rtArgs, builder.getAttr<ArgAttr>(ArgType::CBPort,
+                                               getArgOp.getOperandIndex()));
+          return;
+        }
+
+        ArgAttr arg = builder.getAttr<ArgAttr>(ArgType::BufferAddress,
+                                               getArgOp.getOperandIndex());
+        insertSortedUnique(rtArgs, arg);
+        return;
+      }
+
+      if (mlir::isa<d2m::GlobalSemaphoreType>(argType)) {
+        ArgAttr arg = builder.getAttr<ArgAttr>(ArgType::GlobalSemaphore,
+                                               getArgOp.getOperandIndex());
+        insertSortedUnique(rtArgs, arg);
+        return;
+      }
+
+      if (mlir::isa<d2m::LocalSemaphoreType>(argType)) {
+        insertSortedUnique(
+            rtArgs, builder.getAttr<ArgAttr>(ArgType::LocalSemaphore,
+                                             getArgOp.getOperandIndex()));
+        return;
+      }
+
+      if (mlir::isa<IndexType, IntegerType, FloatType>(argType)) {
+        ArgAttr arg = builder.getAttr<ArgAttr>(ArgType::Scalar,
+                                               getArgOp.getOperandIndex());
+        insertSortedUnique(rtArgs, arg);
+      }
+    });
+  }
+
   LogicalResult
   matchAndRewrite(func::FuncOp op, func::FuncOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
@@ -3092,17 +3159,7 @@ public:
 
     SmallVector<ArgAttr> rtArgSpecVector;
     SmallVector<ArgAttr> ctArgSpecVector;
-
-    // Zero-input functions: just convert attrs and set function type.
-    // The D2MGetCBRewriter will append CB entries to the ArgSpec as it
-    // processes get_cb ops within the function body.
-    if (op.getFunctionType().getNumInputs() == 0) {
-      rewriter.modifyOpInPlace(op, [&]() {
-        op.setType(rewriter.getFunctionType(TypeRange(), TypeRange()));
-        convertFunctionAttrs(rewriter, op, rtArgSpecVector, ctArgSpecVector);
-      });
-      return success();
-    }
+    collectArgSpecs(rewriter, op, rtArgSpecVector, ctArgSpecVector);
 
     rewriter.modifyOpInPlace(op, [&]() {
       op.setType(rewriter.getFunctionType(TypeRange(), TypeRange()));
@@ -3356,10 +3413,10 @@ namespace mlir::tt {
 
 void populateD2MToTTKernelPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
-    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode) {
+    const d2m::CBProducerConsumer &cbProducerConsumer) {
   // clang-format off
-  patterns.add<ttkernel::D2MKernelFunctionArgsRewriter,
-               ttkernel::PassthroughRewriter<memref::CastOp>,
+  patterns.add<ttkernel::D2MKernelFunctionArgsRewriter>(typeConverter, ctx);
+  patterns.add<ttkernel::PassthroughRewriter<memref::CastOp>,
                ttkernel::MemRefSubviewRewriter,
 
                // FPU.
@@ -3478,8 +3535,7 @@ void populateD2MToTTKernelPatterns(
                ttkernel::D2MSemaphoreWaitRewriter,
                ttkernel::D2MDeviceSynchronizeRewriter>(typeConverter, ctx);
 
-  patterns.add<ttkernel::D2MGetArgRewriter>(typeConverter, ctx,
-                                                      ttnnMode);
+  patterns.add<ttkernel::D2MGetArgRewriter>(typeConverter, ctx);
   patterns.add<ttkernel::D2MGetCBRewriter>(typeConverter, ctx);
   patterns.add<ttkernel::D2MDMAReadRewriter>(typeConverter, ctx, &cbProducerConsumer);
   patterns.add<ttkernel::D2MDMAWriteRewriter>(typeConverter, ctx, &cbProducerConsumer);

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -178,7 +178,7 @@ struct ConvertD2MToTTKernel
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
         patterns, typeConverter);
     populateD2MToTTKernelPatterns(&getContext(), patterns, typeConverter,
-                                  cbProducerConsumer, ttnnMode);
+                                  cbProducerConsumer);
     scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter,
                                                          patterns, target);
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -56,6 +56,7 @@ struct ConvertD2MToTTKernel
     // Workaround: Passes are required to be copy-constructible but autogen'ed
     // base class copy constructors ignore Pass option fields.
     this->ttnnMode = rhs.ttnnMode;
+    this->forceCompileTimeArgs = rhs.forceCompileTimeArgs;
   }
 
   void runOnOperation() final {
@@ -178,7 +179,7 @@ struct ConvertD2MToTTKernel
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
         patterns, typeConverter);
     populateD2MToTTKernelPatterns(&getContext(), patterns, typeConverter,
-                                  cbProducerConsumer);
+                                  cbProducerConsumer, forceCompileTimeArgs);
     scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter,
                                                          patterns, target);
 

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -59,17 +59,19 @@ public:
     ttkernel::ArgSpecAttr kernelSpec =
         kernelFunc->getAttrOfType<ttkernel::ArgSpecAttr>(
             ttkernel::ArgSpecAttr::name);
+    SmallVector<ttmetal::KernelArgAttr> crtArgs;
     SmallVector<ttmetal::KernelArgAttr> rtArgs;
     SmallVector<ttmetal::KernelArgAttr> ctArgs;
     for (ttkernel::ArgAttr arg : kernelSpec.getRtArgs()) {
+      auto &args = arg.getIsUniform() ? crtArgs : rtArgs;
       if (arg.getArgType() == ttkernel::ArgType::CBPort) {
-        rtArgs.push_back(builder.getAttr<ttmetal::KernelArgAttr>(
+        args.push_back(builder.getAttr<ttmetal::KernelArgAttr>(
             arg.getArgType(), cbOperandIndexToPort.at(arg.getOperandIndex())));
       } else if (arg.getArgType() == ttkernel::ArgType::NamedArgument) {
-        rtArgs.push_back(builder.getAttr<ttmetal::KernelArgAttr>(
+        args.push_back(builder.getAttr<ttmetal::KernelArgAttr>(
             arg.getArgType(), arg.getOperandIndex()));
       } else {
-        rtArgs.push_back(builder.getAttr<ttmetal::KernelArgAttr>(
+        args.push_back(builder.getAttr<ttmetal::KernelArgAttr>(
             arg.getArgType(), argMapping.at(arg.getOperandIndex())));
       }
     }
@@ -85,7 +87,7 @@ public:
             arg.getArgType(), argMapping.at(arg.getOperandIndex())));
       }
     }
-    return builder.getAttr<ttmetal::KernelArgsAttr>(rtArgs, ctArgs);
+    return builder.getAttr<ttmetal::KernelArgsAttr>(crtArgs, rtArgs, ctArgs);
   }
 
   static ArrayAttr convertThreadsToKernelConfigs(
@@ -737,7 +739,8 @@ private:
                                       const SpatialRemapTable &remapTable,
                                       size_t mergedCbSlotBase) {
     size_t operandIndex = kernelArg.getOperandIndex();
-    if (kernelArg.getType() == ttkernel::ArgType::BufferAddress) {
+    if (kernelArg.getType() == ttkernel::ArgType::BufferAddress ||
+        kernelArg.getType() == ttkernel::ArgType::Scalar) {
       if (auto unified = remapTable.lookupIO(enqueueProgram, operandIndex)) {
         operandIndex = *unified;
       }
@@ -762,11 +765,18 @@ private:
                   ttmetal::EnqueueProgramOp enqueueProgram,
                   const SpatialRemapTable &remapTable,
                   size_t mergedCbSlotBase) {
+    SmallVector<KernelArgAttr> remappedCommonRuntimeArgs;
     SmallVector<KernelArgAttr> remappedRuntimeArgs;
     SmallVector<KernelArgAttr> remappedCompileTimeArgs;
+    remappedCommonRuntimeArgs.reserve(kernelArgs.getCommonRtArgs().size());
     remappedRuntimeArgs.reserve(kernelArgs.getRtArgs().size());
     remappedCompileTimeArgs.reserve(kernelArgs.getCtArgs().size());
 
+    for (KernelArgAttr commonRuntimeArg : kernelArgs.getCommonRtArgs()) {
+      remappedCommonRuntimeArgs.push_back(
+          remapKernelArg(builder, commonRuntimeArg, enqueueProgram, remapTable,
+                         mergedCbSlotBase));
+    }
     for (KernelArgAttr runtimeArg : kernelArgs.getRtArgs()) {
       remappedRuntimeArgs.push_back(remapKernelArg(
           builder, runtimeArg, enqueueProgram, remapTable, mergedCbSlotBase));
@@ -777,7 +787,8 @@ private:
                          mergedCbSlotBase));
     }
 
-    return builder.getAttr<KernelArgsAttr>(remappedRuntimeArgs,
+    return builder.getAttr<KernelArgsAttr>(remappedCommonRuntimeArgs,
+                                           remappedRuntimeArgs,
                                            remappedCompileTimeArgs);
   }
 

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -256,10 +256,16 @@ createSemaphoreDescriptors(Builder &builder, const ArrayAttr &threads,
       continue;
     }
 
-    for (auto ctArg : kernelSpec.getCtArgs()) {
-      if (ctArg.getArgType() == ttkernel::ArgType::LocalSemaphore) {
-        seenSemaphoreIndices.insert(ctArg.getOperandIndex());
+    auto collectLocalSemaphore = [&](ttkernel::ArgAttr arg) {
+      if (arg.getArgType() == ttkernel::ArgType::LocalSemaphore) {
+        seenSemaphoreIndices.insert(arg.getOperandIndex());
       }
+    };
+    for (auto rtArg : kernelSpec.getRtArgs()) {
+      collectLocalSemaphore(rtArg);
+    }
+    for (auto ctArg : kernelSpec.getCtArgs()) {
+      collectLocalSemaphore(ctArg);
     }
   }
 
@@ -304,10 +310,8 @@ static SmallVector<mlir::Attribute> createKernelDescriptors(
     auto kernelSpec = kernelFunc->getAttrOfType<ttkernel::ArgSpecAttr>(
         ttkernel::ArgSpecAttr::name);
 
-    // Note: D2MToTTKernel will only populate kernelSpec with rtargs in the
-    // ttnn-mode, however despite the name, they are actually common runtime
-    // args. TTKernel ArgSpec does not have crt field, and the normal tt-metal
-    // path doesn't use rt args at all.
+    // Uniform TTKernel runtime args are modeled as common runtime args in
+    // TTNN generic descriptors.
     auto crtArgs = kernelSpec.getRtArgs();
     auto ctArgs = kernelSpec.getCtArgs();
     llvm::SmallVector<mlir::Attribute> kernelCTArgs(ctArgs.size());
@@ -863,6 +867,11 @@ remapSpatialKernelArgs(MLIRContext *ctx, ArrayRef<Attribute> args,
       if (auto unified = remapTable.lookupAdditional(
               generic, globalSem.getGlobalSemaphoreIndex())) {
         mapped = ttnn::KernelArgGlobalSemaphoreAttr::get(ctx, *unified);
+      }
+    } else if (auto scalar = mlir::dyn_cast<ttnn::KernelArgScalarAttr>(arg)) {
+      if (auto unified =
+              remapTable.lookupAdditional(generic, scalar.getOperandIndex())) {
+        mapped = ttnn::KernelArgScalarAttr::get(ctx, *unified);
       }
     }
     out.push_back(mapped);

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -4,7 +4,7 @@
 #include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"
 
 #include "ttmlir/Asserts.h"
-#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
@@ -29,7 +29,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <array>
 #include <functional>
@@ -487,7 +486,7 @@ public:
       return Builder(ctx).getI64Type();
     });
     addConversion([ctx](mlir::tt::ttkernel::CBType type) -> Type {
-      return Builder(ctx).getType<emitc::OpaqueType>("::tt::CB");
+      return IntegerType::get(ctx, 32, IntegerType::Unsigned);
     });
     addConversion([ctx](mlir::tt::ttkernel::LocalSemaphoreType type) -> Type {
       // Convert semaphore to an address type. (i32)
@@ -1135,12 +1134,12 @@ public:
       return literal.getResult();
     }
 
+    const bool isCBArg = mlir::isa<ttkernel::CBType>(op.getResult().getType());
     auto call = rewriter.create<emitc::CallOpaqueOp>(
         op.getLoc(), resultType, getOpName(op), nullptr,
         getTemplateArgs(rewriter, op), adaptor.getOperands());
 
-    // Relay the preassigned CB runtime arg index.
-    if (mlir::isa<ttkernel::CBType>(op.getResult().getType())) {
+    if (isCBArg) {
       auto idxAttr =
           op->template getAttrOfType<IntegerAttr>("ttkernel.cb_arg_idx");
       assert(idxAttr && "CB runtime arg must have a stable lowering name");

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -293,7 +293,10 @@ void createD2MToTTNNPipeline(OpPassManager &pm,
 void createD2MToTTKernelPreEmitCPipeline(OpPassManager &pm,
                                          const D2MPipelineOptions &options) {
   d2m::ConvertD2MToTTKernelOptions D2MToTTKernelOptions;
-  { D2MToTTKernelOptions.ttnnMode = options.ttnnMode; }
+  {
+    D2MToTTKernelOptions.ttnnMode = options.ttnnMode;
+    D2MToTTKernelOptions.forceCompileTimeArgs = options.forceCompileTimeArgs;
+  }
   pm.addPass(tt::createConvertD2MToTTKernelPass(D2MToTTKernelOptions));
   pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(ttkernel::createTTKernelControlDstSection());

--- a/lib/Dialect/D2M/Transforms/NormalizeThreadArgs.cpp
+++ b/lib/Dialect/D2M/Transforms/NormalizeThreadArgs.cpp
@@ -23,6 +23,16 @@ namespace mlir::tt::d2m {
 
 namespace {
 
+static ResolutionStageAttr getResolutionStageForArg(MLIRContext *ctx,
+                                                    Type argType) {
+  const bool runtimeResolved =
+      mlir::isa<MemRefType, d2m::GlobalSemaphoreType, d2m::LocalSemaphoreType,
+                IndexType, IntegerType, FloatType>(argType);
+  return ResolutionStageAttr::get(ctx, runtimeResolved
+                                           ? ResolutionStage::Runtime
+                                           : ResolutionStage::Compile);
+}
+
 static void rewriteOperand(IRRewriter &rewriter, Operation *op,
                            OpOperand &operand, unsigned operandIndex) {
   MemRefType memref = mlir::cast<MemRefType>(operand.get().getType());
@@ -32,8 +42,7 @@ static void rewriteOperand(IRRewriter &rewriter, Operation *op,
   rewriter.setInsertionPoint(op);
   Operation *buf = rewriter.create<GetArgOp>(
       op->getLoc(), memref, operandIndex,
-      ResolutionStageAttr::get(rewriter.getContext(),
-                               ResolutionStage::Compile));
+      getResolutionStageForArg(rewriter.getContext(), memref));
   operand.set(buf->getResult(0));
 }
 
@@ -82,8 +91,8 @@ public:
     ModuleOp moduleOp = getOperation();
     IRRewriter rewriter(&getContext());
 
-    // Fill in resolution_stage = compile on any existing get_* ops that don't
-    // already have the attribute set.
+    // Fill in resolution_stage on any existing get_* ops that don't already
+    // have the attribute set.
     auto compileAttr =
         ResolutionStageAttr::get(&getContext(), ResolutionStage::Compile);
     moduleOp->walk([&](Operation *op) {
@@ -96,8 +105,11 @@ public:
           })
           .Case<GetArgOp>([&](GetArgOp argOp) {
             if (!argOp.getResolutionStageAttr()) {
-              rewriter.modifyOpInPlace(
-                  argOp, [&]() { argOp.setResolutionStageAttr(compileAttr); });
+              auto resolutionStage =
+                  getResolutionStageForArg(&getContext(), argOp.getType());
+              rewriter.modifyOpInPlace(argOp, [&]() {
+                argOp.setResolutionStageAttr(resolutionStage);
+              });
             }
           });
     });
@@ -135,10 +147,9 @@ public:
           for (auto &block : region) {
             rewriter.setInsertionPointToStart(&block);
 
-            auto compileTimeAttr = ResolutionStageAttr::get(
-                &getContext(), ResolutionStage::Compile);
-            Value replacement = rewriter.create<GetArgOp>(arg.getLoc(), argType,
-                                                          i, compileTimeAttr);
+            Value replacement = rewriter.create<GetArgOp>(
+                arg.getLoc(), argType, i,
+                getResolutionStageForArg(&getContext(), argType));
             rewriter.setInsertionPointAfter(replacement.getDefiningOp());
 
             rewriter.replaceUsesWithIf(arg, replacement, [&](OpOperand &use) {

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -16,7 +16,6 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
-#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::tt::d2m {
@@ -28,6 +27,12 @@ namespace {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+static void appendUnique(SmallVectorImpl<Value> &values, Value value) {
+  if (!llvm::is_contained(values, value)) {
+    values.push_back(value);
+  }
+}
 
 bool isAliasedStore(RemoteStoreOp storeOp) {
   auto operandAliasOp =
@@ -172,8 +177,8 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
 
   for (auto [start, end] : computeRegions) {
 
-    DenseSet<Value> loadedCBOperands;
-    DenseSet<Value> storedCBOperands;
+    SmallVector<Value> loadedCBOperands;
+    SmallVector<Value> storedCBOperands;
 
     // For memref load and stores, trace to cb operand to get producers and
     // consumers for syncrhonized region.
@@ -183,7 +188,7 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
       op.walk([&](memref::LoadOp loadOp) {
         Value cb = traceComputeMemrefToCB(loadOp.getMemref(), genericOp);
         if (cb) {
-          loadedCBOperands.insert(cb);
+          appendUnique(loadedCBOperands, cb);
         }
         return WalkResult::advance();
       });
@@ -193,7 +198,7 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
       op.walk([&](memref::StoreOp storeOp) {
         Value cb = traceComputeMemrefToCB(storeOp.getMemref(), genericOp);
         if (cb) {
-          storedCBOperands.insert(cb);
+          appendUnique(storedCBOperands, cb);
         }
         return WalkResult::advance();
       });
@@ -205,13 +210,13 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
         Value cbOutput =
             traceComputeMemrefToCB(tileMatmulBlockOp.getOutput(), genericOp);
         if (cbA) {
-          loadedCBOperands.insert(cbA);
+          appendUnique(loadedCBOperands, cbA);
         }
         if (cbB) {
-          loadedCBOperands.insert(cbB);
+          appendUnique(loadedCBOperands, cbB);
         }
         if (cbOutput) {
-          storedCBOperands.insert(cbOutput);
+          appendUnique(storedCBOperands, cbOutput);
         }
         return WalkResult::advance();
       });
@@ -219,16 +224,14 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
 
     // Remove allocs in load that are also in store since this is output cb
     // reuse and not an actual input.
-    for (Value storedCBOperand : storedCBOperands) {
-      if (loadedCBOperands.contains(storedCBOperand)) {
-        loadedCBOperands.erase(storedCBOperand);
-      }
-    }
+    DenseSet<Value> storedCBOperandSet(storedCBOperands.begin(),
+                                       storedCBOperands.end());
+    llvm::erase_if(loadedCBOperands, [&](Value loadedCBOperand) {
+      return storedCBOperandSet.contains(loadedCBOperand);
+    });
 
-    utils::wrapInSynchronizedRegion(
-        rewriter, start, end,
-        SmallVector<Value>(loadedCBOperands.begin(), loadedCBOperands.end()),
-        SmallVector<Value>(storedCBOperands.begin(), storedCBOperands.end()));
+    utils::wrapInSynchronizedRegion(rewriter, start, end, loadedCBOperands,
+                                    storedCBOperands);
   }
 
   return success();

--- a/lib/Dialect/TTKernel/IR/TTKernelOpsTypes.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOpsTypes.cpp
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
-#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
+
+#include <algorithm>
 
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.cpp.inc"
 
@@ -34,11 +36,60 @@ getOrCreateArgSpec(mlir::func::FuncOp op) {
   return {rtArgSpecVector, ctArgSpecVector};
 }
 
+bool mlir::tt::ttkernel::ArgSpecAttr::isSameArg(ArgAttr lhs, ArgAttr rhs) {
+  return lhs.getArgType() == rhs.getArgType() &&
+         lhs.getOperandIndex() == rhs.getOperandIndex() &&
+         lhs.getIsUniform() == rhs.getIsUniform() &&
+         lhs.getArgumentName() == rhs.getArgumentName();
+}
+
+bool mlir::tt::ttkernel::ArgSpecAttr::isLessArg(ArgAttr lhs, ArgAttr rhs) {
+  if (lhs.getArgType() != rhs.getArgType()) {
+    return static_cast<uint32_t>(lhs.getArgType()) <
+           static_cast<uint32_t>(rhs.getArgType());
+  }
+  if (lhs.getOperandIndex() != rhs.getOperandIndex()) {
+    return lhs.getOperandIndex() < rhs.getOperandIndex();
+  }
+  if (lhs.getIsUniform() != rhs.getIsUniform()) {
+    return lhs.getIsUniform() < rhs.getIsUniform();
+  }
+  return lhs.getArgumentName().getValue() < rhs.getArgumentName().getValue();
+}
+
+static void incrementCompileArgUsers(func::FuncOp op, size_t firstIndex) {
+  op->walk([&](GetCompileArgValOp getArgOp) {
+    uint32_t index = getArgOp.getArgIndex();
+    if (index >= firstIndex) {
+      getArgOp.setArgIndex(index + 1);
+    }
+  });
+}
+
 static size_t appendArgImpl(func::FuncOp op, ArgAttr arg, bool isCompileTime) {
   auto [rtArgSpecVector, ctArgSpecVector] = getOrCreateArgSpec(op);
   auto &argSpecVector = isCompileTime ? ctArgSpecVector : rtArgSpecVector;
-  size_t nextIndex = argSpecVector.size();
-  argSpecVector.push_back(arg);
+  auto *it = std::find_if(argSpecVector.begin(), argSpecVector.end(),
+                          [&](ArgAttr existingArg) {
+                            return ArgSpecAttr::isSameArg(arg, existingArg);
+                          });
+  if (it != argSpecVector.end()) {
+    return static_cast<size_t>(std::distance(argSpecVector.begin(), it));
+  }
+
+  auto *insertionIt =
+      isCompileTime
+          ? std::lower_bound(argSpecVector.begin(), argSpecVector.end(), arg,
+                             [](ArgAttr lhs, ArgAttr rhs) {
+                               return ArgSpecAttr::isLessArg(lhs, rhs);
+                             })
+          : argSpecVector.end();
+  size_t nextIndex =
+      static_cast<size_t>(std::distance(argSpecVector.begin(), insertionIt));
+  if (isCompileTime && insertionIt != argSpecVector.end()) {
+    incrementCompileArgUsers(op, nextIndex);
+  }
+  argSpecVector.insert(insertionIt, arg);
   auto argSpec =
       ArgSpecAttr::get(arg.getContext(), rtArgSpecVector, ctArgSpecVector);
   op->setAttr(ArgSpecAttr::name, argSpec);

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -990,6 +990,7 @@ DeviceComputeKernelConfigAttr::withDstFullSyncEn(bool value) const {
                    mlir::tt::ttnn::KernelArgAddressOfTensorAttr,
                    mlir::tt::ttnn::KernelArgSemaphoreAtAttr,
                    mlir::tt::ttnn::KernelArgGlobalSemaphoreAttr,
+                   mlir::tt::ttnn::KernelArgScalarAttr,
                    mlir::tt::ttnn::KernelArgNamedArgAttr>(arg)) {
       return emitError() << "Unexpected common runtime argument";
     }

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -45,12 +45,7 @@ namespace {
 class ScopedModuleHelper {
 public:
   ScopedModuleHelper(OpBuilder *builder, Location loc, Region *region,
-                     ThreadType threadType, StringRef originalSymbolName = "")
-      : builder(builder), loc(loc) {
-    if (!originalSymbolName.empty()) {
-      emitComment(originalSymbolName);
-    }
-
+                     ThreadType threadType) {
     std::set<llvm::StringRef> headers;
 
     // Baseline, always required.
@@ -232,10 +227,6 @@ public:
 
   ~ScopedModuleHelper() = default;
 
-  void emitComment(StringRef str) {
-    builder->create<emitc::VerbatimOp>(loc, (Twine("// ") + str).str());
-  }
-
   void emitLlk(const char *generated, unsigned int len) {
     llvm::StringRef snippet(generated, len);
     // Prevent duplicated emissions.
@@ -300,8 +291,6 @@ void dprint(Arg &&arg, ArgV&&... argv) {
   }
 
 private:
-  OpBuilder *builder;
-  Location loc;
   std::set<llvm::StringRef> emittedLlks;
   llvm::SmallVector<llvm::StringRef> llksToEmit;
 };
@@ -326,8 +315,7 @@ cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType) {
 
   Region *kernelMainRegion;
   {
-    ScopedModuleHelper threadConfigHelper(&builder, loc, region, threadType,
-                                          origEntry.getName());
+    ScopedModuleHelper threadConfigHelper(&builder, loc, region, threadType);
 
     // Clone 'region' into a new func op nested inside 'moduleWrapper':
     auto kernelMain = builder.create<func::FuncOp>(

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -905,9 +905,10 @@ toFlatbuffer(FlatbufferObjectCache &cache, KernelArgAttr kernelArg) {
 static flatbuffers::Offset<target::metal::KernelArgs>
 kernelArgsToFlatbuffer(FlatbufferObjectCache &cache,
                        KernelArgsAttr kernelArgs) {
+  auto crtArgs = toFlatbuffer(cache, kernelArgs.getCommonRtArgs());
   auto rtArgs = toFlatbuffer(cache, kernelArgs.getRtArgs());
   auto ctArgs = toFlatbuffer(cache, kernelArgs.getCtArgs());
-  return target::metal::CreateKernelArgs(*cache.fbb, rtArgs, ctArgs);
+  return target::metal::CreateKernelArgs(*cache.fbb, crtArgs, rtArgs, ctArgs);
 }
 
 static flatbuffers::Offset<target::metal::NocConfig>

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -391,6 +391,13 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
           currentProgramName, debugInfo, kernelConfig->debug_info()->c_str(),
           kernelConfig->loc() ? kernelConfig->loc()->c_str() : nullptr);
 
+      std::vector<uint32_t> commonRtArgsVec = processRuntimeArgs(
+          kernelConfig->args()->crt_args(), command->arg_refs_type(),
+          command->arg_refs(), meshBuffers, global_semaphores,
+          local_semaphore_initializer, command->cbs(), deviceAddressValidator,
+          createSemaphore, hostBuffers);
+      tt_metal::SetCommonRuntimeArgs(program, handle, commonRtArgsVec);
+
       std::vector<uint32_t> rtArgsVec = processRuntimeArgs(
           kernelConfig->args()->rt_args(), command->arg_refs_type(),
           command->arg_refs(), meshBuffers, global_semaphores,

--- a/test/ttmlir/Conversion/D2MToTTKernel/cb_port_custom_ports.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/cb_port_custom_ports.mlir
@@ -1,22 +1,21 @@
 // RUN: ttmlir-opt --ttcore-register-device --convert-d2m-to-ttkernel %s | FileCheck %s
 
-// Test that d2m.get_cb ops correctly lower to get_compile_time_arg_val ops,
-// making CB ports programmable via ct_args. This is critical for the spatial
-// op, where multiple generics share the CB namespace and need distinct port
-// assignments.
+// Test that d2m.get_cb ops correctly lower to get_common_arg_val ops, making CB
+// ports programmable via common runtime args. This is critical for cache reuse
+// because CB port assignments do not need to participate in the kernel hash.
 
 #l1_ = #ttcore.memory_space<l1>
 
 module {
   // CHECK-LABEL: func.func @custom_cb_ports
-  // Verify that operand indices appear in the ArgSpec ct_args.
-  // CHECK-SAME: ct_args = [<arg_type = cb_port, operand_index = 3>, <arg_type = cb_port, operand_index = 5>]
+  // Verify that operand indices appear in the ArgSpec rt_args.
+  // CHECK-SAME: rt_args = [<arg_type = cb_port, operand_index = 3>, <arg_type = cb_port, operand_index = 5>]
   func.func @custom_cb_ports() attributes {d2m.thread = #d2m.thread<compute>} {
     %c0 = arith.constant 0 : index
     %cb0 = d2m.get_cb(3) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>
     %cb1 = d2m.get_cb(5) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>
-    // CHECK: ttkernel.get_compile_time_arg_val(0)
-    // CHECK: ttkernel.get_compile_time_arg_val(1)
+    // CHECK: ttkernel.get_common_arg_val
+    // CHECK: ttkernel.get_common_arg_val
     %in = d2m.wait %cb0 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
     %out = d2m.reserve %cb1 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
     %t = memref.load %in[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
@@ -26,13 +25,13 @@ module {
 
   // CHECK-LABEL: func.func @default_cb_ports
   // When port == operand_index (the common case), verify it still works.
-  // CHECK-SAME: ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]
+  // CHECK-SAME: rt_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]
   func.func @default_cb_ports() attributes {d2m.thread = #d2m.thread<compute>} {
     %c0 = arith.constant 0 : index
     %cb0 = d2m.get_cb(0) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>
     %cb1 = d2m.get_cb(1) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>
-    // CHECK: ttkernel.get_compile_time_arg_val(0)
-    // CHECK: ttkernel.get_compile_time_arg_val(1)
+    // CHECK: ttkernel.get_common_arg_val
+    // CHECK: ttkernel.get_common_arg_val
     %in = d2m.wait %cb0 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
     %out = d2m.reserve %cb1 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
     %t = memref.load %in[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>

--- a/test/ttmlir/Conversion/D2MToTTKernel/force_compile_time_args.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/force_compile_time_args.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --ttcore-register-device --convert-d2m-to-ttkernel %s | FileCheck %s --check-prefix=SMART
+// RUN: ttmlir-opt --ttcore-register-device "--convert-d2m-to-ttkernel=force-compile-time-args=true" %s | FileCheck %s --check-prefix=FORCE
+
+#l1 = #ttcore.memory_space<l1>
+
+module {
+  // SMART-LABEL: func.func private @arg_placement
+  // SMART-SAME: ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = buffer_address, operand_index = 1>, <arg_type = local_semaphore, operand_index = 3>, <arg_type = scalar, operand_index = 2>]
+  // SMART: ttkernel.get_common_arg_val
+  // SMART-NOT: ttkernel.get_compile_time_arg_val
+  // FORCE-LABEL: func.func private @arg_placement
+  // FORCE-SAME: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = buffer_address, operand_index = 1>, <arg_type = local_semaphore, operand_index = 3>, <arg_type = scalar, operand_index = 2>]
+  // FORCE: ttkernel.get_compile_time_arg_val
+  // FORCE-NOT: ttkernel.get_common_arg_val
+  func.func private @arg_placement() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
+    %cb = d2m.get_cb(0) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+    %buf = d2m.get_arg(1) : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
+    %sem = d2m.get_arg(3) : !d2m.local_semaphore
+    %scalar = d2m.get_arg(2) : ui32
+    return
+  }
+}

--- a/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
@@ -6,8 +6,8 @@ module {
     %sem0 = d2m.get_arg(0) : !d2m.local_semaphore
     %c1 = arith.constant 1 : index
     d2m.semaphore_set %sem0, %c1 : !d2m.local_semaphore
-    // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
-    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
+    // CHECK: %[[ARG:[0-9]+]] = ttkernel.get_common_arg_val
+    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[ARG]])
     // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast(%[[SEM]])
     // CHECK: ttkernel.noc_semaphore_set(%[[PTR]], %c1)
     return
@@ -20,8 +20,8 @@ module {
     %y  = arith.constant 2 : index
     %x  = arith.constant 3 : index
     d2m.semaphore_inc %sem0, %c1, core[%y, %x] : !d2m.local_semaphore
-    // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
-    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
+    // CHECK: %[[ARG:[0-9]+]] = ttkernel.get_common_arg_val
+    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[ARG]])
     // CHECK: %[[NOC:[0-9]+]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[SEM]])
     // CHECK: ttkernel.noc_semaphore_inc(%[[NOC]], %c1) :
     // CHECK-NOT: posted
@@ -37,8 +37,8 @@ module {
     %h  = arith.constant 2 : index
     %w  = arith.constant 3 : index
     d2m.semaphore_set %sem0, %c7, core[%y, %x] mcast[%h, %w] : !d2m.local_semaphore
-    // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
-    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
+    // CHECK: %[[ARG:[0-9]+]] = ttkernel.get_common_arg_val
+    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[ARG]])
     // CHECK: %[[NOC:[a-zA-Z0-9_]+]] = arith.constant 0 : i8
     // CHECK: %[[MADDR:[0-9]+]] = ttkernel.get_noc_multicast_addr({{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[SEM]], %[[NOC]])
     // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast(%[[SEM]])
@@ -73,8 +73,8 @@ module {
     %sem0 = d2m.get_arg(0) : !d2m.local_semaphore
     %c2 = arith.constant 2 : index
     d2m.semaphore_wait %sem0, %c2 : !d2m.local_semaphore
-    // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
-    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
+    // CHECK: %[[ARG:[0-9]+]] = ttkernel.get_common_arg_val
+    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[ARG]])
     // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast(%[[SEM]])
     // CHECK: ttkernel.experimental.semaphore_wait(%[[PTR]], %c2)
     return
@@ -86,11 +86,11 @@ module {
     %c2 = arith.constant 2 : index
     %c0 = arith.constant 0 : index
     d2m.semaphore_wait %sem0, %c2 reset %c0 : !d2m.local_semaphore
-    // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
-    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
+    // CHECK: %[[ARG:[0-9]+]] = ttkernel.get_common_arg_val
+    // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[ARG]])
     // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast(%[[SEM]])
     // CHECK: ttkernel.experimental.semaphore_wait(%[[PTR]], %c2)
-    // CHECK: ttkernel.noc_semaphore_set(%[[PTR]], %c0)
+    // CHECK: ttkernel.noc_semaphore_set(%[[PTR]], {{%c0(_0)?}})
     return
   }
 

--- a/test/ttmlir/Conversion/D2MToTTMetal/generic_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/generic_lowering.mlir
@@ -12,7 +12,7 @@ module {
     %cb_2 = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<1x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_>
     // TODO: add alias example
     // CHECK: "ttmetal.enqueue_program"
-    // CHECK-SAME: {{.*}}cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, dm_core = 1, noc0>, #ttmetal.noc_config<@datamovement_kernel1, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, dm_core = 0, noc1>, #ttmetal.compute_config<@compute_kernel2, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, hifi4, true, false, false, [default]>]
+    // CHECK-SAME: {{.*}}cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args<common_rt_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]  >, dm_core = 1, noc0>, #ttmetal.noc_config<@datamovement_kernel1, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args<common_rt_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]  >, dm_core = 0, noc1>, #ttmetal.compute_config<@compute_kernel2, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args<common_rt_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]  >, hifi4, true, false, false, [default]>]
     %0 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
     %1 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
     %2 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore

--- a/test/ttmlir/Conversion/D2MToTTMetal/generic_scalar_additional_arg.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/generic_scalar_additional_arg.mlir
@@ -20,7 +20,7 @@ module {
     // CHECK: "ttmetal.enqueue_program"
     // CHECK-SAME: cb_ports = array<i64: 0, 1>
     // CHECK-SAME: compute_config<@compute_kernel
-    // CHECK-SAME: ct_args = [<cb_port[0]>, <cb_port[1]>, <scalar[2]>]
+    // CHECK-SAME: common_rt_args = [<cb_port[0]>, <cb_port[1]>, <scalar[2]>]
     d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<compute, @compute_kernel>]}
         ins(%arg0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)
         outs(%alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -181,8 +181,8 @@ module {
   ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
   // CHECK-LABEL: func.func @spatial_two_regions_buffer_address_remap
   // CHECK-COUNT-1: "ttmetal.enqueue_program"
-  // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_b0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args<rt_args = [<buffer_address[0]>] ct_args = [<cb_port[0]>, <cb_port[1]>]>, dm_core = 1, noc0>
-  // CHECK-SAME: #ttmetal.noc_config<@dm_b1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args<rt_args = [<buffer_address[2]>] ct_args = [<cb_port[2]>, <cb_port[3]>]>, dm_core = 1, noc0>]
+  // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_b0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args<common_rt_args = [<buffer_address[0]>]  ct_args = [<cb_port[0]>, <cb_port[1]>]>, dm_core = 1, noc0>
+  // CHECK-SAME: #ttmetal.noc_config<@dm_b1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args<common_rt_args = [<buffer_address[2]>]  ct_args = [<cb_port[2]>, <cb_port[3]>]>, dm_core = 1, noc0>]
   // CHECK-NOT: d2m.spatial
   func.func @spatial_two_regions_buffer_address_remap(
       %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,

--- a/test/ttmlir/Conversion/D2MToTTNN/scalar_arg.mlir
+++ b/test/ttmlir/Conversion/D2MToTTNN/scalar_arg.mlir
@@ -47,7 +47,8 @@ module {
     // its raw d2m operand index <4>.
     // CHECK: "ttnn.generic"(%{{.*}}, %{{.*}}, %arg1)
     // CHECK-SAME: operandSegmentSizes = array<i32: 2, 1>
-    // CHECK-SAME: ct_args = [#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>, #ttnn.kernel_arg_scalar<2>]
+    // CHECK-SAME: ct_args = [#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>]
+    // CHECK-SAME: common_rt_args = [#ttnn.kernel_arg_scalar<2>]
     // CHECK-SAME: (tensor<32x32xf32, {{.*}}>, tensor<32x32xf32, {{.*}}>, i32) -> ()
     d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<compute, @compute_kernel0>]}
         ins(%view_input : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>)
@@ -60,10 +61,12 @@ module {
   }
   func.func private @compute_kernel0() attributes {
     ttkernel.arg_spec = #ttkernel.arg_spec<
+      rt_args = [
+        <arg_type = scalar, operand_index = 4>
+      ]
       ct_args = [
         <arg_type = cb_port, operand_index = 2>,
-        <arg_type = cb_port, operand_index = 3>,
-        <arg_type = scalar, operand_index = 4>
+        <arg_type = cb_port, operand_index = 3>
       ]
     >,
     ttkernel.thread = #ttkernel.thread<compute>

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -273,10 +273,10 @@ module {
       "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<col>}> : (!cb0_tiles, !cb1_tiles) -> ()
       "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<scalar>}> : (!cb0_tiles, !cb1_tiles) -> ()
       "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<none>}> : (!cb0_tiles, !cb1_tiles) -> ()
-      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::ROW">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
-      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::COL">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
-      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::SCALAR">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
-      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::NONE">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::ROW">]} : (ui32, ui32) -> ()
+      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::COL">]} : (ui32, ui32) -> ()
+      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::SCALAR">]} : (ui32, ui32) -> ()
+      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::NONE">]} : (ui32, ui32) -> ()
       return
     }
 

--- a/test/ttmlir/Dialect/D2M/arguments/d2m_to_ttkernel_argument_lowering.mlir
+++ b/test/ttmlir/Dialect/D2M/arguments/d2m_to_ttkernel_argument_lowering.mlir
@@ -3,9 +3,9 @@
 
 // Test for lowering aliased cb types.
 #l1 = #ttcore.memory_space<l1>
-// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>
-// CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
-// CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<1024, f32>
+// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]
+// CHECK: %0 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
+// CHECK: %1 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<1024, f32>
 func.func private @cb_lowering() attributes {d2m.thread = #d2m.thread<compute>, tt.function_type = "kernel"} {
   %arg0 = d2m.get_cb(0) : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
   %arg1 = d2m.get_cb(1) : <memref<32x32xf32, #l1>>
@@ -25,10 +25,10 @@ func.func private @cb_lowering() attributes {d2m.thread = #d2m.thread<compute>, 
 
 // Test for lowering scalar types.
 #l1 = #ttcore.memory_space<l1>
-// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = scalar, operand_index = 2>]>
-// CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1024, f32>
-// CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
-// CHECK: %2 = ttkernel.get_compile_time_arg_val(2) : () -> ui32
+// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = scalar, operand_index = 2>]
+// CHECK: %0 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<1024, f32>
+// CHECK: %1 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
+// CHECK: %2 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
 func.func private @scalar_lowering() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
   %cb0 = d2m.get_cb(0) : <memref<32x32xf32, #l1>>
   %cb1 = d2m.get_cb(1) : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
@@ -49,10 +49,10 @@ func.func private @scalar_lowering() attributes {d2m.thread = #d2m.thread<datamo
 
 // Test for lowering global semaphore types.
 #l1 = #ttcore.memory_space<l1>
-// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 1>, <arg_type = global_semaphore, operand_index = 3>, <arg_type = buffer_address, operand_index = 1>]>
+// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = cb_port, operand_index = 1>, <arg_type = buffer_address, operand_index = 1>, <arg_type = global_semaphore, operand_index = 3>]
 func.func private @datamovement_kernel1() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
-  // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, f32>>
-  // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.l1_addr
+  // CHECK: %0 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<4, !ttcore.tile<32x32, f32>>
+  // CHECK: %1 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.l1_addr
   %arg1 = d2m.get_cb(1) : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>>
   %arg3 = d2m.get_arg(3) : !d2m.global_semaphore
   %c2 = arith.constant 2 : index
@@ -61,7 +61,7 @@ func.func private @datamovement_kernel1() attributes {d2m.thread = #d2m.thread<d
   scf.for %arg4 = %c0 to %c2 step %c1 {
     scf.for %arg5 = %c0 to %c2 step %c1 {
       %0 = d2m.wait %arg1 : <memref<2x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      // CHECK: %3 = ttkernel.get_compile_time_arg_val(2) : () -> i32
+      // CHECK: %3 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> i32
       %1 = d2m.get_arg(1) : memref<2x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
       %tx = d2m.dma_write %0[%c0], %1[%arg4, %arg5, %c0], <4> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) -> !d2m.mem_tx<write>
       d2m.dma_wait %tx : !d2m.mem_tx<write>
@@ -79,12 +79,12 @@ func.func private @datamovement_kernel1() attributes {d2m.thread = #d2m.thread<d
 #l1 = #ttcore.memory_space<l1>
 #map1 = affine_map<() -> ()>
 
-// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = local_semaphore, operand_index = 5>, <arg_type = local_semaphore, operand_index = 6>, <arg_type = buffer_address, operand_index = 0>]>
+// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = buffer_address, operand_index = 0>, <arg_type = local_semaphore, operand_index = 5>, <arg_type = local_semaphore, operand_index = 6>]
 func.func private @datamovement_kernel4() attributes {d2m.thread = #d2m.thread<datamovement, dm_core = 1>, tt.function_type = "kernel"} {
-  // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
-  // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> i32
+  // CHECK: %0 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
+  // CHECK: %1 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> i32
   // CHECK: %2 = ttkernel.get_semaphore(%1) : (i32) -> !ttkernel.local_semaphore
-  // CHECK: %3 = ttkernel.get_compile_time_arg_val(2) : () -> i32
+  // CHECK: %3 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> i32
   // CHECK: %4 = ttkernel.get_semaphore(%3) : (i32) -> !ttkernel.local_semaphore
   %arg0 = d2m.get_cb(0) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
   %arg5 = d2m.get_arg(5) : !d2m.local_semaphore
@@ -100,7 +100,7 @@ func.func private @datamovement_kernel4() attributes {d2m.thread = #d2m.thread<d
   scf.for %arg7 = %c0 to %c4 step %c1 {
     %1 = d2m.reserve %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
     scf.if %0 {
-      // CHECK: %10 = ttkernel.get_compile_time_arg_val(3) : () -> i32
+      // CHECK: %10 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> i32
       %2 = d2m.get_arg(0) : memref<8x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
       %tx = d2m.dma_read %2[%core0, %arg7, %c0], %1[%c0], <1> : (memref<8x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
       d2m.dma_wait %tx : !d2m.mem_tx<read>
@@ -135,30 +135,30 @@ module {
 
     return
   }
-  // CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = scalar, operand_index = 2>, <arg_type = scalar, operand_index = 3>, <arg_type = scalar, operand_index = 4>, <arg_type = scalar, operand_index = 5>, <arg_type = scalar, operand_index = 6>, <arg_type = scalar, operand_index = 7>, <arg_type = scalar, operand_index = 8>, <arg_type = scalar, operand_index = 9>, <arg_type = scalar, operand_index = 10>, <arg_type = scalar, operand_index = 11>]>
+  // CHECK: ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = scalar, operand_index = 2>, <arg_type = scalar, operand_index = 3>, <arg_type = scalar, operand_index = 4>, <arg_type = scalar, operand_index = 5>, <arg_type = scalar, operand_index = 6>, <arg_type = scalar, operand_index = 7>, <arg_type = scalar, operand_index = 8>, <arg_type = scalar, operand_index = 9>, <arg_type = scalar, operand_index = 10>, <arg_type = scalar, operand_index = 11>]
   func.func private @datamovement0() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
-    // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1024, f32>
-    // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
-    // CHECK: %2 = ttkernel.get_compile_time_arg_val(2) : () -> ui32
-    // CHECK: %3 = ttkernel.bitcast %2 : ui32 to i32
-    // CHECK: %4 = ttkernel.get_compile_time_arg_val(3) : () -> ui32
-    // CHECK: %5 = ttkernel.bitcast %4 : ui32 to si32
-    // CHECK: %6 = ttkernel.get_compile_time_arg_val(4) : () -> ui32
-    // CHECK: %7 = ttkernel.bitcast %6 : ui32 to ui16
-    // CHECK: %8 = ttkernel.get_compile_time_arg_val(5) : () -> ui32
-    // CHECK: %9 = ttkernel.bitcast %8 : ui32 to si16
-    // CHECK: %10 = ttkernel.get_compile_time_arg_val(6) : () -> ui32
-    // CHECK: %11 = ttkernel.bitcast %10 : ui32 to ui8
-    // CHECK: %12 = ttkernel.get_compile_time_arg_val(7) : () -> ui32
-    // CHECK: %13 = ttkernel.bitcast %12 : ui32 to si8
-    // CHECK: %14 = ttkernel.get_compile_time_arg_val(8) : () -> ui32
-    // CHECK: %15 = ttkernel.bitcast %14 : ui32 to i1
-    // CHECK: %16 = ttkernel.get_compile_time_arg_val(9) : () -> ui32
-    // CHECK: %17 = ttkernel.bitcast %16 : ui32 to f32
-    // CHECK: %18 = ttkernel.get_compile_time_arg_val(10) : () -> ui32
-    // CHECK: %19 = ttkernel.bitcast %18 : ui32 to bf16
-    // CHECK: %20 = ttkernel.get_compile_time_arg_val(11) : () -> ui32
-    // CHECK: %21 = ttkernel.bitcast %20 : ui32 to f16
+    // CHECK: %0 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<1024, f32>
+    // CHECK: %1 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to i32
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to si32
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to ui16
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to si16
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to ui8
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to si8
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to i1
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to f32
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to bf16
+    // CHECK: ttkernel.get_common_arg_val(%{{.*}}) : (index) -> ui32
+    // CHECK: ttkernel.bitcast %{{.*}} : ui32 to f16
     %arg0 = d2m.get_cb(0) : !d2m.cb<memref<32x32xf32, #l1>>
     %arg1 = d2m.get_cb(1) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
     %arg2 = d2m.get_arg(2) : i32
@@ -197,15 +197,15 @@ module {
         ins(%view, %arg1 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>)
         outs(%alloc : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>)
      {
-      // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
-      // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
-      // CHECK: %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+      // CHECK: %0 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+      // CHECK: %1 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+      // CHECK: %2 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
       %0 = d2m.get_cb(0) resolution_stage =  compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %1 = d2m.get_cb(1) resolution_stage =  compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %2 = d2m.get_cb(2) resolution_stage =  compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %3 = d2m.reserve %1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
       %c0 = arith.constant 0 : index
-      // CHECK: %3 = ttkernel.get_compile_time_arg_val(3) : () -> i32
+      // CHECK: %3 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> i32
       %4 = d2m.get_arg(0) resolution_stage =  compile : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
       %tx = d2m.dma_read %4[%c0, %c0, %c0], %3[%c0], <1> : (memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
       d2m.dma_wait %tx : !d2m.mem_tx<read>
@@ -221,17 +221,17 @@ module {
 #l1 = #ttcore.memory_space<l1>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 module {
-  // CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>, <arg_type = buffer_address, operand_index = 0>]>
+  // CHECK: ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>, <arg_type = buffer_address, operand_index = 0>]
   func.func @runtime_arg_test() {
-    // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
-    // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
-    // CHECK: %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+    // CHECK: %0 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+    // CHECK: %1 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+    // CHECK: %2 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
     %0 = d2m.get_cb(0) resolution_stage = compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
     %1 = d2m.get_cb(1) resolution_stage = compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
     %2 = d2m.get_cb(2) resolution_stage = compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
     %3 = d2m.reserve %1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
     %c0 = arith.constant 0 : index
-    // CHECK: %3 = ttkernel.get_compile_time_arg_val(3) : () -> i32
+    // CHECK: %3 = ttkernel.get_common_arg_val(%{{.*}}) : (index) -> i32
     %4 = d2m.get_arg(0) resolution_stage = runtime : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
     %tx = d2m.dma_read %4[%c0, %c0, %c0], %3[%c0], <1> : (memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
     d2m.dma_wait %tx : !d2m.mem_tx<read>

--- a/test/ttmlir/Dialect/D2M/arguments/normalize_thread_args.mlir
+++ b/test/ttmlir/Dialect/D2M/arguments/normalize_thread_args.mlir
@@ -71,7 +71,7 @@ module {
         outs(%alloc_1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
         additionalArgs(%2 : !d2m.global_semaphore)
      {
-    // CHECK: d2m.get_arg(2) resolution_stage =  compile : !d2m.global_semaphore
+    // CHECK: d2m.get_arg(2) resolution_stage =  runtime : !d2m.global_semaphore
     ^unified0():
       %cb0 = d2m.get_cb(0) : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
       %cb1 = d2m.get_cb(1) : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
@@ -103,8 +103,8 @@ module {
         outs(%alloc_out : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
         additionalArgs(%0, %1, %2, %3 : !d2m.local_semaphore, !d2m.local_semaphore, !d2m.local_semaphore, !d2m.local_semaphore)
     {
-    // CHECK: %4 = d2m.get_arg(3) resolution_stage =  compile : !d2m.local_semaphore
-    // CHECK: %5 = d2m.get_arg(2) resolution_stage =  compile : !d2m.local_semaphore
+    // CHECK: %4 = d2m.get_arg(3) resolution_stage =  runtime : !d2m.local_semaphore
+    // CHECK: %5 = d2m.get_arg(2) resolution_stage =  runtime : !d2m.local_semaphore
     ^datamovement0():
       %cb0 = d2m.get_cb(0) : <memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>>
       %cb1 = d2m.get_cb(1) : <memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>>
@@ -123,8 +123,8 @@ module {
         d2m.semaphore_wait %1, %c1 reset %c0 : !d2m.local_semaphore
       }
     }, {
-    // CHECK: %4 = d2m.get_arg(5) resolution_stage =  compile : !d2m.local_semaphore
-    // CHECK: %5 = d2m.get_arg(4) resolution_stage =  compile : !d2m.local_semaphore
+    // CHECK: %4 = d2m.get_arg(5) resolution_stage =  runtime : !d2m.local_semaphore
+    // CHECK: %5 = d2m.get_arg(4) resolution_stage =  runtime : !d2m.local_semaphore
     ^datamovement1():
       %cb0 = d2m.get_cb(0) : <memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>>
       %cb1 = d2m.get_cb(1) : <memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>>
@@ -167,7 +167,7 @@ module {
       %2 = d2m.get_cb(2) : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %3 = d2m.wait %1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
       %c0 = arith.constant 0 : index
-      // CHECK: d2m.get_arg(0) resolution_stage =  compile : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+      // CHECK: d2m.get_arg(0) resolution_stage =  runtime : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
       %tx = d2m.dma_read %view[%c0, %c0, %c0], %3[%c0], <1> : (memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
       d2m.dma_wait %tx : !d2m.mem_tx<read>
     }, {
@@ -192,7 +192,7 @@ module {
         outs(%alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
         additionalArgs(%arg0 : index)
      {
-    // CHECK: %0 = d2m.get_arg(2) resolution_stage =  compile : index
+    // CHECK: %0 = d2m.get_arg(2) resolution_stage =  runtime : index
     ^unified0():
       %cb0 = d2m.get_cb(0) : <memref<32x32xf32, #l1>>
       %cb1 = d2m.get_cb(1) : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
@@ -220,16 +220,16 @@ module {
         additionalArgs(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8, %arg9 : i32, si32, ui16, si16, ui8, si8, i1, f32, bf16, f16)
      {
     ^unified0():
-      // CHECK: %0 = d2m.get_arg(11) resolution_stage =  compile : f16
-      // CHECK: %1 = d2m.get_arg(10) resolution_stage =  compile : bf16
-      // CHECK: %2 = d2m.get_arg(9) resolution_stage =  compile : f32
-      // CHECK: %3 = d2m.get_arg(8) resolution_stage =  compile : i1
-      // CHECK: %4 = d2m.get_arg(7) resolution_stage =  compile : si8
-      // CHECK: %5 = d2m.get_arg(6) resolution_stage =  compile : ui8
-      // CHECK: %6 = d2m.get_arg(5) resolution_stage =  compile : si16
-      // CHECK: %7 = d2m.get_arg(4) resolution_stage =  compile : ui16
-      // CHECK: %8 = d2m.get_arg(3) resolution_stage =  compile : si32
-      // CHECK: %9 = d2m.get_arg(2) resolution_stage =  compile : i32
+      // CHECK: %0 = d2m.get_arg(11) resolution_stage =  runtime : f16
+      // CHECK: %1 = d2m.get_arg(10) resolution_stage =  runtime : bf16
+      // CHECK: %2 = d2m.get_arg(9) resolution_stage =  runtime : f32
+      // CHECK: %3 = d2m.get_arg(8) resolution_stage =  runtime : i1
+      // CHECK: %4 = d2m.get_arg(7) resolution_stage =  runtime : si8
+      // CHECK: %5 = d2m.get_arg(6) resolution_stage =  runtime : ui8
+      // CHECK: %6 = d2m.get_arg(5) resolution_stage =  runtime : si16
+      // CHECK: %7 = d2m.get_arg(4) resolution_stage =  runtime : ui16
+      // CHECK: %8 = d2m.get_arg(3) resolution_stage =  runtime : si32
+      // CHECK: %9 = d2m.get_arg(2) resolution_stage =  runtime : i32
       // unrealized_conversion_cast are inserted to force the argument to not be canonicalized away
       %temp0 = builtin.unrealized_conversion_cast %arg0 : i32 to i32
       %temp1 = builtin.unrealized_conversion_cast %arg1 : si32 to si32
@@ -272,9 +272,9 @@ module {
      {
       %index_scratch = memref.alloc() : memref<1x1024xi32, #l1>
       %row_scratch = memref.alloc() : memref<1x1024xf32, #l1>
-      // CHECK: %[[INDICES:.*]] = d2m.get_arg(0) resolution_stage =  compile : memref<1x1x2x4xi32, #l1>
-      // CHECK: %[[WEIGHT:.*]] = d2m.get_arg(1) resolution_stage =  compile : memref<1x1x8x16xf32, #l1>
-      // CHECK: %[[OUTPUT:.*]] = d2m.get_arg(2) resolution_stage =  compile : memref<1x1x8x16xf32, #l1>
+      // CHECK: %[[INDICES:.*]] = d2m.get_arg(0) resolution_stage =  runtime : memref<1x1x2x4xi32, #l1>
+      // CHECK: %[[WEIGHT:.*]] = d2m.get_arg(1) resolution_stage =  runtime : memref<1x1x8x16xf32, #l1>
+      // CHECK: %[[OUTPUT:.*]] = d2m.get_arg(2) resolution_stage =  runtime : memref<1x1x8x16xf32, #l1>
       // CHECK: d2m.indexed_row_copy %[[INDICES]], %[[WEIGHT]], %[[OUTPUT]] scratch
       d2m.indexed_row_copy %indices, %weight, %output scratch %index_scratch, %row_scratch<8, 16> {indicesShape = array<i64: 2, 4>} : memref<1x1x2x4xi32, #l1>, memref<1x1x8x16xf32, #l1>, memref<1x1x8x16xf32, #l1>, memref<1x1024xi32, #l1>, memref<1x1024xf32, #l1>
     }

--- a/test/ttmlir/Dialect/D2M/generic/generic_global_semaphores.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_global_semaphores.mlir
@@ -29,7 +29,7 @@ module {
       : tensor<8x8x1x1xui32, #sem_layout> -> !d2m.global_semaphore
 
     // CHECK: ttmetal.enqueue_program
-    // CHECK-SAME: #ttmetal.kernel_args< ct_args = [{{.*}}<global_semaphore[2]>{{.*}}]
+    // CHECK-SAME: #ttmetal.kernel_args<common_rt_args = [{{.*}}<global_semaphore[2]>{{.*}}]
     // The below check is to ensure that the semaphore buffer is deallocated after the generic operation (i.e liveness analysis is working).
     %result = "d2m.generic"(%arg0, %output, %sem) <{
       block_factors = [],
@@ -86,7 +86,7 @@ module {
 
     return %result : tensor<2x2x2x2x!ttcore.tile<32x32, f32>, #layout>
 
-    // CHECK: func.func {{.*}} {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [{{.*}}<arg_type = global_semaphore, operand_index = {{[0-9]+}}>{{.*}}]>, {{.*}}}
+    // CHECK: func.func {{.*}} {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [{{.*}}<arg_type = global_semaphore, operand_index = {{[0-9]+}}>{{.*}}] {{.*}}}
     // CHECK: "experimental::semaphore_wait"
   }
 }


### PR DESCRIPTION
### Problem description

For the entire D2M builder test suite of around 2200 tests:
- The first run generates around 12000 unique kernels, and they take a very long time to compile.
  - Metal's auto kernel deduplication reports reusing around 13000 compiled kernels fresh from the cache.
- The second run of the same test suite gets only 78% kernel cache hit rate, and even after five runs we still can't get to 100%.

This slows down the CI, result in terrible model TTFT, and impacts subsequent token generations.

Reasons:
- The pipeline uses kernel compile time arguments to carry memory addresses, CB IDs, semaphores, scalar operands, etc.
- Everytime their value and/or order changes, `Kernel::compute_hash()` produces a different hash.
- The pipeline also injects "unstable" kernel symbols as comments into all kernels, which also change the hash.
  - Comments like `// datamovement_kernel0` and `// compute_kernel3` are rarely helpful.

Therefore, the generated kernels are non-deterministic and frequently misse the cache even if they're from the exact same op.

Since only the order/schema of run-time args participate in the hash, a more efficient approach is:
- Use compile-time args (CTAs) only for values that genuinely specialize the kernel or template instantiation.
- Use common run-time args (CRTAs) for values that are uniform across the kernel's execution core grid.
- Use per-core run-time args (RTAs) only when a value differs across cores of the same kernel launch.

###What's changed

- The `NormalizeThreadArgs` pass now tag memrefs, semaphores and scalar types with `resolution_stage = runtime`.
  - Existing `d2m.get_arg` ops without an explicit resolution stage are also tagged using this rule.
- The `TTMetal` dialect's `kernel_args` attribute now has a new `common_rt_args` field for CRTAs.
- The `D2MToTTKernel` pass now populates `ttkernel.arg_spec` in a stable & deduplicated manner:
  - The `D2MKernelFunctionArgsRewriter` now pre-collects function args into `arg_spec.rt_args` with sorting & deduplication.
  - Both `D2MGetArgRewriter` and `D2MGetCBRewriter` now also prefer (C)RTAs, aligning with their TTNN mode.
  - CB-backed memref args, `d2m.get_cb`, buffer addresses, global semaphores, local semaphores, and scalar args now all enter `arg_spec.rt_args`.
    - The index lookup of RTA & CRTA are under their own index spaces (implied by `is_uniform`).
  - Uniform run-time args are lowered to `ttkernel.get_common_arg_val`, non-uniform run-time args are lowered to `ttkernel.get_arg_val`.
  - Updated `appendArgImpl()` in `TTKernelOpsTypes.cpp` so that:
    - (C)RTAs are deduplicated.
    - CTAs are inserted in a sorted order, and existing `ttkernel.get_compile_time_arg_val` are updated if the insertion shifted its arg index.
- The `D2MToTTMetal` pass:
  - Emit uniform run-time args as CRTAs and non-uniform run-time args as RTAs.
  - Updated spatial remapping to handle CRTAs, including scalar and buffer operands.
- The `SplitUnifiedThread` pass:
  - The loaded/stored CB collections now use `SmallVector` instead of `DenseSet` to preserve insertion order (with deduplication).
  - The removal of output/reused CBs from the loaded list is thus also deterministic.
- The `TTKernelToEmitC` pass now emit CB ID as `u32` (because `get{,_common}_arg_val<T>()` only supports 4-byte types), and removed the deprecated `tt::CB` enum.
- The `TTKernelToCpp` pass no longer inject comments into the kernels.
- The `D2MToTTNN` pass now also discovers local semaphores from `arg_spec.rt_args`
- The D2M runtime:
  - TTMetal flatbuffers now serializes `KernelArgs.crt_args`.
  - The D2M runtime now materialize CRTAs with the existing `processRuntimeArgs` helper and upload them with `SetCommonRuntimeArgs`.
  - Ordinary `SetRuntimeArgs` remains the path for genuinely per-core args, and the fabric path can still append per-core fabric-specific arguments.
- Added the temporary `force-compile-time-args` flag to go back to the old all-CTA behavior for performance evaluation.

Result:
- The number of unique kernels in the first run of the D2M test suite is reduced to around 5300, a 65% reduction.
- The second run of the entire D2M builder test suite gets 100% kernel cache hit rate.