### PR TITLE
Simplify decompose layout pass

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
-#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
@@ -13,14 +12,35 @@
 #include "ttmlir/Support/Logger.h"
 
 #include "llvm/Support/MathExtras.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
+#include <optional>
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNDECOMPOSELAYOUTS
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
 
+// This pass lowers a high-level `ttnn.to_layout` into a sequence of primitive
+// ops (to_device / from_device / typecast / to_layout / to_memory_config).
+// The strategy is intentionally simple and split into two steps:
+//
+//   Step 1 (layout + dtype): perform the layout (tilize/untilize) and dtype
+//     (typecast) changes. If a single `to_layout` can do both (float-family
+//     RM -> TILE on device) it is emitted as one op; otherwise a separate
+//     `typecast` and `to_layout` are emitted, ordered by the input tilization
+//     (input TILE -> typecast then untilize; input RM -> tilize then typecast).
+//     The typecast runs on device for any dtype, so as long as one
+//     side is device-capable the layout op is ordered to run on that dtype.
+//     When neither dtype can tilize/untilize on device (e.g. uint8 <-> uint8),
+//     only the tilize/untilize itself round-trips to host; the typecast still
+//     runs on device (as a TILE->TILE cast) unless the work is genuinely
+//     host-resident (both sides on host, or a CPU-hoisted boundary).
+//
+//   Step 2 (memory move): a single memory move places the tensor in the output
+//     memory. If the input memory is preferred, the move is appended after step
+//     1; otherwise it is prepended. When one side is host the move is a
+//     to_device / from_device; otherwise it is a to_memory_config.
+//
 class TTNNDecomposeLayouts
     : public impl::TTNNDecomposeLayoutsBase<TTNNDecomposeLayouts> {
 
@@ -81,54 +101,13 @@ private:
     bool isTilized() const { return layoutEnum == ttnn::Layout::Tile; }
   };
 
-  struct OpsToCreate {
-    bool createToDeviceOp = false;
-    bool createFromDeviceOp = false;
-    bool createToLayoutOp = false;
-    bool createDataTypeCastOp = false;
-    bool createToMemoryConfigOp = false;
+  //===--------------------------------------------------------------------===//
+  // CPU-hoist boundary detection.
+  //===--------------------------------------------------------------------===//
 
-    bool createSomeOp() const {
-      return createToLayoutOp || createDataTypeCastOp || createToDeviceOp ||
-             createFromDeviceOp || createToMemoryConfigOp;
-    }
-
-    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                         const OpsToCreate opsToCreate) {
-      os << "OpsToCreate{ \n"
-         << "\t"
-         << "CreateToDeviceOp: " << opsToCreate.createToDeviceOp << "\n"
-         << "\t"
-         << "CreateFromDeviceOp: " << opsToCreate.createFromDeviceOp << "\n"
-         << "\t"
-         << "CreateToLayoutOp: " << opsToCreate.createToLayoutOp << "\n"
-         << "\t"
-         << "CreateTypecastOp: " << opsToCreate.createDataTypeCastOp << "\n"
-         << "\t"
-         << "CreateToMemoryConfigOp: " << opsToCreate.createToMemoryConfigOp
-         << "\n}\n";
-      return os;
-    }
-  };
-
-  struct OpCreationInfo {
-    LayoutInfo input;
-    LayoutInfo output;
-    OpsToCreate opsToCreate;
-
-    OpCreationInfo(const LayoutInfo &input, const LayoutInfo &output,
-                   const OpsToCreate &opsToCreate)
-        : input(input), output(output), opsToCreate(opsToCreate) {}
-
-    bool shouldUntilize() const {
-      return opsToCreate.createToLayoutOp && !output.isTilized();
-    }
-
-    bool shouldTilize() const {
-      return opsToCreate.createToLayoutOp && output.isTilized();
-    }
-  };
-
+  // True if `value` is the result of a CPU-hoisted function call. Such values
+  // live on host; we keep the layout/typecast work on host (before moving to
+  // device) to minimize intermediate DRAM/L1 usage.
   bool isOutputFromCPUHoistedFunction(mlir::Value value) const {
     if (auto callOp = value.getDefiningOp<func::CallOp>()) {
       return callOp->hasAttr(ttmlir::utils::g_cpuHoistFuncCallAttrName);
@@ -136,6 +115,8 @@ private:
     return false;
   }
 
+  // True if the result of `op` feeds a CPU-hoisted function call. We move to
+  // host first and perform the layout/typecast there.
   bool isInputToCPUHoistedFunction(ttnn::ToLayoutOp op) const {
     if (!op.getResult().hasOneUse()) {
       return false;
@@ -147,9 +128,11 @@ private:
     return false;
   }
 
-  bool canTilizeDataTypeOnDevice(const ttcore::DataType &dataType) const {
-    // tt-metal tilize supports: bfloat16, float32, uint32, int32, uint16
-    // See: ttnn/operations/data_movement/tilize/device/tilize_op.cpp
+  //===--------------------------------------------------------------------===//
+  // Device capability predicates.
+  //===--------------------------------------------------------------------===//
+
+  bool canChangeTileLayoutDataTypeOnDevice(ttcore::DataType dataType) const {
     return dataType == ttcore::DataType::BFloat16 ||
            dataType == ttcore::DataType::Float32 ||
            dataType == ttcore::DataType::UInt32 ||
@@ -157,16 +140,90 @@ private:
            dataType == ttcore::DataType::Int32;
   }
 
-  bool canUntilizeDataTypeOnDevice(const ttcore::DataType &dataType) const {
-    // tt-metal untilize supports: bfloat16, float32, uint32, int32, uint16.
-    // (requires use_pack_untilize for uint32/int32)
-    // See: ttnn/operations/data_movement/untilize/device/untilize_op.cpp
-    return dataType == ttcore::DataType::BFloat16 ||
-           dataType == ttcore::DataType::Float32 ||
-           dataType == ttcore::DataType::UInt32 ||
-           dataType == ttcore::DataType::UInt16 ||
-           dataType == ttcore::DataType::Int32;
+  // ttnn.to_layout only performs a real numeric conversion within the float
+  // family;
+  bool isFloatFamily(ttcore::DataType dataType) const {
+    switch (dataType) {
+    case ttcore::DataType::UInt32:
+    case ttcore::DataType::UInt16:
+    case ttcore::DataType::UInt8:
+    case ttcore::DataType::Int32:
+    case ttcore::DataType::Bool:
+      return false;
+    default:
+      return true;
+    }
   }
+
+  //===--------------------------------------------------------------------===//
+  // Change predicates and memory preference.
+  //===--------------------------------------------------------------------===//
+
+  bool hasLayoutChange(const LayoutInfo &input,
+                       const LayoutInfo &output) const {
+    return input.layoutEnum != output.layoutEnum;
+  }
+
+  bool hasDtypeChange(const LayoutInfo &input, const LayoutInfo &output) const {
+    return input.dataType != output.dataType;
+  }
+
+  bool hasMemoryChange(const LayoutInfo &input,
+                       const LayoutInfo &output) const {
+    if (input.bufferType != output.bufferType) {
+      return true;
+    }
+    // Same buffer type. If both are on host there is nothing more to compare.
+    if (input.isOnHost()) {
+      return false;
+    }
+    if (input.tensorMemoryLayout != output.tensorMemoryLayout) {
+      return true;
+    }
+    // Reshard if either the virtual grid or the physical placement (CRS)
+    // changes. Same CRS can host different virtual grids and same gridShape can
+    // sit on different CRSes; both demand a reshard.
+    if (input.isSharded() && output.isSharded()) {
+      return input.gridShape != output.gridShape ||
+             input.coreRangeSet != output.coreRangeSet;
+    }
+    return false;
+  }
+
+  // Decide whether the layout/dtype change runs before the memory move (in the
+  // input memory) or after it (in the output memory). The memory move is always
+  // placed last unless tt-metal's sharded (un)tilize constraints (or a host
+  // boundary) require it first.
+  bool layoutChangeRunsBeforeMemoryMove(const LayoutInfo &input,
+                                        const LayoutInfo &output,
+                                        bool needLayout) const {
+    // Host boundary: move onto the device first (host input), or finish the
+    // work on device before reading it back (host output).
+    if (input.isOnHost() || output.isOnHost()) {
+      return !input.isOnHost();
+    }
+    if (needLayout) {
+      // Tilize (RM -> TILE): run the tilize first, then reshard. Tilizing a
+      // tensor that was first resharded into the (sharded) output memory can
+      // produce a non-tile-aligned physical shard that tt-metal rejects.
+      if (output.isTilized()) {
+        return true;
+      }
+      // Untilize (TILE -> RM): deshard first when the input is L1-sharded (or
+      // when moving L1 -> DRAM), then untilize the interleaved tensor;
+      // otherwise untilize in place and move afterwards.
+      bool deshardFirst =
+          input.isL1Sharded() || (input.bufferType == ttnn::BufferType::L1 &&
+                                  output.bufferType == ttnn::BufferType::DRAM);
+      return !deshardFirst;
+    }
+    // Pure typecast / memory move: typecast in place, memory config last.
+    return true;
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Layout info extraction.
+  //===--------------------------------------------------------------------===//
 
   std::pair<LayoutInfo, LayoutInfo>
   getInputOutputLayouts(ttnn::ToLayoutOp op) const {
@@ -174,7 +231,6 @@ private:
 
     auto inputLayoutAttr =
         mlir::cast<TTNNLayoutAttr>(op.getInput().getType().getEncoding());
-
     auto outputLayoutAttr =
         mlir::cast<TTNNLayoutAttr>(op.getResult().getType().getEncoding());
 
@@ -206,257 +262,96 @@ private:
     return {input, output};
   }
 
-  OpsToCreate determineRequiredOps(const LayoutInfo &input,
-                                   const LayoutInfo &output) const {
-    OpsToCreate opsToCreate;
-
-    opsToCreate.createToDeviceOp =
-        (input.bufferType != output.bufferType) && input.isOnHost();
-    opsToCreate.createFromDeviceOp =
-        (input.bufferType != output.bufferType) && output.isOnHost();
-
-    opsToCreate.createDataTypeCastOp = input.dataType != output.dataType;
-    opsToCreate.createToLayoutOp = input.layoutEnum != output.layoutEnum;
-
-    // ToDeviceOp can handle the creation of the memory config of the initial
-    // device tensor
-    if (!opsToCreate.createToDeviceOp && output.isOnDevice()) {
-      opsToCreate.createToMemoryConfigOp =
-          output.tensorMemoryLayout &&
-          (input.tensorMemoryLayout != output.tensorMemoryLayout);
-      opsToCreate.createToMemoryConfigOp |=
-          (input.bufferType == ttnn::BufferType::DRAM &&
-           output.bufferType == ttnn::BufferType::L1) ||
-          (input.bufferType == ttnn::BufferType::L1 &&
-           output.bufferType == ttnn::BufferType::DRAM);
-      // Reshard if either the virtual grid or the physical placement (CRS)
-      // changes. Same CRS can host different virtual grids (e.g. BlockSharded
-      // {2,4} vs {4,2} on the same 8-core rectangle), and same gridShape can
-      // sit on different CRSes (custom placement) — both demand a reshard.
-      // Applies to both L1 <-> L1 and DRAM <-> DRAM resharding.
-      opsToCreate.createToMemoryConfigOp |=
-          (input.isSharded() && output.isSharded() &&
-           (input.gridShape != output.gridShape ||
-            input.coreRangeSet != output.coreRangeSet));
-    }
-
-    TTMLIR_DEBUG(ttmlir::LogComponent::General,
-                 "Decompose layouts pass ops to create: {}", opsToCreate);
-    return opsToCreate;
-  }
-
-  bool isCreationValid(ttnn::ToLayoutOp op, const LayoutInfo &input,
-                       const LayoutInfo &output,
-                       const OpsToCreate &opsToCreate) const {
-
-    if (!opsToCreate.createSomeOp()) {
-      op->emitError(
-          "Redundant ttnn::ToLayoutOp - no ttnn layout ops "
-          "needed, this may be due to the forcing of tile/row major layouts.");
-      return false;
-    }
-
-    if (opsToCreate.createToDeviceOp && opsToCreate.createFromDeviceOp) {
-      op->emitError("Cannot create both ToDeviceOp and FromDeviceOp");
-      return false;
-    }
-
-    if (opsToCreate.createToMemoryConfigOp &&
-        output.bufferType == ttnn::BufferType::SystemMemory) {
-      op->emitError(
-          "ToMemoryConfigOp only supported for device output tensors");
-      return false;
-    }
-
-    if (input.isOnHost() && opsToCreate.createFromDeviceOp) {
-      op->emitError("Unexpected FromDeviceOp on host tensor");
-      return false;
-    }
-
-    if (input.isOnDevice() && opsToCreate.createToDeviceOp) {
-      op->emitError("Unexpected ToDeviceOp on device tensor");
-      return false;
-    }
-    return true;
-  }
-
-  /* Helper functions to create ttnn layout ops */
+  //===--------------------------------------------------------------------===//
+  // Primitive op creation. These unconditionally create the requested op.
+  //===--------------------------------------------------------------------===//
 
   template <typename OpType, typename... Args>
   mlir::Value createOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                       mlir::Value currentInput, Args &&...args) const {
-
-    rewriter.setInsertionPoint(op);
-    return rewriter.create<OpType>(op.getLoc(), op.getType(), currentInput,
-                                   std::forward<Args>(args)...);
-  }
-
-  template <typename OpType, typename... Args>
-  mlir::Value createOp(IRRewriter &rewriter, ttnn::ToLayoutOp op,
-                       RankedTensorType newResultType, mlir::Value currentInput,
+                       RankedTensorType resultType, mlir::Value input,
                        Args &&...args) const {
     rewriter.setInsertionPoint(op);
-    return rewriter.create<OpType>(op.getLoc(), newResultType, currentInput,
+    return rewriter.create<OpType>(op.getLoc(), resultType, input,
                                    std::forward<Args>(args)...);
   }
 
-  mlir::Value createToDeviceOpIfNeeded(ttnn::ToLayoutOp op,
-                                       IRRewriter &rewriter,
-                                       mlir::Value currentInput,
-                                       const OpCreationInfo &info,
-                                       bool forceCreate = false) const {
-    if (!info.opsToCreate.createToDeviceOp && !forceCreate) {
-      return currentInput;
-    }
-    RankedTensorType currentInputType =
-        mlir::cast<RankedTensorType>(currentInput.getType());
+  // Encode `target`'s memory (buffer / memory layout / grid / CRS) onto the
+  // current tensor type, keeping the current layout and dtype.
+  RankedTensorType withTargetMemory(RankedTensorType currentType,
+                                    const LayoutInfo &target) const {
+    TTNNLayoutAttr encoding = TTNNLayoutAttr::Builder(currentType)
+                                  .setBufferType(target.bufferType)
+                                  .setMemoryLayout(target.tensorMemoryLayout)
+                                  .setGridShape(target.gridShape)
+                                  .setCoreRangeSet(target.coreRangeSet)
+                                  .build();
+    return utils::RankedTensorTypeFactory::create(currentType, encoding);
+  }
 
-    TTNNLayoutAttr newEncoding =
-        TTNNLayoutAttr::Builder(currentInputType)
-            .setBufferType(info.output.bufferType)
-            .setMemoryLayout(info.output.tensorMemoryLayout)
-            .setGridShape(info.output.gridShape)
-            .setCoreRangeSet(info.output.coreRangeSet)
-            .build();
-    RankedTensorType newResultType =
-        utils::RankedTensorTypeFactory::create(currentInputType, newEncoding);
-
+  mlir::Value createToDeviceOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                               mlir::Value current,
+                               const LayoutInfo &target) const {
+    RankedTensorType currentType =
+        mlir::cast<RankedTensorType>(current.getType());
+    RankedTensorType resultType = withTargetMemory(currentType, target);
     mlir::Value device = utils::getOrInsertDevice(rewriter, op);
-
-    // Create new ranked tensor type with host memory buffer type
-    return this->createOp<ttnn::ToDeviceOp>(rewriter, op, newResultType,
-                                            currentInput, device);
+    return createOp<ttnn::ToDeviceOp>(op, rewriter, resultType, current,
+                                      device);
   }
 
-  // FromDeviceOp
-  mlir::Value createFromDeviceOpIfNeeded(ttnn::ToLayoutOp op,
-                                         IRRewriter &rewriter,
-                                         mlir::Value currentInput,
-                                         const OpCreationInfo &info,
-                                         bool forceCreate = false) const {
-    if (!info.opsToCreate.createFromDeviceOp && !forceCreate) {
-      return currentInput;
-    }
-    RankedTensorType currentInputType =
-        mlir::cast<RankedTensorType>(currentInput.getType());
-    RankedTensorType newResultType = utils::RankedTensorTypeFactory::create(
-        currentInputType, ttnn::BufferType::SystemMemory);
-    return this->createOp<ttnn::FromDeviceOp>(rewriter, op, newResultType,
-                                              currentInput);
+  mlir::Value createFromDeviceOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                                 mlir::Value current) const {
+    RankedTensorType currentType =
+        mlir::cast<RankedTensorType>(current.getType());
+    RankedTensorType resultType = utils::RankedTensorTypeFactory::create(
+        currentType, ttnn::BufferType::SystemMemory);
+    return createOp<ttnn::FromDeviceOp>(op, rewriter, resultType, current);
   }
 
-  mlir::Value createToLayoutOpIfNeeded(ttnn::ToLayoutOp op,
-                                       IRRewriter &rewriter,
-                                       mlir::Value currentInput,
-                                       const OpCreationInfo &info) const {
-    if (!info.opsToCreate.createToLayoutOp) {
-      return currentInput;
-    }
-    RankedTensorType newResultType = utils::RankedTensorTypeFactory::create(
-        mlir::cast<RankedTensorType>(currentInput.getType()),
-        info.output.layoutEnum);
-
-    return this->createOp<ttnn::ToLayoutOp>(rewriter, op, newResultType,
-                                            currentInput);
-  }
-
-  mlir::Value createDataTypeCastingOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                                      mlir::Value currentInput,
-                                      const OpCreationInfo &info) const {
-    RankedTensorType newResultType = utils::RankedTensorTypeFactory::create(
-        mlir::cast<RankedTensorType>(currentInput.getType()),
-        info.output.dataType);
-    return this->createOp<ttnn::TypecastOp>(rewriter, op, newResultType,
-                                            currentInput);
-  }
-
+  // Create a to_layout op. When `dtype` is set, the result also changes data
+  // type (a fused tilize/untilize + cast).
   mlir::Value
-  createDataTypeCastingOpIfNeeded(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                                  mlir::Value currentInput,
-                                  const OpCreationInfo &info) const {
-    if (!info.opsToCreate.createDataTypeCastOp) {
-      return currentInput;
+  createToLayoutOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                   mlir::Value current, ttnn::Layout targetLayout,
+                   std::optional<ttcore::DataType> dtype = std::nullopt) const {
+    RankedTensorType currentType =
+        mlir::cast<RankedTensorType>(current.getType());
+    RankedTensorType resultType =
+        utils::RankedTensorTypeFactory::create(currentType, targetLayout);
+    if (dtype) {
+      resultType = utils::RankedTensorTypeFactory::create(resultType, *dtype);
     }
-    return this->createDataTypeCastingOp(op, rewriter, currentInput, info);
+    return createOp<ttnn::ToLayoutOp>(op, rewriter, resultType, current);
   }
 
-  mlir::Value createToMemoryConfigOpIfNeeded(ttnn::ToLayoutOp op,
-                                             IRRewriter &rewriter,
-                                             mlir::Value currentInput,
-                                             const OpCreationInfo &info,
-                                             bool forceCreate = false) const {
-    if (!info.opsToCreate.createToMemoryConfigOp && !forceCreate) {
-      return currentInput;
-    }
-    RankedTensorType currentInputType =
-        mlir::cast<RankedTensorType>(currentInput.getType());
-    TTNNLayoutAttr currentLayout =
-        utils::getLayoutAttrFromTensor(currentInputType);
-
-    // Skip if the current input is already interleaved in the target buffer
-    // type. This can happen when a forced createToDeviceOp already placed
-    // the tensor in the correct memory config — the precomputed
-    // createToMemoryConfigOp flag doesn't account for intermediate ops.
-    // For interleaved tensors the only remaining difference would be the
-    // physical encoding shape (memref), which has no runtime effect.
-    // We only skip for interleaved because sharded tensors may need a
-    // reshard (different shard grid) even with matching buffer type and
-    // memory layout.
-    if (currentLayout.getBufferType() == info.output.bufferType &&
-        currentLayout.getMemLayout() == info.output.tensorMemoryLayout &&
-        currentLayout.getMemLayout().getValue() ==
-            TensorMemoryLayout::Interleaved) {
-      return currentInput;
-    }
-
-    ttcore::DataType dataType = currentLayout.getDataType();
-
-    // ttnn.copy (used internally by to_memory_config) does not support uint16.
-    // Cast to uint32 first, perform the memory config change, then cast back.
-    // Metal issue reference:
-    // https://github.com/tenstorrent/tt-metal/issues/41689
-    bool needsWorkaround = dataType == ttcore::DataType::UInt16;
-    if (needsWorkaround) {
-      ttcore::DataType workaroundDtype = ttcore::DataType::UInt32;
-      RankedTensorType workaroundType = utils::RankedTensorTypeFactory::create(
-          currentInputType, workaroundDtype);
-      currentInput = this->createOp<ttnn::TypecastOp>(
-          rewriter, op, workaroundType, currentInput);
-      currentInputType = mlir::cast<RankedTensorType>(currentInput.getType());
-    }
-
-    TTNNLayoutAttr newLayout =
-        TTNNLayoutAttr::Builder(currentInputType)
-            .setBufferType(info.output.bufferType)
-            .setMemoryLayout(info.output.tensorMemoryLayout)
-            .setGridShape(info.output.gridShape)
-            .setCoreRangeSet(info.output.coreRangeSet)
-            .build();
-    RankedTensorType newResultType =
-        utils::RankedTensorTypeFactory::create(currentInputType, newLayout);
-    mlir::Value result = this->createOp<ttnn::ToMemoryConfigOp>(
-        rewriter, op, newResultType, currentInput);
-
-    if (needsWorkaround) {
-      RankedTensorType origType = utils::RankedTensorTypeFactory::create(
-          mlir::cast<RankedTensorType>(result.getType()), dataType);
-      result = this->createOp<ttnn::TypecastOp>(rewriter, op, origType, result);
-    }
-
-    return result;
+  mlir::Value createTypecastOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                               mlir::Value current,
+                               ttcore::DataType targetDtype) const {
+    RankedTensorType currentType =
+        mlir::cast<RankedTensorType>(current.getType());
+    RankedTensorType resultType =
+        utils::RankedTensorTypeFactory::create(currentType, targetDtype);
+    return createOp<ttnn::TypecastOp>(op, rewriter, resultType, current);
   }
 
-  // Workaround for tt-metal#30541: ttnn.tilize does not support
-  // HEIGHT_SHARDED L1 tensors with non-tile-aligned shard shapes.
-  // Check whether the tilize pad workaround is needed.
-  bool needsShardedTilizePadWorkaround(ttnn::ToLayoutOp op,
-                                       const OpCreationInfo &info) const {
-    if (!info.input.isL1Sharded()) {
-      return false;
-    }
-    auto inputType = mlir::cast<RankedTensorType>(op.getInput().getType());
-    auto encoding = mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
-    if (!encoding) {
+  mlir::Value createToMemoryConfigOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                                     mlir::Value current,
+                                     const LayoutInfo &target) const {
+    RankedTensorType currentType =
+        mlir::cast<RankedTensorType>(current.getType());
+    RankedTensorType resultType = withTargetMemory(currentType, target);
+    return createOp<ttnn::ToMemoryConfigOp>(op, rewriter, resultType, current);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // tt-metal#30541 sharded tilize pad workaround.
+  //===--------------------------------------------------------------------===//
+
+  // ttnn.tilize does not support HEIGHT_SHARDED L1 tensors with non-tile-
+  // aligned shard shapes. Detect that case from the tensor about to be tilized.
+  bool needsShardedTilizePadWorkaround(RankedTensorType type) const {
+    auto encoding = mlir::dyn_cast<TTNNLayoutAttr>(type.getEncoding());
+    if (!encoding || encoding.getBufferType() != ttnn::BufferType::L1) {
       return false;
     }
     auto memLayout = encoding.getMemLayout();
@@ -464,8 +359,8 @@ private:
         memLayout.getValue() != TensorMemoryLayout::HeightSharded) {
       return false;
     }
-    ArrayRef<int64_t> shape = inputType.getShape();
-    int64_t rank = inputType.getRank();
+    ArrayRef<int64_t> shape = type.getShape();
+    int64_t rank = type.getRank();
     if (rank < 2) {
       return false;
     }
@@ -473,23 +368,20 @@ private:
            (shape[rank - 1] % TILE_WIDTH != 0);
   }
 
-  // Workaround for tt-metal#30541: unshard → pad → tilize → slice.
-  // Returns a DRAM INTERLEAVED, tilized, original-shape tensor.
-  // The caller is responsible for typecast and final memory config (reshard).
+  // Workaround for tt-metal#30541: unshard -> pad -> tilize -> slice.
+  // Returns a DRAM INTERLEAVED, tilized, original-shape tensor. The caller is
+  // responsible for any subsequent typecast and the final memory config.
   mlir::Value handleShardedTilizeWithPadding(ttnn::ToLayoutOp op,
                                              IRRewriter &rewriter,
-                                             mlir::Value currentInput,
-                                             const OpCreationInfo &info) const {
-    auto inputType = mlir::cast<RankedTensorType>(currentInput.getType());
+                                             mlir::Value current,
+                                             ttnn::Layout targetLayout) const {
+    auto inputType = mlir::cast<RankedTensorType>(current.getType());
     TTNNLayoutAttr inputEncoding =
         mlir::cast<TTNNLayoutAttr>(inputType.getEncoding());
     ArrayRef<int64_t> shape = inputType.getShape();
     int64_t rank = inputType.getRank();
-    ttcore::DataType dataType = inputEncoding.getDataType();
 
     // Step 1: Unshard to DRAM INTERLEAVED.
-    // ttnn.copy (to_memory_config) doesn't support u16 (tt-metal#41689),
-    // so u16 tensors use a host round-trip (from_device → to_device).
     TTNNLayoutAttr dramEncoding =
         TTNNLayoutAttr::Builder(inputEncoding, shape)
             .setBufferType(BufferType::DRAM)
@@ -500,19 +392,7 @@ private:
         RankedTensorType::get(shape, inputType.getElementType(), dramEncoding);
 
     rewriter.setInsertionPoint(op);
-
-    if (dataType == ttcore::DataType::UInt16) {
-      auto hostType = utils::RankedTensorTypeFactory::create(
-          inputType, BufferType::SystemMemory);
-      mlir::Value hostVal =
-          rewriter.create<FromDeviceOp>(op.getLoc(), hostType, currentInput);
-      mlir::Value device = utils::getOrInsertDevice(rewriter, op);
-      currentInput =
-          rewriter.create<ToDeviceOp>(op.getLoc(), dramType, hostVal, device);
-    } else {
-      currentInput = rewriter.create<ToMemoryConfigOp>(op.getLoc(), dramType,
-                                                       currentInput);
-    }
+    current = rewriter.create<ToMemoryConfigOp>(op.getLoc(), dramType, current);
 
     // Step 2: Pad to tile-aligned dimensions.
     int64_t h = shape[rank - 2];
@@ -534,752 +414,345 @@ private:
       padding[(rank - 1) * 2 + 1] = paddedW - w;
     }
 
-    auto currentInputType =
-        mlir::cast<RankedTensorType>(currentInput.getType());
+    auto currentInputType = mlir::cast<RankedTensorType>(current.getType());
     auto paddedType =
         utils::RankedTensorTypeFactory::create(currentInputType, paddedShape);
-
-    currentInput = rewriter.create<PadOp>(
-        op.getLoc(), paddedType, currentInput,
+    current = rewriter.create<PadOp>(
+        op.getLoc(), paddedType, current,
         rewriter.getDenseI32ArrayAttr(padding), rewriter.getF32FloatAttr(0.0f),
         /*use_multicore=*/rewriter.getBoolAttr(true));
 
     // Step 3: Tilize on padded DRAM tensor.
     RankedTensorType paddedTiledType = utils::RankedTensorTypeFactory::create(
-        mlir::cast<RankedTensorType>(currentInput.getType()),
-        info.output.layoutEnum);
-    currentInput = rewriter.create<ttnn::ToLayoutOp>(
-        op.getLoc(), paddedTiledType, currentInput);
+        mlir::cast<RankedTensorType>(current.getType()), targetLayout);
+    current = rewriter.create<ttnn::ToLayoutOp>(op.getLoc(), paddedTiledType,
+                                                current);
 
     // Step 4: Slice back to original shape.
     SmallVector<int32_t> begins(rank, 0);
     SmallVector<int32_t> ends(shape.begin(), shape.end());
     SmallVector<int32_t> steps(rank, 1);
-
     RankedTensorType slicedType = utils::RankedTensorTypeFactory::create(
-        mlir::cast<RankedTensorType>(currentInput.getType()), shape);
-    currentInput = rewriter.create<SliceStaticOp>(
-        op.getLoc(), slicedType, currentInput, rewriter.getI32ArrayAttr(begins),
+        mlir::cast<RankedTensorType>(current.getType()), shape);
+    current = rewriter.create<SliceStaticOp>(
+        op.getLoc(), slicedType, current, rewriter.getI32ArrayAttr(begins),
         rewriter.getI32ArrayAttr(ends), rewriter.getI32ArrayAttr(steps));
 
-    return currentInput;
+    return current;
   }
 
-  /* Functions that create ops based on the layouts of the input output tensors
-   */
+  //===--------------------------------------------------------------------===//
+  // Cross-orientation reshard guard.
+  //===--------------------------------------------------------------------===//
 
-  void handleHostInputNoLayoutNoTypecast(ttnn::ToLayoutOp op,
-                                         IRRewriter &rewriter,
-                                         mlir::Value currentInput,
-                                         const OpCreationInfo &info) const {
-    // If the input tensor is on host and we don't need to create a ToLayoutOp
-    // nor a TypecastOp we can create a ToDeviceOp and a ToMemoryConfigOp if
-    // needed and return
-    currentInput =
-        this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-    currentInput =
-        this->createToMemoryConfigOpIfNeeded(op, rewriter, currentInput, info);
-    op.getResult().replaceAllUsesWith(currentInput);
+  // A TILE sharded->sharded reshard that crosses L1<->DRAM silently corrupts
+  // (or raises) for certain orientation changes; route it through an
+  // interleaved buffer instead.
+  bool needsReshardViaInterleaved(TTNNLayoutAttr currentEncoding,
+                                  const LayoutInfo &target) const {
+    if (currentEncoding.getLayout() != ttnn::Layout::Tile) {
+      return false;
+    }
+    auto currentML = currentEncoding.getMemLayout();
+    bool currentSharded =
+        currentML && isShardedMemoryLayout(currentML.getValue());
+    if (!currentSharded || !target.isSharded()) {
+      return false;
+    }
+    BufferType cb = currentEncoding.getBufferType();
+    BufferType tb = target.bufferType;
+    bool crossesL1Dram = (cb == BufferType::L1 && tb == BufferType::DRAM) ||
+                         (cb == BufferType::DRAM && tb == BufferType::L1);
+    if (!crossesL1Dram) {
+      return false;
+    }
+    TensorMemoryLayout co = currentML.getValue();
+    TensorMemoryLayout to = target.tensorMemoryLayout.getValue();
+    bool eitherHeightSharded = co == TensorMemoryLayout::HeightSharded ||
+                               to == TensorMemoryLayout::HeightSharded;
+    bool bothWidthSharded = co == TensorMemoryLayout::WidthSharded &&
+                            to == TensorMemoryLayout::WidthSharded;
+    return (eitherHeightSharded && co != to) || bothWidthSharded;
   }
 
-  void handleHostInputLayoutNoTypecast(ttnn::ToLayoutOp op,
-                                       IRRewriter &rewriter,
-                                       mlir::Value currentInput,
-                                       const OpCreationInfo &info) const {
-    const LayoutInfo &input = info.input;
-    const LayoutInfo &output = info.output;
-    assert(input.dataType == output.dataType &&
-           "Data type should be the same if we're not creating typecast op");
+  // Move the current tensor into `target`'s memory. Picks to_device /
+  // from_device when a host side is involved, otherwise to_memory_config.
+  mlir::Value createMemoryMove(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                               mlir::Value current,
+                               const LayoutInfo &target) const {
+    RankedTensorType currentType =
+        mlir::cast<RankedTensorType>(current.getType());
+    auto currentEncoding =
+        mlir::cast<TTNNLayoutAttr>(currentType.getEncoding());
+    bool currentOnHost =
+        currentEncoding.getBufferType() == ttnn::BufferType::SystemMemory;
+    bool targetOnHost = target.isOnHost();
 
-    // If the output is on the host, we can perform layout conversion on host.
-    if (output.isOnHost()) {
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+    if (currentOnHost && !targetOnHost) {
+      return createToDeviceOp(op, rewriter, current, target);
+    }
+    if (!currentOnHost && targetOnHost) {
+      return createFromDeviceOp(op, rewriter, current);
+    }
+    if (currentOnHost && targetOnHost) {
+      return current;
     }
 
-    // If the input value is an output from a CPU-hoisted function, we should
-    // perform layout change on host to minimize intermediate DRAM/L1 usage.
-    if (isOutputFromCPUHoistedFunction(currentInput)) {
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+    // Device to device.
+    if (needsReshardViaInterleaved(currentEncoding, target)) {
+      TTNNLayoutAttr interEncoding =
+          TTNNLayoutAttr::Builder(currentEncoding, currentType.getShape())
+              .setBufferType(target.bufferType)
+              .setMemoryLayout(TensorMemoryLayout::Interleaved)
+              .setGridShape({1, 1})
+              .build();
+      RankedTensorType interType = RankedTensorType::get(
+          currentType.getShape(), currentType.getElementType(), interEncoding);
+      current =
+          createOp<ttnn::ToMemoryConfigOp>(op, rewriter, interType, current);
     }
-
-    // If the output is on device and we can untilize on device, move to device
-    // and untilize.
-    if (info.shouldUntilize() && canUntilizeDataTypeOnDevice(output.dataType)) {
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If the output is on device and we should untilize, we untilize on
-    // host and then move the tensor to device.
-    if (info.shouldUntilize() &&
-        !canUntilizeDataTypeOnDevice(output.dataType)) {
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If the tensor tilizable on device, we can move the tensor to device and
-    // perform the tilization on device.
-    if (info.shouldTilize() && canTilizeDataTypeOnDevice(output.dataType)) {
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // Otherwise, if tensor is not in a tilizable data format, we perform
-    // tilizing on host and than move the tensor to device.
-    if (info.shouldTilize() && !canTilizeDataTypeOnDevice(output.dataType)) {
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    llvm_unreachable("Unreachable code path");
+    return createToMemoryConfigOp(op, rewriter, current, target);
   }
 
-  void handleHostInputNoLayoutTypecast(ttnn::ToLayoutOp op,
-                                       IRRewriter &rewriter,
-                                       mlir::Value currentInput,
-                                       const OpCreationInfo &info) const {
-    const LayoutInfo &input = info.input;
-    const LayoutInfo &output = info.output;
-    assert(input.layoutEnum == output.layoutEnum &&
-           "Layout should be the same if we're not creating a ToLayoutOp");
-
-    // If the output is on the host, we can perform the data type cast directly
-    // on the host.
-    if (output.isOnHost()) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+  // True if the current tensor already lives in `target`'s memory.
+  bool memoryMatchesTarget(mlir::Value current,
+                           const LayoutInfo &target) const {
+    auto encoding = mlir::cast<TTNNLayoutAttr>(
+        mlir::cast<RankedTensorType>(current.getType()).getEncoding());
+    if (encoding.getBufferType() != target.bufferType) {
+      return false;
     }
-
-    // If the input value is an output from a CPU-hoisted function, we should
-    // perform typecast on host to minimize intermediate DRAM/L1 usage.
-    if (isOutputFromCPUHoistedFunction(currentInput)) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+    if (target.isOnHost()) {
+      return true;
     }
-
-    // Device typecast only supports tilized tensors. Therefore, if the output
-    // tensor is in row-major (input as well is in row-major) and resides on the
-    // device, we should perform the data type casting on the host before moving
-    // the tensor back to the device.
-    if (!output.isTilized()) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+    if (encoding.getMemLayout() != target.tensorMemoryLayout) {
+      return false;
     }
-
-    // If the output tensor is tilized and resides on the device, we can move
-    // the tensor to the device and perform the data type cast directly on the
-    // device.
-    if (output.isTilized()) {
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+    bool currentSharded =
+        encoding.getMemLayout() &&
+        isShardedMemoryLayout(encoding.getMemLayout().getValue());
+    if (currentSharded && target.isSharded()) {
+      if (ArrayRef<int64_t>(encoding.getGridShape()) !=
+          ArrayRef<int64_t>(target.gridShape)) {
+        return false;
+      }
+      if (encoding.getCoreRangeSet() != target.coreRangeSet) {
+        return false;
+      }
     }
-
-    llvm_unreachable("Unreachable code path");
+    return true;
   }
 
-  void handleHostInputLayoutTypecast(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                                     mlir::Value currentInput,
-                                     const OpCreationInfo &info) const {
-    const LayoutInfo &input = info.input;
-    const LayoutInfo &output = info.output;
+  //===--------------------------------------------------------------------===//
+  // Layout + dtype transformations.
+  //===--------------------------------------------------------------------===//
 
-    // If the output tensor is on host, we can perform the data type cast and
-    // layout conversion on host.
-    if (output.isOnHost()) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+  // Apply just the layout change (tilize/untilize), keeping the current dtype.
+  mlir::Value createLayoutStep(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                               mlir::Value current,
+                               const LayoutInfo &output) const {
+    if (output.isTilized() &&
+        needsShardedTilizePadWorkaround(
+            mlir::cast<RankedTensorType>(current.getType()))) {
+      return handleShardedTilizeWithPadding(op, rewriter, current,
+                                            output.layoutEnum);
     }
-
-    // If the input value is an output from a CPU-hoisted function, we should
-    // perform both typecast and layout change on host to minimize
-    // intermediate DRAM/L1 usage.
-    if (isOutputFromCPUHoistedFunction(currentInput)) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we can untilize on device, move to device if
-    // needed, perform the typecast first and then untilize
-    if (info.shouldUntilize() && canUntilizeDataTypeOnDevice(output.dataType)) {
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we cannot untilize on device, untilize and typecast on host
-    if (info.shouldUntilize() &&
-        !canUntilizeDataTypeOnDevice(output.dataType)) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we need to tilize and change the data type from a tilizable data
-    // format to another format, we can move the tensor to the device, perform
-    // the tilization, and then cast the data type on the device
-    if (info.shouldTilize() && canTilizeDataTypeOnDevice(input.dataType)) {
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we need to tilize and change the data format from another format
-    // to a tilizable data format, we can cast the data type on host, move
-    // the tensor to device, and then tilize on device.
-    if (info.shouldTilize() && canTilizeDataTypeOnDevice(output.dataType)) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we need to tilize and the input/output data types are not device
-    // tilizable do everything on host
-    if (info.shouldTilize() && !canTilizeDataTypeOnDevice(input.dataType) &&
-        !canTilizeDataTypeOnDevice(output.dataType)) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    llvm_unreachable("Unreachable code path");
+    return createToLayoutOp(op, rewriter, current, output.layoutEnum);
   }
 
-  void handleHostInputLayoutConversion(ttnn::ToLayoutOp op,
-                                       IRRewriter &rewriter,
-                                       mlir::Value currentInput,
-                                       const OpCreationInfo &info) const {
-    const OpsToCreate &opsToCreate = info.opsToCreate;
-    if (!opsToCreate.createToLayoutOp && !opsToCreate.createDataTypeCastOp) {
-      return handleHostInputNoLayoutNoTypecast(op, rewriter, currentInput,
-                                               info);
+  // Perform the layout and dtype changes. `onDevice` indicates whether the
+  // chain runs on device (enables the fused layout+dtype op for the float
+  // family) or on host (order is irrelevant, so typecast then layout).
+  mlir::Value
+  layoutAndDtypeTransformations(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                                mlir::Value current, const LayoutInfo &input,
+                                const LayoutInfo &output, bool onDevice) const {
+    bool needLayout = hasLayoutChange(input, output);
+    bool needDtype = hasDtypeChange(input, output);
+    if (!needLayout && !needDtype) {
+      return current;
     }
-    if (opsToCreate.createToLayoutOp && !opsToCreate.createDataTypeCastOp) {
-      return handleHostInputLayoutNoTypecast(op, rewriter, currentInput, info);
+
+    bool tilizing = needLayout && output.isTilized();
+    bool padWorkaround = onDevice && tilizing &&
+                         needsShardedTilizePadWorkaround(
+                             mlir::cast<RankedTensorType>(current.getType()));
+
+    // A single to_layout can do both layout and dtype only for a float-family
+    // RM -> TILE conversion on device (and not when the pad workaround is in
+    // play, which displaces the tensor to DRAM interleaved).
+    if (onDevice && needLayout && needDtype && tilizing && !input.isTilized() &&
+        isFloatFamily(input.dataType) && isFloatFamily(output.dataType) &&
+        !padWorkaround) {
+      return createToLayoutOp(op, rewriter, current, output.layoutEnum,
+                              output.dataType);
     }
-    if (!opsToCreate.createToLayoutOp && opsToCreate.createDataTypeCastOp) {
-      return handleHostInputNoLayoutTypecast(op, rewriter, currentInput, info);
+
+    if (needLayout && !needDtype) {
+      return createLayoutStep(op, rewriter, current, output);
     }
-    if (opsToCreate.createToLayoutOp && opsToCreate.createDataTypeCastOp) {
-      return handleHostInputLayoutTypecast(op, rewriter, currentInput, info);
+    if (!needLayout && needDtype) {
+      return createTypecastOp(op, rewriter, current, output.dataType);
     }
-    llvm_unreachable("Unreachable code path");
+
+    // Both changes, emitted as separate ops.
+    if (!onDevice) {
+      // On host the order is irrelevant; typecast first then change layout.
+      current = createTypecastOp(op, rewriter, current, output.dataType);
+      return createLayoutStep(op, rewriter, current, output);
+    }
+
+    // On device the tilize/untilize must run on a device-capable dtype. The
+    // typecast runs on device for any dtype, so order the two ops to place the
+    // layout change on whichever side (input or output dtype) is
+    // device-capable, keeping the typecast on device too.
+    if (input.isTilized()) {
+      // Untilize. Untilize on the output dtype (typecast first) when it can run
+      // on device; otherwise untilize on the input dtype first, then typecast.
+      if (canChangeTileLayoutDataTypeOnDevice(output.dataType)) {
+        current = createTypecastOp(op, rewriter, current, output.dataType);
+        return createLayoutStep(op, rewriter, current, output);
+      }
+      current = createLayoutStep(op, rewriter, current, output);
+      return createTypecastOp(op, rewriter, current, output.dataType);
+    }
+    // Tilize. Tilize on the input dtype (tilize first) when it can run on
+    // device; otherwise typecast to the output dtype first, then tilize.
+    if (canChangeTileLayoutDataTypeOnDevice(input.dataType)) {
+      current = createLayoutStep(op, rewriter, current, output);
+      return createTypecastOp(op, rewriter, current, output.dataType);
+    }
+    current = createTypecastOp(op, rewriter, current, output.dataType);
+    return createLayoutStep(op, rewriter, current, output);
   }
 
-  void handleDeviceInputNoLayoutNoTypecast(ttnn::ToLayoutOp op,
+  // The tilize/untilize itself must run on host when neither the input nor the
+  // output dtype can (un)tilize on device. (The typecast may still run on
+  // device; see canKeepTypecastOnDevice.) The tilize/untilize can run on either
+  // the input or output dtype depending on op ordering, so the work stays on
+  // device as long as at least one side is device-capable.
+  bool layoutChangeNeedsHost(const LayoutInfo &input, const LayoutInfo &output,
+                             bool needLayout) const {
+    if (!needLayout) {
+      return false;
+    }
+    return !canChangeTileLayoutDataTypeOnDevice(input.dataType) &&
+           !canChangeTileLayoutDataTypeOnDevice(output.dataType);
+  }
+
+  // For a device-involved transfer whose tilize/untilize must run on host, the
+  // typecast can still run on device when the device side holds the tensor in
+  // TILE form for an (always-supported) TILE->TILE typecast:
+  //   - untilize: the (TILE) input is on device, so typecast there first;
+  //   - tilize:   the (TILE) output is on device, so typecast there last.
+  bool canKeepTypecastOnDevice(const LayoutInfo &input,
+                               const LayoutInfo &output) const {
+    return input.isTilized() ? input.isOnDevice() : output.isOnDevice();
+  }
+
+  // Run the tilize/untilize on host while keeping the typecast on device. The
+  // device typecast is a TILE->TILE op; the host op only changes layout (the
+  // dtype is preserved across the host round-trip). Requires
+  // canKeepTypecastOnDevice(input, output).
+  mlir::Value hostLayoutWithDeviceTypecast(ttnn::ToLayoutOp op,
                                            IRRewriter &rewriter,
-                                           mlir::Value currentInput,
-                                           const OpCreationInfo &info) const {
-    // If the input tensor is on device and we don't need to create a ToLayoutOp
-    // nor a TypecastOp we can create a FromDeviceOp and a ToMemoryConfigOp if
-    // needed and return
-    currentInput =
-        this->createToMemoryConfigOpIfNeeded(op, rewriter, currentInput, info);
-    currentInput =
-        this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-    op.getResult().replaceAllUsesWith(currentInput);
-  }
-
-  // Untilize a device tensor on-device (optionally typecasting first), then
-  // move it to host if needed. Shared by handleDeviceInputLayoutNoTypecast and
-  // handleDeviceInputLayoutTypecast.
-  //
-  // The memory-config change is ordered relative to the untilize based on the
-  // input placement:
-  //   - L1-sharded, or L1 -> DRAM: change memory config *before* untilizing.
-  //     ttnn::untilize does support sharded I/O, but only when the input shard
-  //     is tile-aligned and the (row-major) output shard row size is aligned
-  //     to the allocator alignment. A width-sharded tensor whose per-core
-  //     shard isn't tile-aligned (e.g. 268 elements over 9 cores -> 30/core)
-  //     yields a row-major output shard (1, 30) that satisfies neither:
-  //     ttnn::to_layout first FATALs building its TILE spec from that shard,
-  //     and even past that a 30xui32 (120B) row isn't 16B-aligned. Deshard to
-  //     the target memory config first, then untilize the interleaved tensor.
-  //     For L1 -> DRAM, moving while still tiled keeps the row-major
-  //     intermediate from clashing with live L1 buffers. (tt-xla #5118)
-  //   - otherwise: untilize first, then change memory config.
-  //
-  // createDataTypeCastingOpIfNeeded / createToMemoryConfigOpIfNeeded are no-ops
-  // when their op isn't required, so this is safe for the no-typecast caller.
-  void untilizeOnDeviceThenFromHost(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                                    mlir::Value currentInput,
-                                    const OpCreationInfo &info) const {
-    const LayoutInfo &input = info.input;
-    const LayoutInfo &output = info.output;
-    currentInput =
-        this->createDataTypeCastingOpIfNeeded(op, rewriter, currentInput, info);
-    if (input.isL1Sharded() || (input.bufferType == ttnn::BufferType::L1 &&
-                                output.bufferType == ttnn::BufferType::DRAM)) {
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-    } else {
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-    }
-    currentInput =
-        this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-    op.getResult().replaceAllUsesWith(currentInput);
-  }
-
-  void handleDeviceInputLayoutNoTypecast(ttnn::ToLayoutOp op,
-                                         IRRewriter &rewriter,
-                                         mlir::Value currentInput,
-                                         const OpCreationInfo &info) const {
-    const LayoutInfo &input = info.input;
-    const LayoutInfo &output = info.output;
-    const OpsToCreate &opsToCreate = info.opsToCreate;
-    assert(input.dataType == output.dataType &&
-           "Data type should be the same if we're not creating typecast op");
-
-    // If the result feeds into a CPU-hoisted function, we should move to host
-    // first and perform layout change on host to minimize intermediate DRAM/L1
-    // usage.
-    if (isInputToCPUHoistedFunction(op)) {
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we can untilize on device, untilize on device then move to host.
-    if (info.shouldUntilize() && canUntilizeDataTypeOnDevice(input.dataType)) {
-      untilizeOnDeviceThenFromHost(op, rewriter, currentInput, info);
-      return;
-    }
-
-    // If we want to untilize, but we cannot untilize on
-    // device, move to host and then untilize
-    if (info.shouldUntilize() && !canUntilizeDataTypeOnDevice(input.dataType) &&
-        opsToCreate.createFromDeviceOp) {
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // This is a rare untilize case, where we want to untilize a device tensor
-    // but keep it on device. To handle this we need to move the tensor to host,
-    // untilize it, and then move it back to device
-    if (info.shouldUntilize() && !canUntilizeDataTypeOnDevice(input.dataType) &&
-        !opsToCreate.createFromDeviceOp) {
-      // Force-create a FromDeviceOp
-      currentInput = this->createFromDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, /*forceCreate=*/true);
-      // untilize on host
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      // move back to device and convert memory config if needed
-      currentInput = createToDeviceOpIfNeeded(op, rewriter, currentInput, info,
-                                              /*forceCreate=*/true);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we should tilize and the input data type is device-tilizable, tilize
-    // on device
-    if (info.shouldTilize() && canTilizeDataTypeOnDevice(input.dataType)) {
-      if (needsShardedTilizePadWorkaround(op, info)) {
-        // tt-metal#30541: unshard → pad → tilize → slice, then force reshard.
-        currentInput =
-            handleShardedTilizeWithPadding(op, rewriter, currentInput, info);
-        currentInput = this->createToMemoryConfigOpIfNeeded(
-            op, rewriter, currentInput, info, /*forceCreate=*/true);
-      } else {
-        currentInput =
-            this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-        currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                            currentInput, info);
+                                           mlir::Value current,
+                                           const LayoutInfo &input,
+                                           const LayoutInfo &output) const {
+    bool needDtype = hasDtypeChange(input, output);
+    if (input.isTilized()) {
+      // Untilize: typecast on device (TILE) first, untilize on host, then land
+      // in the output memory.
+      if (needDtype) {
+        current = createTypecastOp(op, rewriter, current, output.dataType);
       }
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we should tilize and the input data type is not device tilizable,
-    // tilize on host
-    if (info.shouldTilize() && !canTilizeDataTypeOnDevice(input.dataType) &&
-        opsToCreate.createFromDeviceOp) {
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we want to tilize a device tensor that is not device tilizable, we
-    // need to tilize on host and move it back
-    if (info.shouldTilize() && !canTilizeDataTypeOnDevice(input.dataType) &&
-        !opsToCreate.createFromDeviceOp) {
-      // Force-create a FromDeviceOp
-      currentInput = this->createFromDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, /*forceCreate=*/true);
-      // tilize on host
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      // move back to device and convert memory config if needed
-      currentInput = this->createToDeviceOpIfNeeded(op, rewriter, currentInput,
-                                                    info, /*forceCreate=*/true);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    llvm_unreachable("Unreachable code path");
-  }
-
-  void handleDeviceInputNoLayoutTypecast(ttnn::ToLayoutOp op,
-                                         IRRewriter &rewriter,
-                                         mlir::Value currentInput,
-                                         const OpCreationInfo &info) const {
-    const LayoutInfo &input = info.input;
-    const LayoutInfo &output = info.output;
-    const OpsToCreate &opsToCreate = info.opsToCreate;
-    assert(input.layoutEnum == output.layoutEnum &&
-           "Layout should be the same if we're not creating toLayout op");
-
-    // If the result feeds into a CPU-hoisted function, we should move to host
-    // first and perform typecast on host to minimize intermediate DRAM/L1
-    // usage.
-    if (isInputToCPUHoistedFunction(op)) {
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If the output is not tilized and we're moving to host anyway, typecast
-    // on host to avoid a redundant on-device typecast.
-    if (!output.isTilized() && opsToCreate.createFromDeviceOp) {
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // Otherwise typecast directly on device. This covers both the tilized case
-    // and the device-to-device untilized case.
-    // If the input is sharded, typecast should happen after converting to
-    // memory.
-    if (input.isSharded()) {
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-    } else {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-    }
-    currentInput =
-        this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-    op.getResult().replaceAllUsesWith(currentInput);
-  }
-
-  void handleDeviceInputLayoutTypecast(ttnn::ToLayoutOp op,
-                                       IRRewriter &rewriter,
-                                       mlir::Value currentInput,
-                                       const OpCreationInfo &info) const {
-    const LayoutInfo &input = info.input;
-    const LayoutInfo &output = info.output;
-    const OpsToCreate &opsToCreate = info.opsToCreate;
-
-    // If the result feeds into a CPU-hoisted function, we should move to host
-    // first and perform both typecast and layout change on host to minimize
-    // intermediate DRAM/L1 usage.
-    if (isInputToCPUHoistedFunction(op)) {
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we need to untilize and the output can be untilized on device,
-    // typecast and untilize on device.
-    if (info.shouldUntilize() && canUntilizeDataTypeOnDevice(output.dataType)) {
-      untilizeOnDeviceThenFromHost(op, rewriter, currentInput, info);
-      return;
-    }
-
-    // If we need to untilize and the output cannot be untilized on
-    // device typecast on device then untilize on host
-    if (info.shouldUntilize() &&
-        !canUntilizeDataTypeOnDevice(output.dataType) &&
-        opsToCreate.createFromDeviceOp) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // In case of device to device untilize, where we cannot
-    // untilize on device, typecast on device, untilize on host, then move
-    // back to device
-    if (info.shouldUntilize() &&
-        !canUntilizeDataTypeOnDevice(output.dataType) &&
-        !opsToCreate.createFromDeviceOp) {
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput = this->createFromDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, /*forceCreate=*/true);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToDeviceOpIfNeeded(op, rewriter, currentInput,
-                                                    info, /*forceCreate=*/true);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
-    }
-
-    // If we should tilize and the input data type is device tilizable, tilize
-    // and typecast on device
-    if (info.shouldTilize() && canTilizeDataTypeOnDevice(input.dataType)) {
-      if (needsShardedTilizePadWorkaround(op, info)) {
-        // tt-metal#30541: unshard → pad → tilize → slice, then typecast and
-        // force reshard.
-        currentInput =
-            handleShardedTilizeWithPadding(op, rewriter, currentInput, info);
-        currentInput = this->createDataTypeCastingOpIfNeeded(
-            op, rewriter, currentInput, info);
-        currentInput = this->createToMemoryConfigOpIfNeeded(
-            op, rewriter, currentInput, info, /*forceCreate=*/true);
-      } else {
-        currentInput =
-            this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-        currentInput = this->createDataTypeCastingOpIfNeeded(
-            op, rewriter, currentInput, info);
-        currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                            currentInput, info);
+      current = createFromDeviceOp(op, rewriter, current);
+      current = createLayoutStep(op, rewriter, current, output);
+      if (output.isOnDevice()) {
+        current = createToDeviceOp(op, rewriter, current, output);
       }
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+      return current;
     }
-
-    // If we should tilize and the input data type is not device tilizable and
-    // we want to read back from device do everything on host
-    if (info.shouldTilize() && !canTilizeDataTypeOnDevice(input.dataType) &&
-        opsToCreate.createFromDeviceOp) {
-      currentInput =
-          this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+    // Tilize: tilize on host (dtype preserved), move to the output memory, then
+    // typecast on device (TILE).
+    if (input.isOnDevice()) {
+      current = createFromDeviceOp(op, rewriter, current);
     }
-
-    // If we should tilize and the input data type is not device tilizable and
-    // we don't want to read back from device: tilize on host, move back to
-    // device, and typecast on device
-    if (info.shouldTilize() && !canTilizeDataTypeOnDevice(input.dataType) &&
-        !opsToCreate.createFromDeviceOp) {
-      // Force-create a FromDeviceOp
-      currentInput = this->createFromDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, /*forceCreate=*/true);
-      // tilize on host
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      // move back to device and convert data type/memory config if needed
-      currentInput = this->createToDeviceOpIfNeeded(op, rewriter, currentInput,
-                                                    info, /*forceCreate=*/true);
-      currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
-                                                           currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
-      op.getResult().replaceAllUsesWith(currentInput);
-      return;
+    current = createLayoutStep(op, rewriter, current, output);
+    current = createToDeviceOp(op, rewriter, current, output);
+    if (needDtype) {
+      current = createTypecastOp(op, rewriter, current, output.dataType);
     }
-
-    llvm_unreachable("Unreachable code path");
+    return current;
   }
 
-  void handleDeviceInputLayoutConversion(ttnn::ToLayoutOp op,
-                                         IRRewriter &rewriter,
-                                         mlir::Value currentInput,
-                                         const OpCreationInfo &info) const {
-    const OpsToCreate &opsToCreate = info.opsToCreate;
-    if (!opsToCreate.createToLayoutOp && !opsToCreate.createDataTypeCastOp) {
-      handleDeviceInputNoLayoutNoTypecast(op, rewriter, currentInput, info);
-      return;
-    }
-    if (opsToCreate.createToLayoutOp && !opsToCreate.createDataTypeCastOp) {
-      handleDeviceInputLayoutNoTypecast(op, rewriter, currentInput, info);
-      return;
-    }
-    if (not opsToCreate.createToLayoutOp && opsToCreate.createDataTypeCastOp) {
-      handleDeviceInputNoLayoutTypecast(op, rewriter, currentInput, info);
-      return;
-    }
-    if (opsToCreate.createToLayoutOp && opsToCreate.createDataTypeCastOp) {
-      handleDeviceInputLayoutTypecast(op, rewriter, currentInput, info);
-      return;
-    }
-    llvm_unreachable("Unreachable code path");
-  }
+  //===--------------------------------------------------------------------===//
+  // Orchestration.
+  //===--------------------------------------------------------------------===//
 
-  /*
-   * Logic for creating ops. Conditions/constraints include:
-   * - When possible, we want to execute operations on device.
-   * - Tilize on device requires dataformat of bfloat16 or float32.
-   * - Typecast on device requires TILIZED tensor.
-   * - Untilize on device requires even width, and page size >
-   *   sizeof(uint32_t). For now, we will always untilize on host. We rarely
-   * need device to device untilize, so the perf hit should be acceptable.
-   */
   mlir::LogicalResult createLayoutConversionOps(ttnn::ToLayoutOp op,
                                                 IRRewriter &rewriter) const {
     auto [input, output] = getInputOutputLayouts(op);
-    OpsToCreate opsToCreate = determineRequiredOps(input, output);
-    if (not isCreationValid(op, input, output, opsToCreate)) {
+
+    bool needLayout = hasLayoutChange(input, output);
+    bool needDtype = hasDtypeChange(input, output);
+    bool needMemory = hasMemoryChange(input, output);
+
+    if (!needLayout && !needDtype && !needMemory) {
+      op->emitError(
+          "Redundant ttnn::ToLayoutOp - no ttnn layout ops needed, this may be "
+          "due to the forcing of tile/row major layouts.");
       return failure();
     }
 
-    OpCreationInfo info(input, output, opsToCreate);
+    mlir::Value current = op.getInput();
 
-    Value currentInput = op.getInput();
+    // CPU-hoisted boundaries keep the layout/typecast work on host.
+    bool cpuHoistOnHost = isOutputFromCPUHoistedFunction(current) ||
+                          isInputToCPUHoistedFunction(op);
+    bool bothOnHost = input.isOnHost() && output.isOnHost();
+    bool layoutNeedsHost = layoutChangeNeedsHost(input, output, needLayout);
 
-    if (input.isOnHost()) {
-      handleHostInputLayoutConversion(op, rewriter, currentInput, info);
-      return success();
+    // The typecast runs on host only for genuinely host-resident work: both
+    // sides on host, a CPU-hoisted boundary, or a host (un)tilize whose device
+    // side cannot hold the TILE tensor for an on-device typecast.
+    bool fullyOnHost =
+        bothOnHost || cpuHoistOnHost ||
+        (layoutNeedsHost && !canKeepTypecastOnDevice(input, output));
+
+    if (fullyOnHost) {
+      // Bring the tensor to host (if needed), do the layout/dtype changes
+      // there, then move to the output memory (if it is on device). to_device
+      // carries the full target memory config, so no separate to_memory_config
+      // is required.
+      if (input.isOnDevice()) {
+        current = createFromDeviceOp(op, rewriter, current);
+      }
+      current = layoutAndDtypeTransformations(op, rewriter, current, input,
+                                              output, /*onDevice=*/false);
+      if (output.isOnDevice()) {
+        current = createToDeviceOp(op, rewriter, current, output);
+      }
+    } else if (layoutNeedsHost) {
+      // The tilize/untilize must run on host, but the typecast stays on device.
+      current =
+          hostLayoutWithDeviceTypecast(op, rewriter, current, input, output);
+    } else if (layoutChangeRunsBeforeMemoryMove(input, output, needLayout)) {
+      // The layout/dtype changes run in the input memory; the memory move (if
+      // any) comes after.
+      current = layoutAndDtypeTransformations(op, rewriter, current, input,
+                                              output, /*onDevice=*/true);
+      if (!memoryMatchesTarget(current, output)) {
+        current = createMemoryMove(op, rewriter, current, output);
+      }
+    } else {
+      // Move to the output memory first, then run the layout/dtype changes.
+      current = createMemoryMove(op, rewriter, current, output);
+      current = layoutAndDtypeTransformations(op, rewriter, current, input,
+                                              output, /*onDevice=*/true);
     }
-    handleDeviceInputLayoutConversion(op, rewriter, currentInput, info);
+
+    op.getResult().replaceAllUsesWith(current);
     return success();
   }
 };

--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -76,31 +76,6 @@ public:
   }
 
 private:
-  struct LayoutInfo {
-    ttnn::BufferType bufferType;
-    ttnn::Layout layoutEnum;
-    ttcore::DataType dataType;
-    ttnn::TensorMemoryLayoutAttr tensorMemoryLayout;
-    llvm::SmallVector<int64_t> gridShape;
-    ttnn::CoreRangeSetAttr coreRangeSet;
-
-    bool isSharded() const {
-      return tensorMemoryLayout &&
-             isShardedMemoryLayout(tensorMemoryLayout.getValue());
-    }
-    bool isL1Sharded() const {
-      return bufferType == ttnn::BufferType::L1 && isSharded();
-    }
-    bool isDramSharded() const {
-      return bufferType == ttnn::BufferType::DRAM && isSharded();
-    }
-    bool isOnHost() const {
-      return bufferType == ttnn::BufferType::SystemMemory;
-    }
-    bool isOnDevice() const { return !isOnHost(); }
-    bool isTilized() const { return layoutEnum == ttnn::Layout::Tile; }
-  };
-
   //===--------------------------------------------------------------------===//
   // CPU-hoist boundary detection.
   //===--------------------------------------------------------------------===//
@@ -132,7 +107,8 @@ private:
   // Device capability predicates.
   //===--------------------------------------------------------------------===//
 
-  bool canChangeTileLayoutDataTypeOnDevice(ttcore::DataType dataType) const {
+  bool
+  isOnDeviceLayoutChangeSupportedForDataType(ttcore::DataType dataType) const {
     return dataType == ttcore::DataType::BFloat16 ||
            dataType == ttcore::DataType::Float32 ||
            dataType == ttcore::DataType::UInt32 ||
@@ -141,7 +117,7 @@ private:
   }
 
   // ttnn.to_layout only performs a real numeric conversion within the float
-  // family;
+  // family.
   bool isFloatFamily(ttcore::DataType dataType) const {
     switch (dataType) {
     case ttcore::DataType::UInt32:
@@ -159,33 +135,32 @@ private:
   // Change predicates and memory preference.
   //===--------------------------------------------------------------------===//
 
-  bool hasLayoutChange(const LayoutInfo &input,
-                       const LayoutInfo &output) const {
-    return input.layoutEnum != output.layoutEnum;
+  bool hasLayoutChange(TTNNLayoutAttr input, TTNNLayoutAttr output) const {
+    return input.getLayout() != output.getLayout();
   }
 
-  bool hasDtypeChange(const LayoutInfo &input, const LayoutInfo &output) const {
-    return input.dataType != output.dataType;
+  bool hasDtypeChange(TTNNLayoutAttr input, TTNNLayoutAttr output) const {
+    return input.getDataType() != output.getDataType();
   }
 
-  bool hasMemoryChange(const LayoutInfo &input,
-                       const LayoutInfo &output) const {
-    if (input.bufferType != output.bufferType) {
+  bool hasMemoryChange(TTNNLayoutAttr input, TTNNLayoutAttr output) const {
+    if (input.getBufferType() != output.getBufferType()) {
       return true;
     }
     // Same buffer type. If both are on host there is nothing more to compare.
-    if (input.isOnHost()) {
+    if (input.isSystemBufferType()) {
       return false;
     }
-    if (input.tensorMemoryLayout != output.tensorMemoryLayout) {
+    if (input.getMemLayout() != output.getMemLayout()) {
       return true;
     }
     // Reshard if either the virtual grid or the physical placement (CRS)
     // changes. Same CRS can host different virtual grids and same gridShape can
     // sit on different CRSes; both demand a reshard.
-    if (input.isSharded() && output.isSharded()) {
-      return input.gridShape != output.gridShape ||
-             input.coreRangeSet != output.coreRangeSet;
+    if (input.hasShardedTensorMemoryLayout() &&
+        output.hasShardedTensorMemoryLayout()) {
+      return input.getGridShape() != output.getGridShape() ||
+             input.getCoreRangeSet() != output.getCoreRangeSet();
     }
     return false;
   }
@@ -194,27 +169,27 @@ private:
   // input memory) or after it (in the output memory). The memory move is always
   // placed last unless tt-metal's sharded (un)tilize constraints (or a host
   // boundary) require it first.
-  bool layoutChangeRunsBeforeMemoryMove(const LayoutInfo &input,
-                                        const LayoutInfo &output,
-                                        bool needLayout) const {
+  bool
+  shouldLayoutAndDtypeChangesRunBeforeMemoryMove(TTNNLayoutAttr input,
+                                                 TTNNLayoutAttr output) const {
     // Host boundary: move onto the device first (host input), or finish the
     // work on device before reading it back (host output).
-    if (input.isOnHost() || output.isOnHost()) {
-      return !input.isOnHost();
+    if (input.isSystemBufferType() || output.isSystemBufferType()) {
+      return !input.isSystemBufferType();
     }
-    if (needLayout) {
+    if (hasLayoutChange(input, output)) {
       // Tilize (RM -> TILE): run the tilize first, then reshard. Tilizing a
       // tensor that was first resharded into the (sharded) output memory can
       // produce a non-tile-aligned physical shard that tt-metal rejects.
-      if (output.isTilized()) {
+      if (output.isTiled()) {
         return true;
       }
       // Untilize (TILE -> RM): deshard first when the input is L1-sharded (or
       // when moving L1 -> DRAM), then untilize the interleaved tensor;
       // otherwise untilize in place and move afterwards.
-      bool deshardFirst =
-          input.isL1Sharded() || (input.bufferType == ttnn::BufferType::L1 &&
-                                  output.bufferType == ttnn::BufferType::DRAM);
+      bool deshardFirst = input.hasShardedL1TensorMemoryLayout() ||
+                          (input.getBufferType() == ttnn::BufferType::L1 &&
+                           output.getBufferType() == ttnn::BufferType::DRAM);
       return !deshardFirst;
     }
     // Pure typecast / memory move: typecast in place, memory config last.
@@ -225,41 +200,19 @@ private:
   // Layout info extraction.
   //===--------------------------------------------------------------------===//
 
-  std::pair<LayoutInfo, LayoutInfo>
+  std::pair<TTNNLayoutAttr, TTNNLayoutAttr>
   getInputOutputLayouts(ttnn::ToLayoutOp op) const {
-    LayoutInfo input, output;
-
     auto inputLayoutAttr =
         mlir::cast<TTNNLayoutAttr>(op.getInput().getType().getEncoding());
     auto outputLayoutAttr =
         mlir::cast<TTNNLayoutAttr>(op.getResult().getType().getEncoding());
-
-    input.bufferType = inputLayoutAttr.getBufferType();
-    output.bufferType = outputLayoutAttr.getBufferType();
-
-    input.layoutEnum = inputLayoutAttr.getLayout();
-    output.layoutEnum = outputLayoutAttr.getLayout();
-
-    input.dataType = inputLayoutAttr.getDataType();
-    output.dataType = outputLayoutAttr.getDataType();
-
-    input.tensorMemoryLayout = inputLayoutAttr.getMemLayout();
-    output.tensorMemoryLayout = outputLayoutAttr.getMemLayout();
-
-    input.gridShape =
-        llvm::SmallVector<int64_t>(inputLayoutAttr.getGridShape());
-    output.gridShape =
-        llvm::SmallVector<int64_t>(outputLayoutAttr.getGridShape());
-
-    input.coreRangeSet = inputLayoutAttr.getCoreRangeSet();
-    output.coreRangeSet = outputLayoutAttr.getCoreRangeSet();
 
     TTMLIR_DEBUG(ttmlir::LogComponent::General,
                  "Decompose layouts pass for op {} \nInput layout: {} \nOutput "
                  "layout: {} \n",
                  op, inputLayoutAttr, outputLayoutAttr);
 
-    return {input, output};
+    return {inputLayoutAttr, outputLayoutAttr};
   }
 
   //===--------------------------------------------------------------------===//
@@ -267,52 +220,49 @@ private:
   //===--------------------------------------------------------------------===//
 
   template <typename OpType, typename... Args>
-  mlir::Value createOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                       RankedTensorType resultType, mlir::Value input,
-                       Args &&...args) const {
-    rewriter.setInsertionPoint(op);
-    return rewriter.create<OpType>(op.getLoc(), resultType, input,
+  mlir::Value createOp(IRRewriter &rewriter, RankedTensorType resultType,
+                       mlir::Value input, Args &&...args) const {
+    return rewriter.create<OpType>(input.getLoc(), resultType, input,
                                    std::forward<Args>(args)...);
   }
 
   // Encode `target`'s memory (buffer / memory layout / grid / CRS) onto the
   // current tensor type, keeping the current layout and dtype.
   RankedTensorType withTargetMemory(RankedTensorType currentType,
-                                    const LayoutInfo &target) const {
+                                    TTNNLayoutAttr target) const {
     TTNNLayoutAttr encoding = TTNNLayoutAttr::Builder(currentType)
-                                  .setBufferType(target.bufferType)
-                                  .setMemoryLayout(target.tensorMemoryLayout)
-                                  .setGridShape(target.gridShape)
-                                  .setCoreRangeSet(target.coreRangeSet)
+                                  .setBufferType(target.getBufferType())
+                                  .setMemoryLayout(target.getMemLayout())
+                                  .setGridShape(target.getGridShape())
+                                  .setCoreRangeSet(target.getCoreRangeSet())
                                   .build();
     return utils::RankedTensorTypeFactory::create(currentType, encoding);
   }
 
-  mlir::Value createToDeviceOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                               mlir::Value current,
-                               const LayoutInfo &target) const {
+  mlir::Value createToDeviceOp(IRRewriter &rewriter, mlir::Value current,
+                               TTNNLayoutAttr target) const {
     RankedTensorType currentType =
         mlir::cast<RankedTensorType>(current.getType());
     RankedTensorType resultType = withTargetMemory(currentType, target);
-    mlir::Value device = utils::getOrInsertDevice(rewriter, op);
-    return createOp<ttnn::ToDeviceOp>(op, rewriter, resultType, current,
-                                      device);
+    mlir::Value device =
+        utils::getOrInsertDevice(rewriter, rewriter.getInsertionBlock());
+    return createOp<ttnn::ToDeviceOp>(rewriter, resultType, current, device);
   }
 
-  mlir::Value createFromDeviceOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+  mlir::Value createFromDeviceOp(IRRewriter &rewriter,
                                  mlir::Value current) const {
     RankedTensorType currentType =
         mlir::cast<RankedTensorType>(current.getType());
     RankedTensorType resultType = utils::RankedTensorTypeFactory::create(
         currentType, ttnn::BufferType::SystemMemory);
-    return createOp<ttnn::FromDeviceOp>(op, rewriter, resultType, current);
+    return createOp<ttnn::FromDeviceOp>(rewriter, resultType, current);
   }
 
   // Create a to_layout op. When `dtype` is set, the result also changes data
   // type (a fused tilize/untilize + cast).
   mlir::Value
-  createToLayoutOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                   mlir::Value current, ttnn::Layout targetLayout,
+  createToLayoutOp(IRRewriter &rewriter, mlir::Value current,
+                   ttnn::Layout targetLayout,
                    std::optional<ttcore::DataType> dtype = std::nullopt) const {
     RankedTensorType currentType =
         mlir::cast<RankedTensorType>(current.getType());
@@ -321,26 +271,24 @@ private:
     if (dtype) {
       resultType = utils::RankedTensorTypeFactory::create(resultType, *dtype);
     }
-    return createOp<ttnn::ToLayoutOp>(op, rewriter, resultType, current);
+    return createOp<ttnn::ToLayoutOp>(rewriter, resultType, current);
   }
 
-  mlir::Value createTypecastOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                               mlir::Value current,
+  mlir::Value createTypecastOp(IRRewriter &rewriter, mlir::Value current,
                                ttcore::DataType targetDtype) const {
     RankedTensorType currentType =
         mlir::cast<RankedTensorType>(current.getType());
     RankedTensorType resultType =
         utils::RankedTensorTypeFactory::create(currentType, targetDtype);
-    return createOp<ttnn::TypecastOp>(op, rewriter, resultType, current);
+    return createOp<ttnn::TypecastOp>(rewriter, resultType, current);
   }
 
-  mlir::Value createToMemoryConfigOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                                     mlir::Value current,
-                                     const LayoutInfo &target) const {
+  mlir::Value createToMemoryConfigOp(IRRewriter &rewriter, mlir::Value current,
+                                     TTNNLayoutAttr target) const {
     RankedTensorType currentType =
         mlir::cast<RankedTensorType>(current.getType());
     RankedTensorType resultType = withTargetMemory(currentType, target);
-    return createOp<ttnn::ToMemoryConfigOp>(op, rewriter, resultType, current);
+    return createOp<ttnn::ToMemoryConfigOp>(rewriter, resultType, current);
   }
 
   //===--------------------------------------------------------------------===//
@@ -371,8 +319,7 @@ private:
   // Workaround for tt-metal#30541: unshard -> pad -> tilize -> slice.
   // Returns a DRAM INTERLEAVED, tilized, original-shape tensor. The caller is
   // responsible for any subsequent typecast and the final memory config.
-  mlir::Value handleShardedTilizeWithPadding(ttnn::ToLayoutOp op,
-                                             IRRewriter &rewriter,
+  mlir::Value handleShardedTilizeWithPadding(IRRewriter &rewriter,
                                              mlir::Value current,
                                              ttnn::Layout targetLayout) const {
     auto inputType = mlir::cast<RankedTensorType>(current.getType());
@@ -380,6 +327,7 @@ private:
         mlir::cast<TTNNLayoutAttr>(inputType.getEncoding());
     ArrayRef<int64_t> shape = inputType.getShape();
     int64_t rank = inputType.getRank();
+    Location loc = current.getLoc();
 
     // Step 1: Unshard to DRAM INTERLEAVED.
     TTNNLayoutAttr dramEncoding =
@@ -391,8 +339,7 @@ private:
     RankedTensorType dramType =
         RankedTensorType::get(shape, inputType.getElementType(), dramEncoding);
 
-    rewriter.setInsertionPoint(op);
-    current = rewriter.create<ToMemoryConfigOp>(op.getLoc(), dramType, current);
+    current = rewriter.create<ToMemoryConfigOp>(loc, dramType, current);
 
     // Step 2: Pad to tile-aligned dimensions.
     int64_t h = shape[rank - 2];
@@ -418,15 +365,14 @@ private:
     auto paddedType =
         utils::RankedTensorTypeFactory::create(currentInputType, paddedShape);
     current = rewriter.create<PadOp>(
-        op.getLoc(), paddedType, current,
-        rewriter.getDenseI32ArrayAttr(padding), rewriter.getF32FloatAttr(0.0f),
+        loc, paddedType, current, rewriter.getDenseI32ArrayAttr(padding),
+        rewriter.getF32FloatAttr(0.0f),
         /*use_multicore=*/rewriter.getBoolAttr(true));
 
     // Step 3: Tilize on padded DRAM tensor.
     RankedTensorType paddedTiledType = utils::RankedTensorTypeFactory::create(
         mlir::cast<RankedTensorType>(current.getType()), targetLayout);
-    current = rewriter.create<ttnn::ToLayoutOp>(op.getLoc(), paddedTiledType,
-                                                current);
+    current = rewriter.create<ttnn::ToLayoutOp>(loc, paddedTiledType, current);
 
     // Step 4: Slice back to original shape.
     SmallVector<int32_t> begins(rank, 0);
@@ -435,7 +381,7 @@ private:
     RankedTensorType slicedType = utils::RankedTensorTypeFactory::create(
         mlir::cast<RankedTensorType>(current.getType()), shape);
     current = rewriter.create<SliceStaticOp>(
-        op.getLoc(), slicedType, current, rewriter.getI32ArrayAttr(begins),
+        loc, slicedType, current, rewriter.getI32ArrayAttr(begins),
         rewriter.getI32ArrayAttr(ends), rewriter.getI32ArrayAttr(steps));
 
     return current;
@@ -448,51 +394,61 @@ private:
   // A TILE sharded->sharded reshard that crosses L1<->DRAM silently corrupts
   // (or raises) for certain orientation changes; route it through an
   // interleaved buffer instead.
+  // TT-metal issue: https://github.com/tenstorrent/tt-metal/issues/49224
   bool needsReshardViaInterleaved(TTNNLayoutAttr currentEncoding,
-                                  const LayoutInfo &target) const {
+                                  TTNNLayoutAttr target) const {
     if (currentEncoding.getLayout() != ttnn::Layout::Tile) {
       return false;
     }
     auto currentML = currentEncoding.getMemLayout();
     bool currentSharded =
         currentML && isShardedMemoryLayout(currentML.getValue());
-    if (!currentSharded || !target.isSharded()) {
+    if (!currentSharded || !target.hasShardedTensorMemoryLayout()) {
       return false;
     }
-    BufferType cb = currentEncoding.getBufferType();
-    BufferType tb = target.bufferType;
-    bool crossesL1Dram = (cb == BufferType::L1 && tb == BufferType::DRAM) ||
-                         (cb == BufferType::DRAM && tb == BufferType::L1);
+    BufferType currentBufferType = currentEncoding.getBufferType();
+    BufferType targetBufferType = target.getBufferType();
+    bool crossesL1Dram = (currentBufferType == BufferType::L1 &&
+                          targetBufferType == BufferType::DRAM) ||
+                         (currentBufferType == BufferType::DRAM &&
+                          targetBufferType == BufferType::L1);
     if (!crossesL1Dram) {
       return false;
     }
-    TensorMemoryLayout co = currentML.getValue();
-    TensorMemoryLayout to = target.tensorMemoryLayout.getValue();
-    bool eitherHeightSharded = co == TensorMemoryLayout::HeightSharded ||
-                               to == TensorMemoryLayout::HeightSharded;
-    bool bothWidthSharded = co == TensorMemoryLayout::WidthSharded &&
-                            to == TensorMemoryLayout::WidthSharded;
-    return (eitherHeightSharded && co != to) || bothWidthSharded;
+    TensorMemoryLayout currentShardLayout = currentML.getValue();
+    TensorMemoryLayout targetShardLayout = target.getMemLayout().getValue();
+    // Empirically (see the metal issue) the direct reshard is only safe for a
+    // same-orientation height reshard (HS->HS) and block->width (BS->WS).
+    // Everything else corrupts or raises, which reduces to two rules:
+    //   - a width-sharded source is never safe (WS->{HS,WS,BS}), and
+    //   - height-sharding on either side combined with an orientation change
+    //     (HS<->WS, HS<->BS) is never safe.
+    bool sourceWidthSharded =
+        currentShardLayout == TensorMemoryLayout::WidthSharded;
+    bool eitherHeightSharded =
+        currentShardLayout == TensorMemoryLayout::HeightSharded ||
+        targetShardLayout == TensorMemoryLayout::HeightSharded;
+    return sourceWidthSharded ||
+           (eitherHeightSharded && currentShardLayout != targetShardLayout);
   }
 
   // Move the current tensor into `target`'s memory. Picks to_device /
   // from_device when a host side is involved, otherwise to_memory_config.
-  mlir::Value createMemoryMove(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                               mlir::Value current,
-                               const LayoutInfo &target) const {
+  mlir::Value createMemoryMove(IRRewriter &rewriter, mlir::Value current,
+                               TTNNLayoutAttr target) const {
     RankedTensorType currentType =
         mlir::cast<RankedTensorType>(current.getType());
     auto currentEncoding =
         mlir::cast<TTNNLayoutAttr>(currentType.getEncoding());
     bool currentOnHost =
         currentEncoding.getBufferType() == ttnn::BufferType::SystemMemory;
-    bool targetOnHost = target.isOnHost();
+    bool targetOnHost = target.isSystemBufferType();
 
     if (currentOnHost && !targetOnHost) {
-      return createToDeviceOp(op, rewriter, current, target);
+      return createToDeviceOp(rewriter, current, target);
     }
     if (!currentOnHost && targetOnHost) {
-      return createFromDeviceOp(op, rewriter, current);
+      return createFromDeviceOp(rewriter, current);
     }
     if (currentOnHost && targetOnHost) {
       return current;
@@ -502,45 +458,15 @@ private:
     if (needsReshardViaInterleaved(currentEncoding, target)) {
       TTNNLayoutAttr interEncoding =
           TTNNLayoutAttr::Builder(currentEncoding, currentType.getShape())
-              .setBufferType(target.bufferType)
+              .setBufferType(BufferType::DRAM)
               .setMemoryLayout(TensorMemoryLayout::Interleaved)
               .setGridShape({1, 1})
               .build();
       RankedTensorType interType = RankedTensorType::get(
           currentType.getShape(), currentType.getElementType(), interEncoding);
-      current =
-          createOp<ttnn::ToMemoryConfigOp>(op, rewriter, interType, current);
+      current = createOp<ttnn::ToMemoryConfigOp>(rewriter, interType, current);
     }
-    return createToMemoryConfigOp(op, rewriter, current, target);
-  }
-
-  // True if the current tensor already lives in `target`'s memory.
-  bool memoryMatchesTarget(mlir::Value current,
-                           const LayoutInfo &target) const {
-    auto encoding = mlir::cast<TTNNLayoutAttr>(
-        mlir::cast<RankedTensorType>(current.getType()).getEncoding());
-    if (encoding.getBufferType() != target.bufferType) {
-      return false;
-    }
-    if (target.isOnHost()) {
-      return true;
-    }
-    if (encoding.getMemLayout() != target.tensorMemoryLayout) {
-      return false;
-    }
-    bool currentSharded =
-        encoding.getMemLayout() &&
-        isShardedMemoryLayout(encoding.getMemLayout().getValue());
-    if (currentSharded && target.isSharded()) {
-      if (ArrayRef<int64_t>(encoding.getGridShape()) !=
-          ArrayRef<int64_t>(target.gridShape)) {
-        return false;
-      }
-      if (encoding.getCoreRangeSet() != target.coreRangeSet) {
-        return false;
-      }
-    }
-    return true;
+    return createToMemoryConfigOp(rewriter, current, target);
   }
 
   //===--------------------------------------------------------------------===//
@@ -548,32 +474,31 @@ private:
   //===--------------------------------------------------------------------===//
 
   // Apply just the layout change (tilize/untilize), keeping the current dtype.
-  mlir::Value createLayoutStep(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                               mlir::Value current,
-                               const LayoutInfo &output) const {
-    if (output.isTilized() &&
-        needsShardedTilizePadWorkaround(
-            mlir::cast<RankedTensorType>(current.getType()))) {
-      return handleShardedTilizeWithPadding(op, rewriter, current,
-                                            output.layoutEnum);
+  mlir::Value createLayoutStep(IRRewriter &rewriter, mlir::Value current,
+                               TTNNLayoutAttr output,
+                               bool padWorkaround) const {
+    if (padWorkaround) {
+      return handleShardedTilizeWithPadding(rewriter, current,
+                                            output.getLayout());
     }
-    return createToLayoutOp(op, rewriter, current, output.layoutEnum);
+    return createToLayoutOp(rewriter, current, output.getLayout());
   }
 
   // Perform the layout and dtype changes. `onDevice` indicates whether the
   // chain runs on device (enables the fused layout+dtype op for the float
   // family) or on host (order is irrelevant, so typecast then layout).
-  mlir::Value
-  layoutAndDtypeTransformations(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                                mlir::Value current, const LayoutInfo &input,
-                                const LayoutInfo &output, bool onDevice) const {
-    bool needLayout = hasLayoutChange(input, output);
+  mlir::Value layoutAndDtypeTransformations(IRRewriter &rewriter,
+                                            mlir::Value current,
+                                            TTNNLayoutAttr input,
+                                            TTNNLayoutAttr output,
+                                            bool onDevice) const {
+    bool needsLayoutChange = hasLayoutChange(input, output);
     bool needDtype = hasDtypeChange(input, output);
-    if (!needLayout && !needDtype) {
+    if (!needsLayoutChange && !needDtype) {
       return current;
     }
 
-    bool tilizing = needLayout && output.isTilized();
+    bool tilizing = needsLayoutChange && output.isTiled();
     bool padWorkaround = onDevice && tilizing &&
                          needsShardedTilizePadWorkaround(
                              mlir::cast<RankedTensorType>(current.getType()));
@@ -581,49 +506,50 @@ private:
     // A single to_layout can do both layout and dtype only for a float-family
     // RM -> TILE conversion on device (and not when the pad workaround is in
     // play, which displaces the tensor to DRAM interleaved).
-    if (onDevice && needLayout && needDtype && tilizing && !input.isTilized() &&
-        isFloatFamily(input.dataType) && isFloatFamily(output.dataType) &&
-        !padWorkaround) {
-      return createToLayoutOp(op, rewriter, current, output.layoutEnum,
-                              output.dataType);
+    if (onDevice && needsLayoutChange && needDtype && tilizing &&
+        !input.isTiled() && isFloatFamily(input.getDataType()) &&
+        isFloatFamily(output.getDataType()) && !padWorkaround) {
+      return createToLayoutOp(rewriter, current, output.getLayout(),
+                              output.getDataType());
     }
 
-    if (needLayout && !needDtype) {
-      return createLayoutStep(op, rewriter, current, output);
+    if (needsLayoutChange && !needDtype) {
+      return createLayoutStep(rewriter, current, output, padWorkaround);
     }
-    if (!needLayout && needDtype) {
-      return createTypecastOp(op, rewriter, current, output.dataType);
+    if (!needsLayoutChange && needDtype) {
+      return createTypecastOp(rewriter, current, output.getDataType());
     }
 
     // Both changes, emitted as separate ops.
     if (!onDevice) {
       // On host the order is irrelevant; typecast first then change layout.
-      current = createTypecastOp(op, rewriter, current, output.dataType);
-      return createLayoutStep(op, rewriter, current, output);
+      current = createTypecastOp(rewriter, current, output.getDataType());
+      return createLayoutStep(rewriter, current, output, padWorkaround);
     }
 
     // On device the tilize/untilize must run on a device-capable dtype. The
     // typecast runs on device for any dtype, so order the two ops to place the
     // layout change on whichever side (input or output dtype) is
     // device-capable, keeping the typecast on device too.
-    if (input.isTilized()) {
-      // Untilize. Untilize on the output dtype (typecast first) when it can run
-      // on device; otherwise untilize on the input dtype first, then typecast.
-      if (canChangeTileLayoutDataTypeOnDevice(output.dataType)) {
-        current = createTypecastOp(op, rewriter, current, output.dataType);
-        return createLayoutStep(op, rewriter, current, output);
+    if (input.isTiled()) {
+      // Untilize on the output dtype (typecast first) when it can run on
+      // device.
+      if (isOnDeviceLayoutChangeSupportedForDataType(output.getDataType())) {
+        current = createTypecastOp(rewriter, current, output.getDataType());
+        return createLayoutStep(rewriter, current, output, padWorkaround);
       }
-      current = createLayoutStep(op, rewriter, current, output);
-      return createTypecastOp(op, rewriter, current, output.dataType);
+      // Otherwise untilize on the input dtype first, then typecast.
+      current = createLayoutStep(rewriter, current, output, padWorkaround);
+      return createTypecastOp(rewriter, current, output.getDataType());
     }
-    // Tilize. Tilize on the input dtype (tilize first) when it can run on
-    // device; otherwise typecast to the output dtype first, then tilize.
-    if (canChangeTileLayoutDataTypeOnDevice(input.dataType)) {
-      current = createLayoutStep(op, rewriter, current, output);
-      return createTypecastOp(op, rewriter, current, output.dataType);
+    // Tilize on the input dtype (tilize first) when it can run on device.
+    if (isOnDeviceLayoutChangeSupportedForDataType(input.getDataType())) {
+      current = createLayoutStep(rewriter, current, output, padWorkaround);
+      return createTypecastOp(rewriter, current, output.getDataType());
     }
-    current = createTypecastOp(op, rewriter, current, output.dataType);
-    return createLayoutStep(op, rewriter, current, output);
+    // Otherwise typecast to the output dtype first, then tilize.
+    current = createTypecastOp(rewriter, current, output.getDataType());
+    return createLayoutStep(rewriter, current, output, padWorkaround);
   }
 
   // The tilize/untilize itself must run on host when neither the input nor the
@@ -631,13 +557,13 @@ private:
   // device; see canKeepTypecastOnDevice.) The tilize/untilize can run on either
   // the input or output dtype depending on op ordering, so the work stays on
   // device as long as at least one side is device-capable.
-  bool layoutChangeNeedsHost(const LayoutInfo &input, const LayoutInfo &output,
-                             bool needLayout) const {
-    if (!needLayout) {
+  bool layoutChangeNeedsHost(TTNNLayoutAttr input,
+                             TTNNLayoutAttr output) const {
+    if (!hasLayoutChange(input, output)) {
       return false;
     }
-    return !canChangeTileLayoutDataTypeOnDevice(input.dataType) &&
-           !canChangeTileLayoutDataTypeOnDevice(output.dataType);
+    return !isOnDeviceLayoutChangeSupportedForDataType(input.getDataType()) &&
+           !isOnDeviceLayoutChangeSupportedForDataType(output.getDataType());
   }
 
   // For a device-involved transfer whose tilize/untilize must run on host, the
@@ -645,45 +571,10 @@ private:
   // TILE form for an (always-supported) TILE->TILE typecast:
   //   - untilize: the (TILE) input is on device, so typecast there first;
   //   - tilize:   the (TILE) output is on device, so typecast there last.
-  bool canKeepTypecastOnDevice(const LayoutInfo &input,
-                               const LayoutInfo &output) const {
-    return input.isTilized() ? input.isOnDevice() : output.isOnDevice();
-  }
-
-  // Run the tilize/untilize on host while keeping the typecast on device. The
-  // device typecast is a TILE->TILE op; the host op only changes layout (the
-  // dtype is preserved across the host round-trip). Requires
-  // canKeepTypecastOnDevice(input, output).
-  mlir::Value hostLayoutWithDeviceTypecast(ttnn::ToLayoutOp op,
-                                           IRRewriter &rewriter,
-                                           mlir::Value current,
-                                           const LayoutInfo &input,
-                                           const LayoutInfo &output) const {
-    bool needDtype = hasDtypeChange(input, output);
-    if (input.isTilized()) {
-      // Untilize: typecast on device (TILE) first, untilize on host, then land
-      // in the output memory.
-      if (needDtype) {
-        current = createTypecastOp(op, rewriter, current, output.dataType);
-      }
-      current = createFromDeviceOp(op, rewriter, current);
-      current = createLayoutStep(op, rewriter, current, output);
-      if (output.isOnDevice()) {
-        current = createToDeviceOp(op, rewriter, current, output);
-      }
-      return current;
-    }
-    // Tilize: tilize on host (dtype preserved), move to the output memory, then
-    // typecast on device (TILE).
-    if (input.isOnDevice()) {
-      current = createFromDeviceOp(op, rewriter, current);
-    }
-    current = createLayoutStep(op, rewriter, current, output);
-    current = createToDeviceOp(op, rewriter, current, output);
-    if (needDtype) {
-      current = createTypecastOp(op, rewriter, current, output.dataType);
-    }
-    return current;
+  bool canKeepTypecastOnDevice(TTNNLayoutAttr input,
+                               TTNNLayoutAttr output) const {
+    return input.isTiled() ? input.isDeviceBufferType()
+                           : output.isDeviceBufferType();
   }
 
   //===--------------------------------------------------------------------===//
@@ -694,30 +585,42 @@ private:
                                                 IRRewriter &rewriter) const {
     auto [input, output] = getInputOutputLayouts(op);
 
-    bool needLayout = hasLayoutChange(input, output);
+    bool needsLayoutChange = hasLayoutChange(input, output);
     bool needDtype = hasDtypeChange(input, output);
     bool needMemory = hasMemoryChange(input, output);
 
-    if (!needLayout && !needDtype && !needMemory) {
+    if (!needsLayoutChange && !needDtype && !needMemory) {
       op->emitError(
           "Redundant ttnn::ToLayoutOp - no ttnn layout ops needed, this may be "
           "due to the forcing of tile/row major layouts.");
       return failure();
     }
 
+    mlir::Value current = buildLayoutConversion(op, rewriter, input, output);
+
+    op.getResult().replaceAllUsesWith(current);
+    return success();
+  }
+
+  // Emits the layout/dtype/memory conversion ops and returns the final value.
+  mlir::Value buildLayoutConversion(ttnn::ToLayoutOp op, IRRewriter &rewriter,
+                                    TTNNLayoutAttr input,
+                                    TTNNLayoutAttr output) const {
     mlir::Value current = op.getInput();
 
+    rewriter.setInsertionPoint(op);
+
     // CPU-hoisted boundaries keep the layout/typecast work on host.
-    bool cpuHoistOnHost = isOutputFromCPUHoistedFunction(current) ||
-                          isInputToCPUHoistedFunction(op);
-    bool bothOnHost = input.isOnHost() && output.isOnHost();
-    bool layoutNeedsHost = layoutChangeNeedsHost(input, output, needLayout);
+    bool isCpuHoistedInputOrResult = isOutputFromCPUHoistedFunction(current) ||
+                                     isInputToCPUHoistedFunction(op);
+    bool bothOnHost = input.isSystemBufferType() && output.isSystemBufferType();
+    bool layoutNeedsHost = layoutChangeNeedsHost(input, output);
 
     // The typecast runs on host only for genuinely host-resident work: both
     // sides on host, a CPU-hoisted boundary, or a host (un)tilize whose device
     // side cannot hold the TILE tensor for an on-device typecast.
     bool fullyOnHost =
-        bothOnHost || cpuHoistOnHost ||
+        bothOnHost || isCpuHoistedInputOrResult ||
         (layoutNeedsHost && !canKeepTypecastOnDevice(input, output));
 
     if (fullyOnHost) {
@@ -725,35 +628,67 @@ private:
       // there, then move to the output memory (if it is on device). to_device
       // carries the full target memory config, so no separate to_memory_config
       // is required.
-      if (input.isOnDevice()) {
-        current = createFromDeviceOp(op, rewriter, current);
+      if (input.isDeviceBufferType()) {
+        current = createFromDeviceOp(rewriter, current);
       }
-      current = layoutAndDtypeTransformations(op, rewriter, current, input,
-                                              output, /*onDevice=*/false);
-      if (output.isOnDevice()) {
-        current = createToDeviceOp(op, rewriter, current, output);
+      current = layoutAndDtypeTransformations(rewriter, current, input, output,
+                                              /*onDevice=*/false);
+      if (output.isDeviceBufferType()) {
+        current = createToDeviceOp(rewriter, current, output);
       }
-    } else if (layoutNeedsHost) {
-      // The tilize/untilize must run on host, but the typecast stays on device.
-      current =
-          hostLayoutWithDeviceTypecast(op, rewriter, current, input, output);
-    } else if (layoutChangeRunsBeforeMemoryMove(input, output, needLayout)) {
-      // The layout/dtype changes run in the input memory; the memory move (if
-      // any) comes after.
-      current = layoutAndDtypeTransformations(op, rewriter, current, input,
-                                              output, /*onDevice=*/true);
-      if (!memoryMatchesTarget(current, output)) {
-        current = createMemoryMove(op, rewriter, current, output);
-      }
-    } else {
-      // Move to the output memory first, then run the layout/dtype changes.
-      current = createMemoryMove(op, rewriter, current, output);
-      current = layoutAndDtypeTransformations(op, rewriter, current, input,
-                                              output, /*onDevice=*/true);
+      return current;
     }
 
-    op.getResult().replaceAllUsesWith(current);
-    return success();
+    if (layoutNeedsHost) {
+      // The tilize/untilize must run on host, but the typecast stays on device
+      // as a TILE->TILE op (the dtype is preserved across the host round-trip).
+      // Reached only when canKeepTypecastOnDevice(input, output) holds.
+      bool needDtype = hasDtypeChange(input, output);
+      if (input.isTiled()) {
+        // Untilize: typecast on device (TILE) first, untilize on host, then
+        // land in the output memory.
+        if (needDtype) {
+          current = createTypecastOp(rewriter, current, output.getDataType());
+        }
+        current = createFromDeviceOp(rewriter, current);
+        current = createLayoutStep(rewriter, current, output,
+                                   /*padWorkaround=*/false);
+        if (output.isDeviceBufferType()) {
+          current = createToDeviceOp(rewriter, current, output);
+        }
+        return current;
+      }
+      // Tilize: tilize on host (dtype preserved), move to the output memory,
+      // then typecast on device (TILE).
+      if (input.isDeviceBufferType()) {
+        current = createFromDeviceOp(rewriter, current);
+      }
+      current = createLayoutStep(rewriter, current, output,
+                                 /*padWorkaround=*/false);
+      current = createToDeviceOp(rewriter, current, output);
+      if (needDtype) {
+        current = createTypecastOp(rewriter, current, output.getDataType());
+      }
+      return current;
+    }
+
+    if (shouldLayoutAndDtypeChangesRunBeforeMemoryMove(input, output)) {
+      // The layout/dtype changes run in the input memory; the memory move (if
+      // any) comes after.
+      current = layoutAndDtypeTransformations(rewriter, current, input, output,
+                                              /*onDevice=*/true);
+      auto currentEncoding = mlir::cast<TTNNLayoutAttr>(
+          mlir::cast<RankedTensorType>(current.getType()).getEncoding());
+      if (hasMemoryChange(currentEncoding, output)) {
+        current = createMemoryMove(rewriter, current, output);
+      }
+      return current;
+    }
+
+    // Move to the output memory first, then run the layout/dtype changes.
+    current = createMemoryMove(rewriter, current, output);
+    return layoutAndDtypeTransformations(rewriter, current, input, output,
+                                         /*onDevice=*/true);
   }
 };
 } // namespace mlir::tt::ttnn

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
@@ -54,19 +54,19 @@ module attributes {} {
 
     // Test case when we move tensor from host to device for row-major case.
     func.func @from_host_to_device_layout_to_layout_create_data_cast_op_rm(%arg0: tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16> {
-        // Typecast on device only works for tile layout. Verify that for the row-major case we insert the typecast op to cast the data type on host and than move the tensor to device.
+        // Device typecast supports row-major tensors, so for the row-major case we move the tensor to device and cast the data type on device.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
-        // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
+        // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
-        // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[CASTING_OP]], %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        // CHECK-NEXT: return %[[CASTING_OP]]
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
     // Test case when we move tensor from host to device for tile case.
     func.func @from_host_to_device_layout_to_layout_create_data_cast_op_tile(%arg0: tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16> {
-        // Typecast on device only works for tile layout. Verify that for the tile case we insert the to_device op and the typecast op to cast the data type on device.
+        // Verify that for the tile case we insert the to_device op and the typecast op to cast the data type on device.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
@@ -192,31 +192,29 @@ module attributes {} {
 
     // Test case when we move tensor from host to device for row-major -> tile case and cast input from bf16.
     func.func @from_host_to_device_data_type_from_bf16_to_f32_from_rm_to_tile(%arg0: tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile> {
-        // This test verifies that the `to_device`, `to_layout` and `typecast` operations are correctly inserted to change the layout from row-major to tile and cast
-        // data type from bf16 to f32 on device.
+        // bf16 -> f32 is a float-family conversion, so the tilize and the cast fuse
+        // into a single device `to_layout` that changes both layout and dtype.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: !ttcore.tile<32x32,
-        // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
-        // CHECK-SAME: -> tensor<{{.*}}f32
-        // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+        // CHECK-SAME: -> tensor<{{.*}}!ttcore.tile<32x32, f32>
+        // CHECK-NOT: "ttnn.typecast"
+        // CHECK: return %[[TO_LAYOUT_OP]]
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_tile>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case and cast input to bf16.
     func.func @from_host_to_device_data_type_from_f32_to_bf16_from_rm_to_tile(%arg0: tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16> {
-        // This test verifies that the `to_device`, `to_layout` and `typecast` operations are correctly inserted to move f32 tensor to device,
-        // change layout from row-major to tile on device (now possible with F32), and then cast to bf16 on device.
+        // f32 -> bf16 is a float-family conversion, so the tilize and the cast fuse
+        // into a single device `to_layout` that changes both layout and dtype.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: !ttcore.tile<32x32,
-        // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
-        // CHECK-SAME: -> tensor<{{.*}}bf16
-        // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        // CHECK-SAME: -> tensor<{{.*}}!ttcore.tile<32x32, bf16>
+        // CHECK-NOT: "ttnn.typecast"
+        // CHECK: return %[[TO_LAYOUT_OP]]
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
@@ -16,24 +16,18 @@
 
 module attributes {} {
 
-    // Verify that when moving a ui16 tensor from device L1 row-major to device
-    // DRAM tiled, a typecast workaround is inserted around to_memory_config
-    // because ttnn.copy (used internally by ttnn.to_memory_config) does not
-    // support ui16. The expected decomposition is:
-    //   to_layout (tilize on device, L1 rm ui16 -> L1 tile ui16)
-    //   typecast (ui16 -> u32, L1 tile)
-    //   to_memory_config (L1 tile u32 -> DRAM tile u32)
-    //   typecast (u32 -> ui16, DRAM tile)
-    func.func @device_l1_rm_ui16_to_dram_tile_ui16_inserts_typecast_workaround(%arg0: tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16> {
-        // CHECK-LABEL: func.func @device_l1_rm_ui16_to_dram_tile_ui16_inserts_typecast_workaround
+    // Moving a ui16 tensor from device L1 row-major to device DRAM tiled:
+    // tilize on device in the (preferred) L1 input memory, then a single
+    // to_memory_config moves the tilized tensor to DRAM. uint16 to_memory_config
+    // works like every other dtype, so no typecast workaround is needed.
+    func.func @device_l1_rm_ui16_to_dram_tile_ui16(%arg0: tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16> {
+        // CHECK-LABEL: func.func @device_l1_rm_ui16_to_dram_tile_ui16
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-NEXT: %[[TYPECAST_U32:.*]] = "ttnn.typecast"(%[[TO_LAYOUT]])
-        // CHECK-SAME: -> tensor<{{.*}}ui32
-        // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST_U32]])
-        // CHECK-NEXT: %[[TYPECAST_U16:.*]] = "ttnn.typecast"(%[[TO_MEM_CONFIG]])
-        // CHECK-SAME: -> tensor<{{.*}}ui16
-        // CHECK-NEXT: return %[[TYPECAST_U16]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
+        // CHECK-SAME: !ttcore.tile<32x32, u16>
+        // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TO_LAYOUT]])
+        // CHECK-NOT: "ttnn.typecast"
+        // CHECK: return %[[TO_MEM_CONFIG]]
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
         return %0 : tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
     }
 

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_dram_sharded.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_dram_sharded.mlir
@@ -121,7 +121,8 @@ module attributes {} {
     //===------------------------------------------------------------------===//
 
     // Host TILE f32 to DRAM-sharded RM bf16. to_device places the tile in
-    // DRAM-sharded, then typecast and untilize run on device.
+    // DRAM-sharded, then typecast and untilize run on device. Untilize + dtype
+    // cannot fuse, so the typecast stays a separate op.
     func.func @host_tile_f32_to_dram_ws_rm_bf16(%arg0: tensor<32x384xf32, #host_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16> {
         // CHECK-LABEL: func.func @host_tile_f32_to_dram_ws_rm_bf16
         // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%arg0
@@ -188,31 +189,30 @@ module attributes {} {
     // Tilize, with typecast
     //===------------------------------------------------------------------===//
 
-    // Host RM f32 to DRAM-sharded TILE bf16. Tilize and typecast both run
-    // on device after the host-to-device transfer.
+    // Host RM f32 to DRAM-sharded TILE bf16. After the host-to-device transfer,
+    // the f32 -> bf16 tilize fuses into a single device `to_layout` (float-family
+    // RM -> TILE) that changes both layout and dtype.
     func.func @host_rm_f32_to_dram_ws_tile_bf16(%arg0: tensor<32x384xf32, #host_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16> {
         // CHECK-LABEL: func.func @host_rm_f32_to_dram_ws_tile_bf16
         // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"
         // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_WS_RM_F32]]>
         // CHECK: %[[TILIZE:.*]] = "ttnn.to_layout"(%[[TO_DEV]])
-        // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_WS_TILE_F32]]>
-        // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%[[TILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
-        // CHECK: return %[[CAST]]
+        // CHECK-NOT: "ttnn.typecast"
+        // CHECK: return %[[TILIZE]]
         %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #host_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16>
     }
 
-    // DRAM-interleaved RM f32 to DRAM-sharded TILE bf16. Tilize runs on
-    // the interleaved input, typecast on the tilized result, and a final
+    // DRAM-interleaved RM f32 to DRAM-sharded TILE bf16. The f32 -> bf16 tilize
+    // fuses into a single device `to_layout` on the interleaved input, then a
     // reshard lands the tensor in DRAM-sharded.
     func.func @dram_il_rm_f32_to_dram_ws_tile_bf16(%arg0: tensor<32x384xf32, #dram_il_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16> {
         // CHECK-LABEL: func.func @dram_il_rm_f32_to_dram_ws_tile_bf16
         // CHECK: %[[TILIZE:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_IL_TILE_F32]]>
-        // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%[[TILIZE]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
-        // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[CAST]])
+        // CHECK-NOT: "ttnn.typecast"
+        // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[TILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: return %[[RESHARD]]
         %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #dram_il_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
@@ -224,15 +224,15 @@ module attributes {} {
     //===------------------------------------------------------------------===//
 
     // DRAM-sharded TILE to DRAM-interleaved TILE with a dtype change.
-    // ttnn.typecast requires input and output memory layouts to match, so
-    // the unshard must happen before the typecast.
-    func.func @dram_ws_tile_bf16_to_dram_il_tile_f32_unshards_before_typecast(%arg0: tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xf32, #dram_il_tile_f32> {
-        // CHECK-LABEL: func.func @dram_ws_tile_bf16_to_dram_il_tile_f32_unshards_before_typecast
-        // CHECK: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
-        // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_TILE_BF16]]>
-        // CHECK-NEXT: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[TO_MEM_CONFIG]])
-        // CHECK-SAME: -> tensor<{{.*}}f32
-        // CHECK-NEXT: return %[[TYPECAST]]
+    // DRAM-sharded is the preferred memory, so the typecast runs in place on the
+    // sharded input, then a single to_memory_config unshards to interleaved.
+    func.func @dram_ws_tile_bf16_to_dram_il_tile_f32(%arg0: tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xf32, #dram_il_tile_f32> {
+        // CHECK-LABEL: func.func @dram_ws_tile_bf16_to_dram_il_tile_f32
+        // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg0)
+        // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_WS_TILE_F32]]>
+        // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST]])
+        // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_IL_TILE_F32]]>
+        // CHECK-NEXT: return %[[TO_MEM_CONFIG]]
         %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xf32, #dram_il_tile_f32>
         return %0 : tensor<32x384xf32, #dram_il_tile_f32>
     }

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
@@ -55,19 +55,19 @@ module attributes {} {
 
     // Test case when we move tensor from host to device for row-major case.
     func.func @from_host_to_device_layout_to_layout_create_data_cast_op_rm(%arg0: tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16> {
-        // Typecast on device only works for tile layout. Verify that for the row-major case we insert the typecast op to cast the data type on host and than move the tensor to device.
+        // Device typecast supports row-major tensors, so for the row-major case we move the tensor to device and cast the data type on device.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
-        // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
+        // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
-        // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[CASTING_OP]], %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        // CHECK-NEXT: return %[[CASTING_OP]]
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
     // Test case when we move tensor from host to device for tile case.
     func.func @from_host_to_device_layout_to_layout_create_data_cast_op_tile(%arg0: tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16> {
-        // Typecast on device only works for tile layout. Verify that for the tile case we insert the to_device op and the typecast op to cast the data type on device.
+        // Verify that for the tile case we insert the to_device op and the typecast op to cast the data type on device.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
@@ -193,31 +193,29 @@ module attributes {} {
 
     // Test case when we move tensor from host to device for row-major -> tile case and cast input from bf16.
     func.func @from_host_to_device_data_type_from_bf16_to_f32_from_rm_to_tile(%arg0: tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile> {
-        // This test verifies that the `to_device`, `to_layout` and `typecast` operations are correctly inserted to change the layout from row-major to tile and cast
-        // data type from bf16 to f32 on device.
+        // bf16 -> f32 is a float-family conversion, so the tilize and the cast fuse
+        // into a single device `to_layout` that changes both layout and dtype.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: !ttcore.tile<32x32,
-        // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}f32
-        // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+        // CHECK-NOT: "ttnn.typecast"
+        // CHECK: return %[[TO_LAYOUT_OP]]
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_tile>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case and cast input to bf16.
     func.func @from_host_to_device_data_type_from_f32_to_bf16_from_rm_to_tile(%arg0: tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16> {
-        // This test verifies that the `to_device`, `to_layout` and `typecast` operations are correctly inserted to move f32 tensor to device,
-        // change layout from row-major to tile on device (now possible with F32), and then cast to bf16 on device.
+        // f32 -> bf16 is a float-family conversion, so the tilize and the cast fuse
+        // into a single device `to_layout` that changes both layout and dtype.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
-        // CHECK-SAME: !ttcore.tile<32x32,
-        // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
-        // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        // CHECK-NOT: "ttnn.typecast"
+        // CHECK: return %[[TO_LAYOUT_OP]]
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -237,13 +235,15 @@ module attributes {} {
     }
 
     // Test case when we move tensor from l1 sharded to dram tile with typecast.
+    // L1 block-sharded is the preferred memory, so the typecast runs in place on
+    // the sharded input and a single to_memory_config then unshards to DRAM.
     func.func @from_l1_sharded_to_dram_tile_bf16(%arg0: tensor<1x1x784x512xf32, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <7x8>, memref<4x2x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,6)>]>>>) -> tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>> {
         // CHECK-LABEL: func.func @from_l1_sharded_to_dram_tile_bf16
-        // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
-        // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[MEM_CONFIG]])
+        // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}bf16
-        // CHECK: return %[[TYPECAST]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<1x1x784x512xf32, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <7x8>, memref<4x2x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,6)>]>>>) -> tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
+        // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST]])
+        // CHECK: return %[[MEM_CONFIG]]
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<1x1x784x512xf32, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <7x8>, memref<4x2x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,6)>]>>>) -> tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
         return %0 : tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
     }
 

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
@@ -12,24 +12,17 @@
 
 module attributes {} {
 
-    // Verify that when moving a ui16 tensor from device L1 row-major to device
-    // DRAM tiled, a typecast workaround is inserted around to_memory_config
-    // because ttnn.copy (used internally by ttnn.to_memory_config) does not
-    // support ui16. The expected decomposition is:
-    //   to_layout (tilize on device, L1 rm ui16 -> L1 tile ui16)
-    //   typecast (ui16 -> u32, L1 tile)
-    //   to_memory_config (L1 tile u32 -> DRAM tile u32)
-    //   typecast (u32 -> ui16, DRAM tile)
-    func.func @device_l1_rm_ui16_to_dram_tile_ui16_inserts_typecast_workaround(%arg0: tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16> {
-        // CHECK-LABEL: func.func @device_l1_rm_ui16_to_dram_tile_ui16_inserts_typecast_workaround
+    // Moving a ui16 tensor from device L1 row-major to device DRAM tiled: tilize
+    // on device in the (preferred) L1 input memory, then a single to_memory_config
+    // moves the tilized tensor to DRAM. uint16 to_memory_config works like every
+    // other dtype, so no typecast workaround is needed.
+    func.func @device_l1_rm_ui16_to_dram_tile_ui16(%arg0: tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16> {
+        // CHECK-LABEL: func.func @device_l1_rm_ui16_to_dram_tile_ui16
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-NEXT: %[[TYPECAST_U32:.*]] = "ttnn.typecast"(%[[TO_LAYOUT]])
-        // CHECK-SAME: -> tensor<64x128xui32
-        // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST_U32]])
-        // CHECK-NEXT: %[[TYPECAST_U16:.*]] = "ttnn.typecast"(%[[TO_MEM_CONFIG]])
-        // CHECK-SAME: -> tensor<64x128xui16
-        // CHECK-NEXT: return %[[TYPECAST_U16]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
+        // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TO_LAYOUT]])
+        // CHECK-NOT: "ttnn.typecast"
+        // CHECK: return %[[TO_MEM_CONFIG]]
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
         return %0 : tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
@@ -53,9 +53,8 @@ module attributes {} {
     }
 
     // DRAM interleaved RM bf16 -> L1 interleaved RM f32. Dtype change plus a
-    // memory move. The typecast runs on the DRAM input, then a single
-    // to_memory_config moves the (already-typecast) result to L1; no host
-    // round-trip.
+    // memory move. The typecast runs in place on the DRAM input, then a single
+    // to_memory_config moves the result to L1; no host round-trip.
     func.func @dram_il_rm_bf16_to_l1_il_rm_f32(%arg0: tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32> {
         // CHECK-LABEL: func.func @dram_il_rm_bf16_to_l1_il_rm_f32
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
@@ -63,7 +62,7 @@ module attributes {} {
         // CHECK-NEXT: %[[MEM:.*]] = "ttnn.to_memory_config"(%[[CAST]])
         // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<l1>
         // CHECK-NEXT: return %[[MEM]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
         return %0 : tensor<32x128xf32, #l1_il_rm_f32>
     }
 

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_untilize_on_device.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_untilize_on_device.mlir
@@ -21,36 +21,38 @@
 module attributes {} {
 
     // Test: L1 interleaved tile -> DRAM interleaved row-major (bf16).
-    // Verify we move to DRAM first (toMemoryConfig), then untilize (toLayout).
-    // This avoids creating a large row-major intermediate in L1.
+    // Moving L1 -> DRAM, so the tile tensor unshards to DRAM first
+    // (toMemoryConfig), then untilize runs on the DRAM interleaved tensor. This
+    // keeps the row-major intermediate from clashing with live L1 buffers.
     func.func @from_l1_tile_to_dram_rm_bf16(%arg0: tensor<32x2048xbf16, #ttnn_layout_device_l1_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16> {
         // CHECK-LABEL: func.func @from_l1_tile_to_dram_rm_bf16
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[MEM_CONFIG]])
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x2048xbf16, #ttnn_layout_device_l1_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xbf16, #ttnn_layout_device_l1_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
         return %0 : tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
     }
 
     // Test: L1 interleaved tile -> DRAM interleaved row-major (f32).
-    // Same ordering: toMemoryConfig first, then toLayout.
+    // Same ordering: unshard to DRAM first (toMemoryConfig), then untilize.
     func.func @from_l1_tile_to_dram_rm_f32(%arg0: tensor<32x2048xf32, #ttnn_layout_device_l1_tile_f32>) -> tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32> {
         // CHECK-LABEL: func.func @from_l1_tile_to_dram_rm_f32
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[MEM_CONFIG]])
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x2048xf32, #ttnn_layout_device_l1_tile_f32>) -> tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xf32, #ttnn_layout_device_l1_tile_f32>) -> tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32>
         return %0 : tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32>
     }
 
     // Test: DRAM interleaved tile -> L1 interleaved row-major (bf16).
-    // Verify we untilize first (toLayout in DRAM), then move to L1 (toMemoryConfig).
+    // The input is DRAM interleaved (not sharded), so the untilize runs in place
+    // first (toLayout), then a single toMemoryConfig moves the result to L1.
     func.func @from_dram_tile_to_l1_rm_bf16(%arg0: tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16> {
         // CHECK-LABEL: func.func @from_dram_tile_to_l1_rm_bf16
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TO_LAYOUT]])
         // CHECK: return %[[MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16>
         return %0 : tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16>
     }
 
@@ -64,13 +66,16 @@ module attributes {} {
     }
 
     // Test: L1 block sharded tile -> DRAM interleaved row-major (bf16).
-    // Verify we unshard to DRAM first (toMemoryConfig), then untilize (toLayout).
+    // The input is sharded, so it unshards to DRAM interleaved first
+    // (toMemoryConfig), then untilize runs on the interleaved tensor. Untilizing
+    // a sharded tensor can hit non-tile-aligned per-core shards, so the deshard
+    // must come first.
     func.func @from_l1_sharded_tile_to_dram_rm_bf16(%arg0: tensor<32x256xbf16, #ttnn_layout_device_l1_block_sharded_tile_bf16>) -> tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small> {
         // CHECK-LABEL: func.func @from_l1_sharded_tile_to_dram_rm_bf16
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[MEM_CONFIG]])
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x256xbf16, #ttnn_layout_device_l1_block_sharded_tile_bf16>) -> tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small>
+        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x256xbf16, #ttnn_layout_device_l1_block_sharded_tile_bf16>) -> tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small>
         return %0 : tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small>
     }
 
@@ -88,22 +93,19 @@ module attributes {} {
         return %0 : tensor<32x2048xui16, #ttnn_layout_device_dram_rm_ui16>
     }
 
-    // Test: DRAM tile -> L1 row-major (ui16). Untilize stays on device (toLayout),
-    // then the DRAM -> L1 move goes through the existing ui16 to_memory_config
-    // typecast workaround (ui16 -> u32 -> u32 -> ui16), since ttnn.copy does not
-    // support ui16. The key point is no host round-trip (no from_device).
+    // Test: DRAM tile -> L1 row-major (ui16). The input is DRAM interleaved
+    // (not sharded), so the untilize runs in place first (toLayout), then a
+    // single toMemoryConfig moves the row-major result to L1. uint16
+    // to_memory_config works directly, so there is no typecast workaround and no
+    // host round-trip (no from_device).
     func.func @from_dram_tile_to_l1_rm_ui16(%arg0: tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_l1_rm_ui16> {
         // CHECK-LABEL: func.func @from_dram_tile_to_l1_rm_ui16
         // CHECK-NOT: "ttnn.from_device"
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
-        // CHECK-SAME: -> tensor<32x2048xui16, #[[DRAM_RM_UI16]]>
-        // CHECK: %[[TYPECAST_U32:.*]] = "ttnn.typecast"(%[[TO_LAYOUT]])
-        // CHECK-SAME: -> tensor<{{.*}}ui32
-        // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST_U32]])
-        // CHECK: %[[TYPECAST_U16:.*]] = "ttnn.typecast"(%[[MEM_CONFIG]])
-        // CHECK-SAME: -> tensor<32x2048xui16, #[[L1_RM_UI16]]>
+        // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TO_LAYOUT]])
+        // CHECK-NOT: "ttnn.typecast"
         // CHECK-NOT: "ttnn.from_device"
-        // CHECK: return %[[TYPECAST_U16]]
+        // CHECK: return %[[MEM_CONFIG]]
         %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_l1_rm_ui16>
         return %0 : tensor<32x2048xui16, #ttnn_layout_device_l1_rm_ui16>
     }


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/8264

### Problem description
There is a lot of repetitive code in decompose layout pass that can be simplified.

### What's changed
Creation of ops are done at a single place. Order is determined by explicit checks. Limitations of tt-metal are documented and tagged. Workarounds for those constraints are implemented in separate functions.

### Checklist
- [x] New/Existing tests provide coverage for changes

<!-- xla-validate -->
---
### tt-xla Validation

**Base (uplifted):** `ba8aa2a`

| Test Suite | Run | Status |
|------------|-----|--------|
| full-mlir-uplift-qualification | [Run #28517589164](https://github.com/tenstorrent/tt-xla/actions/runs/28517589164) | :white_check_mark: passed |

#### Performance Benchmark (n150-perf)

| Run | mlir | Status |
|-----|------|--------|
| [Run #28521225871](https://github.com/tenstorrent/tt-xla/actions/runs/28521225871) | PR (`c6f53990e`) | :x: failed |
| [Run #28521228480](https://github.com/tenstorrent/tt-xla/actions/runs/28521228480) | baseline (XLA main) | :x: failed |

Both benchmark runs report a workflow `failure` conclusion, but the failing models are
**identical in the PR and baseline** (e.g. `ufld_v2`, `mobilenetv2`, `ministral_8b`,
`vllm_llama`, `vllm_ministral`, `vllm_qwen3_*`) — i.e. pre-existing failures, not caused
by this PR.

**Perf comparison** (`gh-perf-report`, baseline `28521228480` vs PR `28521225871`) — host
samples/sec; device-perf artifacts were not produced so device metrics are N/A:

- 59 comparisons: **5 regressions, 7 improvements, 47 neutral** (±5% threshold)
- Regressions: `bert` -5.5%, `resnet_jax` -7.1%, `swin` -8.2%, `vllm_bge_m3_encode_batch1` -15.1%, `vllm_phi_1` -7.5%
- Improvements: `segformer` +9.6%, `vllm_qwen2_5_7b_instruct` +14.1%, `vllm_phi_2` +7.5%, `vllm_qwen2_5_3b_instruct` +7.9%, `vllm_qwen2_5_0_5b_instruct` +8.3%, `vllm_phi_1_5` +5.6%, `unet_for_conditional_generation` +5.1%

The regressions and improvements are small, roughly symmetric, and inconsistent in
direction across sibling models (e.g. `vllm_phi_1` down while `vllm_phi_1_5`/`vllm_phi_2`
up) — consistent with shared-runner host-throughput noise rather than a systematic
regression from the decompose-layout change. No device-perf regression signal available.
<!-- /xla-validate -->






