### PR TITLE
[TTNN] Keep mesh_partition in row-major in TTNNLayout

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3256,12 +3256,6 @@ def TTNN_MeshPartitionOp: TTNN_Op<"mesh_partition"> {
                        OptionalAttr<UI32Attr>:$cluster_axis);
   let results = (outs AnyRankedTensor:$result);
   let hasVerifier = 1;
-
-  let extraClassDeclaration = [{
-    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-      return wa::TTNNOperandsWorkaroundsFactory::createMeshPartitionOpOperandsWorkarounds();
-    }
-  }];
 }
 
 def TTNN_PermuteOp : TTNN_Op<"permute"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -257,12 +257,6 @@ public:
   // Create workarounds for upsample op operands.
   static TTNNOperandsWorkarounds createUpsampleOpOperandsWorkarounds();
 
-  // Create workarounds for mesh partition op operands. The input and output
-  // tensors are always in row-major layout.
-  // TODO (hshah): Remove once
-  // https://github.com/tenstorrent/tt-metal/issues/37676 is fixed.
-  static TTNNOperandsWorkarounds createMeshPartitionOpOperandsWorkarounds();
-
   // Create workarounds for gather op operands. The input and index tensors must
   // always be in TILED layout.
   // tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/41451

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -273,20 +273,6 @@ TTNNOperandsWorkaroundsFactory::createScatterOpOperandsWorkarounds(
       .addOutputOperandWorkaround(inputSourceWorkaround); // result
 }
 
-// Factory method to create a set of workarounds for mesh partition op operands.
-// The input and output tensors associated with the op should always be in
-// row-major layout.
-// TODO (hshah): Remove once
-// https://github.com/tenstorrent/tt-metal/issues/37676 is fixed.
-TTNNOperandsWorkarounds
-TTNNOperandsWorkaroundsFactory::createMeshPartitionOpOperandsWorkarounds() {
-  wa::TTNNOperandWorkarounds rowMajorWorkaround;
-  rowMajorWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
-  return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
-      .addInputOperandWorkaround(rowMajorWorkaround)
-      .addOutputOperandWorkaround(rowMajorWorkaround);
-}
-
 // Factory method to create a set of workarounds for slice op input operands.
 // ttnn::SliceStaticOp requires uint32 on input if the slice is strided
 // and input is < uint32.

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -222,7 +222,7 @@ public:
     // Skip toLayout ops
     if (mlir::isa<ttir::ToLayoutOp>(op) ||
         op->hasTrait<mlir::tt::ttcore::Trait::TTCoreCreationOpTrait>() ||
-        mlir::isa<ttir::MeshShardOp>(op)) {
+        mlir::isa<ttir::MeshShardOp, ttir::MeshPartitionOp>(op)) {
       return failure();
     }
 
@@ -448,6 +448,49 @@ public:
           resultType.getShape(), resultType.getElementType(), newLayout);
       rewriter.modifyOpInPlace(
           op, [&]() { op->getResult(0).setType(resultSystemMemoryType); });
+      modified = true;
+    }
+    return success(modified);
+  }
+};
+} // namespace
+
+namespace {
+
+// Keep ttir::MeshPartitionOp I/O in row-major.
+//
+// MeshPartitionOp typically reslices weights/parameters and is const-eval'd, so
+// it runs once. Tiling pads the last two dims to 32x32, blowing up device
+// memory for small trailing dims (e.g. conv weights ...x3x3) with no compute
+// benefit. Consumers re-tilize as needed.
+class TTNNLayoutMeshPartitionRewriter
+    : public OpRewritePattern<ttir::MeshPartitionOp> {
+public:
+  TTNNLayoutMeshPartitionRewriter(MLIRContext *ctx)
+      : OpRewritePattern<ttir::MeshPartitionOp>(ctx) {}
+
+  LogicalResult matchAndRewrite(ttir::MeshPartitionOp op,
+                                PatternRewriter &rewriter) const override {
+    bool modified = false;
+    Value input = op.getOperand();
+    Location newLoc = appendInputSuffix(op.getLoc(), 0);
+    std::optional<Value> inputLayout = createToLayoutOp(
+        rewriter, newLoc, input, g_defaultMemorySpaceDevice, /* tiled */ false);
+    if (inputLayout.has_value()) {
+      rewriter.modifyOpInPlace(op, [&]() { op->setOperand(0, *inputLayout); });
+      modified = true;
+    }
+
+    RankedTensorType resultType =
+        mlir::cast<RankedTensorType>(op.getResult().getType());
+    TTNNLayoutAttr newLayout =
+        createLayoutAttr(rewriter.getContext(), resultType,
+                         g_defaultMemorySpaceDevice, /* isTiled */ false);
+    if (newLayout != resultType.getEncoding()) {
+      auto resultRowMajorType = RankedTensorType::get(
+          resultType.getShape(), resultType.getElementType(), newLayout);
+      rewriter.modifyOpInPlace(
+          op, [&]() { op->getResult(0).setType(resultRowMajorType); });
       modified = true;
     }
     return success(modified);
@@ -756,6 +799,7 @@ public:
       patterns.add<TTNNLayoutFuncReturnRewriter>(&getContext());
       patterns.add<TTNNLayoutHoistedFuncCallRewriter>(&getContext());
       patterns.add<TTNNLayoutMeshShardRewriter>(&getContext());
+      patterns.add<TTNNLayoutMeshPartitionRewriter>(&getContext());
 
       // Rewrite LoadCachedOp call sites to have correct result types matching
       // callee function signatures in case const-eval function signatures have


### PR DESCRIPTION
### Ticket
Reapplied changes from draft https://github.com/tenstorrent/tt-mlir/pull/8672, should be useful for similar cases too, though no current repro

Fix for https://github.com/tenstorrent/tt-xla/issues/5207

### Problem description
- OperationValidationAndFallback pass (enabled for optimization_level > 0) leaves MeshPartitionOp input/output tiled (even though for the 1D tiled scenario, it should fall back to RowMajor - https://github.com/tenstorrent/tt-metal/issues/37676). Reason is CCLs not having proper OpModel support yet, hence check being made as if it were singlechip - checking wrongly computed dimensions.
- There was a TTNN workaround for enforcing the RowMajor layout, but it doesn't fire when optimization_level > 0.

### What's changed
- Add TTNNLayoutMeshPartitionRewriter to force the op's input and output to row-major, and skip mesh_partition in the generic layout rewriter so it doesn't get the default tiled DRAM layout. Consumers re-tilize if needed.
- Remove the TTNNWorkaround, as it isn't needed anymore.

### Checklist
https://github.com/tenstorrent/tt-xla/actions/runs/28016244387
- [x] gpt_oss_20b_tp_batch_size_1 on llmbox fixed
- [x] qwen_2_5_coder_32b_instruct_tp on llmbox fixed
- [x] other errors present on nightly already, not caused by this PR
