### PR TITLE
[StableHLO] Fuse disguised row scatters into single-axis scatters

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/StableHLOFusing.cpp
+++ b/lib/Dialect/StableHLO/Transforms/StableHLOFusing.cpp
@@ -307,6 +307,120 @@ public:
   }
 };
 
+// Fuses a disguised row scatter into a single-axis one: index
+// concat(real_row, column_iota) at dims=[0,1] flattens to a single-core 1D
+// scatter (L1 clash). Re-emit with dims=[0], column as window.
+class CollapseRowScatterPattern
+    : public OpRewritePattern<::mlir::stablehlo::ScatterOp> {
+  using OpRewritePattern<::mlir::stablehlo::ScatterOp>::OpRewritePattern;
+
+  // True if `value` is an iota (through broadcast_in_dim). `axis` >= 0 requires
+  // the iota to vary along that axis, rejecting a row-axis iota.
+  static bool tracesToIota(::mlir::Value value, int64_t axis = -1) {
+    while (value) {
+      ::mlir::Operation *def = value.getDefiningOp();
+      if (!def) {
+        return false;
+      }
+      if (auto iota = ::mlir::dyn_cast<::mlir::stablehlo::IotaOp>(def)) {
+        return axis < 0 ||
+               static_cast<int64_t>(iota.getIotaDimension()) == axis;
+      }
+      auto bcast = ::mlir::dyn_cast<::mlir::stablehlo::BroadcastInDimOp>(def);
+      if (!bcast) {
+        return false;
+      }
+      if (axis < 0) {
+        value = bcast.getOperand();
+        continue;
+      }
+      // Map result `axis` to its operand axis; a broadcast dim can't carry it.
+      ArrayRef<int64_t> dims = bcast.getBroadcastDimensions();
+      int64_t mapped = -1;
+      for (int64_t j = 0; j < static_cast<int64_t>(dims.size()); ++j) {
+        if (dims[j] == axis) {
+          mapped = j;
+          break;
+        }
+      }
+      if (mapped < 0) {
+        return false;
+      }
+      value = bcast.getOperand();
+      axis = mapped;
+    }
+    return false;
+  }
+
+public:
+  LogicalResult matchAndRewrite(::mlir::stablehlo::ScatterOp op,
+                                ::mlir::PatternRewriter &rewriter) const final {
+    auto dimNumbers = op.getScatterDimensionNumbers();
+    if (op.getInputs().size() != 1) {
+      return failure();
+    }
+    auto operandType =
+        mlir::cast<RankedTensorType>(op.getInputs()[0].getType());
+    if (operandType.getRank() != 2) {
+      return failure();
+    }
+    if (!dimNumbers.getUpdateWindowDims().empty()) {
+      return failure(); // element-wise only
+    }
+    ArrayRef<int64_t> scatterDims = dimNumbers.getScatterDimsToOperandDims();
+    if (scatterDims.size() != 2 || scatterDims[0] != 0 || scatterDims[1] != 1) {
+      return failure();
+    }
+
+    int64_t indexVectorDim = dimNumbers.getIndexVectorDim();
+    auto concat = op.getScatterIndices()
+                      .getDefiningOp<::mlir::stablehlo::ConcatenateOp>();
+    if (!concat ||
+        static_cast<int64_t>(concat.getDimension()) != indexVectorDim ||
+        concat.getInputs().size() != 2) {
+      return failure();
+    }
+
+    // Component 0 = row, component 1 = column iota.
+    Value rowComp = concat.getInputs()[0];
+    Value colComp = concat.getInputs()[1];
+    auto rowType = mlir::cast<RankedTensorType>(rowComp.getType());
+    if (rowType.getRank() != 3 || rowType.getShape()[indexVectorDim] != 1) {
+      return failure();
+    }
+    if (tracesToIota(rowComp) || !tracesToIota(colComp, /*columnAxis=*/1)) {
+      return failure();
+    }
+    int64_t numRows = rowType.getShape()[0];
+
+    // Row is constant across columns -> take column 0.
+    Location loc = op.getLoc();
+    auto slicedType =
+        RankedTensorType::get({numRows, 1, 1}, rowType.getElementType());
+    Value sliced = rewriter.create<::mlir::stablehlo::SliceOp>(
+        loc, slicedType, rowComp, rewriter.getDenseI64ArrayAttr({0, 0, 0}),
+        rewriter.getDenseI64ArrayAttr({numRows, 1, 1}),
+        rewriter.getDenseI64ArrayAttr({1, 1, 1}));
+    auto rowIndexType =
+        RankedTensorType::get({numRows, 1}, rowType.getElementType());
+    Value rowIndex = rewriter.create<::mlir::stablehlo::ReshapeOp>(
+        loc, rowIndexType, sliced);
+
+    // Re-emit as a single-axis scatter; the dead concat/iota is left for DCE.
+    auto newDimNumbers = ::mlir::stablehlo::ScatterDimensionNumbersAttr::get(
+        rewriter.getContext(), /*update_window_dims=*/{1},
+        /*inserted_window_dims=*/{0}, /*input_batching_dims=*/{},
+        /*scatter_indices_batching_dims=*/{},
+        /*scatter_dims_to_operand_dims=*/{0}, /*index_vector_dim=*/1);
+    auto newScatter = rewriter.create<::mlir::stablehlo::ScatterOp>(
+        loc, op.getResultTypes(), op.getInputs(), rowIndex, op.getUpdates(),
+        newDimNumbers, op.getIndicesAreSorted(), op.getUniqueIndices());
+    newScatter.getUpdateComputation().takeBody(op.getUpdateComputation());
+    rewriter.replaceOp(op, newScatter.getResults());
+    return success();
+  }
+};
+
 struct StableHLOFusingPass
     : public impl::StableHLOFusingPassBase<StableHLOFusingPass> {
 public:
@@ -317,6 +431,7 @@ public:
     RewritePatternSet patterns(&getContext());
     patterns.add<ConcatenateToBroadcastInDimFusionPattern>(&getContext());
     patterns.add<ReshapeGatherFusionPattern>(&getContext());
+    patterns.add<CollapseRowScatterPattern>(&getContext());
 
     GreedyRewriteConfig config;
     config.setUseTopDownTraversal(true);

--- a/test/ttmlir/Dialect/StableHLO/stablehlo_fusing_collapse_scatter.mlir
+++ b/test/ttmlir/Dialect/StableHLO/stablehlo_fusing_collapse_scatter.mlir
@@ -1,0 +1,64 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-fusing -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module @collapse_row_scatter {
+  // index = concat(row, column iota via broadcast_in_dim) -> collapse to a
+  // single-axis scatter (dims=[0], column as update window).
+  func.func @disguised_row_scatter(%operand: tensor<4x8xbf16>,
+                                   %rows: tensor<2x8x1xi64>,
+                                   %update: tensor<2x8xbf16>) -> tensor<4x8xbf16> {
+    %iota = stablehlo.iota dim = 0 : tensor<8xi64>
+    %bcast = stablehlo.broadcast_in_dim %iota, dims = [1]
+        : (tensor<8xi64>) -> tensor<2x8x1xi64>
+    %idx = stablehlo.concatenate %rows, %bcast, dim = 2
+        : (tensor<2x8x1xi64>, tensor<2x8x1xi64>) -> tensor<2x8x2xi64>
+    %r = "stablehlo.scatter"(%operand, %idx, %update) <{scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 2>}> ({
+    ^bb0(%a: tensor<bf16>, %b: tensor<bf16>):
+      %s = stablehlo.add %a, %b : tensor<bf16>
+      stablehlo.return %s : tensor<bf16>
+    }) : (tensor<4x8xbf16>, tensor<2x8x2xi64>, tensor<2x8xbf16>) -> tensor<4x8xbf16>
+    return %r : tensor<4x8xbf16>
+    // CHECK-LABEL: func.func @disguised_row_scatter
+    // CHECK: "stablehlo.scatter"
+    // CHECK-SAME: update_window_dims = [1]
+    // CHECK-SAME: scatter_dims_to_operand_dims = [0]
+  }
+
+  // Both index components are real (no iota) -> left unchanged.
+  func.func @genuine_2d_scatter(%operand: tensor<4x8xbf16>,
+                                %rows: tensor<3x1xi64>,
+                                %cols: tensor<3x1xi64>,
+                                %update: tensor<3xbf16>) -> tensor<4x8xbf16> {
+    %idx = stablehlo.concatenate %rows, %cols, dim = 1
+        : (tensor<3x1xi64>, tensor<3x1xi64>) -> tensor<3x2xi64>
+    %r = "stablehlo.scatter"(%operand, %idx, %update) <{scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>}> ({
+    ^bb0(%a: tensor<bf16>, %b: tensor<bf16>):
+      %s = stablehlo.add %a, %b : tensor<bf16>
+      stablehlo.return %s : tensor<bf16>
+    }) : (tensor<4x8xbf16>, tensor<3x2xi64>, tensor<3xbf16>) -> tensor<4x8xbf16>
+    return %r : tensor<4x8xbf16>
+    // CHECK-LABEL: func.func @genuine_2d_scatter
+    // CHECK: scatter_dims_to_operand_dims = [0, 1]
+  }
+
+  // The iota varies along the row axis (broadcast dims = [0]), not the column
+  // axis, so it is not the identity column map -> left unchanged.
+  func.func @row_axis_iota_not_collapsed(%operand: tensor<4x8xbf16>,
+                                         %rows: tensor<2x8x1xi64>,
+                                         %update: tensor<2x8xbf16>) -> tensor<4x8xbf16> {
+    %iota = stablehlo.iota dim = 0 : tensor<2xi64>
+    %bcast = stablehlo.broadcast_in_dim %iota, dims = [0]
+        : (tensor<2xi64>) -> tensor<2x8x1xi64>
+    %idx = stablehlo.concatenate %rows, %bcast, dim = 2
+        : (tensor<2x8x1xi64>, tensor<2x8x1xi64>) -> tensor<2x8x2xi64>
+    %r = "stablehlo.scatter"(%operand, %idx, %update) <{scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 2>}> ({
+    ^bb0(%a: tensor<bf16>, %b: tensor<bf16>):
+      %s = stablehlo.add %a, %b : tensor<bf16>
+      stablehlo.return %s : tensor<bf16>
+    }) : (tensor<4x8xbf16>, tensor<2x8x2xi64>, tensor<2x8xbf16>) -> tensor<4x8xbf16>
+    return %r : tensor<4x8xbf16>
+    // CHECK-LABEL: func.func @row_axis_iota_not_collapsed
+    // CHECK: scatter_dims_to_operand_dims = [0, 1]
+  }
+}


### PR DESCRIPTION
### Ticket

fixes https://github.com/tenstorrent/tt-xla/issues/5350

### Problem description
`torch.scatter_reduce(dim=0)` lowers to a multi-dim `stablehlo.scatter` whose column coordinate is just a positional `iota` (the column stays in place) — i.e. a single-axis **row scatter-add** wearing a 2-coordinate costume (`scatter_dims_to_operand_dims = [0, 1]`).

Because of the `[0,1]` dims it (1) misses the existing embedding-backward lowering and (2) is flattened to a **1-D** `ttnn.scatter` in StableHLOToTTIR. The TTNN scatter kernel splits work by rows, so a 1-D tensor runs on a **single core**, whose static circular buffers overflow L1 once the surrounding activations are sharded:

```
Statically allocated circular buffers in program N clash with L1 buffers on core range [0-0 - 0-0]
```

Hit in HiDream-I1's MoE scatter-back 

### What's changed

Added `CollapseRowScatterPattern` to the existing **`stablehlo-fusing`** pass, which runs **before** Shardy/SPMD partitioning while the clean `concat(row, iota)` form is still visible. When a scatter's index is `concat(real_row_idx, column_iota)` — the second coordinate a positional iota **varying along the column axis** — it emits a single-axis scatter (`scatter_dims_to_operand_dims = [0]`, column moved to an `update_window_dim`) as a fusion: a new `stablehlo.scatter` replaces the old one and the now-dead `iota`/`broadcast_in_dim`/`concatenate` are left to DCE, so a shared iota (used by other ops) is preserved.

Downstream the single-axis form matches the **existing embedding-backward conversion** → multi-core, no 1-D flatten, no L1 clash.

The match is conservative — rank-2, element-wise, `concat(real, iota)`, and the iota is confirmed to index the **column** axis (traced through `broadcast_in_dim` to the `IotaOp`), so a row-axis iota is never mis-collapsed. Genuine multi-coordinate scatters are left unchanged.

**Impact:** Resolves the single-core L1 clash in HiDream-I1's sharded MoE; the transformer now facing OOM from downstream ops.


### Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [jul7_scatter_reduce_before_fix.log](https://github.com/user-attachments/files/29738568/jul7_scatter_reduce_before_fix.log)
- [jul7_hidreaml1_transformer_before_fix.log](https://github.com/user-attachments/files/29738563/jul7_hidreaml1_transformer_before_fix.log)
- [jul7_hidreaml1_transformer_after_fix.log.zip](https://github.com/user-attachments/files/29738561/jul7_hidreaml1_transformer_after_fix.log.zip)
- [jul7_scatter_reduce_after_fix.log](https://github.com/user-attachments/files/29738565/jul7_scatter_reduce_after_fix.log)



