### PR TITLE
Add Exp rewriter

### DIFF
--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -47,6 +47,8 @@ namespace mlir::tt::ttkernel {
 
 // ............................................................................
 
+static constexpr uint32_t ONE_AS_FP32 = 0x3F800000u;
+
 static std::string datatypeToDataformatStr(ttcore::DataType dtype) {
   std::string expression = "DataFormat::";
   switch (dtype) {
@@ -634,6 +636,158 @@ public:
     return success();
   }
 };
+
+static bool hasNonDefaultExpTileScale(IntegerAttr scaleAttr) {
+  return scaleAttr && static_cast<uint32_t>(scaleAttr.getInt()) != ONE_AS_FP32;
+}
+
+static StringRef
+getInputClampingTemplateArg(ttkernel::InputClamping inputClamping) {
+  switch (inputClamping) {
+  case ttkernel::InputClamping::None:
+    return "InputClamping::None";
+  case ttkernel::InputClamping::ClampToNegative:
+    return "InputClamping::ClampToNegative";
+  }
+  llvm_unreachable("Unhandled ttkernel::InputClamping value");
+}
+
+static int getLastSetTemplateArg(ArrayRef<bool> isSet) {
+  const int size = static_cast<int>(isSet.size());
+  for (int i = size - 1; i >= 0; --i) {
+    if (isSet[i]) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+static void appendExpApproxTemplateArg(SmallVectorImpl<Attribute> &args,
+                                       MLIRContext *ctx, BoolAttr approxAttr) {
+  const bool approx = approxAttr && approxAttr.getValue();
+  args.push_back(emitc::OpaqueAttr::get(ctx, approx ? "true" : "false"));
+}
+
+static void appendExpInputClampingTemplateArg(
+    SmallVectorImpl<Attribute> &args, MLIRContext *ctx,
+    ttkernel::InputClampingAttr inputClampingAttr) {
+  const ttkernel::InputClamping inputClamping =
+      inputClampingAttr ? inputClampingAttr.getValue()
+                        : ttkernel::InputClamping::ClampToNegative;
+  args.push_back(
+      emitc::OpaqueAttr::get(ctx, getInputClampingTemplateArg(inputClamping)));
+}
+
+static ArrayAttr
+getExpInitTemplateArgs(MLIRContext *ctx, BoolAttr approxAttr,
+                       IntegerAttr scaleAttr,
+                       ttkernel::InputClampingAttr inputClampingAttr) {
+  const int lastSet = getLastSetTemplateArg(
+      {static_cast<bool>(approxAttr), static_cast<bool>(scaleAttr),
+       static_cast<bool>(inputClampingAttr)});
+  if (lastSet < 0) {
+    return ArrayAttr();
+  }
+
+  SmallVector<Attribute, 3> args;
+  appendExpApproxTemplateArg(args, ctx, approxAttr);
+  if (lastSet >= 1) {
+    const uint32_t scaleBits =
+        scaleAttr ? static_cast<uint32_t>(scaleAttr.getInt()) : ONE_AS_FP32;
+    args.push_back(emitc::OpaqueAttr::get(ctx, std::to_string(scaleBits)));
+  }
+  if (lastSet >= 2) {
+    appendExpInputClampingTemplateArg(args, ctx, inputClampingAttr);
+  }
+  return ArrayAttr::get(ctx, args);
+}
+
+static ArrayAttr
+getExpTileTemplateArgs(MLIRContext *ctx, BoolAttr approxAttr, bool scaleEn,
+                       ttkernel::InputClampingAttr inputClampingAttr,
+                       IntegerAttr iterationsAttr) {
+  const int lastSet =
+      getLastSetTemplateArg({static_cast<bool>(approxAttr), scaleEn,
+                             static_cast<bool>(inputClampingAttr),
+                             static_cast<bool>(iterationsAttr)});
+  if (lastSet < 0) {
+    return ArrayAttr();
+  }
+
+  SmallVector<Attribute, 4> args;
+  appendExpApproxTemplateArg(args, ctx, approxAttr);
+  if (lastSet >= 1) {
+    args.push_back(emitc::OpaqueAttr::get(ctx, scaleEn ? "true" : "false"));
+  }
+  if (lastSet >= 2) {
+    appendExpInputClampingTemplateArg(args, ctx, inputClampingAttr);
+  }
+  if (lastSet >= 3) {
+    const int64_t iterations = iterationsAttr ? iterationsAttr.getInt() : 8;
+    std::string iterationsStr = std::to_string(iterations);
+    args.push_back(emitc::OpaqueAttr::get(ctx, iterationsStr));
+  }
+  return ArrayAttr::get(ctx, args);
+}
+
+class TTKernelExpTileInitOpRewriter
+    : public OpConversionPattern<ttkernel::ExpTileInitOp> {
+public:
+  using OpConversionPattern<ttkernel::ExpTileInitOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttkernel::ExpTileInitOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, "exp_tile_init", nullptr,
+        getExpInitTemplateArgs(op.getContext(), op.getApproxAttr(),
+                               op.getScaleAttr(), op.getInputClampingAttr()),
+        adaptor.getOperands());
+    return success();
+  }
+};
+
+class TTKernelExpTileOpRewriter
+    : public OpConversionPattern<ttkernel::ExpTileOp> {
+public:
+  using OpConversionPattern<ttkernel::ExpTileOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttkernel::ExpTileOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    IntegerAttr scaleAttr = op.getScaleAttr();
+    const bool scaleEn = hasNonDefaultExpTileScale(scaleAttr);
+
+    SmallVector<Value> operands(adaptor.getOperands());
+    if (scaleEn) {
+      operands.push_back(
+          rewriter
+              .create<emitc::LiteralOp>(
+                  op.getLoc(),
+                  rewriter.getType<emitc::OpaqueType>("VectorMode"),
+                  "VectorMode::RC")
+              .getResult());
+      const uint32_t fp16bScaleBits =
+          (static_cast<uint32_t>(scaleAttr.getInt()) >> 16) & 0xffffu;
+      operands.push_back(
+          rewriter
+              .create<emitc::LiteralOp>(
+                  op.getLoc(), rewriter.getType<emitc::OpaqueType>("uint16_t"),
+                  (Twine("static_cast<uint16_t>(") + Twine(fp16bScaleBits) +
+                   "u)")
+                      .str())
+              .getResult());
+    }
+
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, "exp_tile", nullptr,
+        getExpTileTemplateArgs(op.getContext(), op.getApproxAttr(), scaleEn,
+                               op.getInputClampingAttr(),
+                               op.getIterationsAttr()),
+        operands);
+    return success();
+  }
+};
 } // namespace
 
 namespace {
@@ -703,9 +857,8 @@ public:
   }
 
   static bool hasNonDefaultExpTileScale(IntegerAttr scaleAttr) {
-    constexpr uint32_t defaultScale = 0x3F800000u; // 1.0 encoded as fp32.
     return scaleAttr &&
-           static_cast<uint32_t>(scaleAttr.getInt()) != defaultScale;
+           static_cast<uint32_t>(scaleAttr.getInt()) != ONE_AS_FP32;
   }
 
   ArrayAttr getTemplateArgs(Builder &builder, SourceOp op) const {
@@ -901,13 +1054,13 @@ public:
           op.getContext(),
           (approxAttr && approxAttr.getValue()) ? "true" : "false"));
       if (lastSet >= 1) {
-        uint32_t scale =
-            scaleAttr ? static_cast<uint32_t>(scaleAttr.getInt()) : 0x3F800000u;
+        const uint32_t scale =
+            scaleAttr ? static_cast<uint32_t>(scaleAttr.getInt()) : ONE_AS_FP32;
         template_args.push_back(
             emitc::OpaqueAttr::get(op.getContext(), std::to_string(scale)));
       }
       if (lastSet >= 2) {
-        ttkernel::InputClamping inputClamping =
+        const ttkernel::InputClamping inputClamping =
             clampAttr ? clampAttr.getValue()
                       : ttkernel::InputClamping::ClampToNegative;
         template_args.push_back(emitc::OpaqueAttr::get(
@@ -2599,8 +2752,7 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::ErfTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ErfcTileInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ErfcTileOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::ExpTileInitOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::ExpTileOp>,
+        TTKernelExpTileInitOpRewriter, TTKernelExpTileOpRewriter,
         TTKernelToEmitCOpaqueRewriter<ttkernel::Exp2TileInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::Exp2TileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::Expm1TileInitOp>,

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -931,8 +931,9 @@ module {
     func.func @exp_tile_runtime_scale() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
       %dst_index = arith.constant 3 : i32
-      // CHECK: emitc.call_opaque "exp_tile"(%[[DST_INDEX]])
-      // CHECK-SAME: args = [0 : index, #emitc.opaque<"VectorMode::RC">, #emitc.opaque<"16384">]
+      // CHECK: %[[VECTOR_MODE:.*]] = emitc.literal "VectorMode::RC" : !emitc.opaque<"VectorMode">
+      // CHECK: %[[SCALE:.*]] = emitc.literal "static_cast<uint16_t>(16384u)" : !emitc.opaque<"uint16_t">
+      // CHECK: emitc.call_opaque "exp_tile"(%[[DST_INDEX]], %[[VECTOR_MODE]], %[[SCALE]])
       // CHECK-SAME: template_args = [#emitc.opaque<"true">, #emitc.opaque<"true">, #emitc.opaque<"InputClamping::None">]
       "ttkernel.exp_tile"(%dst_index) <{approx = true, input_clamping = #ttkernel.input_clamping<none>, scale = 1073741824 : i32}> : (i32) -> ()
       return


### PR DESCRIPTION
### Ticket
None

### Problem description
Emitted C code for the exp doesn't have runtime arguments VectorMode::RC and the scale when scaling is enabled.

### What's changed
Replace default rewriters by custom.

1. ExpTileInit op rewriter adds template args depending on the lasts custom argument. So it may add 0-3 template arguments.
2. ExpTile op rewriter:

- adds template args up to the last explicitly set attribute;
- adds runtime call arguments `VectorMode::RC` and `uint16_t scale` are added only when scale_en is true.

### Checklist
- [X] Existing tests provide coverage for changes
