### PR TITLE
[TTNN] Pluggable layout cost model + analytical-time objective (opt-in)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/LayoutCostModel.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/LayoutCostModel.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_LAYOUTCOSTMODEL_H
+#define TTMLIR_DIALECT_TTNN_ANALYSIS_LAYOUTCOSTMODEL_H
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
+
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/ArrayRef.h"
+
+#include <memory>
+
+namespace mlir::tt::ttnn {
+
+/// Selects how layout candidates are ranked on the beam path.
+enum class LayoutCostModelKind {
+  /// Local lexicographic `LayoutScore` heuristic (historical default).
+  Heuristic,
+  // Additional kinds (e.g. accumulated analytical-time cost) are added behind
+  // this seam without touching the beam machinery.
+};
+
+/// Strategy for ranking layout candidates during memory-layout propagation.
+///
+/// The beam path funnels all candidate comparison through a single `better(...)`
+/// call, so swapping the cost model swaps the optimization objective without
+/// changing the beam machinery. The default `Heuristic` model reproduces the
+/// historical local `LayoutScore` ordering exactly.
+class LayoutCostModel {
+public:
+  virtual ~LayoutCostModel() = default;
+
+  /// Annotate a freshly-evaluated candidate with any model-specific data used
+  /// for later comparison (e.g. an accumulated path cost). Called once per
+  /// candidate after `score`, `producerCandidateIndices` and `reshardLayouts`
+  /// are populated. `producerChoices[i]` is the resolved producer candidate for
+  /// tensor operand `i` (nullptr for block args / constants). The default
+  /// implementation does nothing — the heuristic compares `score` directly.
+  virtual void
+  annotate(Operation *op, BeamCandidate &candidate,
+           llvm::ArrayRef<const BeamCandidate *> producerChoices) const {}
+
+  /// Strict-weak ordering: returns true if candidate `a` is strictly better
+  /// than `b` for `op`. This is the only comparator the beam uses.
+  virtual bool better(Operation *op, const BeamCandidate &a,
+                      const BeamCandidate &b) const = 0;
+};
+
+/// Create the cost model for the given kind.
+std::unique_ptr<LayoutCostModel> createLayoutCostModel(LayoutCostModelKind kind);
+
+} // namespace mlir::tt::ttnn
+
+#endif // TTMLIR_DIALECT_TTNN_ANALYSIS_LAYOUTCOSTMODEL_H

--- a/include/ttmlir/Dialect/TTNN/Analysis/LayoutCostModel.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/LayoutCostModel.h
@@ -6,6 +6,7 @@
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_LAYOUTCOSTMODEL_H
 
 #include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
+#include "ttmlir/Dialect/TTNN/Utils/Roofline.h"
 
 #include "mlir/IR/Operation.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -51,8 +52,11 @@ public:
                       const BeamCandidate &b) const = 0;
 };
 
-/// Create the cost model for the given kind.
-std::unique_ptr<LayoutCostModel> createLayoutCostModel(LayoutCostModelKind kind);
+/// Create the cost model for the given kind. `hwSpec` supplies the hardware
+/// constants the AnalyticalTime model needs for its real-time roofline (ignored
+/// by the Heuristic model).
+std::unique_ptr<LayoutCostModel>
+createLayoutCostModel(LayoutCostModelKind kind, roofline::HwSpec hwSpec);
 
 } // namespace mlir::tt::ttnn
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/LayoutCostModel.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/LayoutCostModel.h
@@ -18,8 +18,11 @@ namespace mlir::tt::ttnn {
 enum class LayoutCostModelKind {
   /// Local lexicographic `LayoutScore` heuristic (historical default).
   Heuristic,
-  // Additional kinds (e.g. accumulated analytical-time cost) are added behind
-  // this seam without touching the beam machinery.
+  /// Accumulated analytical-time cost: per-op roofline (from the constraint
+  /// query's coreCount/residency) plus reshard `bytes / BW(slowest leg)`,
+  /// summed along the producer chain. Minimizes estimated time, so it trades
+  /// reshards against op parallelism instead of ranking a local tuple.
+  AnalyticalTime,
 };
 
 /// Strategy for ranking layout candidates during memory-layout propagation.

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
@@ -6,6 +6,7 @@
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_MEMORYLAYOUTPROPAGATION_H
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/Analysis/LayoutCostModel.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagationObserver.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
@@ -88,6 +89,10 @@ private:
   /// Observer (NullObject pattern: always non-null, no-op when tracing
   /// disabled).
   std::unique_ptr<LayoutPropagationObserver> observer;
+
+  /// Cost model used to rank beam candidates. Defaults to the local heuristic;
+  /// the comparator at every selection site funnels through this.
+  std::unique_ptr<LayoutCostModel> costModel;
 
   /// Process a single op. Returns top-K candidates sorted by score descending.
   llvm::SmallVector<BeamCandidate, 0> processOp(Operation *op);

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
@@ -43,7 +43,8 @@ public:
       const TensorTypeLayoutsMap *tensorTypePossibleLayouts = nullptr,
       size_t beamWidth = 8, size_t maxInputCandidatesPerOperand = 64,
       size_t maxReshardCandidatesPerType = 4,
-      std::unique_ptr<LayoutPropagationObserver> observer = nullptr);
+      std::unique_ptr<LayoutPropagationObserver> observer = nullptr,
+      LayoutCostModelKind costModelKind = LayoutCostModelKind::Heuristic);
 
   /// Destructor defined in .cpp (observer is forward-declared).
   ~MemoryLayoutPropagation();
@@ -149,6 +150,15 @@ private:
   /// Map from tensor-operand index (used in producerCandidateIndices) back to
   /// the actual defining op. Skips non-tensor operands.
   Operation *getProducerForOperandIdx(Operation *op, size_t tensorOperandIdx);
+
+  /// Resolve the chosen producer beam candidate behind each tensor operand of
+  /// `op`, given the per-operand producer indices recorded on a candidate.
+  /// `result[i]` is the producer `BeamCandidate*` feeding tensor operand `i`,
+  /// or nullptr when the operand has no in-beam producer (block arg / constant /
+  /// stale index). Used by the cost model to read accumulated path cost.
+  llvm::SmallVector<const BeamCandidate *> resolveProducerChoices(
+      Operation *op,
+      const llvm::SmallVector<size_t> &producerCandidateIndices);
 
   /// Look up the chosen BeamCandidate for an op (using finalChoice index into
   /// beamState). Returns nullptr if op is not in beamState or beam is empty.

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
@@ -69,6 +69,13 @@ struct LayoutScore {
   /// Memory footprint from ValidationResult (for tie-breaking).
   uint64_t outputL1Usage = 0;
 
+  /// Total output tensor footprint in bytes, independent of buffer type
+  /// (L1 or DRAM). Unlike `outputL1Usage` (which is 0 for DRAM outputs), this
+  /// is the real size of the produced tensor, so cost models can charge DRAM
+  /// output writes and size reshards out of DRAM-resident producers. Not part
+  /// of the heuristic ordering (`operator>`/`operator==`).
+  uint64_t outputBytes = 0;
+
   /// Higher score is better.
   bool operator>(const LayoutScore &other) const;
   bool operator==(const LayoutScore &other) const;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
@@ -92,6 +92,10 @@ struct BeamCandidate {
   /// Quality score for this candidate.
   LayoutScore score;
 
+  /// Accumulated analytical-time path cost (filled by the AnalyticalTime cost
+  /// model; unused by the default Heuristic model). Lower is better.
+  double accumulatedCost = 0.0;
+
   /// Backend validation result.
   op_constraint_validation::ValidationResult validationResult;
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
@@ -76,6 +76,12 @@ struct LayoutScore {
   /// of the heuristic ordering (`operator>`/`operator==`).
   uint64_t outputBytes = 0;
 
+  /// Matmul compute work in 32x32x32 tile-multiplies (0 for non-matmul ops).
+  /// Lets the analytical-time model add a compute roofline term so it does not
+  /// trade away matmul parallelism for fewer reshards. Layout-independent (same
+  /// for every candidate of an op); not part of the heuristic ordering.
+  uint64_t tileMuls = 0;
+
   /// Higher score is better.
   bool operator>(const LayoutScore &other) const;
   bool operator==(const LayoutScore &other) const;

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -544,6 +544,14 @@ struct TTIRToTTNNCommonPipelineOptions
       llvm::cl::desc("Print per-op compile-time statistics at DEBUG level."),
       llvm::cl::init(false)};
 
+  // Beam cost model used by the greedy memory layout propagation.
+  Option<std::string> layoutCostModel{
+      *this, "layout-cost-model",
+      llvm::cl::desc("Greedy optimizer beam cost model: heuristic (local "
+                     "LayoutScore, default) or time (accumulated "
+                     "analytical-time over the producer chain)."),
+      llvm::cl::init("heuristic")};
+
   void resolveCreateD2MSubgraphsOptions() const {
     // enable-d2m-elementwise-fusion is a sub-option of
     // enable-create-d2m-subgraphs and should only be enabled if

--- a/include/ttmlir/Dialect/TTNN/Transforms/GreedyMemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/GreedyMemoryLayoutPropagation.h
@@ -28,6 +28,7 @@ struct TTNNGreedyMemoryLayoutPropagationPipelineOptions {
   bool enableDecisionTrace = false;
   std::string decisionTraceDir = "ttrt-artifacts/decision_trace";
   bool enableCompileTimeStats = false;
+  std::string layoutCostModel = "heuristic";
 };
 
 std::unique_ptr<::mlir::Pass> createTTNNGreedyMemoryLayoutPropagation(

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -868,6 +868,9 @@ def TTNNGreedyMemoryLayoutPropagation : Pass<"ttnn-greedy-memory-layout-propagat
            "Directory for decision trace JSON output.">,
     Option<"enableCompileTimeStats", "enable-compile-time-stats", "bool", "false",
            "Print per-op compile-time statistics at DEBUG level.">,
+    Option<"layoutCostModel", "layout-cost-model", "std::string", "\"heuristic\"",
+           "Beam cost model: heuristic (local LayoutScore, default) or "
+           "time (accumulated analytical-time over the producer chain).">,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Utils/Roofline.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Roofline.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_UTILS_ROOFLINE_H
+#define TTMLIR_DIALECT_TTNN_UTILS_ROOFLINE_H
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+
+#include "mlir/IR/Value.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace mlir::tt::ttnn::roofline {
+
+// Theoretical single-chip hardware constants used by the analytical roofline.
+// Shared source of truth for both perf-target estimation
+// (TTNNCollectPerfMetrics) and the analytical-time layout cost model so the
+// two never diverge.
+struct HwSpec {
+  uint64_t dramBandwidthBytesPerSec = 0; // aggregate, shared across all cores
+  uint64_t aiclkHz = 0;
+  uint64_t cyclesPerTileMatmul = 32; // HiFi2: 32 cycles / 32x32x32 tile-mul
+
+  // Per-core L1 SRAM bandwidth. Public specs put L1 at ~1 TB/s per core at
+  // ~1 GHz, scaling linearly with clock; 1e12 B/s / 1e9 Hz = 1000 B per Hz.
+  uint64_t perCoreL1BandwidthBytesPerSec() const { return aiclkHz * 1000ULL; }
+};
+
+// HW spec for a given arch (Wormhole B0, Blackhole). Returns std::nullopt for
+// archs the roofline is not calibrated for.
+std::optional<HwSpec> getHwSpec(ttcore::Arch arch);
+
+// Number of 32x32x32 tile-multiplies for a matmul with the given lhs and result
+// values, accounting for a transposed lhs. Returns 0 if shapes are < rank 2.
+uint64_t getNumTileMatmuls(Value lhs, Value result, bool transposeA);
+
+} // namespace mlir::tt::ttnn::roofline
+
+#endif // TTMLIR_DIALECT_TTNN_UTILS_ROOFLINE_H

--- a/lib/Dialect/TTNN/Analysis/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Analysis/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_dialect_library(MLIRTTNNAnalysis
         L1ChainConfig.cpp
         L1InterleavedFallbackAnalysis.cpp
         L1SpillManagement.cpp
+        LayoutCostModel.cpp
         MemoryLayoutPropagation.cpp
         LegalOpConfigAnalysis.cpp
         LegalOpLayoutAnalysis.cpp

--- a/lib/Dialect/TTNN/Analysis/LayoutCostModel.cpp
+++ b/lib/Dialect/TTNN/Analysis/LayoutCostModel.cpp
@@ -13,13 +13,6 @@ namespace mlir::tt::ttnn {
 
 namespace {
 
-// Relative bandwidth / penalty constants for the analytical proxy.
-// TODO: source BW_L1 : BW_DRAM from system_desc. Decode is weight-streaming
-// bound, so the memory term dominates and these relative values rank correctly.
-constexpr double kBwDram = 1.0;
-constexpr double kBwL1 = 8.0;
-constexpr double kDramPenalty = kBwL1 / kBwDram; // any DRAM leg pays DRAM BW
-
 /// Historical default: rank by the local lexicographic `LayoutScore`, with
 /// `preferCandidate` as the tiebreak. Lifted verbatim from the previous inline
 /// beam comparator so the default build is byte-for-byte unchanged.
@@ -34,12 +27,15 @@ public:
   }
 };
 
-/// Accumulated analytical-time cost: minimize estimated graph time = sum of
-/// per-op roofline cost + reshard-edge cost along the producer chain. Reads
-/// only data the constraint query already produced (coreCount/residency/bytes)
-/// -- no getOpRuntime. Lower accumulatedCost wins.
+/// Accumulated analytical-time cost: minimize estimated graph time (in
+/// microseconds) = sum of per-op roofline cost + reshard-edge cost along the
+/// producer chain. Reads only data the constraint query already produced
+/// (coreCount/residency/bytes) plus shape-derived matmul tile-muls -- no
+/// getOpRuntime. Lower accumulatedCost wins.
 class AnalyticalTimeCostModel final : public LayoutCostModel {
 public:
+  explicit AnalyticalTimeCostModel(roofline::HwSpec hw) : hw(hw) {}
+
   void annotate(
       Operation *op, BeamCandidate &candidate,
       llvm::ArrayRef<const BeamCandidate *> producerChoices) const override {
@@ -67,49 +63,75 @@ public:
   }
 
 private:
-  // Per-op roofline (memory term) from the constraint result: cost of reading
-  // DRAM inputs plus writing the output. coreCount is op-aware via
-  // RuleBook::adjustScore (e.g. RMSNorm is input-driven).
-  // TODO: add the compute term (FLOPs/(cores*peak)) for compute-bound ops.
-  static double nodeCost(const BeamCandidate &candidate) {
-    const LayoutScore &s = candidate.score;
-    double cores = static_cast<double>(std::max<int64_t>(s.coreCount, 1));
-    double inputTerm =
-        static_cast<double>(s.inputDramBytes) / (cores * kBwDram);
-    // Output write: an L1 output is written across `cores` at L1 bandwidth; a
-    // DRAM output pays the (much slower) DRAM bandwidth with no core
-    // parallelism. Critically, a DRAM output is NOT free -- otherwise the model
-    // demotes L1 glue ops to DRAM, shattering the on-chip chain into reshards.
-    double bytes = static_cast<double>(s.outputBytes);
-    double outputTerm =
-        s.isL1 ? bytes / (cores * kBwL1) : bytes / kBwDram;
-    return inputTerm + outputTerm;
+  // Time (us) to move `bytes` through aggregate DRAM bandwidth (shared across
+  // cores) or per-core L1 bandwidth (scaled by the number of cores).
+  double dramUs(uint64_t bytes) const {
+    return hw.dramBandwidthBytesPerSec
+               ? static_cast<double>(bytes) * 1e6 /
+                     static_cast<double>(hw.dramBandwidthBytesPerSec)
+               : 0.0;
+  }
+  double l1Us(uint64_t bytes, double cores) const {
+    uint64_t perCore = hw.perCoreL1BandwidthBytesPerSec();
+    return perCore ? static_cast<double>(bytes) * 1e6 /
+                         (cores * static_cast<double>(perCore))
+                   : 0.0;
   }
 
-  // One reshard op per edge; cost = bytes / BW(slowest leg). Bytes proxied by
-  // the producer's buffer-agnostic output footprint (outputBytes, nonzero even
-  // for DRAM-resident producers); a DRAM leg (producer or target in DRAM) pays
-  // the DRAM penalty.
-  static double reshardCost(const BeamCandidate *producer,
-                            TTNNLayoutAttr targetLayout) {
+  // Per-op roofline in us: max(compute, memory). Compute is the matmul
+  // tile-mul time at the candidate's core count (0 for non-matmul ops, so they
+  // are memory-bound). Memory is DRAM-input read (incl. streamed weights) plus
+  // the output write (L1 across cores, or aggregate DRAM). max() means dropping
+  // cores raises the compute term on compute-bound ops -- so the model will not
+  // trade away matmul parallelism for fewer reshards.
+  double nodeCost(const BeamCandidate &candidate) const {
+    const LayoutScore &s = candidate.score;
+    double cores = static_cast<double>(std::max<int64_t>(s.coreCount, 1));
+
+    double computeUs = 0.0;
+    if (s.tileMuls != 0 && hw.aiclkHz != 0) {
+      computeUs = static_cast<double>(s.tileMuls * hw.cyclesPerTileMatmul) *
+                  1e6 / (cores * static_cast<double>(hw.aiclkHz));
+    }
+
+    double outWriteUs = s.isL1 ? l1Us(s.outputBytes, cores)
+                               : dramUs(s.outputBytes);
+    double memUs = dramUs(s.inputDramBytes) + outWriteUs;
+
+    return std::max(computeUs, memUs);
+  }
+
+  // One reshard op per edge: time to move the producer's output through the
+  // slowest leg. A DRAM leg (producer or target in DRAM) pays aggregate DRAM
+  // bandwidth; an L1->L1 reshard moves through L1 across the producer's cores.
+  // Bytes use the producer's buffer-agnostic footprint (nonzero even for
+  // DRAM-resident producers, unlike outputL1Usage).
+  double reshardCost(const BeamCandidate *producer,
+                     TTNNLayoutAttr targetLayout) const {
     if (!producer) {
       return 0.0;
     }
-    double bytes = static_cast<double>(producer->score.outputBytes);
+    uint64_t bytes = producer->score.outputBytes;
     bool dramLeg = !producer->score.isL1 || !targetLayout.hasL1BufferType();
-    return bytes * (dramLeg ? kDramPenalty : 1.0);
+    if (dramLeg) {
+      return dramUs(bytes);
+    }
+    double cores = static_cast<double>(std::max<int64_t>(producer->score.coreCount, 1));
+    return l1Us(bytes, cores);
   }
+
+  roofline::HwSpec hw;
 };
 
 } // namespace
 
 std::unique_ptr<LayoutCostModel>
-createLayoutCostModel(LayoutCostModelKind kind) {
+createLayoutCostModel(LayoutCostModelKind kind, roofline::HwSpec hwSpec) {
   switch (kind) {
   case LayoutCostModelKind::Heuristic:
     return std::make_unique<HeuristicCostModel>();
   case LayoutCostModelKind::AnalyticalTime:
-    return std::make_unique<AnalyticalTimeCostModel>();
+    return std::make_unique<AnalyticalTimeCostModel>(hwSpec);
   }
   llvm_unreachable("unknown LayoutCostModelKind");
 }

--- a/lib/Dialect/TTNN/Analysis/LayoutCostModel.cpp
+++ b/lib/Dialect/TTNN/Analysis/LayoutCostModel.cpp
@@ -6,9 +6,19 @@
 
 #include "llvm/Support/ErrorHandling.h"
 
+#include <algorithm>
+#include <cstdint>
+
 namespace mlir::tt::ttnn {
 
 namespace {
+
+// Relative bandwidth / penalty constants for the analytical proxy.
+// TODO: source BW_L1 : BW_DRAM from system_desc. Decode is weight-streaming
+// bound, so the memory term dominates and these relative values rank correctly.
+constexpr double kBwDram = 1.0;
+constexpr double kBwL1 = 8.0;
+constexpr double kDramPenalty = kBwL1 / kBwDram; // any DRAM leg pays DRAM BW
 
 /// Historical default: rank by the local lexicographic `LayoutScore`, with
 /// `preferCandidate` as the tiebreak. Lifted verbatim from the previous inline
@@ -24,6 +34,63 @@ public:
   }
 };
 
+/// Accumulated analytical-time cost: minimize estimated graph time = sum of
+/// per-op roofline cost + reshard-edge cost along the producer chain. Reads
+/// only data the constraint query already produced (coreCount/residency/bytes)
+/// -- no getOpRuntime. Lower accumulatedCost wins.
+class AnalyticalTimeCostModel final : public LayoutCostModel {
+public:
+  void annotate(
+      Operation *op, BeamCandidate &candidate,
+      llvm::ArrayRef<const BeamCandidate *> producerChoices) const override {
+    double cost = nodeCost(candidate);
+    // Path cost so far: each candidate commits to one producer per operand.
+    for (const BeamCandidate *producer : producerChoices) {
+      if (producer) {
+        cost += producer->accumulatedCost;
+      }
+    }
+    // Reshard edges (one runtime op each): producer output -> required input.
+    for (const auto &entry : candidate.reshardLayouts) {
+      size_t operandIdx = entry.first;
+      const BeamCandidate *producer =
+          operandIdx < producerChoices.size() ? producerChoices[operandIdx]
+                                              : nullptr;
+      cost += reshardCost(producer, entry.second);
+    }
+    candidate.accumulatedCost = cost;
+  }
+
+  bool better(Operation *, const BeamCandidate &a,
+              const BeamCandidate &b) const override {
+    return a.accumulatedCost < b.accumulatedCost;
+  }
+
+private:
+  // Per-op roofline (memory term) from the constraint result. coreCount is
+  // op-aware via RuleBook::adjustScore (e.g. RMSNorm is input-driven).
+  // TODO: add the compute term (FLOPs/(cores*peak)) for compute-bound ops.
+  static double nodeCost(const BeamCandidate &candidate) {
+    const LayoutScore &s = candidate.score;
+    double cores = static_cast<double>(std::max<int64_t>(s.coreCount, 1));
+    return static_cast<double>(s.inputDramBytes) / (cores * kBwDram) +
+           static_cast<double>(s.outputL1Usage) / (cores * kBwL1);
+  }
+
+  // One reshard op per edge; cost = bytes / BW(slowest leg). Bytes proxied by
+  // the producer's output footprint; a DRAM leg (producer or target in DRAM)
+  // pays the DRAM penalty.
+  static double reshardCost(const BeamCandidate *producer,
+                            TTNNLayoutAttr targetLayout) {
+    if (!producer) {
+      return 0.0;
+    }
+    double bytes = static_cast<double>(producer->score.outputL1Usage);
+    bool dramLeg = !producer->score.isL1 || !targetLayout.hasL1BufferType();
+    return bytes * (dramLeg ? kDramPenalty : 1.0);
+  }
+};
+
 } // namespace
 
 std::unique_ptr<LayoutCostModel>
@@ -31,6 +98,8 @@ createLayoutCostModel(LayoutCostModelKind kind) {
   switch (kind) {
   case LayoutCostModelKind::Heuristic:
     return std::make_unique<HeuristicCostModel>();
+  case LayoutCostModelKind::AnalyticalTime:
+    return std::make_unique<AnalyticalTimeCostModel>();
   }
   llvm_unreachable("unknown LayoutCostModelKind");
 }

--- a/lib/Dialect/TTNN/Analysis/LayoutCostModel.cpp
+++ b/lib/Dialect/TTNN/Analysis/LayoutCostModel.cpp
@@ -67,25 +67,35 @@ public:
   }
 
 private:
-  // Per-op roofline (memory term) from the constraint result. coreCount is
-  // op-aware via RuleBook::adjustScore (e.g. RMSNorm is input-driven).
+  // Per-op roofline (memory term) from the constraint result: cost of reading
+  // DRAM inputs plus writing the output. coreCount is op-aware via
+  // RuleBook::adjustScore (e.g. RMSNorm is input-driven).
   // TODO: add the compute term (FLOPs/(cores*peak)) for compute-bound ops.
   static double nodeCost(const BeamCandidate &candidate) {
     const LayoutScore &s = candidate.score;
     double cores = static_cast<double>(std::max<int64_t>(s.coreCount, 1));
-    return static_cast<double>(s.inputDramBytes) / (cores * kBwDram) +
-           static_cast<double>(s.outputL1Usage) / (cores * kBwL1);
+    double inputTerm =
+        static_cast<double>(s.inputDramBytes) / (cores * kBwDram);
+    // Output write: an L1 output is written across `cores` at L1 bandwidth; a
+    // DRAM output pays the (much slower) DRAM bandwidth with no core
+    // parallelism. Critically, a DRAM output is NOT free -- otherwise the model
+    // demotes L1 glue ops to DRAM, shattering the on-chip chain into reshards.
+    double bytes = static_cast<double>(s.outputBytes);
+    double outputTerm =
+        s.isL1 ? bytes / (cores * kBwL1) : bytes / kBwDram;
+    return inputTerm + outputTerm;
   }
 
   // One reshard op per edge; cost = bytes / BW(slowest leg). Bytes proxied by
-  // the producer's output footprint; a DRAM leg (producer or target in DRAM)
-  // pays the DRAM penalty.
+  // the producer's buffer-agnostic output footprint (outputBytes, nonzero even
+  // for DRAM-resident producers); a DRAM leg (producer or target in DRAM) pays
+  // the DRAM penalty.
   static double reshardCost(const BeamCandidate *producer,
                             TTNNLayoutAttr targetLayout) {
     if (!producer) {
       return 0.0;
     }
-    double bytes = static_cast<double>(producer->score.outputL1Usage);
+    double bytes = static_cast<double>(producer->score.outputBytes);
     bool dramLeg = !producer->score.isL1 || !targetLayout.hasL1BufferType();
     return bytes * (dramLeg ? kDramPenalty : 1.0);
   }

--- a/lib/Dialect/TTNN/Analysis/LayoutCostModel.cpp
+++ b/lib/Dialect/TTNN/Analysis/LayoutCostModel.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/LayoutCostModel.h"
+
+#include "llvm/Support/ErrorHandling.h"
+
+namespace mlir::tt::ttnn {
+
+namespace {
+
+/// Historical default: rank by the local lexicographic `LayoutScore`, with
+/// `preferCandidate` as the tiebreak. Lifted verbatim from the previous inline
+/// beam comparator so the default build is byte-for-byte unchanged.
+class HeuristicCostModel final : public LayoutCostModel {
+public:
+  bool better(Operation *op, const BeamCandidate &a,
+              const BeamCandidate &b) const override {
+    if (a.score != b.score) {
+      return a.score > b.score;
+    }
+    return preferCandidate(op, a, b);
+  }
+};
+
+} // namespace
+
+std::unique_ptr<LayoutCostModel>
+createLayoutCostModel(LayoutCostModelKind kind) {
+  switch (kind) {
+  case LayoutCostModelKind::Heuristic:
+    return std::make_unique<HeuristicCostModel>();
+  }
+  llvm_unreachable("unknown LayoutCostModelKind");
+}
+
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -32,6 +32,26 @@
 
 namespace mlir::tt::ttnn {
 
+// Hardware roofline constants for the function's target arch, for the
+// analytical-time cost model. Falls back to Blackhole constants if the system
+// desc is missing or the arch is uncalibrated (the model is opt-in and only
+// WH/BH are calibrated today; the heuristic default never reaches here).
+static roofline::HwSpec getHwSpecForFunc(func::FuncOp func) {
+  if (auto module = func->getParentOfType<ModuleOp>()) {
+    if (auto sysDesc = module->getAttrOfType<ttcore::SystemDescAttr>(
+            ttcore::SystemDescAttr::name)) {
+      auto chipDescs = sysDesc.getChipDescs();
+      if (!chipDescs.empty()) {
+        if (auto spec =
+                roofline::getHwSpec(chipDescs[0].getArch().getValue())) {
+          return *spec;
+        }
+      }
+    }
+  }
+  return roofline::getHwSpec(ttcore::Arch::Blackhole).value();
+}
+
 MemoryLayoutPropagation::MemoryLayoutPropagation(
     func::FuncOp func,
     const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
@@ -53,7 +73,7 @@ MemoryLayoutPropagation::MemoryLayoutPropagation(
   // Cost model selects the beam objective (local heuristic by default; the
   // analytical-time model is selected via the layout-cost-model pipeline
   // option). Every candidate comparison funnels through it.
-  costModel = createLayoutCostModel(costModelKind);
+  costModel = createLayoutCostModel(costModelKind, getHwSpecForFunc(func));
 }
 
 MemoryLayoutPropagation::~MemoryLayoutPropagation() = default;

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -37,7 +37,8 @@ MemoryLayoutPropagation::MemoryLayoutPropagation(
     const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
     const TensorTypeLayoutsMap *tensorTypePossibleLayouts, size_t beamWidth,
     size_t maxInputCandidatesPerOperand, size_t maxReshardCandidatesPerType,
-    std::unique_ptr<LayoutPropagationObserver> observer)
+    std::unique_ptr<LayoutPropagationObserver> observer,
+    LayoutCostModelKind costModelKind)
     : func(func), deviceAttr(ttcore::lookupDevice(func)),
       legalConfigs(legalConfigs),
       tensorTypePossibleLayouts(tensorTypePossibleLayouts),
@@ -49,9 +50,10 @@ MemoryLayoutPropagation::MemoryLayoutPropagation(
   } else {
     this->observer = std::make_unique<LayoutPropagationObserver>();
   }
-  // Default to the historical local heuristic. Alternative cost models are
-  // selected here once wired to a pipeline option.
-  costModel = createLayoutCostModel(LayoutCostModelKind::Heuristic);
+  // Cost model selects the beam objective (local heuristic by default; the
+  // analytical-time model is selected via the layout-cost-model pipeline
+  // option). Every candidate comparison funnels through it.
+  costModel = createLayoutCostModel(costModelKind);
 }
 
 MemoryLayoutPropagation::~MemoryLayoutPropagation() = default;
@@ -177,6 +179,11 @@ std::optional<BeamCandidate> MemoryLayoutPropagation::evaluateHint(
     candidate.producerCandidateIndices = producerCandidateIndices;
     candidate.reshardLayouts = reshardLayouts;
     candidate.outputLayouts = result.actualOutputLayouts;
+
+    // Let the cost model attach any path-dependent data (e.g. accumulated
+    // analytical-time cost over the producer chain). No-op for the heuristic.
+    costModel->annotate(op, candidate,
+                        resolveProducerChoices(op, producerCandidateIndices));
 
     TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                  "    VALID candidate for {0}: hint[{1}]={2} "
@@ -1119,6 +1126,30 @@ MemoryLayoutPropagation::getProducerForOperandIdx(Operation *op,
   return nullptr;
 }
 
+llvm::SmallVector<const BeamCandidate *>
+MemoryLayoutPropagation::resolveProducerChoices(
+    Operation *op,
+    const llvm::SmallVector<size_t> &producerCandidateIndices) {
+  llvm::SmallVector<const BeamCandidate *> producers;
+  producers.reserve(producerCandidateIndices.size());
+  for (size_t operandIdx = 0; operandIdx < producerCandidateIndices.size();
+       ++operandIdx) {
+    Operation *producerOp = getProducerForOperandIdx(op, operandIdx);
+    const BeamCandidate *producer = nullptr;
+    if (producerOp) {
+      auto it = beamState.find(producerOp);
+      if (it != beamState.end()) {
+        size_t prodIdx = producerCandidateIndices[operandIdx];
+        if (prodIdx < it->second.size()) {
+          producer = &it->second[prodIdx];
+        }
+      }
+    }
+    producers.push_back(producer);
+  }
+  return producers;
+}
+
 void MemoryLayoutPropagation::consolidateBeam() {
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "consolidateBeam: starting backward pass for {0} ops in beam",
@@ -1246,9 +1277,11 @@ size_t MemoryLayoutPropagation::resolveForForkPoint(
         }
       }
     }
+    // Primary objective at a fork is reshard reuse (freeCount); the cost model
+    // breaks ties between equally-reusable producer candidates.
     if (freeCount > bestFreeCount ||
         (freeCount == bestFreeCount &&
-         forkBeam[k].score > forkBeam[bestK].score)) {
+         costModel->better(forkOp, forkBeam[k], forkBeam[bestK]))) {
       bestFreeCount = freeCount;
       bestK = k;
     }

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -49,6 +49,9 @@ MemoryLayoutPropagation::MemoryLayoutPropagation(
   } else {
     this->observer = std::make_unique<LayoutPropagationObserver>();
   }
+  // Default to the historical local heuristic. Alternative cost models are
+  // selected here once wired to a pipeline option.
+  costModel = createLayoutCostModel(LayoutCostModelKind::Heuristic);
 }
 
 MemoryLayoutPropagation::~MemoryLayoutPropagation() = default;
@@ -560,11 +563,8 @@ MemoryLayoutPropagation::processOp(Operation *op) {
   // downstream consumers (e.g. L1-spill's first-fit walk) see a fixed
   // beam-slot assignment across runs.
   std::stable_sort(candidates.begin(), candidates.end(),
-                   [op](const BeamCandidate &a, const BeamCandidate &b) {
-                     if (a.score != b.score) {
-                       return a.score > b.score;
-                     }
-                     return preferCandidate(op, a, b);
+                   [&](const BeamCandidate &a, const BeamCandidate &b) {
+                     return costModel->better(op, a, b);
                    });
 
   if (candidates.size() > beamWidth) {

--- a/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
@@ -82,6 +82,14 @@ scoreCandidate(Operation *op, const OpConfig &config,
     score.coreCount *= dim;
   }
 
+  // Total output footprint (shard size * number of shards), independent of
+  // buffer type. For L1 outputs this matches outputL1Usage; for DRAM outputs
+  // outputL1Usage is 0 but this is the real tensor size.
+  score.outputBytes = layout.getShardSizeInBytes();
+  for (auto dim : layout.getGridShape()) {
+    score.outputBytes *= dim;
+  }
+
   return getRuleBook(op).adjustScore(op, score, config, inputLayouts,
                                      requiresReshard);
 }

--- a/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
@@ -4,7 +4,11 @@
 
 #include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Roofline.h"
+
+#include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir::tt::ttnn {
 
@@ -64,6 +68,17 @@ scoreCandidate(Operation *op, const OpConfig &config,
   LayoutScore score;
   score.requiresReshard = requiresReshard;
   score.outputL1Usage = result.outputL1Usage;
+
+  // Matmul compute work (tile-multiplies), layout-independent. Lets the
+  // analytical-time cost model price the compute roofline so it does not trade
+  // away matmul parallelism. 0 for non-matmul ops.
+  score.tileMuls =
+      llvm::TypeSwitch<Operation *, uint64_t>(op)
+          .Case<MatmulOp, LinearOp>([](auto m) {
+            return roofline::getNumTileMatmuls(m.getA(), m.getResult(),
+                                               m.getTransposeA());
+          })
+          .Default(uint64_t{0});
 
   TTNNLayoutAttr layout = result.getFirstActualOutputLayout();
   if (!layout) {

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -148,6 +148,7 @@ void createTTNNPipelineAnalysisPasses(
       propagationOptions.decisionTraceDir = options.decisionTraceDir;
       propagationOptions.enableCompileTimeStats =
           options.enableCompileTimeStats;
+      propagationOptions.layoutCostModel = options.layoutCostModel;
 
       TTNNGreedyL1SpillManagementOptions spillOptions;
       spillOptions.enableDecisionTrace = options.enableDecisionTrace;

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
@@ -68,6 +68,7 @@ public:
     enableDecisionTrace = opts.enableDecisionTrace;
     decisionTraceDir = std::move(opts.decisionTraceDir);
     enableCompileTimeStats = opts.enableCompileTimeStats;
+    layoutCostModel = std::move(opts.layoutCostModel);
     overrideOutputLayout = std::move(opts.overrideOutputLayout);
     overrideConv2dConfig = std::move(opts.overrideConv2dConfig);
     overrideConv3dConfig = std::move(opts.overrideConv3dConfig);
@@ -169,6 +170,16 @@ public:
       });
     });
 
+    // Resolve the beam cost model selected via the pipeline option.
+    LayoutCostModelKind costModelKind = LayoutCostModelKind::Heuristic;
+    if (layoutCostModel == "time") {
+      costModelKind = LayoutCostModelKind::AnalyticalTime;
+    } else if (layoutCostModel != "heuristic") {
+      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                   "Unknown layout-cost-model '{0}'; using heuristic.",
+                   layoutCostModel);
+    }
+
     // Step 4: Run layout propagation for each forward device function.
     moduleOp->walk([&](func::FuncOp func) {
       if (!ttmlir::utils::isForwardDeviceFunc(func)) {
@@ -198,7 +209,7 @@ public:
           static_cast<size_t>(beamWidth),
           static_cast<size_t>(maxInputCandidatesPerOperand),
           static_cast<size_t>(maxReshardCandidatesPerType),
-          std::move(observer));
+          std::move(observer), costModelKind);
       propagation.run();
 
       // Sync D2M subgraph function types to match dispatch op's current inputs

--- a/lib/Dialect/TTNN/Transforms/TTNNCollectPerfMetrics.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNCollectPerfMetrics.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Roofline.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/FunctionTypes.h"
 #include "ttmlir/Support/Logger.h"
@@ -88,10 +89,8 @@ struct AggregatedMetrics {
 inline bool isValidWeightForTargetCalculation(mlir::Value v);
 bool constEvalDoesNotChangeTensorVolume(ttcore::LoadCachedOp loadCachedOp);
 uint64_t bytesAtBfp8(RankedTensorType t);
-uint64_t getNumTileMatmuls(Value lhs, Value result, bool transposeA);
 
-// Tile dimensions used to round matmul / SDPA dims up to whole 32x32 tiles.
-constexpr int64_t kTileHeight = ttcore::TileType::getDefaultShape()[0];
+// Tile width used to round matmul / SDPA dims up to whole 32-wide tiles.
 constexpr int64_t kTileWidth = ttcore::TileType::getDefaultShape()[1];
 
 // Round `x` up to a whole number of tiles along a 32-wide dimension.
@@ -197,8 +196,8 @@ struct PerfTargets {
           llvm::TypeSwitch<Operation *, bool>(op)
               .Case<MatmulOp, LinearOp>([&](auto m) {
                 weights = {m.getB()};
-                tileMuls = getNumTileMatmuls(m.getA(), m.getResult(),
-                                             m.getTransposeA());
+                tileMuls = roofline::getNumTileMatmuls(m.getA(), m.getResult(),
+                                                       m.getTransposeA());
                 return true;
               })
               .Case<ScaledDotProductAttentionDecodeOp,
@@ -455,35 +454,8 @@ uint64_t bytesAtBfp8(RankedTensorType t) {
       static_cast<double>(t.getNumElements()) * 17.0 / 16.0 + 0.5);
 }
 
-uint64_t getNumTileMatmuls(Value lhs, Value result, bool transposeA) {
-  ArrayRef<int64_t> lhsShape =
-      mlir::cast<RankedTensorType>(lhs.getType()).getShape();
-  ArrayRef<int64_t> resultShape =
-      mlir::cast<RankedTensorType>(result.getType()).getShape();
-
-  // Both operands must be at least rank 2 to extract M/K/N.
-  if (lhsShape.size() < 2 || resultShape.size() < 2) {
-    return 0;
-  }
-
-  int64_t M = resultShape[resultShape.size() - 2];
-  // The contraction dim K is the last dim of A, unless A is transposed, in
-  // which case it is the second-to-last dim.
-  int64_t K = transposeA ? lhsShape[lhsShape.size() - 2]
-                         : lhsShape[lhsShape.size() - 1];
-  int64_t N = resultShape[resultShape.size() - 1];
-  int64_t batch = 1;
-  for (size_t i = 0; i < resultShape.size() - 2; i++) {
-    batch *= resultShape[i];
-  }
-
-  // Tilize M, K, N
-  int64_t tilesM = (M + kTileHeight - 1) / kTileHeight;
-  int64_t tilesK = (K + kTileWidth - 1) / kTileWidth;
-  int64_t tilesN = (N + kTileWidth - 1) / kTileWidth;
-
-  return static_cast<uint64_t>(batch) * tilesM * tilesK * tilesN;
-}
+// getNumTileMatmuls moved to TTNN/Utils/Roofline.h (shared with the
+// analytical-time layout cost model).
 
 class TTNNCollectPerfMetrics
     : public impl::TTNNCollectPerfMetricsBase<TTNNCollectPerfMetrics> {
@@ -599,24 +571,17 @@ private:
     for (int64_t d : chipDesc.getGrid()) {
       t.numTensixCores *= static_cast<uint64_t>(d);
     }
-    // HiFi2 = 32 cycles / 32x32x32 tile-mul. Same on WH and BH per
-    // tech_reports/matrix_engine/matrix_engine.md.
-    t.cyclesPerTileMatmul = 32;
-    switch (t.arch) {
-    case ttcore::Arch::WormholeB0:
-      t.dramBandwidthBytesPerSec = 288ULL * 1000ULL * 1000ULL * 1000ULL;
-      t.aiclkHz = 1000ULL * 1000ULL * 1000ULL; // 1.0 GHz
-      return success();
-    case ttcore::Arch::Blackhole:
-      t.dramBandwidthBytesPerSec = 512ULL * 1000ULL * 1000ULL * 1000ULL;
-      t.aiclkHz = 1350ULL * 1000ULL * 1000ULL; // 1.35 GHz
-      return success();
-    case ttcore::Arch::Quasar:
+    std::optional<roofline::HwSpec> spec = roofline::getHwSpec(t.arch);
+    if (!spec) {
       return module.emitError()
              << "TTNNCollectPerfMetrics: perf target estimate not calibrated "
-                "for arch 'quasar'.";
+                "for arch '"
+             << ttcore::stringifyArch(t.arch) << "'.";
     }
-    llvm_unreachable("unknown ttcore::Arch value");
+    t.dramBandwidthBytesPerSec = spec->dramBandwidthBytesPerSec;
+    t.aiclkHz = spec->aiclkHz;
+    t.cyclesPerTileMatmul = spec->cyclesPerTileMatmul;
+    return success();
   }
 
   FailureOr<PerfTargets> computePerfTargets(ModuleOp module) {

--- a/lib/Dialect/TTNN/Utils/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Utils/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(TTMLIRTTNNUtils
   OptimizerOverrides.cpp
   OptimizerUtils.cpp
   PassOverrides.cpp
+  Roofline.cpp
   TransformUtils.cpp
   Utils.cpp
   VerificationUtils.cpp

--- a/lib/Dialect/TTNN/Utils/Roofline.cpp
+++ b/lib/Dialect/TTNN/Utils/Roofline.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Utils/Roofline.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::tt::ttnn::roofline {
+
+std::optional<HwSpec> getHwSpec(ttcore::Arch arch) {
+  HwSpec spec;
+  // HiFi2 = 32 cycles / 32x32x32 tile-mul; same on WH and BH per
+  // tech_reports/matrix_engine/matrix_engine.md.
+  spec.cyclesPerTileMatmul = 32;
+  switch (arch) {
+  case ttcore::Arch::WormholeB0:
+    spec.dramBandwidthBytesPerSec = 288ULL * 1000ULL * 1000ULL * 1000ULL;
+    spec.aiclkHz = 1000ULL * 1000ULL * 1000ULL; // 1.0 GHz
+    return spec;
+  case ttcore::Arch::Blackhole:
+    spec.dramBandwidthBytesPerSec = 512ULL * 1000ULL * 1000ULL * 1000ULL;
+    spec.aiclkHz = 1350ULL * 1000ULL * 1000ULL; // 1.35 GHz
+    return spec;
+  default:
+    return std::nullopt;
+  }
+}
+
+uint64_t getNumTileMatmuls(Value lhs, Value result, bool transposeA) {
+  auto lhsType = mlir::dyn_cast<RankedTensorType>(lhs.getType());
+  auto resultType = mlir::dyn_cast<RankedTensorType>(result.getType());
+  if (!lhsType || !resultType) {
+    return 0;
+  }
+  ArrayRef<int64_t> lhsShape = lhsType.getShape();
+  ArrayRef<int64_t> resultShape = resultType.getShape();
+
+  // Both operands must be at least rank 2 to extract M/K/N.
+  if (lhsShape.size() < 2 || resultShape.size() < 2) {
+    return 0;
+  }
+
+  int64_t M = resultShape[resultShape.size() - 2];
+  // The contraction dim K is the last dim of A, unless A is transposed, in
+  // which case it is the second-to-last dim.
+  int64_t K = transposeA ? lhsShape[lhsShape.size() - 2]
+                         : lhsShape[lhsShape.size() - 1];
+  int64_t N = resultShape[resultShape.size() - 1];
+  int64_t batch = 1;
+  for (size_t i = 0; i < resultShape.size() - 2; i++) {
+    batch *= resultShape[i];
+  }
+
+  const int64_t tileH = ttcore::TileType::getDefaultShape()[0];
+  const int64_t tileW = ttcore::TileType::getDefaultShape()[1];
+  int64_t tilesM = (M + tileH - 1) / tileH;
+  int64_t tilesK = (K + tileW - 1) / tileW;
+  int64_t tilesN = (N + tileW - 1) / tileW;
+
+  return static_cast<uint64_t>(batch) * tilesM * tilesK * tilesN;
+}
+
+} // namespace mlir::tt::ttnn::roofline


### PR DESCRIPTION
## Summary

Adds a **pluggable cost model** to the greedy memory-layout-propagation optimizer and a new **analytical-time** objective behind it, selectable via a pipeline option. **Off by default** — the existing local `LayoutScore` heuristic remains the default and is byte-for-byte unchanged.

```
ttir-to-ttnn-backend-pipeline="... layout-cost-model=time"   # opt in
# default: layout-cost-model=heuristic  (unchanged behavior)
```

Draft for review of the full changeset in one place.

## What it does

The default heuristic ranks each layout candidate by a **local** lexicographic tuple (coreCount, isSharded, isL1, …). It has no notion of the *reshards its choice forces on neighbors*, so it over-shards prefill and emits large numbers of `to_memory_config` ops.

The `time` model instead minimizes an **accumulated analytical-time cost** (real microseconds) over the producer chain: a per-op roofline `max(compute, memory)` plus a reshard-edge cost, summed along the chain. It trades reshards against op parallelism in one metric space, using only data `getOpConstraints` already produces plus shape-derived matmul tile-muls — **no `getOpRuntime`**.

Roofline (real units, reusing the per-arch HW constants from #8740 via a shared `TTNN/Utils/Roofline` helper):
- `compute_us = tileMuls·cyclesPerTile / (cores·aiclk)` (0 for non-matmul ops)
- `memory_us  = dram_read_us + (L1 ? l1_write_us : dram_write_us)` — DRAM at aggregate BW, L1 at per-core BW (~1 TB/s @ 1 GHz, clock-scaled)
- `node = max(compute_us, memory_us)`; reshard = bytes / BW(slowest leg)

## Structure (6 commits)

1. Pluggable `LayoutCostModel` seam on the beam path (no-op default).
2. `AnalyticalTimeCostModel`.
3. Wire it through the beam path + `layout-cost-model` pass option.
4. Forward the option through `ttir-to-ttnn-backend-pipeline`.
5. **Fix DRAM-output undercosting**: a DRAM output had `outputL1Usage=0`, so it looked free and the model demoted L1 glue ops to DRAM, shattering on-chip chains into reshards. Added buffer-agnostic `outputBytes`; DRAM writes are charged and reshards sized by it.
6. **Compute roofline term**: the node cost modeled only memory, so on multi-chip TP prefill the model would trade matmul parallelism for fewer reshards. Adding `max(compute, memory)` (real µs) makes it hold cores on compute-bound matmuls while still minimizing reshards on memory-bound glue. Shared `Roofline` util dedups the per-arch constants + `getNumTileMatmuls` with #8740.

## Validation (tt-xla LLM benchmarks)

`time` vs `heuristic`, CI-compiled graphs + e2e device perf. Single-chip (Blackhole p150) and multi-chip TP (qb2-blackhole, n300-llmbox).

**Single-chip (p150):** prefill reshards **−91 to −95%**, decode −1 to −4%, matmul cores held, **TTFT −22 to −38%**, throughput flat.

**Multi-chip (qb2-blackhole, 9–10 TP models):** prefill reshards **−86 to −90%**, **matmul cores held** (the compute term recovered the parallelism an earlier memory-only cost would have traded away — e.g. qwen_3_14b −23.5% → held), **TTFT −17 to −26%**, throughput flat.

**No regressions:** lean-baseline models neutral (±2%); decode throughput-bound on untouched matmuls; heuristic path byte-identical (`check-ttmlir` unchanged: 1903 pass, same pre-existing conv3d silicon-run failure).

## Notes / follow-ups (not in this PR)

- Decode reshard parity with tt-metal is a separate **op-fusion** effort (fused RoPE / paged-KV-update), not addressable by layout cost.
- L2 lit tests for the `time` model to be added before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)