### PR TITLE
[Conversion] Add CHLO -> TTIR pass for inverse trig and error functions

### DIFF
--- a/include/ttmlir/Conversion/CHLOToTTIR/CHLOToTTIR.h
+++ b/include/ttmlir/Conversion/CHLOToTTIR/CHLOToTTIR.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_CHLOTOTTIR_CHLOTOTTIR_H
+#define TTMLIR_CONVERSION_CHLOTOTTIR_CHLOTOTTIR_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::tt {
+
+#ifdef TTMLIR_ENABLE_STABLEHLO
+namespace ttir {
+
+#define GEN_PASS_DECL_CONVERTCHLOTOTTIR
+#include "ttmlir/Conversion/Passes.h.inc"
+
+} // namespace ttir
+
+void populateCHLOToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
+                                TypeConverter &typeConverter);
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertCHLOToTTIRPass();
+#endif
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_CONVERSION_CHLOTOTTIR_CHLOTOTTIR_H

--- a/include/ttmlir/Conversion/Passes.h
+++ b/include/ttmlir/Conversion/Passes.h
@@ -8,6 +8,7 @@
 #include "ttmlir/Conversion/ArithToD2MTileOps/ArithToD2MTileOps.h"
 #ifdef TTMLIR_ENABLE_STABLEHLO
 #include "ttmlir/Conversion/ArithToStableHLO/ArithToStableHLO.h"
+#include "ttmlir/Conversion/CHLOToTTIR/CHLOToTTIR.h"
 #include "ttmlir/Conversion/StableHLOToTTIR/ShardyToTTIR.h"
 #include "ttmlir/Conversion/StableHLOToTTIR/StableHLOLegalizeComposite.h"
 #include "ttmlir/Conversion/StableHLOToTTIR/StableHLOToTTIR.h"

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -18,6 +18,17 @@ let summary = "Convert StableHLO dialect to TTIR dialect.";
       "Enable partial conversion mode, allowing unconverted ops to remain">
   ];
 }
+def ConvertCHLOToTTIR : Pass<"convert-chlo-to-ttir", "::mlir::ModuleOp"> {
+  let summary = "Convert CHLO dialect ops to TTIR dialect.";
+  let description = [{
+    Directly maps CHLO inverse-trig and error-function ops (acos, asin, atan,
+    erf, erfc) onto their existing TTIR equivalents, avoiding decomposition into
+    many primitive StableHLO ops. Intended to run before CHLO decomposition and
+    the StableHLO -> TTIR lowering.
+  }];
+  let constructor = "createConvertCHLOToTTIRPass()";
+  let dependentDialects = ["mlir::chlo::ChloDialect", "mlir::tt::ttir::TTIRDialect"];
+}
 def ConvertArithToStableHLO : Pass<"convert-arith-to-stablehlo", "::mlir::ModuleOp"> {
 let summary = "Convert Arith Dialect to StableHLO dialect.";
   let constructor = "createConvertArithToStableHLOPass()";

--- a/lib/Conversion/CHLOToTTIR/CHLOToTTIR.cpp
+++ b/lib/Conversion/CHLOToTTIR/CHLOToTTIR.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/CHLOToTTIR/CHLOToTTIR.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/ChloOps.h"
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace mlir::tt::ttir {
+
+#define GEN_PASS_DEF_CONVERTCHLOTOTTIR
+#include "ttmlir/Conversion/Passes.h.inc"
+
+} // namespace mlir::tt::ttir
+
+namespace {
+// Maps a unary elementwise CHLO op 1:1 onto its existing TTIR equivalent.
+// CHLO inverse-trig and error-function ops share their operand/result type with
+// the matching TTIR op, so the rewrite is a straight op replacement.
+template <typename SrcOp, typename DestOp>
+class CHLOToTTIROpConversionPattern : public OpConversionPattern<SrcOp> {
+  using OpConversionPattern<SrcOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(SrcOp srcOp, typename SrcOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto outputType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+    rewriter.replaceOpWithNewOp<DestOp>(srcOp, outputType,
+                                        adaptor.getOperands());
+    return success();
+  }
+};
+} // namespace
+
+namespace mlir::tt {
+
+void populateCHLOToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
+                                TypeConverter &typeConverter) {
+  patterns.add<
+      CHLOToTTIROpConversionPattern<mlir::chlo::AcosOp, mlir::tt::ttir::AcosOp>,
+      CHLOToTTIROpConversionPattern<mlir::chlo::AsinOp, mlir::tt::ttir::AsinOp>,
+      CHLOToTTIROpConversionPattern<mlir::chlo::AtanOp, mlir::tt::ttir::AtanOp>,
+      CHLOToTTIROpConversionPattern<mlir::chlo::ErfOp, mlir::tt::ttir::ErfOp>,
+      CHLOToTTIROpConversionPattern<mlir::chlo::ErfcOp,
+                                    mlir::tt::ttir::ErfcOp>>(typeConverter, ctx);
+}
+
+} // namespace mlir::tt
+
+namespace mlir::tt::ttir {
+namespace {
+struct ConvertCHLOToTTIRPass
+    : public ttir::impl::ConvertCHLOToTTIRBase<ConvertCHLOToTTIRPass> {
+
+  void runOnOperation() final {
+    mlir::ConversionTarget target(getContext());
+
+    target.addLegalDialect<ttir::TTIRDialect>();
+    target.addLegalDialect<ttcore::TTCoreDialect>();
+
+    // Only the directly-mappable CHLO ops are illegal; every other op
+    // (including the rest of CHLO/StableHLO) is left untouched so this pass can
+    // run before the standard CHLO decomposition and StableHLO -> TTIR lowering.
+    target.addIllegalOp<mlir::chlo::AcosOp, mlir::chlo::AsinOp,
+                        mlir::chlo::AtanOp, mlir::chlo::ErfOp,
+                        mlir::chlo::ErfcOp>();
+
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+
+    RewritePatternSet patterns(&getContext());
+    ::mlir::tt::populateCHLOToTTIRPatterns(&getContext(), patterns,
+                                           typeConverter);
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+} // namespace mlir::tt::ttir
+
+namespace mlir::tt {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertCHLOToTTIRPass() {
+  return std::make_unique<ttir::ConvertCHLOToTTIRPass>();
+}
+
+} // namespace mlir::tt

--- a/lib/Conversion/CHLOToTTIR/CMakeLists.txt
+++ b/lib/Conversion/CHLOToTTIR/CMakeLists.txt
@@ -1,0 +1,21 @@
+include_directories(${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo)
+include_directories(${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo-build)
+include_directories(${TTMLIR_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+add_mlir_conversion_library(TTMLIRCHLOToTTIR
+  CHLOToTTIR.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/ttmlir/Conversion/CHLOToTTIR
+
+  DEPENDS
+  TTMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRTransforms
+  ChloOps
+  MLIRTTIRDialect
+)

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -17,4 +17,5 @@ add_subdirectory(TTNNToTTIR)
 
 if (TTMLIR_ENABLE_STABLEHLO)
 add_subdirectory(StableHLOToTTIR)
+add_subdirectory(CHLOToTTIR)
 endif()

--- a/test/ttmlir/Conversion/CHLOToTTIR/chlo_to_ttir.mlir
+++ b/test/ttmlir/Conversion/CHLOToTTIR/chlo_to_ttir.mlir
@@ -1,0 +1,43 @@
+// RUN: ttmlir-opt --convert-chlo-to-ttir -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// CHLO inverse-trig and error-function ops map 1:1 onto the existing TTIR ops,
+// so --convert-chlo-to-ttir should rewrite each one directly without
+// decomposing it into many primitive ops.
+module {
+  // CHECK-LABEL: func.func @chlo_acos
+  func.func @chlo_acos(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+    // CHECK: "ttir.acos"
+    // CHECK-NOT: chlo.acos
+    %0 = "chlo.acos"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+    return %0 : tensor<13x21x3xf32>
+  }
+
+  // CHECK-LABEL: func.func @chlo_asin
+  func.func @chlo_asin(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+    // CHECK: "ttir.asin"
+    %0 = "chlo.asin"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+    return %0 : tensor<13x21x3xf32>
+  }
+
+  // CHECK-LABEL: func.func @chlo_atan
+  func.func @chlo_atan(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+    // CHECK: "ttir.atan"
+    %0 = "chlo.atan"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+    return %0 : tensor<13x21x3xf32>
+  }
+
+  // CHECK-LABEL: func.func @chlo_erf
+  func.func @chlo_erf(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+    // CHECK: "ttir.erf"
+    %0 = "chlo.erf"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+    return %0 : tensor<13x21x3xf32>
+  }
+
+  // CHECK-LABEL: func.func @chlo_erfc
+  func.func @chlo_erfc(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+    // CHECK: "ttir.erfc"
+    %0 = "chlo.erfc"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+    return %0 : tensor<13x21x3xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
#7921

### Problem description
tt-mlir has no CHLO support. The CHLO inverse-trig and error-function ops (`chlo.acos`, `chlo.asin`, `chlo.atan`, `chlo.erf`, `chlo.erfc`) — emitted by JAX/TF/PyTorch-XLA frontends — currently either have no frontend path (`erfc`), only work via a legacy `custom_call @mhlo.erf` (`erf`), or are impossible to compile because core StableHLO doesn't define them as unary ops (`acos`/`asin`/`atan`). Without a direct conversion they decompose into 10-20+ primitive StableHLO ops.

### What's changed
Adds a `convert-chlo-to-ttir` pass (`lib/Conversion/CHLOToTTIR/`) that maps these five CHLO ops 1:1 onto their existing TTIR equivalents (all of which already have full TTNN lowering). It runs as a partial conversion — only the five ops are illegal, everything else (including the rest of CHLO/StableHLO) is left untouched — so it can run before the standard CHLO decomposition and StableHLO -> TTIR lowering.

- New `CHLOToTTIR` pass + patterns, header, CMake.
- Registered as `--convert-chlo-to-ttir`, gated behind `TTMLIR_ENABLE_STABLEHLO` exactly like the existing StableHLOToTTIR integration (no effect on STABLEHLO=OFF builds).
- Lit test covering all five mappings.

Scoped to the standalone pass + tests; wiring it into the StableHLO pipeline (before decomposition) can follow in a separate change — happy to add it here if preferred.

Verified locally: `--convert-chlo-to-ttir` rewrites all five ops, and the full `test/ttmlir/Conversion` suite passes with no regressions.

### Checklist
- [x] New/Existing tests provide coverage for changes