### PR TITLE
Uplift third_party/tt-metal to 2fb3ce2ca9703bb456701ebe6dddd91b2584989e 2026-06-18

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -920,14 +920,13 @@ def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
       - `input`: The input tensor.
       - `dim`: Specifies the dimension along which the argmax is applied.
       - `keep_dim`: If set to true, the output tensor will have the same number of dimensions as the input tensor.
-      - `use_multicore`: Whether to use multiple cores or not.
 
     IR usage:
     // Input tensor of shape (128, 28, 28, 64)
     %input = ... : tensor<128x28x28x64xbf16>
 
     %empty = "ttnn.empty"(%0) <{....}> : -> tensor<128x28x28xi32>
-    %4 = "ttnn.argmax"(%input, %empty) <{dim = 3 : i32, use_multicore = false}> : (tensor<128x28x28xbf16>, tensor<128x28x28xi32) -> tensor<128x28x28xi32>
+    %4 = "ttnn.argmax"(%input, %empty) <{dim = 3 : i32}> : (tensor<128x28x28xbf16>, tensor<128x28x28xi32) -> tensor<128x28x28xi32>
 
     Example:
       input: [[1, 5, 3],
@@ -945,8 +944,7 @@ def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
 
   let arguments = (ins AnyRankedTensor:$input,
                        OptionalAttr<I32Attr>:$dim,
-                       DefaultValuedAttr<BoolAttr, "false">:$keep_dim,
-                       BoolAttr:$use_multicore);
+                       DefaultValuedAttr<BoolAttr, "false">:$keep_dim);
 
   let extraClassDeclaration = [{
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -380,12 +380,12 @@ struct OpModel<ArgMaxOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, std::optional<int32_t> dim,
-                   bool keepDim, bool multicore, TTNNLayoutAttr outputLayout);
+                   bool keepDim, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              std::optional<int32_t> dim,
-                                             bool keepDim, bool multicore,
+                                             bool keepDim,
                                              TTNNLayoutAttr outputLayout);
 };
 

--- a/include/ttmlir/Target/TTNN/operations/reduction.fbs
+++ b/include/ttmlir/Target/TTNN/operations/reduction.fbs
@@ -24,7 +24,6 @@ table ReductionArgMaxOp {
   out: tt.target.ttnn.TensorRef;
   dim: int32 = null;
   keep_dim: bool;
-  use_multicore: bool;
   memcfg: tt.target.ttnn.MemoryConfig;
 }
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -323,8 +323,7 @@ public:
     }
     rewriter.replaceOpWithNewOp<ttnn::ArgMaxOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), reductionAxis, adaptor.getKeepDim(),
-        /*use_multicore=*/true);
+        adaptor.getInput(), reductionAxis, adaptor.getKeepDim());
     return success();
   }
 };

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1302,7 +1302,6 @@ public:
         emitter.emit(srcOp.getDim()),
         /*keepdim=*/emitter.emit(srcOp.getKeepDim()),
         /*sub_core_grids=*/emitter.emit(std::nullopt),
-        emitter.emit(srcOp.getUseMulticore()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
     };
 

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1604,7 +1604,6 @@ public:
         emitter.emit(srcOp.getDim()),
         emitter.emit(srcOp.getKeepDim()),
         emitter.emit(std::nullopt, "sub_core_grids"),
-        emitter.emit(srcOp.getUseMulticore(), "use_multicore"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
     };
 

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2822,8 +2822,7 @@ ArgMaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ArgMaxOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim(), getKeepDim(), getUseMulticore(),
-      opConfig.outputLayout);
+      inputs[0], getDim(), getKeepDim(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2835,7 +2834,7 @@ ArgMaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<ArgMaxOp>::getOpRuntime, *this, inputShape, inputs[0],
-      getDim(), getKeepDim(), getUseMulticore(), opConfig.outputLayout);
+      getDim(), getKeepDim(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpDimRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpDimRewritePattern.cpp
@@ -88,7 +88,7 @@ ArgMaxOpDimRewritePattern::matchAndRewrite(ttnn::ArgMaxOp srcOp,
       mlir::IntegerType::get(getContext(), 32), rank - 1);
   auto argMaxOp = rewriter.create<ttnn::ArgMaxOp>(
       srcOp->getLoc(), permutedOutputType, forwardPermute, lastDimAttr,
-      srcOp.getKeepDimAttr(), srcOp.getUseMulticoreAttr());
+      srcOp.getKeepDimAttr());
 
   // Inverse permute to restore original dimension order.
   auto inversePermute = rewriter.replaceOpWithNewOp<ttnn::PermuteOp>(

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -4004,8 +4004,7 @@ llvm::Expected<size_t> OpModel<TopKRouterGptOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<int32_t> dim, bool keepDim, bool multicore,
-    TTNNLayoutAttr outputLayout) {
+    std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4018,7 +4017,7 @@ llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
   auto argMaxOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(
         ::ttnn::argmax, device, inputSpec, dim, keepDim, std::nullopt,
-        multicore, detail::getNullableMemoryConfig(outputLayout), std::nullopt);
+        detail::getNullableMemoryConfig(outputLayout), std::nullopt);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), argMaxOpQuery);
@@ -4027,11 +4026,9 @@ llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t>
-OpModel<ArgMaxOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-                                TTNNLayoutAttr inputLayout,
-                                std::optional<int32_t> dim, bool keepDim,
-                                bool multicore, TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<ArgMaxOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4044,7 +4041,7 @@ OpModel<ArgMaxOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   auto argMaxOpQuery = [=]() {
     return QUERY_OP_RUNTIME(
         ::ttnn::argmax, device, inputSpec, dim, keepDim, std::nullopt,
-        multicore, detail::getNullableMemoryConfig(outputLayout), std::nullopt);
+        detail::getNullableMemoryConfig(outputLayout), std::nullopt);
   };
 
   return operation::getOpRuntime(argMaxOpQuery);

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2648,8 +2648,7 @@ createReductionArgMaxOp(FlatbufferObjectCache &cache, ReductionOp op) {
   auto memoryConfig = toFlatbuffer(cache, op.getMemoryConfigAttr());
 
   return ::tt::target::ttnn::CreateReductionArgMaxOp(
-      *cache.fbb, in, output, dim, op.getKeepDim(), op.getUseMulticore(),
-      memoryConfig);
+      *cache.fbb, in, output, dim, op.getKeepDim(), memoryConfig);
 }
 
 template <typename ReductionOp>

--- a/runtime/lib/ttnn/operations/reduction/argmax.cpp
+++ b/runtime/lib/ttnn/operations/reduction/argmax.cpp
@@ -21,7 +21,6 @@ runReductionArgMaxOp(const ::tt::target::ttnn::ReductionArgMaxOp *op,
   ::ttnn::Tensor out = ::ttnn::argmax(in, op->dim(),
                                       /*keepdim=*/op->keep_dim(),
                                       /*sub_core_grids=*/std::nullopt,
-                                      /*use_multicore=*/op->use_multicore(),
                                       /*memory_config_arg=*/outputMemoryConfig,
                                       /*optional_output_tensor=*/std::nullopt);
 

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -1530,6 +1530,11 @@ def module_batch_norm_grad(builder: StableHLOBuilder):
         unit_attrs: Optional[List[str]] = None,
     ):
         builder.set_graph_level_check(True)
+        # variance must be non-negative (it represents E[(x-mean)^2]).
+        # torch.randn can produce negative values causing sqrt(negative) = NaN.
+        builder.set_goldens(
+            {variance: torch.rand(builder.get_shape(variance), dtype=torch.float32)}
+        )
         return builder.batch_norm_grad(
             operand,
             scale,

--- a/test/ttmlir/Conversion/TTNNToTTIR/reduction_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/reduction_op.mlir
@@ -82,7 +82,7 @@ module {
 
         // CHECK: %{{[0-9]+}} = "ttir.argmax"(%{{[0-9]+}}) <{dim_arg = [0 : i32], keep_dim = false}> : (tensor<64x32xbf16, #ttnn_layout{{[0-9]+}}>) -> tensor<32xi32, #ttnn_layout{{[0-9]+}}>
         // CHECK-NOT: "ttnn.argmax"
-        %2 = "ttnn.argmax"(%1) {ttnn.hoist_generic_via_d2m, dim = 0 : i32, keep_dim = false, use_multicore = true} : (tensor<64x32xbf16, #l1_layout>) -> tensor<32xi32, #l1_layout>
+        %2 = "ttnn.argmax"(%1) {ttnn.hoist_generic_via_d2m, dim = 0 : i32, keep_dim = false} : (tensor<64x32xbf16, #l1_layout>) -> tensor<32xi32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<32xi32, #l1_layout>) -> tensor<32xi32, #dram_layout>
 
@@ -166,7 +166,7 @@ module {
 
         // CHECK: %{{[0-9]+}} = "ttir.argmax"(%{{[0-9]+}}) <{keep_dim = true}> : (tensor<64x96xbf16, #ttnn_layout{{[0-9]+}}>) -> tensor<1x1xi32, #ttnn_layout{{[0-9]+}}>
         // CHECK-NOT: "ttnn.argmax"
-        %2 = "ttnn.argmax"(%1) {ttnn.hoist_generic_via_d2m, keep_dim = true, use_multicore = true} : (tensor<64x96xbf16, #l1_layout>) -> tensor<1x1xi32, #l1_layout>
+        %2 = "ttnn.argmax"(%1) {ttnn.hoist_generic_via_d2m, keep_dim = true} : (tensor<64x96xbf16, #l1_layout>) -> tensor<1x1xi32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<1x1xi32, #l1_layout>) -> tensor<1x1xi32, #dram_layout>
 

--- a/test/ttmlir/Conversion/TTNNToTTIR/skip_reduction_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/skip_reduction_op.mlir
@@ -32,8 +32,8 @@ module {
 
         // CHECK-NOT: %{{[0-9]+}} = ttir.empty() : tensor<32xi32, #ttnn_layout1>
         // CHECK-NOT: %{{[0-9]+}} = "ttir.argmax"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32xi32, #ttnn_layout1>) -> tensor<32xi32, #ttnn_layout1>
-        // CHECK: %{{[0-9]+}} = "ttnn.argmax"(%{{[0-9]+}}) <{dim = 1 : i32, keep_dim = false, use_multicore = true}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32xi32, #ttnn_layout1>
-        %2 = "ttnn.argmax"(%1) {dim = 1 : i32, keep_dim = false, use_multicore = true} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xi32, #l1_layout>
+        // CHECK: %{{[0-9]+}} = "ttnn.argmax"(%{{[0-9]+}}) <{dim = 1 : i32, keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>) -> tensor<32xi32, #ttnn_layout1>
+        %2 = "ttnn.argmax"(%1) {dim = 1 : i32, keep_dim = false} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xi32, #l1_layout>
 
         %3 = "ttnn.to_memory_config"(%2) : (tensor<32xi32, #l1_layout>) -> tensor<32xi32, #dram_layout>
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/argmax_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/argmax_workaround.mlir
@@ -11,7 +11,7 @@ module {
     // CHECK-SAME: dim = 2 : i32
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 1, 0>
-    %0 = "ttnn.argmax"(%arg0) <{dim = 0 : i32, keep_dim = false, use_multicore = false}> : (tensor<128x32x64xf32>) -> tensor<32x64xui32>
+    %0 = "ttnn.argmax"(%arg0) <{dim = 0 : i32, keep_dim = false}> : (tensor<128x32x64xf32>) -> tensor<32x64xui32>
     return %0 : tensor<32x64xui32>
   }
 
@@ -24,7 +24,7 @@ module {
     // CHECK-SAME: dim = 3 : i32
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 0, 3, 2, 1>
-    %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = true, use_multicore = false}> : (tensor<2x8x32x64xf32>) -> tensor<2x1x32x64xui32>
+    %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = true}> : (tensor<2x8x32x64xf32>) -> tensor<2x1x32x64xui32>
     return %0 : tensor<2x1x32x64xui32>
   }
 
@@ -34,7 +34,7 @@ module {
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: dim = 1 : i32
-    %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = false, use_multicore = false}> : (tensor<32x64xf32>) -> tensor<32xui32>
+    %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = false}> : (tensor<32x64xf32>) -> tensor<32xui32>
     return %0 : tensor<32xui32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/argmax_layout_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/argmax_layout_validation.mlir
@@ -26,7 +26,7 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x1x32x32xbf16,
     // CHECK-NEXT: "ttnn.argmax"
 
-    %1 = "ttnn.argmax"(%arg0) <{dim = 3 : i32, keep_dim = false, use_multicore = false}> : (tensor<1x1x32x32xf32, #ttnn_layout_tile_f32>) -> tensor<1x1x32xui32, #ttnn_layout_row_major_uint32>
+    %1 = "ttnn.argmax"(%arg0) <{dim = 3 : i32, keep_dim = false}> : (tensor<1x1x32x32xf32, #ttnn_layout_tile_f32>) -> tensor<1x1x32xui32, #ttnn_layout_row_major_uint32>
 
     return %1 : tensor<1x1x32xui32, #ttnn_layout_row_major_uint32>
   }

--- a/test/ttmlir/Dialect/TTNN/reduction/negative_argmax_op.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/negative_argmax_op.mlir
@@ -3,7 +3,7 @@
 
 // CHECK: error: 'ttnn.argmax' op dim attribute value 3 is out of range for input tensor of rank 2, expected value in range [-2, 1]
 func.func @test_argmax_dim_out_of_range_positive(%arg0: tensor<64x64xf32>) -> tensor<64xui32> {
-  %0 = "ttnn.argmax"(%arg0) <{dim = 3 : i32, keep_dim = false, use_multicore = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
+  %0 = "ttnn.argmax"(%arg0) <{dim = 3 : i32, keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
   return %0 : tensor<64xui32>
 }
 
@@ -11,7 +11,7 @@ func.func @test_argmax_dim_out_of_range_positive(%arg0: tensor<64x64xf32>) -> te
 
 // CHECK: error: 'ttnn.argmax' op dim attribute value -3 is out of range for input tensor of rank 2, expected value in range [-2, 1]
 func.func @test_argmax_dim_out_of_range_negative(%arg0: tensor<64x64xf32>) -> tensor<64xui32> {
-  %0 = "ttnn.argmax"(%arg0) <{dim = -3 : i32, keep_dim = false, use_multicore = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
+  %0 = "ttnn.argmax"(%arg0) <{dim = -3 : i32, keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
   return %0 : tensor<64xui32>
 }
 
@@ -19,7 +19,7 @@ func.func @test_argmax_dim_out_of_range_negative(%arg0: tensor<64x64xf32>) -> te
 
 // CHECK: error: 'ttnn.argmax' op expected output shape (64), got (64, 64)
 func.func @test_argmax_wrong_output_shape(%arg0: tensor<64x64xf32>) -> tensor<64x64xui32> {
-  %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = false, use_multicore = false}> : (tensor<64x64xf32>) -> tensor<64x64xui32>
+  %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64x64xui32>
   return %0 : tensor<64x64xui32>
 }
 
@@ -27,7 +27,7 @@ func.func @test_argmax_wrong_output_shape(%arg0: tensor<64x64xf32>) -> tensor<64
 
 // CHECK: error: 'ttnn.argmax' op expected output shape (64, 1), got (64, 64)
 func.func @test_argmax_wrong_output_shape_keep_dim(%arg0: tensor<64x64xf32>) -> tensor<64x64xui32> {
-  %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = true, use_multicore = false}> : (tensor<64x64xf32>) -> tensor<64x64xui32>
+  %0 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, keep_dim = true}> : (tensor<64x64xf32>) -> tensor<64x64xui32>
   return %0 : tensor<64x64xui32>
 }
 
@@ -35,6 +35,6 @@ func.func @test_argmax_wrong_output_shape_keep_dim(%arg0: tensor<64x64xf32>) -> 
 
 // CHECK: error: 'ttnn.argmax' op expected output shape (), got (64)
 func.func @test_argmax_no_dim_wrong_output_shape(%arg0: tensor<64x64xf32>) -> tensor<64xui32> {
-  %0 = "ttnn.argmax"(%arg0) <{keep_dim = false, use_multicore = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
+  %0 = "ttnn.argmax"(%arg0) <{keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64xui32>
   return %0 : tensor<64xui32>
 }

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
@@ -5,7 +5,7 @@ module attributes {} {
   func.func public @argmax_2d(%arg0: tensor<64x64xf32>) -> tensor<64x1xi32> {
     // CHECK-LABEL: func.func public @argmax_2d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 1 : i32, keep_dim = true, use_multicore = true}>
+    // CHECK-SAME: {dim = 1 : i32, keep_dim = true}>
     // CHECK-SAME: tensor<64x64xf32
     // CHECK-SAME: -> tensor<64x1xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<64x64xf32>) -> tensor<64x1xi32>
@@ -17,7 +17,7 @@ module attributes {} {
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 0, 2, 1>
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 2 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 2 : i32, keep_dim = false}>
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x28x28xf32>) -> tensor<128x28xi32>
     return %1 : tensor<128x28xi32>
   }
@@ -26,7 +26,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_3d_last_dim(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 2 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 2 : i32, keep_dim = false}>
     // CHECK-SAME: tensor<128x28x28xf32
     // CHECK-SAME: -> tensor<128x28xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<128x28x28xf32>) -> tensor<128x28xi32>
@@ -37,7 +37,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_4d(
     // CHECK-NOT: "ttnn.permute"
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 3 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 3 : i32, keep_dim = false}>
     // CHECK-SAME: tensor<4x8x128x64xf32
     // CHECK-SAME: -> tensor<4x8x128xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<4x8x128x64xf32>) -> tensor<4x8x128xi32>

--- a/test/ttmlir/EmitC/TTNN/reduction/argmax.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/argmax.mlir
@@ -10,7 +10,7 @@
 func.func public @argmax_2d(%arg0: tensor<64x64xf32>) -> tensor<64xi32> {
   // CHECK-LABEL: func.func public @argmax_2d(
   // CHECK: "ttnn.argmax"
-  // CHECK-SAME: {dim = 1 : i32, use_multicore = false}>
+  // CHECK-SAME: {dim = 1 : i32}>
   // CHECK-SAME: tensor<64x64xf32
   // CHECK-SAME: tensor<64xi32
   // CHECK-SAME: -> tensor<64xi32

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/argmax_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/argmax_op.mlir
@@ -9,7 +9,7 @@ module @module_argmax attributes {} {
   func.func public @argmax_torch_2d(%arg0: tensor<1x32128xf32>) -> tensor<1xi64> {
     // CHECK-LABEL: func.func public @argmax_torch_2d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 1 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 1 : i32, keep_dim = false}>
     // CHECK-SAME: tensor<1x32128xf32
     // CHECK-SAME: -> tensor<1xui32
     %cst = stablehlo.constant dense<0xFF800000> : tensor<f32>
@@ -31,7 +31,7 @@ module @module_argmax attributes {} {
   func.func public @argmax_jax_3d(%arg0: tensor<1x32x32xf32>) -> tensor<1x32xi32> {
     // CHECK-LABEL: func.func public @argmax_jax_3d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 2 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 2 : i32, keep_dim = false}>
     // CHECK-SAME: tensor<1x32x32xf32
     // CHECK-SAME: -> tensor<1x32xui32
     %0 = stablehlo.iota dim = 2 : tensor<1x32x32xi32>
@@ -56,7 +56,7 @@ module @module_argmax attributes {} {
   func.func public @argmax_torch_4d(%arg0: tensor<1x1x128x64xf32>) -> tensor<1x1x128xi64> {
     // CHECK-LABEL: func.func public @argmax_torch_4d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 3 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 3 : i32, keep_dim = false}>
     // CHECK-SAME: tensor<1x1x128x64xf32
     // CHECK-SAME: -> tensor<1x1x128xui32
     %cst = stablehlo.constant dense<0xFF800000> : tensor<f32>

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_argmax.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_argmax.mlir
@@ -18,7 +18,7 @@ module attributes {} {
     // CHECK-LABEL: func.func public @argmax_2d(
     %0 = ttir.empty() : tensor<64xi32>
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 1 : i32, use_multicore = false}>
+    // CHECK-SAME: {dim = 1 : i32}>
     // CHECK-SAME: tensor<64x64xf32
     // CHECK-SAME: tensor<64xi32
     // CHECK-SAME: -> tensor<64xi32

--- a/test/ttmlir/Silicon/TTNN/n150/simple_argmax.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_argmax.mlir
@@ -8,7 +8,7 @@ module attributes {} {
   func.func public @argmax_2d(%arg0: tensor<64x64xf32>) -> tensor<64xi32> {
     // CHECK-LABEL: func.func public @argmax_2d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 1 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 1 : i32, keep_dim = false}>
     // CHECK-SAME: tensor<64x64xf32
     // CHECK-SAME: -> tensor<64xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<64x64xf32>) -> tensor<64xi32>
@@ -18,7 +18,7 @@ module attributes {} {
   func.func public @argmax_3d(%arg0: tensor<1x28x28xf32>) -> tensor<1x28xi32> {
     // CHECK-LABEL: func.func public @argmax_3d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 2 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 2 : i32, keep_dim = false}>
     // CHECK-SAME: tensor<1x28x28xf32
     // CHECK-SAME: -> tensor<1x28xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<1x28x28xf32>) -> tensor<1x28xi32>
@@ -28,7 +28,7 @@ module attributes {} {
   func.func public @argmax_4d(%arg0: tensor<1x1x128x64xf32>) -> tensor<1x1x128xi32> {
     // CHECK-LABEL: func.func public @argmax_4d(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 3 : i32, keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {dim = 3 : i32, keep_dim = false}>
     // CHECK-SAME: tensor<1x1x128x64xf32
     // CHECK-SAME: -> tensor<1x1x128xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<1x1x128x64xf32>) -> tensor<1x1x128xi32>
@@ -38,7 +38,7 @@ module attributes {} {
   func.func public @argmax_all_reduce(%arg0: tensor<2x4x32x32xf32>) -> tensor<i32> {
     // CHECK-LABEL: func.func public @argmax_all_reduce(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {keep_dim = false, use_multicore = true}>
+    // CHECK-SAME: {keep_dim = false}>
     // CHECK-SAME: tensor<2x4x32x32xf32
     // CHECK-SAME: -> tensor<ui32
     %1 = "ttir.argmax"(%arg0) <{keep_dim = false}> : (tensor<2x4x32x32xf32>) -> tensor<i32>
@@ -48,7 +48,7 @@ module attributes {} {
   func.func public @argmax_keepdim(%arg0: tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xui32> {
     // CHECK-LABEL: func.func public @argmax_keepdim(
     // CHECK: "ttnn.argmax"
-    // CHECK-SAME: {dim = 3 : i32, keep_dim = true, use_multicore = true}>
+    // CHECK-SAME: {dim = 3 : i32, keep_dim = true}>
     // CHECK-SAME: tensor<2x4x32x32xf32
     // CHECK-SAME: -> tensor<2x4x32x1xui32
     %1 = "ttir.argmax"(%arg0) <{dim_arg = [3 : i32], keep_dim = true}> : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xui32>

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -461,7 +461,7 @@ TEST_F(OpModelTest, ArgMax) {
 
   // Test case 1: no keepDim
   auto constraintsExp = OpModel<ArgMaxOp>::getOpConstraints(
-      tensorShape, layoutDRAMRowMajor, 1, false, false, layoutDRAMRowMajor);
+      tensorShape, layoutDRAMRowMajor, 1, false, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -469,21 +469,21 @@ TEST_F(OpModelTest, ArgMax) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
   auto runtimeExp = OpModel<ArgMaxOp>::getOpRuntime(
-      tensorShape, layoutDRAMRowMajor, 1, false, false, layoutDRAMRowMajor);
+      tensorShape, layoutDRAMRowMajor, 1, false, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   // Test case 2: with keepDim
   constraintsExp = OpModel<ArgMaxOp>::getOpConstraints(
-      tensorShape, layoutDRAMRowMajor, 1, true, false, layoutDRAMRowMajor);
+      tensorShape, layoutDRAMRowMajor, 1, true, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  runtimeExp = OpModel<ArgMaxOp>::getOpRuntime(
-      tensorShape, layoutDRAMRowMajor, 1, true, false, layoutDRAMRowMajor);
+  runtimeExp = OpModel<ArgMaxOp>::getOpRuntime(tensorShape, layoutDRAMRowMajor,
+                                               1, true, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
@@ -493,7 +493,7 @@ TEST_F(OpModelTest, ArgMax) {
       tensorShape2, BufferType::DRAM, TensorMemoryLayout::Interleaved);
 
   constraintsExp = OpModel<ArgMaxOp>::getOpConstraints(
-      tensorShape2, layoutDRAMRowMajor2, 1, false, false, layoutDRAMRowMajor2);
+      tensorShape2, layoutDRAMRowMajor2, 1, false, layoutDRAMRowMajor2);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
@@ -501,7 +501,7 @@ TEST_F(OpModelTest, ArgMax) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
   runtimeExp = OpModel<ArgMaxOp>::getOpRuntime(
-      tensorShape2, layoutDRAMRowMajor2, 1, false, false, layoutDRAMRowMajor2);
+      tensorShape2, layoutDRAMRowMajor2, 1, false, layoutDRAMRowMajor2);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1212,7 +1212,7 @@ TEST_F(OpModelBase, ArgMaxOpInterface) {
 
   auto argMax =
       builder.create<ArgMaxOp>(builder.getUnknownLoc(), outputType, input,
-                               builder.getI32IntegerAttr(1), false, false);
+                               builder.getI32IntegerAttr(1), false);
 
   // getOutputLayout() hardcodes tiled L1 layout, so we cannot use it
   OpModel backend = dyn_cast<OpModel>(argMax.getOperation());

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "881ddfabc74a7a5df6b70a514efda6b4bb2f8e74")
+set(TT_METAL_VERSION "2fb3ce2ca9703bb456701ebe6dddd91b2584989e")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 2fb3ce2ca9703bb456701ebe6dddd91b2584989e



### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/27786481265
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/27786497001
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):