### PR TITLE
Uplift third_party/tt-metal to 4b39efbe92916e1d3be471d02b79b635e223ac24 2026-06-23

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6696,7 +6696,6 @@ def TTIR_MoeComputeOp : TTIR_NamedOp<"moe_compute", [TTIR_CCL, AttrSizedOperandS
                          UI32Attr:$intermediate_size,
                          DefaultValuedAttr<TTCore_MoEActivationFunctionAttr,
                              "::mlir::tt::ttcore::MoEActivationFunction::Silu">:$activation_function,
-                         OptionalAttr<UI32Attr>:$bh_ring_size,
                          DefaultValuedAttr<BoolAttr, "true">:$compute_only,
 
                          // Full-path-only inputs, unused when compute_only == true.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1819,8 +1819,7 @@ def TTNN_PrepareMoEComputeW0W1WeightsOp :
                          Optional<AnyRankedTensor>:$bias_1,
                          TTNN_Device:$device,
                          UI32Attr:$hidden_size,
-                         UI32Attr:$intermediate_size,
-                         OptionalAttr<UI32Attr>:$bh_ring_size);
+                         UI32Attr:$intermediate_size);
 
     let results = (outs AnyRankedTensor:$result);
 
@@ -1848,8 +1847,7 @@ def TTNN_PrepareMoEComputeW2WeightsOp :
                          Optional<AnyRankedTensor>:$bias_2,
                          TTNN_Device:$device,
                          UI32Attr:$hidden_size,
-                         UI32Attr:$intermediate_size,
-                         OptionalAttr<UI32Attr>:$bh_ring_size);
+                         UI32Attr:$intermediate_size);
 
     let results = (outs AnyRankedTensor:$result);
 
@@ -1884,9 +1882,7 @@ def TTNN_MoeComputeOp : TTNN_Op<"moe_compute",
       `matmul_output` is the final user-visible output. In that mode
       `cluster_axis`, `topology`, `num_links`, `mux_core_range_set`,
       `optional_output_tensor`, and `cross_device_semaphore` are unused, and
-      `combine_output` aliases `matmul_output`. `bh_ring_size` pins the
-      Blackhole matmul ring size (8, 12, or 16; default 12) and is ignored on
-      Wormhole.
+      `combine_output` aliases `matmul_output`.
 
       See `TTIR_MoeComputeOp` for input/output shapes and dtypes.
     }];
@@ -1906,7 +1902,6 @@ def TTNN_MoeComputeOp : TTNN_Op<"moe_compute",
                          BoolAttr:$has_bias,
                          DefaultValuedAttr<TTCore_MoEActivationFunctionAttr,
                              "::mlir::tt::ttcore::MoEActivationFunction::Silu">:$activation_function,
-                         OptionalAttr<UI32Attr>:$bh_ring_size,
                          DefaultValuedAttr<BoolAttr, "true">:$compute_only,
 
                          // Full-path-only inputs, unused when compute_only == true.

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1428,8 +1428,7 @@ struct OpModel<PrepareMoEComputeW0W1WeightsOp> {
                    std::optional<TTNNLayoutAttr> bias0Layout,
                    std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
                    std::optional<TTNNLayoutAttr> bias1Layout,
-                   uint32_t hiddenSize, uint32_t intermediateSize,
-                   std::optional<uint32_t> bhRingSize);
+                   uint32_t hiddenSize, uint32_t intermediateSize);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1442,8 +1441,7 @@ struct OpModel<PrepareMoEComputeW2WeightsOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
                    std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
                    std::optional<TTNNLayoutAttr> bias2Layout,
-                   uint32_t hiddenSize, uint32_t intermediateSize,
-                   std::optional<uint32_t> bhRingSize);
+                   uint32_t hiddenSize, uint32_t intermediateSize);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTNN/operations/ccl.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ccl.fbs
@@ -167,7 +167,6 @@ table PrepareMoEComputeW0W1WeightsOp {
   device: tt.target.DeviceRef;
   hidden_size: uint32;
   intermediate_size: uint32;
-  bh_ring_size: uint32 = null;
   out: tt.target.ttnn.TensorRef;
 }
 
@@ -177,7 +176,6 @@ table PrepareMoEComputeW2WeightsOp {
   device: tt.target.DeviceRef;
   hidden_size: uint32;
   intermediate_size: uint32;
-  bh_ring_size: uint32 = null;
   out: tt.target.ttnn.TensorRef;
 }
 
@@ -201,7 +199,6 @@ table MoeComputeOp {
   topology: tt.target.Topology = null;
   mux_core_range_set: tt.target.ttnn.CoreRangeSet;
   compute_only: bool;
-  bh_ring_size: uint32 = null;
   per_expert_total_tokens: tt.target.ttnn.TensorRef;
   expert_activation: tt.target.ttnn.TensorRef;
   expert_to_token: tt.target.ttnn.TensorRef;

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1866,14 +1866,13 @@ public:
         ttmlir::utils::appendLocationSuffix(op.getLoc(), "_prepare_w0_w1"),
         /*placeholder type, refined by TTNNDeduceMoEComputeLayouts=*/w0Type,
         adaptor.getW0(), adaptor.getW1(), adaptor.getBias_0(),
-        adaptor.getBias_1(), device, hiddenSizeAttr, intermediateSizeAttr,
-        op.getBhRingSizeAttr());
+        adaptor.getBias_1(), device, hiddenSizeAttr, intermediateSizeAttr);
 
     auto w2Prepared = rewriter.create<ttnn::PrepareMoEComputeW2WeightsOp>(
         ttmlir::utils::appendLocationSuffix(op.getLoc(), "_prepare_w2"),
         /*placeholder type, refined by TTNNDeduceMoEComputeLayouts=*/w2Type,
         adaptor.getW2(), adaptor.getBias_2(), device, hiddenSizeAttr,
-        intermediateSizeAttr, op.getBhRingSizeAttr());
+        intermediateSizeAttr);
 
     // The TTNN op (mirroring tt-metal) carries has_bias; derive it from the
     // bias operands.
@@ -1890,8 +1889,8 @@ public:
         w2Prepared.getResult(), /*optional_output_tensor=*/Value(),
         /*cross_device_semaphore=*/Value(), device, op.getLayerIdAttr(),
         op.getOutputHeightShardDimAttr(), op.getIntermediateSizeAttr(),
-        hasBiasAttr, op.getActivationFunctionAttr(), op.getBhRingSizeAttr(),
-        op.getComputeOnlyAttr(), op.getClusterAxisAttr(),
+        hasBiasAttr, op.getActivationFunctionAttr(), op.getComputeOnlyAttr(),
+        op.getClusterAxisAttr(),
         /*num_links=*/mlir::IntegerAttr(), /*topology=*/ttcore::TopologyAttr(),
         /*mux_core_range_set=*/ttnn::CoreRangeSetAttr());
     return success();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -8118,10 +8118,6 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
   if (getClusterAxis()) {
     return emitOpError("compute_only moe_compute must not set cluster_axis");
   }
-  if (getBhRingSize() && *getBhRingSize() != 8 && *getBhRingSize() != 12 &&
-      *getBhRingSize() != 16) {
-    return emitOpError("bh_ring_size must be 8, 12, or 16");
-  }
 
   ::mlir::RankedTensorType inputType = getTilizeInputTensor().getType();
   if (inputType.getRank() < 2) {
@@ -8145,24 +8141,6 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
     return emitOpError() << "w0 hidden dim (" << w0Shape[2]
                          << ") must match tilize_input_tensor hidden_size ("
                          << hiddenSize << ")";
-  }
-
-  // The W0/W1 and W2 matmuls shard their contraction (intermediate_size) and
-  // the W2 output (hidden_size) across the matmul ring (bh_ring_size cores on
-  // BH, default 12; WH is always 12). If either dim has fewer than ring-size
-  // tiles, the per-core shard distribution degenerates and leaves output tiles
-  // uncomputed, so require at least one tile per ring core in both dims.
-  int64_t ringSize = getBhRingSize() ? *getBhRingSize() : 12;
-  int64_t minSize = ringSize * 32;
-  if (hiddenSize < minSize) {
-    return emitOpError() << "hidden_size (" << hiddenSize
-                         << ") must be at least bh_ring_size*32 = " << minSize
-                         << " (one tile per matmul-ring core)";
-  }
-  if (static_cast<int64_t>(getIntermediateSize()) < minSize) {
-    return emitOpError() << "intermediate_size (" << getIntermediateSize()
-                         << ") must be at least bh_ring_size*32 = " << minSize
-                         << " (one tile per matmul-ring core)";
   }
 
   return success();

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3136,10 +3136,6 @@ void mlir::tt::ttnn::MatmulOp::getCanonicalizationPatterns(
         "num_links, mux_core_range_set, optional_output_tensor, or "
         "cross_device_semaphore");
   }
-  if (getBhRingSize() && *getBhRingSize() != 8 && *getBhRingSize() != 12 &&
-      *getBhRingSize() != 16) {
-    return emitOpError("bh_ring_size must be 8, 12, or 16");
-  }
 
   RankedTensorType inputType = getTilizeInputTensor().getType();
   if (inputType.getRank() < 2) {
@@ -3150,24 +3146,6 @@ void mlir::tt::ttnn::MatmulOp::getCanonicalizationPatterns(
     return emitOpError(
         "tilize_input_tensor last dim (hidden_size) must be a positive "
         "multiple of 32");
-  }
-
-  // The W0/W1 and W2 matmuls shard their contraction (intermediate_size) and
-  // the W2 output (hidden_size) across the matmul ring (bh_ring_size cores on
-  // BH, default 12; WH is always 12). If either dim has fewer than ring-size
-  // tiles, the per-core shard distribution degenerates and leaves output tiles
-  // uncomputed, so require at least one tile per ring core in both dims.
-  int64_t ringSize = getBhRingSize() ? *getBhRingSize() : 12;
-  int64_t minSize = ringSize * 32;
-  if (hiddenSize < minSize) {
-    return emitOpError() << "hidden_size (" << hiddenSize
-                         << ") must be at least bh_ring_size*32 = " << minSize
-                         << " (one tile per matmul-ring core)";
-  }
-  if (static_cast<int64_t>(getIntermediateSize()) < minSize) {
-    return emitOpError() << "intermediate_size (" << getIntermediateSize()
-                         << ") must be at least bh_ring_size*32 = " << minSize
-                         << " (one tile per matmul-ring core)";
   }
 
   return success();

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3132,8 +3132,7 @@ PrepareMoEComputeW0W1WeightsOp::getOpConstraints(
       op_model::OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraints,
       *this, getW0().getType().getShape(), inputs[0],
       getW1().getType().getShape(), inputs[1], bias0Shape, bias0Layout,
-      bias1Shape, bias1Layout, getHiddenSize(), getIntermediateSize(),
-      getBhRingSize());
+      bias1Shape, bias1Layout, getHiddenSize(), getIntermediateSize());
 }
 
 llvm::Expected<size_t> PrepareMoEComputeW0W1WeightsOp::getOpRuntime(
@@ -3162,7 +3161,7 @@ PrepareMoEComputeW2WeightsOp::getOpConstraints(
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints, *this,
       getW2().getType().getShape(), inputs[0], bias2Shape, bias2Layout,
-      getHiddenSize(), getIntermediateSize(), getBhRingSize());
+      getHiddenSize(), getIntermediateSize());
 }
 
 llvm::Expected<size_t> PrepareMoEComputeW2WeightsOp::getOpRuntime(

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -828,40 +828,39 @@ static ::ttnn::Tensor
 moeComputePackW0W1(const ::ttnn::Tensor &w0, const ::ttnn::Tensor &w1,
                    std::optional<::ttnn::Tensor> b0,
                    std::optional<::ttnn::Tensor> b1, uint32_t hiddenSize,
-                   uint32_t intermediateSize, uint32_t bhRingSize,
-                   ::ttnn::MeshDevice *device) {
+                   uint32_t intermediateSize, ::ttnn::MeshDevice *device) {
   uint32_t L = w0.logical_shape()[0];
   uint32_t E = w0.logical_shape()[1];
   bool hasBias = b0.has_value();
   ::ttnn::Tensor packed =
       hasBias ? ::ttnn::experimental::prepare_w0_w1_tensor_with_bias(
-                    w0, w1, *b0, *b1, L, E, hiddenSize, intermediateSize,
-                    bhRingSize)
+                    w0, w1, *b0, *b1, L, E, hiddenSize, intermediateSize)
               : ::ttnn::experimental::prepare_w0_w1_tensor_for_moe_compute(
-                    w0, w1, L, E, hiddenSize, intermediateSize, bhRingSize);
+                    w0, w1, L, E, hiddenSize, intermediateSize);
   return ::ttnn::experimental::quantize_weights_via_host(
       packed, ::tt::tt_metal::DataType::BFLOAT4_B,
-      ::ttnn::experimental::get_weight_mem_configs(
-          device, L, E, hiddenSize, intermediateSize, hasBias, bhRingSize)
+      ::ttnn::experimental::get_weight_mem_configs(device, L, E, hiddenSize,
+                                                   intermediateSize, hasBias)
           .w0_w1);
 }
 
-static ::ttnn::Tensor
-moeComputePackW2(const ::ttnn::Tensor &w2, std::optional<::ttnn::Tensor> b2,
-                 uint32_t hiddenSize, uint32_t intermediateSize,
-                 uint32_t bhRingSize, ::ttnn::MeshDevice *device) {
+static ::ttnn::Tensor moeComputePackW2(const ::ttnn::Tensor &w2,
+                                       std::optional<::ttnn::Tensor> b2,
+                                       uint32_t hiddenSize,
+                                       uint32_t intermediateSize,
+                                       ::ttnn::MeshDevice *device) {
   uint32_t L = w2.logical_shape()[0];
   uint32_t E = w2.logical_shape()[1];
   bool hasBias = b2.has_value();
   ::ttnn::Tensor packed =
       hasBias ? ::ttnn::experimental::prepare_w2_tensor_with_bias(
-                    w2, *b2, L, E, intermediateSize, hiddenSize, bhRingSize)
+                    w2, *b2, L, E, intermediateSize, hiddenSize)
               : ::ttnn::experimental::prepare_w2_tensor_for_moe_compute(
-                    w2, L, E, intermediateSize, hiddenSize, bhRingSize);
+                    w2, L, E, intermediateSize, hiddenSize);
   return ::ttnn::experimental::quantize_weights_via_host(
       packed, ::tt::tt_metal::DataType::BFLOAT4_B,
-      ::ttnn::experimental::get_weight_mem_configs(
-          device, L, E, hiddenSize, intermediateSize, hasBias, bhRingSize)
+      ::ttnn::experimental::get_weight_mem_configs(device, L, E, hiddenSize,
+                                                   intermediateSize, hasBias)
           .w2);
 }
 
@@ -877,8 +876,6 @@ static auto makePrepareMoEComputeW0W1WeightsQuery(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  uint32_t ring = bhRingSize.value_or(12);
-
   return [=]() {
     ::ttnn::TensorSpec w0Spec = conversion::getTensorSpec(w0Shape, w0Layout);
     ::ttnn::TensorSpec w1Spec = conversion::getTensorSpec(w1Shape, w1Layout);
@@ -892,7 +889,7 @@ static auto makePrepareMoEComputeW0W1WeightsQuery(
     }
     return ::ttnn::graph::query_op_constraints(
         WRAP_OP(moeComputePackW0W1), device, w0Spec, w1Spec, b0Spec, b1Spec,
-        hiddenSize, intermediateSize, ring, device);
+        hiddenSize, intermediateSize, device);
   };
 }
 
@@ -925,7 +922,6 @@ static auto makePrepareMoEComputeW2WeightsQuery(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  uint32_t ring = bhRingSize.value_or(12);
   return [=]() {
     ::ttnn::TensorSpec w2Spec = conversion::getTensorSpec(w2Shape, w2Layout);
     std::optional<::ttnn::TensorSpec> b2Spec;
@@ -934,7 +930,7 @@ static auto makePrepareMoEComputeW2WeightsQuery(
     }
     return ::ttnn::graph::query_op_constraints(
         WRAP_OP(moeComputePackW2), device, w2Spec, b2Spec, hiddenSize,
-        intermediateSize, ring, device);
+        intermediateSize, device);
   };
 }
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -872,7 +872,7 @@ static auto makePrepareMoEComputeW0W1WeightsQuery(
     std::optional<TTNNLayoutAttr> bias0Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
     std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize, std::optional<uint32_t> bhRingSize) {
+    uint32_t intermediateSize) {
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
@@ -901,10 +901,10 @@ getPrepareMoEComputeW0W1WeightsOpOutputTensorSpec(
     std::optional<TTNNLayoutAttr> bias0Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
     std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize, std::optional<uint32_t> bhRingSize) {
+    uint32_t intermediateSize) {
   auto query = makePrepareMoEComputeW0W1WeightsQuery(
       w0Shape, w0Layout, w1Shape, w1Layout, bias0Shape, bias0Layout, bias1Shape,
-      bias1Layout, hiddenSize, intermediateSize, bhRingSize);
+      bias1Layout, hiddenSize, intermediateSize);
   auto output = operation::executeConstraintQuery(query);
   if (!output) {
     return output.takeError();
@@ -918,7 +918,7 @@ static auto makePrepareMoEComputeW2WeightsQuery(
     llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
     std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize, std::optional<uint32_t> bhRingSize) {
+    uint32_t intermediateSize) {
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
@@ -939,10 +939,9 @@ getPrepareMoEComputeW2WeightsOpOutputTensorSpec(
     llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
     std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize, std::optional<uint32_t> bhRingSize) {
+    uint32_t intermediateSize) {
   auto query = makePrepareMoEComputeW2WeightsQuery(
-      w2Shape, w2Layout, bias2Shape, bias2Layout, hiddenSize, intermediateSize,
-      bhRingSize);
+      w2Shape, w2Layout, bias2Shape, bias2Layout, hiddenSize, intermediateSize);
   auto output = operation::executeConstraintQuery(query);
   if (!output) {
     return output.takeError();
@@ -962,11 +961,11 @@ OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> bias0Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
     std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize, std::optional<uint32_t> bhRingSize) {
+    uint32_t intermediateSize) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto query = makePrepareMoEComputeW0W1WeightsQuery(
       w0Shape, w0Layout, w1Shape, w1Layout, bias0Shape, bias0Layout, bias1Shape,
-      bias1Layout, hiddenSize, intermediateSize, bhRingSize);
+      bias1Layout, hiddenSize, intermediateSize);
   return operation::getOpConstraints(w0Layout.getContext(), query);
 #else
   return OpConstraints{};
@@ -978,11 +977,10 @@ OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
     std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize, std::optional<uint32_t> bhRingSize) {
+    uint32_t intermediateSize) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto query = makePrepareMoEComputeW2WeightsQuery(
-      w2Shape, w2Layout, bias2Shape, bias2Layout, hiddenSize, intermediateSize,
-      bhRingSize);
+      w2Shape, w2Layout, bias2Shape, bias2Layout, hiddenSize, intermediateSize);
   return operation::getOpConstraints(w2Layout.getContext(), query);
 #else
   return OpConstraints{};

--- a/lib/OpModel/TTNN/TTNNOutputTensorInference.cpp
+++ b/lib/OpModel/TTNN/TTNNOutputTensorInference.cpp
@@ -36,14 +36,14 @@ getPrepareMoEComputeW0W1WeightsOpOutputTensorSpec(
     std::optional<TTNNLayoutAttr> bias0Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
     std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize, std::optional<uint32_t> bhRingSize);
+    uint32_t intermediateSize);
 
 llvm::Expected<::ttnn::TensorSpec>
 getPrepareMoEComputeW2WeightsOpOutputTensorSpec(
     llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
     std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize, std::optional<uint32_t> bhRingSize);
+    uint32_t intermediateSize);
 } // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -157,7 +157,7 @@ getPreparedMoEComputeW0W1WeightsOutputType(PrepareMoEComputeW0W1WeightsOp *op) {
   auto specOrErr = getPrepareMoEComputeW0W1WeightsOpOutputTensorSpec(
       w0Type.getShape(), w0Layout, w1Type.getShape(), w1Layout, bias0Shape,
       bias0Layout, bias1Shape, bias1Layout, op->getHiddenSize(),
-      op->getIntermediateSize(), op->getBhRingSize());
+      op->getIntermediateSize());
   if (!specOrErr) {
     llvm::errs() << llvm::toString(specOrErr.takeError());
     assert(false &&
@@ -196,7 +196,7 @@ getPreparedMoEComputeW2WeightsOutputType(PrepareMoEComputeW2WeightsOp *op) {
   }
   auto specOrErr = getPrepareMoEComputeW2WeightsOpOutputTensorSpec(
       w2Type.getShape(), w2Layout, bias2Shape, bias2Layout, op->getHiddenSize(),
-      op->getIntermediateSize(), op->getBhRingSize());
+      op->getIntermediateSize());
   if (!specOrErr) {
     llvm::errs() << llvm::toString(specOrErr.takeError());
     assert(false &&

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1333,13 +1333,9 @@ createOp(FlatbufferObjectCache &cache, PrepareMoEComputeW0W1WeightsOp op) {
   auto out = cache.getOrCreateNoSharding(op.getResult(),
                                          tensorValueToFlatbuffer, std::nullopt);
 
-  // `bh_ring_size` is schema-optional (uint32 = null); same absent-marker
-  // handling as the downstream moe_compute op.
-  auto bhRingSize = toFlatbuffer(cache, op.getBhRingSize());
-
   return ::tt::target::ttnn::CreatePrepareMoEComputeW0W1WeightsOp(
       *cache.fbb, w0, w1, bias0, bias1, deviceRef, op.getHiddenSize(),
-      op.getIntermediateSize(), bhRingSize, out);
+      op.getIntermediateSize(), out);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::PrepareMoEComputeW2WeightsOp>
@@ -1356,13 +1352,9 @@ createOp(FlatbufferObjectCache &cache, PrepareMoEComputeW2WeightsOp op) {
   auto out = cache.getOrCreateNoSharding(op.getResult(),
                                          tensorValueToFlatbuffer, std::nullopt);
 
-  // `bh_ring_size` is schema-optional (uint32 = null); same absent-marker
-  // handling as the downstream moe_compute op.
-  auto bhRingSize = toFlatbuffer(cache, op.getBhRingSize());
-
   return ::tt::target::ttnn::CreatePrepareMoEComputeW2WeightsOp(
       *cache.fbb, w2, bias2, deviceRef, op.getHiddenSize(),
-      op.getIntermediateSize(), bhRingSize, out);
+      op.getIntermediateSize(), out);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::MoeComputeOp>
@@ -1407,10 +1399,6 @@ createOp(FlatbufferObjectCache &cache, MoeComputeOp op) {
   auto numLinks = toFlatbuffer(cache, op.getNumLinks());
   auto topology = toFlatbuffer(cache, op.getTopology());
 
-  // `bh_ring_size` is schema-optional (uint32 = null); same absent-marker
-  // handling as num_links above.
-  auto bhRingSize = toFlatbuffer(cache, op.getBhRingSize());
-
   ::flatbuffers::Offset<::tt::target::ttnn::CoreRangeSet> muxCoreRangeSet = 0;
   if (op.getMuxCoreRangeSetAttr()) {
     muxCoreRangeSet = toFlatbuffer(cache, op.getMuxCoreRangeSetAttr());
@@ -1434,8 +1422,8 @@ createOp(FlatbufferObjectCache &cache, MoeComputeOp op) {
       w2, optionalOutput, crossDeviceSemaphore, deviceRef, op.getLayerId(),
       op.getOutputHeightShardDim(), op.getIntermediateSize(), op.getHasBias(),
       clusterAxis, activation, numLinks, topology, muxCoreRangeSet,
-      op.getComputeOnly(), bhRingSize, perExpertTokens, expertActivation,
-      expertToToken, tilizeOutput, matmulOutput, combineOutput);
+      op.getComputeOnly(), perExpertTokens, expertActivation, expertToToken,
+      tilizeOutput, matmulOutput, combineOutput);
 }
 
 // Convert ttcore::ReduceType to tt::target::ttnn::ScatterReduceType

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -435,9 +435,11 @@ size_t getTraceRegionSize(Device meshDevice) {
   ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
       meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
           DeviceRuntime::TTMetal);
-  return metalMeshDevice.allocator()
-      ->get_statistics(::tt::tt_metal::BufferType::TRACE)
-      .total_allocatable_size_bytes;
+  const std::unique_ptr<::tt::tt_metal::Allocator> &allocator =
+      metalMeshDevice.allocator();
+  return static_cast<size_t>(
+      allocator->get_num_banks(::tt::tt_metal::BufferType::TRACE) *
+      allocator->get_bank_size(::tt::tt_metal::BufferType::TRACE));
 }
 
 size_t getNumDramChannels(Device meshDevice) {

--- a/runtime/lib/ttnn/operations/ccl/moe_compute.cpp
+++ b/runtime/lib/ttnn/operations/ccl/moe_compute.cpp
@@ -47,11 +47,6 @@ void run(const ::tt::target::ttnn::MoeComputeOp *op, ProgramContext &context) {
   LOG_ASSERT(op->compute_only(),
              "moe_compute runtime only supports compute_only=true");
 
-  std::optional<uint32_t> bhRingSize;
-  if (op->bh_ring_size()) {
-    bhRingSize = op->bh_ring_size().value();
-  }
-
   // compute_only: every combine-path input stays unset; tt-metal returns the
   // first five tensors and matmul_output is the final output.
   std::vector<::ttnn::Tensor> results = ::ttnn::experimental::moe_compute(
@@ -62,8 +57,7 @@ void run(const ::tt::target::ttnn::MoeComputeOp *op, ProgramContext &context) {
       /*output_memory_config=*/std::nullopt,
       /*optional_output_tensor=*/std::nullopt,
       /*cross_device_semaphore=*/std::nullopt,
-      toMetalActivation(op->activation_function()), /*compute_only=*/true,
-      bhRingSize);
+      toMetalActivation(op->activation_function()), /*compute_only=*/true);
 
   LOG_ASSERT(results.size() == 5, "moe_compute returned ", results.size(),
              " tensors; expected 5 (compute_only)");

--- a/runtime/lib/ttnn/operations/ccl/prepare_moe_compute_w0_w1_weights.cpp
+++ b/runtime/lib/ttnn/operations/ccl/prepare_moe_compute_w0_w1_weights.cpp
@@ -31,20 +31,18 @@ void run(const ::tt::target::ttnn::PrepareMoEComputeW0W1WeightsOp *op,
   uint32_t E = w0.logical_shape()[1];
   bool hasBias = bias0.has_value();
 
-  uint32_t bhRingSize = op->bh_ring_size() ? op->bh_ring_size().value() : 12;
   ::ttnn::Tensor packed =
       hasBias ? ::ttnn::experimental::prepare_w0_w1_tensor_with_bias(
                     w0, w1, *bias0, *bias1, L, E, op->hidden_size(),
-                    op->intermediate_size(), bhRingSize)
+                    op->intermediate_size())
               : ::ttnn::experimental::prepare_w0_w1_tensor_for_moe_compute(
-                    w0, w1, L, E, op->hidden_size(), op->intermediate_size(),
-                    bhRingSize);
+                    w0, w1, L, E, op->hidden_size(), op->intermediate_size());
 
   ::ttnn::Tensor out = ::ttnn::experimental::quantize_weights_via_host(
       packed, ::tt::tt_metal::DataType::BFLOAT4_B,
       ::ttnn::experimental::get_weight_mem_configs(
           &meshDevice, L, E, op->hidden_size(), op->intermediate_size(),
-          hasBias, bhRingSize)
+          hasBias)
           .w0_w1);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);

--- a/runtime/lib/ttnn/operations/ccl/prepare_moe_compute_w2_weights.cpp
+++ b/runtime/lib/ttnn/operations/ccl/prepare_moe_compute_w2_weights.cpp
@@ -26,20 +26,18 @@ void run(const ::tt::target::ttnn::PrepareMoEComputeW2WeightsOp *op,
   uint32_t E = w2.logical_shape()[1];
   bool hasBias = bias2.has_value();
 
-  uint32_t bhRingSize = op->bh_ring_size() ? op->bh_ring_size().value() : 12;
   ::ttnn::Tensor packed =
-      hasBias ? ::ttnn::experimental::prepare_w2_tensor_with_bias(
-                    w2, *bias2, L, E, op->intermediate_size(),
-                    op->hidden_size(), bhRingSize)
-              : ::ttnn::experimental::prepare_w2_tensor_for_moe_compute(
-                    w2, L, E, op->intermediate_size(), op->hidden_size(),
-                    bhRingSize);
+      hasBias
+          ? ::ttnn::experimental::prepare_w2_tensor_with_bias(
+                w2, *bias2, L, E, op->intermediate_size(), op->hidden_size())
+          : ::ttnn::experimental::prepare_w2_tensor_for_moe_compute(
+                w2, L, E, op->intermediate_size(), op->hidden_size());
 
   ::ttnn::Tensor out = ::ttnn::experimental::quantize_weights_via_host(
       packed, ::tt::tt_metal::DataType::BFLOAT4_B,
       ::ttnn::experimental::get_weight_mem_configs(
           &meshDevice, L, E, op->hidden_size(), op->intermediate_size(),
-          hasBias, bhRingSize)
+          hasBias)
           .w2);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -745,9 +745,11 @@ size_t getL1SmallSize(Device meshDevice) {
 size_t getTraceRegionSize(Device meshDevice) {
   ::ttnn::MeshDevice &ttnnMeshDevice =
       meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
-  return ttnnMeshDevice.allocator()
-      ->get_statistics(::ttnn::BufferType::TRACE)
-      .total_allocatable_size_bytes;
+  const std::unique_ptr<::tt::tt_metal::Allocator> &allocator =
+      ttnnMeshDevice.allocator();
+  return static_cast<size_t>(
+      allocator->get_num_banks(::ttnn::BufferType::TRACE) *
+      allocator->get_bank_size(::ttnn::BufferType::TRACE));
 }
 
 size_t getNumDramChannels(Device meshDevice) {

--- a/runtime/test/ttnn/python/n300/test_runtime_api.py
+++ b/runtime/test/ttnn/python/n300/test_runtime_api.py
@@ -33,7 +33,12 @@ from ..utils import DeviceContext, assert_pcc
 )
 @pytest.mark.parametrize(
     "trace_region_size",
-    [0, 1024, 2048],
+    # tt-metal #47122 changed trace_region_size from per-DRAM-bank reservation to a
+    # total trace budget across all banks. get_trace_region_size() reports the total
+    # physically reserved TRACE DRAM (num_banks * per_bank_size), not the per-bank
+    # pool size. On Wormhole N300 (12 DRAM banks, 32-byte alignment) use multiples of
+    # 384 so reserved total matches the requested budget in the assertion below.
+    [0, 768, 1536],
 )
 def test_open_mesh_device(
     helper,

--- a/runtime/test/ttnn/python/n300/test_runtime_api.py
+++ b/runtime/test/ttnn/python/n300/test_runtime_api.py
@@ -33,12 +33,10 @@ from ..utils import DeviceContext, assert_pcc
 )
 @pytest.mark.parametrize(
     "trace_region_size",
-    # tt-metal #47122 changed trace_region_size from per-DRAM-bank reservation to a
-    # total trace budget across all banks. get_trace_region_size() reports the total
-    # physically reserved TRACE DRAM (num_banks * per_bank_size), not the per-bank
-    # pool size. On Wormhole N300 (12 DRAM banks, 32-byte alignment) use multiples of
-    # 384 so reserved total matches the requested budget in the assertion below.
-    [0, 768, 1536],
+    # tt-metal #47122: trace_region_size is a total budget; #47766 rounds per-bank
+    # reserve to kMaxTraceBufPageSize (8192). On N300 (12 banks) reserved total
+    # equals the request only for 0 or multiples of 12 * 8192 = 98304.
+    [0, 98304, 196608],
 )
 def test_open_mesh_device(
     helper,

--- a/test/python/golden/ttir_ops/ccl/test_moe_compute.py
+++ b/test/python/golden/ttir_ops/ccl/test_moe_compute.py
@@ -138,26 +138,26 @@ def _moe_compute_valid_masks(
 
 
 # Self-consistent configs covering every generality axis (NOT a cross-product:
-# the op verifier requires matmul_num_cores (= bh_ring_size on BH) % width == 0,
+# the op verifier requires matmul_num_cores (= matmul_ring_size on BH) % width == 0,
 # so width=3 is pinned to ring=12). hidden selects width via
 # auto_output_width_shard_dim (largest divisor of hidden/32 that is <= 4):
 # hidden=512 -> width=4, hidden=576 -> width=3. hidden and intermediate must
-# each be >= bh_ring_size*32 (the W2 output is sharded across the ring;
+# each be >= matmul_ring_size*32 (the W2 output is sharded across the ring;
 # w2_shard_tiles in moe_ring_common.h).
 _MOE_CONFIGS = [
-    # id, hidden, intermediate, activation, has_bias, bh_ring_size
-    ("w4_silu_nobias_r16", 512, 512, "silu", False, 16),
-    ("w4_silu_nobias_r8", 512, 512, "silu", False, 8),
-    ("w4_swiglu_bias_r12", 512, 512, "swiglu", True, 12),
-    ("w3_silu_bias_r12", 576, 576, "silu", True, 12),
-    ("w3_swiglu_nobias_r12", 576, 576, "swiglu", False, 12),
+    # id, hidden, intermediate, activation, has_bias
+    ("w4_silu_nobias_r16", 512, 512, "silu", False),
+    ("w4_silu_nobias_r8", 512, 512, "silu", False),
+    ("w4_swiglu_bias_r12", 512, 512, "swiglu", True),
+    ("w3_silu_bias_r12", 576, 576, "silu", True),
+    ("w3_swiglu_nobias_r12", 576, 576, "swiglu", False),
     # Real-model-derived configs: same structural fingerprint as the shipped
     # single-card MoE models (activation, output width_shard_dim, has_bias,
     # hidden/intermediate ratio), scaled down to hidden <= 2048 with a balanced Ht
     # or a single W2 group.
-    ("ds_w4_silu_bias_r8", 2048, 1024, "silu", True, 8),  # DeepSeek-like, H > N
-    ("ds_w4_silu_bias_r16", 2048, 2048, "silu", True, 16),  # DeepSeek-like, ring 16
-    ("gptoss_w3_swiglu_bias_r12", 1344, 1344, "swiglu", True, 12),  # GPT-OSS-like
+    ("ds_w4_silu_bias_r8", 2048, 1024, "silu", True),  # DeepSeek-like, H > N
+    ("ds_w4_silu_bias_r16", 2048, 2048, "silu", True),  # DeepSeek-like, ring 16
+    ("gptoss_w3_swiglu_bias_r12", 1344, 1344, "swiglu", True),  # GPT-OSS-like
 ]
 
 
@@ -169,12 +169,12 @@ _MOE_CONFIGS = [
     reason="Single-card moe_compute doesn't work on WH architecture",
 )
 @pytest.mark.parametrize(
-    "h_size, n_inter, activation, has_bias, bh_ring_size",
+    "h_size, n_inter, activation, has_bias",
     [c[1:] for c in _MOE_CONFIGS],
     ids=[c[0] for c in _MOE_CONFIGS],
 )
 def test_moe_compute_compute_only_verify(
-    h_size, n_inter, activation, has_bias, bh_ring_size, request, system_desc
+    h_size, n_inter, activation, has_bias, request, system_desc
 ):
     """Verify moe_compute compute_only outputs 0-4 on a single Blackhole card.
 
@@ -370,7 +370,6 @@ def test_moe_compute_compute_only_verify(
                 bias_2=bias_2,
                 activation_function=activation,
                 compute_only=True,
-                bh_ring_size=bh_ring_size,
                 output_shapes=[
                     out_per_expert_total_tokens,
                     out_expert_activation,

--- a/test/ttmlir/Dialect/TTIR/ccl/moe_compute/moe_compute_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/moe_compute/moe_compute_negative.mlir
@@ -107,37 +107,3 @@ module attributes {} {
   }
 }
 // CHECK: error: 'ttir.moe_compute' op compute_only moe_compute must not set cluster_axis
-
-// -----
-
-// hidden_size must be at least one tile per matmul-ring core (bh_ring_size*32,
-// default 12*32 = 384); hidden=256 here leaves W2 output tiles uncomputed.
-module attributes {} {
-  func.func @moe_compute_hidden_too_small(
-      %inp: tensor<1x1x128x256xbf16>,
-      %idx: tensor<1x1x128x4xi64>,
-      %scores: tensor<1x1x128x4xbf16>,
-      %map: tensor<1x1x16x4xi64>,
-      %w0: tensor<1x16x256x384xbf16>,
-      %w1: tensor<1x16x256x384xbf16>,
-      %w2: tensor<1x16x384x256xbf16>)
-    -> (tensor<1x1x16x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x128x4xi64>,
-        tensor<1x1x128x256xbf16>, tensor<1x1x128x256xbf16>,
-        tensor<1x1x128x256xbf16>) {
-    %0:6 = "ttir.moe_compute"(%inp, %idx, %scores, %map, %w0, %w1, %w2)
-      <{operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1, 1, 0, 0, 0>,
-        layer_id = 0 : ui32,
-        output_height_shard_dim = 32 : ui32,
-        intermediate_size = 384 : ui32}>
-      : (tensor<1x1x128x256xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>,
-         tensor<1x1x16x4xi64>, tensor<1x16x256x384xbf16>,
-         tensor<1x16x256x384xbf16>, tensor<1x16x384x256xbf16>)
-      -> (tensor<1x1x16x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x128x4xi64>,
-          tensor<1x1x128x256xbf16>, tensor<1x1x128x256xbf16>,
-          tensor<1x1x128x256xbf16>)
-    return %0#0, %0#1, %0#2, %0#3, %0#4, %0#5
-      : tensor<1x1x16x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x128x4xi64>,
-        tensor<1x1x128x256xbf16>, tensor<1x1x128x256xbf16>, tensor<1x1x128x256xbf16>
-  }
-}
-// CHECK: error: 'ttir.moe_compute' op hidden_size (256) must be at least bh_ring_size*32 = 384

--- a/test/ttmlir/Dialect/TTNN/ccl/moe_compute/moe_compute_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/moe_compute/moe_compute_negative.mlir
@@ -94,38 +94,3 @@ module attributes {} {
   }
 }
 // CHECK: error: 'ttnn.moe_compute' op only the compute_only path is supported
-
-// -----
-
-// hidden_size must be at least one tile per matmul-ring core (bh_ring_size*32,
-// default 12*32 = 384); hidden=256 here leaves W2 output tiles uncomputed.
-module attributes {} {
-  func.func @moe_compute_hidden_too_small(
-      %inp: tensor<1x1x128x256xbf16>,
-      %idx: tensor<1x1x128x4xi64>,
-      %scores: tensor<1x1x128x4xbf16>,
-      %map: tensor<1x1x16x4xi64>,
-      %w01: tensor<8x1x16x32x256x128xbf16>,
-      %w2: tensor<8x1x16x32x256x128xbf16>,
-      %device: !ttnn.device)
-    -> (tensor<1x1x16x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x128x4xi64>,
-        tensor<1x1x128x256xbf16>, tensor<1x1x128x256xbf16>,
-        tensor<1x1x128x256xbf16>) {
-    %0:6 = "ttnn.moe_compute"(%inp, %idx, %scores, %map, %w01, %w2, %device)
-      <{operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1, 0, 0, 1>,
-        layer_id = 0 : ui32,
-        output_height_shard_dim = 32 : ui32,
-        intermediate_size = 384 : ui32,
-        has_bias = false}>
-      : (tensor<1x1x128x256xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>,
-         tensor<1x1x16x4xi64>, tensor<8x1x16x32x256x128xbf16>,
-         tensor<8x1x16x32x256x128xbf16>, !ttnn.device)
-      -> (tensor<1x1x16x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x128x4xi64>,
-          tensor<1x1x128x256xbf16>, tensor<1x1x128x256xbf16>,
-          tensor<1x1x128x256xbf16>)
-    return %0#0, %0#1, %0#2, %0#3, %0#4, %0#5
-      : tensor<1x1x16x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x128x4xi64>,
-        tensor<1x1x128x256xbf16>, tensor<1x1x128x256xbf16>, tensor<1x1x128x256xbf16>
-  }
-}
-// CHECK: error: 'ttnn.moe_compute' op hidden_size (256) must be at least bh_ring_size*32 = 384

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "13adda80c119631d18b0bc06163416ba148c25ab")
+set(TT_METAL_VERSION "4b39efbe92916e1d3be471d02b79b635e223ac24")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -17534,7 +17534,6 @@ class TTIRBuilder(Builder):
         bias_2: Optional[Operand] = None,
         activation_function: str = "silu",
         compute_only: bool = True,
-        bh_ring_size: Optional[int] = None,
         output_shapes: Optional[List[Shape]] = None,
         output_types: Optional[List[torch.dtype]] = None,
         unit_attrs: Optional[List[str]] = None,
@@ -17561,9 +17560,6 @@ class TTIRBuilder(Builder):
             f"#ttcore.moe_activation_function<{activation_function}>"
         )
         compute_only_attr = BoolAttr.get(compute_only)
-        bh_ring_size_attr = (
-            IntegerAttr.get(u32, bh_ring_size) if bh_ring_size is not None else None
-        )
 
         loc = self._get_location()
 
@@ -17589,7 +17585,6 @@ class TTIRBuilder(Builder):
             bias_2=bias_2,
             activation_function=activation_attr,
             compute_only=compute_only_attr,
-            bh_ring_size=bh_ring_size_attr,
             loc=loc,
         )
 
@@ -17623,7 +17618,6 @@ class TTIRBuilder(Builder):
             cluster_axis=0,
             activation_function=activation_function,
             compute_only=compute_only,
-            bh_ring_size=bh_ring_size,
             output_types_mlir=[r.type for r in op.results],
         )
         for result, golden in zip(op.results, golden_outputs):

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -2103,7 +2103,6 @@ def ttir_moe_compute_golden(
     num_links=None,
     topology=None,
     compute_only=False,
-    bh_ring_size=None,
     num_worker_cores=0,
     output_types_mlir: Optional[List[Type]] = None,
 ) -> Tuple[


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 4b39efbe92916e1d3be471d02b79b635e223ac24



### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):