### PR TITLE
d2m-jit: eliminate warnings on reductions and matmul tests

### DIFF
--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_matmul_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_matmul_llks.h
@@ -13,7 +13,7 @@ ALWI void matmul_block(uint32_t in0_cb_id, uint32_t in1_cb_id,
                        uint32_t rt_dim, uint32_t kt_dim,
                        uint32_t in1_k_stride) {
   if (transpose) {
-    ckernel::mm_block_init_short(in0_cb_id, in1_cb_id, transpose, 1, 1, 1);
+    ckernel::matmul_block_init(in0_cb_id, in1_cb_id, transpose, 1, 1, 1);
     for (uint32_t r = 0; r < rt_dim; r++) {
       for (uint32_t c = 0; c < ct_dim; c++) {
         uint32_t out_tile_index = idst + r * ct_dim + c;

--- a/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
@@ -155,6 +155,8 @@ inline const llvm::StringMap<HeaderRequirement> &getCalleeToHeadersMap() {
         {"ltz_tile_init",                                  {"api/compute/eltwise_unary/comp.h", ""}},
         {"ltz_tile_int32",                                 {"api/compute/eltwise_unary/comp.h", ""}},
         {"matmul_block",                                   {"api/compute/matmul.h", ""}},
+        {"matmul_block_init",                              {"api/compute/matmul.h", ""}},
+        {"matmul_init",                                    {"api/compute/matmul.h", ""}},
         {"matmul_tiles",                                   {"api/compute/matmul.h", ""}},
         {"mm_block_init",                                  {"api/compute/matmul.h", ""}},
         {"mm_block_init_short",                            {"api/compute/matmul.h", ""}},

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1018,6 +1018,44 @@ private:
 } // namespace
 
 namespace {
+template <typename SourceOp>
+class TTKernelMatmulInitToEmitCRewriter : public OpConversionPattern<SourceOp> {
+public:
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    ValueRange operands = adaptor.getOperands();
+    SmallVector<Attribute, 1> templateArgs;
+    templateArgs.push_back(
+        emitc::OpaqueAttr::get(op.getContext(), "SrcOrder::Reverse"));
+    auto reverseSrcOrder = ArrayAttr::get(op.getContext(), templateArgs);
+
+    rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), TypeRange{}, "compute_kernel_hw_startup", ArrayAttr(),
+        reverseSrcOrder, ValueRange{operands[0], operands[1], operands[2]});
+
+    if constexpr (std::is_same_v<SourceOp, ttkernel::MatmulInitOp>) {
+      rewriter.create<emitc::CallOpaqueOp>(
+          op.getLoc(), TypeRange{}, "matmul_init", ArrayAttr(), ArrayAttr(),
+          ValueRange{operands[0], operands[1], operands[3]});
+    } else {
+      static_assert(std::is_same_v<SourceOp, ttkernel::MatmulBlockInitOp>);
+      rewriter.create<emitc::CallOpaqueOp>(
+          op.getLoc(), TypeRange{}, "matmul_block_init", ArrayAttr(),
+          ArrayAttr(),
+          ValueRange{operands[0], operands[1], operands[3], operands[4],
+                     operands[5], operands[6]});
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class TTKernelBitcastOpRewriter
     : public OpConversionPattern<ttkernel::BitcastOp> {
 public:
@@ -2463,6 +2501,15 @@ public:
     populateMemRefToEmitCConversionPatterns(patterns, typeConverter);
 
     patterns.add<TTKernelBitcastOpRewriter>(typeConverter, context, &state);
+    patterns
+        .add<TTKernelMatmulInitToEmitCRewriter<ttkernel::MatmulInitOp>,
+             TTKernelMatmulInitToEmitCRewriter<ttkernel::MatmulBlockInitOp>>(
+            typeConverter, context);
+    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulInitShortOp>>(
+        typeConverter, context, "matmul_init");
+    patterns
+        .add<TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulBlockInitShortOp>>(
+            typeConverter, context, "matmul_block_init");
     patterns.add<
         TTKernelToEmitCArgValRewriter<ttkernel::GetCompileArgValOp>,
         TTKernelToEmitCArgValRewriter<ttkernel::GetArgValOp>,
@@ -2522,11 +2569,7 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::BinaryOpInitCommonOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::AddTilesInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::AddTilesOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulInitOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulInitShortOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulTilesOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulBlockInitOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulBlockInitShortOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulBlockOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ExperimentalMatmulBlockOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MulTilesInitOp>,

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -32,6 +32,7 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/Cpp/CppEmitter.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <set>
@@ -195,10 +196,11 @@ public:
 
     region->walk([&](emitc::LiteralOp literalOp) {
       llvm::StringRef value = literalOp.getValue();
-      for (const auto &[callee, reqs] : headerMap) {
-        if (value.starts_with(callee)) {
-          insertHeaders(reqs);
-        }
+      llvm::StringRef callee =
+          value.take_until([](char c) { return c == '(' || llvm::isSpace(c); });
+      auto it = headerMap.find(callee);
+      if (it != headerMap.end()) {
+        insertHeaders(it->second);
       }
     });
 

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -57,7 +57,6 @@ public:
     headers.insert("<cstdint>");
     switch (threadType) {
     case ThreadType::Compute:
-      headers.insert("api/compute/compute_kernel_api.h");
       headers.insert("api/compute/common.h");
       break;
     case ThreadType::Noc:
@@ -191,6 +190,15 @@ public:
       if (value.starts_with("experimental::invoke_sfpi")) {
         emitLlk(experimental_invoke_sfpi_llks_generated,
                 experimental_invoke_sfpi_llks_generated_len);
+      }
+    });
+
+    region->walk([&](emitc::LiteralOp literalOp) {
+      llvm::StringRef value = literalOp.getValue();
+      for (const auto &[callee, reqs] : headerMap) {
+        if (value.starts_with(callee)) {
+          insertHeaders(reqs);
+        }
       }
     });
 

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -75,8 +75,8 @@ getAllDeviceConnections(const std::vector<::tt::tt_metal::IDevice *> &devices) {
       try {
         connectedDevice = device->get_connected_ethernet_core(ethernetCore);
       } catch (const std::runtime_error &e) {
-        LOG_WARNING("Skipping ethernet core (", ethernetCore.str(),
-                    ") on chip ", device->id());
+        LOG_DEBUG("Skipping ethernet core (", ethernetCore.str(), ") on chip ",
+                  device->id());
         continue;
       }
       addConnection(device->id(), ethernetCore, std::get<0>(connectedDevice),

--- a/test/ttmlir/Conversion/D2MToTTKernel/matmul_transpose_b.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/matmul_transpose_b.mlir
@@ -16,9 +16,9 @@ module {
     // CHECK-NOT: ttir.matmul
     // The kernel-side transpose arg is a compile-time 1 (i.e. true).
     // CHECK: "emitc.constant"() <{value = 1 : i32}>
-    // CHECK: mm_block_init
-    // CHECK: mm_block_init_short
-    // CHECK: matmul_block
+    // CHECK: compute_kernel_hw_startup
+    // CHECK: matmul_block_init
+    // CHECK: experimental::matmul_block
     // TILE-ERR: 'd2m.tile_matmul' op transpose_b is only supported by tile_matmul_block lowering
     %r = "ttir.matmul"(%lhs, %rhs) <{transpose_b = true}> : (!lhs, !rhs) -> (!matmul_result)
     return %r : !matmul_result

--- a/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_false.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_false.mlir
@@ -17,8 +17,8 @@ module {
     // CHECK-DAG: emitc.verbatim "Noc noc1(1);"
     // CHECK-DAG: noc1.async_write_multicast
     // CHECK-NOT: noc_async_write_barrier
-    // CHECK: mm_block_init
-    // CHECK: mm_block_init_short
+    // CHECK: compute_kernel_hw_startup
+    // CHECK: matmul_block_init
     // CHECK: matmul_block
     %r = "ttir.matmul"(%lhs, %rhs) : (!lhs, !rhs) -> (!matmul_result)
     return %r : !matmul_result

--- a/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_true.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/use_tile_matmul_true.mlir
@@ -17,8 +17,8 @@ module {
     // CHECK-DAG: emitc.verbatim "Noc noc1(1);"
     // CHECK-DAG: noc1.async_write_multicast
     // CHECK-NOT: noc_async_write_barrier
-    // CHECK: mm_init
-    // CHECK: mm_init_short
+    // CHECK: compute_kernel_hw_startup
+    // CHECK: matmul_init
     // CHECK: matmul_tiles
     %r = "ttir.matmul"(%lhs, %rhs) : (!lhs, !rhs) -> (!matmul_result)
     return %r : !matmul_result

--- a/test/ttmlir/Conversion/D2MToTTMetal/decomposable_lowering_dot_general.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/decomposable_lowering_dot_general.mlir
@@ -7,8 +7,9 @@
 module {
   func.func @test_dot_general_2d_2d(%arg0: tensor<64x32xf32>, %arg1: tensor<32x128xf32>) -> tensor<64x128xf32> {
     // CHECK-NOT: ttir.dot_general
-    // CHECK: mm_block_init
-    // CHECK: matmul_block
+    // CHECK: compute_kernel_hw_startup
+    // CHECK: matmul_block_init
+    // CHECK: experimental::matmul_block
     %0 = "ttir.dot_general"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<64x32xf32>, tensor<32x128xf32>) -> tensor<64x128xf32>
     return %0 : tensor<64x128xf32>
   }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -365,7 +365,8 @@ module {
       %cb_C = "ttkernel.get_compile_time_arg_val"() <{arg_index = 2 : i32}> : () -> !cb2_tiles
       // CHECK: %[[TRANSPOSE:.*]] = "emitc.constant"
       %transpose = arith.constant 0 : i32
-      // CHECK: emitc.call_opaque "mm_init"(%[[CB_A]], %[[CB_B]], %[[CB_C]], %[[TRANSPOSE]])
+      // CHECK: emitc.call_opaque "compute_kernel_hw_startup"(%[[CB_A]], %[[CB_B]], %[[CB_C]]) {template_args = [#emitc.opaque<"SrcOrder::Reverse">]}
+      // CHECK: emitc.call_opaque "matmul_init"(%[[CB_A]], %[[CB_B]], %[[TRANSPOSE]])
       "ttkernel.mm_init"(%cb_A, %cb_B, %cb_C, %transpose) : (!cb0_tiles, !cb1_tiles, !cb2_tiles, i32) -> ()
       return
     }
@@ -378,7 +379,7 @@ module {
       %cb_B = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[TRANSPOSE:.*]] = "emitc.constant"
       %transpose = arith.constant 0 : i32
-      // CHECK: emitc.call_opaque "mm_init_short"(%[[CB_A]], %[[CB_B]], %[[TRANSPOSE]])
+      // CHECK: emitc.call_opaque "matmul_init"(%[[CB_A]], %[[CB_B]], %[[TRANSPOSE]])
       "ttkernel.mm_init_short"(%cb_A, %cb_B, %transpose) : (!cb0_tiles, !cb1_tiles, i32) -> ()
       return
     }
@@ -418,7 +419,8 @@ module {
       %ct_dim = arith.constant 1 : i32
       %rt_dim = arith.constant 2 : i32
       %kt_dim = arith.constant 3 : i32
-      // CHECK: emitc.call_opaque "mm_block_init"(%[[CB_A]], %[[CB_B]], %[[CB_C]], %[[TRANSPOSE]], %[[CT_DIM]], %[[RT_DIM]], %[[KT_DIM]])
+      // CHECK: emitc.call_opaque "compute_kernel_hw_startup"(%[[CB_A]], %[[CB_B]], %[[CB_C]]) {template_args = [#emitc.opaque<"SrcOrder::Reverse">]}
+      // CHECK: emitc.call_opaque "matmul_block_init"(%[[CB_A]], %[[CB_B]], %[[TRANSPOSE]], %[[CT_DIM]], %[[RT_DIM]], %[[KT_DIM]])
       "ttkernel.mm_block_init"(%cb_A, %cb_B, %cb_C, %transpose, %ct_dim, %rt_dim, %kt_dim) : (!cb0_tiles, !cb1_tiles, !cb2_tiles, i32, i32, i32, i32) -> ()
       return
     }
@@ -437,7 +439,7 @@ module {
       %ct_dim = arith.constant 1 : i32
       %rt_dim = arith.constant 2 : i32
       %kt_dim = arith.constant 3 : i32
-      // CHECK: emitc.call_opaque "mm_block_init_short"(%[[CB_A]], %[[CB_B]], %[[TRANSPOSE]], %[[CT_DIM]], %[[RT_DIM]], %[[KT_DIM]])
+      // CHECK: emitc.call_opaque "matmul_block_init"(%[[CB_A]], %[[CB_B]], %[[TRANSPOSE]], %[[CT_DIM]], %[[RT_DIM]], %[[KT_DIM]])
       "ttkernel.mm_block_init_short"(%cb_A, %cb_B, %transpose, %ct_dim, %rt_dim, %kt_dim) : (!cb0_tiles, !cb1_tiles, i32, i32, i32, i32) -> ()
       return
     }


### PR DESCRIPTION
reductions: stop emitting a header (api/compute/compute_kernel_api.h) for every compute kernel, demoted ethcore warning message
matmul: updated LLK APIs