### PR TITLE
Fix gather.106 ttir.concat shape mismatch from incorrect sharding propagation

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -4870,8 +4870,22 @@ public:
         rewriter.create<ttir::EmbeddingOp>(srcOp.getLoc(), embeddingOutputType,
                                            ops.startIndices, ops.reshapedInput);
 
-    auto expectedOutputType = mlir::cast<RankedTensorType>(
-        getTypeConverter()->convertType(srcOp.getResult().getType()));
+    // Use the global (unsharded) output shape from the gather's original result
+    // type. When column-parallel FFN/attention weights cause Shardy to
+    // incorrectly propagate a shard annotation onto the gather result (e.g.
+    // marking the sequence dim as split), getTypeConverter()->convertType()
+    // returns a per-shard local shape that is wrong for an embedding lookup
+    // which always produces a fully-replicated output. Using the global shape
+    // avoids the ttir.concat dim-0 mismatch that otherwise surfaces as:
+    //   'ttir.concat' op Output tensor dimension 0 does not match the sum of
+    //   input tensor dimensions: 1 vs. <seq_len>
+    auto srcResultType =
+        mlir::cast<RankedTensorType>(srcOp.getResult().getType());
+    auto convertedType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcResultType));
+    auto expectedOutputType = mlir::RankedTensorType::get(
+        srcResultType.getShape(), convertedType.getElementType(),
+        convertedType.getEncoding());
     rewriter.replaceOp(srcOp, reshapeAndPermuteOutput(rewriter, embeddingOp,
                                                       ops.indexedDim, srcOp,
                                                       expectedOutputType));
@@ -5989,6 +6003,21 @@ public:
     auto inputShape = inputType.getShape();
     auto sliceSizes = srcOp.getSliceSizes();
     int64_t indexedDim = startIndexMap[0];
+
+    // Reject when the gather output has more dimensions than the operand.
+    // This happens when the start_indices tensor has batch dimensions (e.g.
+    // position_ids of shape (1, seq_len) index a 2-D cos/sin table, producing
+    // a 3-D output (1, seq_len, head_dim)). In that case the operand slices
+    // have rank 2 but outputType has rank 3, making the concat invalid along
+    // indexedDim. The embedding pattern (benefit=1) handles these correctly.
+    auto outputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult().getType()));
+    if (outputType.getRank() != inputType.getRank()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "Output rank differs from operand rank — index batch dims "
+                 "not handled by SliceRepeatConcat; defer to embedding");
+    }
+
     int64_t maxIndex = inputShape[indexedDim] - sliceSizes[indexedDim];
     int64_t sliceSize = sliceSizes[indexedDim];
     int32_t starts = 0, ends = 0, lastIndex = 0;
@@ -6049,9 +6078,6 @@ public:
         createSlices(ends, indexedDim, sliceSize,
                      /*sliceStart=*/inputShape[indexedDim] - sliceSize,
                      inputShape, inputType, rewriter, srcOp, input));
-
-    auto outputType = mlir::cast<RankedTensorType>(
-        getTypeConverter()->convertType(srcOp.getResult().getType()));
 
     Value result = rewriter.create<ttir::ConcatOp>(
         srcOp.getLoc(), outputType, slicesToConcat,

--- a/lib/Dialect/StableHLO/Transforms/InsertReshardsForUnpropagatedOps.cpp
+++ b/lib/Dialect/StableHLO/Transforms/InsertReshardsForUnpropagatedOps.cpp
@@ -75,9 +75,15 @@ public:
     mlir::OpBuilder builder(context);
 
     rootModule.walk([&](mlir::Operation *op) {
-      // Restricted to stablehlo.reshape — the only op known to hit this
-      // propagation gap. Other ops have custom sharding rules registered.
-      if (!mlir::isa<mlir::stablehlo::ReshapeOp>(op)) {
+      // Handle ops known to hit the sharding propagation gap: stablehlo.reshape
+      // and stablehlo.gather. For gather, Shardy may propagate a
+      // column-parallel shard annotation from FFN/attention weights through the
+      // residual stream onto position_ids and the gather result, corrupting the
+      // sequence dimension. Inserting a reshard on the sharded operands makes
+      // the gather see fully-replicated inputs and produces the correct output
+      // shape.
+      if (!mlir::isa<mlir::stablehlo::ReshapeOp, mlir::stablehlo::GatherOp>(
+              op)) {
         return;
       }
       if (op->getParentOfType<mlir::sdy::ManualComputationOp>()) {

--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
@@ -115,6 +115,22 @@ module @test_gather_uniform_max_indices {
   }
 }
 
+// Batched constant indices (e.g. RoPE position_ids) index a 2D table and
+// produce a higher-rank output than the operand. The rank mismatch means
+// SliceRepeatConcatPattern cannot build a valid ttir.concat; must fall
+// through to the embedding lowering instead.
+// CHECK-LABEL: func.func @batched_constant_indices_falls_through
+module @test_gather_batched_constant_indices {
+  func.func @batched_constant_indices_falls_through(%arg0: tensor<32x64xbf16>) -> tensor<1x4x64xbf16> {
+    // CHECK-NOT: "ttir.concat"
+    // CHECK: "ttir.embedding"
+    // CHECK-NOT: stablehlo.gather
+    %1 = "stablehlo.constant"() <{value = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>}> : () -> tensor<1x4xi64>
+    %2 = "stablehlo.gather"(%arg0, %1) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 64>}> : (tensor<32x64xbf16>, tensor<1x4xi64>) -> tensor<1x4x64xbf16>
+    return %2 : tensor<1x4x64xbf16>
+  }
+}
+
 // When the indexed dim has size 1 (maxIndex == 0), 0 and maxIndex collapse;
 // all surplus indices become front padding without double-counting them as
 // back padding.


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
When column-parallel FFN weights (w1, w3) are used with InternLM2-style GQA models, Shardy incorrectly propagates the model-dim shard annotation through residual connections onto position_ids and the RoPE cos/sin gather result, corrupting the sequence dimension. This causes the SHLO→TTIR lowering to produce a ttir.concat whose output type (batch=1) doesn't match the sum of sharded inputs (seq_len), resulting in:

  'ttir.concat' op Output tensor dimension 0 does not match the sum of
  input tensor dimensions: 1 vs. <seq_len>

Two fixes:

1. InsertReshardsForUnpropagatedOps: extend to also handle GatherOp alongside ReshapeOp. When a gather's operands are sharded (due to sharding propagation from column-parallel FFN weights) but its result has no sharding annotation, insert sdy.reshard on the operands so the gather sees fully-replicated inputs and produces the correct unsharded output shape.

2. StableHLOGatherToEmbeddingPattern: use the global (unsharded) output shape from the gather's original result type instead of getTypeConverter()->convertType() which carries the incorrectly-propagated per-shard local shape. The embedding lookup always produces a fully-replicated output regardless of weight sharding.

Repro model: OpenGVLab/InternVL2-26B (InternLM2 language model backbone) with 8-way tensor parallel (mesh shape (1, 8)), column-parallel w1/w3 FFN weights.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
