### PR TITLE
[TTIR] Cap fused output width in SharedLHSMatmulFusion

### DIFF
--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -1583,13 +1583,23 @@ public:
   }
 
 private:
+  // Upper bound on the fused output (feature) dimension. Many-way fusions
+  // concatenate every RHS weight/bias along this dim; a rank-1 bias concat
+  // lowers to ttnn.concat's row-major path where one page is the whole row, so
+  // a large fused width overflows per-core L1. Cap keeps even an f32 bias page
+  // (262144 * 4 B = 1 MB) within L1, staying well above realistic QKV/MLP
+  // fusion.
+  static constexpr int64_t kMaxFusedOutputDim = 262144;
+
   struct FusionCandidates {
     SmallVector<OpType> ops;
     int64_t totalOutputDim = 0;
     bool allSameTransposeB = true;
     bool firstTransposeB = false;
 
-    bool isValid() const { return ops.size() >= 3; }
+    bool isValid() const {
+      return ops.size() >= 3 && totalOutputDim <= kMaxFusedOutputDim;
+    }
 
     bool getTargetTransposeB() const {
       return allSameTransposeB ? firstTransposeB : false;

--- a/test/ttmlir/Dialect/TTIR/fusing/shared_lhs_linear_bias.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/shared_lhs_linear_bias.mlir
@@ -80,3 +80,29 @@ module {
     return %0, %1, %2 : tensor<32x384xbf16>, tensor<32x384xbf16>, tensor<32x384xbf16>
   }
 }
+
+// Oversized fusion: the combined output width exceeds kMaxFusedOutputDim
+// (262144), so the three LinearOps must NOT be fused. Fusing them would build
+// one enormous concatenated weight/bias; because the fused bias is rank-1 it
+// forces ttnn.concat onto the row-major (stick) path, which overflows per-core
+// L1. This guards against pathological many-way shared-LHS fusions such as
+// CogVideoX's per-layer AdaLN modulation linears.
+module {
+  func.func @shared_lhs_linear_oversized(
+      %input: tensor<2x512xf32>,
+      %w0: tensor<512x131072xf32>, %b0: tensor<131072xf32>,
+      %w1: tensor<512x131072xf32>, %b1: tensor<131072xf32>,
+      %w2: tensor<512x131072xf32>, %b2: tensor<131072xf32>) -> (tensor<2x131072xf32>, tensor<2x131072xf32>, tensor<2x131072xf32>) {
+    // CHECK-LABEL: func.func @shared_lhs_linear_oversized
+    // Should NOT fuse — three separate linear ops remain.
+    // CHECK: "ttir.linear"
+    // CHECK: "ttir.linear"
+    // CHECK: "ttir.linear"
+    // CHECK-NOT: "ttir.concat"
+    // CHECK-NOT: "ttir.slice_static"
+    %0 = "ttir.linear"(%input, %w0, %b0) <{transpose_a = false, transpose_b = false}> : (tensor<2x512xf32>, tensor<512x131072xf32>, tensor<131072xf32>) -> tensor<2x131072xf32>
+    %1 = "ttir.linear"(%input, %w1, %b1) <{transpose_a = false, transpose_b = false}> : (tensor<2x512xf32>, tensor<512x131072xf32>, tensor<131072xf32>) -> tensor<2x131072xf32>
+    %2 = "ttir.linear"(%input, %w2, %b2) <{transpose_a = false, transpose_b = false}> : (tensor<2x512xf32>, tensor<512x131072xf32>, tensor<131072xf32>) -> tensor<2x131072xf32>
+    return %0, %1, %2 : tensor<2x131072xf32>, tensor<2x131072xf32>, tensor<2x131072xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
[#5114](https://github.com/tenstorrent/tt-xla/issues/5114)

### Problem description
Cogvideox model test fails with 

`ttnn.concat: required CB page size (3465216 B) exceeds per-core L1 capacity (1395296 B); op cannot fit on this device.`

The DiT drives every per-layer AdaLN modulation Linear from the same activation — silu(time_embed), shape 2×512. There are ~84 such linears (one per norm1/norm2 across the transformer blocks). SharedLHSMatmulFusion collects all matmuls/linears that share an LHS and fuses them into a single op with concatenated RHS weights/biases, guarded only by ops.size() >= 3. With no upper bound, it fused all 84 AdaLN linears into one linear with a 512×1554432 weight and — the fatal part — a rank-1 1554432 bias built by an 84-way ttir.concat.

### What's changed

- In TTIRFusing.cpp, `SharedLHSMatmulFusion` now caps the size of a fused group. A new constant kMaxFusedOutputDim = 262144 bounds the concatenated output (feature) dimension, and FusionCandidates::isValid() gains the check.

- return ops.size() >= 3 && totalOutputDim <= kMaxFusedOutputDim;   // was: return ops.size() >= 3;
totalOutputDim is already accumulated in collectCandidates, so when a shared-LHS group's combined output width exceeds the cap the group is reported invalid and left unfused — each projection runs as its own small op , so no giant concat is ever built and the row-major page never approaches L1. The fusion mechanics, bias/weight concatenation, slicing, and the MatmulOp/LinearOp variants are otherwise unchanged.

- The cap gates only SharedLHSMatmulFusion asserting the oversized group stays unfused; the existing positive cases (combined 1152) still fuse. Post this fix, the CogVideoX transformer clears the concat TT_FATAL and proceeds past the fused-AdaLN stage.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs
[cogvideox_transformer_before_fix_june19.zip](https://github.com/user-attachments/files/29202286/cogvideox_transformer_before_fix_june19.zip)
[cogvideox_transformer_after_fix_june19.zip](https://github.com/user-attachments/files/29202280/cogvideox_transformer_after_fix_june19.zip)
