### PR TITLE
[d2m] modify d2m pipeline to improve compile time

### DIFF
--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -210,7 +210,7 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
   Option<bool> enableOpScheduler{
       *this, "enable-op-scheduler",
       llvm::cl::desc("Enable operation scheduling optimization"),
-      llvm::cl::init(true)};
+      llvm::cl::init(false)};
 
   // Option to enable/disable automatic multicast inference for reduction
   // operations.

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -116,6 +116,19 @@ def D2MSFPUTileLoopFission : Pass<"d2m-sfpu-tile-loop-fission", "::mlir::ModuleO
   ];
 }
 
+def D2MAffineLICM : Pass<"d2m-affine-licm", "::mlir::ModuleOp"> {
+  let summary = "Hoist loop-invariant operations from affine loops at module scope";
+  let description = [{
+    Runs loop-invariant code motion over affine loop-like operations from a
+    ModuleOp pass, avoiding the implicit func.func pass adaptor used by the
+    stock affine-loop-invariant-code-motion pass.
+  }];
+
+  let dependentDialects = [
+    "::mlir::affine::AffineDialect"
+  ];
+}
+
 def D2MGenericTileComputeLoops : Pass<"d2m-generic-tile-compute-loops", "::mlir::ModuleOp"> {
   let summary = "Tile linalg.generic compute loops to fit DST register capacity.";
   let description = [{

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -91,7 +91,7 @@ def D2MOpScheduler : Pass<"d2m-op-scheduler", "::mlir::ModuleOp"> {
 
   list<Option> options = [
     Option<"enableOpScheduler", "enable-op-scheduler", "bool", "true",
-           "Enable operation scheduling optimization (currently hard-wired to true internally)">,
+           "Enable operation scheduling optimization">,
   ];
 
   let dependentDialects = [

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -13,7 +13,6 @@
 #include "ttmlir/Transforms/Passes.h"
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
-#include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/EmitC/Transforms/Passes.h"
@@ -225,7 +224,7 @@ void createD2MBackendPipeline(OpPassManager &pm,
   }
   pm.addPass(mlir::createCanonicalizerPass());
 
-  pm.addPass(affine::createAffineLoopInvariantCodeMotionPass());
+  pm.addPass(d2m::createD2MAffineLICM());
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(memref::createFoldMemRefAliasOpsPass());
   pm.addPass(mlir::createLowerAffinePass());

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -195,15 +195,11 @@ void createD2MBackendPipeline(OpPassManager &pm,
   { linalgToAffineOptions.markRootLoops = true; }
   pm.addPass(d2m::createD2MLinalgToAffine(linalgToAffineOptions));
 
-  d2m::D2MOpSchedulerOptions opSchedulerOptions;
-  {
-    // TODO(mbagherbeikTT)
-    // Has to be hard enabled for now until DST allocation is made fully
-    // consistent with elementwise fusion
-    opSchedulerOptions.enableOpScheduler = true; /* options.enableOpScheduler */
-    ;
+  if (options.enableOpScheduler) {
+    d2m::D2MOpSchedulerOptions opSchedulerOptions;
+    { opSchedulerOptions.enableOpScheduler = options.enableOpScheduler; }
+    pm.addPass(d2m::createD2MOpScheduler(opSchedulerOptions));
   }
-  pm.addPass(d2m::createD2MOpScheduler(opSchedulerOptions));
   pm.addPass(d2m::createD2MInsertSpillAndScratch());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(d2m::createD2MLowerScratchAllocate());
@@ -224,12 +220,12 @@ void createD2MBackendPipeline(OpPassManager &pm,
   { insertTileMatmulBlockOptions.useTileMatmul = options.useTileMatmul; }
   pm.addPass(d2m::createD2MInsertTileMatmulBlock(insertTileMatmulBlockOptions));
 
-  pm.addPass(d2m::createD2MSFPUTileLoopFission());
+  if (options.enableElementwiseFusion || options.enableEltwiseReductionFusion) {
+    pm.addPass(d2m::createD2MSFPUTileLoopFission());
+  }
   pm.addPass(mlir::createCanonicalizerPass());
 
-  OpPassManager &funcPm = pm.nest<func::FuncOp>();
-  funcPm.addPass(affine::createAffineLoopInvariantCodeMotionPass());
-
+  pm.addPass(affine::createAffineLoopInvariantCodeMotionPass());
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(memref::createFoldMemRefAliasOpsPass());
   pm.addPass(mlir::createLowerAffinePass());

--- a/lib/Dialect/D2M/Transforms/AffineLICM.cpp
+++ b/lib/Dialect/D2M/Transforms/AffineLICM.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+#include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
+
+namespace mlir::tt::d2m {
+#define GEN_PASS_DEF_D2MAFFINELICM
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
+} // namespace mlir::tt::d2m
+
+namespace {
+
+struct D2MAffineLICM
+    : public mlir::tt::d2m::impl::D2MAffineLICMBase<D2MAffineLICM> {
+  using D2MAffineLICMBase::D2MAffineLICMBase;
+
+  void runOnOperation() override {
+    llvm::SmallVector<mlir::LoopLikeOpInterface> loops;
+    getOperation().walk(
+        [&](mlir::affine::AffineForOp forOp) { loops.push_back(forOp); });
+    getOperation().walk([&](mlir::affine::AffineParallelOp parallelOp) {
+      loops.push_back(parallelOp);
+    });
+
+    // Process inner loops first so newly hoisted operations can be hoisted
+    // again from enclosing loops when they are invariant there too.
+    for (mlir::LoopLikeOpInterface loop : llvm::reverse(loops)) {
+      mlir::moveLoopInvariantCode(loop);
+    }
+  }
+};
+
+} // namespace

--- a/lib/Dialect/D2M/Transforms/AffineLICM.cpp
+++ b/lib/Dialect/D2M/Transforms/AffineLICM.cpp
@@ -7,6 +7,8 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MAFFINELICM
@@ -21,10 +23,11 @@ struct D2MAffineLICM
 
   void runOnOperation() override {
     llvm::SmallVector<mlir::LoopLikeOpInterface> loops;
-    getOperation().walk(
-        [&](mlir::affine::AffineForOp forOp) { loops.push_back(forOp); });
-    getOperation().walk([&](mlir::affine::AffineParallelOp parallelOp) {
-      loops.push_back(parallelOp);
+    getOperation().walk([&](mlir::Operation *op) {
+      if (mlir::isa<mlir::affine::AffineForOp, mlir::affine::AffineParallelOp>(
+              op)) {
+        loops.push_back(mlir::cast<mlir::LoopLikeOpInterface>(op));
+      }
     });
 
     // Process inner loops first so newly hoisted operations can be hoisted

--- a/lib/Dialect/D2M/Transforms/CMakeLists.txt
+++ b/lib/Dialect/D2M/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(MLIRD2MTransforms
         Allocate.cpp
+        AffineLICM.cpp
         DMAOptimizations.cpp
         DecomposeArange.cpp
         DecomposeMasking.cpp

--- a/test/ttmlir/Dialect/D2M/Transforms/affine_licm.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/affine_licm.mlir
@@ -22,3 +22,27 @@ func.func @module_licm() {
 // CHECK-NOT: arith.constant
 // CHECK-NOT: arith.addi
 // CHECK: return
+
+func.func @module_licm_mixed_loop_types() {
+  affine.parallel (%i) = (0) to (4) {
+    affine.for %j = 0 to 4 {
+      %c3 = arith.constant 3 : index
+      %c4 = arith.constant 4 : index
+      %0 = arith.addi %c3, %c4 : index
+    }
+    affine.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @module_licm_mixed_loop_types
+// CHECK: %[[C3:.+]] = arith.constant 3 : index
+// CHECK: %[[C4:.+]] = arith.constant 4 : index
+// CHECK: %{{.+}} = arith.addi %[[C3]], %[[C4]] : index
+// CHECK: affine.for
+// CHECK-NOT: arith.constant
+// CHECK-NOT: arith.addi
+// CHECK: affine.parallel
+// CHECK-NOT: arith.constant
+// CHECK-NOT: arith.addi
+// CHECK: return

--- a/test/ttmlir/Dialect/D2M/Transforms/affine_licm.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/affine_licm.mlir
@@ -1,0 +1,24 @@
+// RUN: ttmlir-opt --d2m-affine-licm %s | FileCheck %s
+
+func.func @module_licm() {
+  affine.for %i = 0 to 4 {
+    affine.for %j = 0 to 4 {
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %0 = arith.addi %c1, %c2 : index
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @module_licm
+// CHECK: %[[C1:.+]] = arith.constant 1 : index
+// CHECK: %[[C2:.+]] = arith.constant 2 : index
+// CHECK: %{{.+}} = arith.addi %[[C1]], %[[C2]] : index
+// CHECK: affine.for
+// CHECK-NOT: arith.constant
+// CHECK-NOT: arith.addi
+// CHECK: affine.for
+// CHECK-NOT: arith.constant
+// CHECK-NOT: arith.addi
+// CHECK: return


### PR DESCRIPTION
### Problem description
Running unnecessary passes and at wrong scope

### What's changed
- D2MOpScheduler is no longer hard-enabled in createD2MBackendPipeline
- The pipeline option enable-op-scheduler now defaults to false, so scheduler only runs with: enable-op-scheduler=true
- D2MSFPUTileLoopFission is gated behind generic fusion, since it only matters for fused generic compute shapes: enable-elementwise-fusion=true or enable-eltwise-reduction-fusion=true
- Added a new D2M pass: --d2m-affine-licm which runs at module level, first step to parallelizing over d2m generics
- It walks affine.for and affine.parallel ops and applies MLIR’s moveLoopInvariantCode utility
- The D2M backend now uses d2m::createD2MAffineLICM() instead of stock affine::createAffineLoopInvariantCodeMotionPass()
- Added lit test

### Checklist
- [ ] New/Existing tests provide coverage for changes
