### PR TITLE
Enable optimizer sharding builder tests (conv2d, rms_norm)

### DIFF
--- a/test/python/golden/optimizer/test_conv_sharding.py
+++ b/test/python/golden/optimizer/test_conv_sharding.py
@@ -32,9 +32,6 @@ def check_sharded_input_output(mlir_file: str, op_name: str):
     return False
 
 
-@pytest.mark.skip(
-    "Causes segfault during pipeline, see https://github.com/tenstorrent/tt-mlir/issues/5283"
-)
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -83,6 +80,7 @@ def test_conv2d_sharding(
         module,
         **get_request_kwargs(request),
         device=device,
+        save_artifacts=True,
         pipeline_options=[
             "optimization-level=2",
         ],

--- a/test/python/golden/optimizer/test_conv_sharding.py
+++ b/test/python/golden/optimizer/test_conv_sharding.py
@@ -76,11 +76,15 @@ def test_conv2d_sharding(
                 unit_attrs=unit_attrs,
             )
 
+    # The sharding assertion below reads ttnn_compiled.mlir, which is only
+    # written when save_artifacts is enabled. Override the key in place so we
+    # don't collide with a save_artifacts already injected by --save-artifacts.
+    kwargs = get_request_kwargs(request)
+    kwargs["save_artifacts"] = True
     output_file_mlir = compile_and_execute_ttir(
         module,
-        **get_request_kwargs(request),
+        **kwargs,
         device=device,
-        save_artifacts=True,
         pipeline_options=[
             "optimization-level=2",
         ],

--- a/test/python/golden/optimizer/test_ttir_rmsnorm_sharding.py
+++ b/test/python/golden/optimizer/test_ttir_rmsnorm_sharding.py
@@ -86,11 +86,15 @@ def test_rmsnorm_sharding(
             )
             return result
 
+    # The sharding assertion below reads ttnn_compiled.mlir, which is only
+    # written when save_artifacts is enabled. Override the key in place so we
+    # don't collide with a save_artifacts already injected by --save-artifacts.
+    kwargs = get_request_kwargs(request)
+    kwargs["save_artifacts"] = True
     output_file_mlir = compile_and_execute_ttir(
         module,
-        **get_request_kwargs(request),
+        **kwargs,
         device=device,
-        save_artifacts=True,
         pipeline_options=[
             "optimization-level=2",
         ],

--- a/test/python/golden/optimizer/test_ttir_rmsnorm_sharding.py
+++ b/test/python/golden/optimizer/test_ttir_rmsnorm_sharding.py
@@ -13,12 +13,8 @@ from builder.base.builder_apis import compile_and_execute_ttir
 from builder.ttir.ttir_builder import TTIRBuilder
 from conftest import get_request_kwargs
 
-# Temporarily disabled: RMSNorm with sharded input causes crash in metal.
 pytestmark = [
     pytest.mark.frontend("ttir"),
-    pytest.mark.skip(
-        reason="Temporarily disabled: RMSNorm sharding causes crash in metal"
-    ),
 ]
 
 
@@ -39,9 +35,6 @@ def check_sharded_output(mlir_file: str, op_name: str):
     return False
 
 
-@pytest.mark.skip(
-    "Causes segfault during pipeline, see https://github.com/tenstorrent/tt-mlir/issues/5283"
-)
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -97,6 +90,7 @@ def test_rmsnorm_sharding(
         module,
         **get_request_kwargs(request),
         device=device,
+        save_artifacts=True,
         pipeline_options=[
             "optimization-level=2",
         ],


### PR DESCRIPTION
### Ticket
Closes #5909, closes #5283

### Problem description
The TTIR builder segfaulted when the optimizer was enabled, because the optimizer needs device access (`getOpConstraints`/OpModel) that the Python TTIR→TTNN pipeline couldn't provide. This blocked end-to-end tests with optimizer + sharding, so `test_conv2d_sharding` and `test_rmsnorm_sharding` were skipped.

### What changed
The mock-device integration (#6719) resolved the root cause: `DevicePassesWrapper` now auto-opens a mock device for constraint queries, so `optimization-level>=1` no longer segfaults from Python.

- **Remove the `@pytest.mark.skip` decorators.** The conv2d segfault is fixed, and the rms_norm "crash in metal" no longer reproduces — the greedy optimizer (default at opt-level ≥ 1 since #7889) width-shards `rms_norm` and it executes correctly on device.
- **Add `save_artifacts=True` to the `compile_and_execute_ttir` calls.** The `check_sharded_*` helpers open `ttnn_compiled.mlir`, which is only written when `save_artifacts=True` (`builder_utils.py`). Without it the tests fail with `FileNotFoundError`. This latent harness bug was never caught because the tests had been skipped since creation.

### Verification
Both tests pass on **n150 silicon** with `optimization-level=2` and `--require-opmodel`:

| Test | Result | Golden PCC |
|------|--------|------------|
| `test_conv2d_sharding` | ✅ PASSED | ~0.9999986 |
| `test_rmsnorm_sharding` | ✅ PASSED | ~0.9999997 |

These run in the existing CI lane (`tests.json`: `test/python/golden/optimizer` on n150/`speedy` with `require-opmodel`), which already builds with `TTMLIR_ENABLE_OPMODEL=ON`.

### Follow-ups (not in this PR)
- The `RMSNormOp` exclusion in `DFShardingPolicy.cpp` `validForSharding` is now dead code on the default (greedy) path.
- `TestRMSNormWidthSharded` (`EXPECT_DEATH` gtest) is stale — it aborts on an unrelated MLIR grid assertion during setup rather than the metal FPE it was meant to guard.
- Consider fixing the harness so sharding-assertion tests don't silently depend on `save_artifacts=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)