### PR TITLE
[d2m] optimizations to frontend passes

### DIFF
--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -121,7 +121,6 @@ void createD2MFrontendPipeline(OpPassManager &pm,
   pm.addPass(d2m::createD2MGridSelection(gridOptOptions));
   pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(d2m::createD2MOptimizeMasks());
-  pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(d2m::createD2MLowerToLayout());
   pm.addPass(d2m::createD2MMaterializeViewReturns());
 

--- a/lib/Dialect/D2M/Transforms/DecomposeMasking.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeMasking.cpp
@@ -14,7 +14,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 #include <functional>
 #include <limits>
@@ -251,10 +251,19 @@ struct DecomposeMaskPattern : OpRewritePattern<MaskOp> {
     if (validColsInLastTile == 0) {
       validColsInLastTile = kTileWidth;
     }
+    bool hasPartialRow = validRowsInLastTile != kTileHeight;
+    bool hasPartialCol = validColsInLastTile != kTileWidth;
 
     // Total tiles in the padded shape.
     int64_t totalTileRows = shardTileRows * gridShape[gridShape.size() - 2];
     int64_t totalTileCols = shardTileCols * gridShape[gridShape.size() - 1];
+    int64_t validTileRows = lastValidRow + 1;
+    int64_t validTileCols = lastValidCol + 1;
+
+    // Fully valid regions can include the final tile row/col when the logical
+    // size is tile-aligned along that dimension.
+    int64_t interiorRowEnd = hasPartialRow ? lastValidRow : validTileRows;
+    int64_t interiorColEnd = hasPartialCol ? lastValidCol : validTileCols;
 
     Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     Value oneIdx = rewriter.create<arith::ConstantIndexOp>(loc, 1);
@@ -278,9 +287,13 @@ struct DecomposeMaskPattern : OpRewritePattern<MaskOp> {
         rewriter.create<arith::ConstantIndexOp>(loc, validColsInLastTile);
 
     TT_assert(rowMaskCB);
-    rewriter.create<WriteRowMaskTileOp>(loc, validRowsVal, rowMaskCB);
+    if (hasPartialRow) {
+      rewriter.create<WriteRowMaskTileOp>(loc, validRowsVal, rowMaskCB);
+    }
     TT_assert(colMaskCB);
-    rewriter.create<WriteColMaskTileOp>(loc, validColsVal, colMaskCB);
+    if (hasPartialCol) {
+      rewriter.create<WriteColMaskTileOp>(loc, validColsVal, colMaskCB);
+    }
 
     // === Tile operation helpers ===
     auto createTileFill = [&]() {
@@ -416,52 +429,66 @@ struct DecomposeMaskPattern : OpRewritePattern<MaskOp> {
           return outermostLoop;
         };
 
+    auto createGlobalRegionLoop =
+        [&](int64_t rowGlobalStart, int64_t rowGlobalEnd,
+            int64_t colGlobalStart, int64_t colGlobalEnd,
+            std::function<void(ArrayRef<Value>, Value, Value)> emitBody) {
+          if (rowGlobalStart >= rowGlobalEnd ||
+              colGlobalStart >= colGlobalEnd) {
+            return static_cast<Operation *>(nullptr);
+          }
+          auto [rowStart, rowEnd] =
+              computeLocalBounds(rewriter, loc, rowGlobalStart, rowGlobalEnd,
+                                 coreY, shardTileRows);
+          auto [colStart, colEnd] =
+              computeLocalBounds(rewriter, loc, colGlobalStart, colGlobalEnd,
+                                 coreX, shardTileCols);
+          return createLocalLoop(rowStart, rowEnd, colStart, colEnd, emitBody);
+        };
+
     OpBuilder::InsertionGuard guard(rewriter);
     Operation *insertionPoint = &region.front().back();
 
     // =========================================================================
     // LOOP 0: Interior tiles - fully valid.
-    // Global region: [0, lastValidRow) x [0, lastValidCol).
+    // Global region: [0, interiorRowEnd) x [0, interiorColEnd).
+    // Tile-aligned dimensions include their final valid tile here.
     // =========================================================================
     {
       rewriter.setInsertionPointAfter(insertionPoint);
-      auto [rowStart, rowEnd] = computeLocalBounds(
-          rewriter, loc, 0, lastValidRow, coreY, shardTileRows);
-      auto [colStart, colEnd] = computeLocalBounds(
-          rewriter, loc, 0, lastValidCol, coreX, shardTileCols);
-      auto *loop =
-          createLocalLoop(rowStart, rowEnd, colStart, colEnd, emitPassthrough);
-      insertionPoint = loop;
+      auto *loop = createGlobalRegionLoop(0, interiorRowEnd, 0, interiorColEnd,
+                                          emitPassthrough);
+      if (loop) {
+        insertionPoint = loop;
+      }
     }
 
     // =========================================================================
     // LOOP 1: Last valid row - needs row masking.
-    // Global region: [lastValidRow, lastValidRow+1) x [0, lastValidCol).
+    // Global region: [lastValidRow, lastValidRow+1) x [0, interiorColEnd).
+    // Emitted only when the row dimension has a partial final tile.
     // =========================================================================
-    {
+    if (hasPartialRow) {
       rewriter.setInsertionPointAfter(insertionPoint);
-      auto [rowStart, rowEnd] = computeLocalBounds(
-          rewriter, loc, lastValidRow, lastValidRow + 1, coreY, shardTileRows);
-      auto [colStart, colEnd] = computeLocalBounds(
-          rewriter, loc, 0, lastValidCol, coreX, shardTileCols);
-      auto *loop =
-          createLocalLoop(rowStart, rowEnd, colStart, colEnd, emitRowMasked);
-      insertionPoint = loop;
+      auto *loop = createGlobalRegionLoop(lastValidRow, lastValidRow + 1, 0,
+                                          interiorColEnd, emitRowMasked);
+      if (loop) {
+        insertionPoint = loop;
+      }
     }
 
     // =========================================================================
     // LOOP 2: Last valid col - needs col masking.
-    // Global region: [0, lastValidRow) x [lastValidCol, lastValidCol+1).
+    // Global region: [0, interiorRowEnd) x [lastValidCol, lastValidCol+1).
+    // Emitted only when the column dimension has a partial final tile.
     // =========================================================================
-    {
+    if (hasPartialCol) {
       rewriter.setInsertionPointAfter(insertionPoint);
-      auto [rowStart, rowEnd] = computeLocalBounds(
-          rewriter, loc, 0, lastValidRow, coreY, shardTileRows);
-      auto [colStart, colEnd] = computeLocalBounds(
-          rewriter, loc, lastValidCol, lastValidCol + 1, coreX, shardTileCols);
-      auto *loop =
-          createLocalLoop(rowStart, rowEnd, colStart, colEnd, emitColMasked);
-      insertionPoint = loop;
+      auto *loop = createGlobalRegionLoop(0, interiorRowEnd, lastValidCol,
+                                          lastValidCol + 1, emitColMasked);
+      if (loop) {
+        insertionPoint = loop;
+      }
     }
 
     // =========================================================================
@@ -469,15 +496,14 @@ struct DecomposeMaskPattern : OpRewritePattern<MaskOp> {
     // Global region: [lastValidRow, lastValidRow+1) x [lastValidCol,
     // lastValidCol+1).
     // =========================================================================
-    if (rowMaskCB && colMaskCB) {
+    if (hasPartialRow && hasPartialCol) {
       rewriter.setInsertionPointAfter(insertionPoint);
-      auto [rowStart, rowEnd] = computeLocalBounds(
-          rewriter, loc, lastValidRow, lastValidRow + 1, coreY, shardTileRows);
-      auto [colStart, colEnd] = computeLocalBounds(
-          rewriter, loc, lastValidCol, lastValidCol + 1, coreX, shardTileCols);
       auto *loop =
-          createLocalLoop(rowStart, rowEnd, colStart, colEnd, emitCornerMasked);
-      insertionPoint = loop;
+          createGlobalRegionLoop(lastValidRow, lastValidRow + 1, lastValidCol,
+                                 lastValidCol + 1, emitCornerMasked);
+      if (loop) {
+        insertionPoint = loop;
+      }
     }
 
     // =========================================================================
@@ -486,29 +512,25 @@ struct DecomposeMaskPattern : OpRewritePattern<MaskOp> {
     // =========================================================================
     {
       rewriter.setInsertionPointAfter(insertionPoint);
-      auto [rowStart, rowEnd] = computeLocalBounds(
-          rewriter, loc, lastValidRow + 1, totalTileRows, coreY, shardTileRows);
-      auto [colStart, colEnd] = computeLocalBounds(
-          rewriter, loc, 0, totalTileCols, coreX, shardTileCols);
-      auto *loop =
-          createLocalLoop(rowStart, rowEnd, colStart, colEnd, emitFill);
-      insertionPoint = loop;
+      auto *loop = createGlobalRegionLoop(validTileRows, totalTileRows, 0,
+                                          totalTileCols, emitFill);
+      if (loop) {
+        insertionPoint = loop;
+      }
     }
 
     // =========================================================================
     // LOOP 5: OOB cols - fill columns beyond valid region (for valid rows
-    // only). Global region: [0, lastValidRow+1) x [lastValidCol+1,
+    // only). Global region: [0, validTileRows) x [validTileCols,
     // totalTileCols).
     // =========================================================================
     {
       rewriter.setInsertionPointAfter(insertionPoint);
-      auto [rowStart, rowEnd] = computeLocalBounds(
-          rewriter, loc, 0, lastValidRow + 1, coreY, shardTileRows);
-      auto [colStart, colEnd] = computeLocalBounds(
-          rewriter, loc, lastValidCol + 1, totalTileCols, coreX, shardTileCols);
-      auto *loop =
-          createLocalLoop(rowStart, rowEnd, colStart, colEnd, emitFill);
-      insertionPoint = loop;
+      auto *loop = createGlobalRegionLoop(0, validTileRows, validTileCols,
+                                          totalTileCols, emitFill);
+      if (loop) {
+        insertionPoint = loop;
+      }
     }
 
     rewriter.setInsertionPointAfter(insertionPoint);
@@ -533,9 +555,7 @@ struct D2MDecomposeMasking
     RewritePatternSet patterns(ctx);
     patterns.add<DecomposeMaskPattern>(ctx, numStreamBuffers);
 
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
-      signalPassFailure();
-    }
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
   }
 };
 

--- a/lib/Dialect/D2M/Transforms/OptimizeMasks.cpp
+++ b/lib/Dialect/D2M/Transforms/OptimizeMasks.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 #include <limits>
 #include <optional>
@@ -1329,6 +1330,21 @@ static bool canReplaceMaskWithInput(MaskOp maskOp) {
   return maskOp.getInput().getType() == maskOp.getResult().getType();
 }
 
+static void eraseDeadTensorEmptyOps(ArrayRef<EmptyOp> emptyOps) {
+  llvm::SmallPtrSet<Operation *, 8> seen;
+  for (EmptyOp emptyOp : emptyOps) {
+    if (!seen.insert(emptyOp).second) {
+      continue;
+    }
+
+    // Tensor d2m.empty ops are destination placeholders. Once the mask using
+    // one is erased, the placeholder should not be left for canonicalization.
+    if (emptyOp->use_empty()) {
+      emptyOp.erase();
+    }
+  }
+}
+
 class D2MOptimizeMasksPass
     : public impl::D2MOptimizeMasksBase<D2MOptimizeMasksPass> {
 public:
@@ -1337,6 +1353,7 @@ public:
   void runOnOperation() override {
     OOBStateMap states;
     SmallVector<MaskOp> masksToErase;
+    SmallVector<EmptyOp> maybeDeadMaskOutputs;
 
     // Pre-order scan: producer ops update `states`; each mask is checked
     // against the state known for its input at that point.
@@ -1356,6 +1373,10 @@ public:
         }
 
         if (redundant) {
+          if (auto output = maskOp.getOutput().getDefiningOp<EmptyOp>();
+              output && isa<RankedTensorType>(output.getResult().getType())) {
+            maybeDeadMaskOutputs.push_back(output);
+          }
           maskOp.getResult().replaceAllUsesWith(maskOp.getInput());
           masksToErase.push_back(maskOp);
         } else {
@@ -1384,6 +1405,7 @@ public:
     for (MaskOp maskOp : masksToErase) {
       maskOp.erase();
     }
+    eraseDeadTensorEmptyOps(maybeDeadMaskOutputs);
   }
 };
 

--- a/lib/Dialect/D2M/Utils/GridSelectionUtils.cpp
+++ b/lib/Dialect/D2M/Utils/GridSelectionUtils.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Utils.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 #include <array>
@@ -151,25 +152,44 @@ computeOptimalVirtualGrid(ArrayRef<int64_t> physicalShape,
           return ttmlir::utils::getFactors(dim);
         }));
 
-    auto factorCombinations =
-        ttmlir::utils::computeCartesianProduct<int64_t>(factors);
-
     // Find grid with the greatest volume that is less than or equal to the
     // target grid volume.
     SmallVector<int64_t> bestGrid = {0};
     int64_t bestGridVolume = 0;
-    for (const auto &grid : factorCombinations) {
-      int64_t gridVolume = ttmlir::utils::volume<int64_t>(grid);
-      if (gridVolume <= targetGridVolume && gridVolume > bestGridVolume) {
-        auto physGrid =
-            utils::findLegalPhysicalGridForVolume(gridVolume, targetGrid);
-        if (!physGrid.empty()) {
 
-          bestGrid = grid;
-          bestGridVolume = ttmlir::utils::volume<int64_t>(bestGrid);
-        }
+    llvm::DenseMap<int64_t, bool> legalVolumeCache;
+    auto isLegalVolume = [&](int64_t gridVolume) {
+      auto it = legalVolumeCache.find(gridVolume);
+      if (it != legalVolumeCache.end()) {
+        return it->second;
       }
-    }
+      bool isLegal =
+          !utils::findLegalPhysicalGridForVolume(gridVolume, targetGrid)
+               .empty();
+      legalVolumeCache[gridVolume] = isLegal;
+      return isLegal;
+    };
+
+    SmallVector<int64_t> candidateGrid(physicalShape.size(), 1);
+    auto enumerateGrids = [&](auto &&self, size_t dim,
+                              int64_t currentVolume) -> void {
+      if (currentVolume > targetGridVolume) {
+        return;
+      }
+      if (dim == factors.size()) {
+        if (currentVolume > bestGridVolume && isLegalVolume(currentVolume)) {
+          bestGrid.assign(candidateGrid.begin(), candidateGrid.end());
+          bestGridVolume = currentVolume;
+        }
+        return;
+      }
+
+      for (int64_t factor : factors[dim]) {
+        candidateGrid[dim] = factor;
+        self(self, dim + 1, currentVolume * factor);
+      }
+    };
+    enumerateGrids(enumerateGrids, /*dim=*/0, /*currentVolume=*/1);
     return bestGrid;
   }
 

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_masking.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_masking.mlir
@@ -22,7 +22,7 @@ module attributes {ttcore.system_desc = #system_desc} {
     // CHECK-SAME: grid = #ttcore.grid<1x1>
     // CHECK: d2m.remote_load
     // CHECK: d2m.write_row_mask_tile
-    // CHECK: d2m.write_col_mask_tile
+    // CHECK-NOT: d2m.write_col_mask_tile
     // CHECK: scf.for
     // CHECK: d2m.tile_where
     // CHECK: d2m.remote_store


### PR DESCRIPTION
### Problem description
Qwen IR takes too long on these passes

### What's changed
- DecomposeMasking.cpp: avoids greedy rewrite driver, skips unnecessary mask tiles/loops for tile-aligned shapes
- GridSelectionUtils.cpp: avoids materializing all grid combinations; adds pruning and cached legality checks
- OptimizeMasks.cpp: removes now-dead tensor d2m.empty outputs when masks are erased
- D2MPipelines.cpp: removes the canonicalizer immediately after D2MOptimizeMasks

Cuts pass runtime down by around 15s

### Checklist
- [ ] New/Existing tests provide coverage for changes
