### PR TITLE
Always skip ToLayout ops in L1Spill pass

### DIFF
--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1258,14 +1258,9 @@ void L1SpillManagement<MemoryTracker>::run() {
       continue;
     }
 
-    // ToLayoutOp with L1 output: workaround-inserted and always immediately
-    // consumed by the target op. MemoryLayoutPropagation skips these, and
-    // pre-decomposition OpModel is inaccurate.
-    // Use farthest-last-use eviction for live tensors if needed to create room,
-    // but do not add the output to liveValues — it is not a long-lived L1
-    // tenant and will be gone (or dead) before any subsequent eviction decision
-    // matters. Being absent from liveValues also means evictAllFromL1 (e.g.
-    // triggered by DistributedRMSNormOp's isNotImplemented) cannot spill it.
+    // ToLayoutOp requires special handling due to the fact it is a complex op
+    // which decomposes into few real TTNN ops. MemoryLayoutPropagation skips
+    // these, and pre-decomposition OpModel is impossible.
     if (isa<ToLayoutOp>(op)) {
       auto resultType =
           mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
@@ -1273,6 +1268,14 @@ void L1SpillManagement<MemoryTracker>::run() {
           mlir::dyn_cast_or_null<TTNNLayoutAttr>(resultType.getEncoding());
       assert(lo && "ToLayoutOp result must have TTNNLayoutAttr encoding");
       if (lo.hasL1BufferType()) {
+        // Case with L1 output: workaround-inserted and always immediately
+        // consumed by the target op.
+        // Use farthest-last-use eviction for live tensors if needed to create
+        // room, but do not add the output to liveValues — it is not a
+        // long-lived L1 tenant and will be gone (or dead) before any subsequent
+        // eviction decision matters. Being absent from liveValues also means
+        // evictAllFromL1 (e.g. triggered by DistributedRMSNormOp's
+        // isNotImplemented) cannot spill it.
         uint64_t derivedL1 = utils::getPerCoreL1Usage(
             lo, ttmlir::utils::volume(lo.getGridShape()));
         TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1283,9 +1286,12 @@ void L1SpillManagement<MemoryTracker>::run() {
         // CBPeakUsage fixed to 0 as we have no validation result for ToLayoutOp
         // itself which is yet to be decomposed.
         ensureFitsL1(op, pos, data, /*cbPeakUsage=*/0, derivedL1);
-        continue;
       }
-      // DRAM ToLayoutOp: fall through to standard processing.
+
+      // Regardless of whether the ToLayoutOp's output is L1 or DRAM, we have no
+      // way of validating this op since it is yet to be decomposed. Usually
+      // this is workaround inserted op, so we can skip it.
+      continue;
     }
 
     // Determine if the op outputs to L1 by inspecting its result types


### PR DESCRIPTION
Fixes #8886

Bug was that we were processing ToLayout ops which are product of workarounds during L1 spill pass..
