### PR TITLE
[Optimizer] Remove redundant PagedUpdateCache rule now that tt-metal enforces it

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
@@ -44,11 +44,6 @@ struct OpRuleBook {
     return nullptr;
   }
 
-  virtual LayoutFilterFn getInputLayoutFilter(RankedTensorType inputType,
-                                              unsigned operandIdx) const {
-    return getInputLayoutFilter(operandIdx);
-  }
-
   /// Whether to generate reshard candidates for this op's inputs.
   /// This is a compile-time optimization: returning false skips
   /// O(K * reshardCandidates) backend validation calls. Use false when

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -78,14 +78,6 @@ struct SplitQKVRuleBook : OpRuleBook {
                  const std::vector<OpConfig> &legalConfigs) const override;
 };
 
-/// PagedUpdateCache constraint: the fill-value (operand 1) must be L1
-/// height-sharded on a {numUsers, 1} virtual grid, where numUsers is the
-/// batch size (input1.shape[1]).
-struct PagedUpdateCacheRuleBook : OpRuleBook {
-  LayoutFilterFn getInputLayoutFilter(RankedTensorType inputType,
-                                      unsigned operandIdx) const override;
-};
-
 /// FillCache / PagedFillCache constraint: the cache buffer (operand 0) is
 /// modified in-place and must remain in DRAM interleaved storage. If the
 /// beam search picks an L1 layout, the optimizer inserts a to_memory_config

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -86,9 +86,7 @@ static TTNNLayoutAttr getOutputLayoutForResult(const BeamCandidate &c,
 /// Returns nullptr when no filtering is needed (all layouts accepted).
 /// Delegates to per-op rule files via OpRuleBook.
 static LayoutFilterFn getInputLayoutFilter(Operation *op, unsigned operandIdx) {
-  auto inputType =
-      mlir::cast<RankedTensorType>(op->getOperand(operandIdx).getType());
-  return getRuleBook(op).getInputLayoutFilter(inputType, operandIdx);
+  return getRuleBook(op).getInputLayoutFilter(operandIdx);
 }
 
 /// Returns true if the operand is already "constant" from the optimizer's

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -82,7 +82,6 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static RmsNormRuleBook rmsNorm;
   static MeshPartitionRuleBook meshPartition;
   static MoeRuleBook moe;
-  static PagedUpdateCacheRuleBook pagedUpdateCache;
   static FillCacheRuleBook fillCache;
   static PagedFillCacheRuleBook pagedFillCache;
 
@@ -123,7 +122,6 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(MeshPartitionOp::getOperationName(), &meshPartition);
     reg(PrepareMoEComputeW0W1WeightsOp::getOperationName(), &moe);
     reg(PrepareMoEComputeW2WeightsOp::getOperationName(), &moe);
-    reg(PagedUpdateCacheOp::getOperationName(), &pagedUpdateCache);
     reg(FillCacheOp::getOperationName(), &fillCache);
     reg(PagedFillCacheOp::getOperationName(), &pagedFillCache);
   });

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -5,8 +5,6 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h"
 
-#include "mlir/IR/BuiltinTypes.h"
-
 namespace mlir::tt::ttnn {
 
 //===----------------------------------------------------------------------===//
@@ -94,40 +92,6 @@ OutputHints SplitQKVRuleBook::getOutputHints(
   // Use NULL hint only to keep input/output DRAM-interleaved.
   // https://github.com/tenstorrent/tt-metal/issues/41526
   return layout_filter_utils::nullHintOnly();
-}
-
-//===----------------------------------------------------------------------===//
-// PagedUpdateCacheRuleBook
-//===----------------------------------------------------------------------===//
-
-LayoutFilterFn
-PagedUpdateCacheRuleBook::getInputLayoutFilter(RankedTensorType inputType,
-                                               unsigned operandIdx) const {
-  // Operand 1 (fill value): L1 height-sharded with virtual grid
-  // {numUsers, 1}, where numUsers = input1.shape[1].  Any other grid
-  // silently produced PCC=0 for upper users
-  // (https://github.com/tenstorrent/tt-metal/issues/44923).  HS in tt-mlir
-  // IR is pinned to {M, 1}, so this is the canonical (and only) HS grid
-  // shape with num_cores == numUsers.
-  //
-  // TODO(bmalesevic): once tt-metal PR #45016 is uplifted, metal enforces
-  // `grid.num_cores() == padded_shape()[1]` from its side and this rule
-  // can be removed; the tripwire at
-  // test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp will fail
-  // and signal the point.
-  if (operandIdx == 1) {
-    int64_t numUsers = inputType.getShape()[1];
-    return [numUsers](TTNNLayoutAttr layout) -> bool {
-      auto ml = layout.getMemLayout();
-      assert(ml && "expected non-null memory layout");
-      auto gridShape = layout.getGridShape();
-      assert(gridShape.size() == 2 && "expected 2D grid shape");
-      return layout.hasL1BufferType() &&
-             ml.getValue() == TensorMemoryLayout::HeightSharded &&
-             gridShape[0] == numUsers && gridShape[1] == 1;
-    };
-  }
-  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -699,9 +699,10 @@ public:
       }
 
       // PagedUpdateCacheOpRewritePattern is only needed below opt-level 2.
-      // At level >= 2 the greedy sharding optimizer (PagedUpdateCacheRuleBook
-      // constraint sink) drives the upstream producer to L1 height-sharded
-      // and inserts a proper ToMemoryConfigOp via beam search.
+      // At level >= 2 the greedy sharding optimizer drives the upstream
+      // producer to L1 height-sharded and inserts a proper ToMemoryConfigOp
+      // via beam search: metal's own grid TT_FATAL (tt-metal #45016) makes the
+      // constraint query reject any other operand-1 layout.
       if (optimizationLevel < 2) {
         patterns
             .add<workarounds::decomposition::PagedUpdateCacheOpRewritePattern>(

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -5499,48 +5499,6 @@ TEST_F(OpModelTest, PagedUpdateCacheOpWithoutPageTable) {
   }
 }
 
-// tt-metal grid validation on PagedUpdateCacheOp operand 1.
-// The kernel requires input1 ("fill value") to be L1 height-sharded on a
-// {numUsers, 1} virtual grid, where numUsers = input1.shape[1]. Any other
-// grid silently produced PCC=0 for the upper users.
-//
-// As of the tt-metal uplift that added `input_num_shards == num_users`
-// (https://github.com/tenstorrent/tt-metal/issues/44923), metal now rejects
-// non-{numUsers, 1} grids, so OpModel surfaces that as a failed constraint
-// query.  This test feeds a {4, 1} grid (num_cores = 4 != numUsers = 8) and
-// asserts the query fails.
-//
-// TODO(#44923): with metal enforcing this from its side, the operand-1 rule
-// in PagedUpdateCacheRuleBook is now redundant and can be dropped (along with
-// this test); deferred to a follow-up cleanup.
-TEST_F(OpModelTest, PagedUpdateCacheOpWrongGridTripwire) {
-  const llvm::SmallVector<int64_t> cacheShape = {8, 4, 32, 256};
-  const llvm::SmallVector<int64_t> inputShape = {1, 8, 12, 256};
-  const llvm::SmallVector<int64_t> updateIndexShape = {8};
-
-  // numUsers = inputShape[1] = 8.  Correct virtual grid is {8, 1}; we use
-  // {4, 1} (evenly divides numUsers, but not equal to it).
-  const llvm::SmallVector<int64_t> wrongVirtualGrid = {4, 1};
-
-  const TTNNLayoutAttr cacheLayout = CreateTiledLayout(
-      cacheShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
-  const TTNNLayoutAttr inputLayoutWrongGrid =
-      CreateTiledLayout(inputShape, BufferType::L1,
-                        TensorMemoryLayout::HeightSharded, wrongVirtualGrid);
-  const TTNNLayoutAttr updateIndexLayout = CreateRowMajorLayoutInt32(
-      updateIndexShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
-
-  auto constraintsExp = OpModel<PagedUpdateCacheOp>::getOpConstraints(
-      cacheShape, cacheLayout, inputShape, inputLayoutWrongGrid,
-      updateIndexShape, updateIndexLayout, std::nullopt, std::nullopt, false,
-      cacheLayout);
-  const bool ok = static_cast<bool>(constraintsExp);
-  if (!ok) {
-    llvm::consumeError(constraintsExp.takeError());
-  }
-  EXPECT_FALSE(ok);
-}
-
 TEST_F(OpModelTest, PagedFillCacheOp) {
   // Test basic PagedUpdateCacheOp with DRAM cache, input, update_index, and
   // page_table tensors

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp
@@ -3,67 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Tripwire tests: pass today, expected to fail when a specific tt-metal
-// change lands.  Each test's comment names the metal issue/PR to track.
-// Kept in a separate target so it compiles fast and the whole file can be
-// removed once the upstream change arrives.
+// change lands.  Each test's comment should name the metal issue/PR it
+// tracks.  Kept in a separate target so it compiles fast and the file can be
+// removed (or individual tripwires dropped) once the upstream change arrives.
+//
+// This file is currently an empty placeholder -- add a TEST_F here when a new
+// tt-metal behavior needs a tripwire.  The PagedUpdateCacheOpWrongGrid
+// tripwire lived here until tt-metal #45016 landed; see git history for an
+// example of the pattern.
 
 #include "OpModelFixture.h"
-
-#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
-#include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
-
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/Error.h"
-
-#include <cstdint>
-#include <optional>
 
 namespace mlir::tt::ttnn::op_model {
 
 class OpModelTripwireTest : public OpModelFixture {};
-
-// PagedUpdateCacheOp operand 1 must be L1 height-sharded with virtual grid
-// {numUsers, 1} = {input1.shape[1], 1}; other grids silently produced
-// PCC=0 for upper users
-// (https://github.com/tenstorrent/tt-metal/issues/44923).
-//
-// tt-metal PR #45016 added the matching TT_FATAL
-// (`grid.num_cores() == padded_shape()[1]`), which has now been uplifted.
-// metal rejects PCC-degrading grids, so OpModel surfaces them as a failed
-// constraint query: this test feeds {4, 1} for numUsers = 8 and asserts the
-// query fails.
-//
-// TODO(#44923): with metal enforcing this from its side, the operand-1 rule
-// in PagedUpdateCacheRuleBook is now redundant and can be dropped, along with
-// this file + target; deferred to a follow-up cleanup.
-TEST_F(OpModelTripwireTest, PagedUpdateCacheOpWrongGrid) {
-  const llvm::SmallVector<int64_t> cacheShape = {8, 4, 32, 256};
-  const llvm::SmallVector<int64_t> inputShape = {1, 8, 12, 256};
-  const llvm::SmallVector<int64_t> updateIndexShape = {8};
-
-  // numUsers = inputShape[1] = 8; the only valid HS grid in tt-mlir IR is
-  // {8, 1}.  We use {4, 1} (num_cores = 4) so metal's TT_FATAL rejects it.
-  const llvm::SmallVector<int64_t> wrongVirtualGrid = {4, 1};
-
-  const TTNNLayoutAttr cacheLayout = CreateTiledLayout(
-      cacheShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
-  const TTNNLayoutAttr inputLayoutWrongGrid =
-      CreateTiledLayout(inputShape, BufferType::L1,
-                        TensorMemoryLayout::HeightSharded, wrongVirtualGrid);
-  const TTNNLayoutAttr updateIndexLayout = CreateRowMajorLayoutInt32(
-      updateIndexShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
-
-  auto constraintsExp = OpModel<PagedUpdateCacheOp>::getOpConstraints(
-      cacheShape, cacheLayout, inputShape, inputLayoutWrongGrid,
-      updateIndexShape, updateIndexLayout, std::nullopt, std::nullopt, false,
-      cacheLayout);
-  const bool ok = static_cast<bool>(constraintsExp);
-  if (!ok) {
-    llvm::consumeError(constraintsExp.takeError());
-  }
-  EXPECT_FALSE(ok);
-}
 
 } // namespace mlir::tt::ttnn::op_model


### PR DESCRIPTION
### Problem description

`PagedUpdateCacheRuleBook` was a tt-mlir-side optimizer constraint added to work around tt-metal [#44923](https://github.com/tenstorrent/tt-metal/issues/44923): for `ttnn.paged_update_cache`, operand 1 (the fill value) had to be L1 height-sharded on a {numUsers, 1} virtual grid (numUsers = input1.shape[1]). Any other grid was silently accepted by metal but produced PCC=0 for the upper users — so the compiler had to pin the layout itself, since the bad config never tripped a constraint query.

Already uplifted tt-metal [#45016](https://github.com/tenstorrent/tt-metal/pull/45016) closed that gap by adding the matching TT_FATAL(grid.num_cores() == padded_shape()[1]). With metal validating the grid, the OpModel constraint query now rejects the bad layouts on its own, making the tt-mlir rule redundant.

### What's changed

Removed the now-redundant guard and its tests, basically reverting #8542 in full (plus the original #8098 rule it built on).

Impact: No runtime behavior change expected — metal now enforces what the rule used to.

### Checklist

- [x] Existing tests provide coverage (metal-side enforcement; the now-obsolete tripwire test removed)
