### PR TITLE
[TTNN] Add conv3d config heuristic under the greedy optimizer

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/Conv3dConfigHeuristic.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/Conv3dConfigHeuristic.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_CONV3DCONFIGHEURISTIC_H
+#define TTMLIR_DIALECT_TTNN_ANALYSIS_CONV3DCONFIGHEURISTIC_H
+
+#include "llvm/ADT/ArrayRef.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace mlir::tt::ttnn {
+
+// Conv3d blocking parameters chosen by the heuristic. Fields use the TTNN
+// Conv3dConfig naming/order, NOT the (C_in, C_out, T, H, W) tuple order of
+// tt-metal's table.
+struct Conv3dBlocking {
+  uint32_t tOutBlock;
+  uint32_t wOutBlock;
+  uint32_t hOutBlock;
+  uint32_t cOutBlock;
+  uint32_t cInBlock;
+};
+
+// Look up tt-metal's default conv3d blockings (the `_DEFAULT_BLOCKINGS` table
+// in models/tt_dit/utils/conv3d.py) keyed by (in_channels, out_channels,
+// kernel). Returns std::nullopt when no entry matches, in which case the caller
+// should keep the existing (conversion) default config.
+//
+// `kernel` is [K_D, K_H, K_W] (TTNN Conv3dOp kernel_size order).
+std::optional<Conv3dBlocking>
+lookupConv3dBlocking(int64_t inChannels, int64_t outChannels,
+                     llvm::ArrayRef<int64_t> kernel);
+
+} // namespace mlir::tt::ttnn
+
+#endif // TTMLIR_DIALECT_TTNN_ANALYSIS_CONV3DCONFIGHEURISTIC_H

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/ConvRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/ConvRules.h
@@ -57,13 +57,20 @@ struct Conv2dRuleBook : OpRuleBook {
 // Conv3d rules:
 //
 // Output hints:
-//   Default (no shard-layout embedding — Conv3d is interleaved-only today).
+//   Full legal configs with Conv3dConfig (no shard-layout embedding — Conv3d
+//   is interleaved-only today). Must forward the configs so Conv3dConfig
+//   (incl. --override-conv3d-config) survives into the chosen candidate.
 //
 // Op-specific attributes:
 //   Set Conv3dConfig + DeviceComputeKernelConfig from candidate.
 //===----------------------------------------------------------------------===//
 
 struct Conv3dRuleBook : OpRuleBook {
+  /// Output hints: full legal configs with Conv3dConfig.
+  OutputHints
+  getOutputHints(Operation *op,
+                 const std::vector<OpConfig> &legalConfigs) const override;
+
   /// Apply Conv3dConfig + DeviceComputeKernelConfig from candidate.
   void applyOpSpecificAttrs(Operation *op,
                             const BeamCandidate &candidate) const override;

--- a/lib/Dialect/TTNN/Analysis/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRTTNNAnalysis
         BFInterleavedPolicy.cpp
         Conv2dConfigSearchSpace.cpp
+        Conv3dConfigHeuristic.cpp
         DFShardingPolicy.cpp
         MatmulProgramConfig.cpp
         GreedyL1InterleavedPolicy.cpp

--- a/lib/Dialect/TTNN/Analysis/Conv3dConfigHeuristic.cpp
+++ b/lib/Dialect/TTNN/Analysis/Conv3dConfigHeuristic.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/Conv3dConfigHeuristic.h"
+
+#include "llvm/ADT/ArrayRef.h"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+
+namespace mlir::tt::ttnn {
+
+namespace {
+// One row of tt-metal's `_DEFAULT_BLOCKINGS` table. The block fields are stored
+// in tt-metal's value-tuple order, (C_in_block, C_out_block, T_out_block,
+// H_out_block, W_out_block), so the entries below can be transcribed verbatim
+// from the Python source; the remap to TTNN Conv3dConfig field order happens in
+// lookupConv3dBlocking.
+struct Conv3dBlockingEntry {
+  int64_t inChannels;
+  int64_t outChannels;
+  std::array<int64_t, 3> kernel; // [K_D, K_H, K_W]
+  uint32_t cInBlock;
+  uint32_t cOutBlock;
+  uint32_t tOutBlock;
+  uint32_t hOutBlock;
+  uint32_t wOutBlock;
+};
+
+// Verbatim mirror of `_DEFAULT_BLOCKINGS` from
+// tt-metal/models/tt_dit/utils/conv3d.py. Keep this a faithful, auditable copy
+// of the upstream table: {in, out, {kd, kh, kw}, C_in_block, C_out_block,
+// T_out_block, H_out_block, W_out_block}.
+constexpr Conv3dBlockingEntry kDefaultBlockings[] = {
+    {96, 3, {3, 3, 3}, 96, 32, 1, 16, 8},
+    {96, 32, {3, 3, 3}, 96, 32, 1, 16, 8},
+    {192, 96, {1, 3, 3}, 192, 96, 1, 4, 8},
+    {96, 96, {3, 3, 3}, 96, 96, 1, 8, 8},
+    {384, 192, {1, 3, 3}, 192, 96, 1, 32, 4},
+    {192, 192, {3, 3, 3}, 96, 96, 1, 8, 4},
+    {32, 384, {3, 3, 3}, 32, 96, 1, 2, 32},
+    {192, 384, {3, 3, 3}, 64, 128, 1, 8, 4},
+    {384, 384, {3, 3, 3}, 96, 96, 1, 8, 4},
+    {384, 768, {3, 3, 3}, 96, 96, 1, 8, 4},
+    {1024, 4096, {3, 3, 3}, 256, 32, 1, 1, 1},
+    {512, 4096, {3, 3, 3}, 256, 32, 1, 1, 1},
+    {256, 512, {3, 3, 3}, 256, 32, 1, 4, 4},
+    {128, 128, {3, 3, 3}, 128, 32, 1, 8, 8},
+    {128, 48, {3, 3, 3}, 128, 32, 1, 8, 8},
+    {1024, 4096, {1, 3, 3}, 256, 32, 1, 1, 1},
+    {1024, 128, {3, 3, 3}, 256, 32, 1, 1, 1},
+};
+} // namespace
+
+std::optional<Conv3dBlocking>
+lookupConv3dBlocking(int64_t inChannels, int64_t outChannels,
+                     llvm::ArrayRef<int64_t> kernel) {
+  if (kernel.size() != 3) {
+    return std::nullopt;
+  }
+  for (const Conv3dBlockingEntry &entry : kDefaultBlockings) {
+    if (entry.inChannels == inChannels && entry.outChannels == outChannels &&
+        entry.kernel[0] == kernel[0] && entry.kernel[1] == kernel[1] &&
+        entry.kernel[2] == kernel[2]) {
+      // Remap from tt-metal's tuple order to TTNN Conv3dConfig field order.
+      return Conv3dBlocking{entry.tOutBlock, entry.wOutBlock, entry.hOutBlock,
+                            entry.cOutBlock, entry.cInBlock};
+    }
+  }
+  return std::nullopt;
+}
+
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.h"
 
+#include "ttmlir/Dialect/TTNN/Analysis/Conv3dConfigHeuristic.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfigAttrs.h"
@@ -125,18 +126,76 @@ applyConv2dConfigOverrides(ConvOpT op,
   }
 }
 
+// Compute the base Conv3dConfig for an op before any user override. Start from
+// the op's current (conversion-default) config and, if tt-metal's
+// `_DEFAULT_BLOCKINGS` table has an entry for this op's (in_channels,
+// out_channels, kernel), replace the five blocking fields with the table
+// values. weights_dtype and compute_with_storage_grid_size are preserved from
+// the op config. On a table miss the op config is returned unchanged. A
+// --override-conv3d-config still wins because it is merged on top of this base
+// (per field) by applyConv3dConfigOverrides.
+//
+// Note: in_channels here is the cin-padded value the conversion stored on the
+// op (padded up to a multiple of the tile width). All `_DEFAULT_BLOCKINGS`
+// input-channel keys are already 32-aligned, so matching is unaffected; only
+// sub-32-channel inputs (which the table never keys on) could differ from
+// tt-metal, where the lookup uses the unpadded channel count.
+static Conv3dConfigAttr conv3dBaseConfig(ttnn::Conv3dOp op) {
+  Conv3dConfigAttr base = op.getConv3dConfigAttr();
+  std::optional<ttcore::DataType> weightsDtype;
+  std::optional<ttcore::GridAttr> grid;
+  if (base) {
+    weightsDtype = base.getWeightsDtype();
+    grid = base.getComputeWithStorageGridSize();
+  }
+
+  llvm::ArrayRef<int32_t> kernel = op.getKernelSize();
+  std::optional<Conv3dBlocking> blocking;
+  if (kernel.size() == 3) {
+    blocking = lookupConv3dBlocking(op.getInChannels(), op.getOutChannels(),
+                                    {static_cast<int64_t>(kernel[0]),
+                                     static_cast<int64_t>(kernel[1]),
+                                     static_cast<int64_t>(kernel[2])});
+  }
+
+  if (!blocking) {
+    // No heuristic match: keep the op's existing config (may be null, which
+    // downstream override merging handles by treating every field as unset).
+    TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
+                 "Conv3d heuristic: no _DEFAULT_BLOCKINGS entry for op {} "
+                 "(in_channels={}, out_channels={}); keeping default config",
+                 op.getLoc(), op.getInChannels(), op.getOutChannels());
+    if (base) {
+      return base;
+    }
+    return Conv3dConfigAttr::get(op.getContext(), std::nullopt, std::nullopt,
+                                 std::nullopt, std::nullopt, std::nullopt,
+                                 std::nullopt, std::nullopt);
+  }
+
+  // kernel is guaranteed to have 3 elements here (blocking is only set above
+  // when kernel.size() == 3).
+  Conv3dConfigAttr matched = Conv3dConfigAttr::get(
+      op.getContext(), weightsDtype, blocking->tOutBlock, blocking->wOutBlock,
+      blocking->hOutBlock, blocking->cOutBlock, blocking->cInBlock, grid);
+  TTMLIR_TRACE(
+      ttmlir::LogComponent::Optimizer,
+      "Conv3d heuristic: _DEFAULT_BLOCKINGS matched op {} (in_channels={}, "
+      "out_channels={}, kernel=[{}, {}, {}]); using config {}",
+      op.getLoc(), op.getInChannels(), op.getOutChannels(), kernel[0],
+      kernel[1], kernel[2], matched);
+  return matched;
+}
+
 static void
 applyConv3dConfigOverrides(ttnn::Conv3dOp op,
                            const Conv3dConfigOverrideParams &overrides,
                            std::vector<OpConfig> &analysisResult) {
-  // Build a Conv3dConfigAttr from the op's current config plus overrides.
-  // If the op has no config yet, start from an empty one (all fields unset).
-  Conv3dConfigAttr base = op.getConv3dConfigAttr();
-  if (!base) {
-    base = Conv3dConfigAttr::get(op.getContext(), std::nullopt, std::nullopt,
-                                 std::nullopt, std::nullopt, std::nullopt,
-                                 std::nullopt, std::nullopt);
-  }
+  // Build a Conv3dConfigAttr from the op's heuristic base config plus
+  // overrides. The base already folds in any tt-metal _DEFAULT_BLOCKINGS entry,
+  // so a partial override pins only its fields and the rest come from the
+  // heuristic (or the conversion default on a table miss).
+  Conv3dConfigAttr base = conv3dBaseConfig(op);
 
   auto pick = [](auto overrideVal, auto existingVal) {
     return overrideVal.has_value() ? overrideVal : existingVal;
@@ -304,17 +363,18 @@ void LegalOpConfigAnalysis::fillOpSpecificAttrs() {
                      convOp, analysisResult.size());
 
         // If applyConv3dConfigOverrides ran, the analysisResult's first
-        // entry already carries the override config — keep it as the base.
-        // Otherwise fall back to the config already attached to the op (if
-        // any). There is no config search; the override (or the op default)
-        // is taken as-is.
+        // entry already carries the override config (merged on top of the
+        // heuristic base) — keep it as the base. Otherwise fall back to the
+        // heuristic base config (tt-metal _DEFAULT_BLOCKINGS lookup, or the
+        // conversion default on a table miss). There is no config search; the
+        // override (or the heuristic) is taken as-is.
         std::optional<Conv3dConfigAttr> conv3dConfig;
         if (const Conv3dAttrs *attrs = std::get_if<Conv3dAttrs>(
                 &analysisResult.begin()->opSpecificAttrs)) {
           conv3dConfig = attrs->conv3dConfig;
         }
-        if (!conv3dConfig.has_value() && convOp.getConv3dConfigAttr()) {
-          conv3dConfig = convOp.getConv3dConfigAttr();
+        if (!conv3dConfig.has_value()) {
+          conv3dConfig = conv3dBaseConfig(convOp);
         }
 
         // Default compute config attached to every emitted Conv3dOp.

--- a/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
@@ -139,13 +139,23 @@ void applyConvSliceConfig(ModuleOp moduleOp) {
 
 OutputHints Conv3dRuleBook::getOutputHints(
     Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
-  // Forward the full legal configs (which carry Conv3dConfig, including any
-  // --override-conv3d-config) as primary hints. Conv3d is interleaved-only, so
-  // unlike Conv2d there is no shard layout to embed. Without this, the base
+  // Forward the interleaved legal configs (which carry Conv3dConfig, including
+  // any --override-conv3d-config) as primary hints. Without this, the base
   // OpRuleBook::getOutputHints emits a null primary hint that drops
   // opSpecificAttrs, so applyOpSpecificAttrs never sees the Conv3dAttrs and the
   // override is silently lost under the greedy optimizer.
-  return OutputHints{legalConfigs, {}};
+  std::vector<OpConfig> configs;
+  configs.reserve(legalConfigs.size());
+  for (const auto &config : legalConfigs) {
+    if (config.outputLayout) {
+      auto ml = config.outputLayout.getMemLayout();
+      if (ml && isShardedMemoryLayout(ml.getValue())) {
+        continue;
+      }
+    }
+    configs.push_back(config);
+  }
+  return OutputHints{configs, {}};
 }
 
 void Conv3dRuleBook::applyOpSpecificAttrs(

--- a/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
@@ -137,6 +137,17 @@ void applyConvSliceConfig(ModuleOp moduleOp) {
 // Conv3dRuleBook
 //===----------------------------------------------------------------------===//
 
+OutputHints Conv3dRuleBook::getOutputHints(
+    Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
+  // Forward the full legal configs (which carry Conv3dConfig, including any
+  // --override-conv3d-config) as primary hints. Conv3d is interleaved-only, so
+  // unlike Conv2d there is no shard layout to embed. Without this, the base
+  // OpRuleBook::getOutputHints emits a null primary hint that drops
+  // opSpecificAttrs, so applyOpSpecificAttrs never sees the Conv3dAttrs and the
+  // override is silently lost under the greedy optimizer.
+  return OutputHints{legalConfigs, {}};
+}
+
 void Conv3dRuleBook::applyOpSpecificAttrs(
     Operation *op, const BeamCandidate &candidate) const {
   auto conv3d = dyn_cast<Conv3dOp>(op);

--- a/test/ttmlir/Conversion/TTIRToTTNN/conv3d_default_config.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTNN/conv3d_default_config.mlir
@@ -1,0 +1,30 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+
+// Every emitted Conv3dOp must carry a *complete* Conv3dConfigAttr. tt-metal
+// only auto-derives a full default config when conv3d_config is absent; given
+// any partial config it leaves the unset fields at their struct defaults
+// (C_out_block = 0, grid = 1x1), which break the kernel's blocking invariants
+// for some shapes. TTIRToTTNN pins c_in_block = TILE_WIDTH (32) and
+// TTNNPrepareConv3dWeights completes the config with tt-metal's own defaults
+// (t/w/h_out_block = 1, c_out_block = 32) plus the device worker grid, so the
+// op's config is the single source of truth on every backend.
+module {
+  func.func @conv3d_default_c_in_block(%arg0: tensor<1x8x28x28x32xbf16>, %arg1: tensor<32x32x3x3x3xbf16>) -> tensor<1x6x26x26x32xbf16> {
+    // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: t_out_block = 1
+    // CHECK-SAME: w_out_block = 1
+    // CHECK-SAME: h_out_block = 1
+    // CHECK-SAME: c_out_block = 32
+    // CHECK-SAME: c_in_block = 32
+    // CHECK-SAME: compute_with_storage_grid_size = #ttcore.grid<
+    %0 = "ttir.conv3d"(%arg0, %arg1)
+            <{
+              stride = array<i32: 1, 1, 1>,
+              padding = array<i32: 0, 0, 0>,
+              padding_mode = "zeros",
+              groups = 1: i32
+            }> : (tensor<1x8x28x28x32xbf16>, tensor<32x32x3x3x3xbf16>) -> tensor<1x6x26x26x32xbf16>
+    return %0 : tensor<1x6x26x26x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_config_override_greedy.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_config_override_greedy.mlir
@@ -1,0 +1,66 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=1 enable-greedy-optimizer=true override-conv3d-config=conv3d_full=weights_dtype#bf16:t_out_block#1:w_out_block#1:h_out_block#1:c_out_block#32:c_in_block#64,conv3d_partial=c_in_block#64" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Same as conv3d_config_override.mlir but with the greedy memory-layout
+// optimizer (enable-greedy-optimizer=true, the default at optimization-level>=1)
+// instead of the chain TTNNOptimizer. Regression test for Conv3dRuleBook
+// getOutputHints: without it the greedy path's base getOutputHints emits a null
+// hint that drops the Conv3dConfig, so --override-conv3d-config was silently
+// ignored under greedy. Both paths must pin the same fields.
+module {
+  // Full override: every field pinned. The emitted conv3d_config must reflect
+  // exactly the override values. TTNNPrepareConv3dWeights additionally fills
+  // compute_with_storage_grid_size from the device worker grid (the override
+  // syntax has no field for it), so a grid must also appear.
+  func.func @full(
+      %arg0: tensor<1x8x28x28x128xbf16>,
+      %arg1: tensor<32x128x3x3x3xbf16>)
+      -> tensor<1x6x26x26x32xbf16> {
+    // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: weights_dtype = bf16
+    // CHECK-SAME: t_out_block = 1
+    // CHECK-SAME: w_out_block = 1
+    // CHECK-SAME: h_out_block = 1
+    // CHECK-SAME: c_out_block = 32
+    // CHECK-SAME: c_in_block = 64
+    // CHECK-SAME: compute_with_storage_grid_size = #ttcore.grid<
+    %0 = "ttir.conv3d"(%arg0, %arg1) <{
+        stride = array<i32: 1, 1, 1>,
+        padding = array<i32: 0, 0, 0>,
+        groups = 1 : i32,
+        padding_mode = "zeros"
+      }> : (tensor<1x8x28x28x128xbf16>, tensor<32x128x3x3x3xbf16>)
+        -> tensor<1x6x26x26x32xbf16> loc(#loc_full)
+    return %0 : tensor<1x6x26x26x32xbf16>
+  }
+
+  // Partial override: only c_in_block pinned at 64. The greedy path must still
+  // carry the override config through; TTNNPrepareConv3dWeights then completes
+  // the unset fields with tt-metal's defaults (t/w/h_out_block = 1,
+  // c_out_block = 32) plus the device worker grid.
+  func.func @partial(
+      %arg0: tensor<1x8x28x28x128xbf16>,
+      %arg1: tensor<32x128x3x3x3xbf16>)
+      -> tensor<1x6x26x26x32xbf16> {
+    // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: t_out_block = 1
+    // CHECK-SAME: w_out_block = 1
+    // CHECK-SAME: h_out_block = 1
+    // CHECK-SAME: c_out_block = 32
+    // CHECK-SAME: c_in_block = 64
+    // CHECK-SAME: compute_with_storage_grid_size = #ttcore.grid<
+    %0 = "ttir.conv3d"(%arg0, %arg1) <{
+        stride = array<i32: 1, 1, 1>,
+        padding = array<i32: 0, 0, 0>,
+        groups = 1 : i32,
+        padding_mode = "zeros"
+      }> : (tensor<1x8x28x28x128xbf16>, tensor<32x128x3x3x3xbf16>)
+        -> tensor<1x6x26x26x32xbf16> loc(#loc_partial)
+    return %0 : tensor<1x6x26x26x32xbf16>
+  }
+}
+#loc_full = loc("conv3d_full")
+#loc_partial = loc("conv3d_partial")

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_heuristic.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_heuristic.mlir
@@ -1,0 +1,63 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=1 enable-greedy-optimizer=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=1 enable-greedy-optimizer=false" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verifies the conv3d config heuristic (tt-metal _DEFAULT_BLOCKINGS lookup in
+// LegalOpConfigAnalysis). When (in_channels, out_channels, kernel) matches a
+// table entry the optimizer pins the table's blocking; otherwise it keeps the
+// conversion default. The heuristic runs the same on both the greedy and chain
+// optimizer paths, so both RUN lines share these checks.
+module {
+  // in=192, out=384, kernel=(3,3,3) matches _DEFAULT_BLOCKINGS:
+  //   (192, 384, (3, 3, 3)): (C_in=64, C_out=128, T=1, H=8, W=4)
+  // Remapped to Conv3dConfig fields: t=1, w=4, h=8, c_out=128, c_in=64. Note
+  // c_out_block=128 and w/h_out_block != 1 distinguish this from the constant
+  // conversion default (t=w=h=1, c_out=32, c_in=32).
+  func.func @match(
+      %arg0: tensor<1x8x28x28x192xbf16>,
+      %arg1: tensor<384x192x3x3x3xbf16>)
+      -> tensor<1x6x26x26x384xbf16> {
+    // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: t_out_block = 1
+    // CHECK-SAME: w_out_block = 4
+    // CHECK-SAME: h_out_block = 8
+    // CHECK-SAME: c_out_block = 128
+    // CHECK-SAME: c_in_block = 64
+    // CHECK-SAME: compute_with_storage_grid_size = #ttcore.grid<
+    %0 = "ttir.conv3d"(%arg0, %arg1) <{
+        stride = array<i32: 1, 1, 1>,
+        padding = array<i32: 0, 0, 0>,
+        groups = 1 : i32,
+        padding_mode = "zeros"
+      }> : (tensor<1x8x28x28x192xbf16>, tensor<384x192x3x3x3xbf16>)
+        -> tensor<1x6x26x26x384xbf16>
+    return %0 : tensor<1x6x26x26x384xbf16>
+  }
+
+  // in=128, out=32, kernel=(3,3,3) is absent from the table, so the optimizer
+  // keeps the constant conversion default: t=w=h=1, c_out=32, c_in=32.
+  func.func @nomatch(
+      %arg0: tensor<1x8x28x28x128xbf16>,
+      %arg1: tensor<32x128x3x3x3xbf16>)
+      -> tensor<1x6x26x26x32xbf16> {
+    // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: t_out_block = 1
+    // CHECK-SAME: w_out_block = 1
+    // CHECK-SAME: h_out_block = 1
+    // CHECK-SAME: c_out_block = 32
+    // CHECK-SAME: c_in_block = 32
+    // CHECK-SAME: compute_with_storage_grid_size = #ttcore.grid<
+    %0 = "ttir.conv3d"(%arg0, %arg1) <{
+        stride = array<i32: 1, 1, 1>,
+        padding = array<i32: 0, 0, 0>,
+        groups = 1 : i32,
+        padding_mode = "zeros"
+      }> : (tensor<1x8x28x28x128xbf16>, tensor<32x128x3x3x3xbf16>)
+        -> tensor<1x6x26x26x32xbf16>
+    return %0 : tensor<1x6x26x26x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_heuristic_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv3d/conv3d_heuristic_override.mlir
@@ -1,0 +1,40 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=1 enable-greedy-optimizer=true override-conv3d-config=conv3d_match=c_out_block#96" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verifies override/heuristic precedence: a --override-conv3d-config field wins
+// over the tt-metal _DEFAULT_BLOCKINGS heuristic, while the fields the override
+// leaves unset come from the heuristic (not the constant conversion default).
+module {
+  // in=192, out=384, kernel=(3,3,3) matches the table entry
+  //   (192, 384, (3, 3, 3)): (C_in=64, C_out=128, T=1, H=8, W=4).
+  // The override pins c_out_block=96, so the emitted config must show
+  // c_out_block=96 (override wins over the heuristic's 128) while
+  // w_out_block=4, h_out_block=8, c_in_block=64 come from the heuristic --
+  // values that differ from both the override and the constant conversion
+  // default (w=h=1, c_in=32), proving the heuristic, not the default, supplied
+  // the unset fields. (c_out_block=96 also divides out_channels=384, so it
+  // survives the post-optimizer config validation.)
+  func.func @match(
+      %arg0: tensor<1x8x28x28x192xbf16>,
+      %arg1: tensor<384x192x3x3x3xbf16>)
+      -> tensor<1x6x26x26x384xbf16> {
+    // CHECK: "ttnn.conv3d"
+    // CHECK-SAME: conv3d_config = #ttnn.conv3d_config<
+    // CHECK-SAME: t_out_block = 1
+    // CHECK-SAME: w_out_block = 4
+    // CHECK-SAME: h_out_block = 8
+    // CHECK-SAME: c_out_block = 96
+    // CHECK-SAME: c_in_block = 64
+    // CHECK-SAME: compute_with_storage_grid_size = #ttcore.grid<
+    %0 = "ttir.conv3d"(%arg0, %arg1) <{
+        stride = array<i32: 1, 1, 1>,
+        padding = array<i32: 0, 0, 0>,
+        groups = 1 : i32,
+        padding_mode = "zeros"
+      }> : (tensor<1x8x28x28x192xbf16>, tensor<384x192x3x3x3xbf16>)
+        -> tensor<1x6x26x26x384xbf16> loc(#loc_match)
+    return %0 : tensor<1x6x26x26x384xbf16>
+  }
+}
+#loc_match = loc("conv3d_match")

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_unittest(OptimizerTests
     TestLegalLayoutAnalysis.cpp
     TestLegalTensorLayoutAnalysis.cpp
     TestConv2dConfigGenerator.cpp
+    TestConv3dConfigHeuristic.cpp
     PARTIAL_SOURCES_INTENDED
 )
 

--- a/test/unittests/Optimizer/TestConv3dConfigHeuristic.cpp
+++ b/test/unittests/Optimizer/TestConv3dConfigHeuristic.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/Conv3dConfigHeuristic.h"
+
+#include "llvm-gtest/gtest/gtest.h"
+
+using namespace mlir::tt::ttnn;
+
+TEST(Conv3dConfigHeuristicTest, ExactMatchRemapsFieldOrder) {
+  // tt-metal _DEFAULT_BLOCKINGS entry:
+  //   (192, 384, (3, 3, 3)): (64, 128, 1, 8, 4)
+  // value tuple order = (C_in_block, C_out_block, T_out, H_out, W_out).
+  std::optional<Conv3dBlocking> blocking =
+      lookupConv3dBlocking(192, 384, {3, 3, 3});
+  ASSERT_TRUE(blocking.has_value());
+  EXPECT_EQ(blocking->tOutBlock, 1u);
+  EXPECT_EQ(blocking->wOutBlock, 4u);
+  EXPECT_EQ(blocking->hOutBlock, 8u);
+  EXPECT_EQ(blocking->cOutBlock, 128u);
+  EXPECT_EQ(blocking->cInBlock, 64u);
+}
+
+TEST(Conv3dConfigHeuristicTest, KernelIsPartOfKey) {
+  // (192, 96, (1, 3, 3)) exists; (192, 96, (3, 3, 3)) does not.
+  EXPECT_TRUE(lookupConv3dBlocking(192, 96, {1, 3, 3}).has_value());
+  EXPECT_FALSE(lookupConv3dBlocking(192, 96, {3, 3, 3}).has_value());
+}
+
+TEST(Conv3dConfigHeuristicTest, MissReturnsNullopt) {
+  // Not in the table.
+  EXPECT_FALSE(lookupConv3dBlocking(128, 32, {3, 3, 3}).has_value());
+  EXPECT_FALSE(lookupConv3dBlocking(7, 13, {3, 3, 3}).has_value());
+}
+
+TEST(Conv3dConfigHeuristicTest, WrongKernelRankIsMiss) {
+  EXPECT_FALSE(lookupConv3dBlocking(192, 384, {3, 3}).has_value());
+  EXPECT_FALSE(lookupConv3dBlocking(192, 384, {3, 3, 3, 3}).has_value());
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8295

### Problem description
Conv3dOp had no config heuristic, and its chosen config was silently dropped under the greedy optimizer (the default at optimization-level>=1): conv3d output is interleaved DRAM, but the base OpRuleBook::getOutputHints emits a null primary hint and only forwards sharded configs as fallbacks, so the Conv3dConfig never became a hint and the null hint won.

### What's changed
- LegalOpConfigAnalysis seeds each Conv3dOp's config from a lookup of tt-metal's _DEFAULT_BLOCKINGS table (models/tt_dit/utils/conv3d.py), keyed by (in_channels, out_channels, kernel). On a match the table's blocking becomes the base config; on a miss the conversion default is kept. Precedence is --override-conv3d-config > heuristic > conversion default, with overrides merged per field on top of the heuristic base. Match and miss are logged via TTMLIR_TRACE under the "optimizer" component, matching conv2d.
- Conv3dRuleBook now overrides getOutputHints to forward the full legal configs as primary hints (no shard-layout embedding -- conv3d is interleaved-only), so the chosen config survives greedy. Conv2dRuleBook already did this.

### Checklist
- [x] New/Existing tests provide coverage for changes
