### PR TITLE
[D2M-JIT] Fix d2m-jit tile matmul accumulator zeroing

### DIFF
--- a/include/ttmlir/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.h
@@ -23,9 +23,14 @@ struct CBUsageInfo {
 
 llvm::DenseMap<Value, CBUsageInfo> getCBUsageInfo(Region &genericRegion);
 
+/// Returns true if `op` is pure and all operations defining its operands are
+/// also purely derived. Block arguments are considered pure roots.
+bool isPurelyDerivedOp(Operation *op,
+                       DenseMap<Operation *, bool> &purelyDerivedOps);
+
 /// Wraps a range of ops [start, end) in a SynchronizedRegionOp.
 ///
-/// PRECONDITION: No op in [start, end) with a side effect (i.e. not pure) may
+/// PRECONDITION: No op in [start, end) that is not purely derived may
 /// produce SSA results that are used outside of [start, end). Since
 /// SynchronizedRegionOp has no results, any such external uses would become
 /// invalid when the original ops are erased.

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1013,32 +1013,12 @@ public:
       }
 
       rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
-      Value dstIdx = getDstIdxFromResult(op.getResult());
-      ensureDominatesInsertionPoint(rewriter, dstIdx);
-
-      // tile_matmul lowers as dst = a @ b + dst, so initialize the
-      // accumulator once before the first K iteration.
-      auto emitZeroAccumulator = [&]() {
-        auto zero = rewriter.create<arith::ConstantOp>(
-            op->getLoc(), rewriter.getF32FloatAttr(0.0));
-        rewriter.create<ttkernel::FillTileInitOp>(op->getLoc());
-        rewriter.create<ttkernel::FillTileOp>(op->getLoc(), dstIdx, zero);
-      };
-      if (Value seedGuard = buildFirstReductionIterationGuard(
-              rewriter, op->getLoc(), op, dstIdx)) {
-        auto ifOp = rewriter.create<scf::IfOp>(op->getLoc(), seedGuard,
-                                               /*withElseRegion=*/false);
-        OpBuilder::InsertionGuard guard(rewriter);
-        rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
-        emitZeroAccumulator();
-      }
-
-      rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
       auto transpose = intConstant<int32_t>(rewriter, op->getLoc(), 0);
       rewriter.create<ttkernel::MatmulInitShortOp>(op->getLoc(), cbA, cbB,
                                                    transpose);
-      rewriter.create<ttkernel::MatmulTilesOp>(
-          op->getLoc(), cbA, cbB, adaptor.getA(), adaptor.getB(), dstIdx);
+      rewriter.create<ttkernel::MatmulTilesOp>(op->getLoc(), cbA, cbB,
+                                               adaptor.getA(), adaptor.getB(),
+                                               adaptor.getC());
     } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileMatmulBlockOp>) {
       auto insertionPoint = rewriter.getInsertionPoint();
       auto cbA = getCB(rewriter, op.getA());

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1016,7 +1016,9 @@ public:
       Value dstIdx = getDstIdxFromResult(op.getResult());
       ensureDominatesInsertionPoint(rewriter, dstIdx);
 
-      auto emitSeed = [&]() {
+      // tile_matmul lowers as dst = a @ b + dst, so initialize the
+      // accumulator once before the first K iteration.
+      auto emitZeroAccumulator = [&]() {
         auto zero = rewriter.create<arith::ConstantOp>(
             op->getLoc(), rewriter.getF32FloatAttr(0.0));
         rewriter.create<ttkernel::FillTileInitOp>(op->getLoc());
@@ -1028,7 +1030,7 @@ public:
                                                /*withElseRegion=*/false);
         OpBuilder::InsertionGuard guard(rewriter);
         rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
-        emitSeed();
+        emitZeroAccumulator();
       }
 
       rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1013,12 +1013,30 @@ public:
       }
 
       rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
+      Value dstIdx = getDstIdxFromResult(op.getResult());
+      ensureDominatesInsertionPoint(rewriter, dstIdx);
+
+      auto emitSeed = [&]() {
+        auto zero = rewriter.create<arith::ConstantOp>(
+            op->getLoc(), rewriter.getF32FloatAttr(0.0));
+        rewriter.create<ttkernel::FillTileInitOp>(op->getLoc());
+        rewriter.create<ttkernel::FillTileOp>(op->getLoc(), dstIdx, zero);
+      };
+      if (Value seedGuard = buildFirstReductionIterationGuard(
+              rewriter, op->getLoc(), op, dstIdx)) {
+        auto ifOp = rewriter.create<scf::IfOp>(op->getLoc(), seedGuard,
+                                               /*withElseRegion=*/false);
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+        emitSeed();
+      }
+
+      rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
       auto transpose = intConstant<int32_t>(rewriter, op->getLoc(), 0);
       rewriter.create<ttkernel::MatmulInitShortOp>(op->getLoc(), cbA, cbB,
                                                    transpose);
-      rewriter.create<ttkernel::MatmulTilesOp>(op->getLoc(), cbA, cbB,
-                                               adaptor.getA(), adaptor.getB(),
-                                               adaptor.getC());
+      rewriter.create<ttkernel::MatmulTilesOp>(
+          op->getLoc(), cbA, cbB, adaptor.getA(), adaptor.getB(), dstIdx);
     } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileMatmulBlockOp>) {
       auto insertionPoint = rewriter.getInsertionPoint();
       auto cbA = getCB(rewriter, op.getA());

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/OpDefinition.h"
@@ -487,6 +488,20 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
               // Continue tracing through this operation's results
               for (OpResult result : op->getResults()) {
                 for (Operation *userOp : result.getUsers()) {
+                  worklist.push_back(userOp);
+                }
+              }
+            }
+
+            if (auto forOp = mlir::dyn_cast<scf::ForOp>(op)) {
+              rewriter.modifyOpInPlace(op, [&]() {
+                for (auto [init, iterArg] : llvm::zip_equal(
+                         forOp.getInitArgs(), forOp.getRegionIterArgs())) {
+                  iterArg.setType(init.getType());
+                }
+              });
+              for (BlockArgument iterArg : forOp.getRegionIterArgs()) {
+                for (Operation *userOp : iterArg.getUsers()) {
                   worklist.push_back(userOp);
                 }
               }
@@ -1235,8 +1250,9 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
               return WalkResult::advance();
             }
             auto *allocOp = remoteStoreOp.getLocalBuffer().getDefiningOp();
-            TT_assertv(mlir::isa<memref::AllocOp>(allocOp),
-                       "Expected memref::AllocOp");
+            if (!mlir::isa_and_nonnull<memref::AllocOp>(allocOp)) {
+              return WalkResult::advance();
+            }
             rewriter.setInsertionPoint(allocOp);
             rewriter.replaceOpWithNewOp<d2m::OperandAliasOp>(
                 allocOp, allocOp->getResultTypes(), remoteStoreOp.getMemref());

--- a/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/MarkSynchronizedBuffers.cpp
@@ -64,7 +64,7 @@ public:
       auto cbUsageInfo = utils::getCBUsageInfo(genericOp.getRegion(0));
       for (auto &[cb, usageInfo] : cbUsageInfo) {
         if (auto allocOp =
-                mlir::dyn_cast<memref::AllocOp>(cb.getDefiningOp())) {
+                mlir::dyn_cast_or_null<memref::AllocOp>(cb.getDefiningOp())) {
           bool forceHoistedCB =
               utils::isReductionScalerBuffer(allocOp.getOperation());
           int32_t bufferCount = numStreamBuffers;

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -43,26 +43,9 @@ static bool isSynchronizableBoundaryOp(
          opsWithSynchronizableOps.contains(op);
 }
 
-static bool containsComputeOp(Operation *op) {
-  if (op->hasTrait<D2MGenericRegionComputeOpTrait>()) {
-    return true;
-  }
-  bool containsCompute = false;
-  op->walk([&](Operation *nestedOp) {
-    if (nestedOp != op &&
-        nestedOp->hasTrait<D2MGenericRegionComputeOpTrait>()) {
-      containsCompute = true;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-  return containsCompute;
-}
-
 static bool canMergeIntoComputeRegion(
     Operation *op, const DenseSet<Operation *> &opsWithSynchronizableOps) {
-  return !isSynchronizableBoundaryOp(op, opsWithSynchronizableOps) &&
-         containsComputeOp(op);
+  return !isSynchronizableBoundaryOp(op, opsWithSynchronizableOps);
 }
 
 static bool hasSynchronizableAncestor(Operation *op, GenericOp genericOp) {

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -34,6 +34,123 @@ static void appendUnique(SmallVectorImpl<Value> &values, Value value) {
   }
 }
 
+static bool isSynchronizableBoundaryOp(
+    Operation *op, const DenseSet<Operation *> &opsWithSynchronizableOps) {
+  return dyn_cast<SynchronizableOpInterface>(op) ||
+         opsWithSynchronizableOps.contains(op);
+}
+
+static bool containsComputeOp(Operation *op) {
+  if (op->hasTrait<D2MGenericRegionComputeOpTrait>()) {
+    return true;
+  }
+  bool containsCompute = false;
+  op->walk([&](Operation *nestedOp) {
+    if (nestedOp != op &&
+        nestedOp->hasTrait<D2MGenericRegionComputeOpTrait>()) {
+      containsCompute = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return containsCompute;
+}
+
+static bool canMergeIntoComputeRegion(
+    Operation *op, const DenseSet<Operation *> &opsWithSynchronizableOps) {
+  return !isSynchronizableBoundaryOp(op, opsWithSynchronizableOps) &&
+         containsComputeOp(op);
+}
+
+static bool hasSynchronizableAncestor(Operation *op, GenericOp genericOp) {
+  for (Operation *parent = op->getParentOp();
+       parent && parent != genericOp.getOperation();
+       parent = parent->getParentOp()) {
+    if (dyn_cast<SynchronizableOpInterface>(parent)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static Operation *getAncestorInBlock(Operation *op, Block *block) {
+  Operation *current = op;
+  while (current && current->getBlock() != block) {
+    current = current->getParentOp();
+  }
+  return current;
+}
+
+static bool getSiblingOpsInNearestCommonBlock(Operation *producer,
+                                              Operation *consumer,
+                                              Operation *&producerBoundary,
+                                              Operation *&consumerBoundary) {
+  for (Operation *producerAncestor = producer; producerAncestor;
+       producerAncestor = producerAncestor->getParentOp()) {
+    if (Operation *candidateConsumerBoundary =
+            getAncestorInBlock(consumer, producerAncestor->getBlock())) {
+      producerBoundary = producerAncestor;
+      consumerBoundary = candidateConsumerBoundary;
+      return true;
+    }
+  }
+  return false;
+}
+
+static LogicalResult expandRangeToCoverNonPureResultUses(Block::iterator &start,
+                                                         Block::iterator &end) {
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    Block *block = start->getBlock();
+    DenseSet<Operation *> opsInRange;
+    for (Operation &op : llvm::make_range(start, end)) {
+      opsInRange.insert(&op);
+    }
+
+    for (Operation &rootOp : llvm::make_range(start, end)) {
+      WalkResult walkResult = rootOp.walk([&](Operation *op) {
+        if (mlir::isPure(op)) {
+          return WalkResult::advance();
+        }
+        for (Value result : op->getResults()) {
+          for (Operation *user : result.getUsers()) {
+            if (llvm::any_of(opsInRange, [&](Operation *rangeOp) {
+                  return rangeOp->isAncestor(user);
+                })) {
+              continue;
+            }
+
+            Operation *userBoundary = getAncestorInBlock(user, block);
+            if (!userBoundary) {
+              return WalkResult::interrupt();
+            }
+            if (userBoundary->isBeforeInBlock(&*start)) {
+              start = userBoundary->getIterator();
+              changed = true;
+              return WalkResult::interrupt();
+            }
+            if (end != block->end() && !userBoundary->isBeforeInBlock(&*end)) {
+              end = std::next(userBoundary->getIterator());
+              changed = true;
+              return WalkResult::interrupt();
+            }
+          }
+        }
+        return WalkResult::advance();
+      });
+      if (walkResult.wasInterrupted()) {
+        if (!changed) {
+          return failure();
+        }
+        break;
+      }
+    }
+  }
+
+  return success();
+}
+
 bool isAliasedStore(RemoteStoreOp storeOp) {
   auto operandAliasOp =
       mlir::dyn_cast<OperandAliasOp>(storeOp.getLocalBuffer().getDefiningOp());
@@ -96,22 +213,22 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
   OpBuilder::InsertionGuard guard(rewriter);
 
   // Collect the ops that directly contain SynchronizableOpInterface ops.
-  // These delimit the scope where compute is synchronized: the outermost
-  // compute ancestor is a direct child of such an op, alongside the
-  // synchronizable ops that bound it.
+  // These delimit scopes where compute is synchronized: the outermost compute
+  // ancestor is a direct child of such an op, alongside the synchronizable ops
+  // that bound it. A unified region may have multiple such scopes when, for
+  // example, a pre-loop zero fill feeds a loop-carried matmul accumulator.
   DenseSet<Operation *> opsWithSynchronizableOps;
   genericOp.getRegion(0).walk([&](Operation *op) {
     if (dyn_cast<SynchronizableOpInterface>(op)) {
       opsWithSynchronizableOps.insert(op->getParentOp());
     }
   });
-  assert(opsWithSynchronizableOps.size() == 1 &&
-         "synchronized scope must be unambiguous");
 
   DenseSet<Operation *> outermostOps;
   bool walkFailed = false;
   genericOp.getRegion(0).walk([&](Operation *op) {
-    if (!op->hasTrait<D2MGenericRegionComputeOpTrait>()) {
+    if (!op->hasTrait<D2MGenericRegionComputeOpTrait>() ||
+        hasSynchronizableAncestor(op, genericOp)) {
       return WalkResult::advance();
     }
 
@@ -156,7 +273,8 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
 
     // Expand above.
     while (start != outermostOp->getBlock()->begin() &&
-           !dyn_cast<SynchronizableOpInterface>(std::prev(start))) {
+           canMergeIntoComputeRegion(&*std::prev(start),
+                                     opsWithSynchronizableOps)) {
       start--;
       if (outermostOps.contains(&*start)) {
         outermostOps.erase(&*start);
@@ -164,15 +282,20 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     }
 
     // Expand below.
-    while (std::next(end) != outermostOp->getBlock()->end() &&
-           !dyn_cast<SynchronizableOpInterface>(std::next(end))) {
+    while (
+        std::next(end) != outermostOp->getBlock()->end() &&
+        canMergeIntoComputeRegion(&*std::next(end), opsWithSynchronizableOps)) {
       end++;
       if (outermostOps.contains(&*end)) {
         outermostOps.erase(&*end);
       }
     }
 
-    computeRegions.push_back({start, std::next(end)});
+    Block::iterator wrappedEnd = std::next(end);
+    if (failed(expandRangeToCoverNonPureResultUses(start, wrappedEnd))) {
+      return failure();
+    }
+    computeRegions.push_back({start, wrappedEnd});
   }
 
   for (auto [start, end] : computeRegions) {
@@ -243,8 +366,9 @@ static LogicalResult processSharedBufferPairs(
     Block *computeBlock, PatternRewriter &rewriter,
     llvm::DenseMap<Value, utils::CBUsageInfo> &cbUsageInfo) {
   for (auto [localBuffer, usageInfo] : cbUsageInfo) {
-    assert(usageInfo.producers.size() == 1 && usageInfo.consumers.size() == 1 &&
-           "Expected exactly one producer and one consumer for CB");
+    if (usageInfo.producers.size() != 1 || usageInfo.consumers.size() != 1) {
+      continue;
+    }
     auto *producer = usageInfo.producers.front();
     auto *consumer = usageInfo.consumers.front();
 
@@ -287,13 +411,13 @@ static LogicalResult processSharedBufferPairs(
 static LogicalResult
 insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
                       llvm::DenseMap<Value, utils::CBUsageInfo> &cbUsageInfo) {
-  SmallVector<RemoteLoadOp> loads;
+  DenseSet<Value> processedProducerBuffers;
 
   computeBlock->walk([&](Operation *op) {
     if (dyn_cast<SynchronizableOpInterface>(op) &&
         !op->hasTrait<D2MGenericRegionDatamovementOpTrait>()) {
       auto synchronizedOp = mlir::cast<SynchronizableOpInterface>(op);
-      // get consumers and insert wait+pop
+      // Get consumers and insert wait+pop.
       for (auto &operand : synchronizedOp->getOpOperands()) {
         if (synchronizedOp.isConsumer(operand)) {
           Location loc = synchronizedOp.getLoc();
@@ -302,12 +426,13 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
               synchronizedOp->getParentOfType<GenericOp>().getOperandIndex(
                   localBuffer);
 
-          // get the associated producer for this operand
-          // Assumes only one producer for this local buffer
-          assert(cbUsageInfo[localBuffer].producers.size() == 1 &&
-                 cbUsageInfo[localBuffer].consumers.size() == 1 &&
-                 "Expected exactly one producer and one consumer for CB");
-          auto *associatedProducer = cbUsageInfo[localBuffer].producers.front();
+          auto usageIt = cbUsageInfo.find(localBuffer);
+          if (usageIt == cbUsageInfo.end() ||
+              usageIt->second.producers.size() != 1 ||
+              usageIt->second.consumers.size() != 1) {
+            continue;
+          }
+          auto *associatedProducer = usageIt->second.producers.front();
           rewriter.setInsertionPoint(synchronizedOp);
           auto cb = d2m::getOrCreateCB(
               rewriter, synchronizedOp->getParentOfType<GenericOp>(),
@@ -322,34 +447,85 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
           rewriter.setInsertionPointAfter(synchronizedOp);
           rewriter.create<PopOp>(loc, cb);
 
-          // Replace uses of the local buffer in compute consumer
+          // Replace uses of the local buffer in compute consumer.
           localBuffer.replaceUsesWithIf(
               waitOp.getResult(),
               [&](OpOperand &use) { return use.getOwner() == synchronizedOp; });
         }
       }
 
-      // Get producers and insert reserve+push.
+      // Get producers and insert reserve+push. Multiple compute producers can
+      // write the same local buffer before a single DMA consumer, e.g. a zero
+      // fill followed by a loop-carried matmul accumulator. Reserve once before
+      // the first producer and push once after the last producer boundary.
       for (auto &operand : synchronizedOp->getOpOperands()) {
         if (synchronizedOp.isProducer(operand)) {
-          Location loc = synchronizedOp.getLoc();
           Value localBuffer = operand.get();
+          if (!processedProducerBuffers.insert(localBuffer).second) {
+            continue;
+          }
+
+          auto usageIt = cbUsageInfo.find(localBuffer);
+          if (usageIt == cbUsageInfo.end() ||
+              usageIt->second.consumers.size() != 1) {
+            continue;
+          }
+
+          SmallVector<Operation *> computeProducers;
+          for (Operation *producer : usageIt->second.producers) {
+            if (!producer->hasTrait<D2MGenericRegionDatamovementOpTrait>()) {
+              computeProducers.push_back(producer);
+            }
+          }
+          if (computeProducers.empty()) {
+            continue;
+          }
+
+          Operation *associatedConsumer = usageIt->second.consumers.front();
+          Operation *sharedConsumerBoundary = nullptr;
+          Operation *firstBoundary = nullptr;
+          Operation *lastBoundary = nullptr;
+          bool skipProducerGroup = false;
+          for (Operation *producer : computeProducers) {
+            Operation *producerBoundary = nullptr;
+            Operation *consumerBoundary = nullptr;
+            if (!getSiblingOpsInNearestCommonBlock(producer, associatedConsumer,
+                                                   producerBoundary,
+                                                   consumerBoundary)) {
+              skipProducerGroup = true;
+              break;
+            }
+            if ((sharedConsumerBoundary &&
+                 sharedConsumerBoundary != consumerBoundary) ||
+                (firstBoundary &&
+                 firstBoundary->getBlock() != producerBoundary->getBlock())) {
+              skipProducerGroup = true;
+              break;
+            }
+            sharedConsumerBoundary = consumerBoundary;
+            if (!firstBoundary ||
+                producerBoundary->isBeforeInBlock(firstBoundary)) {
+              firstBoundary = producerBoundary;
+            }
+            if (!lastBoundary ||
+                lastBoundary->isBeforeInBlock(producerBoundary)) {
+              lastBoundary = producerBoundary;
+            }
+          }
+          if (skipProducerGroup) {
+            continue;
+          }
+
           unsigned cbOperandIdx =
               synchronizedOp->getParentOfType<GenericOp>().getOperandIndex(
                   localBuffer);
-
-          // Get the associated consumer for this operand.
-          // Assumes only one consumer for this local buffer
-          assert(cbUsageInfo[localBuffer].consumers.size() == 1 &&
-                 cbUsageInfo[localBuffer].producers.size() == 1 &&
-                 "Expected exactly one producer and one consumer for CB");
-          auto *associatedConsumer = cbUsageInfo[localBuffer].consumers.front();
-          rewriter.setInsertionPoint(synchronizedOp);
+          Location loc = firstBoundary->getLoc();
+          rewriter.setInsertionPoint(firstBoundary);
           auto cb = d2m::getOrCreateCB(
               rewriter, synchronizedOp->getParentOfType<GenericOp>(),
               computeBlock, cbOperandIdx);
           auto reserveOp = rewriter.create<ReserveOp>(loc, cb);
-          rewriter.setInsertionPointAfter(synchronizedOp);
+          rewriter.setInsertionPointAfter(lastBoundary);
           rewriter.create<PushOp>(loc, cb);
           if (mlir::isa<RemoteStoreOp>(associatedConsumer) &&
               isAliasedStore(mlir::cast<RemoteStoreOp>(associatedConsumer))) {
@@ -357,10 +533,11 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
             rewriter.create<PopOp>(loc, cb);
           }
 
-          // Replace uses of the local buffer in compute consumer
-          localBuffer.replaceUsesWithIf(
-              reserveOp.getResult(),
-              [&](OpOperand &use) { return use.getOwner() == synchronizedOp; });
+          for (Operation *producer : computeProducers) {
+            localBuffer.replaceUsesWithIf(
+                reserveOp.getResult(),
+                [&](OpOperand &use) { return use.getOwner() == producer; });
+          }
         }
       }
     }
@@ -380,8 +557,9 @@ static LogicalResult eraseAliasedLoadStoreOps(
     PatternRewriter &rewriter,
     llvm::DenseMap<Value, utils::CBUsageInfo> &cbUsageInfo) {
   for (auto [localBuffer, usageInfo] : cbUsageInfo) {
-    assert(usageInfo.producers.size() == 1 && usageInfo.consumers.size() == 1 &&
-           "Expected exactly one producer and one consumer for CB");
+    if (usageInfo.producers.size() != 1 || usageInfo.consumers.size() != 1) {
+      continue;
+    }
     auto *producer = usageInfo.producers.front();
     auto *consumer = usageInfo.consumers.front();
 

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -132,6 +132,7 @@ static bool hasCrossNestComputeConsumerFanout(GenericOp genericOp) {
 
 static LogicalResult expandRangeToCoverNonPureResultUses(Block::iterator &start,
                                                          Block::iterator &end) {
+  DenseMap<Operation *, bool> purelyDerivedOps;
   bool changed = true;
   while (changed) {
     changed = false;
@@ -143,7 +144,7 @@ static LogicalResult expandRangeToCoverNonPureResultUses(Block::iterator &start,
 
     for (Operation &rootOp : llvm::make_range(start, end)) {
       WalkResult walkResult = rootOp.walk([&](Operation *op) {
-        if (mlir::isPure(op)) {
+        if (utils::isPurelyDerivedOp(op, purelyDerivedOps)) {
           return WalkResult::advance();
         }
         for (Value result : op->getResults()) {
@@ -333,6 +334,9 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
     Block::iterator wrappedEnd = std::next(end);
     if (failed(expandRangeToCoverNonPureResultUses(start, wrappedEnd))) {
       return failure();
+    }
+    for (Operation &op : llvm::make_range(start, wrappedEnd)) {
+      outermostOps.erase(&op);
     }
     computeRegions.push_back({start, wrappedEnd});
   }

--- a/lib/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.cpp
+++ b/lib/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.cpp
@@ -72,7 +72,7 @@ bool isPurelyDerivedOp(Operation *op,
 // relying on SynchronizableOpInterface, such as in SplitUnifiedThread pass to
 // identify CBs and insert correct CB ops on producer/consumer side).
 //
-// PRECONDITION: No op in [start, end) with a side effect (i.e. not pure) may
+// PRECONDITION: No op in [start, end) that is not purely derived may
 // produce SSA results that are used outside of [start, end).
 Operation *wrapInSynchronizedRegion(RewriterBase &rewriter,
                                     Block::iterator start, Block::iterator end,

--- a/test/d2m-jit/lit/matmul_accumulator.py
+++ b/test/d2m-jit/lit/matmul_accumulator.py
@@ -31,6 +31,18 @@ def k_loop_carried_matmul(lhs, rhs, out, k_blocks):
     remote_store(out, [0, 0], c)
 
 
+@d2m.kernel
+def k_tiled_loop_carried_matmul(lhs, rhs, out, m_blocks, n_blocks, k_blocks):
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            acc = zeros([1, 1])
+            for k in range(k_blocks):
+                a = remote_load(lhs, [m, k])
+                b = remote_load(rhs, [k, n])
+                acc += a @ b
+            remote_store(out, [m, n], acc)
+
+
 def _layout(shape, block_shape):
     return d2m.Layout(
         shape=shape, dtype=d2m.float32, block_shape=list(block_shape), grid_shape=[1, 1]
@@ -84,6 +96,12 @@ out = d2m.empty(_layout((32, 32), (1, 1)))
 k_loop_carried_matmul(lhs, rhs, out, 2, grid=(1, 1))
 _compile_pipeline("LOOP_CARRIED_MATMUL_ACC_PIPELINE", out)
 
+lhs = d2m.empty(_layout((64, 96), (1, 1)))
+rhs = d2m.empty(_layout((96, 64), (1, 1)))
+out = d2m.empty(_layout((64, 64), (1, 1)))
+k_tiled_loop_carried_matmul(lhs, rhs, out, 2, 2, 3, grid=(1, 1))
+_compile_pipeline("TILED_LOOP_CARRIED_MATMUL_ACC_PIPELINE", out)
+
 print("PASS matmul accumulator")
 
 
@@ -99,4 +117,6 @@ print("PASS matmul accumulator")
 # CHECK:       scf.yield
 
 # CHECK-LABEL: LOOP_CARRIED_MATMUL_ACC_PIPELINE
+
+# CHECK-LABEL: TILED_LOOP_CARRIED_MATMUL_ACC_PIPELINE
 # CHECK:       PASS matmul accumulator

--- a/test/d2m-jit/lit/matmul_accumulator.py
+++ b/test/d2m-jit/lit/matmul_accumulator.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR-shape coverage for d2m-jit matmul accumulator initialization."""
+
+import d2m_jit as d2m
+import d2m_jit._src.builder as builder_mod
+
+from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise, _run_pipeline
+
+
+@d2m.kernel
+def k_standalone_matmul(lhs, rhs, out):
+    a = remote_load(lhs, [0, 0])
+    b = remote_load(rhs, [0, 0])
+    c = a @ b
+    remote_store(out, [0, 0], c)
+
+
+@d2m.kernel
+def k_loop_carried_matmul(lhs, rhs, out, k_blocks):
+    c = zeros([1, 1])
+    for k in range(k_blocks):
+        a = remote_load(lhs, [0, k])
+        b = remote_load(rhs, [k, 0])
+        c += a @ b
+    remote_store(out, [0, 0], c)
+
+
+def _layout(shape, block_shape):
+    return d2m.Layout(
+        shape=shape, dtype=d2m.float32, block_shape=list(block_shape), grid_shape=[1, 1]
+    )
+
+
+def _finalize(label, out):
+    builder = _Builder.get()
+    _emit_returns_and_finalise(builder, [out])
+    builder.module.operation.verify()
+    print(label)
+    print(builder.module)
+    _Builder.reset()
+
+
+def _compile_pipeline(label, out):
+    builder = _Builder.get()
+    _emit_returns_and_finalise(builder, [out])
+    builder.module.operation.verify()
+
+    old_use_tile_matmul = d2m.config.use_tile_matmul
+    old_get_system_desc_path = builder_mod._get_system_desc_path
+    d2m.config.use_tile_matmul = True
+    builder_mod._get_system_desc_path = lambda: None
+    try:
+        _run_pipeline(builder)
+        builder.module.operation.verify()
+    finally:
+        d2m.config.use_tile_matmul = old_use_tile_matmul
+        builder_mod._get_system_desc_path = old_get_system_desc_path
+        _Builder.reset()
+
+    print(label)
+
+
+lhs = d2m.empty(_layout((32, 32), (1, 1)))
+rhs = d2m.empty(_layout((32, 32), (1, 1)))
+out = d2m.empty(_layout((32, 32), (1, 1)))
+k_standalone_matmul(lhs, rhs, out, grid=(1, 1))
+_finalize("STANDALONE_MATMUL_ZERO_INIT_IR", out)
+
+lhs = d2m.empty(_layout((32, 64), (1, 1)))
+rhs = d2m.empty(_layout((64, 32), (1, 1)))
+out = d2m.empty(_layout((32, 32), (1, 1)))
+k_loop_carried_matmul(lhs, rhs, out, 2, grid=(1, 1))
+_finalize("LOOP_CARRIED_MATMUL_ACC_IR", out)
+
+lhs = d2m.empty(_layout((32, 64), (1, 1)))
+rhs = d2m.empty(_layout((64, 32), (1, 1)))
+out = d2m.empty(_layout((32, 32), (1, 1)))
+k_loop_carried_matmul(lhs, rhs, out, 2, grid=(1, 1))
+_compile_pipeline("LOOP_CARRIED_MATMUL_ACC_PIPELINE", out)
+
+print("PASS matmul accumulator")
+
+
+# CHECK-LABEL: STANDALONE_MATMUL_ZERO_INIT_IR
+# CHECK:       d2m.tile_fill
+# CHECK:       "d2m.tile_matmul"
+
+# CHECK-LABEL: LOOP_CARRIED_MATMUL_ACC_IR
+# CHECK:       d2m.tile_fill
+# CHECK:       scf.for
+# CHECK-SAME:  iter_args
+# CHECK:       "d2m.tile_matmul"
+# CHECK:       scf.yield
+
+# CHECK-LABEL: LOOP_CARRIED_MATMUL_ACC_PIPELINE
+# CHECK:       PASS matmul accumulator

--- a/test/d2m-jit/test_matmul.py
+++ b/test/d2m-jit/test_matmul.py
@@ -5,8 +5,8 @@
 """`__matmul__` via `linalg.generic` + `d2m.tile_matmul`.
 
 Coverage includes single-tile matmul on a multicore grid, transpose-b
-variants, and a multi-K block matmul that relies on the device-side accumulator
-seed emitted by `D2MToTTKernel`.
+variants, and an explicit multi-K loop-carried accumulator initialized with a
+kernel-body zero block.
 """
 
 import pytest
@@ -29,10 +29,12 @@ def matmul_kernel(lhs, rhs, out, m_blocks, n_blocks):
 
 
 @d2m.kernel
-def matmul_multi_k_kernel(lhs, rhs, out):
-    a = remote_load(lhs, [0, 0])
-    b = remote_load(rhs, [0, 0])
-    c = a @ b
+def matmul_multi_k_kernel(lhs, rhs, out, k_blocks):
+    c = zeros([1, 1])
+    for k in range(k_blocks):
+        a = remote_load(lhs, [0, k])
+        b = remote_load(rhs, [k, 0])
+        c += a @ b
     remote_store(out, [0, 0], c)
 
 
@@ -96,16 +98,16 @@ def test_matmul_correctness_single_tile_multicore():
     assert diff < 0.05, f"per-shard matmul: max diff {diff} too large"
 
 
-def test_matmul_correctness_multi_k_device_seed():
+def test_matmul_correctness_multi_k_loop_carried_accumulator():
     torch.manual_seed(0)
     lhs = torch.randn(32, 64, dtype=torch.float32) * 0.25
     rhs = torch.randn(64, 32, dtype=torch.float32) * 0.25
 
     lhs_layout = d2m.Layout(
-        shape=(32, 64), dtype=d2m.float32, block_shape=[1, 2], grid_shape=[1, 1]
+        shape=(32, 64), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
     )
     rhs_layout = d2m.Layout(
-        shape=(64, 32), dtype=d2m.float32, block_shape=[2, 1], grid_shape=[1, 1]
+        shape=(64, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
     )
     out_layout = d2m.Layout(
         shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
@@ -119,6 +121,7 @@ def test_matmul_correctness_multi_k_device_seed():
             d2m.to_layout(lhs, lhs_layout),
             d2m.to_layout(rhs, rhs_layout),
             out_d,
+            2,
             grid=(1, 1),
         )
         assert_pcc(lhs @ rhs, out_d.to_host(), threshold=0.99)

--- a/test/d2m-jit/test_matmul.py
+++ b/test/d2m-jit/test_matmul.py
@@ -4,19 +4,9 @@
 
 """`__matmul__` via `linalg.generic` + `d2m.tile_matmul`.
 
-Two flavours covered:
-
-1. `test_matmul_compiles_and_runs` -- baseline shape/dtype check using
-   `d2m.empty` for the output. Confirms the IR lowers and runs on
-   silicon. Values are not asserted because the output is uninitialised
-   (the matmul body accumulates).
-
-2. `test_matmul_correctness_via_zeros` -- pre-fill the output with
-   `d2m.zeros(L)` before calling the kernel. This is the recommended
-   pattern for correct values until the device-side accumulator
-   zero-init lands in `_matmul_block`.
-
-3. Parameterized transpose-b correctness over several M/K/N tile shapes.
+Coverage includes single-tile matmul on a multicore grid, transpose-b
+variants, and a multi-K block matmul that relies on the device-side accumulator
+seed emitted by `D2MToTTKernel`.
 """
 
 import pytest
@@ -36,6 +26,14 @@ def matmul_kernel(lhs, rhs, out, m_blocks, n_blocks):
             b = remote_load(rhs, [m_off + m, n_off + n])
             c = a @ b
             remote_store(out, [m_off + m, n_off + n], c)
+
+
+@d2m.kernel
+def matmul_multi_k_kernel(lhs, rhs, out):
+    a = remote_load(lhs, [0, 0])
+    b = remote_load(rhs, [0, 0])
+    c = a @ b
+    remote_store(out, [0, 0], c)
 
 
 @d2m.kernel
@@ -73,14 +71,14 @@ def test_matmul_compiles_and_runs():
     assert result.dtype == torch.float32
 
 
-def test_matmul_correctness_via_zeros():
+def test_matmul_correctness_single_tile_multicore():
     """Per-shard 32x32 matmul: each core's shard is exactly one tile, so
     the kernel emits a single `tile_matmul` per shard. Comparing against
     a per-shard torch matmul (no inter-shard K reduction)."""
     lhs = torch.randn(64, 64, dtype=torch.float32)
     rhs = torch.randn(64, 64, dtype=torch.float32)
     L = _make_layout()
-    out_d = d2m.zeros(L)  # pre-fill accumulator
+    out_d = d2m.empty(L)
     matmul_kernel(
         d2m.to_layout(lhs, L), d2m.to_layout(rhs, L), out_d, 1, 1, grid=(2, 2)
     )
@@ -96,6 +94,36 @@ def test_matmul_correctness_via_zeros():
 
     diff = (expected - result).abs().max().item()
     assert diff < 0.05, f"per-shard matmul: max diff {diff} too large"
+
+
+def test_matmul_correctness_multi_k_device_seed():
+    torch.manual_seed(0)
+    lhs = torch.randn(32, 64, dtype=torch.float32) * 0.25
+    rhs = torch.randn(64, 32, dtype=torch.float32) * 0.25
+
+    lhs_layout = d2m.Layout(
+        shape=(32, 64), dtype=d2m.float32, block_shape=[1, 2], grid_shape=[1, 1]
+    )
+    rhs_layout = d2m.Layout(
+        shape=(64, 32), dtype=d2m.float32, block_shape=[2, 1], grid_shape=[1, 1]
+    )
+    out_layout = d2m.Layout(
+        shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
+    )
+    out_d = d2m.empty(out_layout)
+
+    old_use_tile_matmul = d2m.config.use_tile_matmul
+    d2m.config.use_tile_matmul = True
+    try:
+        matmul_multi_k_kernel(
+            d2m.to_layout(lhs, lhs_layout),
+            d2m.to_layout(rhs, rhs_layout),
+            out_d,
+            grid=(1, 1),
+        )
+        assert_pcc(lhs @ rhs, out_d.to_host(), threshold=0.99)
+    finally:
+        d2m.config.use_tile_matmul = old_use_tile_matmul
 
 
 _TRANSPOSE_B_CASES = [

--- a/test/d2m-jit/test_matmul.py
+++ b/test/d2m-jit/test_matmul.py
@@ -39,6 +39,18 @@ def matmul_multi_k_kernel(lhs, rhs, out, k_blocks):
 
 
 @d2m.kernel
+def matmul_tiled_multi_k_kernel(lhs, rhs, out, m_blocks, n_blocks, k_blocks):
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            acc = zeros([1, 1])
+            for k in range(k_blocks):
+                a = remote_load(lhs, [m, k])
+                b = remote_load(rhs, [k, n])
+                acc += a @ b
+            remote_store(out, [m, n], acc)
+
+
+@d2m.kernel
 def matmul_transpose_b_kernel(lhs, rhs, out):
     a = remote_load(lhs, [0, 0])
     b = remote_load(rhs, [0, 0])
@@ -122,6 +134,39 @@ def test_matmul_correctness_multi_k_loop_carried_accumulator():
             d2m.to_layout(rhs, rhs_layout),
             out_d,
             2,
+            grid=(1, 1),
+        )
+        assert_pcc(lhs @ rhs, out_d.to_host(), threshold=0.99)
+    finally:
+        d2m.config.use_tile_matmul = old_use_tile_matmul
+
+
+def test_matmul_correctness_tiled_mnk_loop_carried_accumulator():
+    torch.manual_seed(0)
+    lhs = torch.randn(64, 96, dtype=torch.float32) * 0.125
+    rhs = torch.randn(96, 64, dtype=torch.float32) * 0.125
+
+    lhs_layout = d2m.Layout(
+        shape=(64, 96), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
+    )
+    rhs_layout = d2m.Layout(
+        shape=(96, 64), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
+    )
+    out_layout = d2m.Layout(
+        shape=(64, 64), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
+    )
+    out_d = d2m.empty(out_layout)
+
+    old_use_tile_matmul = d2m.config.use_tile_matmul
+    d2m.config.use_tile_matmul = True
+    try:
+        matmul_tiled_multi_k_kernel(
+            d2m.to_layout(lhs, lhs_layout),
+            d2m.to_layout(rhs, rhs_layout),
+            out_d,
+            2,
+            2,
+            3,
             grid=(1, 1),
         )
         assert_pcc(lhs @ rhs, out_d.to_host(), threshold=0.99)

--- a/test/ttmlir/Conversion/TTIRToD2M/arange_dst_region.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/arange_dst_region.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-ttmetal-pipeline %s -o /dev/null
+
+// Regression test for d2m-split-unified-thread wrapping DST-dependent pure ops.
+// Arange lowers to a DST sequence where pure tile_add depends on a non-pure
+// memref.load from dst; the wrapper must include the tile_add result store.
+
+module {
+  func.func @arange_1x128_f32(%arg0: tensor<1x128xf32>) -> tensor<1x128xf32> {
+    %0 = "ttir.arange"() <{arange_dimension = 1 : i64, end = 128 : si64, start = 0 : si64, step = 1 : si64}> : () -> tensor<1x128xf32>
+    return %0 : tensor<1x128xf32>
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToD2M/reduction_scaler_cb_sync.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/reduction_scaler_cb_sync.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --mlir-disable-threading --mlir-print-ir-after=d2m-split-unified-thread --ttcore-register-device --ttir-to-ttmetal-pipeline="default-input-memspace=dram default-output-memspace=dram" %s -o /dev/null 2>&1 | FileCheck %s
+
+// Regression test for keeping non-compute scaler loads in the synchronized
+// range. Without the wait/pop for get_cb(4), the DMA thread repeatedly pushes
+// the mean scaler tile and can block on a full CB at runtime.
+
+module {
+  func.func @main(%arg0: tensor<2x128x160xf32>) -> tensor<2x128x1xf32> {
+    %0 = "ttir.mean"(%arg0) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<2x128x160xf32>) -> tensor<2x128x1xf32>
+    return %0 : tensor<2x128x1xf32>
+  }
+}
+
+// CHECK: d2m.generic {{.*}}grid = #ttcore.grid<2x4x1
+// CHECK: }, {
+// CHECK: %[[SCALER_CB:.*]] = d2m.get_cb(4)
+// CHECK: scf.for
+// CHECK: %[[SCALER_WAIT:.*]] = d2m.wait %[[SCALER_CB]]
+// CHECK: %[[SCALER_VIEW:.*]] = memref.collapse_shape %[[SCALER_WAIT]]
+// CHECK: %[[SCALER:.*]] = memref.load %[[SCALER_VIEW]]
+// CHECK: "d2m.tile_reduce_mean"({{.*}}, %[[SCALER]], {{.*}})
+// CHECK: d2m.pop %[[SCALER_CB]]

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -324,9 +324,20 @@ lhs @ rhs              # operator form
 Emits `linalg.generic` with the standard matmul indexing maps
 (parallel/parallel/reduction over M/N/K) and `d2m.tile_matmul` in the body.
 
-`D2MToTTKernel` emits a device-side zero tile for `d2m.tile_matmul`
-accumulators. For multi-K blocks, it guards that fill to the first reduction
-iteration so later K steps accumulate into the same DST tile.
+Standalone `a @ b` generates an in-kernel zero block and uses it as the
+`linalg.generic` DPS init, so tile matmul starts from a defined accumulator.
+For explicit K loops, use a loop-carried accumulator and `+=` so the matmul
+maps directly onto `tile_matmul`'s accumulate operand:
+
+```python
+c = zeros([1, 1])
+for k in range(k_blocks):
+    c += remote_load(lhs, [m, k]) @ remote_load(rhs, [k, n])
+```
+
+The kernel-body `zeros([m, n])` helper takes a literal tile-block shape. It is
+separate from host-side `d2m.zeros(layout)`, which still allocates/fills a full
+layout tensor outside the kernel body.
 
 ### Debug knobs (`d2m.config`)
 
@@ -418,8 +429,8 @@ have been dropped — the DSL emits the post-legalisation form directly.
 - **Spent `LazyTensor`s.** After `to_host`, anything from the previous
   generation that was not passed to `to_host` raises on re-use. If you need
   multiple values out, pass them all to a single `to_host`.
-- **Matmul accumulator is seeded in the generated kernel.** Multi-K blocks
-  rely on the `D2MToTTKernel` first-reduction guard for the zero fill.
+- **Matmul accumulation is explicit in IR.** Standalone `a @ b` gets a
+  generated zero block; explicit K loops should use `zeros([...])` plus `+=`.
 - **Float reductions are per tile/per core.** Use `reduction_layout` for reduced
   outputs. Reductions spanning multiple cores need a core gather/redistribute
   op.
@@ -439,6 +450,5 @@ have been dropped — the DSL emits the post-legalisation form directly.
 
 ## Known issues / TODO
 
-See [TODO.md](TODO.md) for active pipeline gaps (matmul accumulator init,
-host-scope `linalg.generic`), missing API surface (in-kernel typecast, DMA
-primitives, ...), and other follow-ups.
+See [TODO.md](TODO.md) for active pipeline gaps, missing API surface
+(in-kernel typecast, DMA primitives, init helpers, ...), and other follow-ups.

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -324,12 +324,9 @@ lhs @ rhs              # operator form
 Emits `linalg.generic` with the standard matmul indexing maps
 (parallel/parallel/reduction over M/N/K) and `d2m.tile_matmul` in the body.
 
-> **Caveat:** the generated `linalg.generic` accumulates into the output
-> operand, which is currently a fresh `d2m.empty` (undefined-init). Pre-fill
-> the output with `d2m.zeros(L)` and pass it as the out-param to the kernel
-> that calls `@` to get correct values. A device-side fill inside
-> `_matmul_block` is tracked but blocked on a downstream
-> `d2m → ttkernel` materialisation issue.
+`D2MToTTKernel` emits a device-side zero tile for `d2m.tile_matmul`
+accumulators. For multi-K blocks, it guards that fill to the first reduction
+iteration so later K steps accumulate into the same DST tile.
 
 ### Debug knobs (`d2m.config`)
 
@@ -342,6 +339,7 @@ d2m.config.print_ir_after_pipeline  # bool: dump the module after passes
 d2m.config.print_ir_after_each_pass # bool: enable_ir_printing(print_after_all=True)
 d2m.config.print_ir_debug_info      # bool: include locations
 d2m.config.verify_passes            # bool, default True
+d2m.config.use_tile_matmul          # bool: keep explicit tile_matmul loops
 d2m.config.save_flatbuffer_path     # str | None: write fbb to disk before submit
 ```
 
@@ -420,7 +418,8 @@ have been dropped — the DSL emits the post-legalisation form directly.
 - **Spent `LazyTensor`s.** After `to_host`, anything from the previous
   generation that was not passed to `to_host` raises on re-use. If you need
   multiple values out, pass them all to a single `to_host`.
-- **Matmul accumulator is currently undefined.** See the matmul note above.
+- **Matmul accumulator is seeded in the generated kernel.** Multi-K blocks
+  rely on the `D2MToTTKernel` first-reduction guard for the zero fill.
 - **Float reductions are per tile/per core.** Use `reduction_layout` for reduced
   outputs. Reductions spanning multiple cores need a core gather/redistribute
   op.

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -12,43 +12,6 @@ have.
 
 ## Pipeline gaps
 
-### 🔴 Matmul accumulator init breaks `d2m → ttkernel` lowering
-
-**Where:** `_matmul_block` in `api.py`, when the `outs` operand to the
-inner `linalg.generic { d2m.tile_matmul }` is anything other than a
-fresh `d2m.empty`.
-
-**Symptom:** wiring a `linalg.generic { d2m.tile_fill }` as the
-accumulator producer fails late in the pipeline:
-
-```
-error: failed to legalize unresolved materialization from
-  ('memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>')
-  to ('!ttkernel.cb<1, !ttcore.tile<32x32, f32>>')
-  that remained live after conversion
- note: see existing live user here:
-  ttkernel.pack_tile(%c0, %8, %c0, true)
-    : (index, !ttkernel.cb<1, !ttcore.tile<32x32, f32>>, index) -> ()
-```
-
-**Root cause:** `D2MToTTKernel` doesn't recognise the
-`linalg.generic { d2m.tile_fill }` pattern as the producer of the
-matmul accumulator. The conversion emits an
-`unrealized_conversion_cast` from `memref<...>` to `!ttkernel.cb<...>`
-that no later pass can fold away, while `ttkernel.pack_tile` keeps
-using the CB form.
-
-**Workaround for users:** pre-fill the output via `out = d2m.zeros(L)`
-and pass it as the out-param to a kernel that calls `@`. The current
-test `test_matmul.py::test_matmul_correctness_via_zeros` does this.
-
-**Fix shape:** teach `D2MToTTKernel` to handle a fill-pattern producer
-(or to emit a CB-init prologue for the matmul kernel when one is
-detected). A `tile_matmul` op that internally zero-initialises on the
-first reduction step would also work.
-
----
-
 ### 🔴 Multicast kernels hit `SplitUnifiedThread` assertion
 
 **Where:** any kernel that uses the multicast form of `remote_load`

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -83,14 +83,14 @@ but they're meaningful only in generic-op forms we haven't surfaced
 
 ### 🟡 Init helpers
 
-- `arange_block(layout)` — fill a block with `0, 1, 2, …` (per the
-  d2m op).
+- Kernel-body `full([m, n], value)` for block literals. `zeros([m, n])` exists
+  for accumulator blocks; a general fill helper would make the pattern reusable.
+- `arange_block(layout)` — fill a block with `0, 1, 2, ...` (per the d2m op).
 - `fill_arange_tile()` — per-tile arange.
 
 Useful for golden tests and for replacing the current
-`test/d2m-jit/utils.py:arange_tile` host-side helper with a true
-device-side fill. Need the same plumbing the device-side `zeros`/`full`
-fill would need (see the host-scope linalg gap above).
+`test/d2m-jit/utils.py:arange_tile` host-side helper with a true device-side
+fill.
 
 ### 🟡 Kernel-side `print`
 

--- a/tools/d2m-jit/_src/ast.py
+++ b/tools/d2m-jit/_src/ast.py
@@ -22,6 +22,11 @@ from .tensor_layout import Layout
 _D2M_KERNEL_TYPES = {None, "datamovement", "noc", "compute", "unified"}
 
 
+def _as_value(v):
+    """Coerce an OpView or Value to an ir.Value."""
+    return v.result if isinstance(v, OpView) else v
+
+
 class D2MCompiler(ast.NodeVisitor):
     """Unified AST -> MLIR visitor for d2m_jit.
 
@@ -87,6 +92,7 @@ class D2MCompiler(ast.NodeVisitor):
         # Statements
         ast.Pass,
         ast.Assign,
+        ast.AugAssign,
         ast.Return,
         # Function/module
         ast.Module,
@@ -338,6 +344,19 @@ class D2MCompiler(ast.NodeVisitor):
                 scf.YieldOp([])
                 self.symbol_tables.pop()
 
+    @staticmethod
+    def _collect_assigned_names(body):
+        """Direct local names assigned by a statement list, in order."""
+        names = []
+        for stmt in body:
+            if isinstance(stmt, ast.AugAssign) and isinstance(stmt.target, ast.Name):
+                names.append(stmt.target.id)
+            elif isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name):
+                        names.append(target.id)
+        return names
+
     def visit_For(self, node):
         assert node.iter.func.id == "range", "Only range() supported in for loops"
 
@@ -363,14 +382,30 @@ class D2MCompiler(ast.NodeVisitor):
         upper_bound = _to_index(upper_bound)
         step = _to_index(step)
 
-        for_op = scf.ForOp(lower_bound, upper_bound, step)
+        # Existing variables updated in the loop body need scf.for iter_args so
+        # the updated SSA value is visible in later iterations and after the loop.
+        owners = {}
+        carried = []
+        for name in self._collect_assigned_names(node.body):
+            owner = self._var_exists(name)
+            if owner and name not in owners:
+                owners[name] = owner
+                carried.append(name)
+        init_args = [_as_value(owners[name][name]) for name in carried]
+
+        for_op = scf.ForOp(lower_bound, upper_bound, step, iter_args=init_args)
         with InsertionPoint(for_op.body), Location.unknown():
             self.symbol_tables.append({})
             self.symbol_tables[-1][node.target.id] = for_op.induction_variable
+            for i, name in enumerate(carried):
+                self.symbol_tables[-1][name] = for_op.inner_iter_args[i]
             for stmt in node.body:
                 self.visit(stmt)
-            scf.YieldOp([])
+            scf.YieldOp([_as_value(self.symbol_tables[-1][name]) for name in carried])
             self.symbol_tables.pop()
+
+        for i, name in enumerate(carried):
+            owners[name][name] = for_op.results[i]
 
     # --- Async (d2m) -------------------------------------------------------
 
@@ -411,6 +446,39 @@ class D2MCompiler(ast.NodeVisitor):
                 f"Assign target {type(target).__name__} not supported"
             )
         self.symbol_tables[-1][target.id] = self.visit(node.value)
+
+    def visit_AugAssign(self, node):
+        target = node.target
+        if not isinstance(target, ast.Name):
+            raise NotImplementedError(
+                f"AugAssign target {type(target).__name__} not supported"
+            )
+        sym_table = self._var_exists(target.id)
+        if not sym_table:
+            self._fail(
+                node,
+                NameError(f"unknown variable '{target.id}'"),
+                hint=self._hint_for_name(target.id),
+            )
+        lhs = _as_value(sym_table[target.id])
+
+        # Route `c += a @ b` through matmul's accumulator operand instead of
+        # materializing a separate add. This keeps the loop-carried value tied
+        # to the matmul DPS init and models the K-reduction directly.
+        if (
+            isinstance(node.op, ast.Add)
+            and isinstance(node.value, ast.BinOp)
+            and isinstance(node.value.op, ast.MatMult)
+        ):
+            matmul_acc = self._fn_map.get("__matmul_acc__")
+            if matmul_acc is not None:
+                a = _as_value(self.visit(node.value.left))
+                b = _as_value(self.visit(node.value.right))
+                sym_table[target.id] = matmul_acc(lhs, a, b)
+                return
+
+        rhs = self.visit(node.value)
+        sym_table[target.id] = self._emit_binop(node.op, lhs, rhs)
 
     # --- Function calls ----------------------------------------------------
 
@@ -516,6 +584,9 @@ class D2MCompiler(ast.NodeVisitor):
     def visit_BinOp(self, node):
         lhs = self.visit(node.left)
         rhs = self.visit(node.right)
+        return self._emit_binop(node.op, lhs, rhs)
+
+    def _emit_binop(self, op, lhs, rhs):
         if not lhs or not rhs:
             raise ValueError("Binary operands not found")
 
@@ -537,9 +608,9 @@ class D2MCompiler(ast.NodeVisitor):
             return otherwise(lhs, cast_rhs)
 
         def unimplemented(*args, **kwargs):
-            raise NotImplementedError(f"{node.op} not implemented")
+            raise NotImplementedError(f"{op} not implemented")
 
-        match (node.op):
+        match (op):
             case ast.Add():
                 return qualified_or("__add__", arith.addi)
             case ast.Sub():
@@ -568,7 +639,7 @@ class D2MCompiler(ast.NodeVisitor):
                 return qualified_or("__xor__", arith.xori)
             case _:
                 raise NotImplementedError(
-                    f"Binary operator {type(node.op).__name__} not implemented"
+                    f"Binary operator {type(op).__name__} not implemented"
                 )
 
     def visit_UnaryOp(self, node):
@@ -779,11 +850,11 @@ def syntax(syntax_name, args_as_attr=None, kwargs_as_attr=None):
         nonlocal args_as_attr, kwargs_as_attr
         assert callable(fn)
         if args_as_attr is None and kwargs_as_attr is None:
-            D2MCompiler._syntax[fn.__name__] = fn
+            D2MCompiler._syntax[syntax_name] = fn
         else:
             assert args_as_attr is None or isinstance(args_as_attr, list)
             assert kwargs_as_attr is None or isinstance(kwargs_as_attr, dict)
-            D2MCompiler._syntax[fn.__name__] = (
+            D2MCompiler._syntax[syntax_name] = (
                 fn,
                 args_as_attr,
                 kwargs_as_attr or {},

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -153,11 +153,11 @@ def _pipeline_passes():
         f"d2m-be-pipeline{{use-tile-matmul={int(config.use_tile_matmul)}}}",
         "d2m-to-ttkernel-pre-emitc-pipeline",
         "d2m-to-ttmetal-pipeline",
-        "ttkernel-hoist-inits",
+        "func.func(ttkernel-hoist-inits)",
     ]
     if config.insert_profiler_traces:
         traits = config.profiler_traits.strip() or "device-zone"
-        passes.append("insert-device-zone-scopes{traits=" + traits + "}")
+        passes.append("func.func(insert-device-zone-scopes{traits=" + traits + "})")
     passes.append("d2m-emitc-pipeline")
     return passes
 

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -150,7 +150,7 @@ def _pipeline_passes():
         "d2m-lower-multicast-loads",
         "d2m-generic-lower-to-explicit-form",
         "canonicalize",
-        "d2m-be-pipeline{use-tile-matmul=0}",
+        f"d2m-be-pipeline{{use-tile-matmul={int(config.use_tile_matmul)}}}",
         "d2m-to-ttkernel-pre-emitc-pipeline",
         "d2m-to-ttmetal-pipeline",
         "ttkernel-hoist-inits",

--- a/tools/d2m-jit/_src/config.py
+++ b/tools/d2m-jit/_src/config.py
@@ -44,6 +44,9 @@ class _Config:
     verify_passes: bool = _env_bool("D2M_JIT_VERIFY", default=True)
     # Convert all tensor inputs and out-params to DRAM before each kernel call.
     kernel_io_in_dram: bool = _env_bool("D2M_JIT_KERNEL_IO_IN_DRAM")
+    # Keep explicit d2m.tile_matmul loops instead of replacing them with
+    # d2m.tile_matmul_block in the backend pipeline.
+    use_tile_matmul: bool = _env_bool("D2M_JIT_USE_TILE_MATMUL")
     # If set, write the post-pipeline flatbuffer to this path before
     # device submit. Useful for offline inspection with ttrt.
     save_flatbuffer_path: Optional[str] = os.environ.get("D2M_JIT_SAVE_FLATBUFFER_PATH")

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -8,6 +8,7 @@ import ast
 
 from ttmlir.ir import *
 from ttmlir.dialects import d2m, ttcore, arith, linalg
+from ttmlir.dialects._ods_common import get_default_loc_context
 
 from ._src.utils import _asindex
 from ._src.ast import syntax
@@ -622,6 +623,24 @@ def where(cond, true_value, false_value):
     )
 
 
+def _shape_literal(node):
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return [int(_const_value(element)) for element in node.elts]
+    raise D2mJitError(
+        "zeros() expects a literal block shape, e.g. zeros([m_tiles, n_tiles]); "
+        f"got {type(node).__name__}"
+    )
+
+
+@syntax("zeros", args_as_attr=[_shape_literal])
+def _zeros_op(shape):
+    """Kernel-body zero-initialized tile block."""
+    ctx = get_default_loc_context()
+    tile_ty = ttcore.ir.TileType.get(ctx, 32, 32, float32)
+    block_ty = RankedTensorType.get(list(shape), tile_ty)
+    return _zeros_block(block_ty)
+
+
 def _bool_attr_from_ast(node):
     if isinstance(node, ast.Constant) and isinstance(node.value, bool):
         return node.value
@@ -654,6 +673,12 @@ def matmul(lhs, rhs, transpose_b=False):
     return _matmul_block(
         lhs, rhs, transpose_b=_normalize_bool_literal(transpose_b, "transpose_b")
     )
+
+
+@syntax("__matmul_acc__")
+def _matmul_acc(acc, lhs, rhs):
+    """Hidden helper for `c += a @ b`: accumulate matmul into `acc`."""
+    return _matmul_block(lhs, rhs, acc=acc)
 
 
 def _int_attr_from_ast(node, compiler=None):
@@ -1291,10 +1316,12 @@ def _float_scalar_type_for_tile(tile_type):
     data_type = tile_type.data_type_as_int
     if data_type == int(ttcore.DataType.Float32):
         return F32Type.get(ctx)
+    if data_type == int(ttcore.DataType.Float16):
+        return F16Type.get(ctx)
     if data_type == int(ttcore.DataType.BFloat16):
         return BF16Type.get(ctx)
     raise TypeError(
-        f"float reductions require f32 or bf16 tile element types; got {tile_type}"
+        f"float tile fill requires f32, f16, or bf16 tile element types; got {tile_type}"
     )
 
 
@@ -1303,6 +1330,29 @@ def _tile_fill_float(tile_type, value):
     scalar_attr = FloatAttr.get(scalar_type, value)
     scalar = arith.ConstantOp(scalar_type, scalar_attr).result
     return d2m.tile_fill(tile_type, scalar)
+
+
+def _zeros_block(block_ty):
+    """Inputless linalg.generic that fills a tile-tensor block with zeros."""
+    tile_ty = block_ty.element_type
+    rank = block_ty.rank
+    output = d2m.empty(block_ty)
+    identity = AffineMap.get_identity(rank)
+    parallel = Attribute.parse("#linalg.iterator_type<parallel>")
+    generic = linalg.GenericOp(
+        [block_ty],
+        [],
+        [output],
+        ArrayAttr.get([AffineMapAttr.get(identity)]),
+        ArrayAttr.get([parallel] * rank),
+    )
+    body = Block.create_at_start(generic.regions[0], [tile_ty], [Location.unknown()])
+    with InsertionPoint(body):
+        filled = _tile_fill_float(tile_ty, 0.0)
+        if hasattr(filled, "result"):
+            filled = filled.result
+        linalg.yield_([filled])
+    return generic.result
 
 
 def _reduction_input_map(rank, reduce_axis, reduce_index):
@@ -1468,7 +1518,7 @@ def _reduce_block(
     return generic.result
 
 
-def _matmul_block(lhs, rhs, transpose_b=False):
+def _matmul_block(lhs, rhs, transpose_b=False, acc=None):
     """Block-level matmul: `C = A @ B` where each tensor is a 2D block of
     tiles. Emits a linalg.generic with the standard matmul indexing maps
     (parallel/parallel/reduction over M/N/K) and `d2m.tile_matmul` in the
@@ -1478,6 +1528,10 @@ def _matmul_block(lhs, rhs, transpose_b=False):
     rhs: tensor<K x N x !ttcore.tile<...>>, or tensor<N x K x ...> when
          transpose_b is true
     Returns: tensor<M x N x !ttcore.tile<...>>.
+
+    `acc` is an optional caller-supplied accumulator block used as the DPS init.
+    It is how `c += a @ b` maps an explicit K loop onto tile_matmul's native
+    accumulate operand. When omitted, a fresh in-kernel zero block is used.
     """
     transpose_b = _normalize_bool_literal(transpose_b, "transpose_b")
     assert isinstance(lhs.type, RankedTensorType)
@@ -1499,14 +1553,14 @@ def _matmul_block(lhs, rhs, transpose_b=False):
     n_blocks = rhs.type.shape[0] if transpose_b else rhs.type.shape[1]
 
     out_ty = RankedTensorType.get([m_blocks, n_blocks], elem_ty)
-    # TODO: zero-initialise the accumulator. The matmul body computes
-    # `c = c + a @ b`, so an uninitialised output yields garbage. A
-    # host-scope linalg.generic-as-fill (the natural way to express this
-    # at this layer) does not survive the d2m -> ttkernel conversion
-    # today. Users needing correct matmul should pre-fill the output via
-    # `d2m.zeros(L)` and pass that as the out-param to a kernel that
-    # calls `@`.
-    output = d2m.empty(out_ty)
+    if acc is not None:
+        if acc.type != out_ty:
+            raise ValueError(
+                f"matmul accumulator type {acc.type} does not match output type {out_ty}"
+            )
+        output = acc
+    else:
+        output = _zeros_block(out_ty)
 
     # (d0, d1, d2) = (M, N, K).
     d0 = AffineDimExpr.get(0)


### PR DESCRIPTION
## Summary
- Seed `d2m.tile_matmul` DST accumulators with a device-side zero tile before the first reduction iteration.
- Add a `d2m.config.use_tile_matmul` / `D2M_JIT_USE_TILE_MATMUL` knob so d2m-jit can keep explicit `d2m.tile_matmul` loops instead of lowering to `tile_matmul_block`.
- Update d2m-jit matmul tests/docs to use `d2m.empty` outputs now that the accumulator is initialized in the generated kernel.

## Validation
- `git diff --check`
- pre-commit hooks from `git commit`: black, clang-format, copyright, whitespace, large-file, include-style
- Previously validated on the handoff worktree with this same code path: `source env/activate && pytest -q test/d2m-jit/test_matmul.py test/d2m-jit/test_pattern_sdpa.py -q` (`10` tests passed)

## Notes
- The temporary PR worktree does not have its own configured CMake build, so device pytest was not rerun from `/tmp/ttmlir-pr-matmul`.
