### PR TITLE
Fold topk when the reduced dimension has width 1

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6347,6 +6347,7 @@ def TTIR_TopKOp : TTIR_NamedOp<"topk"> {
                       AnyRankedTensor:$indices);
 
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def TTIR_TopKRouterGptOp : TTIR_NamedOp<"topk_router_gpt"> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -6585,6 +6585,36 @@ void mlir::tt::ttir::ProdOp::getCanonicalizationPatterns(
   return success();
 }
 
+// TopKOp canonicalization
+void mlir::tt::ttir::TopKOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *) {
+
+  // A top-k over a dimension of size 1 is a no-op: there is only one element to
+  // select, so the values equal the input and the indices are always zero.
+  // Fold it away so downstream consumers of the (constant) indices can be
+  // constant-evaluated.
+  patterns.add(+[](mlir::tt::ttir::TopKOp op, mlir::PatternRewriter &rewriter) {
+    RankedTensorType inputType = op.getInputTensor().getType();
+    int64_t inputRank = inputType.getRank();
+    int32_t dim = op.getDim();
+    int64_t normalizedDim = dim < 0 ? dim + inputRank : dim;
+
+    if (inputType.getDimSize(normalizedDim) != 1) {
+      return failure();
+    }
+
+    // The values output equals the input (only one element along the reduced
+    // dimension). The verifier guarantees K == 1 here, so shapes match.
+    RankedTensorType indicesType = op.getIndices().getType();
+    auto zeros = rewriter.create<mlir::tt::ttir::ZerosOp>(
+        op.getLoc(), indicesType,
+        llvm::to_vector_of<int32_t>(indicesType.getShape()));
+
+    rewriter.replaceOp(op, {op.getInputTensor(), zeros.getResult()});
+    return success();
+  });
+}
+
 //===----------------------------------------------------------------------===//
 // TopKRouterGptOp
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/TTIR/canonicalize/topk_width_one_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/topk_width_one_fold_tests.mlir
@@ -1,0 +1,31 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// topk with k=1 over a dimension of size 1 is a no-op: values == input and
+// indices are always zero. Verify it folds away.
+func.func @topk_fold_width_one(%arg0: tensor<8x1xbf16>) -> (tensor<8x1xbf16>, tensor<8x1xui16>) {
+  // CHECK-LABEL: func.func @topk_fold_width_one
+  // CHECK-NOT: "ttir.topk"
+  // CHECK: %[[ZEROS:.*]] = "ttir.zeros"() <{shape = array<i32: 8, 1>}> : () -> tensor<8x1xui16>
+  // CHECK: return %arg0, %[[ZEROS]]
+  %values, %indices = "ttir.topk"(%arg0) {k = 1 : i32, dim = -1 : i32} : (tensor<8x1xbf16>) -> (tensor<8x1xbf16>, tensor<8x1xui16>)
+  return %values, %indices : tensor<8x1xbf16>, tensor<8x1xui16>
+}
+
+// Same case but with the reduced dim spelled as a positive index.
+func.func @topk_fold_width_one_positive_dim(%arg0: tensor<4x1xf32>) -> (tensor<4x1xf32>, tensor<4x1xi32>) {
+  // CHECK-LABEL: func.func @topk_fold_width_one_positive_dim
+  // CHECK-NOT: "ttir.topk"
+  // CHECK: %[[ZEROS:.*]] = "ttir.zeros"() <{shape = array<i32: 4, 1>}> : () -> tensor<4x1xi32>
+  // CHECK: return %arg0, %[[ZEROS]]
+  %values, %indices = "ttir.topk"(%arg0) {k = 1 : i32, dim = 1 : i32} : (tensor<4x1xf32>) -> (tensor<4x1xf32>, tensor<4x1xi32>)
+  return %values, %indices : tensor<4x1xf32>, tensor<4x1xi32>
+}
+
+// Negative: reduced dim has size > 1, must NOT fold.
+func.func @topk_no_fold_wide_dim(%arg0: tensor<8x128xbf16>) -> (tensor<8x1xbf16>, tensor<8x1xui16>) {
+  // CHECK-LABEL: func.func @topk_no_fold_wide_dim
+  // CHECK: "ttir.topk"
+  %values, %indices = "ttir.topk"(%arg0) {k = 1 : i32, dim = -1 : i32} : (tensor<8x128xbf16>) -> (tensor<8x1xbf16>, tensor<8x1xui16>)
+  return %values, %indices : tensor<8x1xbf16>, tensor<8x1xui16>
+}


### PR DESCRIPTION
### Ticket
Closes #8927

### Summary
Adds a canonicalization pattern to ttir.topk that folds the op away when the dimension being reduced has size 1. In that case the op is a no-op: there is only a single element to select, so the values output equals the input and the indices output is always zero.

### Motivation
In GLM 4.7's router group mask, we have:


topk<k=1, dim=-1> ([B,1]) -> [B,1]
which always outputs zeros([B,1]) for the indices. Folding this replaces the indices with a constant ttir.zeros, which lets the const-eval pass hoist that part of the graph — enabling the consteval described in [tt-xla#5427](https://github.com/tenstorrent/tt-xla/issues/5427).

### Changes
TTIR_TopKOp: enabled hasCanonicalizer.

Implemented TopKOp::getCanonicalizationPatterns: when the (dim-normalized) reduced dimension has size 1, replace

values → the input tensor (identity), and
indices → a ttir.zeros of the op's declared indices type.
The zeros type is derived from op.getIndices().getType(), so the original index dtype (ui16/ui32/i32/i64) is preserved verbatim. The verifier already guarantees k ≤ dimSize, so k == 1 in the folded case and all shapes/types match.

### Checklist
- [ ] New/Existing tests provide coverage for changes
