### PR TITLE
Make decode RoPE/QKV fusing recognize the canonicalizer-folded permute

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Fusing/DecodeLayoutTransform.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Fusing/DecodeLayoutTransform.h
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_FUSING_DECODELAYOUTTRANSFORM_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_FUSING_DECODELAYOUTTRANSFORM_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+
+#include <optional>
+
+namespace mlir::tt::ttnn::fusing {
+
+// The decode head-split layout transform maps BHSD with seq == 1 ([B,H,1,D])
+// to decode layout [1,B,H,D] (i.e. SBHD with S == 1). Because the moved axis
+// (seq) has size 1, the transform reorders no data and is therefore
+// layout-preserving. It can be expressed either as:
+//   - ttnn.permute {permutation = [2,0,1,3]}, or
+//   - an equivalent ttnn.reshape producing [1,B,H,D]. Its input is either the
+//     4D BHSD form [B,H,1,D] (e.g. a RoPE output) or the folded 2D slice form
+//     [B, H*D] (when the canonicalizer merges the to-heads reshape with the
+//     permute).
+//
+// A pre-fusing canonicalizer folds the layout-preserving permute into the
+// adjacent reshape, so the decode-fusing patterns must treat both forms as the
+// same logical operation. This recognizer is the single place that encodes that
+// equivalence.
+struct DecodeLayoutMatch {
+  RankedTensorType resultType; // The [1, B, H, D] result type.
+  int64_t batch;
+  int64_t numHeads;
+  int64_t headDim;
+};
+
+// Returns a match if `op` realizes the decode layout transform [B,H,1,D] ->
+// [1,B,H,D], expressed as permute {2,0,1,3} or an equivalent reshape. Returns
+// nullopt otherwise.
+inline std::optional<DecodeLayoutMatch>
+matchDecodeLayoutTransform(mlir::Operation *op) {
+  // The result of the transform must be rank-4 decode layout [1, B, H, D].
+  auto asDecodeResult =
+      [](RankedTensorType resultType) -> std::optional<DecodeLayoutMatch> {
+    auto shape = resultType.getShape();
+    if (shape.size() != 4 || shape[0] != 1) {
+      return std::nullopt;
+    }
+    return DecodeLayoutMatch{resultType, shape[1], shape[2], shape[3]};
+  };
+
+  if (auto permuteOp = mlir::dyn_cast<PermuteOp>(op)) {
+    auto inShape =
+        mlir::cast<RankedTensorType>(permuteOp.getInput().getType()).getShape();
+    // Input must be BHSD with seq (dim 2) == 1.
+    if (inShape.size() != 4 || inShape[2] != 1) {
+      return std::nullopt;
+    }
+    if (permuteOp.getPermutation() != llvm::ArrayRef<int64_t>{2, 0, 1, 3}) {
+      return std::nullopt;
+    }
+    return asDecodeResult(permuteOp.getType());
+  }
+
+  if (auto reshapeOp = mlir::dyn_cast<ReshapeOp>(op)) {
+    std::optional<DecodeLayoutMatch> match =
+        asDecodeResult(reshapeOp.getType());
+    if (!match) {
+      return std::nullopt;
+    }
+    auto inShape =
+        mlir::cast<RankedTensorType>(reshapeOp.getInput().getType()).getShape();
+    int64_t b = match->batch;
+    int64_t h = match->numHeads;
+    int64_t d = match->headDim;
+    // 4D BHSD source [B, H, 1, D]: a reshape from this to [1,B,H,D] preserves
+    // row-major element order, so it is exactly permute {2,0,1,3}.
+    bool from4D = inShape.size() == 4 && inShape[0] == b && inShape[1] == h &&
+                  inShape[2] == 1 && inShape[3] == d;
+    // Folded 2D slice source [B, H*D] (seq == 1): the canonicalizer merged the
+    // to-heads reshape ([B,H*D] -> [B,H,1,D]) and the permute into one reshape.
+    bool from2D = inShape.size() == 2 && inShape[0] == b && inShape[1] == h * d;
+    if (!from4D && !from2D) {
+      return std::nullopt;
+    }
+    return match;
+  }
+
+  return std::nullopt;
+}
+
+} // namespace mlir::tt::ttnn::fusing
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_FUSING_DECODELAYOUTTRANSFORM_H

--- a/include/ttmlir/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.h
@@ -66,6 +66,23 @@ public:
                   mlir::PatternRewriter &rewriter) const override;
 };
 
+// Same as RoPEDecodeFusing, but rooted on the canonicalized (folded) form of
+// the decode permute: a layout-preserving reshape (BHSD with seq == 1 ->
+// SBHD). A canonicalizer that runs before fusing folds the layout-preserving
+// permute {2,0,1,3} into the adjacent reshape, so this sibling recognizes that
+// reshape and applies the same decode rewrite.
+//
+// Matches:  rotary_embedding(x, cos, sin) -> reshape {[1,B,H,D]}
+// Produces: permute(x, {2, 0, 1, 3}) -> rotary_embedding(..., token_index=0)
+class RoPEDecodeReshapeFusing : public mlir::OpRewritePattern<ReshapeOp> {
+public:
+  using OpRewritePattern<ReshapeOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReshapeOp reshapeOp,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
 } // namespace mlir::tt::ttnn::fusing
 
 #endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_FUSING_ROPEFUSINGPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
@@ -6,6 +6,7 @@
 
 #include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Fusing/DecodeLayoutTransform.h"
 #include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/RotaryEmbeddingOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
@@ -1040,27 +1041,20 @@ RoPEExpandedFusing::matchAndRewrite(ConcatOp srcOp,
 // RoPEDecodeFusing
 // =============================================================================
 
-mlir::LogicalResult
-RoPEDecodeFusing::matchAndRewrite(PermuteOp permuteOp,
-                                  mlir::PatternRewriter &rewriter) const {
-  auto ropeOp = permuteOp.getInput().getDefiningOp<RotaryEmbeddingOp>();
-  if (!ropeOp) {
-    return failure();
-  }
-
+// Shared body for the decode RoPE rewrite. `layoutOp` is the decode layout
+// transform consuming the RoPE result (a permute or its folded reshape form);
+// it is replaced by a decode-mode RoPE whose input has `perm` applied first.
+static mlir::LogicalResult
+applyRoPEDecodeRewrite(mlir::Operation *layoutOp, RotaryEmbeddingOp ropeOp,
+                       llvm::ArrayRef<int64_t> perm,
+                       mlir::PatternRewriter &rewriter) {
   // Already in decode mode.
   if (ropeOp.getTokenIndex()) {
     return failure();
   }
 
-  // RoPE result must feed only into this permute.
+  // RoPE result must feed only into this layout transform.
   if (!ropeOp.getResult().hasOneUse()) {
-    return failure();
-  }
-
-  // Permutation must be 4D and put S axis (dim 2 in BHSD) at position 0.
-  auto perm = permuteOp.getPermutation();
-  if (perm.size() != 4 || perm[0] != 2) {
     return failure();
   }
 
@@ -1076,7 +1070,7 @@ RoPEDecodeFusing::matchAndRewrite(PermuteOp permuteOp,
     return failure();
   }
 
-  op_model::ScopedSingletonDeviceGuard deviceGuard(permuteOp.getOperation());
+  op_model::ScopedSingletonDeviceGuard deviceGuard(layoutOp);
 
   // Create pre-permute on the original RoPE input: BHSD -> permuted order.
   auto prePermute = ttir_to_ttnn::utils::generatePermute(
@@ -1122,10 +1116,44 @@ RoPEDecodeFusing::matchAndRewrite(PermuteOp permuteOp,
     }
   }
 
-  // Replace the permute's uses with the new RoPE result.
+  // Replace the layout transform's uses with the new RoPE result.
   // The old RoPE op becomes dead and is cleaned up by the rewriter.
-  rewriter.replaceOp(permuteOp, newRope.getResult());
+  rewriter.replaceOp(layoutOp, newRope.getResult());
   return success();
+}
+
+mlir::LogicalResult
+RoPEDecodeFusing::matchAndRewrite(PermuteOp permuteOp,
+                                  mlir::PatternRewriter &rewriter) const {
+  auto ropeOp = permuteOp.getInput().getDefiningOp<RotaryEmbeddingOp>();
+  if (!ropeOp) {
+    return failure();
+  }
+
+  // Permutation must be 4D and put S axis (dim 2 in BHSD) at position 0.
+  auto perm = permuteOp.getPermutation();
+  if (perm.size() != 4 || perm[0] != 2) {
+    return failure();
+  }
+
+  return applyRoPEDecodeRewrite(permuteOp, ropeOp, perm, rewriter);
+}
+
+mlir::LogicalResult RoPEDecodeReshapeFusing::matchAndRewrite(
+    ReshapeOp reshapeOp, mlir::PatternRewriter &rewriter) const {
+  auto ropeOp = reshapeOp.getInput().getDefiningOp<RotaryEmbeddingOp>();
+  if (!ropeOp) {
+    return failure();
+  }
+
+  // The reshape must be the canonicalized (folded) form of permute {2,0,1,3}:
+  // a layout-preserving BHSD ([B,H,1,D]) -> decode layout ([1,B,H,D]) reshape.
+  if (!matchDecodeLayoutTransform(reshapeOp.getOperation())) {
+    return failure();
+  }
+
+  return applyRoPEDecodeRewrite(reshapeOp, ropeOp,
+                                /*perm=*/{2, 0, 1, 3}, rewriter);
 }
 
 } // namespace mlir::tt::ttnn::fusing

--- a/lib/Dialect/TTNN/Transforms/Fusing/SplitQKVFusingPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/SplitQKVFusingPatterns.cpp
@@ -4,7 +4,9 @@
 
 #include "ttmlir/Dialect/TTNN/Transforms/Fusing/SplitQKVFusingPatterns.h"
 
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Fusing/DecodeLayoutTransform.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -50,13 +52,33 @@ struct SliceReshapeMatch {
   SliceStaticOp sliceOp;
   ReshapeOp reshapeOp;
   PermuteOp permuteOp; // nullptr if absent
+  // Set when reshapeOp is the canonicalized (folded) form of the decode permute
+  // [2,0,1,3]: a layout-preserving reshape straight to decode layout [1,B,H,D].
+  // The pre-fusing canonicalizer folds the to-heads reshape and the permute
+  // into a single reshape for the value chain (which has no RoPE between them).
+  // In that case getFinalType() reports the equivalent BHSD type [B,H,1,D] so
+  // the rest of the pattern reasons in a single (BHSD) layout, and the explicit
+  // decode permute is re-materialized on the fused split output.
+  bool decodePermuteFolded = false;
+  int64_t decodeBatch = 0;
+  int64_t decodeNumHeads = 0;
+  int64_t decodeHeadDim = 0;
 
   Operation *getFinalOp() {
     return permuteOp ? permuteOp.getOperation() : reshapeOp.getOperation();
   }
 
   RankedTensorType getFinalType() {
-    return permuteOp ? permuteOp.getType() : reshapeOp.getType();
+    if (permuteOp) {
+      return permuteOp.getType();
+    }
+    if (decodePermuteFolded) {
+      // Equivalent pre-permute BHSD type [B,H,1,D].
+      return utils::RankedTensorTypeFactory::create(
+          reshapeOp.getType(),
+          SmallVector<int64_t>{decodeBatch, decodeNumHeads, 1, decodeHeadDim});
+    }
+    return reshapeOp.getType();
   }
 };
 
@@ -447,7 +469,24 @@ matchSliceReshapeChains(MatMulOpType matmulOp) {
       }
     }
 
-    matches.push_back({sliceOp, reshapeOp, permuteOp});
+    // When no permute follows, the reshape may itself be the canonicalized
+    // (folded) decode layout transform [B,H,1,D] -> [1,B,H,D] (the permute was
+    // folded in by the pre-fusing canonicalizer). Record it so validation and
+    // dim extraction treat it as the equivalent BHSD chain.
+    bool decodePermuteFolded = false;
+    int64_t decodeBatch = 0, decodeNumHeads = 0, decodeHeadDim = 0;
+    if (!permuteOp) {
+      if (std::optional<DecodeLayoutMatch> decodeMatch =
+              matchDecodeLayoutTransform(reshapeOp.getOperation())) {
+        decodePermuteFolded = true;
+        decodeBatch = decodeMatch->batch;
+        decodeNumHeads = decodeMatch->numHeads;
+        decodeHeadDim = decodeMatch->headDim;
+      }
+    }
+
+    matches.push_back({sliceOp, reshapeOp, permuteOp, decodePermuteFolded,
+                       decodeBatch, decodeNumHeads, decodeHeadDim});
   }
 
   return matches;
@@ -533,6 +572,13 @@ bool validateSliceCoverage(MatMulOpType matmulOp,
 //                                       data)
 bool validateReshapeLayouts(SmallVector<SliceReshapeMatch> &matches) {
   for (auto &m : matches) {
+    // The folded decode form is a recognized layout-preserving transform
+    // (slice [B,H*D] -> reshape [1,B,H,D], seq == 1); it is valid by
+    // construction and its effective layout is BHSD (see getFinalType).
+    if (m.decodePermuteFolded) {
+      continue;
+    }
+
     auto sliceShape = m.sliceOp.getType().getShape();
     auto reshapeShape = m.reshapeOp.getType().getShape();
     if (reshapeShape.size() != 4) {
@@ -676,12 +722,26 @@ mlir::LogicalResult createFusedOp(mlir::PatternRewriter &rewriter,
         .getResult();
   };
 
-  rewriter.replaceOp(q.match.getFinalOp(),
-                     maybeTypecast(splitOp.getQuery(), q.match.getFinalType()));
-  rewriter.replaceOp(k.match.getFinalOp(),
-                     maybeTypecast(splitOp.getKey(), k.match.getFinalType()));
-  rewriter.replaceOp(v.match.getFinalOp(),
-                     maybeTypecast(splitOp.getValue(), v.match.getFinalType()));
+  // Replace each matched chain with the corresponding split output. The split
+  // op produces BHSD [B,H,1,D] outputs. For a chain whose decode permute was
+  // folded into its reshape (decodePermuteFolded), re-materialize the explicit
+  // permute [2,0,1,3] so the consumer keeps decode layout [1,B,H,D] and
+  // NLPCreateQKVHeadsDecodeFusing can match it (the same canonical form the
+  // non-folded chains already have).
+  auto replaceHead = [&](QKVHead &head, Value splitResult) {
+    Value result = maybeTypecast(splitResult, head.match.getFinalType());
+    if (head.match.decodePermuteFolded) {
+      result = ttir_to_ttnn::utils::generatePermute(
+                   mlir::cast<TypedValue<RankedTensorType>>(result),
+                   /*permutation=*/{2, 0, 1, 3}, rewriter, matmulOp.getLoc())
+                   .getResult();
+    }
+    rewriter.replaceOp(head.match.getFinalOp(), result);
+  };
+
+  replaceHead(q, splitOp.getQuery());
+  replaceHead(k, splitOp.getKey());
+  replaceHead(v, splitOp.getValue());
 
   return mlir::success();
 }

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -376,6 +376,9 @@ public:
       // TODO(sdjordjevic): #8598 Decouple NLPCreateQKVHeadsDecodeFusing from
       // RoPEDecodeFusing
       patterns.add<fusing::RoPEDecodeFusing>(&getContext());
+      // Sibling that matches the canonicalized (folded reshape) form of the
+      // decode permute the same RoPEDecodeFusing handles.
+      patterns.add<fusing::RoPEDecodeReshapeFusing>(&getContext());
       patterns.add<fusing::SDPAFusing>(&getContext(), validationConfig);
       patterns.add<NLPConcatHeadsDecodeFusing>(&getContext());
       patterns.add<fusing::SplitQueryKeyValueAndSplitHeadsFusing<MatmulOp>>(

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/rotary_embedding/rope_decode_folded_reshape.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/rotary_embedding/rope_decode_folded_reshape.mlir
@@ -1,0 +1,33 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% optimization-level=1" %s | FileCheck %s
+
+// RoPEDecodeFusing must recognize the decode layout transform (BHSD -> SBHD,
+// seq == 1) whether it is expressed as permute [2,0,1,3] or as the equivalent
+// layout-preserving reshape that the pre-fusing canonicalizer folds it into.
+//
+// Here the RoPE output is reshaped (not permuted) to [1,32,8,64]. The decode
+// fusing must still fire, producing a decode-mode rotary_embedding (token_index).
+
+module {
+  // CHECK-LABEL: @rope_decode_with_output_reshape
+  // CHECK: "ttnn.rotary_embedding"
+  // CHECK-SAME: token_index
+  func.func @rope_decode_with_output_reshape(%x: tensor<32x8x1x64xbf16>, %cos: tensor<1x1x1x64xbf16>, %sin: tensor<1x1x1x64xbf16>) -> tensor<1x32x8x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos) <{broadcast_dimensions = array<i64: 32, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+    %x_cos = "ttir.multiply"(%x, %cos_bc) : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+
+    %x_hi = "ttir.slice_static"(%x) <{begins = [0 : i32, 0 : i32, 0 : i32, 32 : i32], ends = [32 : i32, 8 : i32, 1 : i32, 64 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<32x8x1x64xbf16>) -> tensor<32x8x1x32xbf16>
+    %neg_hi = "ttir.neg"(%x_hi) : (tensor<32x8x1x32xbf16>) -> tensor<32x8x1x32xbf16>
+    %x_lo = "ttir.slice_static"(%x) <{begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32], ends = [32 : i32, 8 : i32, 1 : i32, 32 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<32x8x1x64xbf16>) -> tensor<32x8x1x32xbf16>
+    %rotated = "ttir.concat"(%neg_hi, %x_lo) <{dim = 3 : si32}> : (tensor<32x8x1x32xbf16>, tensor<32x8x1x32xbf16>) -> tensor<32x8x1x64xbf16>
+
+    %sin_bc = "ttir.broadcast"(%sin) <{broadcast_dimensions = array<i64: 32, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+    %rot_sin = "ttir.multiply"(%rotated, %sin_bc) : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+    %rope = "ttir.add"(%x_cos, %rot_sin) : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+
+    // Layout-preserving reshape BHSD -> SBHD (seq == 1): the canonicalized form
+    // of permute [2,0,1,3].
+    %result = "ttir.reshape"(%rope) <{shape = [1 : i32, 32 : i32, 8 : i32, 64 : i32]}> : (tensor<32x8x1x64xbf16>) -> tensor<1x32x8x64xbf16>
+    return %result : tensor<1x32x8x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/split_qkv/split_qkv_decode.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/split_qkv/split_qkv_decode.mlir
@@ -1,0 +1,13 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% optimization-level=1" %models/single_blocks_and_layers/qwen_2_5_0_5b_decode_layer.mlir | FileCheck %s
+
+// Decode attention fusing on a real single-layer model IR.
+//
+// The decode head-split chain (RoPEDecodeFusing -> SplitQueryKeyValueAndSplitHeads
+// -> NLPCreateQKVHeadsDecode) is anchored on the layout-preserving permute
+// [2,0,1,3] (BHSD -> SBHD, seq == 1). The canonicalizer that runs before
+// ttnn-fusing folds that permute into the adjacent reshape, so the fusing
+// patterns must recognize the folded reshape form as well. This test guards
+// that the decode op is still produced from the canonicalized IR.
+
+// CHECK: ttnn.nlp_create_qkv_heads_decode


### PR DESCRIPTION
### Ticket
Closes #8907

### Problem Description

A canonicalizer that runs before `ttnn-fusing` folds layout-preserving `ttnn.permute {[2,0,1,3]}` ops (they only reorder the unit seq dim in the decode case, S=1) into the adjacent `ttnn.reshape`. The three patterns that build the decode attention op are all anchored on that explicit permute:

- `RoPEDecodeFusing` — `OpRewritePattern<PermuteOp>`, the root of the decode chain (rewrites `rotary → permute` into `permute → rotary(decode)`).
- `SplitQueryKeyValueAndSplitHeadsFusing` — matches `matmul → slice → reshape → permute`; `validateReshapeLayouts` keys on the permute.
- `NLPCreateQKVHeadsDecodeFusing` — requires each split output consumed by `permute[2,0,1,3]`.

With the permutes folded away, `RoPEDecodeFusing` no longer fires and the whole chain collapses, so decode models stop emitting `ttnn.nlp_create_qkv_heads_decode` (observed on Qwen2.5: 24 → 0).

### What's changed

This PR teaches the fusing to treat the folded reshape and the explicit permute as the same logical operation, via a single shared recognizer:

- **New `DecodeLayoutTransform.h`** — `matchDecodeLayoutTransform()` recognizes the decode transform `[B,H,1,D] → [1,B,H,D]` whether expressed as `permute[2,0,1,3]` or the equivalent folded reshape (4D `[B,H,1,D]` or folded 2D `[B, H*D]` input).
- **`RoPEDecodeFusing`** — body extracted into a shared helper; added a sibling `RoPEDecodeReshapeFusing` rooted on `ReshapeOp`. This alone fixes the Q/K chains (they re-materialize the explicit pre-permute).
- **`SplitQueryKeyValueAndSplitHeadsFusing`** — the value chain's folded reshape is recognized (`decodePermuteFolded`), normalized to BHSD for validation and dim extraction, and the explicit `permute[2,0,1,3]` is re-materialized on the fused split output so `NLPCreateQKVHeadsDecodeFusing` matches unchanged.

The prefill path (`permute[0,2,1,3]`, non-unit dims, never folds) is unaffected.

### Checklist
- [x] New/Existing tests provide coverage for changes
