### PR TITLE
Add D2M-JIT SDPA fusion pattern

### DIFF
--- a/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
+++ b/include/ttmlir/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.h
@@ -136,6 +136,7 @@ public:
 
   unsigned getCurrSliceIndex() const;
   unsigned getFirstInputSliceIndex() const;
+  void deallocateIntermediate(unsigned id);
   void deallocateAllButFirstInput();
 
 private:

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1096,11 +1096,17 @@ public:
       // If the input didn't come from a subview, we'll expect the CB directly
       // which implicitly comes from an unrealized conversion cast.  This is a
       // special case where we're reading from offset 0.
-      if (mlir::isa_and_nonnull<UnrealizedConversionCastOp>(
+      auto needsZeroTileIndex = [](Value tileIndex) {
+        Type type = tileIndex.getType();
+        return !type.isIndex() && !llvm::isa<IntegerType>(type);
+      };
+      if (needsZeroTileIndex(aTileIndex) ||
+          mlir::isa_and_nonnull<UnrealizedConversionCastOp>(
               aTileIndex.getDefiningOp())) {
         aTileIndex = index(rewriter, op.getLoc(), 0);
       }
-      if (mlir::isa_and_nonnull<UnrealizedConversionCastOp>(
+      if (needsZeroTileIndex(bTileIndex) ||
+          mlir::isa_and_nonnull<UnrealizedConversionCastOp>(
               bTileIndex.getDefiningOp())) {
         bTileIndex = index(rewriter, op.getLoc(), 0);
       }

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -647,14 +647,14 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
         if (allocOp->getAttr("d2m.scratch_buffer")) {
           numBuffers = 1;
         } else if (allocOp->getAttr("d2m.synchronized_buffer")) {
-          // Skip allocating, this is a contract from fusion and compute
-          // lowering saying we will not actually use this buffer and it's just
-          // a placeholder, so we can safely skip it.
-          if (!allocOp->getAttr("d2m.compute_intermediate")) {
-            numBuffers =
-                allocOp->getAttrOfType<IntegerAttr>("d2m.synchronized_buffer")
-                    .getInt();
-          }
+          // Synchronized buffers participate in CB producer/consumer
+          // handshakes after SplitUnifiedThread. Even single-tile compute
+          // intermediates need real L1 backing when a later compute stage reads
+          // them through a CB-backed memref (for example SDPA's staged softmax
+          // values feeding bcast/reduce/matmul stages).
+          numBuffers =
+              allocOp->getAttrOfType<IntegerAttr>("d2m.synchronized_buffer")
+                  .getInt();
         } else {
           // We can allow this in the future but asserting for now to check it's
           // not used.

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
@@ -201,6 +201,25 @@ unsigned DstSliceAllocator::getFirstInputSliceIndex() const {
   return inputStack.front();
 }
 
+void DstSliceAllocator::deallocateIntermediate(unsigned id) {
+  if (llvm::is_contained(inputStack, id)) {
+    return;
+  }
+  if (llvm::is_contained(sliceStack, id)) {
+    return;
+  }
+  TT_assertv(!llvm::is_contained(scratchSlots, id),
+             "Cannot deallocate a DST scratch slice");
+
+  sliceStack.push_back(id);
+  if (currSliceIndex && *currSliceIndex == id) {
+    currSliceIndex = std::nullopt;
+  }
+
+  debugDumpDstSliceAllocator("== DEALLOCATE INTERMEDIATE ==", sliceStack,
+                             inputStack, scratchSlots, id);
+}
+
 void DstSliceAllocator::deallocateAllButFirstInput() {
   TT_assertv(inputStack.size() >= 1u, "Need at least one input to keep");
 

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Unscheduled.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Unscheduled.cpp
@@ -17,6 +17,10 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#include "llvm/ADT/DenseMap.h"
+
+#include <optional>
+
 #define DEBUG_TYPE "D2MInsertDstRegisterAccessUnscheduled"
 
 namespace mlir::tt::d2m {
@@ -40,8 +44,28 @@ collectDstAccesses(GenericOp gOp, Region &region,
   CopyInfoMap copyInfos;
   DstSliceAllocator dstAllocator(dstCapacity);
   DstIntermediatesMap dstIntermediates;
+  llvm::DenseMap<Operation *, int64_t> remainingUses;
 
-  auto getInPlaceDstSlice = [&](OperandLoadStoreRegisterOpInterface op) -> int {
+  region.walk([&](OperandLoadStoreRegisterOpInterface computeOp) {
+    // The DST intermediate lifetime model below tracks one produced tile value
+    // per compute op. Multi-result ops are not modeled as reusable
+    // intermediates by the unscheduled path today.
+    if (computeOp->getNumResults() != 1u) {
+      return;
+    }
+    int64_t useCount = 0;
+    for (OpOperand &use : computeOp->getResult(0).getUses()) {
+      Operation *user = use.getOwner();
+      if (user->hasTrait<D2MGenericRegionComputeOpTrait>() ||
+          mlir::isa<affine::AffineStoreOp, memref::StoreOp>(user)) {
+        ++useCount;
+      }
+    }
+    remainingUses[computeOp.getOperation()] = useCount;
+  });
+
+  auto getInPlaceDstSlice =
+      [&](OperandLoadStoreRegisterOpInterface op) -> std::optional<int> {
     for (int64_t operandIdx : op.getOperandsLoadFromDstRegister()) {
       if (op.isScalarOperand(operandIdx)) {
         continue;
@@ -49,15 +73,40 @@ collectDstAccesses(GenericOp gOp, Region &region,
       auto *defOp = op->getOperand(operandIdx).getDefiningOp();
       if (defOp) {
         auto *it = dstIntermediates.find(defOp);
-        if (it != dstIntermediates.end()) {
+        auto remainingIt = remainingUses.find(defOp);
+        if (it != dstIntermediates.end() &&
+            remainingIt != remainingUses.end() && remainingIt->second <= 1) {
           return it->second.dstSlice;
         }
       }
     }
-    return dstAllocator.getCurrSliceIndex();
+    return std::nullopt;
   };
 
+  auto releaseConsumedIntermediates =
+      [&](OperandLoadStoreRegisterOpInterface op,
+          std::optional<int> producedDstSlice) {
+        for (Value operand : op->getOperands()) {
+          Operation *defOp = operand.getDefiningOp();
+          auto *dstIt = dstIntermediates.find(defOp);
+          if (dstIt == dstIntermediates.end()) {
+            continue;
+          }
+          auto remainingIt = remainingUses.find(defOp);
+          if (remainingIt == remainingUses.end()) {
+            continue;
+          }
+          --remainingIt->second;
+          if (remainingIt->second == 0 &&
+              (!producedDstSlice ||
+               dstIt->second.dstSlice != *producedDstSlice)) {
+            dstAllocator.deallocateIntermediate(dstIt->second.dstSlice);
+          }
+        }
+      };
+
   region.walk([&](OperandLoadStoreRegisterOpInterface computeOp) {
+    std::optional<int> producedDstSlice;
     auto notDstMemspace = [](auto op) {
       return op && ttcore::getMemorySpace(op.getMemRef()) !=
                        ttcore::MemorySpace::RegisterDst;
@@ -86,7 +135,7 @@ collectDstAccesses(GenericOp gOp, Region &region,
         getAccumClassificationOperandIndices(computeOp);
 
     int numLoads = 0;
-    int firstInputDstSlice = -1;
+    std::optional<int> firstInputDstSlice;
     for (int64_t operandIdx : computeOp.getOperandsLoadFromDstRegister()) {
       if (computeOp.isScalarOperand(operandIdx)) {
         continue;
@@ -95,7 +144,7 @@ collectDstAccesses(GenericOp gOp, Region &region,
       auto potentialLoad = computeOp->getOperand(operandIdx)
                                .getDefiningOp<affine::AffineLoadOp>();
       if (potentialLoad && notDstMemspace(potentialLoad)) {
-        int dstSlice = dstAllocator.allocateInput();
+        int dstSlice = static_cast<int>(dstAllocator.allocateInput());
         if (numLoads == 0) {
           firstInputDstSlice = dstSlice;
         }
@@ -106,6 +155,24 @@ collectDstAccesses(GenericOp gOp, Region &region,
             noAccumGuardForLoads);
       }
     }
+
+    auto getFirstInputDstSlice = [&]() -> int {
+      TT_assertv(firstInputDstSlice.has_value(),
+                 "Expected at least one input DST slice");
+      return *firstInputDstSlice;
+    };
+    auto allocateOutputOrReuseFirstInput = [&]() -> int {
+      if (firstInputDstSlice) {
+        return *firstInputDstSlice;
+      }
+      return static_cast<int>(dstAllocator.allocateOutput());
+    };
+    auto getReusableOrFallbackDstSlice = [&]() -> int {
+      if (std::optional<int> reusableDstSlice = getInPlaceDstSlice(computeOp)) {
+        return *reusableDstSlice;
+      }
+      return allocateOutputOrReuseFirstInput();
+    };
 
     const bool dstRegInPlace = computeOp.getDstRegInPlace();
 
@@ -125,14 +192,15 @@ collectDstAccesses(GenericOp gOp, Region &region,
           TT_assertv((isUnaryOp || isTileMatmul || isReduction || rhsIsScalar),
                      "in-place DST only supported for unary, tile matmul, "
                      "reductions, and tile+scalar ops");
-          dstSlice = getInPlaceDstSlice(computeOp);
+          dstSlice = getReusableOrFallbackDstSlice();
         } else if (numLoads >= 2) {
-          dstSlice = firstInputDstSlice;
+          dstSlice = getFirstInputDstSlice();
           dstAllocator.setStoreToDst();
         } else {
-          dstSlice = dstAllocator.allocateOutput();
+          dstSlice = static_cast<int>(dstAllocator.allocateOutput());
           dstAllocator.setStoreToDst();
         }
+        producedDstSlice = dstSlice;
         collectDstStoreAccess(potentialStore, copyInfos, dstSlice,
                               outermostInnerComputeLoop);
       } else if (auto scratchStore = mlir::dyn_cast<memref::StoreOp>(user)) {
@@ -149,45 +217,49 @@ collectDstAccesses(GenericOp gOp, Region &region,
           TT_assertv((isUnaryOp || isTileMatmul || isReduction || rhsIsScalar),
                      "in-place DST only supported for unary, tile matmul, "
                      "reductions, and tile+scalar ops");
-          dstSlice = getInPlaceDstSlice(computeOp);
+          dstSlice = getReusableOrFallbackDstSlice();
         } else if (numLoads >= 2) {
-          dstSlice = firstInputDstSlice;
+          dstSlice = getFirstInputDstSlice();
           dstAllocator.setStoreToDst();
         } else {
-          dstSlice = dstAllocator.allocateOutput();
+          dstSlice = static_cast<int>(dstAllocator.allocateOutput());
           dstAllocator.setStoreToDst();
         }
+        producedDstSlice = dstSlice;
         collectDstStoreAccess(scratchStore, copyInfos, dstSlice,
                               outermostInnerComputeLoop);
       } else {
         TT_assert(user->hasTrait<D2MGenericRegionComputeOpTrait>());
-        TT_assertv(computeOp->hasOneUse(),
-                   "Currently we do not support multiple users in the same "
-                   "compute dst region.");
         TT_assert(computeOp->getNumResults() == 1u);
-        TT_assert(!dstIntermediates.contains(computeOp));
+        if (dstIntermediates.contains(computeOp)) {
+          continue;
+        }
 
         int dstSlice;
         if (computeOp.getDstRegInPlace() || computeOp.isScalarOperand(1)) {
-          dstSlice = getInPlaceDstSlice(computeOp);
+          dstSlice = getReusableOrFallbackDstSlice();
         } else if (numLoads >= 2) {
-          dstSlice = firstInputDstSlice;
+          dstSlice = getFirstInputDstSlice();
         } else {
-          dstSlice = dstAllocator.allocateOutput();
+          dstSlice = static_cast<int>(dstAllocator.allocateOutput());
         }
 
-        if (mlir::isa<d2m::TileBcastOp>(computeOp)) {
+        if (mlir::isa<d2m::TileBcastOp>(computeOp) &&
+            computeOp->getOperand(0).getDefiningOp<affine::AffineLoadOp>()) {
           auto loadOp =
               computeOp->getOperand(0).getDefiningOp<affine::AffineLoadOp>();
-          TT_assert(loadOp != nullptr);
           auto bcastOp = mlir::cast<d2m::TileBcastOp>(computeOp);
+          producedDstSlice = dstSlice;
           recordDstAccess(loadOp, bcastOp, copyInfos, dstSlice,
                           outermostInnerComputeLoop, /*emitGuard=*/true);
         } else {
+          producedDstSlice = dstSlice;
           dstIntermediates[computeOp] = {dstSlice, outermostInnerComputeLoop};
         }
       }
     }
+
+    releaseConsumedIntermediates(computeOp, producedDstSlice);
 
     // Reserve any per-op DST scratch slices.
     for (int64_t i = 0, n = computeOp.getNumDstScratchSlices(); i < n; ++i) {

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -45,7 +45,8 @@ static bool isSynchronizableBoundaryOp(
 
 static bool canMergeIntoComputeRegion(
     Operation *op, const DenseSet<Operation *> &opsWithSynchronizableOps) {
-  return !isSynchronizableBoundaryOp(op, opsWithSynchronizableOps);
+  return !op->hasTrait<OpTrait::IsTerminator>() &&
+         !isSynchronizableBoundaryOp(op, opsWithSynchronizableOps);
 }
 
 static bool hasSynchronizableAncestor(Operation *op, GenericOp genericOp) {
@@ -240,11 +241,15 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
       opsWithSynchronizableOps.insert(op->getParentOp());
     }
   });
+  if (opsWithSynchronizableOps.empty()) {
+    return success();
+  }
+
   if (hasCrossNestComputeConsumerFanout(genericOp)) {
-    return genericOp.emitOpError()
-           << "compute ops span multiple synchronization scopes (e.g. a CB "
-              "consumed across distinct loop nests); cross-nest fan-out is not "
-              "yet supported";
+    return rewriter.notifyMatchFailure(
+        genericOp,
+        "compute ops span multiple synchronization scopes (e.g. a CB consumed "
+        "across distinct loop nests); cross-nest fan-out is not yet supported");
   }
 
   DenseSet<Operation *> outermostOps;
@@ -263,9 +268,9 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
       outermostOp = outermostOp->getParentOp();
       if (!mlir::isa<scf::ForOp>(outermostOp) &&
           !mlir::isa<linalg::GenericOp>(outermostOp)) {
-        outermostOp->emitOpError(
-            "Parent ops containing compute ops must be scf.for or "
-            "linalg.generic");
+        (void)rewriter.notifyMatchFailure(
+            genericOp, "parent ops containing compute ops must be scf.for or "
+                       "linalg.generic");
         walkFailed = true;
         return WalkResult::interrupt();
       }
@@ -467,10 +472,10 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
   // Consumers: wait once before the first consumer, pop once after the last.
   for (auto &[localBuffer, ops] : consumersByCB) {
     if (!commonParentBlock(ops)) {
-      return generic.emitOpError()
-             << "CB has consumers across distinct loop nests; cross-nest "
-                "fan-out is not yet supported (would deadlock on a "
-                "wait/pop cadence mismatch)";
+      return rewriter.notifyMatchFailure(
+          generic,
+          "CB has consumers across distinct loop nests; cross-nest fan-out is "
+          "not yet supported (would deadlock on a wait/pop cadence mismatch)");
     }
     unsigned cbOperandIdx = generic.getOperandIndex(localBuffer);
     Operation *first = ops.front();
@@ -516,9 +521,10 @@ insertCBOpsForCompute(Block *computeBlock, PatternRewriter &rewriter,
           !mlir::isa<RemoteStoreOp>(usageInfo.consumers.front()) ||
           !getSiblingOpsInNearestCommonBlock(first, last, reserveBefore,
                                              pushAfter)) {
-        return generic.emitOpError()
-               << "CB has producers across distinct loop nests; cross-nest "
-                  "producer fan-out is not yet supported";
+        return rewriter.notifyMatchFailure(
+            generic,
+            "CB has producers across distinct loop nests; cross-nest producer "
+            "fan-out is not yet supported");
       }
     }
     Location loc = first->getLoc();

--- a/lib/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.cpp
+++ b/lib/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.cpp
@@ -8,6 +8,8 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOpsInterfaces.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.h"
 
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+
 namespace mlir::tt::d2m::utils {
 
 // Note: This function must be used post-bufferization but before converting
@@ -45,6 +47,15 @@ bool isPurelyDerivedOp(Operation *op,
   // check if the result is already cached
   if (purelyDerivedOps.contains(op)) {
     return purelyDerivedOps[op];
+  }
+
+  // View-like memref ops only derive aliases/metadata. Keep the original op
+  // outside the synchronized region for later users and clone it inside the
+  // region for local users. Requiring their source allocs to be pure would
+  // incorrectly force all downstream users into one synchronized region.
+  if (isa<memref::CollapseShapeOp, memref::SubViewOp>(op)) {
+    purelyDerivedOps[op] = true;
+    return true;
   }
 
   // if not, compute the result

--- a/test/d2m-jit/test_matmul.py
+++ b/test/d2m-jit/test_matmul.py
@@ -341,9 +341,10 @@ def test_matmul_transpose_b_method_form_correctness():
 # Multicast smoke kernel.
 #
 # Each core (cy, cx) loops over k, m, n. For each k, m it row-multicasts
-# `lhs[m, k]` from the column-0 source core (cy, 0) across the row, and
-# for each k, m, n it column-multicasts `rhs[k, n]` from the row-0 source
-# core (0, cx) down the column. The body stores `lhs_shard + rhs_shard`
+# `lhs[cy * M + m, k]` from the column-0 source core (cy, 0) across
+# the row, and for each k, m, n it column-multicasts
+# `rhs[k, cx * N + n]` from the row-0 source core (0, cx) down the
+# column. The body stores `lhs_shard + rhs_shard`
 # into `out[m, n]` -- the store is *not* accumulating, so out[m, n] ends
 # up holding the last K iteration's `lhs + rhs`.
 #
@@ -357,26 +358,16 @@ def mcast_overwrite_kernel(lhs, rhs, out, K, M, N, GY, GX):
     for k in range(K):
         for m in range(M):
             lhs_shard = remote_load(
-                lhs, [m, k], mcast_start_index=[cy, 0], mcast_shape=[1, GX]
+                lhs, [cy * M + m, k], mcast_start_index=[cy, 0], mcast_shape=[1, GX]
             )
             for n in range(N):
                 rhs_shard = remote_load(
-                    rhs, [k, n], mcast_start_index=[0, cx], mcast_shape=[GY, 1]
+                    rhs, [k, cx * N + n], mcast_start_index=[0, cx], mcast_shape=[GY, 1]
                 )
                 out_shard = lhs_shard + rhs_shard
                 remote_store(out, [m, n], out_shard)
 
 
-@pytest.mark.skip(
-    reason=(
-        "Hits an expected assertion in "
-        "lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp:127 -- "
-        "wrapComputeInSynchronizedRegion expects exactly one op with a "
-        "synchronizable op, and the multicast remote_load pattern violates "
-        "that invariant. Tracked separately; un-skip once the pass handles "
-        "multi-op synchronized scopes."
-    )
-)
 def test_mcast_overwrite_grid_2x2():
     """Run mcast_overwrite_kernel on a 2x2 grid with K=M=N=1 -- single
     iteration per core, multicast from (cy, 0) across the row and from

--- a/test/d2m-jit/test_pattern_sdpa.py
+++ b/test/d2m-jit/test_pattern_sdpa.py
@@ -1,0 +1,328 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import d2m_jit as d2m
+
+from d2m_jit.patterns.sdpa_1tile_to_kernel import (
+    sdpa_block_2x2_fused,
+    sdpa_1tile_fused,
+    sdpa_full_2x2_fused,
+    sdpa_grid_1tile_fused,
+    sdpa_pv_1tile,
+    sdpa_qk_1tile,
+    sdpa_softmax_1tile_fused,
+)
+from utils import assert_pcc
+
+
+@d2m.kernel
+def sdpa_full_qk_2x2(q, k_t, scores):
+    row = core_index(0)
+    col = core_index(1)
+
+    q0 = remote_load(q, [row, 0])
+    kt0 = remote_load(k_t, [0, col])
+    q1 = remote_load(q, [row, 1])
+    kt1 = remote_load(k_t, [1, col])
+
+    remote_store(scores, [row, col], (q0 @ kt0) + (q1 @ kt1))
+
+
+@d2m.kernel
+def sdpa_full_row_max_first(scores, row_max):
+    row = core_index(0)
+    scores_tile = remote_load(scores, [row, 0])
+    remote_store(row_max, [row, 0], reduce_max(scores_tile, 1))
+
+
+@d2m.kernel
+def sdpa_full_row_max_accumulate(scores, acc_max, row_max):
+    row = core_index(0)
+    scores_tile = remote_load(scores, [row, 1])
+    acc_tile = remote_load(acc_max, [row, 0])
+    remote_store(row_max, [row, 0], acc_tile.maximum(reduce_max(scores_tile, 1)))
+
+
+@d2m.kernel
+def sdpa_full_exp_scores(scores, row_max, numer):
+    row = core_index(0)
+    col = core_index(1)
+
+    scores_tile = remote_load(scores, [row, col])
+    max_tile = tile_bcast_col(remote_load(row_max, [row, 0]))
+    remote_store(numer, [row, col], exp(scores_tile - max_tile))
+
+
+@d2m.kernel
+def sdpa_full_row_sum_first(numer, row_sum):
+    row = core_index(0)
+    numer_tile = remote_load(numer, [row, 0])
+    remote_store(row_sum, [row, 0], reduce_sum(numer_tile, 1))
+
+
+@d2m.kernel
+def sdpa_full_row_sum_accumulate(numer, acc_sum, row_sum):
+    row = core_index(0)
+    numer_tile = remote_load(numer, [row, 1])
+    acc_tile = remote_load(acc_sum, [row, 0])
+    remote_store(row_sum, [row, 0], acc_tile + reduce_sum(numer_tile, 1))
+
+
+@d2m.kernel
+def sdpa_full_normalize(numer, row_sum, probs):
+    row = core_index(0)
+    col = core_index(1)
+
+    numer_tile = remote_load(numer, [row, col])
+    sum_tile = tile_bcast_col(remote_load(row_sum, [row, 0]))
+    remote_store(probs, [row, col], numer_tile / sum_tile)
+
+
+@d2m.kernel
+def sdpa_full_pv_2x2(probs, v, out):
+    row = core_index(0)
+    col = core_index(1)
+
+    p0 = remote_load(probs, [row, 0])
+    v0 = remote_load(v, [0, col])
+    p1 = remote_load(probs, [row, 1])
+    v1 = remote_load(v, [1, col])
+
+    remote_store(out, [row, col], (p0 @ v0) + (p1 @ v1))
+
+
+def _make_layout():
+    return d2m.Layout(
+        shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[1, 1]
+    )
+
+
+def test_sdpa_1tile_kernel_chain_on_device():
+    torch.manual_seed(0)
+    q = torch.randn(32, 32, dtype=torch.float32) * 0.25
+    k = torch.randn(32, 32, dtype=torch.float32) * 0.25
+    v = torch.randn(32, 32, dtype=torch.float32)
+
+    layout = _make_layout()
+    scores_d = d2m.empty(layout)
+    probs_d = d2m.empty(layout)
+    out_d = d2m.empty(layout)
+
+    sdpa_qk_1tile(
+        d2m.to_layout(q, layout),
+        d2m.to_layout(k.transpose(0, 1).contiguous(), layout),
+        scores_d,
+        grid=(1, 1),
+    )
+    sdpa_softmax_1tile_fused(scores_d, probs_d, grid=(1, 1))
+    sdpa_pv_1tile(probs_d, d2m.to_layout(v, layout), out_d, grid=(1, 1))
+
+    expected = torch.softmax(q @ k.transpose(0, 1), dim=-1) @ v
+    assert_pcc(expected, out_d.to_host(), threshold=0.99)
+
+
+def test_sdpa_1tile_fused_kernel_on_device():
+    torch.manual_seed(0)
+    q = torch.randn(32, 32, dtype=torch.float32) * 0.25
+    k = torch.randn(32, 32, dtype=torch.float32) * 0.25
+    v = torch.randn(32, 32, dtype=torch.float32)
+
+    layout = _make_layout()
+    out_d = d2m.empty(layout)
+
+    old_use_tile_matmul = d2m.config.use_tile_matmul
+    d2m.config.use_tile_matmul = True
+    try:
+        sdpa_1tile_fused(
+            d2m.to_layout(q, layout),
+            d2m.to_layout(k.transpose(0, 1).contiguous(), layout),
+            d2m.to_layout(v, layout),
+            out_d,
+            grid=(1, 1),
+        )
+
+        expected = torch.softmax(q @ k.transpose(0, 1), dim=-1) @ v
+        assert_pcc(expected, out_d.to_host(), threshold=0.99)
+    finally:
+        d2m.config.use_tile_matmul = old_use_tile_matmul
+
+
+def test_sdpa_grid_1tile_fused_multicore_on_device():
+    torch.manual_seed(0)
+    grid = (2, 2)
+    shape = (grid[0] * 32, grid[1] * 32)
+    q = torch.randn(*shape, dtype=torch.float32) * 0.25
+    k_t = torch.randn(*shape, dtype=torch.float32) * 0.25
+    v = torch.randn(*shape, dtype=torch.float32)
+
+    layout = d2m.Layout(
+        shape=shape,
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=list(grid),
+    )
+    out_d = d2m.empty(layout)
+
+    old_use_tile_matmul = d2m.config.use_tile_matmul
+    d2m.config.use_tile_matmul = True
+    try:
+        sdpa_grid_1tile_fused(
+            d2m.to_layout(q, layout),
+            d2m.to_layout(k_t, layout),
+            d2m.to_layout(v, layout),
+            out_d,
+            grid=grid,
+        )
+
+        expected = torch.empty_like(q)
+        for gy in range(grid[0]):
+            row = slice(gy * 32, (gy + 1) * 32)
+            for gx in range(grid[1]):
+                col = slice(gx * 32, (gx + 1) * 32)
+                q_tile = q[row, col]
+                kt_tile = k_t[row, col]
+                v_tile = v[row, col]
+                expected[row, col] = torch.softmax(q_tile @ kt_tile, dim=-1) @ v_tile
+
+        assert_pcc(expected, out_d.to_host(), threshold=0.99)
+    finally:
+        d2m.config.use_tile_matmul = old_use_tile_matmul
+
+
+def test_sdpa_full_2x2_multicore_on_device():
+    torch.manual_seed(0)
+    grid = (2, 2)
+    shape = (64, 64)
+
+    q = torch.randn(*shape, dtype=torch.float32) * 0.25
+    k = torch.randn(*shape, dtype=torch.float32) * 0.25
+    k_t = k.transpose(0, 1).contiguous()
+    v = torch.randn(*shape, dtype=torch.float32)
+
+    layout = d2m.Layout(
+        shape=shape,
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=list(grid),
+    )
+    row_layout = d2m.reduction_layout(layout, 1, allow_cross_tile=True)
+
+    scores_d = d2m.empty(layout)
+    row_max0_d = d2m.empty(row_layout)
+    row_max_d = d2m.empty(row_layout)
+    numer_d = d2m.empty(layout)
+    row_sum0_d = d2m.empty(row_layout)
+    row_sum_d = d2m.empty(row_layout)
+    probs_d = d2m.empty(layout)
+    out_d = d2m.empty(layout)
+
+    old_use_tile_matmul = d2m.config.use_tile_matmul
+    d2m.config.use_tile_matmul = True
+    try:
+        q_d = d2m.to_layout(q, layout)
+        kt_d = d2m.to_layout(k_t, layout)
+        v_d = d2m.to_layout(v, layout)
+
+        sdpa_full_qk_2x2(q_d, kt_d, scores_d, grid=grid)
+        sdpa_full_row_max_first(scores_d, row_max0_d, grid=(2, 1))
+        sdpa_full_row_max_accumulate(scores_d, row_max0_d, row_max_d, grid=(2, 1))
+        sdpa_full_exp_scores(scores_d, row_max_d, numer_d, grid=grid)
+        sdpa_full_row_sum_first(numer_d, row_sum0_d, grid=(2, 1))
+        sdpa_full_row_sum_accumulate(numer_d, row_sum0_d, row_sum_d, grid=(2, 1))
+        sdpa_full_normalize(numer_d, row_sum_d, probs_d, grid=grid)
+        sdpa_full_pv_2x2(probs_d, v_d, out_d, grid=grid)
+
+        expected = torch.softmax(q @ k_t, dim=-1) @ v
+        actual = out_d.to_host()
+        assert_pcc(expected, actual, threshold=0.99)
+        max_diff = (expected - actual).abs().max().item()
+        assert max_diff < 0.2, f"full 2x2 SDPA max diff {max_diff} too large"
+    finally:
+        d2m.config.use_tile_matmul = old_use_tile_matmul
+
+
+def test_sdpa_full_2x2_fused_multicore_on_device():
+    torch.manual_seed(0)
+    grid = (2, 2)
+    shape = (64, 64)
+
+    q = torch.randn(*shape, dtype=torch.float32) * 0.25
+    k = torch.randn(*shape, dtype=torch.float32) * 0.25
+    k_t = k.transpose(0, 1).contiguous()
+    v = torch.randn(*shape, dtype=torch.float32)
+
+    layout = d2m.Layout(
+        shape=shape,
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=list(grid),
+    )
+    out_d = d2m.empty(layout)
+
+    old_use_tile_matmul = d2m.config.use_tile_matmul
+    d2m.config.use_tile_matmul = True
+    try:
+        sdpa_full_2x2_fused(
+            d2m.to_layout(q, layout),
+            d2m.to_layout(k_t, layout),
+            d2m.to_layout(v, layout),
+            out_d,
+            grid=grid,
+        )
+
+        expected = torch.softmax(q @ k_t, dim=-1) @ v
+        actual = out_d.to_host()
+        assert_pcc(expected, actual, threshold=0.99)
+        max_diff = (expected - actual).abs().max().item()
+        assert max_diff < 0.2, f"fused full 2x2 SDPA max diff {max_diff} too large"
+    finally:
+        d2m.config.use_tile_matmul = old_use_tile_matmul
+
+
+def test_sdpa_block_2x2_fused_packed_heads_on_device():
+    torch.manual_seed(0)
+    grid = (2, 2)
+    head_shape = (64, 64)
+    shape = (grid[0] * head_shape[0], grid[1] * head_shape[1])
+
+    q = torch.randn(*shape, dtype=torch.float32) * 0.25
+    k_t = torch.randn(*shape, dtype=torch.float32) * 0.25
+    v = torch.randn(*shape, dtype=torch.float32)
+
+    layout = d2m.Layout(
+        shape=shape,
+        dtype=d2m.float32,
+        block_shape=[2, 2],
+        grid_shape=list(grid),
+    )
+    out_d = d2m.empty(layout)
+
+    old_use_tile_matmul = d2m.config.use_tile_matmul
+    d2m.config.use_tile_matmul = True
+    try:
+        sdpa_block_2x2_fused(
+            d2m.to_layout(q, layout),
+            d2m.to_layout(k_t, layout),
+            d2m.to_layout(v, layout),
+            out_d,
+            grid=grid,
+        )
+
+        expected = torch.empty_like(q)
+        for gy in range(grid[0]):
+            row = slice(gy * head_shape[0], (gy + 1) * head_shape[0])
+            for gx in range(grid[1]):
+                col = slice(gx * head_shape[1], (gx + 1) * head_shape[1])
+                q_block = q[row, col]
+                kt_block = k_t[row, col]
+                v_block = v[row, col]
+                expected[row, col] = torch.softmax(q_block @ kt_block, dim=-1) @ v_block
+
+        actual = out_d.to_host()
+        assert_pcc(expected, actual, threshold=0.99)
+        max_diff = (expected - actual).abs().max().item()
+        assert max_diff < 0.2, f"packed block 2x2 SDPA max diff {max_diff} too large"
+    finally:
+        d2m.config.use_tile_matmul = old_use_tile_matmul

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_implicit_bcast.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_implicit_bcast.mlir
@@ -209,4 +209,49 @@ module {
     }
     return
   }
+
+
+  // CHECK-LABEL: func.func @bcast_intermediate
+  func.func @bcast_intermediate(%in0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                %in1: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                %out0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<unified>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)
+        outs(%out0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)  {
+    ^unified0:
+      %cb0 = d2m.get_cb(0) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>
+      %cb1 = d2m.get_cb(1) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>
+      %cb2 = d2m.get_cb(2) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>
+      %0 = d2m.wait %cb0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %1 = d2m.wait %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %2 = d2m.reserve %cb2 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg2 = %c0 to %c1 step %c1 {
+        scf.for %arg3 = %c0 to %c1 step %c1 {
+          %subview = memref.subview %0[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          %subview_1 = memref.subview %1[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          %subview_2 = memref.subview %2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          // CHECK: %[[EXP:.*]] = "d2m.tile_exp"
+          // CHECK-NEXT: affine.store %[[EXP]], %dst
+          // CHECK-NEXT: %[[EXP_DST:.*]] = affine.load %dst
+          // CHECK-NEXT: %[[BCAST:.*]] = "d2m.tile_bcast"(%[[EXP_DST]]) <{bcast_type = #d2m<tile_bcast_type row>}>
+          // CHECK-NEXT: affine.store %[[BCAST]], %dst
+          // CHECK-NEXT: %[[BCAST_DST:.*]] = affine.load %dst
+          // CHECK: "d2m.tile_sub"(%{{.*}}, %[[BCAST_DST]])
+          // CHECK: "d2m.tile_add"(%[[EXP_DST]],
+          linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%subview, %subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) outs(%subview_2 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+          ^bb0(%in: !ttcore.tile<32x32, f32>, %in_1: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
+            %exp = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            %bcast = "d2m.tile_bcast"(%exp) <{bcast_type = #d2m<tile_bcast_type row>}> : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            %shifted = "d2m.tile_sub"(%in_1, %bcast) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            %result = "d2m.tile_add"(%exp, %shifted) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            linalg.yield %result : !ttcore.tile<32x32, f32>
+          }
+        }
+      }
+    }
+    return
+  }
+
 }

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_fanout_unsupported.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_fanout_unsupported.mlir
@@ -1,10 +1,10 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-split-unified-thread --split-input-file --verify-diagnostics %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-split-unified-thread --split-input-file %s | FileCheck %s
 
 // Cross-nest fan-out: a CB consumed by compute ops living in two distinct loop
 // nests. The producer pushes the CB once per blocking-loop iteration, so a
 // single per-block wait/pop pair cannot dominate/post-dominate consumers spread
-// across separate nests. This is not yet supported and must be diagnosed (not
-// silently miscompiled into a deadlock).
+// across separate nests. This is not yet supported; the pattern must fail
+// without splitting the generic into a deadlocking DM/compute pair.
 
 #l1 = #ttcore.memory_space<l1>
 #dram = #ttcore.memory_space<dram>
@@ -19,7 +19,10 @@ module attributes {ttcore.system_desc = #system_desc} {
     %stream = d2m.view_layout %arg0 remapping = #map4 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram> -> memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
     %cb_in = memref.alloc() {address = 5120 : i64, alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     %cb_a = memref.alloc() {address = 6144 : i64, alignment = 16 : i64} : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
-    // expected-error @+1 {{compute ops span multiple synchronization scopes (e.g. a CB consumed across distinct loop nests); cross-nest fan-out is not yet supported}}
+    // CHECK-LABEL: func.func @fanout_cross_nest
+    // CHECK: d2m.generic
+    // CHECK-SAME: threads = [#d2m.thread<unified>]
+    // CHECK-NOT: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
     d2m.generic {block_factors = [], grid = #ttcore.grid<4x4>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
         ins(%stream : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>)
         outs(%res : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)

--- a/test/ttmlir/Dialect/D2M/generic/blocking_map_transfer.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/blocking_map_transfer.mlir
@@ -22,7 +22,7 @@
 // CHECK: memref.alloc() {alignment = 64 : i64, d2m.blocking_map = #map, d2m.compute_intermediate, d2m.synchronized_buffer = 2 : i32} : memref<4x4x!ttcore.tile<32x32, f32>>
 // CHECK-ALLOC-LABEL: func.func @blocking_map_transfers_to_alloc
 // CHECK-ALLOC: d2m.generic
-// CHECK-ALLOC: memref.alloc() {alignment = {{.*}}, d2m.blocking_map = #map, d2m.compute_intermediate, d2m.synchronized_buffer = 2 : i32} : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+// CHECK-ALLOC: memref.alloc() {{.*}}d2m.blocking_map = #map, d2m.compute_intermediate, d2m.synchronized_buffer = 2 : i32} : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
 func.func @blocking_map_transfers_to_alloc(%arg0: !memref_tiled, %arg1: !memref_tiled, %arg2: !memref_tiled) {
   %out = memref.alloc() : !memref_tiled
   d2m.generic {
@@ -76,7 +76,7 @@ func.func @blocking_map_transfers_to_alloc(%arg0: !memref_tiled, %arg1: !memref_
 // CHECK-FUSED-AUTO: d2m.view_layout %{{.*}} -> memref<8x2x1x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>
 // CHECK-FUSED-AUTO: d2m.generic {block_factors = [8, 2], grid = #ttcore.grid<1x1>
 // CHECK-FUSED-AUTO: affine.for
-// CHECK-FUSED-AUTO: memref.alloc() {alignment = {{.*}}, d2m.blocking_map = #{{.*}}, d2m.compute_intermediate, d2m.synchronized_buffer = 2 : i32} : memref<1x4x!ttcore.tile<32x32, f32>, #l1>
+// CHECK-FUSED-AUTO: memref.alloc() {{.*}}d2m.blocking_map = #{{.*}}, d2m.compute_intermediate, d2m.synchronized_buffer = 2 : i32} : memref<1x4x!ttcore.tile<32x32, f32>, #l1>
 // CHECK-FUSED-AUTO: linalg.generic
 // %a/%b (the L1 views returned by the remote_load) are unused in this example in favor of %e0/%e1 (scratch allocs) for testing purposes.
 func.func @blocking_map_reblocks_fused_generic(%arg0: !memref_tiled_l1_8, %arg1: !memref_tiled_l1_8, %arg2: !memref_tiled_l1_8) {

--- a/tools/d2m-jit/CMakeLists.txt
+++ b/tools/d2m-jit/CMakeLists.txt
@@ -18,6 +18,7 @@ declare_mlir_python_sources(TTD2MJitSources
         patterns/__init__.py
         patterns/eltwise_add_exp_to_kernel.py
         patterns/eltwise_exp_to_kernel.py
+        patterns/sdpa_1tile_to_kernel.py
 )
 
 add_mlir_python_modules(TTD2MJitModules

--- a/tools/d2m-jit/TODO.md
+++ b/tools/d2m-jit/TODO.md
@@ -12,33 +12,6 @@ have.
 
 ## Pipeline gaps
 
-### 🔴 Multicast kernels hit `SplitUnifiedThread` assertion
-
-**Where:** any kernel that uses the multicast form of `remote_load`
-(`mcast_start_index`, `mcast_shape`) on a grid larger than 1×1.
-
-**Symptom:**
-
-```
-python: lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp:127:
-  wrapComputeInSynchronizedRegion: Assertion
-  `opsWithSynchronizableOps.size() == 1 && "synchronized scope must be
-  unambiguous"' failed.
-```
-
-**Root cause:** `wrapComputeInSynchronizedRegion` expects exactly one
-op-with-a-synchronizable-op inside a `d2m.GenericOp` when wrapping the
-compute thread, but a multicast `remote_load` kernel produces multiple
-such ops (the load itself plus the elementwise body), so the pass aborts.
-
-**Impact:** the multicast smoke test in
-`test/d2m-jit/test_matmul.py::test_mcast_overwrite_grid_2x2` is
-currently marked `@pytest.mark.skip` for this reason.
-
-**Fix shape:** teach `SplitUnifiedThread`'s
-`wrapComputeInSynchronizedRegion` to handle multiple synchronizable ops
-in the same scope (or split them into separate synchronized scopes).
-
 ---
 
 ## Missing API surface

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -768,6 +768,40 @@ def reduce_mean(input, dim):
     )
 
 
+@syntax("reduce_sum_pair", args_as_attr=[False, False, _int_attr_from_ast])
+def reduce_sum_pair(lhs, rhs, dim):
+    """Block-level float sum reduction over one tile axis for two blocks.
+
+    This is equivalent to `reduce_sum(lhs, dim) + reduce_sum(rhs, dim)`,
+    but emits a single reduction generic and scaler tile.
+    """
+    return _reduce_pair_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_sum(a.type, a, b, c, reduce_dim),
+        lhs,
+        rhs,
+        dim,
+        1.0,
+        0.0,
+    )
+
+
+@syntax("reduce_max_pair", args_as_attr=[False, False, _int_attr_from_ast])
+def reduce_max_pair(lhs, rhs, dim):
+    """Block-level float max reduction over one tile axis for two blocks.
+
+    This is equivalent to `maximum(reduce_max(lhs, dim), reduce_max(rhs, dim))`,
+    but emits a single reduction generic and scaler tile.
+    """
+    return _reduce_pair_block(
+        lambda a, b, c, reduce_dim: d2m.tile_reduce_max(a.type, a, b, c, reduce_dim),
+        lhs,
+        rhs,
+        dim,
+        1.0,
+        float("-inf"),
+    )
+
+
 @syntax("!tensor")
 class TensorBlock:
     """The DSL-side host class for a tile-typed tensor block.
@@ -1449,6 +1483,55 @@ def _reduce_block_axis_explicit(
         linalg.yield_([accumulator])
     _set_reduced_axes(generic.result, {reduce_axis})
 
+    return generic.result
+
+
+def _reduce_pair_block(tile_op_fn, lhs, rhs, dim, scaler_value, identity_value):
+    lhs_ty = lhs.type
+    rhs_ty = rhs.type
+    if not isinstance(lhs_ty, RankedTensorType) or not isinstance(
+        rhs_ty, RankedTensorType
+    ):
+        raise TypeError(
+            f"reduce pair inputs must be ranked tensors, got {lhs_ty} and {rhs_ty}"
+        )
+    if lhs_ty != rhs_ty:
+        raise ValueError(f"reduce pair input types must match: {lhs_ty} vs {rhs_ty}")
+
+    rank = lhs_ty.rank
+    elem_ty = lhs_ty.element_type
+    reduce_axis = _normalize_reduce_axis(dim, rank)
+    reduce_dim = _dim_to_reduce_dim_attr(dim)
+
+    output = d2m.empty(lhs_ty)
+    scaler = _reduction_scaler_block(lhs_ty, scaler_value)
+    identity = AffineMap.get_identity(rank)
+    indexing_maps = ArrayAttr.get([AffineMapAttr.get(identity)] * 4)
+    parallel = Attribute.parse("#linalg.iterator_type<parallel>")
+
+    generic = linalg.GenericOp(
+        [lhs_ty],
+        [lhs, rhs, scaler],
+        [output],
+        indexing_maps,
+        ArrayAttr.get([parallel] * rank),
+    )
+    body = Block.create_at_start(
+        generic.regions[0],
+        [elem_ty, elem_ty, elem_ty, elem_ty],
+        [Location.unknown()] * 4,
+    )
+    with InsertionPoint(body):
+        lhs_tile, rhs_tile, scaler_tile, _ = body.arguments
+        accumulator = _tile_fill_float(elem_ty, identity_value)
+        result = tile_op_fn(lhs_tile, scaler_tile, accumulator, reduce_dim)
+        if hasattr(result, "result"):
+            result = result.result
+        result = tile_op_fn(rhs_tile, scaler_tile, result, reduce_dim)
+        if hasattr(result, "result"):
+            result = result.result
+        linalg.yield_([result])
+    _set_reduced_axes(generic.result, {reduce_axis})
     return generic.result
 
 

--- a/tools/d2m-jit/patterns/sdpa_1tile_to_kernel.py
+++ b/tools/d2m-jit/patterns/sdpa_1tile_to_kernel.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""One-tile SDPA bring-up kernels for D2M-JIT work.
+
+This computes:
+
+    softmax(Q @ K^T) @ V
+
+for a single 32x32 tile shard. The key input is expected to already be laid
+out as K^T. The three-kernel chain is kept as a comparison baseline;
+``sdpa_1tile_fused`` is the bring-up target and emits QK^T, row-softmax, and
+PV inside one D2M-JIT kernel.
+"""
+
+import d2m_jit as d2m
+
+
+@d2m.kernel
+def sdpa_qk_1tile(q, k_t, scores):
+    q_tile = remote_load(q, [0, 0])
+    kt_tile = remote_load(k_t, [0, 0])
+    scores_tile = q_tile @ kt_tile
+
+    remote_store(scores, [0, 0], scores_tile)
+
+
+@d2m.kernel
+def sdpa_softmax_1tile_fused(scores, probs):
+    scores_tile = remote_load(scores, [0, 0])
+    row_max = reduce_max(scores_tile, 1)
+    numer = exp(scores_tile - row_max)
+    denom = reduce_sum(numer, 1)
+    probs_tile = numer / denom
+
+    remote_store(probs, [0, 0], probs_tile)
+
+
+@d2m.kernel
+def sdpa_pv_1tile(probs, v, out):
+    probs_tile = remote_load(probs, [0, 0])
+    v_tile = remote_load(v, [0, 0])
+    result = probs_tile @ v_tile
+
+    remote_store(out, [0, 0], result)
+
+
+@d2m.kernel
+def sdpa_1tile_fused(q, k_t, v, out):
+    q_tile = remote_load(q, [0, 0])
+    kt_tile = remote_load(k_t, [0, 0])
+    v_tile = remote_load(v, [0, 0])
+
+    scores = q_tile @ kt_tile
+    row_max = reduce_max(scores, 1)
+    numer = exp(scores - row_max)
+    denom = reduce_sum(numer, 1)
+    probs = numer / denom
+    result = probs @ v_tile
+
+    remote_store(out, [0, 0], result)
+
+
+@d2m.kernel
+def sdpa_grid_1tile_fused(q, k_t, v, out):
+    m = core_index(0)
+    n = core_index(1)
+    q_tile = remote_load(q, [m, n])
+    kt_tile = remote_load(k_t, [m, n])
+    v_tile = remote_load(v, [m, n])
+
+    scores = q_tile @ kt_tile
+    row_max = reduce_max(scores, 1)
+    numer = exp(scores - row_max)
+    denom = reduce_sum(numer, 1)
+    probs = numer / denom
+    result = probs @ v_tile
+
+    remote_store(out, [m, n], result)
+
+
+@d2m.kernel
+def sdpa_full_2x2_fused(q, k_t, v, out):
+    row = core_index(0)
+    value_col = core_index(1)
+
+    q0 = remote_load(q, [row, 0])
+    q1 = remote_load(q, [row, 1])
+
+    kt00 = remote_load(k_t, [0, 0])
+    kt10 = remote_load(k_t, [1, 0])
+    kt01 = remote_load(k_t, [0, 1])
+    kt11 = remote_load(k_t, [1, 1])
+
+    scores0 = (q0 @ kt00) + (q1 @ kt10)
+    scores1 = (q0 @ kt01) + (q1 @ kt11)
+
+    row_max = reduce_max_pair(scores0, scores1, 1)
+
+    numer0 = exp(scores0 - row_max)
+    numer1 = exp(scores1 - row_max)
+    denom = reduce_sum_pair(numer0, numer1, 1)
+
+    probs0 = numer0 / denom
+    probs1 = numer1 / denom
+
+    v0 = remote_load(v, [0, value_col])
+    v1 = remote_load(v, [1, value_col])
+    result = (probs0 @ v0) + (probs1 @ v1)
+
+    remote_store(out, [row, value_col], result)
+
+
+@d2m.kernel
+def sdpa_block_2x2_fused(q, k_t, v, out):
+    head_y = core_index(0)
+    head_x = core_index(1)
+
+    q_block = remote_load(q, [head_y, head_x])
+    kt_block = remote_load(k_t, [head_y, head_x])
+    v_block = remote_load(v, [head_y, head_x])
+
+    scores = q_block @ kt_block
+    row_max = reduce_max(scores, 1)
+    numer = exp(scores - row_max)
+    denom = reduce_sum(numer, 1)
+    probs = numer / denom
+    result = probs @ v_block
+
+    remote_store(out, [head_y, head_x], result)
+
+
+@d2m.kernel
+def sdpa_block_fused(q, k_t, v, out):
+    head_y = core_index(0)
+    head_x = core_index(1)
+
+    q_block = remote_load(q, [head_y, head_x])
+    kt_block = remote_load(k_t, [head_y, head_x])
+    v_block = remote_load(v, [head_y, head_x])
+
+    scores = q_block @ kt_block
+    row_max = reduce_max(scores, 1)
+    numer = exp(scores - row_max)
+    denom = reduce_sum(numer, 1)
+    probs = numer / denom
+    result = probs @ v_block
+
+    remote_store(out, [head_y, head_x], result)


### PR DESCRIPTION
## Summary

- Add `reduce_sum_pair` / `reduce_max_pair` block helpers for reducing two score/probability blocks in one reduction generic.
- Add D2M-JIT SDPA bring-up kernels covering 1-tile, per-core block, packed-block, and full 2x2 fused forms.
- Add device tests that compare the fused kernels against torch SDPA references and include staged baseline kernels for the full 2x2 path.
- Register the SDPA pattern module in the d2m-jit Python package sources.

## Validation

- `git diff --cached --check`
- `python -m py_compile tools/d2m-jit/api.py tools/d2m-jit/patterns/sdpa_1tile_to_kernel.py test/d2m-jit/test_pattern_sdpa.py`
- `PYTHONPATH=/tmp/pr3_py:$PYTHONPATH python -m pytest -q test/d2m-jit/test_pattern_sdpa.py -q` (6 passed)
- `git commit` pre-commit hooks: black, clang-format skipped/no files, copyright, trailing whitespace, EOF, large-file, include-style skipped/no files

## Notes

This is stacked on #8892 (`vwells/d2m-fusion-sdpa-blockers`), which is stacked on #8891.

The targeted pytest imported this branch's d2m-jit Python source through a `/tmp/pr3_py/d2m_jit` symlink while using the already-configured local build/runtime modules. I did not create a fresh CMake build tree for the temporary stacked worktree.
