### PR TITLE
fix + workaround for unet 3d model

### DIFF
--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1750,6 +1750,20 @@ struct OpModel<GroupNormOp> {
                std::optional<llvm::ArrayRef<int64_t>> biasShape,
                std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
                llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
+
+  // Raw tt-metal group_norm constraint query, i.e. getOpConstraints without the
+  // ROW_MAJOR-input workaround it applies on top (tt-metal#47972). Delete
+  // together with the workaround once tt-metal#47972 is fixed and the tripwire
+  // test gets triggered.
+  static llvm::Expected<OpConstraints> getOpConstraintsRaw(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
+      std::optional<TTNNLayoutAttr> inputMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
+      llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -16,7 +16,13 @@
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device.hpp>
 
+#include <umd/device/cluster.hpp>
+#include <umd/device/cluster_descriptor.hpp>
+
 #include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <optional>
 #include <string>
 
 namespace mlir::tt::ttnn::op_model {
@@ -61,6 +67,41 @@ makeEnvDescriptor(bool isMock, ttcore::Arch arch, uint32_t numChips) {
   if (!isMock) {
     return ::tt::tt_metal::MetalEnvDescriptor{};
   }
+
+  // Prefer the live machine's real cluster descriptor over the canned mock
+  // board, but only when it matches the requested (arch, numChips) mock —
+  // discovery describes the physical box, which may differ (multi-chip mock on
+  // a single-chip box, or a cross-arch mock). Discovery is process-global and
+  // not free, so cache it once and decide per call. Arch is compared via the
+  // total toMetalArch(), so an unmappable live arch falls back to the canned
+  // board instead of aborting.
+  struct DiscoveredCluster {
+    std::string path;
+    ::tt::ARCH arch;
+    uint32_t numChips;
+  };
+  static const std::optional<DiscoveredCluster> discovered =
+      []() -> std::optional<DiscoveredCluster> {
+    try {
+      std::unique_ptr<::tt::umd::ClusterDescriptor> desc =
+          ::tt::umd::Cluster::create_cluster_descriptor();
+      if (!desc || desc->get_number_of_chips() == 0) {
+        return std::nullopt;
+      }
+      return DiscoveredCluster{
+          desc->serialize_to_file().string(), desc->get_arch(),
+          static_cast<uint32_t>(desc->get_number_of_chips())};
+    } catch (const std::exception &) {
+      // No hardware / discovery failed (e.g. headless CI): fall back below.
+      return std::nullopt;
+    }
+  }();
+
+  if (discovered && discovered->arch == toMetalArch(arch) &&
+      discovered->numChips == numChips) {
+    return ::tt::tt_metal::MetalEnvDescriptor{discovered->path};
+  }
+
   auto mockClusterPath =
       ::tt::tt_metal::experimental::get_mock_cluster_desc_name(
           toMetalArch(arch), numChips);

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -6711,6 +6711,32 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
     llvm::APFloat epsilon, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
+  // tt-metal's group_norm hangs on a ROW_MAJOR input, reject row-major input
+  // here to force the optimizer to select a TILE input layout. tt-metal#47972
+  // tracks this issue. The raw query lives in getOpConstraintsRaw so the
+  // tripwire test can observe tt-metal's unguarded verdict; remove both once
+  // tt-metal#47972 is fixed.
+  if (inputLayout.getLayout() == mlir::tt::ttnn::Layout::RowMajor) {
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "group_norm ROW_MAJOR input is unsupported (hangs); requires TILE");
+  }
+#endif // TTMLIR_ENABLE_OPMODEL
+  return getOpConstraintsRaw(
+      inputShape, inputLayout, inputMaskShape, inputMaskLayout, weightShape,
+      weightLayout, biasShape, biasLayout, numGroups, epsilon, outputLayout);
+}
+
+llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraintsRaw(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
+    std::optional<TTNNLayoutAttr> inputMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
+    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
@@ -6761,6 +6787,15 @@ llvm::Expected<size_t> OpModel<GroupNormOp>::getOpRuntime(
     std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
     llvm::APFloat epsilon, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
+  // tt-metal's group_norm hangs on a ROW_MAJOR input, reject row-major input
+  // here to force the optimizer to select a TILE input layout. tt-metal#47972
+  // tracks this issue.
+  if (inputLayout.getLayout() == mlir::tt::ttnn::Layout::RowMajor) {
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "group_norm ROW_MAJOR input is unsupported (hangs); requires TILE");
+  }
+
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires.cpp
@@ -14,8 +14,51 @@
 
 #include "OpModelFixture.h"
 
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
+
 namespace mlir::tt::ttnn::op_model {
 
 class OpModelTripwireTest : public OpModelFixture {};
+
+// tt-metal's group_norm hangs on a ROW_MAJOR input, yet its constraint query
+// reports row-major as legal, so OpModel<GroupNormOp>::getOpConstraints applies
+// a workaround that rejects row-major up front
+// (https://github.com/tenstorrent/tt-metal/issues/47972).
+//
+// This queries tt-metal's *unguarded* verdict via getOpConstraintsRaw and
+// asserts it still reports row-major as legal. Once tt-metal#47972 fixes the
+// query to reject row-major, this flips to a failed query and the EXPECT_TRUE
+// trips — the signal to delete the workaround (and getOpConstraintsRaw) from
+// TTNNOpModel and this test.
+TEST_F(OpModelTripwireTest, GroupNormRowMajorInputStillReportedLegal) {
+  const llvm::SmallVector<int64_t> inputShape = {1, 1, 64, 480};
+  const llvm::SmallVector<int64_t> outputShape = {1, 1, 64, 480};
+  const llvm::SmallVector<int64_t> inputMaskShape = {1, 8, 32, 96};
+  const llvm::SmallVector<int64_t> weightShape = {1, 1, 15, 32};
+  const llvm::SmallVector<int64_t> biasShape = {1, 1, 15, 32};
+
+  // The input layout under test: ROW_MAJOR (the layout the workaround rejects).
+  const TTNNLayoutAttr inputLayoutRowMajor = CreateRowMajorLayout(
+      inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr inputMaskLayout = CreateTiledLayout(
+      inputMaskShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr weightLayout = CreateRowMajorLayout(
+      weightShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr biasLayout = CreateRowMajorLayout(
+      biasShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<GroupNormOp>::getOpConstraintsRaw(
+      inputShape, inputLayoutRowMajor, inputMaskShape, inputMaskLayout,
+      weightShape, weightLayout, biasShape, biasLayout, /*numGroups=*/8,
+      llvm::APFloat(1e-5f), outputLayout);
+  const bool ok = static_cast<bool>(constraintsExp);
+  if (!ok) {
+    llvm::consumeError(constraintsExp.takeError());
+  }
+  EXPECT_TRUE(ok);
+}
 
 } // namespace mlir::tt::ttnn::op_model


### PR DESCRIPTION
### Problem description
Issue 1 — Op-model ignores real chip harvesting: At optimization_level≥1 the op-model opened a mock device built from a canned unharvested per-arch cluster descriptor, so on a harvested Blackhole P100 it planned op placements onto cores that are fused off, baking invalid placements into the flatbuffer and deadlocking the first kernel launch.

Issue 2 — group_norm hangs on a ROW_MAJOR input: tt-metal's ttnn.group_norm deadlocks when given a ROW_MAJOR input (the TILE path works), and the tt-mlir optimizer was selecting row-major for group_norm's input, so the model hung at that op. I've opened a tt-metal issue https://github.com/tenstorrent/tt-metal/issues/47972 to address the hang

### What's changed
- `makeEnvDescriptor` now does live UMD topology discovery (`Cluster::create_cluster_descriptor(`) → serialize) to feed the op-model the real chip's descriptor with its true harvest masks, falling back to the canned board only when no hardware topolology is found.
- Reject a ROW_MAJOR input in the op-model's `OpModel<GroupNormOp>::getOpConstraints` so the optimizer is forced to pick TILE — and crucially this is enforced via validateOperation
    - a NormalizationRules rule-book filter does not work, since the row-major propagation pass pins the layout first using the op-model, not the rule book.
- Added tripwire test so we know when we can remove the "Reject ROW_MAJOR input" group_norm workaround once https://github.com/tenstorrent/tt-metal/pull/48143 is uplifted.

### Checklist
- [x] New/Existing tests provide coverage for changes
