### PR TITLE
[d2m] nested func pass manager

### DIFF
--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -310,7 +310,8 @@ void createD2MEmitCPipeline(OpPassManager &pm,
   pm.addPass(createConvertTTKernelToEmitC());
   pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(createRemoveDeadEmitCExpressionsPass());
-  pm.addPass(mlir::emitc::createFormExpressionsPass());
+  OpPassManager &funcPm = pm.nest<func::FuncOp>();
+  funcPm.addPass(mlir::emitc::createFormExpressionsPass());
 }
 
 void createD2MToTTKernelPipeline(OpPassManager &pm,

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/EmitC/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
@@ -65,11 +66,12 @@ void createTTIRBufferizationPipeline(OpPassManager &pm,
 void createOptimizationPasses(OpPassManager &pm,
                               const D2MPipelineOptions &options) {
   pm.addPass(createCanonicalizerPassWithOptions(options));
-  pm.addPass(mlir::createLoopInvariantCodeMotionPass());
-  pm.addPass(mlir::createSCCPPass());
-  pm.addPass(mlir::createCSEPass());
-  pm.addPass(mlir::arith::createIntRangeOptimizationsPass());
-  pm.addPass(mlir::createLoopInvariantCodeMotionPass());
+  OpPassManager &funcPm = pm.nest<func::FuncOp>();
+  funcPm.addPass(mlir::createLoopInvariantCodeMotionPass());
+  funcPm.addPass(mlir::createSCCPPass());
+  funcPm.addPass(mlir::createCSEPass());
+  funcPm.addPass(mlir::arith::createIntRangeOptimizationsPass());
+  funcPm.addPass(mlir::createLoopInvariantCodeMotionPass());
 }
 
 void createD2MFrontendPipeline(OpPassManager &pm,

--- a/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
+++ b/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Conversion/Passes.h"
 
 #include "mlir/Dialect/EmitC/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -26,7 +27,8 @@ void createPyKernelCompilePipeline(
   pm.addPass(mlir::tt::createRemoveDeadEmitCExpressionsPass());
 
   if (options.enableFormExpressions) {
-    pm.addPass(mlir::emitc::createFormExpressionsPass());
+    OpPassManager &funcPm = pm.nest<func::FuncOp>();
+    funcPm.addPass(mlir::emitc::createFormExpressionsPass());
   }
 }
 


### PR DESCRIPTION
### Problem description
Qwen IR taking way too long to compile and the mlir in built passes contributed a lot to that

### What's changed
- Run the mlir optimization passes on func level not whole module ir so we can parallelize
- Run form expressions pass on func level

Cuts first optimization pass bundle from 164s to 13s saving 151s and second bundle from 86s to 7s saving 79s totaling 230s saved

Cut form expression pass from 86s to 8s saving another 78s

### Checklist
- [ ] New/Existing tests provide coverage for changes
