### PR TITLE
[D2M] Compiled affine maps and other optimizations

### DIFF
--- a/include/ttmlir/AffineMapUtils.h
+++ b/include/ttmlir/AffineMapUtils.h
@@ -9,15 +9,15 @@
 #include "ttmlir/Utils.h"
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
-
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
-#include <atomic>
+#include "llvm/ADT/bit.h"
+
 #include <numeric>
-#include <thread>
 
 namespace ttmlir::utils {
 
@@ -522,6 +522,197 @@ createNDGridCollapseMap(mlir::ArrayRef<int64_t> gridShape,
   return mlir::AffineMap::get(gridRank + shardRank, 0, results, context);
 }
 
+namespace detail {
+
+// A self-contained drop-in replacement of AffineMap::compose(ArrayRef<int64_t>)
+// that compiles & evaluates affine maps using a register-based bytecode VM.
+class CompiledAffineMap {
+public:
+  explicit CompiledAffineMap(mlir::AffineMap map)
+      : numResults_(map.getNumResults()) {
+    llvm::DenseMap<mlir::AffineExpr, uint16_t> exprToReg;
+    resultRegs_.reserve(numResults_);
+    for (int i = 0; i < numResults_; ++i) {
+      resultRegs_.push_back(compileExpr(map.getResult(i), exprToReg));
+    }
+  }
+
+  void evaluate(const int64_t *__restrict inputs,
+                int64_t *__restrict results) const {
+    int64_t regs[kMaxRegs];
+    const Instruction *code = code_.data();
+    unsigned codeSize = static_cast<unsigned>(code_.size());
+    for (unsigned pc = 0; pc < codeSize; ++pc) {
+      int64_t a, b, q, rem;
+      switch (code[pc].op) {
+      case Op::LoadDim:
+        regs[code[pc].dst] = inputs[code[pc].imm];
+        break;
+      case Op::LoadConst:
+        regs[code[pc].dst] = code[pc].imm;
+        break;
+      case Op::Add:
+        regs[code[pc].dst] = regs[code[pc].src1] + regs[code[pc].src2];
+        break;
+      case Op::Mul:
+        regs[code[pc].dst] = regs[code[pc].src1] * regs[code[pc].src2];
+        break;
+      case Op::FloorDiv:
+        a = regs[code[pc].src1];
+        b = regs[code[pc].src2];
+        q = a / b;
+        rem = a % b;
+        regs[code[pc].dst] = (rem != 0 && ((rem ^ b) < 0)) ? q - 1 : q;
+        break;
+      case Op::Mod:
+        a = regs[code[pc].src1];
+        b = regs[code[pc].src2];
+        rem = a % b;
+        regs[code[pc].dst] = (rem != 0 && ((rem ^ b) < 0)) ? rem + b : rem;
+        break;
+      case Op::CeilDiv:
+        a = regs[code[pc].src1];
+        b = regs[code[pc].src2];
+        q = a / b;
+        rem = a % b;
+        regs[code[pc].dst] = (rem != 0 && ((rem ^ b) > 0)) ? q + 1 : q;
+        break;
+      case Op::ShrImm:
+        regs[code[pc].dst] = regs[code[pc].src1] >> code[pc].imm;
+        break;
+      case Op::AndImm:
+        regs[code[pc].dst] = regs[code[pc].src1] & code[pc].imm;
+        break;
+      }
+    }
+    for (int i = 0; i < numResults_; ++i) {
+      results[i] = regs[resultRegs_[i]];
+    }
+  }
+
+  int getNumResults() const { return numResults_; }
+
+private:
+  static constexpr uint16_t kMaxRegs = 512;
+
+  enum class Op : uint8_t {
+    LoadDim,
+    LoadConst,
+    Add,
+    Mul,
+    FloorDiv,
+    Mod,
+    CeilDiv,
+    ShrImm,
+    AndImm,
+  };
+
+  struct Instruction {
+    Op op;
+    uint16_t dst;
+    uint16_t src1;
+    uint16_t src2;
+    int64_t imm;
+  };
+
+  static bool isPowerOf2(int64_t v) { return v > 0 && (v & (v - 1)) == 0; }
+
+  uint16_t emitInstruction(mlir::AffineExpr expr, Instruction inst,
+                           llvm::DenseMap<mlir::AffineExpr, uint16_t> &map) {
+    const uint16_t reg = static_cast<uint16_t>(code_.size());
+    TT_assert(reg < kMaxRegs);
+    inst.dst = reg;
+    code_.push_back(inst);
+    // Memoization for CSE.
+    map[expr] = reg;
+    return reg;
+  }
+
+  uint16_t compileExpr(mlir::AffineExpr expr,
+                       llvm::DenseMap<mlir::AffineExpr, uint16_t> &exprToReg) {
+    // CSE: MLIR AffineExpr objects are pointer-uniqued, compile shared
+    // subexpressions across results once and reuse.
+    auto it = exprToReg.find(expr);
+    if (it != exprToReg.end()) {
+      return it->second;
+    }
+
+    switch (expr.getKind()) {
+    case mlir::AffineExprKind::DimId:
+      return emitInstruction(
+          expr,
+          {Op::LoadDim, 0, 0, 0,
+           static_cast<int64_t>(
+               mlir::cast<mlir::AffineDimExpr>(expr).getPosition())},
+          exprToReg);
+    case mlir::AffineExprKind::SymbolId:
+      llvm_unreachable("Symbols not supported in compiled affine map");
+    case mlir::AffineExprKind::Constant:
+      return emitInstruction(
+          expr,
+          {Op::LoadConst, 0, 0, 0,
+           mlir::cast<mlir::AffineConstantExpr>(expr).getValue()},
+          exprToReg);
+    default:
+      break;
+    }
+
+    auto bin = mlir::cast<mlir::AffineBinaryOpExpr>(expr);
+    const uint16_t lhs = compileExpr(bin.getLHS(), exprToReg);
+
+    // Power-of-2 specialization for FloorDiv and Mod: the RHS of these
+    // operations in MLIR affine expressions is always a constant.
+    if (expr.getKind() == mlir::AffineExprKind::FloorDiv ||
+        expr.getKind() == mlir::AffineExprKind::Mod) {
+      if (auto constRHS =
+              mlir::dyn_cast<mlir::AffineConstantExpr>(bin.getRHS())) {
+        int64_t val = constRHS.getValue();
+        if (isPowerOf2(val)) {
+          if (expr.getKind() == mlir::AffineExprKind::FloorDiv) {
+            return emitInstruction(
+                expr,
+                {Op::ShrImm, 0, lhs, 0,
+                 llvm::countr_zero(static_cast<uint64_t>(val))},
+                exprToReg);
+          }
+          return emitInstruction(expr, {Op::AndImm, 0, lhs, 0, val - 1},
+                                 exprToReg);
+        }
+      }
+    }
+
+    const uint16_t rhs = compileExpr(bin.getRHS(), exprToReg);
+
+    Op binOp;
+    switch (expr.getKind()) {
+    case mlir::AffineExprKind::Add:
+      binOp = Op::Add;
+      break;
+    case mlir::AffineExprKind::Mul:
+      binOp = Op::Mul;
+      break;
+    case mlir::AffineExprKind::Mod:
+      binOp = Op::Mod;
+      break;
+    case mlir::AffineExprKind::FloorDiv:
+      binOp = Op::FloorDiv;
+      break;
+    case mlir::AffineExprKind::CeilDiv:
+      binOp = Op::CeilDiv;
+      break;
+    default:
+      llvm_unreachable("unexpected affine expr kind");
+    }
+    return emitInstruction(expr, {binOp, 0, lhs, rhs, 0}, exprToReg);
+  }
+
+  llvm::SmallVector<Instruction, 128> code_;
+  llvm::SmallVector<uint16_t, 8> resultRegs_;
+  int numResults_;
+};
+
+} // namespace detail
+
 /// Calculates the coalescing factor for an affine map by sampling over the
 /// given input shape. The coalescing factor is the greatest common divisor of
 /// all contiguous run lengths, representing the maximum number of elements that
@@ -548,65 +739,96 @@ createNDGridCollapseMap(mlir::ArrayRef<int64_t> gridShape,
 ///          0,2,4,6,1,3,5,7 (no consecutive runs longer than 1).
 inline size_t calculateCoalescingFactor(mlir::AffineMap map,
                                         mlir::ArrayRef<int64_t> shape,
-                                        int64_t stride,
-                                        unsigned numGridDims = 0) {
+                                        const int64_t stride,
+                                        const unsigned numGridDims = 0) {
   TT_assertv(map.getNumDims() == shape.size(),
              "Map dimensions must match shape size");
   TT_assertv(numGridDims <= shape.size(),
              "Number of grid dims cannot exceed shape size");
+  TT_assertv(map.getNumSymbols() == 0u,
+             "calculateCoalescingFactor expects a symbol-free affine map");
 
-  // Extract grid and shard shapes
   mlir::ArrayRef<int64_t> gridShape = shape.take_front(numGridDims);
   mlir::ArrayRef<int64_t> shardShape = shape.drop_front(numGridDims);
 
-  // If no shard dims, trivially contiguous (volume is 1)
+  // If no shard dims, trivially contiguous (volume is 1).
   if (shardShape.empty()) {
     return 1;
   }
 
-  size_t shardVolume = volume(shardShape);
-  size_t coalescingFactor = shardVolume;
+  detail::CompiledAffineMap compiled(map);
+  const int numResults = compiled.getNumResults();
+  constexpr int kMaxResults = 16;
+  constexpr int kMaxDims = 16;
+  TT_assertv(numResults <= kMaxResults,
+             "calculateCoalescingFactor expects <= 16 map results");
+  TT_assertv(static_cast<int>(map.getNumDims()) <= kMaxDims,
+             "calculateCoalescingFactor expects <= 16 map dims");
 
-  mlir::SmallVector<int64_t> memoryIndex;
-  memoryIndex.resize(gridShape.size() + shardShape.size());
+  const int64_t shardVolume = volume(shardShape);
+  int64_t coalescingFactor = shardVolume;
+
+  int64_t memoryIndex[kMaxDims] = {-1};
+
   sample(gridShape, [&](mlir::ArrayRef<int64_t> gridIndex) {
     if (coalescingFactor == 1) {
       return;
     }
-    size_t currentCoalescingFactor = 0;
-    mlir::SmallVector<int64_t, 4> nextAddress;
-    sample(shardShape, [&](mlir::ArrayRef<int64_t> shardIndex) {
-      if (coalescingFactor == 1) {
-        return;
+    for (unsigned i = 0; i < gridIndex.size(); i++) {
+      memoryIndex[i] = gridIndex[i];
+    }
+    for (unsigned i = 0; i < shardShape.size(); i++) {
+      memoryIndex[numGridDims + i] = 0;
+    }
+
+    int64_t currentCoalescingFactor = 0;
+    int64_t address[kMaxResults] = {-1};
+    int64_t nextAddress[kMaxResults] = {-1};
+
+    for (int64_t iter = 0; iter < shardVolume; iter++) {
+      compiled.evaluate(memoryIndex, address);
+
+      bool contiguous = false;
+      if (iter > 0) {
+        contiguous = true;
+        for (int i = 0; i < numResults; i++) {
+          if (address[i] != nextAddress[i]) {
+            contiguous = false;
+            break;
+          }
+        }
       }
-      for (unsigned i = 0; i < gridIndex.size(); i++) {
-        memoryIndex[i] = gridIndex[i];
-      }
-      for (unsigned i = 0; i < shardIndex.size(); i++) {
-        memoryIndex[gridIndex.size() + i] = shardIndex[i];
-      }
-      mlir::SmallVector<int64_t, 4> address = map.compose(memoryIndex);
-      if (nextAddress.empty() || nextAddress == address) {
+
+      if (iter == 0 || contiguous) {
         ++currentCoalescingFactor;
       } else {
         coalescingFactor = std::gcd(coalescingFactor, currentCoalescingFactor);
-        // If coalescing factor reaches unit size, it cannot change further.
-        // Early exit to save on runtime.
         if (coalescingFactor == 1) {
-          return;
+          break;
         }
-        // current memory access can potentially be coalesced with next
-        // access!
+        // Current memory access can potentially be coalesced with next access!
         currentCoalescingFactor = 1;
       }
-      nextAddress = address;
-      nextAddress.back() += stride;
-    });
-    // Account for final run
+
+      for (int i = 0; i < numResults; i++) {
+        nextAddress[i] = address[i];
+      }
+      nextAddress[numResults - 1] += stride;
+
+      // Increment shard coordinates (assuming row-major order).
+      for (int i = static_cast<int>(shardShape.size()) - 1; i >= 0; i--) {
+        memoryIndex[numGridDims + i]++;
+        if (memoryIndex[numGridDims + i] < shardShape[i]) {
+          break;
+        }
+        memoryIndex[numGridDims + i] = 0;
+      }
+    }
+    // Account for the final run.
     coalescingFactor = std::gcd(coalescingFactor, currentCoalescingFactor);
   });
 
-  return coalescingFactor;
+  return static_cast<size_t>(coalescingFactor);
 }
 
 } // namespace ttmlir::utils

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -4209,6 +4209,7 @@ public:
     unsigned outputSyntheticRank = outputPhysicalRank - outputLogicalRank;
     unsigned inputSyntheticRank = inputPhysicalRank - inputLogicalRank;
     unsigned outputDeviceRank = outputPhysicalRank * 2;
+    unsigned inputDeviceRank = inputPhysicalRank * 2;
 
     // Compose the logical map with the unit-grid device shard coordinates.
     // Rank-1 logical tensors have a synthetic leading physical row dimension,
@@ -4225,27 +4226,12 @@ public:
         logicalMap.compose(outputDeviceToLogical);
 
     SmallVector<AffineExpr> deviceExprs;
+    deviceExprs.reserve(inputDeviceRank);
 
     // Grid coordinate mapping (first inputPhysicalRank results).
     for (unsigned i = 0; i < inputPhysicalRank; ++i) {
-      if (inputPhysicalRank == outputPhysicalRank) {
-        // Same physical rank: identity mapping for grid.
-        deviceExprs.push_back(builder.getAffineDimExpr(i));
-      } else if (inputPhysicalRank < outputPhysicalRank) {
-        // Expanding: map input grid dims to output's last inputPhysicalRank
-        // grid dims.
-        unsigned outputGridIdx = outputPhysicalRank - inputPhysicalRank + i;
-        deviceExprs.push_back(builder.getAffineDimExpr(outputGridIdx));
-      } else {
-        // Contracting: map last outputPhysicalRank input grid
-        // dims to output grid, pad the rest with 0.
-        if (i < inputPhysicalRank - outputPhysicalRank) {
-          deviceExprs.push_back(builder.getAffineConstantExpr(0));
-        } else {
-          unsigned outputGridIdx = i - (inputPhysicalRank - outputPhysicalRank);
-          deviceExprs.push_back(builder.getAffineDimExpr(outputGridIdx));
-        }
-      }
+      // The indexing is all zeros on the unit grid.
+      deviceExprs.push_back(builder.getAffineConstantExpr(0));
     }
 
     // Shard coordinate mapping. Synthetic rank-1 row dims are fixed to zero;


### PR DESCRIPTION
### Problem description

When we can't determine the coalescing factor analytically and fallback to sampling, the process is extremely slow.

For example, compiling the following SDPA op on a release build of tt-mlir takes 29s.

```mlir
func.func @sdpa(%arg0: tensor<1x24x128x128xbf16>, %arg1: tensor<1x8x128x128xbf16>, %arg2: tensor<1x8x128x128xbf16>) -> tensor<1x24x128x128xbf16> {
  %0 = "ttir.scaled_dot_product_attention"(%arg0, %arg1, %arg2) <{is_causal = true, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<1x24x128x128xbf16>, tensor<1x8x128x128xbf16>, tensor<1x8x128x128xbf16>) -> tensor<1x24x128x128xbf16>
  return %0 : tensor<1x24x128x128xbf16>
}
```

According to `--mlir-timing`, over 97% of the time is spend in the `calculateCoalescingFactor()` function.

Reason: a MLIR affine map is actually a tree of C++ objects, every evaluation of the affine map on a coordinate will result in a lot of pointer chasing & virtual dispatch, resulting in abysmal performance.

This issue slows down the compiler every time sampling is used, both for CI and for actual models.

### What's changed

Added a self-contained `CompiledAffineMap` class as a drop-in replacement of `AffineMap::compose(ArrayRef<int64_t>)` to speed up sampling.
- Affine maps are compiled into byte codes for a register-based VM, coordinates are then evaluated in a fast interpreter loop.
- Employed CSE & power-of-2 specialization to further speedup the evaluation.

The inner `sample()` for the shard coordinates is replaced with a simple loop for better performance.

Profiling showed that, on average, `calculateCoalescingFactor()` went from 14s per call to 85ms per call, a 164x speedup.
- Compiling the same SDPA op went from 29s to 1s.
- D2M test suite `test_composite_ops.py` went from 214s to 26s.
- D2M test suite `test_dram_ops.py` went from 3406s to 105s.

Also simplified TM affine maps on the unit grid, since dimensions of size 1 make no contribution.