### PR TITLE
Adding pybinds for ttir-to-emitc-pipeline

### DIFF
--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -250,6 +250,36 @@ void populatePassesModule(nb::module_ &m) {
       },
       nb::arg("module"), nb::arg("options") = "", nb::arg("print_ir") = false);
 
+  m.def(
+      "ttir_to_emitc_pipeline",
+      [](MlirModule module, std::string options = "", bool printIr = false) {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        if (printIr) {
+          pm.getContext()->disableMultithreading();
+          pm.enableIRPrinting(
+              [](mlir::Pass *, mlir::Operation *) { return false; },
+              [](mlir::Pass *, mlir::Operation *) { return true; }, true,
+              false);
+        }
+
+        const auto *pipeline =
+            mlir::PassPipelineInfo::lookup("ttir-to-emitc-pipeline");
+
+        std::function<mlir::LogicalResult(const llvm::Twine &)> err_handler =
+            [](const llvm::Twine &) { return mlir::failure(); };
+
+        if (mlir::failed(pipeline->addToPipeline(pm, options, err_handler))) {
+          throw std::runtime_error("Failed to add pipeline to pass manager");
+        }
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      nb::arg("module"), nb::arg("options") = "", nb::arg("print_ir") = false);
+
   // This binds the vector into an interfaceable object in python and also an
   // opaquely passed one into other functions.
   nb::bind_vector<std::vector<std::pair<std::string, std::string>>>(

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -1414,7 +1414,7 @@ def test_max_pool_2d(
     ],
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
-@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.parametrize("target", ["ttnn", "emitc"])
 def test_avg_pool_2d(
     shape: Shape,
     dtype: torch.dtype,

--- a/tools/builder/base/builder_apis.py
+++ b/tools/builder/base/builder_apis.py
@@ -28,6 +28,7 @@ from ttmlir.passes import (
     stablehlo_pipeline,
     stablehlo_to_ttir_pipeline,
     ttir_to_emitpy_pipeline,
+    ttir_to_emitc_pipeline,
     ttnn_to_flatbuffer_bin,
     ttmetal_to_flatbuffer_bin,
     ttnn_to_flatbuffer_file,
@@ -1308,11 +1309,10 @@ def compile_ttir_module_to_flatbuffer(
         to_file = ttmetal_to_flatbuffer_file
         target_extension = "ttm"
     elif target == "emitc":
-        ttir_to_ttnn_emitc_pipeline = create_custom_ttir_pipeline_fn(
-            "ttir-to-emitc-pipeline", print_ir=print_ir
-        )
         pipeline_fn = (
-            custom_pipeline if custom_pipeline else ttir_to_ttnn_emitc_pipeline
+            custom_pipeline
+            if custom_pipeline
+            else wrap_pipeline_with_print_ir(ttir_to_emitc_pipeline)
         )
         to_target = emitc_to_executable
         target_extension = "cpp"


### PR DESCRIPTION
### Ticket
Closes [#8822](https://github.com/tenstorrent/tt-mlir/issues/8822) 

### Problem description
`ttir-to-emitc-pipeline` has no pybindings, so `builder` uses a workaround that can end up causing multiple devices registered in a graph.  

### What's changed
Pybound the `ttir-to-emitc-pipeline` in `Passes.cpp`

### Checklist
- [ ] New/Existing tests provide coverage for changes
