### PR TITLE
[d2m] emitc fix for duplicate expressions

### DIFF
--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -341,6 +341,17 @@ def RemoveDeadEmitCExpressions : Pass<"remove-dead-emitc-expressions", "::mlir::
   let dependentDialects = ["mlir::emitc::EmitCDialect"];
 }
 
+def FormDeduplicatedEmitCExpressions : Pass<"form-deduplicated-emitc-expressions", "::mlir::func::FuncOp"> {
+  let summary = "Form EmitC expressions with parser-valid captured operands.";
+  let description = [{
+    Form emitc.expression operations while removing duplicate captured
+    operands. Repeated uses in the expression body are remapped to the first
+    corresponding block argument so pipeline-visible IR remains parser-valid.
+  }];
+  let constructor = "createFormDeduplicatedEmitCExpressionsPass()";
+  let dependentDialects = ["mlir::emitc::EmitCDialect"];
+}
+
 def ConvertSFPIToEmitC : Pass<"convert-sfpi-to-emitc", "::mlir::ModuleOp"> {
   let summary = "Convert SFPI dialect to EmitC dialect using GCC RISC-V Tenstorrent builtins.";
   let description = [{

--- a/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
+++ b/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
@@ -15,10 +15,14 @@
 
 namespace mlir::tt {
 #define GEN_PASS_DECL_CONVERTTTKERNELTOEMITC
+#define GEN_PASS_DECL_FORMDEDUPLICATEDEMITCEXPRESSIONS
 #include "ttmlir/Conversion/Passes.h.inc"
 
 std::unique_ptr<OperationPass<func::FuncOp>>
 createRemoveDeadEmitCExpressionsPass();
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createFormDeduplicatedEmitCExpressionsPass();
 } // namespace mlir::tt
 
 #endif

--- a/lib/Conversion/TTKernelToEmitC/RemoveDeadEmitCExpressions.cpp
+++ b/lib/Conversion/TTKernelToEmitC/RemoveDeadEmitCExpressions.cpp
@@ -5,19 +5,115 @@
 #include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"
 
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 
 namespace mlir::tt {
 
 #define GEN_PASS_DEF_REMOVEDEADEMITCEXPRESSIONS
+#define GEN_PASS_DEF_FORMDEDUPLICATEDEMITCEXPRESSIONS
 #include "ttmlir/Conversion/Passes.h.inc"
 
 namespace {
+
+struct UniqueOperands {
+  SmallVector<Value> values;
+  SmallVector<unsigned> remappedIndices;
+  bool hasDuplicates = false;
+};
+
+static UniqueOperands collectUniqueOperands(ValueRange operands) {
+  UniqueOperands uniqueOperands;
+  uniqueOperands.remappedIndices.reserve(operands.size());
+
+  DenseMap<Value, unsigned> uniqueIndices;
+  uniqueIndices.reserve(operands.size());
+  for (Value operand : operands) {
+    auto [it, inserted] =
+        uniqueIndices.try_emplace(operand, uniqueOperands.values.size());
+    if (inserted) {
+      uniqueOperands.values.push_back(operand);
+    } else {
+      uniqueOperands.hasDuplicates = true;
+    }
+    uniqueOperands.remappedIndices.push_back(it->second);
+  }
+
+  return uniqueOperands;
+}
+
+static bool deduplicateExpressionOperands(emitc::ExpressionOp expression);
+
+static bool isFormableExpressionOp(Operation *op) {
+  auto expression = dyn_cast<emitc::CExpressionInterface>(op);
+  if (!expression || isa<emitc::LiteralOp>(op)) {
+    return false;
+  }
+
+  if (isa_and_nonnull<emitc::ExpressionOp>(op->getParentOp())) {
+    return false;
+  }
+
+  return op->getNumResults() == 1 && op->getResult(0).hasOneUse();
+}
+
+static void formDeduplicatedExpression(Operation *op) {
+  UniqueOperands uniqueOperands = collectUniqueOperands(op->getOperands());
+  OpBuilder builder(op);
+  auto expression = builder.create<emitc::ExpressionOp>(
+      op->getLoc(), op->getResult(0).getType(), uniqueOperands.values);
+  Block &body = expression.createBody();
+
+  op->getResult(0).replaceAllUsesWith(expression.getResult());
+  op->moveBefore(&body, body.end());
+
+  for (auto [index, uniqueIndex] :
+       llvm::enumerate(uniqueOperands.remappedIndices)) {
+    op->setOperand(index, body.getArgument(uniqueIndex));
+  }
+
+  builder.setInsertionPointAfter(op);
+  builder.create<emitc::YieldOp>(op->getLoc(), op->getResult(0));
+}
+
+static bool deduplicateExpressionOperands(emitc::ExpressionOp expression) {
+  UniqueOperands uniqueOperands =
+      collectUniqueOperands(expression->getOperands());
+  if (!uniqueOperands.hasDuplicates) {
+    return false;
+  }
+
+  OpBuilder builder(expression);
+  auto newExpression = builder.create<emitc::ExpressionOp>(
+      expression.getLoc(), expression.getResult().getType(),
+      uniqueOperands.values, expression.getDoNotInlineAttr());
+  Block &newBody = newExpression.createBody();
+
+  IRMapping mapping;
+  Block &oldBody = expression.getRegion().front();
+  for (auto [index, oldArgument] : llvm::enumerate(oldBody.getArguments())) {
+    mapping.map(oldArgument,
+                newBody.getArgument(uniqueOperands.remappedIndices[index]));
+  }
+
+  builder.setInsertionPointToEnd(&newBody);
+  for (Operation &op : oldBody.getOperations()) {
+    builder.clone(op, mapping);
+  }
+
+  expression.getResult().replaceAllUsesWith(newExpression.getResult());
+  expression.erase();
+  return true;
+}
+
+static bool isDeadEmitCExpression(Operation *op);
 
 static bool hasNoUses(Operation *op) {
   return op->getNumResults() > 0 &&
@@ -95,6 +191,35 @@ static void eraseDeadVariable(emitc::VariableOp variable,
   }
 }
 
+class FormDeduplicatedEmitCExpressions
+    : public impl::FormDeduplicatedEmitCExpressionsBase<
+          FormDeduplicatedEmitCExpressions> {
+public:
+  using impl::FormDeduplicatedEmitCExpressionsBase<
+      FormDeduplicatedEmitCExpressions>::FormDeduplicatedEmitCExpressionsBase;
+
+  void runOnOperation() final {
+    SmallVector<Operation *> candidates;
+    getOperation().walk<WalkOrder::PreOrder>([&](Operation *op) {
+      if (isFormableExpressionOp(op)) {
+        candidates.push_back(op);
+      }
+    });
+
+    for (Operation *op : candidates) {
+      formDeduplicatedExpression(op);
+    }
+
+    SmallVector<emitc::ExpressionOp> expressions;
+    getOperation().walk([&](emitc::ExpressionOp expression) {
+      expressions.push_back(expression);
+    });
+    for (emitc::ExpressionOp expression : expressions) {
+      deduplicateExpressionOperands(expression);
+    }
+  }
+};
+
 class RemoveDeadEmitCExpressions
     : public impl::RemoveDeadEmitCExpressionsBase<RemoveDeadEmitCExpressions> {
 public:
@@ -134,6 +259,11 @@ public:
 std::unique_ptr<OperationPass<func::FuncOp>>
 createRemoveDeadEmitCExpressionsPass() {
   return std::make_unique<RemoveDeadEmitCExpressions>();
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createFormDeduplicatedEmitCExpressionsPass() {
+  return std::make_unique<FormDeduplicatedEmitCExpressions>();
 }
 
 } // namespace mlir::tt

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -312,7 +312,7 @@ void createD2MEmitCPipeline(OpPassManager &pm,
   funcPm.addPass(createConvertTTKernelToEmitC());
   funcPm.addPass(createCanonicalizerPassWithOptions(options));
   funcPm.addPass(createRemoveDeadEmitCExpressionsPass());
-  funcPm.addPass(mlir::emitc::createFormExpressionsPass());
+  funcPm.addPass(createFormDeduplicatedEmitCExpressionsPass());
 }
 
 void createD2MToTTKernelPipeline(OpPassManager &pm,

--- a/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
+++ b/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
@@ -28,7 +28,7 @@ void createPyKernelCompilePipeline(
   funcPm.addPass(mlir::tt::createRemoveDeadEmitCExpressionsPass());
 
   if (options.enableFormExpressions) {
-    funcPm.addPass(mlir::emitc::createFormExpressionsPass());
+    funcPm.addPass(mlir::tt::createFormDeduplicatedEmitCExpressionsPass());
   }
 }
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/deduplicate_emitc_expression_operands.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/deduplicate_emitc_expression_operands.mlir
@@ -1,0 +1,17 @@
+// RUN: ttmlir-opt %s --form-deduplicated-emitc-expressions | FileCheck %s
+// RUN: ttmlir-opt %s --form-deduplicated-emitc-expressions --mlir-print-ir-after-all -o %t 2> %t.dump
+// RUN: ttmlir-opt %t.dump -o %t.reparsed
+
+module {
+  // CHECK-LABEL: func.func @deduplicate_expression_operands
+  // CHECK: %[[RESULT:.*]] = emitc.expression %[[X:.*]], %[[Y:.*]], %[[ADDR:.*]], %[[NOC:.*]] : (!emitc.size_t, !emitc.size_t, i32, i8) -> i64 {
+  // CHECK-NEXT: %[[MCAST:.*]] = call_opaque "get_noc_multicast_addr"(%[[X]], %[[Y]], %[[X]], %[[ADDR]], %[[NOC]]) : (!emitc.size_t, !emitc.size_t, !emitc.size_t, i32, i8) -> i64
+  // CHECK-NEXT: yield %[[MCAST]] : i64
+  // CHECK-NEXT: }
+  // CHECK-NEXT: return %[[RESULT]] : i64
+  func.func @deduplicate_expression_operands(
+      %x: !emitc.size_t, %y: !emitc.size_t, %addr: i32, %noc: i8) -> i64 {
+    %mcast = emitc.call_opaque "get_noc_multicast_addr"(%x, %y, %x, %addr, %noc) : (!emitc.size_t, !emitc.size_t, !emitc.size_t, i32, i8) -> i64
+    return %mcast : i64
+  }
+}


### PR DESCRIPTION
### Problem description
Emitc form expression pass failing when making fb for Qwen IR after some changes to upstream passes causing duplication of expressions

### What's changed
- Adds form-deduplicated-emitc-expressions, a TT EmitC pass that forms emitc.expression ops while deduplicating captured operands
- Fixes invalid printed IR from emitc.expression when the same SSA value is captured multiple times, by remapping repeated body uses to the first captured block argument
- Replaces raw mlir::emitc::createFormExpressionsPass() usage in D2M and TTKernel pipelines with the new parser-safe TT wrapper pass
- Keeps the implementation scoped to TTKernelToEmitC, without adding a separate public dedup pass
- Adds lit coverage for tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
