### PR TITLE
Enable xfail_strict in golden pytest.ini

### DIFF
--- a/test/python/golden/pytest.ini
+++ b/test/python/golden/pytest.ini
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 [pytest]
+xfail_strict = true
 markers =
   n300: mark test as running on n300
   llmbox: mark test as running on llmbox


### PR DESCRIPTION
Without strict mode, an unexpected pass on an @pytest.mark.xfail test is reported as XPASS but does not fail the session, so stale xfail markers (e.g. when an upstream bug is fixed) go unnoticed. Turning on xfail_strict makes XPASS a hard failure.
