### PR TITLE
[d2m] parse generic empty block correctly

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOps.td
@@ -289,11 +289,7 @@ def D2M_GenericOp
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region VariadicRegion<AnyRegion>:$regions);
 
-  let assemblyFormat = [{ attr-dict `\n`
-    ` ` ` ` ` ` ` ` `ins` `(` $inputs (`:` type($inputs)^)? `)` `\n`
-    ` ` ` ` ` ` ` ` `outs` `(` $outputs  `:` type($outputs) `)` `\n`
-    (` ` ` ` ` ` ` ` `additionalArgs` `(` $additionalArgs `:` type($additionalArgs)^ `)` `\n`)? $regions (`:`  type($results)^ )?
-    }];
+  let hasCustomAssemblyFormat = 1;
 
   let hasVerifier = 1;
   let hasCanonicalizer = 1;

--- a/include/ttmlir/Dialect/D2M/IR/D2MOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOps.td
@@ -289,6 +289,17 @@ def D2M_GenericOp
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region VariadicRegion<AnyRegion>:$regions);
 
+  // Keep this format in sync with GenericOp::parse/print. Empty blocks must
+  // print their block label so a present-but-empty region roundtrips as a
+  // one-block region:
+  //
+  //   d2m.generic {threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+  //       ins()
+  //       outs(%arg0 : memref<1xf32, #l1>) {
+  //   ^datamovement0:
+  //   }, {
+  //   ^compute0:
+  //   }
   let hasCustomAssemblyFormat = 1;
 
   let hasVerifier = 1;

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1470,6 +1470,151 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
 // GenericOp
 //===----------------------------------------------------------------------===//
 
+static ParseResult parseGenericOpOperandList(
+    OpAsmParser &parser, StringRef keyword,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &operands,
+    SmallVectorImpl<Type> &types, bool requireTypes) {
+  if (parser.parseKeyword(keyword) || parser.parseLParen() ||
+      parser.parseOperandList(operands)) {
+    return failure();
+  }
+
+  if (succeeded(parser.parseOptionalColonTypeList(types))) {
+    if (operands.size() != types.size()) {
+      return parser.emitError(parser.getNameLoc())
+             << "expected " << operands.size() << " type"
+             << (operands.size() == 1 ? "" : "s") << " for " << keyword;
+    }
+  } else if (requireTypes && !operands.empty()) {
+    return parser.emitError(parser.getNameLoc())
+           << "expected ':' followed by " << keyword << " operand types";
+  }
+
+  return parser.parseRParen();
+}
+
+static void printGenericOpOperandList(OpAsmPrinter &printer, StringRef keyword,
+                                      ValueRange operands, bool printTypes) {
+  printer << "\n        " << keyword << "(";
+  printer.printOperands(operands);
+  if (printTypes && !operands.empty()) {
+    printer << " : ";
+    llvm::interleaveComma(operands, printer, [&](Value operand) {
+      printer.printType(operand.getType());
+    });
+  }
+  printer << ")";
+}
+
+ParseResult GenericOp::parse(OpAsmParser &parser, OperationState &result) {
+  Builder &builder = parser.getBuilder();
+  SmallVector<OpAsmParser::UnresolvedOperand> inputOperands;
+  SmallVector<OpAsmParser::UnresolvedOperand> outputOperands;
+  SmallVector<OpAsmParser::UnresolvedOperand> additionalArgOperands;
+  SmallVector<Type> inputTypes;
+  SmallVector<Type> outputTypes;
+  SmallVector<Type> additionalArgTypes;
+  SmallVector<Type> resultTypes;
+
+  if (parser.parseOptionalAttrDict(result.attributes) ||
+      parseGenericOpOperandList(parser, "ins", inputOperands, inputTypes,
+                                /*requireTypes=*/true) ||
+      parseGenericOpOperandList(parser, "outs", outputOperands, outputTypes,
+                                /*requireTypes=*/true)) {
+    return failure();
+  }
+
+  if (succeeded(parser.parseOptionalKeyword("additionalArgs"))) {
+    if (parser.parseLParen() ||
+        parser.parseOperandList(additionalArgOperands)) {
+      return failure();
+    }
+
+    if (succeeded(parser.parseOptionalColonTypeList(additionalArgTypes))) {
+      if (additionalArgOperands.size() != additionalArgTypes.size()) {
+        return parser.emitError(parser.getNameLoc())
+               << "expected " << additionalArgOperands.size()
+               << " additionalArgs operand type"
+               << (additionalArgOperands.size() == 1 ? "" : "s");
+      }
+    } else if (!additionalArgOperands.empty()) {
+      return parser.emitError(parser.getNameLoc())
+             << "expected ':' followed by additionalArgs operand types";
+    }
+
+    if (parser.parseRParen()) {
+      return failure();
+    }
+  }
+
+  while (true) {
+    std::unique_ptr<Region> region;
+    OptionalParseResult parseResult = parser.parseOptionalRegion(region);
+    if (!parseResult.has_value()) {
+      break;
+    }
+    if (failed(*parseResult)) {
+      return failure();
+    }
+    result.addRegion(std::move(region));
+
+    if (failed(parser.parseOptionalComma())) {
+      break;
+    }
+  }
+
+  (void)parser.parseOptionalColonTypeList(resultTypes);
+
+  if (parser.resolveOperands(inputOperands, inputTypes, parser.getNameLoc(),
+                             result.operands) ||
+      parser.resolveOperands(outputOperands, outputTypes, parser.getNameLoc(),
+                             result.operands) ||
+      parser.resolveOperands(additionalArgOperands, additionalArgTypes,
+                             parser.getNameLoc(), result.operands)) {
+    return failure();
+  }
+
+  result.addTypes(resultTypes);
+  result.addAttribute(
+      GenericOp::getOperandSegmentSizesAttrName(result.name),
+      builder.getDenseI32ArrayAttr(
+          {static_cast<int32_t>(inputOperands.size()),
+           static_cast<int32_t>(outputOperands.size()),
+           static_cast<int32_t>(additionalArgOperands.size())}));
+  return success();
+}
+
+void GenericOp::print(OpAsmPrinter &printer) {
+  printer.printOptionalAttrDict(
+      (*this)->getAttrs(),
+      /*elidedAttrs=*/{getOperandSegmentSizesAttrName().getValue()});
+
+  printGenericOpOperandList(printer, "ins", getInputs(),
+                            /*printTypes=*/!getInputs().empty());
+  printGenericOpOperandList(printer, "outs", getOutputs(),
+                            /*printTypes=*/true);
+  if (!getAdditionalArgs().empty()) {
+    printGenericOpOperandList(printer, "additionalArgs", getAdditionalArgs(),
+                              /*printTypes=*/true);
+  }
+
+  printer << "\n        ";
+  llvm::interleaveComma(getRegions(), printer, [&](Region &region) {
+    // Preserve present-but-empty blocks in the printed form. Without this, MLIR
+    // prints a one-empty-block region as `{}`, which parses back as a
+    // zero-block region and violates GenericOp's verifier invariant.
+    printer.printRegion(region, /*printEntryBlockArgs=*/true,
+                        /*printBlockTerminators=*/true,
+                        /*printEmptyBlock=*/true);
+  });
+
+  if (getNumResults() > 0) {
+    printer << " : ";
+    llvm::interleaveComma(getResultTypes(), printer,
+                          [&](Type type) { printer.printType(type); });
+  }
+}
+
 void d2m::GenericOp::build(
     mlir::OpBuilder &builder, mlir::OperationState &state, ValueRange inputs,
     ValueRange outputs, ValueRange additionalArgs, ArrayAttr indexingMaps,

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
@@ -422,8 +422,9 @@ module attributes {ttcore.system_desc = #system_desc} {
     // CHECK-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
     // CHECK: d2m.remote_load %{{.*}}[%{{.*}}, %{{.*}}] into %{{.*}}
     // CHECK: d2m.remote_store %{{.*}}[%{{.*}}, %{{.*}}] from %{{.*}}
-    // Compute is emtpy
+    // Compute is empty
     // CHECK: }, {
+    // CHECK-NEXT: ^compute0:
     // CHECK-NEXT: }
     d2m.generic {block_factors = [], grid = #ttcore.grid<4x3>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
         ins(%input : memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)

--- a/test/ttmlir/Dialect/D2M/generic/generic_empty_region_roundtrip.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_empty_region_roundtrip.mlir
@@ -1,0 +1,28 @@
+// RUN: ttmlir-opt %s | ttmlir-opt | FileCheck %s --check-prefix=ROUNDTRIP
+// RUN: ttmlir-opt --ttcore-register-device --d2m-generic-regions-to-funcs %s | FileCheck %s --check-prefix=OUTLINE
+
+#l1 = #ttcore.memory_space<l1>
+
+ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+
+func.func @empty_datamovement_region(%arg0: memref<1xf32, #l1>) {
+  // ROUNDTRIP-LABEL: func.func @empty_datamovement_region
+  // ROUNDTRIP: d2m.generic
+  // ROUNDTRIP-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
+  // ROUNDTRIP: {
+  // ROUNDTRIP-NEXT: ^datamovement0:
+  // ROUNDTRIP: }, {
+  d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+      ins()
+      outs(%arg0 : memref<1xf32, #l1>) {
+  ^datamovement0:
+  }, {
+  ^compute0:
+  }
+  return
+}
+
+// OUTLINE: func.func private @datamovement_kernel0() attributes {d2m.thread = #d2m.thread<datamovement, dm_core = {{[0-9]+}}>, tt.function_type = "kernel"} {
+// OUTLINE-NEXT: return
+// OUTLINE: func.func private @compute_kernel1() attributes {d2m.thread = #d2m.thread<compute>, tt.function_type = "kernel"} {
+// OUTLINE-NEXT: return


### PR DESCRIPTION
### Problem description
Can't dump mlir at certain stages and then reload because we parse incorrectly

### What's changed
- Add custom printer for empty block for d2m generic
- Add lit test

### Checklist
- [ ] New/Existing tests provide coverage for changes
