### PR TITLE
[TTIR] Mark trunc as idempotent

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -499,11 +499,14 @@ def TTIR_FracOp: TTIR_ElementwiseUnaryOp<"frac"> {
     }];
 }
 
-def TTIR_TruncOp: TTIR_ElementwiseUnaryOp<"trunc"> {
+def TTIR_TruncOp: TTIR_ElementwiseUnaryOp<"trunc", [TTIR_Idempotence]> {
     let summary = "Elementwise truncation toward zero.";
     let description = [{
       For each element x, returns the value truncated toward zero (round toward zero),
       preserving the tensor element type.
+
+      This operation has the idempotence property, meaning that applying it multiple times
+      produces the same result as applying it once: trunc(trunc(x)) = trunc(x).
     }];
 }
 

--- a/test/ttmlir/Dialect/TTIR/canonicalize/trunc_idempotence.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/trunc_idempotence.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// trunc rounds toward zero, so it is idempotent: trunc(trunc(x)) = trunc(x).
+// Back-to-back truncs of the same type must fold to a single trunc.
+module {
+  // CHECK-LABEL: func.func @trunc_idempotence_two_in_a_row
+  func.func @trunc_idempotence_two_in_a_row(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    // CHECK: "ttir.trunc"
+    // CHECK-NOT: "ttir.trunc"
+    %1 = "ttir.trunc"(%arg0) : (tensor<64x64xf32>) -> tensor<64x64xf32>
+    %2 = "ttir.trunc"(%1) : (tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %2 : tensor<64x64xf32>
+  }
+
+  // Differing operand/result types must NOT fold.
+  // CHECK-LABEL: func.func @trunc_not_idempotent_different_types
+  func.func @trunc_not_idempotent_different_types(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    // CHECK: "ttir.trunc"
+    // CHECK: "ttir.trunc"
+    %1 = "ttir.trunc"(%arg0) : (tensor<64x64xf32>) -> tensor<64x64xbf16>
+    %2 = "ttir.trunc"(%1) : (tensor<64x64xbf16>) -> tensor<64x64xf32>
+    return %2 : tensor<64x64xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
No ticket — small canonicalization-completeness fix.

### Problem description
`ttir.trunc` rounds toward zero, so applying it twice is redundant: `trunc(trunc(x)) == trunc(x)`. Its sibling elementwise rounding ops — `abs`, `ceil`, `floor`, `sign` — already carry the `TTIR_Idempotence` trait, but `trunc` was missing it, so back-to-back truncs were not folded during canonicalization.

### What's changed
- Added the `TTIR_Idempotence` trait to `TTIR_TruncOp` in `TTIROps.td` (and documented the property in the op description), mirroring `floor`/`ceil`.
- Added a lit test `test/ttmlir/Dialect/TTIR/canonicalize/trunc_idempotence.mlir` covering the fold (two same-type truncs collapse to one) and the differing-types negative case (must not fold).

The trait's existing `verifyIdempotence` guard only folds when operand and result types match and the producing op is the same op, so only genuinely redundant truncs are removed. `check-ttmlir` passes locally, including all existing `Dialect/TTIR/canonicalize` tests.

### Checklist
- [x] New/Existing tests provide coverage for changes