### PR TITLE
[StableHLO] `moe_decode` composite op

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
@@ -67,6 +67,12 @@ inline constexpr llvm::StringLiteral
 inline constexpr llvm::StringLiteral
     kTTSDPACompositeName("tenstorrent.scaled_dot_product_attention");
 
+// Composite name emitted by the frontend for the fused MoE decode block. Kept
+// as the StableHLOToTTIR conversion's custom_call target name too, so the
+// composite (after FlattenOrConvert -> custom_call) lowers to
+// ttcore.composite "moe_decode".
+inline constexpr llvm::StringLiteral kTTMoeDecodeCompositeName("tt.moe_decode");
+
 // Composite names that have custom sharding rules. These composites are
 // converted to stablehlo.custom_call ops so that Shardy can propagate shardings
 // defined by the custom sharding rule for that composite as if the composite
@@ -78,7 +84,7 @@ inline constexpr llvm::StringLiteral kCompositesWithCustomSharding[] = {
     kTTTopKValuesCustomCallTargetName, kTTTopKIndicesCustomCallTargetName,
     kTTArgMaxCustomCallTargetName,     kTTSDPACompositeName,
     kTTGatherCustomCallTargetName,     kTTGatherDimCustomCallTargetName,
-};
+    kTTMoeDecodeCompositeName};
 
 // Target name for the distributed RMS norm custom_call op.
 inline constexpr llvm::StringLiteral

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/StableHLO/Utils/GSPMDUtils.h"
 #include "ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h"
 #include "ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h"
+#include "ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h"
 #include "ttmlir/Dialect/StableHLO/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
@@ -9525,6 +9526,433 @@ public:
 } // namespace
 
 namespace {
+// Device mesh shape for the module. moe_decode lowers in the same pass that
+// converts sdy.mesh -> ttcore.meshes with no guaranteed firing order, so read
+// whichever form is present. Returns {} when the module carries no mesh.
+static llvm::SmallVector<int64_t> getModuleMeshShape(ModuleOp moduleOp) {
+  if (auto meshes =
+          moduleOp->getAttrOfType<ttcore::MeshesAttr>(ttcore::MeshesAttr::name);
+      meshes && !meshes.getMeshes().empty()) {
+    return llvm::SmallVector<int64_t>(meshes.getMeshes()[0].getShape());
+  }
+  llvm::SmallVector<mlir::sdy::MeshOp> meshOps =
+      mlir::tt::shardy_utils::getMeshOps(moduleOp);
+  if (!meshOps.empty()) {
+    return mlir::tt::shardy_utils::getMeshShapeFromMeshAttr(
+        meshOps[0].getMeshAttr());
+  }
+  return {};
+}
+
+// Synthesize the moe_decode expert_mapping as a replicated 2D [D, E] uint16
+// constant where [d, e] = owner(e) = e / expertsPerDevice (same on every row),
+// derived from topology so the frontend composite stays mesh-agnostic.
+// Contiguous owner layout (1xN dispatch ring); the replicated cluster_axis==0
+// interleave (4x8) is a separate TODO.
+static Value synthesizeMoeDecodeExpertMapping(OpBuilder &builder, Location loc,
+                                              int64_t numDevices,
+                                              int64_t expertsPerDevice) {
+  int64_t numExperts = expertsPerDevice * numDevices;
+  auto u16 = builder.getIntegerType(16, /*isSigned=*/false);
+  auto mappingTy = RankedTensorType::get({numDevices, numExperts}, u16);
+
+  llvm::SmallVector<llvm::APInt> values;
+  values.reserve(numDevices * numExperts);
+  for (int64_t d = 0; d < numDevices; ++d) {
+    for (int64_t e = 0; e < numExperts; ++e) {
+      values.emplace_back(/*numBits=*/16,
+                          static_cast<uint64_t>(e / expertsPerDevice),
+                          /*isSigned=*/false);
+    }
+  }
+  return builder.create<ttir::ConstantOp>(
+      loc, mappingTy, DenseElementsAttr::get(mappingTy, values));
+}
+
+// Decompose moe_decode into primitive ops (NOT the fused moe_compute /
+// all_to_all_dispatch_metadata it replaces). Experts are EP-sharded on the
+// cluster axis, so: all_gather the weights to replicate every expert locally,
+// run the expert FFN via two sparse_matmuls with a GLU between, then select
+// each token's top-k experts with a one-hot matmul. This body is inlined when
+// the typed composite promotion is not taken. operands:
+// [tokens, indices, scores, mapping, w0, w1, w2, (b0, b1, b2)?]; scores/mapping
+// are unused (all_gather makes expert ownership irrelevant here).
+static Value buildMoeDecodeDecompositionBody(
+    ConversionPatternRewriter &rewriter, Location loc, ValueRange operands,
+    bool hasBias, int64_t numDevices, int64_t clusterAxis, uint32_t layerId,
+    uint32_t outputHeightShardDim, uint32_t intermediateSize,
+    ttcore::MoEActivationFunction activation,
+    std::optional<uint32_t> bhRingSize, RankedTensorType outputType) {
+  (void)layerId;
+  (void)outputHeightShardDim;
+  (void)intermediateSize;
+  (void)bhRingSize;
+
+  Value tokens = operands[0];
+  Value indices = operands[1];
+  Value w0 = operands[4], w1 = operands[5], w2 = operands[6];
+  Value bias0 = hasBias ? operands[7] : Value();
+  Value bias1 = hasBias ? operands[8] : Value();
+  Value bias2 = hasBias ? operands[9] : Value();
+
+  auto tokensTy = mlir::cast<RankedTensorType>(tokens.getType());
+  auto idxTy = mlir::cast<RankedTensorType>(indices.getType());
+  auto w0Ty = mlir::cast<RankedTensorType>(w0.getType());
+  Type act = tokensTy.getElementType();
+  Type f32 = rewriter.getF32Type();
+
+  int64_t M = tokensTy.getShape()[tokensTy.getRank() - 2];
+  int64_t H = tokensTy.getShape().back();
+  int64_t K = idxTy.getShape().back();
+  int64_t N = w0Ty.getShape()[3];
+  int64_t Eg = w0Ty.getShape()[1] * numDevices; // global expert count
+
+  auto rt = [&](ArrayRef<int64_t> s, Type e) {
+    return RankedTensorType::get(s, e);
+  };
+  auto reshape = [&](Value v, ArrayRef<int64_t> s) -> Value {
+    Type e = mlir::cast<RankedTensorType>(v.getType()).getElementType();
+    return rewriter.create<ttir::ReshapeOp>(
+        loc, rt(s, e), v,
+        rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(s)));
+  };
+  // all_gather along `dim` over the cluster axis: EP-sharded -> global experts.
+  auto allGather = [&](Value v, int64_t dim) -> Value {
+    auto t = mlir::cast<RankedTensorType>(v.getType());
+    SmallVector<int64_t> s(t.getShape());
+    s[dim] *= numDevices;
+    return rewriter.create<ttir::AllGatherOp>(
+        loc, rt(s, t.getElementType()), v, static_cast<int32_t>(dim),
+        static_cast<uint32_t>(clusterAxis));
+  };
+  // Fuse gate/up into one [..., 2C] weight via a block concat [gate | up], not
+  // a stride-2 interleave (whose trailing size-2 dim tilizes to 32 -> 16x DRAM
+  // blowup). The halves are split back out before the GLU.
+  auto fuseLast = [&](Value lhs, Value rhs) -> Value {
+    auto t = mlir::cast<RankedTensorType>(lhs.getType());
+    SmallVector<int64_t> sout(t.getShape());
+    sout.back() *= 2;
+    return rewriter.create<ttir::ConcatOp>(
+        loc, rt(sout, t.getElementType()), ValueRange{lhs, rhs},
+        static_cast<int32_t>(sout.size() - 1));
+  };
+  // out[1,Eg,M,C] += bias[1,Eg,C], broadcast over the token dim.
+  auto addBias = [&](Value x, Value bias, int64_t C) -> Value {
+    return rewriter.create<ttir::AddOp>(loc, rt({1, Eg, M, C}, act), x,
+                                        reshape(bias, {1, Eg, 1, C}));
+  };
+
+  // 1. all_gather weights (+ biases) to replicate every expert locally.
+  Value w0g = allGather(w0, 1); // [1, Eg, H, N]
+  Value w1g = allGather(w1, 1);
+  Value w2g = allGather(w2, 1);       // [1, Eg, N, H]
+  Value wGateUp = fuseLast(w0g, w1g); // [1, Eg, H, 2N]
+  Value bGateUp, b2g;
+  if (hasBias) {
+    bGateUp = fuseLast(allGather(bias0, 1), allGather(bias1, 1)); // [1,Eg,2N]
+    b2g = allGather(bias2, 1);                                    // [1,Eg,H]
+  }
+
+  // 2. one_hot[m,k,e] = (indices[m,k] == e), in f32 for an exact int compare.
+  Value idxB = rewriter.create<ttir::BroadcastOp>(
+      loc, rt({M, K, Eg}, f32),
+      reshape(rewriter.create<ttir::TypecastOp>(loc, rt({M, K}, f32),
+                                                reshape(indices, {M, K})),
+              {M, K, 1}),
+      rewriter.getDenseI64ArrayAttr({1, 1, Eg}));
+  Value arangeE = rewriter.create<ttir::ArangeOp>(
+      loc, rt({M, K, Eg}, f32), /*start=*/0, /*end=*/Eg, /*step=*/1,
+      /*arange_dimension=*/2);
+  Value oneHot = rewriter.create<ttir::TypecastOp>(
+      loc, rt({M, K, Eg}, act),
+      rewriter.create<ttir::EqualOp>(loc, rt({M, K, Eg}, rewriter.getI1Type()),
+                                     idxB, arangeE));
+
+  // All-ones sparsity (compute every expert): a real per-token mask lets
+  // sparse_matmul skip experts, leaving garbage the one-hot select folds in
+  // (0 * NaN). In decode nearly every expert is selected, so this is ~free.
+  Value sparsity = rewriter.create<ttir::FullOp>(
+      loc, rt({1, 1, 1, Eg}, act), rewriter.getF32FloatAttr(1.0f));
+
+  // 3. gate_up: a[1,1,M,H] . b[1,Eg,H,2N] -> [1,1,1,Eg,M,2N] -> [1,Eg,M,2N].
+  Value gateUp4d = reshape(
+      rewriter.create<ttir::SparseMatmulOp>(
+          loc, rt({1, 1, 1, Eg, M, 2 * N}, act), tokens, wGateUp, sparsity,
+          /*is_input_a_sparse=*/rewriter.getBoolAttr(false),
+          /*is_input_b_sparse=*/rewriter.getBoolAttr(true),
+          /*nnz=*/mlir::IntegerAttr()),
+      {1, Eg, M, 2 * N});
+  if (hasBias) {
+    gateUp4d = addBias(gateUp4d, bGateUp, 2 * N);
+  }
+
+  // 4. split the [gate | up] halves + GLU activation.
+  auto interTy = rt({1, Eg, M, N}, act);
+  auto half = [&](int64_t start) -> Value {
+    return rewriter.create<ttir::SliceStaticOp>(
+        loc, interTy, gateUp4d,
+        rewriter.getI32ArrayAttr({0, 0, 0, static_cast<int32_t>(start)}),
+        rewriter.getI32ArrayAttr({1, static_cast<int32_t>(Eg),
+                                  static_cast<int32_t>(M),
+                                  static_cast<int32_t>(start + N)}),
+        rewriter.getI32ArrayAttr({1, 1, 1, 1}));
+  };
+  Value gate = half(0), up = half(N);
+  Value inter;
+  if (activation == ttcore::MoEActivationFunction::SwiGLU) {
+    // (clamp(up,-7,7) + 1) * clamp(gate,_,7) * sigmoid(1.702 * gate_c).
+    Value gateC = rewriter.create<ttir::ClampScalarOp>(
+        loc, interTy, gate,
+        rewriter.getF32FloatAttr(std::numeric_limits<float>::lowest()),
+        rewriter.getF32FloatAttr(7.0f));
+    Value upC = rewriter.create<ttir::ClampScalarOp>(
+        loc, interTy, up, rewriter.getF32FloatAttr(-7.0f),
+        rewriter.getF32FloatAttr(7.0f));
+    Value sig = rewriter.create<ttir::SigmoidOp>(
+        loc, interTy,
+        rewriter.create<ttir::MultiplyOp>(
+            loc, interTy, gateC,
+            rewriter.create<ttir::FullOp>(loc, interTy,
+                                          rewriter.getF32FloatAttr(1.702f))));
+    Value up1 = rewriter.create<ttir::AddOp>(
+        loc, interTy, upC,
+        rewriter.create<ttir::FullOp>(loc, interTy,
+                                      rewriter.getF32FloatAttr(1.0f)));
+    inter = rewriter.create<ttir::MultiplyOp>(
+        loc, interTy,
+        rewriter.create<ttir::MultiplyOp>(loc, interTy, up1, gateC), sig);
+  } else {
+    inter = rewriter.create<ttir::MultiplyOp>(
+        loc, interTy, rewriter.create<ttir::SiluOp>(loc, interTy, gate), up);
+  }
+
+  // 5. down: a[1,Eg,M,N] . b[1,Eg,N,H] -> [1,Eg,M,H].
+  Value down = rewriter.create<ttir::SparseMatmulOp>(
+      loc, rt({1, Eg, M, H}, act), inter, w2g, sparsity,
+      /*is_input_a_sparse=*/rewriter.getBoolAttr(true),
+      /*is_input_b_sparse=*/rewriter.getBoolAttr(false),
+      /*nnz=*/mlir::IntegerAttr());
+  if (hasBias) {
+    down = addBias(down, b2g, H);
+  }
+
+  // 6. top-k select: one_hot[M,K,Eg] . out_all[M,Eg,H] -> [M,K,H] -> [K,M,H].
+  Value outAll = rewriter.create<ttir::PermuteOp>(
+      loc, rt({M, Eg, H}, act), reshape(down, {Eg, M, H}),
+      rewriter.getDenseI64ArrayAttr({1, 0, 2}));
+  Value combine =
+      rewriter.create<ttir::MatmulOp>(loc, rt({M, K, H}, act), oneHot, outAll);
+  return rewriter.create<ttir::PermuteOp>(
+      loc, outputType, combine, rewriter.getDenseI64ArrayAttr({1, 0, 2}));
+}
+
+// Converts stablehlo.custom_call @tt.moe_decode -> ttcore.composite
+// "moe_decode". Mirrors the flash_mla_prefill pattern: parse the string
+// frontend attributes into typed composite_attributes, synthesize a private
+// TTIR decomposition func, and emit the carrier composite that
+// TTNNResolveComposites resolves.
+class StableHLOToTTCoreMoeDecodeOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
+  using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CustomCallOp srcOp,
+                  mlir::stablehlo::CustomCallOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (adaptor.getCallTargetNameAttr() != "tt.moe_decode") {
+      return failure();
+    }
+
+    // Attributes arrive in one of two forms:
+    //  - Route B (builder / direct custom_call): string-valued
+    //    mhlo.frontend_attributes.
+    //  - Route A (StableHLOCompositeBuilder composite that
+    //    FlattenOrConvertComposites converted to a custom_call because
+    //    tt.moe_decode is in kCompositesWithCustomSharding): typed
+    //    composite_attributes carried under tt.composite_attributes.
+    mlir::DictionaryAttr compAttrs =
+        mlir::dyn_cast_or_null<mlir::DictionaryAttr>(srcOp->getDiscardableAttr(
+            mlir::tt::stablehlo::utils::kCustomCallCompositeAttrsKey));
+    mlir::DictionaryAttr fe = mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+        srcOp->getDiscardableAttr("mhlo.frontend_attributes"));
+    if (!compAttrs && !fe) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "moe_decode op must have tt.composite_attributes or "
+                 "mhlo.frontend_attributes.");
+    }
+
+    // Required integer attributes: typed IntegerAttr (Route A) or
+    // string-encoded (Route B).
+    auto readReqInt = [&](StringRef name, int64_t &out) -> LogicalResult {
+      if (compAttrs) {
+        if (auto i = compAttrs.getAs<mlir::IntegerAttr>(name)) {
+          out = i.getInt();
+          return success();
+        }
+      }
+      if (fe) {
+        if (auto s = fe.getAs<mlir::StringAttr>(name)) {
+          if (llvm::to_integer(s.getValue(), out)) {
+            return success();
+          }
+        }
+      }
+      return rewriter.notifyMatchFailure(
+          srcOp, "moe_decode requires integer attribute '" + name.str() + "'.");
+    };
+    // num_devices is NOT a composite attribute: the frontend composite is
+    // mesh-agnostic, so the dispatch-ring device count is derived here from the
+    // module mesh (num_devices = meshShape[cluster_axis]).
+    int64_t clusterAxis, layerId, outputHeightShardDim, intermediateSize;
+    if (failed(readReqInt("cluster_axis", clusterAxis)) ||
+        failed(readReqInt("layer_id", layerId)) ||
+        failed(readReqInt("output_height_shard_dim", outputHeightShardDim)) ||
+        failed(readReqInt("intermediate_size", intermediateSize))) {
+      return failure();
+    }
+
+    llvm::SmallVector<int64_t> meshShape =
+        getModuleMeshShape(srcOp->getParentOfType<ModuleOp>());
+    if (clusterAxis < 0 ||
+        clusterAxis >= static_cast<int64_t>(meshShape.size())) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "moe_decode: cluster_axis out of range for the module mesh "
+                 "(no ttcore.meshes / sdy.mesh, or bad cluster_axis).");
+    }
+    int64_t numDevices = meshShape[clusterAxis];
+
+    // activation_function (optional, default silu). StringAttr in both forms.
+    ttcore::MoEActivationFunction activation =
+        ttcore::MoEActivationFunction::Silu;
+    mlir::StringAttr actStr;
+    if (compAttrs) {
+      actStr = compAttrs.getAs<mlir::StringAttr>("activation_function");
+    }
+    if (!actStr && fe) {
+      actStr = fe.getAs<mlir::StringAttr>("activation_function");
+    }
+    if (actStr) {
+      if (auto sym =
+              ttcore::symbolizeMoEActivationFunction(actStr.getValue())) {
+        activation = *sym;
+      } else {
+        return rewriter.notifyMatchFailure(
+            srcOp, "unknown activation_function '" + actStr.getValue() + "'.");
+      }
+    }
+
+    // bh_ring_size (optional): IntegerAttr (Route A) or string (Route B).
+    std::optional<uint32_t> bhRingSize;
+    if (compAttrs) {
+      if (auto i = compAttrs.getAs<mlir::IntegerAttr>("bh_ring_size")) {
+        bhRingSize = static_cast<uint32_t>(i.getInt());
+      }
+    }
+    if (!bhRingSize && fe) {
+      if (auto brStr = fe.getAs<mlir::StringAttr>("bh_ring_size")) {
+        uint32_t br;
+        if (!llvm::to_integer(brStr.getValue(), br)) {
+          return rewriter.notifyMatchFailure(
+              srcOp, "bh_ring_size must be an integer.");
+        }
+        bhRingSize = br;
+      }
+    }
+
+    // The frontend composite is mesh-agnostic and so omits expert_mapping:
+    //   [tokens, expert_indices, expert_scores, w0, w1, w2, (bias_0,1,2)?]
+    // (6 without bias, 9 with). The mapping is synthesized below from topology
+    // and re-inserted at index 3 to restore the internal 7/10-operand contract
+    // consumed by the decomposition body + TTNNResolveComposites.
+    auto srcOperands = adaptor.getOperands();
+    if (srcOperands.size() != 6 && srcOperands.size() != 9) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "moe_decode expects 6 (no bias) or 9 (bias) operands.");
+    }
+    bool hasBias = srcOperands.size() == 9;
+
+    RankedTensorType outputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult(0).getType()));
+
+    // Synthesize the replicated expert_mapping constant ([D, E] uint16). w0 is
+    // slim-operand index 3 ([L, E_local, H, N]); its expert dim is the already
+    // EP-sharded experts-per-device.
+    auto w0Ty = mlir::cast<RankedTensorType>(srcOperands[3].getType());
+    int64_t expertsPerDevice = w0Ty.getShape()[1];
+    Value mapping = synthesizeMoeDecodeExpertMapping(
+        rewriter, srcOp.getLoc(), numDevices, expertsPerDevice);
+
+    // Full operand list with mapping re-inserted at index 3.
+    SmallVector<Value> operands;
+    operands.reserve(srcOperands.size() + 1);
+    operands.append(srcOperands.begin(), srcOperands.begin() + 3);
+    operands.push_back(mapping);
+    operands.append(srcOperands.begin() + 3, srcOperands.end());
+
+    // Synthesize the private decomposition function.
+    ModuleOp moduleOp = srcOp->getParentOfType<ModuleOp>();
+    std::string decompFuncName = "moe_decode_decomp";
+    {
+      unsigned counter = 0;
+      while (SymbolTable::lookupSymbolIn(moduleOp, decompFuncName)) {
+        decompFuncName = "moe_decode_decomp_" + std::to_string(counter++);
+      }
+    }
+    SmallVector<Type> argTypes =
+        llvm::to_vector(ValueRange(operands).getTypes());
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToEnd(moduleOp.getBody());
+      auto decompFunc = rewriter.create<func::FuncOp>(
+          srcOp.getLoc(), decompFuncName,
+          rewriter.getFunctionType(argTypes, {outputType}));
+      decompFunc.setPrivate();
+      Block *entry = decompFunc.addEntryBlock();
+      rewriter.setInsertionPointToStart(entry);
+      Value res = buildMoeDecodeDecompositionBody(
+          rewriter, srcOp.getLoc(), entry->getArguments(), hasBias, numDevices,
+          clusterAxis, static_cast<uint32_t>(layerId),
+          static_cast<uint32_t>(outputHeightShardDim),
+          static_cast<uint32_t>(intermediateSize), activation, bhRingSize,
+          outputType);
+      rewriter.create<mlir::func::ReturnOp>(srcOp.getLoc(), res);
+    }
+
+    // Typed composite_attributes consumed by the TTNNResolveComposites
+    // "moe_decode" entry (ints as i64 IntegerAttr, activation as a StringAttr).
+    SmallVector<NamedAttribute> compositeAttrs;
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "num_devices", rewriter.getI64IntegerAttr(numDevices)));
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "cluster_axis", rewriter.getI64IntegerAttr(clusterAxis)));
+    compositeAttrs.push_back(
+        rewriter.getNamedAttr("layer_id", rewriter.getI64IntegerAttr(layerId)));
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "output_height_shard_dim",
+        rewriter.getI64IntegerAttr(outputHeightShardDim)));
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "intermediate_size", rewriter.getI64IntegerAttr(intermediateSize)));
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "activation_function",
+        rewriter.getStringAttr(
+            ttcore::stringifyMoEActivationFunction(activation))));
+    if (bhRingSize) {
+      compositeAttrs.push_back(rewriter.getNamedAttr(
+          "bh_ring_size", rewriter.getI64IntegerAttr(*bhRingSize)));
+    }
+
+    rewriter.replaceOpWithNewOp<ttcore::CompositeOp>(
+        srcOp, TypeRange{outputType}, operands,
+        rewriter.getStringAttr("moe_decode"),
+        FlatSymbolRefAttr::get(rewriter.getContext(), decompFuncName),
+        rewriter.getDictionaryAttr(compositeAttrs));
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 // Pattern to convert mhlo.topk to ttir.topk
 class StableHLOTopKOpMHLOConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
@@ -10082,6 +10510,7 @@ static void addScaledDotProductAttentionDecodeOpConversionPattern(
       StableHLOToTTIRScaledDotProductAttentionOpConversionPattern,
       StableHLOToTTIRPagedScaledDotProductAttentionDecodeOpConversionPattern,
       StableHLOToTTCoreFlashMlaPrefillOpConversionPattern,
+      StableHLOToTTCoreMoeDecodeOpConversionPattern,
       StableHLOToTTIRPagedFlashMLADecodeOpConversionPattern,
       StableHLOToTTIRChunkedScaledDotProductAttentionOpConversionPattern>(
       typeConverter, ctx);

--- a/lib/Dialect/StableHLO/Transforms/ApplyArgumentShardStatus.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ApplyArgumentShardStatus.cpp
@@ -45,6 +45,21 @@ updateArgumentShardStatus(MLIRContext *context, mlir::ModuleOp &module,
       }
     }
 
+    // A builder may pre-mark presharded args with ttcore.shard_status; respect
+    // it rather than appending a second one (a duplicate DictionaryAttr key
+    // aborts). Normal StableHLO args carry sdy/gspmd annotations, not a
+    // shard_status, so this only triggers on the pre-marked path.
+    if (argAttrDict &&
+        argAttrDict.contains(mlir::tt::ttcore::ShardStatusAttr::name)) {
+      if (!shardyAnnotationsExist) {
+        mlir::NamedAttribute existing = {
+            mlir::tt::ttcore::ShardStatusAttr::name,
+            argAttrDict.get(mlir::tt::ttcore::ShardStatusAttr::name)};
+        gspmd_utils::updateShardStatusForArgument(context, arg, existing);
+      }
+      continue;
+    }
+
     mlir::NamedAttribute shardStatusNamedAttr = {
         mlir::tt::ttcore::ShardStatusAttr::name,
         mlir::tt::ttcore::ShardStatusAttr::get(context, shardStatus)};
@@ -96,6 +111,19 @@ updateResultShardStatus(MLIRContext *context, mlir::ModuleOp &module,
     if (resultAttrDict) {
       newResultAttrs =
           llvm::SmallVector<mlir::NamedAttribute>(resultAttrDict.getValue());
+    }
+
+    // Respect a pre-existing ttcore.shard_status (e.g. a builder-marked
+    // presharded result) instead of appending a duplicate DictionaryAttr key.
+    if (resultAttrDict &&
+        resultAttrDict.contains(mlir::tt::ttcore::ShardStatusAttr::name)) {
+      if (!shardy_utils::sdyAnnotationsExist(module)) {
+        mlir::NamedAttribute existing = {
+            mlir::tt::ttcore::ShardStatusAttr::name,
+            resultAttrDict.get(mlir::tt::ttcore::ShardStatusAttr::name)};
+        gspmd_utils::updateShardStatusForResult(context, funcOp, i, existing);
+      }
+      continue;
     }
 
     mlir::NamedAttribute shardStatusNamedAttr = {

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -1625,6 +1625,140 @@ getArgMaxShardingRule(mlir::stablehlo::CustomCallOp op) {
   return builder.build();
 }
 
+// =====================================================================
+// moe_decode sharding rule
+// =====================================================================
+// The moe_decode composite is opaque to Shardy: it hides the internal
+// all_to_all_dispatch + moe_compute + selective-reduce-combine. Only the two
+// device-parallel dimensions are sharded along the cluster axis; everything
+// else stays replicated. Because dispatch and combine are internal to the op,
+// the token factor can pass through (no reduction over the token dim is exposed
+// to Shardy), mirroring the per-device sharding the builder test pins via
+// presharded I/O (tokens/idx/scr token dim -> cluster axis; weights expert dim
+// -> cluster axis; mapping + H/N/K/L replicated; output token dim -> cluster
+// axis).
+//
+// Operands (6 without bias, 9 with bias). expert_mapping is NOT an operand:
+// the composite is mesh-agnostic and the mapping is synthesized in
+// StableHLOToTTIR from topology.
+//   [0] tokens         [1, 1, M, H]
+//   [1] expert_indices [1, 1, M, K]
+//   [2] expert_scores  [1, 1, M, K]
+//   [3] w0             [L, E, H, N]
+//   [4] w1             [L, E, H, N]
+//   [5] w2             [L, E, N, H]
+//   [6] bias_0         [L, E, N]   (optional)
+//   [7] bias_1         [L, E, N]   (optional)
+//   [8] bias_2         [L, E, H]   (optional)
+// Result:
+//   [0] combine_output [K, M, H]
+static mlir::sdy::OpShardingRuleAttr
+getMoeDecodeShardingRule(mlir::stablehlo::CustomCallOp op) {
+  const int64_t numOperands = op.getNumOperands();
+  if (numOperands != 6 && numOperands != 9) {
+    op.getOperation()->emitWarning()
+        << "moe_decode expects 6 or 9 operands, got " << numOperands;
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+  const bool hasBias = numOperands == 9;
+
+  auto tokensType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+  auto idxType = llvm::dyn_cast<RankedTensorType>(op.getOperand(1).getType());
+  auto w0Type = llvm::dyn_cast<RankedTensorType>(op.getOperand(3).getType());
+  auto resultType = llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
+
+  if (!tokensType || tokensType.getRank() != 4 || !idxType ||
+      idxType.getRank() != 4 || !w0Type || w0Type.getRank() != 4 ||
+      !resultType || resultType.getRank() != 3) {
+    op.getOperation()->emitWarning()
+        << "moe_decode: tokens/idx/w0 must be 4D and result 3D";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  const int64_t mDim = tokensType.getShape()[2];
+  const int64_t hDim = tokensType.getShape()[3];
+  const int64_t kDim = idxType.getShape()[3];
+  const int64_t lDim = w0Type.getShape()[0];
+  const int64_t eDim = w0Type.getShape()[1];
+  const int64_t nDim = w0Type.getShape()[3];
+
+  mlir::sdy::OpShardingRuleBuilder builder(op);
+
+  // Helper: build an operand-dim vector (length numOperands), all kNull except
+  // the listed (operandIdx -> dim) entries.
+  auto opDims =
+      [&](std::initializer_list<std::pair<int64_t, int64_t>> entries) {
+        SmallVector<int64_t> v(numOperands, mlir::sdy::kNullDim);
+        for (const auto &e : entries) {
+          v[e.first] = e.second;
+        }
+        return v;
+      };
+
+  // Token factor (M): tokens/idx/scr dim 2 -> result dim 1. kPassThrough so the
+  // cluster axis shards the data-parallel token dim through the composite.
+  builder.addFactor(opDims({{0, 2}, {1, 2}, {2, 2}}), {1}, mDim,
+                    mlir::sdy::FactorType::kPassThrough);
+
+  // Expert factor (E): w0/w1/w2 (and biases) dim 1. kPassThrough so the cluster
+  // axis shards the expert dim of the (global) weights into per-device experts.
+  {
+    SmallVector<int64_t> e = opDims({{3, 1}, {4, 1}, {5, 1}});
+    if (hasBias) {
+      e[6] = 1;
+      e[7] = 1;
+      e[8] = 1;
+    }
+    builder.addFactor(e, {mlir::sdy::kNullDim}, eDim,
+                      mlir::sdy::FactorType::kPassThrough);
+  }
+
+  // Hidden factor (H): tokens dim 3, w0/w1 dim 2, w2 dim 3, bias_2 dim 2 ->
+  // result dim 2. Replicated.
+  {
+    SmallVector<int64_t> h = opDims({{0, 3}, {3, 2}, {4, 2}, {5, 3}});
+    if (hasBias) {
+      h[8] = 2;
+    }
+    builder.addFactor(h, {2}, hDim, mlir::sdy::FactorType::kNeedReplication,
+                      /*isBlocked=*/true);
+  }
+
+  // Intermediate factor (N): w0/w1 dim 3, w2 dim 2, bias_0/bias_1 dim 2.
+  // Replicated.
+  {
+    SmallVector<int64_t> n = opDims({{3, 3}, {4, 3}, {5, 2}});
+    if (hasBias) {
+      n[6] = 2;
+      n[7] = 2;
+    }
+    builder.addFactor(n, {mlir::sdy::kNullDim}, nDim,
+                      mlir::sdy::FactorType::kNeedReplication,
+                      /*isBlocked=*/true);
+  }
+
+  // TopK factor (K): idx/scr dim 3 -> result dim 0. Replicated.
+  builder.addFactor(opDims({{1, 3}, {2, 3}}), {0}, kDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  // Layer factor (L): w0/w1/w2 (and biases) dim 0. Replicated.
+  {
+    SmallVector<int64_t> l = opDims({{3, 0}, {4, 0}, {5, 0}});
+    if (hasBias) {
+      l[6] = 0;
+      l[7] = 0;
+      l[8] = 0;
+    }
+    builder.addFactor(l, {mlir::sdy::kNullDim}, lDim,
+                      mlir::sdy::FactorType::kNeedReplication,
+                      /*isBlocked=*/true);
+  }
+
+  return builder.build();
+}
+
 // Sharding rule for RMS norm custom_call (converted from composite).
 //
 // Operands:
@@ -1839,6 +1973,7 @@ private:
           {allToAllDispatchTargetName, getAllToAllDispatchShardingRule},
           {allToAllCombineTargetName, getAllToAllCombineShardingRule},
           {moeExpertTokenRemapTargetName, getMoeExpertTokenRemapShardingRule},
+          {utils::kTTMoeDecodeCompositeName, getMoeDecodeShardingRule},
           {utils::kTTRMSNormCustomCallTargetName, getRMSNormShardingRule},
           {flashMlaPrefillTargetName, getFlashMlaPrefillShardingRule},
           {utils::kTTTopKCustomCallTargetName, getTopKShardingRule},

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1613,11 +1613,13 @@ TTNNOperandsWorkaroundsFactory::createMoeComputeOpOperandsWorkarounds(
 
   TTNNOperandWorkarounds none;
 
+  // Pin indices/scores ROW_MAJOR (the kernel reads them untilized) so layout
+  // propagation doesn't tilize them.
   TTNNOperandsWorkarounds w =
       TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
           .addInputOperandWorkaround(rmBf16) // tilize_input_tensor
-          .addInputOperandWorkaround(none)   // tilize_expert_indices_tensor
-          .addInputOperandWorkaround(none)   // tilize_expert_scores_tensor
+          .addInputOperandWorkaround(rmU16)  // tilize_expert_indices_tensor
+          .addInputOperandWorkaround(rmBf16) // tilize_expert_scores_tensor
           .addInputOperandWorkaround(rmU16)  // tilize_expert_mapping_tensor
           .addInputOperandWorkaround(none)   // matmul_w0_w1_tensor
           .addInputOperandWorkaround(none);  // matmul_w2_tensor

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -6,11 +6,14 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 
 #include "ttmlir/Asserts.h"
@@ -78,6 +81,77 @@ extractFlashMlaPrefillArgs(ttcore::CompositeOp compositeOp) {
   args.isCausal = attrs.getAs<BoolAttr>("is_causal");
   args.scale = attrs.getAs<FloatAttr>("scale");
   return args;
+}
+
+// Operands and attributes recovered from a "moe_decode" composite. moe_decode
+// fuses all_to_all_dispatch_metadata + weight-prep + moe_compute; resolving it
+// here is the single place the a2a->moe boundary is wired. The device-derived
+// tilize-drain core is finalized later by TTNNDeduceMoEComputeLayouts, so this
+// build is device-free (works in force-promote without a device).
+struct MoeDecodeCompositeArgs {
+  Value tokens;
+  Value expertIndices;
+  Value expertScores;
+  Value expertMapping;
+  Value w0, w1, w2;
+  Value bias0, bias1, bias2; // null when has_bias is false
+  bool hasBias = false;
+  int64_t numDevices = 0;
+  int64_t clusterAxis = 0;
+  int64_t layerId = 0;
+  int64_t outputHeightShardDim = 0;
+  int64_t intermediateSize = 0;
+  std::optional<int64_t> bhRingSize;
+  ttcore::MoEActivationFunction activation =
+      ttcore::MoEActivationFunction::Silu;
+};
+
+// inputs: [tokens, expert_indices, expert_scores, expert_mapping, w0, w1, w2,
+//          (bias_0, bias_1, bias_2)?]  (7 without bias, 10 with).
+static MoeDecodeCompositeArgs
+extractMoeDecodeArgs(ttcore::CompositeOp compositeOp) {
+  auto inputs = compositeOp.getInputs();
+  TT_assertv((inputs.size() == 7u || inputs.size() == 10u),
+             "moe_decode expects 7 (no bias) or 10 (bias) inputs, got {}",
+             inputs.size());
+
+  MoeDecodeCompositeArgs a;
+  a.tokens = inputs[0];
+  a.expertIndices = inputs[1];
+  a.expertScores = inputs[2];
+  a.expertMapping = inputs[3];
+  a.w0 = inputs[4];
+  a.w1 = inputs[5];
+  a.w2 = inputs[6];
+  a.hasBias = inputs.size() == 10u;
+  if (a.hasBias) {
+    a.bias0 = inputs[7];
+    a.bias1 = inputs[8];
+    a.bias2 = inputs[9];
+  }
+
+  DictionaryAttr attrs = compositeOp.getCompositeAttributes().value_or(nullptr);
+  TT_assert(attrs);
+  auto readInt = [&](StringRef name) -> int64_t {
+    auto v = attrs.getAs<mlir::IntegerAttr>(name);
+    TT_assertv(v, "moe_decode composite missing integer attribute '{}'",
+               name.str());
+    return v.getInt();
+  };
+  a.numDevices = readInt("num_devices");
+  a.clusterAxis = readInt("cluster_axis");
+  a.layerId = readInt("layer_id");
+  a.outputHeightShardDim = readInt("output_height_shard_dim");
+  a.intermediateSize = readInt("intermediate_size");
+  if (auto br = attrs.getAs<mlir::IntegerAttr>("bh_ring_size")) {
+    a.bhRingSize = br.getInt();
+  }
+  if (auto act = attrs.getAs<mlir::StringAttr>("activation_function")) {
+    if (auto sym = ttcore::symbolizeMoEActivationFunction(act.getValue())) {
+      a.activation = *sym;
+    }
+  }
+  return a;
 }
 
 static void registerBuiltinComposites() {
@@ -175,6 +249,105 @@ static void registerBuiltinComposites() {
             args.key, args.value, args.attentionMask,
             static_cast<uint32_t>(args.headDimV.getValue().getZExtValue()),
             args.isCausal.getValue(), args.scale);
+      }};
+
+  registry["moe_decode"] = CompositeEntry{
+      // Validate: moe_compute / all_to_all_dispatch_metadata are OpModelExempt,
+      // so the contract is enforced by extractMoeDecodeArgs + the typed ops'
+      // verifiers after build. Always promotable.
+      [](ttcore::CompositeOp compositeOp, OpBuilder &) -> OpValidationResult {
+        (void)extractMoeDecodeArgs(compositeOp);
+        return OpValidationResult::success();
+      },
+      // Build all_to_all_dispatch_metadata -> weight-prep -> moe_compute,
+      // wiring
+      // moe's dispatched/indices/scores straight from a2a's results so
+      // TTNNDeduceMoEComputeLayouts can pin both ops onto one drain core.
+      // Result
+      // types are placeholders finalized by workarounds + the deduce pass.
+      [](ttcore::CompositeOp compositeOp, OpBuilder &builder) -> Operation * {
+        MoeDecodeCompositeArgs a = extractMoeDecodeArgs(compositeOp);
+        Location loc = compositeOp.getLoc();
+        MLIRContext *ctx = compositeOp.getContext();
+
+        mlir::IRRewriter rewriter(builder);
+        rewriter.setInsertionPoint(compositeOp);
+
+        auto tokensTy = cast<RankedTensorType>(a.tokens.getType());
+        auto idxTy = cast<RankedTensorType>(a.expertIndices.getType());
+        auto scrTy = cast<RankedTensorType>(a.expertScores.getType());
+        int64_t M = tokensTy.getShape()[tokensTy.getRank() - 2];
+        int64_t H = tokensTy.getShape().back();
+        int64_t K = idxTy.getShape().back();
+        int64_t totalTokens = a.numDevices * M;
+
+        // a2a output placeholder types ([1, tokens_global, C]); deduce +
+        // workarounds finalize their layouts (indices/scores onto the drain
+        // core, dispatched to DRAM interleaved).
+        auto dispatchedTy = ttnn::utils::RankedTensorTypeFactory::create(
+            tokensTy, llvm::SmallVector<int64_t>{1, totalTokens, H});
+        auto outIdxTy = ttnn::utils::RankedTensorTypeFactory::create(
+            idxTy, llvm::SmallVector<int64_t>{1, totalTokens, K});
+        auto outScrTy = ttnn::utils::RankedTensorTypeFactory::create(
+            scrTy, llvm::SmallVector<int64_t>{1, totalTokens, K});
+
+        // Persistent-mode a2a: the dispatched/indices/scores buffers and the
+        // cross-device semaphore are left unbound (the DistributedOpInterface
+        // prelude hooks materialize them); the drain core is internal (the
+        // kernel derives it from the metadata shard spec that
+        // TTNNDeduceMoEComputeLayouts pins). Mirrors the TTIRToTTNN a2a build.
+        auto a2a = rewriter.create<ttnn::AllToAllDispatchMetadataOp>(
+            loc, dispatchedTy, outIdxTy, outScrTy, a.tokens, a.expertIndices,
+            a.expertScores, a.expertMapping, /*dispatched_buffer=*/Value(),
+            /*indices_buffer=*/Value(), /*scores_buffer=*/Value(),
+            /*cross_device_semaphore=*/Value(),
+            rewriter.getI64IntegerAttr(a.numDevices),
+            rewriter.getI64IntegerAttr(a.clusterAxis));
+
+        Value device =
+            ttnn::utils::getOrInsertDevice(rewriter, compositeOp).getResult();
+
+        // Prepack weights. Result types are placeholders refined by the deduce
+        // pass via OpModel (mirrors MoeComputeOpConversionPattern). hidden_size
+        // = w0 K dim (logical shape (L, E, K, N)).
+        auto w0Ty = cast<RankedTensorType>(a.w0.getType());
+        auto w2Ty = cast<RankedTensorType>(a.w2.getType());
+        auto hiddenSizeAttr = rewriter.getUI32IntegerAttr(w0Ty.getShape()[2]);
+        auto intermediateSizeAttr =
+            rewriter.getUI32IntegerAttr(a.intermediateSize);
+
+        auto w0w1Prepared =
+            rewriter.create<ttnn::PrepareMoEComputeW0W1WeightsOp>(
+                loc, /*placeholder=*/w0Ty, a.w0, a.w1, a.bias0, a.bias1, device,
+                hiddenSizeAttr, intermediateSizeAttr);
+        auto w2Prepared = rewriter.create<ttnn::PrepareMoEComputeW2WeightsOp>(
+            loc, /*placeholder=*/w2Ty, a.w2, a.bias2, device, hiddenSizeAttr,
+            intermediateSizeAttr);
+
+        // Fabric-mux cores: same 3x3 default at (1,1) as the standalone
+        // MoeComputeOpConversionPattern.
+        ttnn::CoreRangeSetAttr muxCoreRangeSet = ttnn::CoreRangeSetAttr::get(
+            ctx,
+            ttnn::CoreRangeAttr::get(ctx, ttnn::CoreCoordAttr::get(ctx, 1, 1),
+                                     ttnn::CoreCoordAttr::get(ctx, 3, 3)));
+
+        auto activationAttr =
+            ttcore::MoEActivationFunctionAttr::get(ctx, a.activation);
+
+        // optional_output_tensor + cross_device_semaphore are left unbound; the
+        // MoeComputeOp DistributedOpInterface hooks bind them in the prelude.
+        return rewriter.create<ttnn::MoeComputeOp>(
+            loc, compositeOp.getResultTypes()[0], a2a.getDispatched(),
+            a2a.getIndices(), a2a.getScores(), a.expertMapping,
+            w0w1Prepared.getResult(), w2Prepared.getResult(),
+            /*optional_output_tensor=*/Value(),
+            /*cross_device_semaphore=*/Value(), device,
+            rewriter.getUI32IntegerAttr(a.layerId),
+            rewriter.getUI32IntegerAttr(a.outputHeightShardDim),
+            intermediateSizeAttr, rewriter.getBoolAttr(a.hasBias),
+            activationAttr, rewriter.getUI32IntegerAttr(a.clusterAxis),
+            /*num_links=*/mlir::IntegerAttr(),
+            /*topology=*/ttcore::TopologyAttr(), muxCoreRangeSet);
       }};
 }
 

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -14,6 +14,7 @@
 
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/mock_device.hpp>
 
 #include <umd/device/cluster.hpp>
@@ -22,6 +23,7 @@
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
+#include <limits>
 #include <optional>
 #include <string>
 
@@ -60,8 +62,12 @@ ttcore::Arch fromMetalArch(::tt::ARCH arch) {
 
 // Build a MetalEnvDescriptor for the requested device. Mock mode loads the
 // per-(arch, numChips) mock cluster descriptor; silicon uses the default.
-// Fabric is left DISABLED: multi-chip mock CCL fabric setup is blocked on
-// tt-metal-side work (https://github.com/tenstorrent/tt-metal/issues/44748).
+// For multi-chip mock we enable 1D fabric in the descriptor so CCL
+// op-constraint queries (AllGather/ReduceScatter/AllReduce/DistributedRMSNorm)
+// can build routing across the mock mesh. The mock-fabric routing path was
+// fixed in tt-metal#46133; external callers enable it by passing a
+// FabricConfigDescriptor in the MetalEnvDescriptor. Single-chip mock and
+// silicon need no fabric here.
 ::tt::tt_metal::MetalEnvDescriptor
 makeEnvDescriptor(bool isMock, ttcore::Arch arch, uint32_t numChips) {
   if (!isMock) {
@@ -109,7 +115,16 @@ makeEnvDescriptor(bool isMock, ttcore::Arch arch, uint32_t numChips) {
     llvm::report_fatal_error(
         "Unsupported (arch, numChips) for mock cluster descriptor");
   }
-  return ::tt::tt_metal::MetalEnvDescriptor{*mockClusterPath};
+  if (numChips <= 1) {
+    return ::tt::tt_metal::MetalEnvDescriptor{*mockClusterPath};
+  }
+  ::tt::tt_metal::FabricConfigDescriptor fabricDesc{};
+  fabricDesc.fabric_config = ::tt::tt_fabric::FabricConfig::FABRIC_1D;
+  fabricDesc.reliability_mode =
+      ::tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
+  fabricDesc.num_routing_planes = std::numeric_limits<uint8_t>::max();
+  return ::tt::tt_metal::MetalEnvDescriptor{*mockClusterPath,
+                                            std::move(fabricDesc)};
 }
 
 // Pick the dispatch core type for a device opened on this env. When every


### PR DESCRIPTION
### Ticket
#8536

### Blockers

https://github.com/tenstorrent/tt-mlir/pull/8413

### Problem description
`moe_decode` composite op, which should resolve to the following sequence of TTNN ops:
- `all_to_all_dispatch_metadata`
- `prepare_moe_compute_w0_w1_weights`
- `prepare_moe_compute_w2_weights`
- `moe_compute`

**The work on this branch is claude-generated and not reviewed. It serves as a sanity check for MoE ops bringup.**

### Checklist
- [ ] New/Existing tests provide coverage for changes
