### PR TITLE
[Optimizer] Catch new fragmentation upon replay after CB overlap eviction

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -129,10 +129,8 @@ struct SumL1MemoryTracker {
   /// open a fresh alias group at refcount 1, and bump currentOccupied for
   /// the new slot. Does not touch tensorSizes (callers set it).
   ///
-  /// HARD CONTRACT: the tensor MUST fit. Callers pre-check `wouldAllocateAt`
-  /// (the forward sweep via `ensureFitsL1`; the eviction replay via
-  /// `replayFrom`). A no-fit here is a precondition violation, not a
-  /// recoverable state — it traps.
+  /// HARD CONTRACT: the tensor MUST fit (asserts otherwise). Callers should
+  /// pre-check with `wouldAllocateAt`.
   void allocateAddress(Value result, uint64_t l1SizePerCore);
 
   /// Add `result` to `srcAtSameAddr`'s alias group at the same address
@@ -264,13 +262,6 @@ private:
   /// selected as eviction victims.
   llvm::DenseMap<Value, size_t> allocEventIndex;
 
-  /// Smallest alloc-event index evicted in the current eviction campaign (one
-  /// evictUntil run). Every rebuild restores from this index and replays the
-  /// whole suffix with all accumulated skips, so out-of-order farthest-last-use
-  /// victims can never restore a base that resurrects an already-spilled
-  /// tensor. Reset to SIZE_MAX at the start of each campaign.
-  size_t campaignMinAllocIdx = SIZE_MAX;
-
   /// Results of reshards inserted by insertReshardIntoSchedule (future
   /// consumers). These must never be selected as eviction victims — evicting
   /// them defeats the purpose of the reshard. A DenseSet rather than checking
@@ -279,11 +270,12 @@ private:
   llvm::DenseSet<Value> insertedReshardValues;
 
   /// Mark victim's alloc/dealloc events as skipped, fold its alloc index into
-  /// the current campaign minimum, then rebuild by replaying the whole suffix
-  /// from that minimum (see `replayFrom`). Returns true iff every still-live
-  /// tensor was placed; false means a still-live tensor has no contiguous fit
+  /// `campaignMin` (the smallest alloc-event index evicted so far in the
+  /// enclosing campaign), then rebuild by replaying the whole suffix from that
+  /// minimum (see `replayFrom`). Returns true iff every still-live tensor was
+  /// placed; false means a still-live tensor has no contiguous fit
   /// (fragmentation).
-  bool markEvictedAndRebuild(Value victim);
+  bool markEvictedAndRebuild(Value victim, size_t &campaignMin);
 
   /// Restore the snapshot at `startIdx` and replay every non-skipped event in
   /// [startIdx, end) top-down first-fit. Pre-checks `wouldAllocateAt` before
@@ -436,9 +428,13 @@ private:
   /// skipReshardConsumer is non-null, that one consumer is left reading the
   /// DRAM spill (no reshard inserted for it); all other consumers are still
   /// restored.
+  /// `campaignMin` accumulates the smallest alloc-event index evicted across
+  /// the enclosing campaign (caller inits it to SIZE_MAX) so every rebuild
+  /// replays a self-consistent suffix; see `markEvictedAndRebuild`.
   /// Returns markEvictedAndRebuild's result: true iff the post-eviction replay
   /// placed every still-live tensor.
   bool evictValue(Value victim, int64_t pos, ScheduleData &data,
+                  size_t &campaignMin,
                   Operation *skipReshardConsumer = nullptr);
 
   /// Insert a ToMemoryConfigOp before an already-processed consumer to

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -55,13 +55,13 @@ struct SumL1MemoryTracker {
 
   uint64_t getOccupiedL1() const;
 
-  /// Total per-core bytes that `allocateAddress` could not place (no
-  /// contiguous free block). Accumulates on every no-fit; reset by `init`
-  /// and carried in snapshots so it reflects the current (replayed)
-  /// schedule. Nonzero means the simulated live set is over-subscribed and
-  /// any FRAG_RESOLVED / "output fits" check is reading a phantom-free list.
-  uint64_t getUnplacedBytes() const;
-  bool isOverSubscribed() const;
+  /// True when `allocateAddress` could not place some tensor in any
+  /// contiguous free block (a no-fit). Set on every no-fit, reset by `init`,
+  /// and carried in snapshots so it reflects the current (replayed) schedule.
+  /// While set, the free list is "phantom-free" — it still advertises the
+  /// unplaced tensor's slot as available — so any FRAG_RESOLVED / "output
+  /// fits" check is reading a live set that actually overflows.
+  bool isStillFragmented() const;
 
   void addTensor(Value result, uint64_t l1SizePerCore);
 
@@ -122,7 +122,7 @@ struct SumL1MemoryTracker {
     llvm::DenseMap<Value, std::pair<uint64_t, uint64_t>> tensorAddresses;
     llvm::DenseMap<uint64_t, AliasGroup> aliasGroups;
     uint64_t currentOccupied;
-    uint64_t unplacedBytes;
+    bool stillFragmented;
   };
 
   /// Take a snapshot of the current address simulation state.
@@ -158,8 +158,8 @@ struct SumL1MemoryTracker {
 
 private:
   uint64_t currentOccupied = 0;
-  // Per-core bytes that allocateAddress could not place (sum over no-fits).
-  uint64_t unplacedBytes = 0;
+  // Set when allocateAddress hit a no-fit (no contiguous free block).
+  bool stillFragmented = false;
   llvm::DenseMap<Value, uint64_t> tensorSizes;
 
   // --- Address simulation state ---

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -54,6 +54,15 @@ struct SumL1MemoryTracker {
   void init(uint64_t l1BudgetPerCore);
 
   uint64_t getOccupiedL1() const;
+
+  /// Total per-core bytes that `allocateAddress` could not place (no
+  /// contiguous free block). Accumulates on every no-fit; reset by `init`
+  /// and carried in snapshots so it reflects the current (replayed)
+  /// schedule. Nonzero means the simulated live set is over-subscribed and
+  /// any FRAG_RESOLVED / "output fits" check is reading a phantom-free list.
+  uint64_t getUnplacedBytes() const;
+  bool isOverSubscribed() const;
+
   void addTensor(Value result, uint64_t l1SizePerCore);
 
   /// Add `result` as an alias of `srcAtSameAddr`'s buffer (e.g. a
@@ -113,6 +122,7 @@ struct SumL1MemoryTracker {
     llvm::DenseMap<Value, std::pair<uint64_t, uint64_t>> tensorAddresses;
     llvm::DenseMap<uint64_t, AliasGroup> aliasGroups;
     uint64_t currentOccupied;
+    uint64_t unplacedBytes;
   };
 
   /// Take a snapshot of the current address simulation state.
@@ -148,6 +158,8 @@ struct SumL1MemoryTracker {
 
 private:
   uint64_t currentOccupied = 0;
+  // Per-core bytes that allocateAddress could not place (sum over no-fits).
+  uint64_t unplacedBytes = 0;
   llvm::DenseMap<Value, uint64_t> tensorSizes;
 
   // --- Address simulation state ---

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -55,13 +55,6 @@ struct SumL1MemoryTracker {
 
   uint64_t getOccupiedL1() const;
 
-  /// True when `allocateAddress` hit a no-fit (no contiguous free block for
-  /// some tensor). Set on every no-fit, reset by `init`, carried in snapshots
-  /// so it tracks the replayed schedule. While set, the free list is
-  /// "phantom-free" (it still advertises the unplaced tensor's slot), so any
-  /// "output fits" check is reading a live set that actually overflows.
-  bool isStillFragmented() const;
-
   void addTensor(Value result, uint64_t l1SizePerCore);
 
   /// Add `result` as an alias of `srcAtSameAddr`'s buffer (e.g. a
@@ -121,7 +114,6 @@ struct SumL1MemoryTracker {
     llvm::DenseMap<Value, std::pair<uint64_t, uint64_t>> tensorAddresses;
     llvm::DenseMap<uint64_t, AliasGroup> aliasGroups;
     uint64_t currentOccupied;
-    bool stillFragmented;
   };
 
   /// Take a snapshot of the current address simulation state.
@@ -136,6 +128,11 @@ struct SumL1MemoryTracker {
   /// Allocate an address block for a tensor (top-down first-fit, aligned),
   /// open a fresh alias group at refcount 1, and bump currentOccupied for
   /// the new slot. Does not touch tensorSizes (callers set it).
+  ///
+  /// HARD CONTRACT: the tensor MUST fit. Callers pre-check `wouldAllocateAt`
+  /// (the forward sweep via `ensureFitsL1`; the eviction replay via
+  /// `replayFrom`). A no-fit here is a precondition violation, not a
+  /// recoverable state — it traps.
   void allocateAddress(Value result, uint64_t l1SizePerCore);
 
   /// Add `result` to `srcAtSameAddr`'s alias group at the same address
@@ -157,8 +154,6 @@ struct SumL1MemoryTracker {
 
 private:
   uint64_t currentOccupied = 0;
-  // Set when allocateAddress hit a no-fit (no contiguous free block).
-  bool stillFragmented = false;
   llvm::DenseMap<Value, uint64_t> tensorSizes;
 
   // --- Address simulation state ---
@@ -269,6 +264,13 @@ private:
   /// selected as eviction victims.
   llvm::DenseMap<Value, size_t> allocEventIndex;
 
+  /// Smallest alloc-event index evicted in the current eviction campaign (one
+  /// evictUntil run). Every rebuild restores from this index and replays the
+  /// whole suffix with all accumulated skips, so out-of-order farthest-last-use
+  /// victims can never restore a base that resurrects an already-spilled
+  /// tensor. Reset to SIZE_MAX at the start of each campaign.
+  size_t campaignMinAllocIdx = SIZE_MAX;
+
   /// Results of reshards inserted by insertReshardIntoSchedule (future
   /// consumers). These must never be selected as eviction victims — evicting
   /// them defeats the purpose of the reshard. A DenseSet rather than checking
@@ -276,11 +278,19 @@ private:
   /// ops from MemoryLayoutPropagation, which ARE valid eviction candidates.
   llvm::DenseSet<Value> insertedReshardValues;
 
-  /// Mark victim's alloc/dealloc events as skipped, restore the snapshot
-  /// taken before victim's alloc, then replay all subsequent non-skipped
-  /// events to rebuild a consistent address-simulation state. Reshard
-  /// kAlloc/kDealloc pairs in the log are replayed naturally.
-  void markEvictedAndRebuild(Value victim);
+  /// Mark victim's alloc/dealloc events as skipped, fold its alloc index into
+  /// the current campaign minimum, then rebuild by replaying the whole suffix
+  /// from that minimum (see `replayFrom`). Returns true iff every still-live
+  /// tensor was placed; false means a still-live tensor has no contiguous fit
+  /// (fragmentation).
+  bool markEvictedAndRebuild(Value victim);
+
+  /// Restore the snapshot at `startIdx` and replay every non-skipped event in
+  /// [startIdx, end) top-down first-fit. Pre-checks `wouldAllocateAt` before
+  /// each fresh allocation so `allocateAddress`'s hard contract holds, and
+  /// returns false at the first no-fit (a still-live tensor has no contiguous
+  /// slot). Returns true iff every still-live tensor was placed.
+  bool replayFrom(size_t startIdx);
 
   /// Insert event at pos in l1EventLog and shift all allocEventIndex entries
   /// and addressSnapshots keys >= pos by 1, preserving the index invariants.
@@ -426,7 +436,9 @@ private:
   /// skipReshardConsumer is non-null, that one consumer is left reading the
   /// DRAM spill (no reshard inserted for it); all other consumers are still
   /// restored.
-  void evictValue(Value victim, int64_t pos, ScheduleData &data,
+  /// Returns markEvictedAndRebuild's result: true iff the post-eviction replay
+  /// placed every still-live tensor.
+  bool evictValue(Value victim, int64_t pos, ScheduleData &data,
                   Operation *skipReshardConsumer = nullptr);
 
   /// Insert a ToMemoryConfigOp before an already-processed consumer to

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -55,12 +55,11 @@ struct SumL1MemoryTracker {
 
   uint64_t getOccupiedL1() const;
 
-  /// True when `allocateAddress` could not place some tensor in any
-  /// contiguous free block (a no-fit). Set on every no-fit, reset by `init`,
-  /// and carried in snapshots so it reflects the current (replayed) schedule.
-  /// While set, the free list is "phantom-free" — it still advertises the
-  /// unplaced tensor's slot as available — so any FRAG_RESOLVED / "output
-  /// fits" check is reading a live set that actually overflows.
+  /// True when `allocateAddress` hit a no-fit (no contiguous free block for
+  /// some tensor). Set on every no-fit, reset by `init`, carried in snapshots
+  /// so it tracks the replayed schedule. While set, the free list is
+  /// "phantom-free" (it still advertises the unplaced tensor's slot), so any
+  /// "output fits" check is reading a live set that actually overflows.
   bool isStillFragmented() const;
 
   void addTensor(Value result, uint64_t l1SizePerCore);

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -76,14 +76,12 @@ SumL1MemoryTracker::validateBackendDirect(
 
 uint64_t SumL1MemoryTracker::getOccupiedL1() const { return currentOccupied; }
 
-uint64_t SumL1MemoryTracker::getUnplacedBytes() const { return unplacedBytes; }
-
-bool SumL1MemoryTracker::isOverSubscribed() const { return unplacedBytes > 0; }
+bool SumL1MemoryTracker::isStillFragmented() const { return stillFragmented; }
 
 void SumL1MemoryTracker::init(uint64_t l1BudgetPerCore) {
   l1Budget = l1BudgetPerCore;
   currentOccupied = 0;
-  unplacedBytes = 0;
+  stillFragmented = false;
   tensorSizes.clear();
   freeList.clear();
   freeList.push_back({0, l1Budget});
@@ -92,7 +90,8 @@ void SumL1MemoryTracker::init(uint64_t l1BudgetPerCore) {
 }
 
 SumL1MemoryTracker::Snapshot SumL1MemoryTracker::takeSnapshot() const {
-  return {freeList, tensorAddresses, aliasGroups, currentOccupied, unplacedBytes};
+  return {freeList, tensorAddresses, aliasGroups, currentOccupied,
+          stillFragmented};
 }
 
 void SumL1MemoryTracker::restoreSnapshot(const Snapshot &snapshot) {
@@ -100,7 +99,7 @@ void SumL1MemoryTracker::restoreSnapshot(const Snapshot &snapshot) {
   tensorAddresses = snapshot.tensorAddresses;
   aliasGroups = snapshot.aliasGroups;
   currentOccupied = snapshot.currentOccupied;
-  unplacedBytes = snapshot.unplacedBytes;
+  stillFragmented = snapshot.stillFragmented;
 }
 
 void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
@@ -132,12 +131,12 @@ void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
     }
   }
   // No fit: the tensor cannot be placed in any contiguous free block. Do NOT
-  // silently drop it — record the unplaced bytes so callers can detect that
-  // the simulated live set is over-subscribed (getLowestOccupiedAddress /
-  // wouldAllocateAt would otherwise read a phantom-free list that still
-  // advertises this tensor's slot as available, leading to a false
-  // FRAG_RESOLVED). Leave freeList/tensorAddresses/currentOccupied untouched.
-  unplacedBytes += l1SizePerCore;
+  // silently drop it — flag the live set as fragmented so callers can detect
+  // that it does not actually fit (getLowestOccupiedAddress / wouldAllocateAt
+  // would otherwise read a phantom-free list that still advertises this
+  // tensor's slot as available, leading to a false FRAG_RESOLVED). Leave
+  // freeList/tensorAddresses/currentOccupied untouched.
+  stillFragmented = true;
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                "Address simulator: no fit for {} bytes (aligned {})",
                l1SizePerCore, alignedSize);
@@ -654,16 +653,16 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
     inputLayouts = utils::extractInputLayouts(op);
     result = memoryTracker.validate(op, inputLayouts, config);
     // validate() is sum-based and can succeed while a replay dropped a
-    // still-live tensor (over-subscribed free list); keep evicting until the
-    // live set genuinely fits.
-    return result.isSuccess() && !memoryTracker.isOverSubscribed();
+    // still-live tensor (no contiguous fit); keep evicting until the live set
+    // genuinely fits.
+    return result.isSuccess() && !memoryTracker.isStillFragmented();
   });
 
-  // Treat an over-subscribed simulator as a failure even if the sum-based
+  // Treat a still-fragmented simulator as a failure even if the sum-based
   // validate() reported success: eviction was exhausted (only reshards / empty
   // live set) yet a replay could not place every live tensor. Fall through to
   // the self-demote branch rather than adding an op whose layout overflows.
-  if (result.isSuccess() && !memoryTracker.isOverSubscribed()) {
+  if (result.isSuccess() && !memoryTracker.isStillFragmented()) {
     uint64_t l1Size = result.outputL1Usage;
     if (l1Size > 0) {
       l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
@@ -1043,13 +1042,14 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
                "    NO_FIT: output {0} bytes can't fit contiguously, evicting",
                outputL1Size);
 
-  // Require both a contiguous fit for this op's output AND a non-over-subscribed
-  // live set: a replay during eviction may have dropped another still-live
-  // tensor (no-fit), which leaves the free list phantom-free and would let a
-  // bare wouldAllocateAt succeed on a layout that actually overflows.
+  // Require both a contiguous fit for this op's output AND a live set with no
+  // unplaced tensor: a replay during eviction may have dropped another
+  // still-live tensor (no-fit), which leaves the free list phantom-free and
+  // would let a bare wouldAllocateAt succeed on a layout that actually
+  // overflows.
   bool resolved = evictUntil(pos, data, [&]() {
     return memoryTracker.wouldAllocateAt(outputL1Size).has_value() &&
-           !memoryTracker.isOverSubscribed();
+           !memoryTracker.isStillFragmented();
   });
   if (!resolved) {
     demoteToDram(op);
@@ -1093,7 +1093,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
   uint64_t cushionedCBUsage = cbPeakUsage + cbFragCushion;
 
   // Evict tensors (farthest last-use first) until CB overlap resolves AND the
-  // whole replayed live set is placeable. isOverSubscribed() guards against a
+  // whole replayed live set is placeable. isStillFragmented() guards against a
   // replay (markEvictedAndRebuild) having dropped a still-live tensor that no
   // longer fits: without it, wouldAllocateAt/getLowestOccupiedAddress read a
   // phantom-free list and the loop would stop while the live set actually
@@ -1106,22 +1106,22 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
     }
     uint64_t effLowest =
         std::min(*specAddr, memoryTracker.getLowestOccupiedAddress());
-    return !memoryTracker.isOverSubscribed() && cushionedCBUsage <= effLowest;
+    return !memoryTracker.isStillFragmented() && cushionedCBUsage <= effLowest;
   });
 
   // Eviction may have been exhausted (only inserted reshards left, or empty
-  // live set) while the live set is still over-subscribed. In that case the
-  // free list is phantom-free (a dropped tensor's slot looks available), so the
-  // checks below would falsely resolve. Demote this op's output to DRAM as a
-  // best-effort fallback and surface the unresolved over-subscription instead
-  // of silently shipping a layout that clashes on device.
-  if (memoryTracker.isOverSubscribed()) {
+  // live set) while the live set is still fragmented (a replay left a tensor
+  // unplaced). In that case the free list is phantom-free (the dropped tensor's
+  // slot looks available), so the checks below would falsely resolve. Demote
+  // this op's output to DRAM as a best-effort fallback and surface the
+  // unresolved fragmentation instead of silently shipping a layout that clashes
+  // on device.
+  if (memoryTracker.isStillFragmented()) {
     demoteToDram(op);
     evictForDramCBGrowth(op, pos, data);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "    FRAG_DEMOTE (live set still over-subscribed by {0} B after "
-                 "exhausting eviction): output to DRAM",
-                 memoryTracker.getUnplacedBytes());
+                 "    FRAG_DEMOTE (live set still fragmented after exhausting "
+                 "eviction): output to DRAM");
     return 0;
   }
 

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -130,12 +130,8 @@ void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
       return;
     }
   }
-  // No fit: the tensor cannot be placed in any contiguous free block. Do NOT
-  // silently drop it — flag the live set as fragmented so callers can detect
-  // that it does not actually fit (getLowestOccupiedAddress / wouldAllocateAt
-  // would otherwise read a phantom-free list that still advertises this
-  // tensor's slot as available, leading to a false FRAG_RESOLVED). Leave
-  // freeList/tensorAddresses/currentOccupied untouched.
+  // No contiguous free block fits. Flag over-subscription rather than silently
+  // dropping the tensor; state is left unchanged. See isStillFragmented().
   stillFragmented = true;
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                "Address simulator: no fit for {} bytes (aligned {})",
@@ -1092,13 +1088,9 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
   // unmodeled runtime fragmentation from transient internal op allocations.
   uint64_t cushionedCBUsage = cbPeakUsage + cbFragCushion;
 
-  // Evict tensors (farthest last-use first) until CB overlap resolves AND the
-  // whole replayed live set is placeable. isStillFragmented() guards against a
-  // replay (markEvictedAndRebuild) having dropped a still-live tensor that no
-  // longer fits: without it, wouldAllocateAt/getLowestOccupiedAddress read a
-  // phantom-free list and the loop would stop while the live set actually
-  // overflows. Keep evicting (which can spill the offending large tensor) until
-  // it genuinely fits.
+  // Evict (farthest last-use first) until CB overlap clears AND the replayed
+  // live set genuinely fits. The isStillFragmented() guard is load-bearing —
+  // without it the loop stops on a phantom-free list (see its doc).
   evictUntil(pos, data, [&]() {
     auto specAddr = memoryTracker.wouldAllocateAt(outputL1Size);
     if (!specAddr) {
@@ -1109,13 +1101,9 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
     return !memoryTracker.isStillFragmented() && cushionedCBUsage <= effLowest;
   });
 
-  // Eviction may have been exhausted (only inserted reshards left, or empty
-  // live set) while the live set is still fragmented (a replay left a tensor
-  // unplaced). In that case the free list is phantom-free (the dropped tensor's
-  // slot looks available), so the checks below would falsely resolve. Demote
-  // this op's output to DRAM as a best-effort fallback and surface the
-  // unresolved fragmentation instead of silently shipping a layout that clashes
-  // on device.
+  // Eviction couldn't place the whole live set (only reshards left, or empty).
+  // Demote this op's output to DRAM rather than ship a layout that clashes on
+  // device — without this, the phantom-free list would falsely resolve below.
   if (memoryTracker.isStillFragmented()) {
     demoteToDram(op);
     evictForDramCBGrowth(op, pos, data);

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -76,9 +76,14 @@ SumL1MemoryTracker::validateBackendDirect(
 
 uint64_t SumL1MemoryTracker::getOccupiedL1() const { return currentOccupied; }
 
+uint64_t SumL1MemoryTracker::getUnplacedBytes() const { return unplacedBytes; }
+
+bool SumL1MemoryTracker::isOverSubscribed() const { return unplacedBytes > 0; }
+
 void SumL1MemoryTracker::init(uint64_t l1BudgetPerCore) {
   l1Budget = l1BudgetPerCore;
   currentOccupied = 0;
+  unplacedBytes = 0;
   tensorSizes.clear();
   freeList.clear();
   freeList.push_back({0, l1Budget});
@@ -87,7 +92,7 @@ void SumL1MemoryTracker::init(uint64_t l1BudgetPerCore) {
 }
 
 SumL1MemoryTracker::Snapshot SumL1MemoryTracker::takeSnapshot() const {
-  return {freeList, tensorAddresses, aliasGroups, currentOccupied};
+  return {freeList, tensorAddresses, aliasGroups, currentOccupied, unplacedBytes};
 }
 
 void SumL1MemoryTracker::restoreSnapshot(const Snapshot &snapshot) {
@@ -95,6 +100,7 @@ void SumL1MemoryTracker::restoreSnapshot(const Snapshot &snapshot) {
   tensorAddresses = snapshot.tensorAddresses;
   aliasGroups = snapshot.aliasGroups;
   currentOccupied = snapshot.currentOccupied;
+  unplacedBytes = snapshot.unplacedBytes;
 }
 
 void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
@@ -125,7 +131,13 @@ void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
       return;
     }
   }
-  // No fit — log warning. Sum tracker still works; frag check will catch it.
+  // No fit: the tensor cannot be placed in any contiguous free block. Do NOT
+  // silently drop it — record the unplaced bytes so callers can detect that
+  // the simulated live set is over-subscribed (getLowestOccupiedAddress /
+  // wouldAllocateAt would otherwise read a phantom-free list that still
+  // advertises this tensor's slot as available, leading to a false
+  // FRAG_RESOLVED). Leave freeList/tensorAddresses/currentOccupied untouched.
+  unplacedBytes += l1SizePerCore;
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                "Address simulator: no fit for {} bytes (aligned {})",
                l1SizePerCore, alignedSize);
@@ -641,10 +653,17 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
   evictUntil(pos, data, [&]() {
     inputLayouts = utils::extractInputLayouts(op);
     result = memoryTracker.validate(op, inputLayouts, config);
-    return result.isSuccess();
+    // validate() is sum-based and can succeed while a replay dropped a
+    // still-live tensor (over-subscribed free list); keep evicting until the
+    // live set genuinely fits.
+    return result.isSuccess() && !memoryTracker.isOverSubscribed();
   });
 
-  if (result.isSuccess()) {
+  // Treat an over-subscribed simulator as a failure even if the sum-based
+  // validate() reported success: eviction was exhausted (only reshards / empty
+  // live set) yet a replay could not place every live tensor. Fall through to
+  // the self-demote branch rather than adding an op whose layout overflows.
+  if (result.isSuccess() && !memoryTracker.isOverSubscribed()) {
     uint64_t l1Size = result.outputL1Usage;
     if (l1Size > 0) {
       l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
@@ -1024,8 +1043,13 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
                "    NO_FIT: output {0} bytes can't fit contiguously, evicting",
                outputL1Size);
 
+  // Require both a contiguous fit for this op's output AND a non-over-subscribed
+  // live set: a replay during eviction may have dropped another still-live
+  // tensor (no-fit), which leaves the free list phantom-free and would let a
+  // bare wouldAllocateAt succeed on a layout that actually overflows.
   bool resolved = evictUntil(pos, data, [&]() {
-    return memoryTracker.wouldAllocateAt(outputL1Size).has_value();
+    return memoryTracker.wouldAllocateAt(outputL1Size).has_value() &&
+           !memoryTracker.isOverSubscribed();
   });
   if (!resolved) {
     demoteToDram(op);
@@ -1068,7 +1092,13 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
   // unmodeled runtime fragmentation from transient internal op allocations.
   uint64_t cushionedCBUsage = cbPeakUsage + cbFragCushion;
 
-  // Evict tensors (farthest last-use first) until CB overlap resolves.
+  // Evict tensors (farthest last-use first) until CB overlap resolves AND the
+  // whole replayed live set is placeable. isOverSubscribed() guards against a
+  // replay (markEvictedAndRebuild) having dropped a still-live tensor that no
+  // longer fits: without it, wouldAllocateAt/getLowestOccupiedAddress read a
+  // phantom-free list and the loop would stop while the live set actually
+  // overflows. Keep evicting (which can spill the offending large tensor) until
+  // it genuinely fits.
   evictUntil(pos, data, [&]() {
     auto specAddr = memoryTracker.wouldAllocateAt(outputL1Size);
     if (!specAddr) {
@@ -1076,8 +1106,24 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
     }
     uint64_t effLowest =
         std::min(*specAddr, memoryTracker.getLowestOccupiedAddress());
-    return cushionedCBUsage <= effLowest;
+    return !memoryTracker.isOverSubscribed() && cushionedCBUsage <= effLowest;
   });
+
+  // Eviction may have been exhausted (only inserted reshards left, or empty
+  // live set) while the live set is still over-subscribed. In that case the
+  // free list is phantom-free (a dropped tensor's slot looks available), so the
+  // checks below would falsely resolve. Demote this op's output to DRAM as a
+  // best-effort fallback and surface the unresolved over-subscription instead
+  // of silently shipping a layout that clashes on device.
+  if (memoryTracker.isOverSubscribed()) {
+    demoteToDram(op);
+    evictForDramCBGrowth(op, pos, data);
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "    FRAG_DEMOTE (live set still over-subscribed by {0} B after "
+                 "exhausting eviction): output to DRAM",
+                 memoryTracker.getUnplacedBytes());
+    return 0;
+  }
 
   // After eviction, re-check both conditions with the updated free list.
   auto freshOutputAddr = memoryTracker.wouldAllocateAt(outputL1Size);

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -76,12 +76,9 @@ SumL1MemoryTracker::validateBackendDirect(
 
 uint64_t SumL1MemoryTracker::getOccupiedL1() const { return currentOccupied; }
 
-bool SumL1MemoryTracker::isStillFragmented() const { return stillFragmented; }
-
 void SumL1MemoryTracker::init(uint64_t l1BudgetPerCore) {
   l1Budget = l1BudgetPerCore;
   currentOccupied = 0;
-  stillFragmented = false;
   tensorSizes.clear();
   freeList.clear();
   freeList.push_back({0, l1Budget});
@@ -90,8 +87,7 @@ void SumL1MemoryTracker::init(uint64_t l1BudgetPerCore) {
 }
 
 SumL1MemoryTracker::Snapshot SumL1MemoryTracker::takeSnapshot() const {
-  return {freeList, tensorAddresses, aliasGroups, currentOccupied,
-          stillFragmented};
+  return {freeList, tensorAddresses, aliasGroups, currentOccupied};
 }
 
 void SumL1MemoryTracker::restoreSnapshot(const Snapshot &snapshot) {
@@ -99,7 +95,6 @@ void SumL1MemoryTracker::restoreSnapshot(const Snapshot &snapshot) {
   tensorAddresses = snapshot.tensorAddresses;
   aliasGroups = snapshot.aliasGroups;
   currentOccupied = snapshot.currentOccupied;
-  stillFragmented = snapshot.stillFragmented;
 }
 
 void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
@@ -130,12 +125,11 @@ void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
       return;
     }
   }
-  // No contiguous free block fits. Flag over-subscription rather than silently
-  // dropping the tensor; state is left unchanged. See isStillFragmented().
-  stillFragmented = true;
-  TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
-               "Address simulator: no fit for {} bytes (aligned {})",
-               l1SizePerCore, alignedSize);
+  // Unreachable: callers MUST pre-check `wouldAllocateAt` (the forward sweep
+  // via ensureFitsL1; the eviction replay via replayFrom). Reaching here means
+  // a placement bypassed that check — a precondition violation.
+  llvm_unreachable("allocateAddress: no contiguous free block; caller must "
+                   "pre-check wouldAllocateAt");
 }
 
 void SumL1MemoryTracker::addTensor(Value result, uint64_t l1SizePerCore) {
@@ -645,20 +639,20 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
   auto config = extractOpConfigFromIR(op);
   auto result =
       op_constraint_validation::ValidationResult::outOfMemoryError("");
-  evictUntil(pos, data, [&]() {
+  bool resolved = evictUntil(pos, data, [&]() {
     inputLayouts = utils::extractInputLayouts(op);
     result = memoryTracker.validate(op, inputLayouts, config);
-    // validate() is sum-based and can succeed while a replay dropped a
-    // still-live tensor (no contiguous fit); keep evicting until the live set
-    // genuinely fits.
-    return result.isSuccess() && !memoryTracker.isStillFragmented();
+    return result.isSuccess();
   });
+  // evictUntil already failed the pass on unresolvable fragmentation; bail
+  // before touching the truncated tracker.
+  if (compilationFailed) {
+    return;
+  }
 
-  // Treat a still-fragmented simulator as a failure even if the sum-based
-  // validate() reported success: eviction was exhausted (only reshards / empty
-  // live set) yet a replay could not place every live tensor. Fall through to
-  // the self-demote branch rather than adding an op whose layout overflows.
-  if (result.isSuccess() && !memoryTracker.isStillFragmented()) {
+  // resolved ⟹ validate() succeeded against a fully-placed live set; otherwise
+  // the op's own output doesn't fit, so self-demote below.
+  if (resolved) {
     uint64_t l1Size = result.outputL1Usage;
     if (l1Size > 0) {
       l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
@@ -723,7 +717,7 @@ void L1SpillManagement<MemoryTracker>::insertEventIntoLog(size_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
+bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
   // O(1) lookup of victim's alloc event.
   auto idxIt = allocEventIndex.find(victim);
   assert(idxIt != allocEventIndex.end() &&
@@ -742,36 +736,62 @@ void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
     }
   }
 
-  // Restore snapshot taken before the victim's allocation.
-  auto snapIt = addressSnapshots.find(allocIdx);
+  // Fold this victim into the campaign minimum and rebuild the whole suffix
+  // from there. Restoring from the per-victim allocIdx would be unsound:
+  // farthest-last-use victims are unordered w.r.t. alloc order, so a later
+  // victim could restore a base predating an earlier eviction and resurrect an
+  // already-spilled tensor. Replaying from the minimum with all accumulated
+  // skips re-applies every eviction.
+  campaignMinAllocIdx = std::min(campaignMinAllocIdx, allocIdx);
+  return replayFrom(campaignMinAllocIdx);
+}
+
+//===----------------------------------------------------------------------===//
+// replayFrom
+//===----------------------------------------------------------------------===//
+
+template <typename MemoryTracker>
+bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
+  auto snapIt = addressSnapshots.find(startIdx);
   assert(snapIt != addressSnapshots.end() &&
-         "snapshot not found for evicted tensor");
+         "snapshot not found for replay start index");
   memoryTracker.restoreSnapshot(snapIt->second);
 
-  // Replay events from the alloc point forward, skipping evicted tensors.
-  // Update snapshots during replay so future evictions see accurate state.
-  for (size_t i = allocIdx; i < l1EventLog.size(); ++i) {
+  // Replay events from startIdx forward, skipping evicted tensors. Update
+  // snapshots during replay so future restores see the current schedule.
+  for (size_t i = startIdx; i < l1EventLog.size(); ++i) {
     if (l1EventLog[i].skipped) {
       continue;
     }
-    if (l1EventLog[i].kind == L1Event::kAlloc) {
-      addressSnapshots[i] = memoryTracker.takeSnapshot();
-      // View-eligible reshape: alias if src is still address-tracked in
-      // this replay, otherwise fresh-allocate (the counterfactual when
-      // src was evicted to DRAM).
-      Operation *defOp = l1EventLog[i].tensor.getDefiningOp();
-      if (defOp && canReshapeBeView(defOp) &&
-          memoryTracker.hasTensorAddress(defOp->getOperand(0))) {
-        memoryTracker.allocateAddressAt(l1EventLog[i].tensor,
-                                        defOp->getOperand(0));
-      } else {
-        memoryTracker.allocateAddress(l1EventLog[i].tensor,
-                                      l1EventLog[i].sizePerCore);
-      }
-    } else {
+    if (l1EventLog[i].kind == L1Event::kDealloc) {
       memoryTracker.freeAddress(l1EventLog[i].tensor);
+      continue;
     }
+    addressSnapshots[i] = memoryTracker.takeSnapshot();
+    // View-eligible reshape: alias if src is still address-tracked in this
+    // replay (consumes no fresh L1), otherwise fresh-allocate (the
+    // counterfactual when src was evicted to DRAM).
+    Operation *defOp = l1EventLog[i].tensor.getDefiningOp();
+    if (defOp && canReshapeBeView(defOp) &&
+        memoryTracker.hasTensorAddress(defOp->getOperand(0))) {
+      memoryTracker.allocateAddressAt(l1EventLog[i].tensor,
+                                      defOp->getOperand(0));
+      continue;
+    }
+    // Pre-check allocateAddress's hard contract and stop at the first no-fit:
+    // a still-live tensor has no contiguous slot here (fragmentation). The
+    // partial tracker is discarded by the next eviction's restore-from-min
+    // (or, at terminal exhaustion, by failing the pass) — it is never trusted.
+    if (!memoryTracker.wouldAllocateAt(l1EventLog[i].sizePerCore)) {
+      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                   "Replay: no contiguous fit for {0} bytes",
+                   l1EventLog[i].sizePerCore);
+      return false;
+    }
+    memoryTracker.allocateAddress(l1EventLog[i].tensor,
+                                  l1EventLog[i].sizePerCore);
   }
+  return true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -779,7 +799,7 @@ void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictValue(
+bool L1SpillManagement<MemoryTracker>::evictValue(
     Value victim, int64_t pos, ScheduleData &data,
     Operation *skipReshardConsumer) {
   liveValues.erase(victim);
@@ -956,7 +976,7 @@ void L1SpillManagement<MemoryTracker>::evictValue(
     insertEventIntoLog(ins.pos, ins.event);
   }
 
-  markEvictedAndRebuild(victim);
+  return markEvictedAndRebuild(victim);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1015,13 +1035,46 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
     });
   };
 
-  while (!shouldStop() && !liveValues.empty() && !onlyReshardsRemain()) {
+  // Start a fresh campaign: every rebuild restores from the minimum alloc
+  // index evicted in THIS campaign (see markEvictedAndRebuild).
+  campaignMinAllocIdx = SIZE_MAX;
+
+  // shouldStop() inspects tracker state, so it is only trustworthy after a
+  // rebuild that placed every live tensor. The entry state qualifies — the
+  // forward sweep placed everything via the infallible allocateAddress.
+  bool rebuildPlacedAll = true;
+  while (true) {
+    if (rebuildPlacedAll && shouldStop()) {
+      break;
+    }
+    if (liveValues.empty() || onlyReshardsRemain()) {
+      break;
+    }
     Value victim = evictFarthestUse();
     if (!victim) {
       break;
     }
-    evictValue(victim, pos, data);
+    rebuildPlacedAll = evictValue(victim, pos, data);
   }
+
+  // Unresolvable fragmentation: eviction is exhausted yet a still-live tensor
+  // has no contiguous L1 slot (the total may fit; the free space doesn't).
+  // Demoting the current op cannot help — the unplaceable tensor is in the
+  // already-scheduled suffix (or a non-evictable inserted reshard), independent
+  // of the op whose output is not yet added. Fail loudly instead of shipping a
+  // layout that clashes at runtime.
+  if (!rebuildPlacedAll) {
+    Operation *blockedOp = data.schedule[pos];
+    blockedOp->emitError(
+        "L1SpillManagement: a live tensor has no contiguous L1 placement even "
+        "after evicting every spillable tensor (fragmentation: a non-evictable "
+        "inserted reshard or irreducible working set cannot be relocated)");
+    compilationFailed = true;
+    return false;
+  }
+
+  // rebuildPlacedAll is true here, so the tracker reflects a clean rebuild and
+  // shouldStop() is trustworthy.
   return shouldStop();
 }
 
@@ -1038,15 +1091,14 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
                "    NO_FIT: output {0} bytes can't fit contiguously, evicting",
                outputL1Size);
 
-  // Require both a contiguous fit for this op's output AND a live set with no
-  // unplaced tensor: a replay during eviction may have dropped another
-  // still-live tensor (no-fit), which leaves the free list phantom-free and
-  // would let a bare wouldAllocateAt succeed on a layout that actually
-  // overflows.
   bool resolved = evictUntil(pos, data, [&]() {
-    return memoryTracker.wouldAllocateAt(outputL1Size).has_value() &&
-           !memoryTracker.isStillFragmented();
+    return memoryTracker.wouldAllocateAt(outputL1Size).has_value();
   });
+  // evictUntil already failed the pass on unresolvable fragmentation; bail
+  // before touching the truncated tracker.
+  if (compilationFailed) {
+    return 0;
+  }
   if (!resolved) {
     demoteToDram(op);
     evictForDramCBGrowth(op, pos, data);
@@ -1059,9 +1111,12 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
   auto freshInputLayouts = utils::extractInputLayouts(op);
   auto freshConfig = extractOpConfigFromIR(op);
   auto freshResult = memoryTracker.validate(op, freshInputLayouts, freshConfig);
-  if (freshResult.isSuccess()) {
+  uint64_t freshL1 = freshResult.outputL1Usage;
+  // Honor allocateAddress's contract: the size handed back must still fit
+  // (re-validate could in principle return a larger output than was checked).
+  if (freshResult.isSuccess() &&
+      (freshL1 == 0 || memoryTracker.wouldAllocateAt(freshL1))) {
     applyOutputConfig(op, freshResult);
-    uint64_t freshL1 = freshResult.outputL1Usage;
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "    NO_FIT resolved: L1 now {0}/{1}",
                  memoryTracker.getOccupiedL1(), l1BudgetPerCore);
@@ -1088,52 +1143,30 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
   // unmodeled runtime fragmentation from transient internal op allocations.
   uint64_t cushionedCBUsage = cbPeakUsage + cbFragCushion;
 
-  // Evict (farthest last-use first) until CB overlap clears AND the replayed
-  // live set genuinely fits. The isStillFragmented() guard is load-bearing —
-  // without it the loop stops on a phantom-free list (see its doc).
-  evictUntil(pos, data, [&]() {
+  // Evict (farthest last-use first) until the output has a contiguous fit AND
+  // the CB region no longer overlaps the lowest live tensor.
+  bool resolved = evictUntil(pos, data, [&]() {
     auto specAddr = memoryTracker.wouldAllocateAt(outputL1Size);
     if (!specAddr) {
       return false;
     }
     uint64_t effLowest =
         std::min(*specAddr, memoryTracker.getLowestOccupiedAddress());
-    return !memoryTracker.isStillFragmented() && cushionedCBUsage <= effLowest;
+    return cushionedCBUsage <= effLowest;
   });
-
-  // Eviction couldn't place the whole live set (only reshards left, or empty).
-  // Demote this op's output to DRAM rather than ship a layout that clashes on
-  // device — without this, the phantom-free list would falsely resolve below.
-  if (memoryTracker.isStillFragmented()) {
-    demoteToDram(op);
-    evictForDramCBGrowth(op, pos, data);
-    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "    FRAG_DEMOTE (live set still fragmented after exhausting "
-                 "eviction): output to DRAM");
+  // evictUntil already failed the pass on unresolvable fragmentation; bail
+  // before touching the truncated tracker.
+  if (compilationFailed) {
     return 0;
   }
 
-  // After eviction, re-check both conditions with the updated free list.
-  auto freshOutputAddr = memoryTracker.wouldAllocateAt(outputL1Size);
-  if (!freshOutputAddr) {
+  // Eviction was exhausted (op's own output won't fit / CB still overlaps).
+  // Demote this op's output to DRAM rather than ship a clashing layout.
+  if (!resolved) {
     demoteToDram(op);
     evictForDramCBGrowth(op, pos, data);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "    FRAG_DEMOTE (still no-fit after eviction): output to "
-                 "DRAM");
-    return 0;
-  }
-
-  uint64_t freshEffectiveLowest =
-      std::min(*freshOutputAddr, memoryTracker.getLowestOccupiedAddress());
-  if (cushionedCBUsage > freshEffectiveLowest) {
-    demoteToDram(op);
-    evictForDramCBGrowth(op, pos, data);
-    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "    FRAG_DEMOTE (CB overlap persists): cb={0}+cushion={1}"
-                 "={2} > effectiveLowest={3}",
-                 cbPeakUsage, cbFragCushion, cushionedCBUsage,
-                 freshEffectiveLowest);
+                 "    FRAG_DEMOTE: eviction exhausted, output to DRAM");
     return 0;
   }
 
@@ -1141,13 +1174,15 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
   auto inputLayouts = utils::extractInputLayouts(op);
   auto config = extractOpConfigFromIR(op);
   auto freshResult = memoryTracker.validate(op, inputLayouts, config);
-  if (freshResult.isSuccess()) {
-    uint64_t freshL1 = freshResult.outputL1Usage;
+  uint64_t freshL1 = freshResult.outputL1Usage;
+  // Honor allocateAddress's contract: the size handed back must still fit
+  // largest free block.
+  if (freshResult.isSuccess() &&
+      (freshL1 == 0 || memoryTracker.wouldAllocateAt(freshL1))) {
     applyOutputConfig(op, freshResult);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "    FRAG_RESOLVED: L1 now {0}/{1}",
                  memoryTracker.getOccupiedL1(), l1BudgetPerCore);
-    memoryTracker.logState();
     return freshL1;
   }
 
@@ -1267,6 +1302,11 @@ void L1SpillManagement<MemoryTracker>::run() {
   // Farthest-last-use eviction sweep with validation-based enforcement.
   for (int64_t pos = 0; pos < static_cast<int64_t>(data.schedule.size());
        ++pos) {
+    // A handler hit unresolvable fragmentation and failed the pass; stop the
+    // sweep rather than process further ops against a discarded result.
+    if (compilationFailed) {
+      break;
+    }
     Operation *op = data.schedule[pos];
 
     // Eviction can insert a reshard for `op`, shifting `op` past `pos`. Rewind

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -125,9 +125,6 @@ void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
       return;
     }
   }
-  // Unreachable: callers MUST pre-check `wouldAllocateAt` (the forward sweep
-  // via ensureFitsL1; the eviction replay via replayFrom). Reaching here means
-  // a placement bypassed that check — a precondition violation.
   llvm_unreachable("allocateAddress: no contiguous free block; caller must "
                    "pre-check wouldAllocateAt");
 }
@@ -639,7 +636,7 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
   auto config = extractOpConfigFromIR(op);
   auto result =
       op_constraint_validation::ValidationResult::outOfMemoryError("");
-  bool resolved = evictUntil(pos, data, [&]() {
+  bool fitsAfterEviction = evictUntil(pos, data, [&]() {
     inputLayouts = utils::extractInputLayouts(op);
     result = memoryTracker.validate(op, inputLayouts, config);
     return result.isSuccess();
@@ -650,9 +647,8 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
     return;
   }
 
-  // resolved ⟹ validate() succeeded against a fully-placed live set; otherwise
-  // the op's own output doesn't fit, so self-demote below.
-  if (resolved) {
+  // fitsAfterEviction ⟹ validate() succeeded against a fully-placed live set.
+  if (fitsAfterEviction) {
     uint64_t l1Size = result.outputL1Usage;
     if (l1Size > 0) {
       l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
@@ -717,7 +713,8 @@ void L1SpillManagement<MemoryTracker>::insertEventIntoLog(size_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
+bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(
+    Value victim, size_t &campaignMin) {
   // O(1) lookup of victim's alloc event.
   auto idxIt = allocEventIndex.find(victim);
   assert(idxIt != allocEventIndex.end() &&
@@ -742,8 +739,8 @@ bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
   // victim could restore a base predating an earlier eviction and resurrect an
   // already-spilled tensor. Replaying from the minimum with all accumulated
   // skips re-applies every eviction.
-  campaignMinAllocIdx = std::min(campaignMinAllocIdx, allocIdx);
-  return replayFrom(campaignMinAllocIdx);
+  campaignMin = std::min(campaignMin, allocIdx);
+  return replayFrom(campaignMin);
 }
 
 //===----------------------------------------------------------------------===//
@@ -800,7 +797,7 @@ bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
 
 template <typename MemoryTracker>
 bool L1SpillManagement<MemoryTracker>::evictValue(
-    Value victim, int64_t pos, ScheduleData &data,
+    Value victim, int64_t pos, ScheduleData &data, size_t &campaignMin,
     Operation *skipReshardConsumer) {
   liveValues.erase(victim);
   Operation *victimOp = victim.getDefiningOp();
@@ -976,7 +973,7 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
     insertEventIntoLog(ins.pos, ins.event);
   }
 
-  return markEvictedAndRebuild(victim);
+  return markEvictedAndRebuild(victim, campaignMin);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1035,18 +1032,16 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
     });
   };
 
-  // Start a fresh campaign: every rebuild restores from the minimum alloc
-  // index evicted in THIS campaign (see markEvictedAndRebuild).
-  campaignMinAllocIdx = SIZE_MAX;
+  // A fresh campaign: every rebuild restores from the smallest alloc index
+  // evicted in this campaign and replays the whole suffix with all accumulated
+  // skips (see evictValue / markEvictedAndRebuild).
+  size_t campaignMin = SIZE_MAX;
 
   // shouldStop() inspects tracker state, so it is only trustworthy after a
   // rebuild that placed every live tensor. The entry state qualifies — the
   // forward sweep placed everything via the infallible allocateAddress.
   bool rebuildPlacedAll = true;
-  while (true) {
-    if (rebuildPlacedAll && shouldStop()) {
-      break;
-    }
+  while (!rebuildPlacedAll || !shouldStop()) {
     if (liveValues.empty() || onlyReshardsRemain()) {
       break;
     }
@@ -1054,11 +1049,9 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
     if (!victim) {
       break;
     }
-    rebuildPlacedAll = evictValue(victim, pos, data);
+    rebuildPlacedAll = evictValue(victim, pos, data, campaignMin);
   }
 
-  // Unresolvable fragmentation: eviction is exhausted yet a still-live tensor
-  // has no contiguous L1 slot (the total may fit; the free space doesn't).
   // Demoting the current op cannot help — the unplaceable tensor is in the
   // already-scheduled suffix (or a non-evictable inserted reshard), independent
   // of the op whose output is not yet added. Fail loudly instead of shipping a
@@ -1073,8 +1066,6 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
     return false;
   }
 
-  // rebuildPlacedAll is true here, so the tracker reflects a clean rebuild and
-  // shouldStop() is trustworthy.
   return shouldStop();
 }
 
@@ -1091,7 +1082,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
                "    NO_FIT: output {0} bytes can't fit contiguously, evicting",
                outputL1Size);
 
-  bool resolved = evictUntil(pos, data, [&]() {
+  bool fitsAfterEviction = evictUntil(pos, data, [&]() {
     return memoryTracker.wouldAllocateAt(outputL1Size).has_value();
   });
   // evictUntil already failed the pass on unresolvable fragmentation; bail
@@ -1099,7 +1090,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
   if (compilationFailed) {
     return 0;
   }
-  if (!resolved) {
+  if (!fitsAfterEviction) {
     demoteToDram(op);
     evictForDramCBGrowth(op, pos, data);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1145,7 +1136,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
 
   // Evict (farthest last-use first) until the output has a contiguous fit AND
   // the CB region no longer overlaps the lowest live tensor.
-  bool resolved = evictUntil(pos, data, [&]() {
+  bool fitsAfterEviction = evictUntil(pos, data, [&]() {
     auto specAddr = memoryTracker.wouldAllocateAt(outputL1Size);
     if (!specAddr) {
       return false;
@@ -1162,7 +1153,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
 
   // Eviction was exhausted (op's own output won't fit / CB still overlaps).
   // Demote this op's output to DRAM rather than ship a clashing layout.
-  if (!resolved) {
+  if (!fitsAfterEviction) {
     demoteToDram(op);
     evictForDramCBGrowth(op, pos, data);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1208,6 +1199,9 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
         toEvict.push_back(operand);
       }
     }
+    // Its own mini-campaign: campaignMin accumulates across the sibling spills.
+    size_t campaignMin = SIZE_MAX;
+    bool fitsAfterSiblingSpill = true;
     for (Value victim : toEvict) {
       TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                    "    SPILL_SIBLING_OPERAND: evicting {0} to DRAM to "
@@ -1218,7 +1212,20 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
       // mixed-input failure and reshard it straight back, defeating the
       // homogeneous spill. Past/future consumers of the operand are still
       // restored, so their IR stays valid.
-      evictValue(victim, pos, data, /*skipReshardConsumer=*/op);
+      //
+      // Those reshards can fragment L1; keep the last result, since the replay
+      // reflects the fully-spilled state and early fragmentation clears as the
+      // rest spill.
+      fitsAfterSiblingSpill = evictValue(victim, pos, data, campaignMin,
+                                         /*skipReshardConsumer=*/op);
+    }
+    if (!fitsAfterSiblingSpill) {
+      op->emitError(
+          "L1SpillManagement: sibling-operand spill left a live tensor with no "
+          "contiguous L1 placement (fragmentation cannot be resolved by "
+          "demoting this op)");
+      compilationFailed = true;
+      return 0;
     }
   }
 

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -815,19 +815,16 @@ TEST_F(ReshardCbOverlapTest, OverlapWithReshardInputFailsCompilation) {
 
 class FragmentationTrackerTest : public L1SpillTestFixture {};
 
-// Regression for the address-simulator "silent drop" bug. When allocateAddress
-// cannot place a tensor in any contiguous free block it used to log and return,
-// recording no address and leaving currentOccupied / the free list optimistic.
-// That made the dropped tensor invisible to getOccupiedL1 and
-// getLowestOccupiedAddress, so a downstream eviction stop predicate
-// (wouldAllocateAt + "output fits" / FRAG_RESOLVED) would read a phantom-free
-// list and accept a layout that overflows at runtime (the phi2 circular-buffer
-// clash). The fix flags the no-fit so the unplaced tensor is observable; the
-// eviction loops consult isStillFragmented() to keep spilling. This pins that
-// tracker contract (the eviction-loop integration is covered end-to-end by the
-// phi2 repro, which needs geometric fragmentation this sum-based fixture cannot
-// easily construct).
-TEST_F(FragmentationTrackerTest, NoFitFlagsFragmentationAndRoundTrips) {
+// allocateAddress is an infallible contract: callers MUST pre-check
+// wouldAllocateAt and never place a tensor that does not fit. This pins that
+// pre-check — wouldAllocateAt reports nullopt exactly when no contiguous block
+// fits, which is what the forward sweep (ensureFitsL1) and the eviction replay
+// (replayFrom) rely on to avoid placing a tensor with no contiguous fit. The
+// eviction-loop integration (a replay that can't place a still-live tensor →
+// keep evicting, no false FRAG_RESOLVED) is covered end-to-end by the phi2
+// repro, which needs geometric fragmentation this sum-based fixture cannot
+// easily construct.
+TEST_F(FragmentationTrackerTest, WouldAllocateAtReportsNoFitAndRoundTrips) {
   l1BudgetPerCore = 100 * kKiB;
   auto tt = tensorType({1, 1, 1024, 1024}, makeL1Sharded({1, 1, 1024, 1024}));
   auto args = beginFunc({tt, tt});
@@ -835,27 +832,25 @@ TEST_F(FragmentationTrackerTest, NoFitFlagsFragmentationAndRoundTrips) {
 
   mlir::tt::ttnn::SumL1MemoryTracker tracker;
   tracker.init(l1BudgetPerCore);
-  EXPECT_FALSE(tracker.isStillFragmented());
 
-  // First tensor fits (60 KiB of a 100 KiB budget).
+  // 60 KiB fits in a fresh 100 KiB budget; place it (pre-check passes).
+  EXPECT_TRUE(tracker.wouldAllocateAt(60 * kKiB).has_value());
   tracker.addTensor(args[0], 60 * kKiB);
-  EXPECT_FALSE(tracker.isStillFragmented());
   EXPECT_EQ(tracker.getOccupiedL1(), 60 * kKiB);
 
-  // Second 60 KiB tensor cannot fit in the remaining 40 KiB → no-fit. It must
-  // be flagged, NOT silently dropped: currentOccupied stays at the placed
-  // 60 KiB and the fragmentation becomes observable.
-  tracker.addTensor(args[1], 60 * kKiB);
-  EXPECT_TRUE(tracker.isStillFragmented());
-  EXPECT_EQ(tracker.getOccupiedL1(), 60 * kKiB)
-      << "currentOccupied must not count the unplaced tensor";
+  // A second 60 KiB no longer fits the remaining 40 KiB — wouldAllocateAt says
+  // so, so a caller must NOT hand it to addTensor (that would trip the
+  // allocateAddress contract). A 30 KiB tensor still fits.
+  EXPECT_FALSE(tracker.wouldAllocateAt(60 * kKiB).has_value());
+  EXPECT_TRUE(tracker.wouldAllocateAt(30 * kKiB).has_value());
 
-  // The fragmentation flag is carried by snapshots (so replay-based eviction
-  // reflects the current counterfactual), cleared by init, and round-trips
-  // through restore.
+  // State round-trips through snapshot/restore (occupancy + free list), which
+  // the replay restore path depends on.
   auto snap = tracker.takeSnapshot();
   tracker.init(l1BudgetPerCore);
-  EXPECT_FALSE(tracker.isStillFragmented());
+  EXPECT_EQ(tracker.getOccupiedL1(), 0u);
+  EXPECT_TRUE(tracker.wouldAllocateAt(100 * kKiB).has_value());
   tracker.restoreSnapshot(snap);
-  EXPECT_TRUE(tracker.isStillFragmented());
+  EXPECT_EQ(tracker.getOccupiedL1(), 60 * kKiB);
+  EXPECT_FALSE(tracker.wouldAllocateAt(60 * kKiB).has_value());
 }

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -808,3 +808,58 @@ TEST_F(ReshardCbOverlapTest, OverlapWithReshardInputFailsCompilation) {
   EXPECT_NE(diag.find("cannot be placed"), std::string::npos)
       << "expected a clear placement error; got: " << diag;
 }
+
+//===----------------------------------------------------------------------===//
+// OverSubscriptionTrackerTest
+//===----------------------------------------------------------------------===//
+
+class OverSubscriptionTrackerTest : public L1SpillTestFixture {};
+
+// Regression for the address-simulator "silent drop" bug. When allocateAddress
+// cannot place a tensor in any contiguous free block it used to log and return,
+// recording no address and leaving currentOccupied / the free list optimistic.
+// That made the dropped tensor invisible to getOccupiedL1 and
+// getLowestOccupiedAddress, so a downstream eviction stop predicate
+// (wouldAllocateAt + "output fits" / FRAG_RESOLVED) would read a phantom-free
+// list and accept a layout that overflows at runtime (the phi2 circular-buffer
+// clash). The fix records the unplaced bytes so over-subscription is
+// observable; the eviction loops consult isOverSubscribed() to keep spilling.
+// This pins that tracker contract (the eviction-loop integration is covered
+// end-to-end by the phi2 repro, which needs geometric fragmentation this
+// sum-based fixture cannot easily construct).
+TEST_F(OverSubscriptionTrackerTest, NoFitRecordsUnplacedBytesAndRoundTrips) {
+  l1BudgetPerCore = 100 * kKiB;
+  auto tt = tensorType({1, 1, 1024, 1024}, makeL1Sharded({1, 1, 1024, 1024}));
+  auto args = beginFunc({tt, tt});
+  finishFunc({args[0]});
+
+  mlir::tt::ttnn::SumL1MemoryTracker tracker;
+  tracker.init(l1BudgetPerCore);
+  EXPECT_FALSE(tracker.isOverSubscribed());
+  EXPECT_EQ(tracker.getUnplacedBytes(), 0u);
+
+  // First tensor fits (60 KiB of a 100 KiB budget).
+  tracker.addTensor(args[0], 60 * kKiB);
+  EXPECT_FALSE(tracker.isOverSubscribed());
+  EXPECT_EQ(tracker.getOccupiedL1(), 60 * kKiB);
+
+  // Second 60 KiB tensor cannot fit in the remaining 40 KiB → no-fit. It must
+  // be recorded as unplaced, NOT silently dropped: currentOccupied stays at the
+  // placed 60 KiB and over-subscription becomes observable.
+  tracker.addTensor(args[1], 60 * kKiB);
+  EXPECT_TRUE(tracker.isOverSubscribed());
+  EXPECT_EQ(tracker.getUnplacedBytes(), 60 * kKiB);
+  EXPECT_EQ(tracker.getOccupiedL1(), 60 * kKiB)
+      << "currentOccupied must not count the unplaced tensor";
+
+  // The over-subscription is carried by snapshots (so replay-based eviction
+  // reflects the current counterfactual), cleared by init, and round-trips
+  // through restore.
+  auto snap = tracker.takeSnapshot();
+  tracker.init(l1BudgetPerCore);
+  EXPECT_FALSE(tracker.isOverSubscribed());
+  EXPECT_EQ(tracker.getUnplacedBytes(), 0u);
+  tracker.restoreSnapshot(snap);
+  EXPECT_TRUE(tracker.isOverSubscribed());
+  EXPECT_EQ(tracker.getUnplacedBytes(), 60 * kKiB);
+}

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -810,10 +810,10 @@ TEST_F(ReshardCbOverlapTest, OverlapWithReshardInputFailsCompilation) {
 }
 
 //===----------------------------------------------------------------------===//
-// OverSubscriptionTrackerTest
+// FragmentationTrackerTest
 //===----------------------------------------------------------------------===//
 
-class OverSubscriptionTrackerTest : public L1SpillTestFixture {};
+class FragmentationTrackerTest : public L1SpillTestFixture {};
 
 // Regression for the address-simulator "silent drop" bug. When allocateAddress
 // cannot place a tensor in any contiguous free block it used to log and return,
@@ -822,12 +822,12 @@ class OverSubscriptionTrackerTest : public L1SpillTestFixture {};
 // getLowestOccupiedAddress, so a downstream eviction stop predicate
 // (wouldAllocateAt + "output fits" / FRAG_RESOLVED) would read a phantom-free
 // list and accept a layout that overflows at runtime (the phi2 circular-buffer
-// clash). The fix records the unplaced bytes so over-subscription is
-// observable; the eviction loops consult isOverSubscribed() to keep spilling.
-// This pins that tracker contract (the eviction-loop integration is covered
-// end-to-end by the phi2 repro, which needs geometric fragmentation this
-// sum-based fixture cannot easily construct).
-TEST_F(OverSubscriptionTrackerTest, NoFitRecordsUnplacedBytesAndRoundTrips) {
+// clash). The fix flags the no-fit so the unplaced tensor is observable; the
+// eviction loops consult isStillFragmented() to keep spilling. This pins that
+// tracker contract (the eviction-loop integration is covered end-to-end by the
+// phi2 repro, which needs geometric fragmentation this sum-based fixture cannot
+// easily construct).
+TEST_F(FragmentationTrackerTest, NoFitFlagsFragmentationAndRoundTrips) {
   l1BudgetPerCore = 100 * kKiB;
   auto tt = tensorType({1, 1, 1024, 1024}, makeL1Sharded({1, 1, 1024, 1024}));
   auto args = beginFunc({tt, tt});
@@ -835,31 +835,27 @@ TEST_F(OverSubscriptionTrackerTest, NoFitRecordsUnplacedBytesAndRoundTrips) {
 
   mlir::tt::ttnn::SumL1MemoryTracker tracker;
   tracker.init(l1BudgetPerCore);
-  EXPECT_FALSE(tracker.isOverSubscribed());
-  EXPECT_EQ(tracker.getUnplacedBytes(), 0u);
+  EXPECT_FALSE(tracker.isStillFragmented());
 
   // First tensor fits (60 KiB of a 100 KiB budget).
   tracker.addTensor(args[0], 60 * kKiB);
-  EXPECT_FALSE(tracker.isOverSubscribed());
+  EXPECT_FALSE(tracker.isStillFragmented());
   EXPECT_EQ(tracker.getOccupiedL1(), 60 * kKiB);
 
   // Second 60 KiB tensor cannot fit in the remaining 40 KiB → no-fit. It must
-  // be recorded as unplaced, NOT silently dropped: currentOccupied stays at the
-  // placed 60 KiB and over-subscription becomes observable.
+  // be flagged, NOT silently dropped: currentOccupied stays at the placed
+  // 60 KiB and the fragmentation becomes observable.
   tracker.addTensor(args[1], 60 * kKiB);
-  EXPECT_TRUE(tracker.isOverSubscribed());
-  EXPECT_EQ(tracker.getUnplacedBytes(), 60 * kKiB);
+  EXPECT_TRUE(tracker.isStillFragmented());
   EXPECT_EQ(tracker.getOccupiedL1(), 60 * kKiB)
       << "currentOccupied must not count the unplaced tensor";
 
-  // The over-subscription is carried by snapshots (so replay-based eviction
+  // The fragmentation flag is carried by snapshots (so replay-based eviction
   // reflects the current counterfactual), cleared by init, and round-trips
   // through restore.
   auto snap = tracker.takeSnapshot();
   tracker.init(l1BudgetPerCore);
-  EXPECT_FALSE(tracker.isOverSubscribed());
-  EXPECT_EQ(tracker.getUnplacedBytes(), 0u);
+  EXPECT_FALSE(tracker.isStillFragmented());
   tracker.restoreSnapshot(snap);
-  EXPECT_TRUE(tracker.isOverSubscribed());
-  EXPECT_EQ(tracker.getUnplacedBytes(), 60 * kKiB);
+  EXPECT_TRUE(tracker.isStillFragmented());
 }


### PR DESCRIPTION
### Ticket

Fixes phi2 runtime crash: https://github.com/tenstorrent/tt-xla/issues/5206

### Problem description

L1SpillManagement's address simulator (`SumL1MemoryTracker::allocateAddress`) silently dropped a tensor when it didn't fit any contiguous free block — recording no address and not bumping `currentOccupied`. This happens on the eviction-replay path (`markEvictedAndRebuild`), which is ungated. The dropped tensor then looked free, so the eviction loop's stop check (which only verified the current op's output fit) stopped early and logged a false `FRAG_RESOLVED`, shipping a layout that overflows L1 at runtime — the fc1-projection slice's circular buffers clash with the reshard pinned at the L1 base.

### What's changed

- allocateAddress is now an infallible contract — it traps (llvm_unreachable) on a no-fit instead of silently dropping the tensor. Callers pre-check wouldAllocateAt: the forward sweep via ensureFitsL1, the eviction replay via the new replayFrom.
- The eviction replay detects and propagates a no-fit: replayFrom pre-checks wouldAllocateAt before each allocation and returns false at the first no-fit, threaded up markEvictedAndRebuild → evictValue → evictUntil.
- Restore-from-min: each rebuild now restores from the smallest alloc index evicted in the current campaign and replays the whole suffix with all accumulated skips (was: per-victim snapshot), so out-of-order farthest-last-use victims can't restore a base that resurrects an already-spilled tensor.
- evictUntil trusts shouldStop() only after a rebuild that placed the whole live set, so eviction keeps spilling until the offending reshard actually goes to DRAM — the slice then reads its input from DRAM and the CBs no longer clash. (handleFragmentation/handleNoFit/handleOOM gate on this rather than on a bare wouldAllocateAt/validate against a possibly phantom-free tracker.)
- Unresolvable fragmentation (eviction exhausted while a live tensor still has no contiguous fit) now fails the pass with a clear diagnostic instead of shipping a layout that clashes on device.
- Test: FragmentationTrackerTest.WouldAllocateAtReportsNoFitAndRoundTrips pinning the wouldAllocateAt pre-check contract + snapshot round-trip.

Graph impact: +3 to_memory_config spills total; on-device execution unchanged.

### Checklist
- [x] phi2 bs32/isl128/bfp_bf8/trace runs to completion, no n150 regressions (false perf-regression checks for vllms, unrelated DRAM OOM)
  before:https://github.com/tenstorrent/tt-xla/actions/runs/28435942024
  after: https://github.com/tenstorrent/tt-xla/actions/runs/28435821779
after rebase: https://github.com/tenstorrent/tt-xla/actions/runs/28596915977