### PR TITLE
[d2m] move d2m affine lowering after canonicalization

### DIFF
--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -63,9 +63,7 @@ void createTTIRBufferizationPipeline(OpPassManager &pm,
   //    pm, bufferDeallocationOptions);
 }
 
-void addFunctionOptimizationPasses(OpPassManager &funcPm,
-                                   const D2MPipelineOptions &options) {
-  funcPm.addPass(createCanonicalizerPassWithOptions(options));
+void addFunctionOptimizationPasses(OpPassManager &funcPm) {
   funcPm.addPass(mlir::createLoopInvariantCodeMotionPass());
   funcPm.addPass(mlir::createSCCPPass());
   funcPm.addPass(mlir::createCSEPass());
@@ -267,7 +265,9 @@ void createD2MBackendPipeline(OpPassManager &pm,
 
   pm.addPass(d2m::createD2MGenericRegionsToFuncs());
   OpPassManager &postGenericRegionsFuncPm = pm.nest<func::FuncOp>();
-  addFunctionOptimizationPasses(postGenericRegionsFuncPm, options);
+  postGenericRegionsFuncPm.addPass(createCanonicalizerPassWithOptions(options));
+  postGenericRegionsFuncPm.addPass(mlir::createLowerAffinePass());
+  addFunctionOptimizationPasses(postGenericRegionsFuncPm);
 }
 
 void createD2MToTTMetalPipeline(OpPassManager &pm,
@@ -303,7 +303,8 @@ void createD2MToTTKernelPreEmitCPipeline(OpPassManager &pm,
   funcPm.addPass(tt::createConvertD2MToTTKernelPass(D2MToTTKernelOptions));
   funcPm.addPass(createCanonicalizerPassWithOptions(options));
   funcPm.addPass(ttkernel::createTTKernelControlDstSection());
-  addFunctionOptimizationPasses(funcPm, options);
+  funcPm.addPass(createCanonicalizerPassWithOptions(options));
+  addFunctionOptimizationPasses(funcPm);
 }
 
 void createD2MEmitCPipeline(OpPassManager &pm,

--- a/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
@@ -9,7 +9,6 @@
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
-#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -189,20 +188,6 @@ static Value generateDMAWithCoalescing(OpBuilder &builder, Location loc,
 }
 
 namespace {
-class AffineApplyCreatedListener : public RewriterBase::Listener {
-public:
-  bool wasAffineApplyCreated() const { return affineApplyCreated; }
-
-  void notifyOperationInserted(Operation *op, OpBuilder::InsertPoint) override {
-    if (isa<affine::AffineApplyOp>(op)) {
-      affineApplyCreated = true;
-    }
-  }
-
-private:
-  bool affineApplyCreated = false;
-};
-
 class D2MLowerDMAReadToFullyIndexed : public OpRewritePattern<DMAReadOp> {
 public:
   D2MLowerDMAReadToFullyIndexed(MLIRContext *context,
@@ -509,16 +494,7 @@ public:
                                                     debugCoalescingInference);
     dmaPatterns.add<D2MLowerLocalCopyToFullyIndexed>(&getContext(),
                                                      debugCoalescingInference);
-    AffineApplyCreatedListener listener;
-    walkAndApplyPatterns(getOperation(), std::move(dmaPatterns), &listener);
-
-    if (!listener.wasAffineApplyCreated()) {
-      return;
-    }
-
-    RewritePatternSet affineToStdPatterns(&getContext());
-    populateAffineToStdConversionPatterns(affineToStdPatterns);
-    walkAndApplyPatterns(getOperation(), std::move(affineToStdPatterns));
+    walkAndApplyPatterns(getOperation(), std::move(dmaPatterns));
   }
 };
 } // namespace

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-lower-dma-to-fully-indexed-form %s | FileCheck %s --implicit-check-not=affine.apply
+// RUN: ttmlir-opt --ttcore-register-device --d2m-lower-dma-to-fully-indexed-form %s | FileCheck %s
 
 #dram = #ttcore.memory_space<dram>
 #l1 = #ttcore.memory_space<l1>


### PR DESCRIPTION
Keep LowerDMA affine index expressions compact through the first canonicalizer, then lower affine before the remaining scalar optimization passes.

### Problem description
Qwen IR taking too long, can parallelize and reorder passes to do better. Keep LowerDMA affine index expressions compact through the first canonicalizer, then lower affine before the remaining scalar optimization passes

### What's changed
- Move affine lowering out of lower dma
- Update lit test

Timing went down almost 300 seconds. Went down because we remove the affine apply listener and then lower affine moves after generic region to func so we can run nested pm to parallelize. also helps with the canonicalizer

Before:
```
  Total Execution Time: 817.8602 seconds

  ----User Time----  ----Wall Time----  ----Name----
    0.1068 (  0.0%)    0.1068 (  0.0%)  Parser
    0.0366 (  0.0%)    0.0366 (  0.0%)  TTCoreMarkFunctionsAsForwardPass
    0.0488 (  0.0%)    0.0488 (  0.0%)  TTCoreWrapDeviceModulePass
    0.0375 (  0.0%)    0.0375 (  0.0%)  CPUHoistManuallyTaggedOpsTransform
  2058.9819 ( 99.0%)  796.0448 ( 97.3%)  Pipeline Collection : ['ttcore.cpu_module', 'ttcore.device_module']
  2058.9780 ( 99.0%)  796.0409 ( 97.3%)    'ttcore.device_module' Pipeline
  2058.9754 ( 99.0%)  796.0382 ( 97.3%)      'builtin.module' Pipeline
    0.0361 (  0.0%)    0.0361 (  0.0%)        mlir::tt::ttir::TTIRMultiDeviceTensorAnnotation
    0.0362 (  0.0%)    0.0362 (  0.0%)        TTCoreRegisterDevicePass
    0.0796 (  0.0%)    0.0796 (  0.0%)        PredicateTypeAlignment
    0.1174 (  0.0%)    0.1174 (  0.0%)        ElementTypeNormalization
    0.1525 (  0.0%)    0.1525 (  0.0%)        TTIRDecomposeComposites
    0.0592 (  0.0%)    0.0592 (  0.0%)        TTIRToTTIRDecomposition
    0.1782 (  0.0%)    0.1782 (  0.0%)        TTIRExplicateTMs
   32.9366 (  1.6%)   32.9366 (  4.0%)        TTIREraseInverseOps
    0.1031 (  0.0%)    0.1031 (  0.0%)        TTIRMoveReshapeToConstant
    0.1039 (  0.0%)    0.1039 (  0.0%)        TTIRFoldConstantReshapeBroadcast
    0.1666 (  0.0%)    0.1666 (  0.0%)        TTIRReductionForceKeepDim
    0.0500 (  0.0%)    0.0500 (  0.0%)        TTIRDecomposeComplexReshape
    0.1812 (  0.0%)    0.1812 (  0.0%)        TTIRImplicitBroadcastFold
    0.1596 (  0.0%)    0.1596 (  0.0%)        Canonicalizer
    0.0454 (  0.0%)    0.0454 (  0.0%)        TTIRDecomposeComplexPermute
    2.7060 (  0.1%)    2.7060 (  0.3%)        TTIRToD2M
    1.3165 (  0.1%)    1.3165 (  0.2%)        D2MScalarizeConstTensors
    1.7099 (  0.1%)    1.7099 (  0.2%)        D2MMaterializeViewReturns
    4.0291 (  0.2%)    4.0291 (  0.5%)        D2MGridSelection
    4.8091 (  0.2%)    4.8091 (  0.6%)        Canonicalizer
    3.8144 (  0.2%)    3.8144 (  0.5%)        D2MOptimizeMasks
    4.3825 (  0.2%)    4.3825 (  0.5%)        Canonicalizer
    4.3503 (  0.2%)    4.3503 (  0.5%)        D2MLowerToLayout
    3.7310 (  0.2%)    3.7310 (  0.5%)        D2MMaterializeViewReturns
    7.6398 (  0.4%)    7.6398 (  0.9%)        Canonicalizer
   14.3683 (  0.7%)   14.3683 (  1.8%)        TTCoreOneShotBufferizePass
    3.2267 (  0.2%)    3.2267 (  0.4%)        D2MInsertScratchBuffers
    2.9681 (  0.1%)    2.9681 (  0.4%)        D2MGenericApplyInterchange
    7.0134 (  0.3%)    7.0134 (  0.9%)        D2MGenerateOuterLoops
    5.9250 (  0.3%)    5.9250 (  0.7%)        D2MDecomposeMasking
   19.6571 (  0.9%)   19.6571 (  2.4%)        D2MReblockGenerics
    5.5969 (  0.3%)    5.5969 (  0.7%)        D2MMaterializeViewReturns
    5.4400 (  0.3%)    5.4400 (  0.7%)        D2MMarkSynchronizedBuffers
   28.3584 (  1.4%)   28.3584 (  3.5%)        D2MAllocate
    4.7351 (  0.2%)    4.7351 (  0.6%)        D2MLowerMulticastLoads
    8.2066 (  0.4%)    8.2066 (  1.0%)        D2MLowerToExplicitForm
   18.7256 (  0.9%)   18.7256 (  2.3%)        Canonicalizer
    9.1385 (  0.4%)    9.1385 (  1.1%)        D2MDecomposeArange
    7.7356 (  0.4%)    7.7356 (  0.9%)        D2MGenericTileComputeLoops
   22.5585 (  1.1%)   22.5585 (  2.8%)        D2MLinalgToAffine
   14.4839 (  0.7%)   14.4839 (  1.8%)        D2MOpScheduler
    4.4067 (  0.2%)    4.4067 (  0.5%)        D2MInsertSpillAndScratch
   17.0232 (  0.8%)   17.0232 (  2.1%)        Canonicalizer
    3.3158 (  0.2%)    3.3158 (  0.4%)        D2MLowerScratchAllocate
    7.5680 (  0.4%)    7.5680 (  0.9%)        Canonicalizer
   14.8306 (  0.7%)   14.8306 (  1.8%)        D2MInsertDstRegisterAccessUnscheduled
   14.3747 (  0.7%)   14.3747 (  1.8%)        D2MInsertDstRegisterAccessScheduled
    3.7972 (  0.2%)    3.7972 (  0.5%)        D2MInsertTileMatmulBlock
    4.4735 (  0.2%)    4.4735 (  0.5%)        D2MSFPUTileLoopFission
   14.1372 (  0.7%)   14.1372 (  1.7%)        Canonicalizer
    5.5697 (  0.3%)    5.5697 (  0.7%)        'func.func' Pipeline
    5.5697 (  0.3%)    5.5697 (  0.7%)          AffineLoopInvariantCodeMotion
    8.6885 (  0.4%)    8.6885 (  1.1%)        LowerAffinePass
   15.9456 (  0.8%)   15.9456 (  1.9%)        FoldMemRefAliasOpsPass
    6.8705 (  0.3%)    6.8705 (  0.8%)        LowerAffinePass
   15.0005 (  0.7%)   15.0005 (  1.8%)        D2MGenericLinearizeMemref
    6.3703 (  0.3%)    6.3703 (  0.8%)        LowerAffinePass
    5.5214 (  0.3%)    5.5214 (  0.7%)        D2MHoistCBAllocs
   31.0011 (  1.5%)   31.0011 (  3.8%)        D2MSplitUnifiedThread
    4.7000 (  0.2%)    4.7000 (  0.6%)        D2MPreallocateMcastSemaphores
   24.2689 (  1.2%)   24.2689 (  3.0%)        D2MScheduleDMA
   22.5249 (  1.1%)   22.5249 (  2.8%)        Canonicalizer
   17.6283 (  0.8%)   17.6283 (  2.2%)        D2MLowerLoadStoreOpsToDMA
    5.2965 (  0.3%)    5.2965 (  0.6%)        D2MOptimizeDMA
    7.1858 (  0.3%)    7.1858 (  0.9%)        D2MExpandDMAReadCompositeView
  106.2781 (  5.1%)  106.2781 ( 13.0%)        D2MLowerDMAToFullyIndexedForm
   42.0700 (  2.0%)   42.0700 (  5.1%)        D2MNormalizeThreadArgs
   23.0185 (  1.1%)   23.0185 (  2.8%)        D2MGenericRegionsToFuncs
  1058.9130 ( 50.9%)   88.2843 ( 10.8%)        'func.func' Pipeline
  387.8712 ( 18.6%)   33.8956 (  4.1%)          Canonicalizer
   57.5301 (  2.8%)    4.9601 (  0.6%)          LoopInvariantCodeMotion
   99.0966 (  4.8%)    8.4615 (  1.0%)          SCCP
   77.7295 (  3.7%)    6.8300 (  0.8%)          CSE
    0.3317 (  0.0%)    0.0476 (  0.0%)            (A) DominanceInfo
   85.4154 (  4.1%)    7.8498 (  1.0%)          ArithIntRangeOpts
   11.2886 (  0.5%)    1.4512 (  0.2%)          LoopInvariantCodeMotion
   61.1723 (  2.9%)    5.3552 (  0.7%)          ConvertD2MToTTKernel
    1.1757 (  0.1%)    0.1347 (  0.0%)            (A) tt::d2m::CBProducerConsumer
   71.9812 (  3.5%)    6.3780 (  0.8%)          Canonicalizer
   10.7137 (  0.5%)    1.4374 (  0.2%)          TTKernelControlDstSection
   41.7238 (  2.0%)    4.3813 (  0.5%)          Canonicalizer
   12.3683 (  0.6%)    1.5163 (  0.2%)          LoopInvariantCodeMotion
   29.4192 (  1.4%)    3.0899 (  0.4%)          SCCP
   20.7214 (  1.0%)    1.8942 (  0.2%)          CSE
    0.4096 (  0.0%)    0.0573 (  0.0%)            (A) DominanceInfo
   74.8849 (  3.6%)    7.1834 (  0.9%)          ArithIntRangeOpts
   10.4544 (  0.5%)    2.2385 (  0.3%)          LoopInvariantCodeMotion
    5.8461 (  0.3%)    5.8461 (  0.7%)        ConvertD2MToTTMetal
  204.0241 (  9.8%)   17.0180 (  2.1%)        'func.func' Pipeline
    6.4074 (  0.3%)    0.7862 (  0.1%)          TTKernelHoistInits
    6.8573 (  0.3%)    0.9167 (  0.1%)          TTKernelDedupInits
   63.5807 (  3.1%)    5.4699 (  0.7%)          ConvertTTKernelToEmitC
   16.5979 (  0.8%)    2.0652 (  0.3%)          Canonicalizer
    4.7374 (  0.2%)    0.7278 (  0.1%)          RemoveDeadEmitCExpressions
  103.8350 (  5.0%)    8.9116 (  1.1%)          FormExpressionsPass
   18.1130 (  0.9%)   18.1130 (  2.2%)  Output
    3.4727 (  0.2%)    3.4727 (  0.4%)  Rest
  2080.7973 (100.0%)  817.8602 (100.0%)  Total
```

After:
```
  Total Execution Time: 531.8945 seconds

  ----User Time----  ----Wall Time----  ----Name----
    0.1044 (  0.0%)    0.1044 (  0.0%)  Parser
    0.0358 (  0.0%)    0.0358 (  0.0%)  TTCoreMarkFunctionsAsForwardPass
    0.0483 (  0.0%)    0.0483 (  0.0%)  TTCoreWrapDeviceModulePass
    0.0368 (  0.0%)    0.0368 (  0.0%)  CPUHoistManuallyTaggedOpsTransform
  1218.4867 ( 98.1%)  508.6358 ( 95.6%)  Pipeline Collection : ['ttcore.cpu_module', 'ttcore.device_module']
  1218.4829 ( 98.1%)  508.6321 ( 95.6%)    'ttcore.device_module' Pipeline
  1218.4804 ( 98.1%)  508.6295 ( 95.6%)      'builtin.module' Pipeline
    0.0350 (  0.0%)    0.0350 (  0.0%)        mlir::tt::ttir::TTIRMultiDeviceTensorAnnotation
    0.0351 (  0.0%)    0.0351 (  0.0%)        TTCoreRegisterDevicePass
    0.0787 (  0.0%)    0.0787 (  0.0%)        PredicateTypeAlignment
    0.1149 (  0.0%)    0.1149 (  0.0%)        ElementTypeNormalization
    0.1500 (  0.0%)    0.1500 (  0.0%)        TTIRDecomposeComposites
    0.0578 (  0.0%)    0.0578 (  0.0%)        TTIRToTTIRDecomposition
    0.1751 (  0.0%)    0.1751 (  0.0%)        TTIRExplicateTMs
   32.3209 (  2.6%)   32.3209 (  6.1%)        TTIREraseInverseOps
    0.1006 (  0.0%)    0.1006 (  0.0%)        TTIRMoveReshapeToConstant
    0.1008 (  0.0%)    0.1008 (  0.0%)        TTIRFoldConstantReshapeBroadcast
    0.1630 (  0.0%)    0.1630 (  0.0%)        TTIRReductionForceKeepDim
    0.0487 (  0.0%)    0.0487 (  0.0%)        TTIRDecomposeComplexReshape
    0.1775 (  0.0%)    0.1775 (  0.0%)        TTIRImplicitBroadcastFold
    0.1567 (  0.0%)    0.1567 (  0.0%)        Canonicalizer
    0.0442 (  0.0%)    0.0442 (  0.0%)        TTIRDecomposeComplexPermute
    2.6126 (  0.2%)    2.6126 (  0.5%)        TTIRToD2M
    1.2763 (  0.1%)    1.2763 (  0.2%)        D2MScalarizeConstTensors
    1.6629 (  0.1%)    1.6629 (  0.3%)        D2MMaterializeViewReturns
    3.9249 (  0.3%)    3.9249 (  0.7%)        D2MGridSelection
    4.6865 (  0.4%)    4.6865 (  0.9%)        Canonicalizer
    3.6945 (  0.3%)    3.6945 (  0.7%)        D2MOptimizeMasks
    3.5729 (  0.3%)    3.5729 (  0.7%)        Canonicalizer
    3.2783 (  0.3%)    3.2783 (  0.6%)        D2MLowerToLayout
    2.5098 (  0.2%)    2.5098 (  0.5%)        D2MMaterializeViewReturns
    6.0416 (  0.5%)    6.0416 (  1.1%)        Canonicalizer
    9.7702 (  0.8%)    9.7702 (  1.8%)        TTCoreOneShotBufferizePass
    2.5595 (  0.2%)    2.5595 (  0.5%)        D2MInsertScratchBuffers
    2.4356 (  0.2%)    2.4356 (  0.5%)        D2MGenericApplyInterchange
   13.2233 (  1.1%)   13.2233 (  2.5%)        D2MGenerateOuterLoops
    3.8237 (  0.3%)    3.8237 (  0.7%)        D2MDecomposeMasking
    9.9958 (  0.8%)    9.9958 (  1.9%)        D2MReblockGenerics
    3.9105 (  0.3%)    3.9105 (  0.7%)        D2MMaterializeViewReturns
    4.5265 (  0.4%)    4.5265 (  0.9%)        D2MMarkSynchronizedBuffers
   20.4999 (  1.7%)   20.4999 (  3.9%)        D2MAllocate
    4.0505 (  0.3%)    4.0505 (  0.8%)        D2MLowerMulticastLoads
    5.6663 (  0.5%)    5.6663 (  1.1%)        D2MLowerToExplicitForm
   14.3358 (  1.2%)   14.3358 (  2.7%)        Canonicalizer
    6.3084 (  0.5%)    6.3084 (  1.2%)        D2MDecomposeArange
    5.6640 (  0.5%)    5.6640 (  1.1%)        D2MGenericTileComputeLoops
   15.8638 (  1.3%)   15.8638 (  3.0%)        D2MLinalgToAffine
    9.9691 (  0.8%)    9.9691 (  1.9%)        D2MOpScheduler
    3.2518 (  0.3%)    3.2518 (  0.6%)        D2MInsertSpillAndScratch
   12.5456 (  1.0%)   12.5456 (  2.4%)        Canonicalizer
    2.8052 (  0.2%)    2.8052 (  0.5%)        D2MLowerScratchAllocate
    5.9465 (  0.5%)    5.9465 (  1.1%)        Canonicalizer
   11.8141 (  1.0%)   11.8141 (  2.2%)        D2MInsertDstRegisterAccessUnscheduled
   10.7236 (  0.9%)   10.7236 (  2.0%)        D2MInsertDstRegisterAccessScheduled
    3.1640 (  0.3%)    3.1640 (  0.6%)        D2MInsertTileMatmulBlock
    3.4650 (  0.3%)    3.4650 (  0.7%)        D2MSFPUTileLoopFission
   10.7994 (  0.9%)   10.7994 (  2.0%)        Canonicalizer
    3.4417 (  0.3%)    3.4417 (  0.6%)        'func.func' Pipeline
    3.4417 (  0.3%)    3.4417 (  0.6%)          AffineLoopInvariantCodeMotion
    6.7100 (  0.5%)    6.7100 (  1.3%)        LowerAffinePass
   11.7785 (  0.9%)   11.7785 (  2.2%)        FoldMemRefAliasOpsPass
    4.5022 (  0.4%)    4.5022 (  0.8%)        LowerAffinePass
   11.1235 (  0.9%)   11.1235 (  2.1%)        D2MGenericLinearizeMemref
    4.5577 (  0.4%)    4.5577 (  0.9%)        LowerAffinePass
    4.0674 (  0.3%)    4.0674 (  0.8%)        D2MHoistCBAllocs
   22.7516 (  1.8%)   22.7516 (  4.3%)        D2MSplitUnifiedThread
    3.8978 (  0.3%)    3.8978 (  0.7%)        D2MPreallocateMcastSemaphores
   17.7439 (  1.4%)   17.7439 (  3.3%)        D2MScheduleDMA
   17.7916 (  1.4%)   17.7916 (  3.3%)        Canonicalizer
   12.7695 (  1.0%)   12.7695 (  2.4%)        D2MLowerLoadStoreOpsToDMA
    4.0504 (  0.3%)    4.0504 (  0.8%)        D2MOptimizeDMA
    3.8801 (  0.3%)    3.8801 (  0.7%)        D2MExpandDMAReadCompositeView
   40.6365 (  3.3%)   40.6365 (  7.6%)        D2MLowerDMAToFullyIndexedForm
    5.3867 (  0.4%)    5.3867 (  1.0%)        D2MNormalizeThreadArgs
    2.6978 (  0.2%)    2.6978 (  0.5%)        D2MGenericRegionsToFuncs
  495.3146 ( 39.9%)   41.2907 (  7.8%)        'func.func' Pipeline
   65.9993 (  5.3%)    5.8763 (  1.1%)          Canonicalizer
   37.7445 (  3.0%)    3.2400 (  0.6%)          LowerAffinePass
   31.5483 (  2.5%)    2.7340 (  0.5%)          LoopInvariantCodeMotion
   52.7976 (  4.3%)    4.5968 (  0.9%)          SCCP
   32.8001 (  2.6%)    2.8273 (  0.5%)          CSE
    0.1327 (  0.0%)    0.0173 (  0.0%)            (A) DominanceInfo
   52.1057 (  4.2%)    4.5368 (  0.9%)          ArithIntRangeOpts
    7.6258 (  0.6%)    1.0443 (  0.2%)          LoopInvariantCodeMotion
   35.8227 (  2.9%)    3.1347 (  0.6%)          ConvertD2MToTTKernel
    0.5810 (  0.0%)    0.0529 (  0.0%)            (A) tt::d2m::CBProducerConsumer
   47.6906 (  3.8%)    4.0664 (  0.8%)          Canonicalizer
    6.8614 (  0.6%)    1.0331 (  0.2%)          TTKernelControlDstSection
   27.4860 (  2.2%)    2.8639 (  0.5%)          Canonicalizer
    8.0984 (  0.7%)    1.0680 (  0.2%)          LoopInvariantCodeMotion
   18.3988 (  1.5%)    1.9902 (  0.4%)          SCCP
   13.1805 (  1.1%)    1.1248 (  0.2%)          CSE
    0.1017 (  0.0%)    0.0147 (  0.0%)            (A) DominanceInfo
   48.4592 (  3.9%)    4.3618 (  0.8%)          ArithIntRangeOpts
    6.5716 (  0.5%)    1.0015 (  0.2%)          LoopInvariantCodeMotion
    5.6686 (  0.5%)    5.6686 (  1.1%)        ConvertD2MToTTMetal
  214.5363 ( 17.3%)   17.8867 (  3.4%)        'func.func' Pipeline
    5.6809 (  0.5%)    0.7252 (  0.1%)          TTKernelHoistInits
    6.1872 (  0.5%)    0.8368 (  0.2%)          TTKernelDedupInits
   58.0658 (  4.7%)    5.0793 (  1.0%)          ConvertTTKernelToEmitC
   15.4119 (  1.2%)    1.9671 (  0.4%)          Canonicalizer
    4.1145 (  0.3%)    0.6707 (  0.1%)          RemoveDeadEmitCExpressions
  124.2538 ( 10.0%)   10.5955 (  2.0%)          FormExpressionsPass
   19.5634 (  1.6%)   19.5634 (  3.7%)  Output
    3.4699 (  0.3%)    3.4699 (  0.7%)  Rest
  1241.7454 (100.0%)  531.8945 (100.0%)  Total
```

### Checklist
- [ ] New/Existing tests provide coverage for changes
