### PR TITLE
[d2m] cache d2m dma coalescing analysis

### DIFF
--- a/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
@@ -282,11 +282,11 @@ public:
                                 CoalescingFactorCache &coalescingCache)
       : OpRewritePattern<DMAReadOp>(context),
         debugCoalescingInference(debugCoalescingInference),
-        coalescingCache(coalescingCache) {}
+        coalescingCache(&coalescingCache) {}
 
 private:
   bool debugCoalescingInference;
-  CoalescingFactorCache &coalescingCache;
+  CoalescingFactorCache *coalescingCache = nullptr;
 
 public:
   LogicalResult matchAndRewrite(DMAReadOp op,
@@ -319,8 +319,8 @@ public:
 
     size_t elemSizeBytes = getElementSizeBytes(remoteMemrefType);
     size_t coalescingFactor =
-        coalescingCache.get(remoteMemoryMap, gridShape, shardShape,
-                            elemSizeBytes, debugCoalescingInference);
+        coalescingCache->get(remoteMemoryMap, gridShape, shardShape,
+                             elemSizeBytes, debugCoalescingInference);
 
     SmallVector<Value> gridIndices(op.getSrcIndices());
 
@@ -353,11 +353,11 @@ public:
                                  CoalescingFactorCache &coalescingCache)
       : OpRewritePattern<DMAWriteOp>(context),
         debugCoalescingInference(debugCoalescingInference),
-        coalescingCache(coalescingCache) {}
+        coalescingCache(&coalescingCache) {}
 
 private:
   bool debugCoalescingInference;
-  CoalescingFactorCache &coalescingCache;
+  CoalescingFactorCache *coalescingCache = nullptr;
 
 public:
   LogicalResult matchAndRewrite(DMAWriteOp op,
@@ -417,8 +417,8 @@ public:
 
     size_t elemSizeBytes = getElementSizeBytes(remoteMemrefType);
     size_t coalescingFactor =
-        coalescingCache.get(remoteMemoryMap, gridShape, shardShape,
-                            elemSizeBytes, debugCoalescingInference);
+        coalescingCache->get(remoteMemoryMap, gridShape, shardShape,
+                             elemSizeBytes, debugCoalescingInference);
 
     SmallVector<Value> gridIndices(op.getDstIndices());
     SmallVector<Value> startDevice(op.getStartDevice());

--- a/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
@@ -15,10 +15,68 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MLOWERDMATOFULLYINDEXEDFORM
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
+
+struct CoalescingCacheKey {
+  AffineMap map;
+  SmallVector<int64_t, 8> shape;
+  unsigned numGridDims = 0;
+  size_t elemSizeBytes = 0;
+
+  bool operator==(const CoalescingCacheKey &other) const {
+    return map == other.map && shape == other.shape &&
+           numGridDims == other.numGridDims &&
+           elemSizeBytes == other.elemSizeBytes;
+  }
+};
+
+struct CoalescingCacheKeyInfo {
+  static CoalescingCacheKey getEmptyKey() {
+    return CoalescingCacheKey{AffineMap::getFromOpaquePointer(
+                                  DenseMapInfo<const void *>::getEmptyKey()),
+                              {},
+                              0,
+                              0};
+  }
+
+  static CoalescingCacheKey getTombstoneKey() {
+    return CoalescingCacheKey{
+        AffineMap::getFromOpaquePointer(
+            DenseMapInfo<const void *>::getTombstoneKey()),
+        {},
+        0,
+        0};
+  }
+
+  static unsigned getHashValue(const CoalescingCacheKey &key) {
+    return static_cast<unsigned>(llvm::hash_combine(
+        key.map.getAsOpaquePointer(), key.numGridDims, key.elemSizeBytes,
+        llvm::hash_combine_range(key.shape.begin(), key.shape.end())));
+  }
+
+  static bool isEqual(const CoalescingCacheKey &lhs,
+                      const CoalescingCacheKey &rhs) {
+    return lhs == rhs;
+  }
+};
+
+using CoalescingCache =
+    DenseMap<CoalescingCacheKey, size_t, CoalescingCacheKeyInfo>;
+
+class CoalescingFactorCache {
+public:
+  size_t get(AffineMap memoryMap, ArrayRef<int64_t> gridShape,
+             ArrayRef<int64_t> shardShape, size_t elemSizeBytes,
+             bool debugCoalescingInference);
+
+private:
+  CoalescingCache cache;
+};
 
 static size_t getElementSizeBytes(MemRefType memref) {
   mlir::Type elementType = memref.getElementType();
@@ -109,6 +167,27 @@ static size_t calculateCoalescingFactorWithFallback(
   }
 
   return coalescingFactor;
+}
+
+size_t CoalescingFactorCache::get(AffineMap memoryMap,
+                                  ArrayRef<int64_t> gridShape,
+                                  ArrayRef<int64_t> shardShape,
+                                  size_t elemSizeBytes,
+                                  bool debugCoalescingInference) {
+  CoalescingCacheKey key;
+  key.map = memoryMap;
+  key.shape.append(gridShape.begin(), gridShape.end());
+  key.shape.append(shardShape.begin(), shardShape.end());
+  key.numGridDims = gridShape.size();
+  key.elemSizeBytes = elemSizeBytes;
+
+  auto [it, inserted] = cache.try_emplace(std::move(key));
+  if (inserted) {
+    it->second = calculateCoalescingFactorWithFallback(
+        memoryMap, gridShape, shardShape, elemSizeBytes,
+        debugCoalescingInference);
+  }
+  return it->second;
 }
 
 // Core loop generation with coalescing guard.  Handles both the fully
@@ -206,12 +285,15 @@ private:
 class D2MLowerDMAReadToFullyIndexed : public OpRewritePattern<DMAReadOp> {
 public:
   D2MLowerDMAReadToFullyIndexed(MLIRContext *context,
-                                bool debugCoalescingInference)
+                                bool debugCoalescingInference,
+                                CoalescingFactorCache *coalescingCache)
       : OpRewritePattern<DMAReadOp>(context),
-        debugCoalescingInference(debugCoalescingInference) {}
+        debugCoalescingInference(debugCoalescingInference),
+        coalescingCache(coalescingCache) {}
 
 private:
   bool debugCoalescingInference;
+  CoalescingFactorCache *coalescingCache = nullptr;
 
 public:
   LogicalResult matchAndRewrite(DMAReadOp op,
@@ -243,9 +325,9 @@ public:
     AffineMap localMemoryMap = utils::getMemoryMap(device, localMemref, false);
 
     size_t elemSizeBytes = getElementSizeBytes(remoteMemrefType);
-    size_t coalescingFactor = calculateCoalescingFactorWithFallback(
-        remoteMemoryMap, gridShape, shardShape, elemSizeBytes,
-        debugCoalescingInference);
+    size_t coalescingFactor =
+        coalescingCache->get(remoteMemoryMap, gridShape, shardShape,
+                             elemSizeBytes, debugCoalescingInference);
 
     SmallVector<Value> gridIndices(op.getSrcIndices());
 
@@ -274,12 +356,15 @@ public:
 class D2MLowerDMAWriteToFullyIndexed : public OpRewritePattern<DMAWriteOp> {
 public:
   D2MLowerDMAWriteToFullyIndexed(MLIRContext *context,
-                                 bool debugCoalescingInference)
+                                 bool debugCoalescingInference,
+                                 CoalescingFactorCache *coalescingCache)
       : OpRewritePattern<DMAWriteOp>(context),
-        debugCoalescingInference(debugCoalescingInference) {}
+        debugCoalescingInference(debugCoalescingInference),
+        coalescingCache(coalescingCache) {}
 
 private:
   bool debugCoalescingInference;
+  CoalescingFactorCache *coalescingCache = nullptr;
 
 public:
   LogicalResult matchAndRewrite(DMAWriteOp op,
@@ -338,9 +423,9 @@ public:
     AffineMap localMemoryMap = utils::getMemoryMap(device, localMemref, false);
 
     size_t elemSizeBytes = getElementSizeBytes(remoteMemrefType);
-    size_t coalescingFactor = calculateCoalescingFactorWithFallback(
-        remoteMemoryMap, gridShape, shardShape, elemSizeBytes,
-        debugCoalescingInference);
+    size_t coalescingFactor =
+        coalescingCache->get(remoteMemoryMap, gridShape, shardShape,
+                             elemSizeBytes, debugCoalescingInference);
 
     SmallVector<Value> gridIndices(op.getDstIndices());
     SmallVector<Value> startDevice(op.getStartDevice());
@@ -502,11 +587,12 @@ public:
       D2MLowerDMAToFullyIndexedForm>::D2MLowerDMAToFullyIndexedFormBase;
 
   void runOnOperation() final {
+    CoalescingFactorCache coalescingCache;
     RewritePatternSet dmaPatterns(&getContext());
-    dmaPatterns.add<D2MLowerDMAReadToFullyIndexed>(&getContext(),
-                                                   debugCoalescingInference);
-    dmaPatterns.add<D2MLowerDMAWriteToFullyIndexed>(&getContext(),
-                                                    debugCoalescingInference);
+    dmaPatterns.add<D2MLowerDMAReadToFullyIndexed>(
+        &getContext(), debugCoalescingInference, &coalescingCache);
+    dmaPatterns.add<D2MLowerDMAWriteToFullyIndexed>(
+        &getContext(), debugCoalescingInference, &coalescingCache);
     dmaPatterns.add<D2MLowerLocalCopyToFullyIndexed>(&getContext(),
                                                      debugCoalescingInference);
     AffineApplyCreatedListener listener;

--- a/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
@@ -23,7 +23,7 @@ namespace mlir::tt::d2m {
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 struct CoalescingCacheKey {
-  AffineMap map;
+  const void *map = nullptr;
   SmallVector<int64_t, 8> shape;
   unsigned numGridDims = 0;
   size_t elemSizeBytes = 0;
@@ -37,25 +37,18 @@ struct CoalescingCacheKey {
 
 struct CoalescingCacheKeyInfo {
   static CoalescingCacheKey getEmptyKey() {
-    return CoalescingCacheKey{AffineMap::getFromOpaquePointer(
-                                  DenseMapInfo<const void *>::getEmptyKey()),
-                              {},
-                              0,
-                              0};
+    return CoalescingCacheKey{
+        DenseMapInfo<const void *>::getEmptyKey(), {}, 0, 0};
   }
 
   static CoalescingCacheKey getTombstoneKey() {
     return CoalescingCacheKey{
-        AffineMap::getFromOpaquePointer(
-            DenseMapInfo<const void *>::getTombstoneKey()),
-        {},
-        0,
-        0};
+        DenseMapInfo<const void *>::getTombstoneKey(), {}, 0, 0};
   }
 
   static unsigned getHashValue(const CoalescingCacheKey &key) {
     return static_cast<unsigned>(llvm::hash_combine(
-        key.map.getAsOpaquePointer(), key.numGridDims, key.elemSizeBytes,
+        key.map, key.numGridDims, key.elemSizeBytes,
         llvm::hash_combine_range(key.shape.begin(), key.shape.end())));
   }
 
@@ -175,7 +168,7 @@ size_t CoalescingFactorCache::get(AffineMap memoryMap,
                                   size_t elemSizeBytes,
                                   bool debugCoalescingInference) {
   CoalescingCacheKey key;
-  key.map = memoryMap;
+  key.map = memoryMap.getAsOpaquePointer();
   key.shape.append(gridShape.begin(), gridShape.end());
   key.shape.append(shardShape.begin(), shardShape.end());
   key.numGridDims = gridShape.size();
@@ -286,14 +279,14 @@ class D2MLowerDMAReadToFullyIndexed : public OpRewritePattern<DMAReadOp> {
 public:
   D2MLowerDMAReadToFullyIndexed(MLIRContext *context,
                                 bool debugCoalescingInference,
-                                CoalescingFactorCache *coalescingCache)
+                                CoalescingFactorCache &coalescingCache)
       : OpRewritePattern<DMAReadOp>(context),
         debugCoalescingInference(debugCoalescingInference),
         coalescingCache(coalescingCache) {}
 
 private:
   bool debugCoalescingInference;
-  CoalescingFactorCache *coalescingCache = nullptr;
+  CoalescingFactorCache &coalescingCache;
 
 public:
   LogicalResult matchAndRewrite(DMAReadOp op,
@@ -326,8 +319,8 @@ public:
 
     size_t elemSizeBytes = getElementSizeBytes(remoteMemrefType);
     size_t coalescingFactor =
-        coalescingCache->get(remoteMemoryMap, gridShape, shardShape,
-                             elemSizeBytes, debugCoalescingInference);
+        coalescingCache.get(remoteMemoryMap, gridShape, shardShape,
+                            elemSizeBytes, debugCoalescingInference);
 
     SmallVector<Value> gridIndices(op.getSrcIndices());
 
@@ -357,14 +350,14 @@ class D2MLowerDMAWriteToFullyIndexed : public OpRewritePattern<DMAWriteOp> {
 public:
   D2MLowerDMAWriteToFullyIndexed(MLIRContext *context,
                                  bool debugCoalescingInference,
-                                 CoalescingFactorCache *coalescingCache)
+                                 CoalescingFactorCache &coalescingCache)
       : OpRewritePattern<DMAWriteOp>(context),
         debugCoalescingInference(debugCoalescingInference),
         coalescingCache(coalescingCache) {}
 
 private:
   bool debugCoalescingInference;
-  CoalescingFactorCache *coalescingCache = nullptr;
+  CoalescingFactorCache &coalescingCache;
 
 public:
   LogicalResult matchAndRewrite(DMAWriteOp op,
@@ -424,8 +417,8 @@ public:
 
     size_t elemSizeBytes = getElementSizeBytes(remoteMemrefType);
     size_t coalescingFactor =
-        coalescingCache->get(remoteMemoryMap, gridShape, shardShape,
-                             elemSizeBytes, debugCoalescingInference);
+        coalescingCache.get(remoteMemoryMap, gridShape, shardShape,
+                            elemSizeBytes, debugCoalescingInference);
 
     SmallVector<Value> gridIndices(op.getDstIndices());
     SmallVector<Value> startDevice(op.getStartDevice());
@@ -590,9 +583,9 @@ public:
     CoalescingFactorCache coalescingCache;
     RewritePatternSet dmaPatterns(&getContext());
     dmaPatterns.add<D2MLowerDMAReadToFullyIndexed>(
-        &getContext(), debugCoalescingInference, &coalescingCache);
+        &getContext(), debugCoalescingInference, coalescingCache);
     dmaPatterns.add<D2MLowerDMAWriteToFullyIndexed>(
-        &getContext(), debugCoalescingInference, &coalescingCache);
+        &getContext(), debugCoalescingInference, coalescingCache);
     dmaPatterns.add<D2MLowerLocalCopyToFullyIndexed>(&getContext(),
                                                      debugCoalescingInference);
     AffineApplyCreatedListener listener;


### PR DESCRIPTION
### Problem description
Qwen IR takes too long on this pass. Need to avoid recomputing coalescing factors for repeated DMA map/shape combinations and emit simpler coalescing loop IR so LowerDMA does less redundant analysis work

### What's changed
- Adds a CoalescingFactorCache backed by DenseMap
- Caches DMA coalescing-factor computation by affine map, grid shape, shard shape, grid rank, and element size
- Reuses the cache for both d2m.dma_read and d2m.dma_write lowering
- Keeps the cache scoped to the pass run, so repeated DMA map/shape combinations avoid recomputing the expensive analytical/sampling fallback path

Cut model compilation time by over half when doing sampling

Before:
```
  Total Execution Time: 1857.7358 seconds

  ----User Time----  ----Wall Time----  ----Name----
    0.1089 (  0.0%)    0.1089 (  0.0%)  Parser
    0.0370 (  0.0%)    0.0370 (  0.0%)  TTCoreMarkFunctionsAsForwardPass
    0.0493 (  0.0%)    0.0493 (  0.0%)  TTCoreWrapDeviceModulePass
    0.0378 (  0.0%)    0.0378 (  0.0%)  CPUHoistManuallyTaggedOpsTransform
  2702.1051 ( 99.2%)  1836.1882 ( 98.8%)  Pipeline Collection : ['ttcore.cpu_module', 'ttcore.device_module']
  2702.1013 ( 99.2%)  1836.1843 ( 98.8%)    'ttcore.device_module' Pipeline
  2702.0987 ( 99.2%)  1836.1817 ( 98.8%)      'builtin.module' Pipeline
    0.0358 (  0.0%)    0.0358 (  0.0%)        mlir::tt::ttir::TTIRMultiDeviceTensorAnnotation
    0.0360 (  0.0%)    0.0360 (  0.0%)        TTCoreRegisterDevicePass
    0.0793 (  0.0%)    0.0793 (  0.0%)        PredicateTypeAlignment
    0.1174 (  0.0%)    0.1174 (  0.0%)        ElementTypeNormalization
    0.1528 (  0.0%)    0.1528 (  0.0%)        TTIRDecomposeComposites
    0.0598 (  0.0%)    0.0598 (  0.0%)        TTIRToTTIRDecomposition
    0.1795 (  0.0%)    0.1795 (  0.0%)        TTIRExplicateTMs
   32.5798 (  1.2%)   32.5798 (  1.8%)        TTIREraseInverseOps
    0.1037 (  0.0%)    0.1037 (  0.0%)        TTIRMoveReshapeToConstant
    0.1038 (  0.0%)    0.1038 (  0.0%)        TTIRFoldConstantReshapeBroadcast
    0.1672 (  0.0%)    0.1672 (  0.0%)        TTIRReductionForceKeepDim
    0.0505 (  0.0%)    0.0505 (  0.0%)        TTIRDecomposeComplexReshape
    0.1825 (  0.0%)    0.1825 (  0.0%)        TTIRImplicitBroadcastFold
    0.1596 (  0.0%)    0.1596 (  0.0%)        Canonicalizer
    0.0457 (  0.0%)    0.0457 (  0.0%)        TTIRDecomposeComplexPermute
    2.6841 (  0.1%)    2.6841 (  0.1%)        TTIRToD2M
    1.3000 (  0.0%)    1.3000 (  0.1%)        D2MScalarizeConstTensors
    1.6951 (  0.1%)    1.6951 (  0.1%)        D2MMaterializeViewReturns
    4.0117 (  0.1%)    4.0117 (  0.2%)        D2MGridSelection
    4.8090 (  0.2%)    4.8090 (  0.3%)        Canonicalizer
    3.7408 (  0.1%)    3.7408 (  0.2%)        D2MOptimizeMasks
    3.6542 (  0.1%)    3.6542 (  0.2%)        Canonicalizer
    3.3623 (  0.1%)    3.3623 (  0.2%)        D2MLowerToLayout
    2.5705 (  0.1%)    2.5705 (  0.1%)        D2MMaterializeViewReturns
    6.1588 (  0.2%)    6.1588 (  0.3%)        Canonicalizer
   10.1542 (  0.4%)   10.1542 (  0.5%)        TTCoreOneShotBufferizePass
    2.6073 (  0.1%)    2.6073 (  0.1%)        D2MInsertScratchBuffers
    2.4624 (  0.1%)    2.4624 (  0.1%)        D2MGenericApplyInterchange
    5.0510 (  0.2%)    5.0510 (  0.3%)        D2MGenerateOuterLoops
    3.9342 (  0.1%)    3.9342 (  0.2%)        D2MDecomposeMasking
   10.2411 (  0.4%)   10.2411 (  0.6%)        D2MReblockGenerics
    4.0424 (  0.1%)    4.0424 (  0.2%)        D2MMaterializeViewReturns
    4.6730 (  0.2%)    4.6730 (  0.3%)        D2MMarkSynchronizedBuffers
   20.5942 (  0.8%)   20.5942 (  1.1%)        D2MAllocate
    4.1741 (  0.2%)    4.1741 (  0.2%)        D2MLowerMulticastLoads
    5.4362 (  0.2%)    5.4362 (  0.3%)        D2MLowerToExplicitForm
   14.6602 (  0.5%)   14.6602 (  0.8%)        Canonicalizer
    6.3990 (  0.2%)    6.3990 (  0.3%)        D2MDecomposeArange
    5.9051 (  0.2%)    5.9051 (  0.3%)        D2MGenericTileComputeLoops
   16.4723 (  0.6%)   16.4723 (  0.9%)        D2MLinalgToAffine
   10.2922 (  0.4%)   10.2922 (  0.6%)        D2MOpScheduler
    3.3862 (  0.1%)    3.3862 (  0.2%)        D2MInsertSpillAndScratch
   13.0374 (  0.5%)   13.0374 (  0.7%)        Canonicalizer
    2.8996 (  0.1%)    2.8996 (  0.2%)        D2MLowerScratchAllocate
    6.1267 (  0.2%)    6.1267 (  0.3%)        Canonicalizer
   12.1873 (  0.4%)   12.1873 (  0.7%)        D2MInsertDstRegisterAccessUnscheduled
   11.0434 (  0.4%)   11.0434 (  0.6%)        D2MInsertDstRegisterAccessScheduled
    3.2810 (  0.1%)    3.2810 (  0.2%)        D2MInsertTileMatmulBlock
    3.5882 (  0.1%)    3.5882 (  0.2%)        D2MSFPUTileLoopFission
   11.1430 (  0.4%)   11.1430 (  0.6%)        Canonicalizer
    3.5724 (  0.1%)    3.5724 (  0.2%)        'func.func' Pipeline
    3.5724 (  0.1%)    3.5724 (  0.2%)          AffineLoopInvariantCodeMotion
    6.9741 (  0.3%)    6.9741 (  0.4%)        LowerAffinePass
   12.0845 (  0.4%)   12.0845 (  0.7%)        FoldMemRefAliasOpsPass
    4.6770 (  0.2%)    4.6770 (  0.3%)        LowerAffinePass
   11.4809 (  0.4%)   11.4809 (  0.6%)        D2MGenericLinearizeMemref
    4.7579 (  0.2%)    4.7579 (  0.3%)        LowerAffinePass
    4.2197 (  0.2%)    4.2197 (  0.2%)        D2MHoistCBAllocs
   23.5790 (  0.9%)   23.5790 (  1.3%)        D2MSplitUnifiedThread
    4.0474 (  0.1%)    4.0474 (  0.2%)        D2MPreallocateMcastSemaphores
   18.3580 (  0.7%)   18.3580 (  1.0%)        D2MScheduleDMA
   18.5668 (  0.7%)   18.5668 (  1.0%)        Canonicalizer
   13.2330 (  0.5%)   13.2330 (  0.7%)        D2MLowerLoadStoreOpsToDMA
    4.1881 (  0.2%)    4.1881 (  0.2%)        D2MOptimizeDMA
    4.0315 (  0.1%)    4.0315 (  0.2%)        D2MExpandDMAReadCompositeView
  1295.5867 ( 47.6%)  1295.5867 ( 69.7%)        D2MLowerDMAToFullyIndexedForm
   41.4934 (  1.5%)   41.4934 (  2.2%)        D2MNormalizeThreadArgs
   23.5836 (  0.9%)   23.5836 (  1.3%)        D2MGenericRegionsToFuncs
  681.1276 ( 25.0%)   56.8137 (  3.1%)        'func.func' Pipeline
  252.5661 (  9.3%)   21.9916 (  1.2%)          Canonicalizer
   37.9247 (  1.4%)    3.2805 (  0.2%)          LoopInvariantCodeMotion
   64.4045 (  2.4%)    5.5384 (  0.3%)          SCCP
   51.9110 (  1.9%)    4.4841 (  0.2%)          CSE
    0.1155 (  0.0%)    0.0106 (  0.0%)            (A) DominanceInfo
   54.3189 (  2.0%)    5.2840 (  0.3%)          ArithIntRangeOpts
    7.5799 (  0.3%)    1.1344 (  0.1%)          LoopInvariantCodeMotion
   36.3544 (  1.3%)    3.2295 (  0.2%)          ConvertD2MToTTKernel
    0.6214 (  0.0%)    0.0652 (  0.0%)            (A) tt::d2m::CBProducerConsumer
   46.4240 (  1.7%)    4.3000 (  0.2%)          Canonicalizer
    6.9134 (  0.3%)    1.1028 (  0.1%)          TTKernelControlDstSection
   26.9946 (  1.0%)    3.1772 (  0.2%)          Canonicalizer
    8.0645 (  0.3%)    1.1603 (  0.1%)          LoopInvariantCodeMotion
   18.3748 (  0.7%)    2.1999 (  0.1%)          SCCP
   13.0524 (  0.5%)    1.2987 (  0.1%)          CSE
    0.0981 (  0.0%)    0.0131 (  0.0%)            (A) DominanceInfo
   47.9651 (  1.8%)    4.9237 (  0.3%)          ArithIntRangeOpts
    6.4209 (  0.2%)    1.0629 (  0.1%)          LoopInvariantCodeMotion
    5.7861 (  0.2%)    5.7861 (  0.3%)        ConvertD2MToTTMetal
  184.7893 (  6.8%)   15.4056 (  0.8%)        'func.func' Pipeline
    5.7202 (  0.2%)    0.7311 (  0.0%)          TTKernelHoistInits
    6.3116 (  0.2%)    0.8529 (  0.0%)          TTKernelDedupInits
   57.9460 (  2.1%)    4.9493 (  0.3%)          ConvertTTKernelToEmitC
   15.2110 (  0.6%)    1.9256 (  0.1%)          Canonicalizer
    4.1941 (  0.2%)    0.6853 (  0.0%)          RemoveDeadEmitCExpressions
   94.5552 (  3.5%)    8.0525 (  0.4%)          FormExpressionsPass
   17.8760 (  0.7%)   17.8760 (  1.0%)  Output
    3.4386 (  0.1%)    3.4386 (  0.2%)  Rest
  2723.6528 (100.0%)  1857.7358 (100.0%)  Total
```
After:
```
  Total Execution Time: 817.8602 seconds

  ----User Time----  ----Wall Time----  ----Name----
    0.1068 (  0.0%)    0.1068 (  0.0%)  Parser
    0.0366 (  0.0%)    0.0366 (  0.0%)  TTCoreMarkFunctionsAsForwardPass
    0.0488 (  0.0%)    0.0488 (  0.0%)  TTCoreWrapDeviceModulePass
    0.0375 (  0.0%)    0.0375 (  0.0%)  CPUHoistManuallyTaggedOpsTransform
  2058.9819 ( 99.0%)  796.0448 ( 97.3%)  Pipeline Collection : ['ttcore.cpu_module', 'ttcore.device_module']
  2058.9780 ( 99.0%)  796.0409 ( 97.3%)    'ttcore.device_module' Pipeline
  2058.9754 ( 99.0%)  796.0382 ( 97.3%)      'builtin.module' Pipeline
    0.0361 (  0.0%)    0.0361 (  0.0%)        mlir::tt::ttir::TTIRMultiDeviceTensorAnnotation
    0.0362 (  0.0%)    0.0362 (  0.0%)        TTCoreRegisterDevicePass
    0.0796 (  0.0%)    0.0796 (  0.0%)        PredicateTypeAlignment
    0.1174 (  0.0%)    0.1174 (  0.0%)        ElementTypeNormalization
    0.1525 (  0.0%)    0.1525 (  0.0%)        TTIRDecomposeComposites
    0.0592 (  0.0%)    0.0592 (  0.0%)        TTIRToTTIRDecomposition
    0.1782 (  0.0%)    0.1782 (  0.0%)        TTIRExplicateTMs
   32.9366 (  1.6%)   32.9366 (  4.0%)        TTIREraseInverseOps
    0.1031 (  0.0%)    0.1031 (  0.0%)        TTIRMoveReshapeToConstant
    0.1039 (  0.0%)    0.1039 (  0.0%)        TTIRFoldConstantReshapeBroadcast
    0.1666 (  0.0%)    0.1666 (  0.0%)        TTIRReductionForceKeepDim
    0.0500 (  0.0%)    0.0500 (  0.0%)        TTIRDecomposeComplexReshape
    0.1812 (  0.0%)    0.1812 (  0.0%)        TTIRImplicitBroadcastFold
    0.1596 (  0.0%)    0.1596 (  0.0%)        Canonicalizer
    0.0454 (  0.0%)    0.0454 (  0.0%)        TTIRDecomposeComplexPermute
    2.7060 (  0.1%)    2.7060 (  0.3%)        TTIRToD2M
    1.3165 (  0.1%)    1.3165 (  0.2%)        D2MScalarizeConstTensors
    1.7099 (  0.1%)    1.7099 (  0.2%)        D2MMaterializeViewReturns
    4.0291 (  0.2%)    4.0291 (  0.5%)        D2MGridSelection
    4.8091 (  0.2%)    4.8091 (  0.6%)        Canonicalizer
    3.8144 (  0.2%)    3.8144 (  0.5%)        D2MOptimizeMasks
    4.3825 (  0.2%)    4.3825 (  0.5%)        Canonicalizer
    4.3503 (  0.2%)    4.3503 (  0.5%)        D2MLowerToLayout
    3.7310 (  0.2%)    3.7310 (  0.5%)        D2MMaterializeViewReturns
    7.6398 (  0.4%)    7.6398 (  0.9%)        Canonicalizer
   14.3683 (  0.7%)   14.3683 (  1.8%)        TTCoreOneShotBufferizePass
    3.2267 (  0.2%)    3.2267 (  0.4%)        D2MInsertScratchBuffers
    2.9681 (  0.1%)    2.9681 (  0.4%)        D2MGenericApplyInterchange
    7.0134 (  0.3%)    7.0134 (  0.9%)        D2MGenerateOuterLoops
    5.9250 (  0.3%)    5.9250 (  0.7%)        D2MDecomposeMasking
   19.6571 (  0.9%)   19.6571 (  2.4%)        D2MReblockGenerics
    5.5969 (  0.3%)    5.5969 (  0.7%)        D2MMaterializeViewReturns
    5.4400 (  0.3%)    5.4400 (  0.7%)        D2MMarkSynchronizedBuffers
   28.3584 (  1.4%)   28.3584 (  3.5%)        D2MAllocate
    4.7351 (  0.2%)    4.7351 (  0.6%)        D2MLowerMulticastLoads
    8.2066 (  0.4%)    8.2066 (  1.0%)        D2MLowerToExplicitForm
   18.7256 (  0.9%)   18.7256 (  2.3%)        Canonicalizer
    9.1385 (  0.4%)    9.1385 (  1.1%)        D2MDecomposeArange
    7.7356 (  0.4%)    7.7356 (  0.9%)        D2MGenericTileComputeLoops
   22.5585 (  1.1%)   22.5585 (  2.8%)        D2MLinalgToAffine
   14.4839 (  0.7%)   14.4839 (  1.8%)        D2MOpScheduler
    4.4067 (  0.2%)    4.4067 (  0.5%)        D2MInsertSpillAndScratch
   17.0232 (  0.8%)   17.0232 (  2.1%)        Canonicalizer
    3.3158 (  0.2%)    3.3158 (  0.4%)        D2MLowerScratchAllocate
    7.5680 (  0.4%)    7.5680 (  0.9%)        Canonicalizer
   14.8306 (  0.7%)   14.8306 (  1.8%)        D2MInsertDstRegisterAccessUnscheduled
   14.3747 (  0.7%)   14.3747 (  1.8%)        D2MInsertDstRegisterAccessScheduled
    3.7972 (  0.2%)    3.7972 (  0.5%)        D2MInsertTileMatmulBlock
    4.4735 (  0.2%)    4.4735 (  0.5%)        D2MSFPUTileLoopFission
   14.1372 (  0.7%)   14.1372 (  1.7%)        Canonicalizer
    5.5697 (  0.3%)    5.5697 (  0.7%)        'func.func' Pipeline
    5.5697 (  0.3%)    5.5697 (  0.7%)          AffineLoopInvariantCodeMotion
    8.6885 (  0.4%)    8.6885 (  1.1%)        LowerAffinePass
   15.9456 (  0.8%)   15.9456 (  1.9%)        FoldMemRefAliasOpsPass
    6.8705 (  0.3%)    6.8705 (  0.8%)        LowerAffinePass
   15.0005 (  0.7%)   15.0005 (  1.8%)        D2MGenericLinearizeMemref
    6.3703 (  0.3%)    6.3703 (  0.8%)        LowerAffinePass
    5.5214 (  0.3%)    5.5214 (  0.7%)        D2MHoistCBAllocs
   31.0011 (  1.5%)   31.0011 (  3.8%)        D2MSplitUnifiedThread
    4.7000 (  0.2%)    4.7000 (  0.6%)        D2MPreallocateMcastSemaphores
   24.2689 (  1.2%)   24.2689 (  3.0%)        D2MScheduleDMA
   22.5249 (  1.1%)   22.5249 (  2.8%)        Canonicalizer
   17.6283 (  0.8%)   17.6283 (  2.2%)        D2MLowerLoadStoreOpsToDMA
    5.2965 (  0.3%)    5.2965 (  0.6%)        D2MOptimizeDMA
    7.1858 (  0.3%)    7.1858 (  0.9%)        D2MExpandDMAReadCompositeView
  106.2781 (  5.1%)  106.2781 ( 13.0%)        D2MLowerDMAToFullyIndexedForm
   42.0700 (  2.0%)   42.0700 (  5.1%)        D2MNormalizeThreadArgs
   23.0185 (  1.1%)   23.0185 (  2.8%)        D2MGenericRegionsToFuncs
  1058.9130 ( 50.9%)   88.2843 ( 10.8%)        'func.func' Pipeline
  387.8712 ( 18.6%)   33.8956 (  4.1%)          Canonicalizer
   57.5301 (  2.8%)    4.9601 (  0.6%)          LoopInvariantCodeMotion
   99.0966 (  4.8%)    8.4615 (  1.0%)          SCCP
   77.7295 (  3.7%)    6.8300 (  0.8%)          CSE
    0.3317 (  0.0%)    0.0476 (  0.0%)            (A) DominanceInfo
   85.4154 (  4.1%)    7.8498 (  1.0%)          ArithIntRangeOpts
   11.2886 (  0.5%)    1.4512 (  0.2%)          LoopInvariantCodeMotion
   61.1723 (  2.9%)    5.3552 (  0.7%)          ConvertD2MToTTKernel
    1.1757 (  0.1%)    0.1347 (  0.0%)            (A) tt::d2m::CBProducerConsumer
   71.9812 (  3.5%)    6.3780 (  0.8%)          Canonicalizer
   10.7137 (  0.5%)    1.4374 (  0.2%)          TTKernelControlDstSection
   41.7238 (  2.0%)    4.3813 (  0.5%)          Canonicalizer
   12.3683 (  0.6%)    1.5163 (  0.2%)          LoopInvariantCodeMotion
   29.4192 (  1.4%)    3.0899 (  0.4%)          SCCP
   20.7214 (  1.0%)    1.8942 (  0.2%)          CSE
    0.4096 (  0.0%)    0.0573 (  0.0%)            (A) DominanceInfo
   74.8849 (  3.6%)    7.1834 (  0.9%)          ArithIntRangeOpts
   10.4544 (  0.5%)    2.2385 (  0.3%)          LoopInvariantCodeMotion
    5.8461 (  0.3%)    5.8461 (  0.7%)        ConvertD2MToTTMetal
  204.0241 (  9.8%)   17.0180 (  2.1%)        'func.func' Pipeline
    6.4074 (  0.3%)    0.7862 (  0.1%)          TTKernelHoistInits
    6.8573 (  0.3%)    0.9167 (  0.1%)          TTKernelDedupInits
   63.5807 (  3.1%)    5.4699 (  0.7%)          ConvertTTKernelToEmitC
   16.5979 (  0.8%)    2.0652 (  0.3%)          Canonicalizer
    4.7374 (  0.2%)    0.7278 (  0.1%)          RemoveDeadEmitCExpressions
  103.8350 (  5.0%)    8.9116 (  1.1%)          FormExpressionsPass
   18.1130 (  0.9%)   18.1130 (  2.2%)  Output
    3.4727 (  0.2%)    3.4727 (  0.4%)  Rest
  2080.7973 (100.0%)  817.8602 (100.0%)  Total
```

### Checklist
- [ ] New/Existing tests provide coverage for changes
