### PR TITLE
[d2m] materialize explicit NoC operands in d2m TTKernel lowering

### DIFF
--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -68,12 +68,8 @@ static FailureOr<int32_t> getKernelNocIndex(Operation *op) {
 }
 
 // Early resolution & materialization of the DM kernel's NoC index in the
-// pipeline (before TTKernelToEmitC & D2MToTTMetal).
-//
-// Returns null when the NoC index cannot be resolved (e.g. a function with no
-// d2m.thread attribute). Callers pass the null Value straight through as an
-// absent optional `noc` operand, so TTKernelToEmitC falls back to the kernel's
-// default `noc_index` global variable.
+// pipeline (before TTKernelToEmitC & D2MToTTMetal). Returns null when the NoC
+// index cannot be resolved (e.g. a function with no d2m.thread attribute).
 static Value materializeKernelNocId(OpBuilder &rewriter, Operation *op) {
   FailureOr<int32_t> nocIdx = getKernelNocIndex(op);
   if (failed(nocIdx)) {
@@ -2207,7 +2203,8 @@ static NocEndpoint buildNocEndpoint(OpBuilder &rewriter, Location loc, Value cb,
 }
 
 static Value materializeTranslatedNocAddr(OpBuilder &rewriter, Location loc,
-                                          const NocEndpoint &endpoint) {
+                                          const NocEndpoint &endpoint,
+                                          Value nocId = {}) {
   if (endpoint.memorySpace == ttcore::MemorySpace::DeviceDRAM) {
     return rewriter.create<ttkernel::GetNocAddrFromBankIDOp>(
         loc, endpoint.bankId, endpoint.address);
@@ -2215,7 +2212,7 @@ static Value materializeTranslatedNocAddr(OpBuilder &rewriter, Location loc,
 
   TT_assert(endpoint.memorySpace == ttcore::MemorySpace::DeviceL1);
   return rewriter.create<ttkernel::GetNocAddrOp>(
-      loc, endpoint.coreXY[0], endpoint.coreXY[1], endpoint.address);
+      loc, endpoint.coreXY[0], endpoint.coreXY[1], endpoint.address, nocId);
 }
 
 static SmallVector<Value> decomposeLinearIndex(OpBuilder &rewriter,
@@ -2464,8 +2461,8 @@ public:
       auto dstEndpoint = buildNocEndpoint(rewriter, op.getLoc(),
                                           adaptor.getDst(), op.getDstIndices(),
                                           chipDesc, op.getDstMemorySpace());
-      auto dstNocAddr =
-          materializeTranslatedNocAddr(rewriter, op.getLoc(), dstEndpoint);
+      auto dstNocAddr = materializeTranslatedNocAddr(rewriter, op.getLoc(),
+                                                     dstEndpoint, nocId);
       auto size =
           intConstant<int32_t>(rewriter, op->getLoc(), op.getSizeBytes());
       auto meshId = intConstant<int16_t>(rewriter, op->getLoc(), 0);
@@ -3249,11 +3246,12 @@ public:
     if (op.getStartDevice().size() > 0) {
       assert(mlir::isa<d2m::SemaphoreIncOp>(op) &&
              "only d2m.semaphore_inc to remote device is allowed.");
+      Value nocId = materializeKernelNocId(rewriter, op.getOperation());
       auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
           rewriter, op.getLoc(), ttcore::getOpChipDescAttr(op),
           op.getDstCoreIndex());
       auto nocAddr = rewriter.create<ttkernel::GetNocAddrOp>(
-          op.getLoc(), virtX, virtY, semaphoreAddr);
+          op.getLoc(), virtX, virtY, semaphoreAddr, nocId);
       auto meshId = intConstant<int16_t>(rewriter, op->getLoc(), 0);
       auto fcm = getFabricConnectionManager(op);
 
@@ -3291,7 +3289,7 @@ public:
           OpBuilder::InsertionGuard guard(rewriter);
           rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
           rewriter.create<ttkernel::NocSemaphoreIncOp>(op.getLoc(), nocAddr,
-                                                       value);
+                                                       value, nocId);
           rewriter.create<scf::YieldOp>(op.getLoc());
         }
       }
@@ -3309,12 +3307,13 @@ public:
     } else if (op.getMcastShape().empty()) {
       assert(!mlir::isa<d2m::SemaphoreSetOp>(op) &&
              "d2m.semaphore_set to single remote core is illegal.");
+      Value nocId = materializeKernelNocId(rewriter, op.getOperation());
       auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
           rewriter, op.getLoc(), chipDesc, op.getDstCoreIndex());
       auto nocAddr = rewriter.create<ttkernel::GetNocAddrOp>(
-          op.getLoc(), virtX, virtY, semaphoreAddr);
+          op.getLoc(), virtX, virtY, semaphoreAddr, nocId);
       rewriter.replaceOpWithNewOp<ttkernel::NocSemaphoreIncOp>(op, nocAddr,
-                                                               value);
+                                                               value, nocId);
     } else {
       assert(!mlir::isa<d2m::SemaphoreIncOp>(op) &&
              "d2m.semaphore_inc multicast is illegal.");
@@ -3341,13 +3340,13 @@ public:
         return rewriter.notifyMatchFailure(
             op, "unable to resolve datamovement kernel NoC index");
       }
-      Value nocId = intConstant<int8_t>(rewriter, op->getLoc(), *nocIdx);
+      Value mcastNocId = intConstant<int8_t>(rewriter, op->getLoc(), *nocIdx);
 
       flipMcastCoordsIfNoc1(*nocIdx, virtX, virtY, virtMcastEndX,
                             virtMcastEndY);
       auto mcastAddr = rewriter.create<ttkernel::GetNocMulticastAddrOp>(
           op.getLoc(), virtX, virtY, virtMcastEndX, virtMcastEndY,
-          semaphoreAddr, nocId);
+          semaphoreAddr, mcastNocId);
 
       auto semaphorePtr = rewriter.create<ttkernel::CastToL1PtrOp>(
           op.getLoc(), ttkernel::L1AddrPtrType::get(rewriter.getContext(), 32),
@@ -3405,8 +3404,9 @@ public:
     auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
         rewriter, op.getLoc(), ttcore::getOpChipDescAttr(op),
         op.getCoreIndices());
+    Value nocId = materializeKernelNocId(rewriter, op.getOperation());
     auto globalSemAddr = rewriter.create<ttkernel::GetNocAddrOp>(
-        op.getLoc(), virtX, virtY, adaptor.getSyncSemaphore());
+        op.getLoc(), virtX, virtY, adaptor.getSyncSemaphore(), nocId);
     auto globalSemPtr = rewriter.create<ttkernel::CastToL1PtrOp>(
         op.getLoc(), ttkernel::L1AddrPtrType::get(rewriter.getContext(), 32),
         adaptor.getSyncSemaphore());

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2204,7 +2204,7 @@ static NocEndpoint buildNocEndpoint(OpBuilder &rewriter, Location loc, Value cb,
 
 static Value materializeTranslatedNocAddr(OpBuilder &rewriter, Location loc,
                                           const NocEndpoint &endpoint,
-                                          Value nocId = {}) {
+                                          Value nocId) {
   if (endpoint.memorySpace == ttcore::MemorySpace::DeviceDRAM) {
     return rewriter.create<ttkernel::GetNocAddrFromBankIDOp>(
         loc, endpoint.bankId, endpoint.address);

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -308,15 +308,14 @@ static std::string getResultVariableName(Value result,
 // For a non-constant `nocId` (determined at runtime), splice into an inline
 // temporary `Noc({})`.
 //
-// When the optional `noc` op operand is absent and there is no way to
-// statically resolve the NoC index, fall back to the NoC the kernel ultimately
-// launches on (its `noc_index` global variable) with the explicit `Noc
-// noc(noc_index);` declaration.
-static std::string ensureNocDeclaration(Operation *useOp,
-                                        ConversionPatternRewriter &rewriter,
-                                        TTKernelToEmitCConversionState &state,
-                                        SmallVectorImpl<Value> &operands,
-                                        Value nocId = {}) {
+// When the NoC index is not statically known and the operand is not present,
+// fail the conversion. D2M-generated TTKernel IR should materialize this
+// operand explicitly, and hand-authored TTKernel IR must do the same before
+// EmitC.
+static FailureOr<std::string>
+ensureNocDeclaration(Operation *useOp, ConversionPatternRewriter &rewriter,
+                     TTKernelToEmitCConversionState &state,
+                     SmallVectorImpl<Value> &operands, Value nocId = {}) {
   FailureOr<int64_t> nocIdx = getStaticNocIndex(useOp, state, nocId);
   if (succeeded(nocIdx)) {
     std::string nocName = "noc" + std::to_string(*nocIdx);
@@ -345,15 +344,12 @@ static std::string ensureNocDeclaration(Operation *useOp,
   if (nocId) {
     // Explicit but non-constant nocId: splice the runtime value inline.
     operands.push_back(nocId);
-    return "Noc({})";
+    return std::string("Noc({})");
   }
 
-  // Unresolvable and no per-op override: construct from the `noc_index` kernel
-  // global variable, defined by the Metalium DM core config and the
-  // `-DNOC_INDEX` SFPI cmdline flag.
-  return ensureFunctionScopedDeclaration(useOp, rewriter, state,
-                                         "Noc noc(noc_index);", "noc",
-                                         /*duplicateCheckPrefix=*/"Noc noc(");
+  (void)rewriter.notifyMatchFailure(
+      useOp, "NoC operand is required for TTKernel-to-EmitC conversion");
+  return failure();
 }
 
 // Like `ensureNocDeclaration`, but for rewriters that splice the endpoint and
@@ -365,13 +361,16 @@ static FailureOr<std::string> ensureStaticNocDeclaration(
     Operation *useOp, ConversionPatternRewriter &rewriter, Value nocId,
     llvm::StringRef opDesc, TTKernelToEmitCConversionState &state) {
   SmallVector<Value, 1> nocOperands;
-  std::string nocName =
+  FailureOr<std::string> nocName =
       ensureNocDeclaration(useOp, rewriter, state, nocOperands, nocId);
+  if (failed(nocName)) {
+    return failure();
+  }
   if (!nocOperands.empty()) {
     return rewriter.notifyMatchFailure(
         useOp, "dynamic NoC ID is not supported for " + opDesc.str());
   }
-  return nocName;
+  return *nocName;
 }
 
 static std::string
@@ -1231,8 +1230,11 @@ public:
     TT_assert(resultType);
 
     SmallVector<Value, 1> nocOperands;
-    std::string nocName = ensureNocDeclaration(
+    FailureOr<std::string> nocName = ensureNocDeclaration(
         op.getOperation(), rewriter, state, nocOperands, adaptor.getNoc());
+    if (failed(nocName)) {
+      return failure();
+    }
     std::string endpoint = ensureEndpointDeclaration(
         op.getOperation(), rewriter, "UnicastEndpoint", "unicast_ep", state);
     SmallVector<Value, 4> operands = {adaptor.getX(), adaptor.getY(),
@@ -1245,7 +1247,7 @@ public:
         "uint64_t " + varName + " = " + endpoint +
         ".get_noc_unicast_addr(static_cast<uint32_t>({}), "
         "static_cast<uint32_t>({}), static_cast<uint32_t>({}), " +
-        nocName + ".get_noc_id());";
+        *nocName + ".get_noc_id());";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.replaceOp(
@@ -1273,9 +1275,12 @@ public:
                   ttkernel::NocAsyncAtomicBarrierOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     SmallVector<Value, 1> operands;
-    std::string nocName = ensureNocDeclaration(
+    FailureOr<std::string> nocName = ensureNocDeclaration(
         op.getOperation(), rewriter, state, operands, adaptor.getNoc());
-    std::string callStr = nocName + ".async_atomic_barrier();";
+    if (failed(nocName)) {
+      return failure();
+    }
+    std::string callStr = *nocName + ".async_atomic_barrier();";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);
@@ -1300,9 +1305,12 @@ public:
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     SmallVector<Value, 1> operands;
-    std::string nocName = ensureNocDeclaration(
+    FailureOr<std::string> nocName = ensureNocDeclaration(
         op.getOperation(), rewriter, state, operands, adaptor.getNoc());
-    std::string callStr = nocName + "." + methodName + "();";
+    if (failed(nocName)) {
+      return failure();
+    }
+    std::string callStr = *nocName + "." + methodName + "();";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);
@@ -1328,10 +1336,13 @@ public:
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     SmallVector<Value, 2> operands;
-    std::string nocName = ensureNocDeclaration(
+    FailureOr<std::string> nocName = ensureNocDeclaration(
         op.getOperation(), rewriter, state, operands, adaptor.getNoc());
+    if (failed(nocName)) {
+      return failure();
+    }
     operands.push_back(adaptor.getTrid());
-    std::string callStr = nocName + "." + methodName +
+    std::string callStr = *nocName + "." + methodName +
                           "<NocOptions::TXN_ID>(NocOptVals{{.trid = {}});";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
@@ -1624,8 +1635,11 @@ public:
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     SmallVector<Value, 9> operands;
-    std::string nocName = ensureNocDeclaration(
+    FailureOr<std::string> nocName = ensureNocDeclaration(
         op.getOperation(), rewriter, state, operands, adaptor.getNoc());
+    if (failed(nocName)) {
+      return failure();
+    }
     std::string endpoint = ensureEndpointDeclaration(
         op.getOperation(), rewriter, "MulticastEndpoint", "mcast_ep", state);
 
@@ -1650,7 +1664,7 @@ public:
         ".noc_x_end = {}, .noc_y_end = {}, "
         ".addr = static_cast<uint32_t>({})}";
 
-    std::string callStr = nocName + ".async_write_multicast" + templateArg +
+    std::string callStr = *nocName + ".async_write_multicast" + templateArg +
                           "(CoreLocalMem<uint32_t>({}), " + endpoint +
                           ", {}, {}, {{} , " + dstArgs + ", " +
                           (linked ? "true" : "false") + ");";

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -8,7 +8,6 @@
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
-#include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.h"
 
 #include "mlir/Conversion/ArithToEmitC/ArithToEmitC.h"
 #include "mlir/Conversion/MemRefToEmitC/MemRefToEmitC.h"
@@ -32,7 +31,6 @@
 
 #include <array>
 #include <functional>
-#include <optional>
 #include <string>
 
 using namespace mlir;
@@ -167,16 +165,12 @@ static bool mayHaveRuntimeCBArgs(func::FuncOp funcOp) {
   return !argSpec || !argSpec.getRtArgs().empty();
 }
 
-namespace {
 struct TTKernelToEmitCConversionState {
   llvm::DenseMap<Block *, llvm::StringSet<>> cbDeclarations;
   llvm::DenseMap<Operation *, llvm::StringSet<>> functionScopedDeclarations;
-  llvm::DenseMap<Operation *, std::optional<int64_t>> staticNocIndices;
   llvm::DenseMap<Operation *, std::array<bool, 2>> staticNocDeclarations;
   llvm::DenseMap<Operation *, uint64_t> resultVariableCounters;
-  llvm::StringMap<int64_t> kernelNocIndices;
 };
-} // namespace
 
 static void setInsertionPointAfterDefOrBlockStart(Value value,
                                                   OpBuilder &builder) {
@@ -239,42 +233,9 @@ static FailureOr<int64_t> extractNocIndex(Attribute value) {
   return nocIdx;
 }
 
-static void cacheKernelNocIndices(ModuleOp moduleOp,
-                                  TTKernelToEmitCConversionState &state) {
-  moduleOp.walk([&](ttmetal::EnqueueProgramOp enqueueProgram) {
-    for (Attribute kernelConfig : enqueueProgram.getKernelConfigs()) {
-      auto nocConfig = mlir::dyn_cast<ttmetal::NocConfigAttr>(kernelConfig);
-      if (!nocConfig) {
-        continue;
-      }
-
-      int64_t nocIdx = -1;
-      switch (nocConfig.getNocIndex()) {
-      case ttcore::NocIndex::Noc0:
-        nocIdx = 0;
-        break;
-      case ttcore::NocIndex::Noc1:
-        nocIdx = 1;
-        break;
-      }
-      std::string kernelSymbol =
-          nocConfig.getKernelSymbol().getRootReference().str();
-      auto it = state.kernelNocIndices.find(kernelSymbol);
-      if (it != state.kernelNocIndices.end()) {
-        TT_assertv(it->second == nocIdx,
-                   "malformed IR: kernel symbol `{}` has conflicting NoC "
-                   "indices {} and {}",
-                   kernelSymbol, it->second, nocIdx);
-        continue;
-      }
-      state.kernelNocIndices.try_emplace(kernelSymbol, nocIdx);
-    }
-  });
-}
-
-static FailureOr<int64_t>
-getStaticNocIndex(Operation *useOp, TTKernelToEmitCConversionState &state,
-                  Value nocId = {}) {
+static FailureOr<int64_t> getStaticNocIndex(Operation *,
+                                            TTKernelToEmitCConversionState &,
+                                            Value nocId = {}) {
   if (nocId) {
     if (auto constantOp = nocId.getDefiningOp<arith::ConstantOp>()) {
       return extractNocIndex(constantOp.getValue());
@@ -285,30 +246,7 @@ getStaticNocIndex(Operation *useOp, TTKernelToEmitCConversionState &state,
     return failure();
   }
 
-  auto funcOp = useOp->getParentOfType<func::FuncOp>();
-  if (!funcOp) {
-    return failure();
-  }
-
-  Operation *func = funcOp.getOperation();
-  if (auto it = state.staticNocIndices.find(func);
-      it != state.staticNocIndices.end()) {
-    if (it->second) {
-      return *it->second;
-    }
-    return failure();
-  }
-
-  StringRef kernelSymbol = funcOp.getSymName();
-  FailureOr<int64_t> nocIdx = failure();
-  auto nocIt = state.kernelNocIndices.find(kernelSymbol);
-  if (nocIt != state.kernelNocIndices.end()) {
-    nocIdx = nocIt->second;
-  }
-
-  state.staticNocIndices.try_emplace(
-      func, succeeded(nocIdx) ? std::optional<int64_t>(*nocIdx) : std::nullopt);
-  return nocIdx;
+  return failure();
 }
 
 static void setInsertionPointToFunctionStart(Operation *useOp,
@@ -2439,7 +2377,6 @@ public:
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
     TTKernelToEmitCConversionState state;
-    cacheKernelNocIndices(moduleOp, state);
     ConversionPlan config(moduleOp.getContext(), state);
     bool failedConversion = false;
     moduleOp.walk([&](func::FuncOp funcOp) {

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -165,12 +165,14 @@ static bool mayHaveRuntimeCBArgs(func::FuncOp funcOp) {
   return !argSpec || !argSpec.getRtArgs().empty();
 }
 
+namespace {
 struct TTKernelToEmitCConversionState {
   llvm::DenseMap<Block *, llvm::StringSet<>> cbDeclarations;
   llvm::DenseMap<Operation *, llvm::StringSet<>> functionScopedDeclarations;
   llvm::DenseMap<Operation *, std::array<bool, 2>> staticNocDeclarations;
   llvm::DenseMap<Operation *, uint64_t> resultVariableCounters;
 };
+} // namespace
 
 static void setInsertionPointAfterDefOrBlockStart(Value value,
                                                   OpBuilder &builder) {
@@ -233,9 +235,7 @@ static FailureOr<int64_t> extractNocIndex(Attribute value) {
   return nocIdx;
 }
 
-static FailureOr<int64_t> getStaticNocIndex(Operation *,
-                                            TTKernelToEmitCConversionState &,
-                                            Value nocId = {}) {
+static FailureOr<int64_t> getStaticNocIndex(Value nocId) {
   if (nocId) {
     if (auto constantOp = nocId.getDefiningOp<arith::ConstantOp>()) {
       return extractNocIndex(constantOp.getValue());
@@ -316,7 +316,7 @@ static FailureOr<std::string>
 ensureNocDeclaration(Operation *useOp, ConversionPatternRewriter &rewriter,
                      TTKernelToEmitCConversionState &state,
                      SmallVectorImpl<Value> &operands, Value nocId = {}) {
-  FailureOr<int64_t> nocIdx = getStaticNocIndex(useOp, state, nocId);
+  FailureOr<int64_t> nocIdx = getStaticNocIndex(nocId);
   if (succeeded(nocIdx)) {
     std::string nocName = "noc" + std::to_string(*nocIdx);
     auto funcOp = useOp->getParentOfType<func::FuncOp>();

--- a/test/python/golden/d2m/fabric_api_snippets/test_fabric_mcast.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_fabric_mcast.mlir
@@ -38,9 +38,10 @@ module attributes {} {
     // Get CB write pointers
     %cb0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<24, !ttcore.tile<32x32, bf16>>
     %write_ptr = ttkernel.get_write_ptr(%cb0) : (!ttkernel.cb<24, !ttcore.tile<32x32, bf16>>) -> i32
+    %noc_idx = arith.constant 0 : i8
 
     // Get noc address
-    %noc_addr = ttkernel.get_noc_addr(%translated_x, %translated_y, %write_ptr) : (index, index, i32) -> !ttkernel.noc_addr
+    %noc_addr = ttkernel.get_noc_addr(%translated_x, %translated_y, %write_ptr, %noc_idx) : (index, index, i32, i8) -> !ttkernel.noc_addr
 
     // Get my device id
     %my_device_id = "ttkernel.experimental.get_my_device_id"() : () -> i16

--- a/test/python/golden/d2m/fabric_api_snippets/test_fabric_sem_inc.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_fabric_sem_inc.mlir
@@ -39,7 +39,8 @@ module attributes {} {
     // Get noc address
     %global_semaphore = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.l1_addr
     %global_semaphore_ptr = ttkernel.reinterpret_cast(%global_semaphore) : (!ttkernel.l1_addr) -> !ttkernel.l1_addr_ptr
-    %global_semaphore_noc_addr = ttkernel.get_noc_addr(%translated_x, %translated_y, %global_semaphore) : (index, index, !ttkernel.l1_addr) -> !ttkernel.noc_addr
+    %noc_idx = arith.constant 0 : i8
+    %global_semaphore_noc_addr = ttkernel.get_noc_addr(%translated_x, %translated_y, %global_semaphore, %noc_idx) : (index, index, !ttkernel.l1_addr, i8) -> !ttkernel.noc_addr
     %incr = arith.constant 1 : index
 
     // Get my device id

--- a/test/python/golden/d2m/fabric_api_snippets/test_fabric_unicast.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_fabric_unicast.mlir
@@ -37,9 +37,10 @@ module attributes {} {
     // Get CB write pointers
     %cb0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<24, !ttcore.tile<32x32, bf16>>
     %write_ptr = ttkernel.get_write_ptr(%cb0) : (!ttkernel.cb<24, !ttcore.tile<32x32, bf16>>) -> i32
+    %noc_idx = arith.constant 0 : i8
 
     // Get noc address
-    %noc_addr = ttkernel.get_noc_addr(%translated_x, %translated_y, %write_ptr) : (index, index, i32) -> !ttkernel.noc_addr
+    %noc_addr = ttkernel.get_noc_addr(%translated_x, %translated_y, %write_ptr, %noc_idx) : (index, index, i32, i8) -> !ttkernel.noc_addr
 
     // Get my device id
     %my_device_id = "ttkernel.experimental.get_my_device_id"() : () -> i16

--- a/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
@@ -22,8 +22,9 @@ module {
     d2m.semaphore_inc %sem0, %c1, core[%y, %x] : !d2m.local_semaphore
     // CHECK: %[[ARG:[0-9]+]] = ttkernel.get_common_arg_val
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[ARG]])
-    // CHECK: %[[NOC:[0-9]+]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[SEM]])
-    // CHECK: ttkernel.noc_semaphore_inc(%[[NOC]], %c1) :
+    // CHECK: %[[NOC_ID:[a-zA-Z0-9_]+]] = arith.constant 1 : i8
+    // CHECK: %[[NOC:[0-9]+]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[SEM]], %[[NOC_ID]])
+    // CHECK: ttkernel.noc_semaphore_inc(%[[NOC]], %c1, %[[NOC_ID]]) :
     // CHECK-NOT: posted
     return
   }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/trid_noc.mlir
@@ -42,15 +42,17 @@ func.func @trid_write_path() -> () attributes {ttkernel.thread = #ttkernel.threa
 
 // -----
 
-// A TRID barrier with no NOC operand uses the default `noc` object. The trid is
-// the sole verbatim argument.
-// CHECK-LABEL: func @trid_barrier_default_noc
-// CHECK: emitc.verbatim "Noc noc(noc_index);"
+// A TRID barrier with an explicit NOC operand uses the selected static NoC
+// object. The trid is the sole verbatim argument.
+// CHECK-LABEL: func @trid_barrier_explicit_noc
+// CHECK: emitc.verbatim "Noc noc0(0);"
 // CHECK: %[[TRID:.*]] = "emitc.constant"() <{value = 3 : i32}> : () -> i32
-// CHECK: emitc.verbatim "noc.async_write_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}]}});" args %[[TRID]] : i32
-func.func @trid_barrier_default_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+// CHECK: %[[NOC_IDX:.*]] = "emitc.constant"() <{value = 0 : i8}> : () -> i8
+// CHECK: emitc.verbatim "noc0.async_write_barrier<NocOptions::TXN_ID>(NocOptVals{{[{][{]}}.trid = {}{{[}]}});" args %[[TRID]] : i32
+func.func @trid_barrier_explicit_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
   %trid = arith.constant 3 : i32
-  "ttkernel.noc_async_write_barrier_with_trid"(%trid) : (i32) -> ()
+  %noc_idx = arith.constant 0 : i8
+  "ttkernel.noc_async_write_barrier_with_trid"(%trid, %noc_idx) : (i32, i8) -> ()
   return
 }
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1927,16 +1927,18 @@ module {
     // CHECK-LABEL: func @get_noc_addr
     func.func @get_noc_addr() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.verbatim "UnicastEndpoint unicast_ep;"
-      // CHECK: emitc.verbatim "Noc noc(noc_index);"
+      // CHECK: emitc.verbatim "Noc noc0(0);"
       // CHECK: %[[X:.*]] = "emitc.constant"
       %x = arith.constant 1 : index
       // CHECK: %[[Y:.*]] = "emitc.constant"
       %y = arith.constant 2 : index
       // CHECK: %[[ADDR:.*]] = "emitc.constant"
       %addr = arith.constant 262400 : i32
-      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %[[X]], %[[Y]], %[[ADDR]]
+      // CHECK: %[[NOC:.*]] = "emitc.constant"
+      %noc = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc0.get_noc_id());" args %[[X]], %[[Y]], %[[ADDR]]
       // CHECK: emitc.literal "noc_addr_{{[0-9]+}}" : i64
-      "ttkernel.get_noc_addr"(%x, %y, %addr) : (index, index, i32) -> (!ttkernel.noc_addr)
+      "ttkernel.get_noc_addr"(%x, %y, %addr, %noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       return
     }
 
@@ -1997,7 +1999,7 @@ module {
     // CHECK-LABEL: func @noc_async_read
     func.func @noc_async_read() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.verbatim "UnicastEndpoint unicast_ep;"
-      // CHECK: emitc.verbatim "Noc noc(noc_index);"
+      // CHECK: emitc.verbatim "Noc noc0(0);"
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
@@ -2005,8 +2007,9 @@ module {
       %dst_addr = arith.constant 303104 : i32
       // CHECK: %[[SIZE:.*]] = "emitc.constant"
       %size = arith.constant 2048 : i32
-      // CHECK: emitc.verbatim "noc.async_read
-      ttkernel.noc_async_read core[%x, %y], %temp, %dst_addr, %size : (index, index, i32, i32, i32) -> ()
+      %noc = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "noc0.async_read
+      ttkernel.noc_async_read core[%x, %y], %temp, %dst_addr, %size, noc %noc : (index, index, i32, i32, i32, i8) -> ()
       return
     }
 
@@ -2016,14 +2019,15 @@ module {
       %offset = arith.constant 4096 : i32
       %dst = arith.constant 8192 : i32
       %size = arith.constant 128 : i32
+      %noc = arith.constant 0 : i8
       // CHECK: emitc.verbatim "AllocatorBank<AllocatorBankType::DRAM> dram_ep;"
-      // CHECK: emitc.verbatim "Noc noc(noc_index);"
-      // CHECK: emitc.verbatim "noc.async_read(dram_ep
+      // CHECK: emitc.verbatim "Noc noc0(0);"
+      // CHECK: emitc.verbatim "noc0.async_read(dram_ep
       // CHECK-SAME: .bank_id = static_cast<uint32_t>
       // CHECK-SAME: .addr = static_cast<uint32_t>
       // CHECK-NOT: emitc.call_opaque "get_noc_addr_from_bank_id"
       // CHECK-NOT: emitc.call_opaque "noc_async_read"
-      ttkernel.noc_async_read bank[%bank_id], %offset, %dst, %size : (i32, i32, i32, i32) -> ()
+      ttkernel.noc_async_read bank[%bank_id], %offset, %dst, %size, noc %noc : (i32, i32, i32, i32, i8) -> ()
       return
     }
 
@@ -2034,8 +2038,9 @@ module {
       %temp = arith.constant 262400 : i32
       // CHECK: %[[SIZE:.*]] = "emitc.constant"
       %size = arith.constant 2048 : i32
-      // CHECK: emitc.verbatim "noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
-      ttkernel.noc_async_read_one_packet_set_state(core[%x, %y], %temp, %size) : (index, index, i32, i32) -> ()
+      %noc = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "noc0.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+      ttkernel.noc_async_read_one_packet_set_state(core[%x, %y], %temp, %size, noc %noc) : (index, index, i32, i32, i8) -> ()
       return
     }
 
@@ -2047,17 +2052,19 @@ module {
       // CHECK: %[[DST_ADDR:.*]] = "emitc.constant"
       %dst_addr = arith.constant 327680 : i32
       %size = arith.constant 2048 : i32
-      // CHECK: emitc.verbatim "noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
-      ttkernel.noc_async_read_one_packet_with_state(core[%x, %y], %temp, %dst_addr, %size) : (index, index, i32, i32, i32) -> ()
+      %noc = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "noc0.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+      ttkernel.noc_async_read_one_packet_with_state(core[%x, %y], %temp, %dst_addr, %size, noc %noc) : (index, index, i32, i32, i32, i8) -> ()
       // TODO: test %dst_addr of type TTKernel_L1Addr?
       return
     }
 
     // CHECK-LABEL: func @noc_async_read_barrier
     func.func @noc_async_read_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: emitc.verbatim "Noc noc(noc_index);"
-      // CHECK: emitc.verbatim "noc.async_read_barrier();"
-      "ttkernel.noc_async_read_barrier"() : () -> ()
+      // CHECK: emitc.verbatim "Noc noc0(0);"
+      %noc_id = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "noc0.async_read_barrier();"
+      "ttkernel.noc_async_read_barrier"(%noc_id) : (i8) -> ()
       return
     }
 
@@ -2074,7 +2081,7 @@ module {
     // CHECK-LABEL: func @noc_async_write
     func.func @noc_async_write() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.verbatim "UnicastEndpoint unicast_ep;"
-      // CHECK: emitc.verbatim "Noc noc(noc_index);"
+      // CHECK: emitc.verbatim "Noc noc0(0);"
       // CHECK: %[[SRC_ADDR:.*]] = "emitc.constant"
       %src_addr = arith.constant 303104 : i32
       %x = arith.constant 1 : index
@@ -2082,8 +2089,9 @@ module {
       %temp = arith.constant 262400 : i32
       // CHECK: %[[SIZE:.*]] = "emitc.constant"
       %size = arith.constant 2048 : i32
-      // CHECK: emitc.verbatim "noc.async_write
-      ttkernel.noc_async_write %src_addr, core[%x, %y], %temp, %size : (i32, index, index, i32, i32) -> ()
+      %noc = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "noc0.async_write
+      ttkernel.noc_async_write %src_addr, core[%x, %y], %temp, %size, noc %noc : (i32, index, index, i32, i32, i8) -> ()
       return
     }
 
@@ -2133,8 +2141,9 @@ module {
       %src = arith.constant 303104 : i32
       %size = arith.constant 64 : i32
       %num_dests = arith.constant 4 : i32
+      %noc0 = arith.constant 0 : i8
       %noc = arith.constant 1 : i8
-      // CHECK-DAG: emitc.verbatim "Noc noc(noc_index);"
+      // CHECK-DAG: emitc.verbatim "Noc noc0(0);"
       // CHECK-DAG: emitc.verbatim "Noc noc1(1);"
       // CHECK: %[[XS2:.*]] = "emitc.constant"() <{value = 0 : index}>
       // CHECK: %[[YS2:.*]] = "emitc.constant"() <{value = 1 : index}>
@@ -2145,8 +2154,8 @@ module {
       // CHECK: %[[SIZE2:.*]] = "emitc.constant"() <{value = 64 : i32}>
       // CHECK: %[[NUM_DESTS2:.*]] = "emitc.constant"() <{value = 4 : i32}>
       // CHECK: %[[NOC2:.*]] = "emitc.constant"() <{value = 1 : i8}>
-      // CHECK: emitc.verbatim "noc.async_write_barrier();"
-      "ttkernel.noc_async_write_barrier"() : () -> ()
+      // CHECK: emitc.verbatim "noc0.async_write_barrier();"
+      "ttkernel.noc_async_write_barrier"(%noc0) : (i8) -> ()
       // CHECK: emitc.verbatim "noc1.async_write_multicast(
       // CHECK-SAME: args %[[SRC2]], %[[SIZE2]], %[[NUM_DESTS2]], %[[XE2]], %[[YE2]], %[[XS2]], %[[YS2]], %[[ADDR2]]
       ttkernel.noc_async_write_multicast(%src, %size, %num_dests, start_xy[%xe, %ye], end_xy[%xs, %ys], %addr, noc %noc) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
@@ -2189,9 +2198,10 @@ module {
 
     // CHECK-LABEL: func @noc_async_write_barrier
     func.func @noc_async_write_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: emitc.verbatim "Noc noc(noc_index);"
-      // CHECK: emitc.verbatim "noc.async_write_barrier();"
-      "ttkernel.noc_async_write_barrier"() : () -> ()
+      // CHECK: emitc.verbatim "Noc noc0(0);"
+      %noc_id = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "noc0.async_write_barrier();"
+      "ttkernel.noc_async_write_barrier"(%noc_id) : (i8) -> ()
       return
     }
 
@@ -2220,7 +2230,8 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      %addr_noc = arith.constant 0 : i8
+      %addr = "ttkernel.get_noc_addr"(%x, %y, %temp, %addr_noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       // CHECK: %[[INCR:.*]] = "emitc.constant"
       %incr = arith.constant 1 : i32
       // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
@@ -2236,11 +2247,12 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      %noc_id = arith.constant 0 : i8
+      %addr = "ttkernel.get_noc_addr"(%x, %y, %temp, %noc_id) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       // CHECK: %[[INCR:.*]] = "emitc.constant"
       %incr = arith.constant 1 : i32
-      // CHECK: emitc.call_opaque "noc_semaphore_inc"(%[[ADDR]], %[[INCR]]) {template_args = [#emitc.opaque<"true">]}
-      "ttkernel.noc_semaphore_inc"(%addr, %incr) <{posted = true}> : (!ttkernel.noc_addr, i32) -> ()
+      // CHECK: emitc.call_opaque "noc_semaphore_inc"(%[[ADDR]], %[[INCR]], {{.*}}) {template_args = [#emitc.opaque<"true">]}
+      "ttkernel.noc_semaphore_inc"(%addr, %incr, %noc_id) <{posted = true}> : (!ttkernel.noc_addr, i32, i8) -> ()
       return
     }
 
@@ -2250,13 +2262,14 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr) // dummy l1 addr (use mcast getter)
+      %noc_id = arith.constant 0 : i8
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp, %noc_id) : (index, index, i32, i8) -> (!ttkernel.noc_addr) // dummy l1 addr (use mcast getter)
       // CHECK: %[[INCR:.*]] = "emitc.constant"
       %incr = arith.constant 1 : i32
       // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
       %num_dsts = arith.constant 8 : i32
-      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]])
-      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts) : (!ttkernel.noc_addr, i32, i32) -> ()
+      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]], {{.*}})
+      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts, %noc_id) : (!ttkernel.noc_addr, i32, i32, i8) -> ()
       return
     }
 
@@ -2266,7 +2279,8 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      %addr_noc = arith.constant 0 : i8
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp, %addr_noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       // CHECK: %[[INCR:.*]] = "emitc.constant"
       %incr = arith.constant 1 : i32
       // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
@@ -2284,13 +2298,14 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      %noc_id = arith.constant 0 : i8
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp, %noc_id) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       // CHECK: %[[INCR:.*]] = "emitc.constant"
       %incr = arith.constant 1 : i32
       // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
       %num_dsts = arith.constant 8 : i32
-      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]]) {template_args = [#emitc.opaque<"true">]}
-      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts) <{posted = true}> : (!ttkernel.noc_addr, i32, i32) -> ()
+      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]], {{.*}}) {template_args = [#emitc.opaque<"true">]}
+      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts, %noc_id) <{posted = true}> : (!ttkernel.noc_addr, i32, i32, i8) -> ()
       return
     }
 
@@ -2302,12 +2317,13 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      %noc_id = arith.constant 0 : i8
+      %addr = "ttkernel.get_noc_addr"(%x, %y, %temp, %noc_id) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       // CHECK: %[[INCR:.*]] = "emitc.constant"
       %incr = arith.constant 1 : i32
-      // CHECK: emitc.call_opaque "noc_semaphore_inc"(%[[ADDR]], %[[INCR]]) :
+      // CHECK: emitc.call_opaque "noc_semaphore_inc"(%[[ADDR]], %[[INCR]], {{.*}}) :
       // CHECK-NOT: template_args
-      "ttkernel.noc_semaphore_inc"(%addr, %incr) <{posted = false}> : (!ttkernel.noc_addr, i32) -> ()
+      "ttkernel.noc_semaphore_inc"(%addr, %incr, %noc_id) <{posted = false}> : (!ttkernel.noc_addr, i32, i8) -> ()
       return
     }
 
@@ -2317,14 +2333,15 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      %noc_id = arith.constant 0 : i8
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp, %noc_id) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       // CHECK: %[[INCR:.*]] = "emitc.constant"
       %incr = arith.constant 1 : i32
       // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
       %num_dsts = arith.constant 8 : i32
-      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]]) :
+      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]], {{.*}}) :
       // CHECK-NOT: template_args
-      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts) <{posted = false}> : (!ttkernel.noc_addr, i32, i32) -> ()
+      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts, %noc_id) <{posted = false}> : (!ttkernel.noc_addr, i32, i32, i8) -> ()
       return
     }
 
@@ -2334,7 +2351,8 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      %addr_noc = arith.constant 0 : i8
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp, %addr_noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       // CHECK: %[[INCR:.*]] = "emitc.constant"
       %incr = arith.constant 1 : i32
       // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
@@ -2348,9 +2366,10 @@ module {
 
     // CHECK-LABEL: func @noc_async_atomic_barrier
     func.func @noc_async_atomic_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-      // CHECK: emitc.verbatim "Noc noc(noc_index);"
-      // CHECK: emitc.verbatim "noc.async_atomic_barrier();"
-      ttkernel.noc_async_atomic_barrier() : () -> ()
+      // CHECK: emitc.verbatim "Noc noc0(0);"
+      %noc_id = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "noc0.async_atomic_barrier();"
+      ttkernel.noc_async_atomic_barrier(%noc_id) : (i8) -> ()
       return
     }
 
@@ -2401,7 +2420,8 @@ module {
       %noc_x = arith.constant 1 : index
       %noc_y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      %addr_noc = arith.constant 0 : i8
+      %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %temp, %addr_noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       // CHECK: emitc.call_opaque "noc_semaphore_set_remote"(%[[SRC_ADDR]], %[[DST_NOC_ADDR]])
       "ttkernel.remote_sram_write_u32"(%src_addr, %dst_noc_addr) : (!ttkernel.l1_addr, !ttkernel.noc_addr) -> ()
       return
@@ -2440,9 +2460,10 @@ module {
       %remote_table_addr = arith.addi %table_base, %table_offset : i32
       %noc_x = arith.constant 1 : index
       %noc_y = arith.constant 2 : index
-      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc.get_noc_id());" args %{{.*}}, %{{.*}}, %[[REMOTE_TABLE_ADDR]]
+      %addr_noc = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "uint64_t noc_addr_{{[0-9]+}} = unicast_ep.get_noc_unicast_addr(static_cast<uint32_t>({}), static_cast<uint32_t>({}), static_cast<uint32_t>({}), noc0.get_noc_id());" args %{{.*}}, %{{.*}}, %[[REMOTE_TABLE_ADDR]]
       // CHECK: %[[DST_NOC_ADDR:.*]] = emitc.literal "noc_addr_{{[0-9]+}}" : i64
-      %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %remote_table_addr) : (index, index, i32) -> !ttkernel.noc_addr
+      %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %remote_table_addr, %addr_noc) : (index, index, i32, i8) -> !ttkernel.noc_addr
       // CHECK: emitc.call_opaque "noc_semaphore_set_remote"(%[[STAGING_ADDR]], %[[DST_NOC_ADDR]])
       "ttkernel.remote_sram_write_u32"(%staging_addr, %dst_noc_addr) : (i32, !ttkernel.noc_addr) -> ()
       %sink = arith.addi %loaded, %word_offset : i32
@@ -2478,7 +2499,8 @@ module {
       %noc_x = arith.constant 1 : index
       %noc_y = arith.constant 1 : index
       %temp = arith.constant 262400 : i32
-      %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      %addr_noc = arith.constant 0 : i8
+      %dst_noc_addr = "ttkernel.get_noc_addr"(%noc_x, %noc_y, %temp, %addr_noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr)
       // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
       %noc_id = arith.constant 1 : i8
       // CHECK: emitc.call_opaque "noc_semaphore_set_remote"(%[[SRC_ADDR]], %[[DST_NOC_ADDR]], %[[NOC_ID]])
@@ -2519,7 +2541,8 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp2 = arith.constant 262400 : i32
-      %dst_mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp2) : (index, index, i32) -> (!ttkernel.noc_addr) // dummy l1 addr (use mcast getter)
+      %addr_noc = arith.constant 0 : i8
+      %dst_mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp2, %addr_noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr) // dummy l1 addr (use mcast getter)
       // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
       %num_dsts = arith.constant 8 : i32
       // CHECK: emitc.call_opaque "noc_semaphore_set_multicast"(%[[SRC_ADDR]], %[[DST_MCAST_ADDR]], %[[NUM_DSTS]])
@@ -2538,7 +2561,8 @@ module {
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
       %temp2 = arith.constant 303104 : i32
-      %dst_mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp2) : (index, index, i32) -> (!ttkernel.noc_addr) // dummy l1 addr (use mcast getter)
+      %addr_noc = arith.constant 0 : i8
+      %dst_mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp2, %addr_noc) : (index, index, i32, i8) -> (!ttkernel.noc_addr) // dummy l1 addr (use mcast getter)
       // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
       %num_dsts = arith.constant 8 : i32
       // CHECK: emitc.call_opaque "noc_semaphore_set_multicast_loopback_src"(%[[SRC_ADDR]], %[[DST_MCAST_ADDR]], %[[NUM_DSTS]])
@@ -2558,14 +2582,15 @@ module {
       %temp_addr = arith.constant 262400 : i32
       %tile_size = arith.constant 8 : i32
       %tile = arith.constant 1 : i32
+      %noc = arith.constant 0 : i8
       // CHECK: emitc.verbatim "auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();"
       %tensor_accessor_args = ttkernel.TensorAccessorArgs(%cta_offset, %crta_offset)
       // CHECK: %[[ACCESSOR:.*]] = emitc.call_opaque "TensorAccessor"
       %s = "ttkernel.TensorAccessor"(%tensor_accessor_args, %temp_addr, %tile_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
-      // CHECK: emitc.verbatim "noc.async_write(CoreLocalMem<uint32_t>({}), {}, {}.get_aligned_page_size()
-      "ttkernel.noc_async_write_tile"(%tile, %s, %temp_addr) : (i32, !ttkernel.TensorAccessor, i32) -> ()
-      // CHECK: emitc.verbatim "noc.async_read({}, CoreLocalMem<uint32_t>({}), {}.get_aligned_page_size()
-      "ttkernel.noc_async_read_tile"(%tile, %s, %temp_addr) : (i32, !ttkernel.TensorAccessor, i32) -> ()
+      // CHECK: emitc.verbatim "noc0.async_write(CoreLocalMem<uint32_t>({}), {}, {}.get_aligned_page_size()
+      "ttkernel.noc_async_write_tile"(%tile, %s, %temp_addr, %noc) : (i32, !ttkernel.TensorAccessor, i32, i8) -> ()
+      // CHECK: emitc.verbatim "noc0.async_read({}, CoreLocalMem<uint32_t>({}), {}.get_aligned_page_size()
+      "ttkernel.noc_async_read_tile"(%tile, %s, %temp_addr, %noc) : (i32, !ttkernel.TensorAccessor, i32, i8) -> ()
       return
     }
 
@@ -2586,27 +2611,28 @@ module {
       %tensor_accessor = "ttkernel.TensorAccessor"(%tensor_accessor_args, %bank_address, %page_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
       %temp1 = arith.constant 0 : i32
       %temp2 = arith.constant 32: i32
-      // CHECK: emitc.verbatim "uint64_t [[NOC_ADDR:.*]] = {}.get_noc_addr({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32
+      %noc = arith.constant 0 : i8
+      // CHECK: emitc.verbatim "uint64_t [[NOC_ADDR:.*]] = {}.get_noc_addr({}, {}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32, i8
       // CHECK: emitc.literal "[[NOC_ADDR]]" : i64
-      %noc_addr = "ttkernel.tensor_accessor.get_noc_addr"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> !ttkernel.noc_addr
-      // CHECK: emitc.verbatim "uint32_t [[SHARD_ADDR:.*]] = {}.get_shard_noc_addr({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32
+      %noc_addr = "ttkernel.tensor_accessor.get_noc_addr"(%tensor_accessor, %temp1, %temp2, %noc) : (!ttkernel.TensorAccessor, i32, i32, i8) -> !ttkernel.noc_addr
+      // CHECK: emitc.verbatim "uint32_t [[SHARD_ADDR:.*]] = {}.get_shard_noc_addr({}, {}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32, i8
       // CHECK: emitc.literal "[[SHARD_ADDR]]"
-      %shard_noc_addr = "ttkernel.tensor_accessor.get_shard_noc_addr"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> i32
+      %shard_noc_addr = "ttkernel.tensor_accessor.get_shard_noc_addr"(%tensor_accessor, %temp1, %temp2, %noc) : (!ttkernel.TensorAccessor, i32, i32, i8) -> i32
       // CHECK: emitc.verbatim "PageMapping [[BANK_AND_OFFSET:.*]] = {}.get_bank_and_offset({});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32
       // CHECK: emitc.literal "[[BANK_AND_OFFSET]]" : !emitc.opaque<"PageMapping">
       %bank_and_offset = "ttkernel.tensor_accessor.get_bank_and_offset"(%tensor_accessor, %temp1) : (!ttkernel.TensorAccessor, i32) -> !ttkernel.PageMapping
-      // CHECK: emitc.verbatim "bool [[IS_LOCAL_BANK:.*]] = {}.is_local_bank({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32
+      // CHECK: emitc.verbatim "bool [[IS_LOCAL_BANK:.*]] = {}.is_local_bank({}, {}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32, i8
       // CHECK: emitc.literal "[[IS_LOCAL_BANK]]" : i1
-      %is_local_bank = "ttkernel.tensor_accessor.is_local_bank"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> i1
-      // CHECK: emitc.verbatim "bool [[IS_LOCAL_ADDR:.*]] = {}.is_local_addr({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32
+      %is_local_bank = "ttkernel.tensor_accessor.is_local_bank"(%tensor_accessor, %temp1, %temp2, %noc) : (!ttkernel.TensorAccessor, i32, i32, i8) -> i1
+      // CHECK: emitc.verbatim "bool [[IS_LOCAL_ADDR:.*]] = {}.is_local_addr({}, {}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32, i8
       // CHECK: emitc.literal "[[IS_LOCAL_ADDR]]" : i1
-      %is_local_addr = "ttkernel.tensor_accessor.is_local_addr"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> i1
-      // CHECK: emitc.verbatim "bool [[IS_LOCAL_PAGE:.*]] = {}.is_local_page({});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32
+      %is_local_addr = "ttkernel.tensor_accessor.is_local_addr"(%tensor_accessor, %temp1, %temp2, %noc) : (!ttkernel.TensorAccessor, i32, i32, i8) -> i1
+      // CHECK: emitc.verbatim "bool [[IS_LOCAL_PAGE:.*]] = {}.is_local_page({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i8
       // CHECK: emitc.literal "[[IS_LOCAL_PAGE]]" : i1
-      %is_local_page = "ttkernel.tensor_accessor.is_local_page"(%tensor_accessor, %temp1) : (!ttkernel.TensorAccessor, i32) -> i1
-      // CHECK: emitc.verbatim "bool [[IS_LOCAL_SHARD:.*]] = {}.is_local_shard({});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32
+      %is_local_page = "ttkernel.tensor_accessor.is_local_page"(%tensor_accessor, %temp1, %noc) : (!ttkernel.TensorAccessor, i32, i8) -> i1
+      // CHECK: emitc.verbatim "bool [[IS_LOCAL_SHARD:.*]] = {}.is_local_shard({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i8
       // CHECK: emitc.literal "[[IS_LOCAL_SHARD]]" : i1
-      %is_local_shard = "ttkernel.tensor_accessor.is_local_shard"(%tensor_accessor, %temp1) : (!ttkernel.TensorAccessor, i32) -> i1
+      %is_local_shard = "ttkernel.tensor_accessor.is_local_shard"(%tensor_accessor, %temp1, %noc) : (!ttkernel.TensorAccessor, i32, i8) -> i1
       return
     }
 

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -10,13 +10,14 @@
 // CHECK: void kernel_main
 func.func @ttkernel_noc_cb() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     // CHECK: UnicastEndpoint [[EP:unicast_ep]]
-    // CHECK: Noc [[NOC:noc]]
+    // CHECK: Noc [[NOC:noc0]]
     // CHECK: int32_t [[C0:.*]] = 32
     %c32_i32 = arith.constant 32 : i32
     // CHECK: size_t [[A0:.*]] = 0
     %c0_idx = arith.constant 0 : index
     // CHECK: int32_t [[A1:.*]] = 262144;
     %c262144_i32 = arith.constant 262144 : i32
+    %noc0 = arith.constant 0 : i8
     %cb = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
     // CHECK: CircularBuffer [[CB:cb_ctarg_0]](get_compile_time_arg_val(0));
     %c1_i32 = arith.constant 1 : i32
@@ -24,9 +25,9 @@ func.func @ttkernel_noc_cb() -> () attributes {ttkernel.arg_spec = #ttkernel.arg
     "ttkernel.cb_reserve_back"(%cb, %c1_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, i32) -> ()
     %wptr = "ttkernel.get_write_ptr"(%cb) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>) -> i32
     // CHECK: [[NOC]].async_read([[EP]], CoreLocalMem<uint32_t>([[CB]].get_write_ptr()), [[C0]]
-    ttkernel.noc_async_read core[%c0_idx, %c0_idx], %c262144_i32, %wptr, %c32_i32 : (index, index, i32, i32, i32) -> ()
+    ttkernel.noc_async_read core[%c0_idx, %c0_idx], %c262144_i32, %wptr, %c32_i32, noc %noc0 : (index, index, i32, i32, i32, i8) -> ()
     // CHECK: [[NOC]].async_read_barrier()
-    ttkernel.noc_async_read_barrier() : () -> ()
+    ttkernel.noc_async_read_barrier(%noc0) : (i8) -> ()
     // CHECK: [[CB]].push_back
     "ttkernel.cb_push_back"(%cb, %c1_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, i32) -> ()
     // CHECK: return
@@ -36,7 +37,7 @@ func.func @ttkernel_noc_cb() -> () attributes {ttkernel.arg_spec = #ttkernel.arg
 // CHECK: void kernel_main
 func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
     // CHECK: UnicastEndpoint [[EP1:unicast_ep]]
-    // CHECK: Noc [[NOC1:noc]]
+    // CHECK: Noc [[NOC1:noc0]]
     // CHECK: int32_t [[B0:.*]] = 262432
     %c262432_i32 = arith.constant 262432 : i32
     // CHECK: int32_t [[B1:.*]] = 262208
@@ -49,12 +50,13 @@ func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<n
     %c0_idx = arith.constant 0 : index
     // CHECK: int32_t [[A1:.*]] = 262144;
     %c262144_i32 = arith.constant 262144 : i32
+    %noc0 = arith.constant 0 : i8
     // CHECK: [[NOC1]].async_read([[EP1]], CoreLocalMem<uint32_t>([[C1]]), [[C0]]
-    ttkernel.noc_async_read core[%c0_idx, %c0_idx], %c262144_i32, %c262400_i32, %c32_i32 : (index, index, i32, i32, i32) -> ()
+    ttkernel.noc_async_read core[%c0_idx, %c0_idx], %c262144_i32, %c262400_i32, %c32_i32, noc %noc0 : (index, index, i32, i32, i32, i8) -> ()
     // CHECK: uint64_t [[NOCADDR1:.*]] = [[EP1]].get_noc_unicast_addr(static_cast<uint32_t>([[A0]]), static_cast<uint32_t>([[A0]]), static_cast<uint32_t>([[B1]]), [[NOC1]].get_noc_id())
-    %4 = ttkernel.get_noc_addr(%c0_idx, %c0_idx, %c262208_i32) : (index, index, i32) -> !ttkernel.noc_addr
+    %4 = ttkernel.get_noc_addr(%c0_idx, %c0_idx, %c262208_i32, %noc0) : (index, index, i32, i8) -> !ttkernel.noc_addr
     // CHECK: [[NOC1]].async_read([[EP1]], CoreLocalMem<uint32_t>([[B0]]), [[C0]]
-    ttkernel.noc_async_read core[%c0_idx, %c0_idx], %c262208_i32, %c262432_i32, %c32_i32 : (index, index, i32, i32, i32) -> ()
+    ttkernel.noc_async_read core[%c0_idx, %c0_idx], %c262208_i32, %c262432_i32, %c32_i32, noc %noc0 : (index, index, i32, i32, i32, i8) -> ()
     // CHECK: int32_t [[SEM:.*]] = get_semaphore
     %sem = ttkernel.get_semaphore(%c0_idx) : (index) -> !ttkernel.local_semaphore
     // CHECK: noc_semaphore_set_remote([[SEM]], [[NOCADDR1]])
@@ -68,11 +70,11 @@ func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<n
     // CHECK: noc1.inline_dw_write<NocOptions::INLINE_L1>([[EP1]], [[INLINE_VALUE]]
     ttkernel.noc_inline_dw_write(core[%c0_idx, %c0_idx], %c262208_i32, %inline_value, %be, noc %noc) : (index, index, i32, i32, i8, i8) -> ()
     // CHECK: [[NOC1]].async_atomic_barrier()
-    ttkernel.noc_async_atomic_barrier() : () -> ()
+    ttkernel.noc_async_atomic_barrier(%noc0) : (i8) -> ()
     // CHECK: noc1.async_atomic_barrier()
     ttkernel.noc_async_atomic_barrier(%noc) : (i8) -> ()
     // CHECK: [[NOC1]].async_read_barrier()
-    ttkernel.noc_async_read_barrier() : () -> ()
+    ttkernel.noc_async_read_barrier(%noc0) : (i8) -> ()
     // CHECK: return
     func.return
 }
@@ -108,7 +110,7 @@ func.func @ttkernel_noc_with_noc_id() -> () attributes {ttkernel.thread = #ttker
 func.func @ttkernel_noc_oo_render() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
     // CHECK-DAG: UnicastEndpoint [[EP:unicast_ep]]
     // CHECK-DAG: MulticastEndpoint [[MEP:mcast_ep]]
-    // CHECK-DAG: Noc [[NOC:noc]]
+    // CHECK-DAG: Noc [[NOC:noc0]]
     %trid = arith.constant 3 : i32
     %x = arith.constant 0 : index
     %y = arith.constant 1 : index
@@ -118,42 +120,44 @@ func.func @ttkernel_noc_oo_render() -> () attributes {ttkernel.thread = #ttkerne
     %num = arith.constant 7 : i32
     %xe = arith.constant 3 : index
     %ye = arith.constant 3 : index
+    %noc0 = arith.constant 0 : i8
 
     // CHECK: [[NOC]].set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>([[EP]], {{.*}}, {.noc_x = {{.*}}, .noc_y = {{.*}}, .addr = static_cast<uint32_t>({{.*}})});
-    ttkernel.noc_async_read_one_packet_set_state(core[%x, %y], %addr, %size) : (index, index, i32, i32) -> ()
+    ttkernel.noc_async_read_one_packet_set_state(core[%x, %y], %addr, %size, noc %noc0) : (index, index, i32, i32, i8) -> ()
 
     // CHECK: [[NOC]].async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>([[EP]], CoreLocalMem<uint32_t>({{.*}}), {{.*}}, {.noc_x = {{.*}}, .noc_y = {{.*}}, .addr = static_cast<uint32_t>({{.*}})}, {});
-    ttkernel.noc_async_read_one_packet_with_state(core[%x, %y], %addr, %dstl1, %size) : (index, index, i32, i32, i32) -> ()
+    ttkernel.noc_async_read_one_packet_with_state(core[%x, %y], %addr, %dstl1, %size, noc %noc0) : (index, index, i32, i32, i32, i8) -> ()
 
     // The TRID write must close with a single balanced `NocOptVals{...}`.
     // CHECK: [[NOC]].async_write<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(CoreLocalMem<uint32_t>({{.*}}), [[EP]], {{.*}}, {} , {.noc_x = {{.*}}, .noc_y = {{.*}}, .addr = static_cast<uint32_t>({{.*}})}, NocOptVals{.trid = {{[^}]*}}});
-    ttkernel.noc_async_write_one_packet_with_trid(%dstl1, core[%x, %y], %addr, %size, %trid) : (i32, index, index, i32, i32, i32) -> ()
+    ttkernel.noc_async_write_one_packet_with_trid(%dstl1, core[%x, %y], %addr, %size, %trid, noc %noc0) : (i32, index, index, i32, i32, i32, i8) -> ()
 
     // CHECK: [[NOC]].async_write_multicast<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(CoreLocalMem<uint32_t>({{.*}}), [[MEP]], {{.*}}, {{.*}}, {} , noc_traits_t<MulticastEndpoint>::dst_args_mcast_type{.noc_x_start = {{.*}}, .noc_y_start = {{.*}}, .noc_x_end = {{.*}}, .noc_y_end = {{.*}}, .addr = static_cast<uint32_t>({{.*}})}, false);
-    ttkernel.noc_async_write_multicast_one_packet(%dstl1, %size, %num, start_xy[%x, %y], end_xy[%xe, %ye], %addr) : (i32, i32, i32, index, index, index, index, i32) -> ()
+    ttkernel.noc_async_write_multicast_one_packet(%dstl1, %size, %num, start_xy[%x, %y], end_xy[%xe, %ye], %addr, noc %noc0) : (i32, i32, i32, index, index, index, index, i32, i8) -> ()
 
     // The TRID barrier must close with a single balanced `NocOptVals{...}`.
     // CHECK: [[NOC]].async_read_barrier<NocOptions::TXN_ID>(NocOptVals{.trid = {{[^}]*}}});
-    ttkernel.noc_async_read_barrier_with_trid(%trid) : (i32) -> ()
+    ttkernel.noc_async_read_barrier_with_trid(%trid, %noc0) : (i32, i8) -> ()
     // CHECK: return
     func.return
 }
 
 // CHECK: void kernel_main
 func.func @ttkernel_noc_oo_tile_render() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-    // CHECK: Noc [[NOC:noc]]
+    // CHECK: Noc [[NOC:noc0]]
     %cta = arith.constant 2 : i32
     %crta = arith.constant 0 : i32
     %addr = arith.constant 262400 : i32
     %tile_size = arith.constant 8 : i32
     %tile = arith.constant 1 : i32
+    %noc0 = arith.constant 0 : i8
     %args = ttkernel.TensorAccessorArgs(%cta, %crta)
     // CHECK: TensorAccessor [[ACC:v[0-9]+]] = TensorAccessor(
     %s = "ttkernel.TensorAccessor"(%args, %addr, %tile_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
     // CHECK: [[NOC]].async_read([[ACC]], CoreLocalMem<uint32_t>({{.*}}), [[ACC]].get_aligned_page_size(), {.page_id = static_cast<uint32_t>({{.*}})}, {});
-    "ttkernel.noc_async_read_tile"(%tile, %s, %addr) : (i32, !ttkernel.TensorAccessor, i32) -> ()
+    "ttkernel.noc_async_read_tile"(%tile, %s, %addr, %noc0) : (i32, !ttkernel.TensorAccessor, i32, i8) -> ()
     // CHECK: [[NOC]].async_write(CoreLocalMem<uint32_t>({{.*}}), [[ACC]], [[ACC]].get_aligned_page_size(), {} , {.page_id = static_cast<uint32_t>({{.*}})});
-    "ttkernel.noc_async_write_tile"(%tile, %s, %addr) : (i32, !ttkernel.TensorAccessor, i32) -> ()
+    "ttkernel.noc_async_write_tile"(%tile, %s, %addr, %noc0) : (i32, !ttkernel.TensorAccessor, i32, i8) -> ()
     // CHECK: return
     func.return
 }

--- a/tools/pykernel/_src/kernel_ast.py
+++ b/tools/pykernel/_src/kernel_ast.py
@@ -871,8 +871,16 @@ class TTKernelCompiler(TTCompilerBase):
         self._fn_map["noc_async_write_tile"] = self._wrap_noc_async_write_tile
         self._fn_map["noc_async_read"] = self._wrap_noc_async_read
         self._fn_map["noc_async_write"] = self._wrap_noc_async_write
+        self._fn_map["noc_async_read_barrier"] = self._wrap_noc_async_read_barrier
+        self._fn_map["noc_async_write_barrier"] = self._wrap_noc_async_write_barrier
 
-    def _wrap_noc_async_read_tile(self, tile_id, addr_gen, dst_addr):
+    def _default_noc_id(self):
+        return arith.ConstantOp(IntegerType.get_signless(8, self.ctx), 0)
+
+    def _noc_or_default(self, noc):
+        return self._default_noc_id() if noc is None else noc
+
+    def _wrap_noc_async_read_tile(self, tile_id, addr_gen, dst_addr, noc=None):
         """Cast tile_id to i32 for noc_async_read_tile operation."""
         if isinstance(tile_id, OpView):
             tile_id = tile_id.result
@@ -880,14 +888,18 @@ class TTKernelCompiler(TTCompilerBase):
         if hasattr(tile_id, "type") and isinstance(tile_id.type, IndexType):
             tile_id = arith.index_cast(IntegerType.get_signless(32), tile_id)
 
-        return ttkernel.noc_async_read_tile(tile_id, addr_gen, dst_addr)
+        return ttkernel.noc_async_read_tile(
+            tile_id, addr_gen, dst_addr, noc=self._noc_or_default(noc)
+        )
 
-    def _wrap_noc_async_write_tile(self, tile_id, addr_gen, src_addr):
+    def _wrap_noc_async_write_tile(self, tile_id, addr_gen, src_addr, noc=None):
         """Extract result from operations for noc_async_write_tile."""
         if isinstance(tile_id, OpView):
             tile_id = tile_id.result
 
-        return ttkernel.noc_async_write_tile(tile_id, addr_gen, src_addr)
+        return ttkernel.noc_async_write_tile(
+            tile_id, addr_gen, src_addr, noc=self._noc_or_default(noc)
+        )
 
     def _as_operand_list(self, operand_or_operands):
         if operand_or_operands is None:
@@ -897,7 +909,13 @@ class TTKernelCompiler(TTCompilerBase):
         return [operand_or_operands]
 
     def _wrap_noc_async_read(
-        self, src_address, dst_local_l1_addr, size, src_bank_id=None, src_core=None
+        self,
+        src_address,
+        dst_local_l1_addr,
+        size,
+        src_bank_id=None,
+        src_core=None,
+        noc=None,
     ):
         """Build modal noc_async_read using either a DRAM bank or L1 core."""
         if (src_bank_id is None) == (src_core is None):
@@ -911,10 +929,17 @@ class TTKernelCompiler(TTCompilerBase):
             src_address,
             dst_local_l1_addr,
             size,
+            noc=self._noc_or_default(noc),
         )
 
     def _wrap_noc_async_write(
-        self, src_local_l1_addr, dst_address, size, dst_bank_id=None, dst_core=None
+        self,
+        src_local_l1_addr,
+        dst_address,
+        size,
+        dst_bank_id=None,
+        dst_core=None,
+        noc=None,
     ):
         """Build modal noc_async_write using either a DRAM bank or L1 core."""
         if (dst_bank_id is None) == (dst_core is None):
@@ -928,7 +953,14 @@ class TTKernelCompiler(TTCompilerBase):
             self._as_operand_list(dst_bank_id),
             dst_address,
             size,
+            noc=self._noc_or_default(noc),
         )
+
+    def _wrap_noc_async_read_barrier(self, noc=None):
+        return ttkernel.noc_async_read_barrier(noc=self._noc_or_default(noc))
+
+    def _wrap_noc_async_write_barrier(self, noc=None):
+        return ttkernel.noc_async_write_barrier(noc=self._noc_or_default(noc))
 
     # Root Nodes
     def visit_FunctionDef(self, node):


### PR DESCRIPTION
### Problem
Remove global noc index lookup so we can run this pass on func level and get better parallelization

### What's changed
- Threads explicit nocId into translated L1 ttkernel.get_noc_addr
- Threads nocId into remote semaphore increment paths
- Threads nocId into device sync get_noc_addr
- Avoids materializing unused NoC constants in multicast semaphore lowering
- Removes TTMetal enqueue-program NoC cache/inference
- Removes kernelNocIndices / staticNocIndices
- Removes TTMetalOps.h and <optional> includes
- Makes ensureNocDeclaration fail if a NoC-using op has no noc operand
- Keeps static noc0/noc1 and dynamic Noc({}) paths when the operand is explicit
- Updates checks to expect explicit nocId on get_noc_addr and noc_semaphore_inc
- Updates hand-authored TTKernel IR to pass explicit i8 NoC operands
- Updates checks from default noc(noc_index)/noc to explicit noc0, noc1, or dynamic Noc({})

### Checklist
- [ ] New/Existing tests provide coverage for changes
