### PR TITLE
[TTNN] Canonicalize splat ttnn.constant to ttnn.full

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3073,6 +3073,7 @@ def TTNN_ConstantOp : TTNN_CreationOp<"constant", [AllShapesMatch<["value", "res
       }
     }];
 
+    let hasCanonicalizer = 1;
     let hasVerifier = 1;
 }
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTIR/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsInterfaces.cpp.inc"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
@@ -23,6 +24,7 @@
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
 #include "mlir/Dialect/Traits.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
@@ -155,6 +157,26 @@ foldConsecutiveDataCastOps(T op, ::mlir::PatternRewriter &rewriter) {
   }
 
   return success();
+}
+
+// ConstantOp canonicalization
+void mlir::tt::ttnn::ConstantOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *) {
+  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape): false positive from
+  // ttnn.full's OperationState builder (cf. D2MDialect.cpp). Directive, not a
+  // comment -- do not remove.
+  patterns.add(
+      +[](mlir::tt::ttnn::ConstantOp op, mlir::PatternRewriter &rewriter) {
+        mlir::Attribute fillValueAttr =
+            mlir::tt::ttir::utils::splatToFillValue(rewriter, op.getValue());
+        if (!fillValueAttr) {
+          return mlir::failure();
+        }
+        rewriter.replaceOpWithNewOp<mlir::tt::ttnn::FullOp>(
+            op, op.getType(), fillValueAttr, op.getDevice());
+        return mlir::success();
+      });
+  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
 }
 
 //===----------------------------------------------------------------------===//
@@ -1258,6 +1280,7 @@ verifyPoolingOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
     return emitOpError("Step cannot be zero.");
   }
 
+  // NOLINTNEXTLINE(clang-analyzer-core.DivideZero): guarded above
   int64_t numValues = (getEnd() - getStart()) / getStep();
 
   if (numValues <= 0) {

--- a/test/ttmlir/Silicon/TTNN/n150/creation/constant/splat_constant.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/creation/constant/splat_constant.mlir
@@ -1,0 +1,29 @@
+
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --canonicalize -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+#system_memory = #ttnn.buffer_type<system_memory>
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout_host_rm_bf16 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xbf16, #system_memory>>
+#ttnn_layout_device_tile_bf16 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+module attributes {} {
+    // Splat constant created on host (row-major).
+    func.func @const_splat_host() -> tensor<32x32xbf16, #ttnn_layout_host_rm_bf16> {
+        // CHECK-LABEL: func.func @const_splat_host
+        // CHECK: ttnn.full
+        // CHECK-NOT: ttnn.constant
+        %0 = "ttnn.constant"() <{value = dense<2.000000e+00> : tensor<32x32xbf16>, layout = #ttnn.layout<row_major>}> : () -> tensor<32x32xbf16, #ttnn_layout_host_rm_bf16>
+        return %0 : tensor<32x32xbf16, #ttnn_layout_host_rm_bf16>
+    }
+
+    // Splat constant created on device (tile layout) — the shape produced by
+    // const-eval hoisting that triggered the original crash.
+    func.func @const_splat_device_tile() -> tensor<32x32xbf16, #ttnn_layout_device_tile_bf16> {
+        // CHECK-LABEL: func.func @const_splat_device_tile
+        // CHECK: ttnn.full
+        // CHECK-NOT: ttnn.constant
+        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+        %1 = "ttnn.constant"(%0) <{value = dense<2.000000e+00> : tensor<32x32xbf16>, layout = #ttnn.layout<tile>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_device_tile_bf16>
+        return %1 : tensor<32x32xbf16, #ttnn_layout_device_tile_bf16>
+    }
+}


### PR DESCRIPTION
Closes #8926

### Problem
Running certain models (e.g. Ministral-8B, Gemma) crashed at flatbuffer load with `Invalid data size` / `Bad StatusOr Error code 13`.
Root cause: a **splat**-valued `ttnn.constant` (every element identical) stores only a single element in its `DenseElementsAttr` (`getRawData()` returns one element). The flatbuffer serializer wrote that one element while the tensor descriptor reported `numElements`, so the runtime's size check (`numElements * elementSize == buffer size`) failed at load.


### Fix
`ttnn.constant` is a tt-mlir-only op that embeds its full dense payload into the flatbuffer. `ttnn.full` expresses the same tensor with just a scalar fill value + shape, lowers directly to `ttnn::full`, and embeds no data, so it is both
smaller and immune to the size-check bug.
This adds a canonicalization on `ttnn.constant` that rewrites a splat to `ttnn.full`, mirroring the existing `ttir.constant` → `ttir.full` canonicalizer. The TTIR-level rewrite already covers constants from the normal frontend path; this handles splat `ttnn.constant` ops that appear *after* TTIR→TTNN conversion (e.g. materialized by const eval hoisting) and never went through it, the case that triggered the crash. A `canonicalize` pass runs after the final const-eval hoist, so these are rewritten before serialization.
The earlier serialize-side splat expansion (embedding the full replicated tensor) is therefore no longer needed and is reverted.

### Testing
- Updated `test/ttmlir/Silicon/TTNN/n150/creation/constant/splat_constant.mlir` to assert splat `ttnn.constant` → `ttnn.full` (host row-major + device tile).
- Verified locally: canonicalization fires on both cases; `dense_resource` / non-splat constants correctly remain `ttnn.constant` (`layout_to_creation_ops_canonicalizer`, `const-eval`, negative verifier
  tests all pass).
- End-to-end on-device validation via tt-xla vLLM nightly with this commit as `mlir_override` (Ministral-8B / Gemma warmup no longer crashes).