### PR TITLE
[ttkernel] Fix DPrintOp emitc lowering for fmt-style DEVICE_PRINT

### DIFF
--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1794,40 +1794,41 @@ public:
           .getResult();
     };
 
-    auto operandsIter = adaptor.getOperands().begin();
-    auto operandsEnd = adaptor.getOperands().end();
-    StringRef rest;
-    SmallVector<Value> vargs;
-    do {
-      std::tie(fmt, rest) = fmt.split("{}");
-      if (!fmt.empty()) {
-        vargs.push_back(stringlit(fmt));
-      }
-      if (operandsIter != operandsEnd) {
-        if (mlir::isa<ttkernel::CBType>(
-                op.getOperands()[operandsIter.getIndex()].getType()) &&
-            op->getParentOfType<func::FuncOp>()
-                    ->getAttrOfType<ttkernel::ThreadTypeAttr>(
-                        ttkernel::ThreadTypeAttr::name)
-                    .getValue() == ttkernel::ThreadType::Compute) {
-          auto cbPrinter =
-              rewriter
-                  .create<emitc::CallOpaqueOp>(
-                      op.getLoc(),
-                      rewriter.getType<emitc::OpaqueType>("ttmlir::CBPrinter"),
-                      "ttmlir::CBPrinter", nullptr, nullptr,
-                      ValueRange{*operandsIter++})
-                  .getResult(0);
-          vargs.push_back(cbPrinter);
-        } else {
-          vargs.push_back(*operandsIter++);
-        }
-      }
-      fmt = rest;
-    } while (!fmt.empty());
+    // Lower to a single fmt-style DPRINT call:
+    //   DPRINT("<fmt with {} placeholders>", arg0, arg1, ...)
+    // The new tt-metal DEVICE_PRINT is fmt-style and requires the format
+    // string to be a compile-time literal: passing each arg through a
+    // template wrapper as DPRINT("{}", arg) would format string-literal
+    // pieces (and "\n") as pointer addresses rather than text, so the
+    // format string must be emitted verbatim as the first argument and the
+    // operands passed positionally for the {} placeholders.
+    bool isComputeThread = op->getParentOfType<func::FuncOp>()
+                               ->getAttrOfType<ttkernel::ThreadTypeAttr>(
+                                   ttkernel::ThreadTypeAttr::name)
+                               .getValue() == ttkernel::ThreadType::Compute;
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        op, TypeRange(), "ttmlir::dprint", nullptr, nullptr, vargs);
+    SmallVector<Value> vargs;
+    vargs.push_back(stringlit(fmt));
+    for (auto operand : adaptor.getOperands()) {
+      auto operandIndex = vargs.size() - 1;
+      if (mlir::isa<ttkernel::CBType>(
+              op.getOperands()[operandIndex].getType()) &&
+          isComputeThread) {
+        auto cbPrinter =
+            rewriter
+                .create<emitc::CallOpaqueOp>(
+                    op.getLoc(),
+                    rewriter.getType<emitc::OpaqueType>("ttmlir::CBPrinter"),
+                    "ttmlir::CBPrinter", nullptr, nullptr, ValueRange{operand})
+                .getResult(0);
+        vargs.push_back(cbPrinter);
+      } else {
+        vargs.push_back(operand);
+      }
+    }
+
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(op, TypeRange(), "DPRINT",
+                                                     nullptr, nullptr, vargs);
     return success();
   }
 };

--- a/test/ttmlir/Translate/TTKernel/ttkernel_dprint.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_dprint.mlir
@@ -4,10 +4,11 @@
 #l1_ = #ttcore.memory_space<l1>
 func.func @kernel_main() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
     %c42_i32 = arith.constant 42 : i32
-    // CHECK: ttmlir::dprint("Hello world, ", v1, "!\n");
+    // CHECK: DPRINT("Hello world, {}!\n", v{{[0-9]+}});
     ttkernel.dprint("Hello world, {}!\\n", %c42_i32) : (i32) -> ()
     %cb = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1024, f32>
-    // CHECK: ttmlir::CBPrinter
+    // CHECK: ttmlir::CBPrinter [[CB:v[0-9]+]] = ttmlir::CBPrinter(
+    // CHECK: DPRINT("{}", [[CB]]);
     ttkernel.dprint("{}", %cb) : (!ttkernel.cb<1024, f32>) -> ()
     func.return
 }


### PR DESCRIPTION
The ttkernel.dprint -> emitc lowering split the format string and emitted ttmlir::dprint(piece, val, piece, val, ...) where the wrapper did DPRINT("{}", arg) per argument (legacy stream-style emulation). tt-metal's new fmt-style DEVICE_PRINT formats a const char* argument as a pointer address rather than string text, so string-literal pieces (and "\n") printed as addresses and no real newline was ever emitted -- the host buffers DPRINT output until a newline, so nothing surfaced at all despite the device writing and the host reading correctly.

Lower directly to a single fmt-style DPRINT("<fmt with {}>", op0, op1, ...) call using the original format string as a compile-time literal plus the operands positionally (CBPrinter-wrapped for compute-thread CB operands).