### PR TITLE
[D2M-JIT] Reuse disjoint CB ports

### DIFF
--- a/include/ttmlir/Dialect/D2M/Utils/CBUtils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/CBUtils.h
@@ -5,9 +5,11 @@
 #ifndef TTMLIR_DIALECT_D2M_UTILS_CBUTILS_H
 #define TTMLIR_DIALECT_D2M_UTILS_CBUTILS_H
 
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir::tt::d2m {
 
@@ -15,6 +17,19 @@ class GenericOp;
 
 Value getOrCreateCB(RewriterBase &rewriter, GenericOp generic, Block *block,
                     unsigned cbOperandIndex);
+
+/// Optional op attribute mapping logical generic operand indices to physical CB
+/// ports. Consumers default to identity when the attribute is absent.
+StringRef getPhysicalCBPortMapAttrName();
+void setPhysicalCBPortMap(Operation *op, ArrayRef<int64_t> logicalToPhysical);
+DenseI64ArrayAttr getPhysicalCBPortMap(Operation *op);
+int64_t getPhysicalCBPort(Operation *op, int64_t logicalOperandIdx);
+
+/// Reuse CB ports for additional CB-backed generic operands whose lifetimes do
+/// not overlap. Input/output operands are treated as fixed ports and count
+/// against `maxPhysicalCBPorts`, but are not remapped.
+void reuseDisjointCBPorts(RewriterBase &rewriter, GenericOp generic,
+                          int64_t maxPhysicalCBPorts = 32);
 
 /// Trace a value through view-like operations (subview, expand_shape, etc.)
 /// and return the defining op if it matches OpT.  Returns null otherwise.

--- a/include/ttmlir/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.h
@@ -11,9 +11,12 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Region.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+
+#include <string>
 
 namespace mlir::tt::d2m::utils {
 struct CBUsageInfo {
@@ -34,10 +37,10 @@ bool isPurelyDerivedOp(Operation *op,
 /// produce SSA results that are used outside of [start, end). Since
 /// SynchronizedRegionOp has no results, any such external uses would become
 /// invalid when the original ops are erased.
-Operation *wrapInSynchronizedRegion(RewriterBase &rewriter,
-                                    Block::iterator start, Block::iterator end,
-                                    const SmallVector<Value> &consumers,
-                                    const SmallVector<Value> &producers);
+FailureOr<Operation *> wrapInSynchronizedRegion(
+    RewriterBase &rewriter, Block::iterator start, Block::iterator end,
+    const SmallVector<Value> &consumers, const SmallVector<Value> &producers,
+    std::string *failureMessage = nullptr);
 
 /// Unwraps a SynchronizedRegionOp by hoisting its ops to the parent level.
 LogicalResult

--- a/lib/Conversion/D2MToTTKernel/CMakeLists.txt
+++ b/lib/Conversion/D2MToTTKernel/CMakeLists.txt
@@ -9,4 +9,5 @@ add_mlir_conversion_library(TTMLIRD2MToTTKernel
   MLIRIR
   MLIRPass
   MLIRD2MAnalysis
+  MLIRD2MUtils
 )

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/D2M/Analysis/CBProducerConsumer.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOpsTypes.h"
+#include "ttmlir/Dialect/D2M/Utils/CBUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
@@ -3152,7 +3153,9 @@ public:
       if (mlir::isa<ttkernel::CBType>(convertedType)) {
         // CB-backed memref (e.g. scratch buffer with CBLayoutAttr).
         // Handle identically to D2MGetCBRewriter: CBPort kernel arg.
-        arg = rewriter.getAttr<ArgAttr>(ArgType::CBPort, op.getOperandIndex());
+        int64_t physicalPort =
+            d2m::getPhysicalCBPort(entry, op.getOperandIndex());
+        arg = rewriter.getAttr<ArgAttr>(ArgType::CBPort, physicalPort);
         argResultType = convertedType;
 
         replaceOpWithKernelArg(op.getOperation(), argResultType, entry, arg,
@@ -3223,8 +3226,8 @@ public:
     // Append a CBPort entry to the parent function's ArgSpec. The operand index
     // tells the runtime which operand's buffer to associate with this CB.
     func::FuncOp entry = op->getParentOfType<func::FuncOp>();
-    ArgAttr cbArg =
-        rewriter.getAttr<ArgAttr>(ArgType::CBPort, op.getCbOperandIdx());
+    int64_t physicalPort = d2m::getPhysicalCBPort(entry, op.getCbOperandIdx());
+    ArgAttr cbArg = rewriter.getAttr<ArgAttr>(ArgType::CBPort, physicalPort);
     Type cbType = getTypeConverter()->convertType(op.getResult().getType());
 
     replaceOpWithKernelArg(op.getOperation(), cbType, entry, cbArg,
@@ -3329,9 +3332,10 @@ public:
                        SmallVectorImpl<ArgAttr> &rtArgs,
                        SmallVectorImpl<ArgAttr> &ctArgs) const {
     op.walk([&](d2m::GetCBOp getCBOp) {
-      insertKernelArg(
-          rtArgs, ctArgs,
-          builder.getAttr<ArgAttr>(ArgType::CBPort, getCBOp.getCbOperandIdx()));
+      int64_t physicalPort =
+          d2m::getPhysicalCBPort(op, getCBOp.getCbOperandIdx());
+      insertKernelArg(rtArgs, ctArgs,
+                      builder.getAttr<ArgAttr>(ArgType::CBPort, physicalPort));
     });
 
     op.walk([&](d2m::GetArgOp getArgOp) {
@@ -3339,9 +3343,11 @@ public:
       if (auto memrefType = mlir::dyn_cast<MemRefType>(argType)) {
         Type convertedType = getTypeConverter()->convertType(memrefType);
         if (mlir::isa<ttkernel::CBType>(convertedType)) {
-          insertKernelArg(rtArgs, ctArgs,
-                          builder.getAttr<ArgAttr>(ArgType::CBPort,
-                                                   getArgOp.getOperandIndex()));
+          int64_t physicalPort =
+              d2m::getPhysicalCBPort(op, getArgOp.getOperandIndex());
+          insertKernelArg(
+              rtArgs, ctArgs,
+              builder.getAttr<ArgAttr>(ArgType::CBPort, physicalPort));
           return;
         }
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Conversion/D2MToTTKernel/D2MToTTKernel.h"
+#include "ttmlir/Dialect/D2M/Utils/CBUtils.h"
 
 #include "ttmlir/Dialect/D2M/Analysis/CBProducerConsumer.h"
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
@@ -219,6 +220,7 @@ struct ConvertD2MToTTKernel
     // The d2m.thread attr is kept until the end of this pass, when body
     // rewrites have consumed nocIndex.
     funcOp->removeAttr(d2m::ThreadAttr::name);
+    funcOp->removeAttr(d2m::getPhysicalCBPortMapAttrName());
   };
 };
 } // namespace

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Support/LogicalResult.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -51,6 +52,31 @@ public:
                      ttcore::Arch arch, ttmetal::MathFidelity mathFidelity)
       : OpConversionPattern<d2m::GenericOp>(ctx), symbolTable_(&symbolTable),
         arch_(arch), mathFidelity_(mathFidelity) {}
+
+  static void collectCBOperandIndicesFromArgs(ArrayRef<ttkernel::ArgAttr> args,
+                                              DenseSet<size_t> &indices) {
+    for (ttkernel::ArgAttr arg : args) {
+      if (arg.getArgType() == ttkernel::ArgType::CBPort) {
+        indices.insert(arg.getOperandIndex());
+      }
+    }
+  }
+
+  DenseSet<size_t> collectReferencedCBOperandIndices(ArrayAttr threads) const {
+    DenseSet<size_t> indices;
+    for (Attribute threadAttr : threads) {
+      d2m::ThreadAttr thread = mlir::cast<d2m::ThreadAttr>(threadAttr);
+      auto kernelFunc = symbolTable_->lookup<func::FuncOp>(
+          thread.getKernelSymbol().getRootReference());
+      assert(kernelFunc && "thread kernel symbol must resolve");
+      auto kernelSpec = kernelFunc->getAttrOfType<ttkernel::ArgSpecAttr>(
+          ttkernel::ArgSpecAttr::name);
+      assert(kernelSpec && "thread kernel must have an ArgSpec");
+      collectCBOperandIndicesFromArgs(kernelSpec.getRtArgs(), indices);
+      collectCBOperandIndicesFromArgs(kernelSpec.getCtArgs(), indices);
+    }
+    return indices;
+  }
 
   static KernelArgsAttr
   evalKernelArgsFromSpec(Builder &builder, const SymbolTable &symbolTable,
@@ -177,6 +203,8 @@ public:
     llvm::SmallVector<Value> cbs;
     llvm::SmallVector<int64_t> cbPorts;
     DenseMap<size_t, size_t> cbOperandIndexToPort;
+    DenseSet<size_t> referencedCBOperandIndices =
+        collectReferencedCBOperandIndices(op.getThreads());
     unsigned ioSize = op.getInputsAndOutputs().size();
     for (unsigned i = 0; i < op.getAdditionalArgs().size(); ++i) {
       auto operandIndex = ioSize + i;
@@ -190,6 +218,9 @@ public:
       } else if (auto memrefType =
                      mlir::dyn_cast_if_present<MemRefType>(operand.getType());
                  memrefType) {
+        if (!referencedCBOperandIndices.contains(operandIndex)) {
+          continue;
+        }
         // Hoisted CB buffer (already converted to CreateBufferOp by
         // MemrefAllocRewriter).
         if (auto aliasOp = mlir::dyn_cast<d2m::OperandAliasOp>(

--- a/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/D2M/Utils/CBUtils.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/FunctionTypes.h"
 
@@ -170,6 +171,7 @@ public:
       materializeCoreCoordinateOperandsInPhysicalSpace(generic, builder);
 
       SmallVector<Attribute> threads;
+      Attribute physicalCBPortMap = getPhysicalCBPortMap(generic);
       auto origThreads = generic.getThreadsAttr().getValue();
       const auto chipDesc = ttcore::getOpChipDescAttr(generic);
       int unassignedDmCoreCounter = 0;
@@ -197,6 +199,9 @@ public:
                               {}));
         func.setPrivate();
         func->setAttr(d2m::ThreadAttr::name, threadAttrWithoutSym);
+        if (physicalCBPortMap) {
+          func->setAttr(getPhysicalCBPortMapAttrName(), physicalCBPortMap);
+        }
         func.getBody().takeBody(region);
         materializeCapturedConstants(func);
         ttmlir::utils::setFunctionType(func,

--- a/lib/Dialect/D2M/Transforms/HoistCBAllocs.cpp
+++ b/lib/Dialect/D2M/Transforms/HoistCBAllocs.cpp
@@ -93,26 +93,16 @@ private:
           auto newAllocOp = attachCBLayoutAttribute(rewriter, allocOp, 1);
           allocsToHoist.push_back(newAllocOp);
         } else if (allocOp->getAttr("d2m.synchronized_buffer")) {
-          if (allocOp->getAttr("d2m.compute_intermediate")) {
-            // Skip hoisting, these are fake buffers added by fusion that are
-            // guaranteed to not be used
-            if (allocOp->getAttrOfType<IntegerAttr>("address")) {
-              allocOp.emitError("compute intermediate buffer must not have "
-                                "address attribute");
-              return WalkResult::interrupt();
-            }
-          } else {
-            if (!allocOp->getAttrOfType<IntegerAttr>("address")) {
-              allocOp.emitError(
-                  "synchronized buffer must have address attribute");
-              return WalkResult::interrupt();
-            }
-            auto newAllocOp = attachCBLayoutAttribute(
-                rewriter, allocOp,
-                allocOp->getAttrOfType<IntegerAttr>("d2m.synchronized_buffer")
-                    .getInt());
-            allocsToHoist.push_back(newAllocOp);
+          if (!allocOp->getAttrOfType<IntegerAttr>("address")) {
+            allocOp.emitError(
+                "synchronized buffer must have address attribute");
+            return WalkResult::interrupt();
           }
+          auto newAllocOp = attachCBLayoutAttribute(
+              rewriter, allocOp,
+              allocOp->getAttrOfType<IntegerAttr>("d2m.synchronized_buffer")
+                  .getInt());
+          allocsToHoist.push_back(newAllocOp);
         } else {
           allocOp.emitError("unexpected alloc op: expected d2m.scratch_buffer "
                             "or d2m.synchronized_buffer attribute");

--- a/lib/Dialect/D2M/Transforms/NormalizeThreadArgs.cpp
+++ b/lib/Dialect/D2M/Transforms/NormalizeThreadArgs.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.h"
+#include "ttmlir/Dialect/D2M/Utils/CBUtils.h"
 #include "ttmlir/FunctionTypes.h"
 #include "ttmlir/Utils.h"
 
@@ -160,6 +161,8 @@ public:
           }
         }
       }
+
+      reuseDisjointCBPorts(rewriter, generic);
     });
   }
 };

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -384,8 +384,13 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
       return storedCBOperandSet.contains(loadedCBOperand);
     });
 
-    utils::wrapInSynchronizedRegion(rewriter, start, end, loadedCBOperands,
-                                    storedCBOperands);
+    std::string failureMessage;
+    FailureOr<Operation *> synchronizedOp =
+        utils::wrapInSynchronizedRegion(rewriter, start, end, loadedCBOperands,
+                                        storedCBOperands, &failureMessage);
+    if (failed(synchronizedOp)) {
+      return rewriter.notifyMatchFailure(genericOp, failureMessage);
+    }
   }
 
   return success();

--- a/lib/Dialect/D2M/Utils/CBUtils.cpp
+++ b/lib/Dialect/D2M/Utils/CBUtils.cpp
@@ -10,8 +10,196 @@
 #include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLExtras.h"
+
+#include <functional>
+#include <optional>
 
 namespace mlir::tt::d2m {
+
+namespace {
+
+constexpr StringLiteral kPhysicalCBPortMapAttrName = "d2m.physical_cb_ports";
+
+struct CBUseWindow {
+  Operation *firstUser = nullptr;
+  Operation *lastUser = nullptr;
+
+  void addUse(Operation *user) {
+    if (!firstUser || user->isBeforeInBlock(firstUser)) {
+      firstUser = user;
+    }
+    if (!lastUser || lastUser->isBeforeInBlock(user)) {
+      lastUser = user;
+    }
+  }
+
+  bool valid() const { return firstUser && lastUser; }
+};
+
+struct CBPortLifetime {
+  // These point into the generic operand list and analyzed regions. They stay
+  // valid because reuseDisjointCBPorts does not rewrite operands or
+  // erase/reorder region ops while collecting and applying the physical CB port
+  // map.
+  OpOperand *operand = nullptr;
+  Type type;
+  llvm::DenseMap<Block *, CBUseWindow> useWindows;
+  SmallVector<GetArgOp> getArgs;
+  SmallVector<GetCBOp> getCBs;
+
+  int64_t getOperandIndex() const { return operand->getOperandNumber(); }
+};
+
+struct CBReuseGroup {
+  CBPortLifetime *representative = nullptr;
+  SmallVector<CBPortLifetime *> members;
+};
+
+enum class CBUseWindowOrder {
+  Unknown,
+  FirstBeforeSecond,
+  SecondBeforeFirst,
+  Overlap,
+};
+
+static Type getCBBackedMemRefType(Type type) {
+  if (auto cbType = mlir::dyn_cast<CBType>(type)) {
+    return cbType.getUnderlyingAs<MemRefType>();
+  }
+
+  auto memrefType = mlir::dyn_cast<MemRefType>(type);
+  if (!memrefType) {
+    return {};
+  }
+
+  if (mlir::isa<ttcore::DeviceLayoutInterface>(memrefType.getLayout())) {
+    return {};
+  }
+
+  if (ttcore::getMemorySpace(memrefType) == ttcore::MemorySpace::RegisterDst) {
+    return {};
+  }
+
+  if (mlir::isa<StridedLayoutAttr>(memrefType.getLayout())) {
+    return {};
+  }
+
+  return memrefType;
+}
+
+static CBUseWindowOrder getRelativeOrder(const CBUseWindow &lhs,
+                                         const CBUseWindow &rhs) {
+  if (!lhs.valid() || !rhs.valid()) {
+    return CBUseWindowOrder::Unknown;
+  }
+  if (lhs.lastUser->isBeforeInBlock(rhs.firstUser)) {
+    return CBUseWindowOrder::FirstBeforeSecond;
+  }
+  if (rhs.lastUser->isBeforeInBlock(lhs.firstUser)) {
+    return CBUseWindowOrder::SecondBeforeFirst;
+  }
+  return CBUseWindowOrder::Overlap;
+}
+
+static bool canShareCBPort(const CBPortLifetime &lhs,
+                           const CBPortLifetime &rhs) {
+  if (lhs.type != rhs.type || lhs.useWindows.size() != rhs.useWindows.size()) {
+    return false;
+  }
+
+  CBUseWindowOrder requiredOrder = CBUseWindowOrder::Unknown;
+  for (const auto &[block, lhsWindow] : lhs.useWindows) {
+    auto it = rhs.useWindows.find(block);
+    if (it == rhs.useWindows.end()) {
+      return false;
+    }
+
+    CBUseWindowOrder order = getRelativeOrder(lhsWindow, it->second);
+    if (order == CBUseWindowOrder::Overlap) {
+      return false;
+    }
+    if (order == CBUseWindowOrder::Unknown) {
+      continue;
+    }
+    if (requiredOrder != CBUseWindowOrder::Unknown && requiredOrder != order) {
+      return false;
+    }
+    requiredOrder = order;
+  }
+
+  return true;
+}
+
+static Operation *getEnclosingOperationInBlock(Operation *op, Block *block) {
+  while (op && op->getBlock() != block) {
+    op = op->getParentOp();
+  }
+  return op;
+}
+
+static void addResultUseWindow(Value value, Block *block,
+                               CBPortLifetime &lifetime) {
+  for (Operation *user : value.getUsers()) {
+    if (Operation *orderedUser = getEnclosingOperationInBlock(user, block)) {
+      lifetime.useWindows[block].addUse(orderedUser);
+    }
+  }
+}
+
+static OpOperand *getGenericOperand(GenericOp generic, int64_t operandIdx) {
+  if (operandIdx < 0 ||
+      operandIdx >= static_cast<int64_t>(generic->getNumOperands())) {
+    return nullptr;
+  }
+  return &generic->getOpOperand(static_cast<unsigned>(operandIdx));
+}
+
+static std::optional<std::reference_wrapper<CBPortLifetime>>
+getOrCreateLifetime(llvm::MapVector<OpOperand *, CBPortLifetime> &lifetimes,
+                    GenericOp generic, int64_t operandIdx, Type type) {
+  OpOperand *operand = getGenericOperand(generic, operandIdx);
+  if (!operand) {
+    return std::nullopt;
+  }
+
+  CBPortLifetime &lifetime = lifetimes[operand];
+  lifetime.operand = operand;
+  if (!lifetime.type) {
+    lifetime.type = type;
+  }
+  if (lifetime.type != type) {
+    return std::nullopt;
+  }
+  return lifetime;
+}
+
+} // namespace
+
+StringRef getPhysicalCBPortMapAttrName() { return kPhysicalCBPortMapAttrName; }
+
+void setPhysicalCBPortMap(Operation *op, ArrayRef<int64_t> logicalToPhysical) {
+  op->setAttr(getPhysicalCBPortMapAttrName(),
+              DenseI64ArrayAttr::get(op->getContext(), logicalToPhysical));
+}
+
+DenseI64ArrayAttr getPhysicalCBPortMap(Operation *op) {
+  if (!op) {
+    return nullptr;
+  }
+  return op->getAttrOfType<DenseI64ArrayAttr>(getPhysicalCBPortMapAttrName());
+}
+
+int64_t getPhysicalCBPort(Operation *op, int64_t logicalOperandIdx) {
+  DenseI64ArrayAttr portMap = getPhysicalCBPortMap(op);
+  if (!portMap || logicalOperandIdx < 0 ||
+      logicalOperandIdx >= static_cast<int64_t>(portMap.asArrayRef().size())) {
+    return logicalOperandIdx;
+  }
+  int64_t physicalPort = portMap.asArrayRef()[logicalOperandIdx];
+  return physicalPort < 0 ? logicalOperandIdx : physicalPort;
+}
 
 Value getOrCreateCB(RewriterBase &rewriter, GenericOp generic, Block *block,
                     unsigned cbOperandIndex) {
@@ -42,6 +230,151 @@ Value getOrCreateCB(RewriterBase &rewriter, GenericOp generic, Block *block,
                                         ResolutionStage::Compile))
            .getResult();
   return cb;
+}
+
+void reuseDisjointCBPorts(RewriterBase &rewriter, GenericOp generic,
+                          int64_t maxPhysicalCBPorts) {
+  int64_t firstAdditionalArgIdx =
+      generic.getInputs().size() + generic.getOutputs().size();
+  llvm::MapVector<OpOperand *, CBPortLifetime> lifetimes;
+  rewriter.modifyOpInPlace(
+      generic, [&]() { generic->removeAttr(getPhysicalCBPortMapAttrName()); });
+
+  for (Region &region : generic->getRegions()) {
+    if (region.empty()) {
+      continue;
+    }
+
+    Block *block = &region.front();
+
+    block->walk([&](GetArgOp getArgOp) {
+      int64_t operandIdx = getArgOp.getOperandIndex();
+      Type cbBackedType = getCBBackedMemRefType(getArgOp.getResult().getType());
+      if (!cbBackedType) {
+        return WalkResult::advance();
+      }
+
+      auto lifetime =
+          getOrCreateLifetime(lifetimes, generic, operandIdx, cbBackedType);
+      if (!lifetime) {
+        return WalkResult::advance();
+      }
+      lifetime->get().getArgs.push_back(getArgOp);
+      addResultUseWindow(getArgOp.getResult(), block, lifetime->get());
+      return WalkResult::advance();
+    });
+
+    block->walk([&](GetCBOp getCBOp) {
+      int64_t operandIdx = getCBOp.getCbOperandIdx();
+      Type cbBackedType = getCBBackedMemRefType(getCBOp.getResult().getType());
+      if (!cbBackedType) {
+        return WalkResult::advance();
+      }
+
+      auto lifetime =
+          getOrCreateLifetime(lifetimes, generic, operandIdx, cbBackedType);
+      if (!lifetime) {
+        return WalkResult::advance();
+      }
+      lifetime->get().getCBs.push_back(getCBOp);
+      addResultUseWindow(getCBOp.getResult(), block, lifetime->get());
+      return WalkResult::advance();
+    });
+  }
+
+  SmallVector<CBReuseGroup> groups;
+  SmallVector<CBPortLifetime *> activeAdditionalLifetimes;
+  llvm::DenseMap<CBPortLifetime *, CBPortLifetime *> representativeFor;
+  int64_t fixedPortCount = 0;
+
+  for (auto &entry : lifetimes) {
+    CBPortLifetime &lifetime = entry.second;
+    representativeFor[&lifetime] = &lifetime;
+    if (lifetime.useWindows.empty()) {
+      continue;
+    }
+
+    if (lifetime.getOperandIndex() < firstAdditionalArgIdx) {
+      ++fixedPortCount;
+      continue;
+    }
+
+    groups.push_back({&lifetime, {&lifetime}});
+    activeAdditionalLifetimes.push_back(&lifetime);
+  }
+
+  int64_t physicalPortCount = fixedPortCount + activeAdditionalLifetimes.size();
+  for (CBPortLifetime *lifetime : llvm::reverse(activeAdditionalLifetimes)) {
+    if (physicalPortCount <= maxPhysicalCBPorts) {
+      break;
+    }
+
+    CBReuseGroup *ownGroup = nullptr;
+    for (CBReuseGroup &group : groups) {
+      if (group.representative == lifetime) {
+        ownGroup = &group;
+        break;
+      }
+    }
+    if (ownGroup && ownGroup->members.size() > 1) {
+      continue;
+    }
+
+    CBReuseGroup *selectedGroup = nullptr;
+    for (CBReuseGroup &group : groups) {
+      CBPortLifetime *representative = group.representative;
+      if (representative->getOperandIndex() >= lifetime->getOperandIndex() ||
+          representativeFor.lookup(representative) != representative) {
+        continue;
+      }
+
+      bool canShare = true;
+      for (CBPortLifetime *member : group.members) {
+        if (!canShareCBPort(*lifetime, *member)) {
+          canShare = false;
+          break;
+        }
+      }
+      if (canShare) {
+        selectedGroup = &group;
+        break;
+      }
+    }
+
+    if (!selectedGroup) {
+      continue;
+    }
+
+    selectedGroup->members.push_back(lifetime);
+    representativeFor[lifetime] = selectedGroup->representative;
+    --physicalPortCount;
+  }
+
+  SmallVector<int64_t> logicalToPhysical;
+  logicalToPhysical.reserve(generic->getNumOperands());
+  for (int64_t operandIdx = 0,
+               operandCount = static_cast<int64_t>(generic->getNumOperands());
+       operandIdx < operandCount; ++operandIdx) {
+    logicalToPhysical.push_back(operandIdx);
+  }
+
+  bool hasReuse = false;
+  for (auto &entry : lifetimes) {
+    CBPortLifetime &lifetime = entry.second;
+    CBPortLifetime *representative = representativeFor.lookup(&lifetime);
+    if (!representative || representative == &lifetime) {
+      continue;
+    }
+
+    hasReuse = true;
+    logicalToPhysical[lifetime.getOperandIndex()] =
+        representative->getOperandIndex();
+  }
+
+  if (hasReuse) {
+    rewriter.modifyOpInPlace(
+        generic, [&]() { setPhysicalCBPortMap(generic, logicalToPhysical); });
+  }
 }
 
 } // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.cpp
+++ b/lib/Dialect/D2M/Utils/SynchronizableOpInterfaceUtils.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.h"
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "llvm/ADT/DenseSet.h"
 
 namespace mlir::tt::d2m::utils {
 
@@ -76,6 +77,87 @@ bool isPurelyDerivedOp(Operation *op,
   return isPurelyDerived;
 }
 
+static bool isNestedInSet(Operation *op,
+                          const llvm::DenseSet<Operation *> &ops) {
+  for (; op; op = op->getParentOp()) {
+    if (ops.contains(op)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static Operation *
+getUserOutsideRange(Operation *op,
+                    const llvm::DenseSet<Operation *> &opsInRange) {
+  for (Value result : op->getResults()) {
+    for (Operation *user : result.getUsers()) {
+      if (!isNestedInSet(user, opsInRange)) {
+        return user;
+      }
+    }
+  }
+  return nullptr;
+}
+
+static void setOutsideUseFailureMessage(Operation *op, Operation *user,
+                                        std::string *failureMessage) {
+  if (!failureMessage) {
+    return;
+  }
+  failureMessage->clear();
+  llvm::raw_string_ostream os(*failureMessage);
+  os << "found use of op result outside the range of ops being wrapped: "
+     << *user << "\nproducer: " << *op;
+}
+
+static LogicalResult
+verifyNoOutsideUses(Operation *op,
+                    const llvm::DenseSet<Operation *> &opsInRange,
+                    std::string *failureMessage) {
+  if (Operation *user = getUserOutsideRange(op, opsInRange)) {
+    setOutsideUseFailureMessage(op, user, failureMessage);
+    return failure();
+  }
+  return success();
+}
+
+static bool
+isDefinedByErasedOp(Value value,
+                    const llvm::DenseSet<Operation *> &opsToEraseSet) {
+  Operation *definingOp = value.getDefiningOp();
+  return definingOp && isNestedInSet(definingOp, opsToEraseSet);
+}
+
+static bool
+hasOperandDefinedByErasedOp(Operation *op,
+                            const llvm::DenseSet<Operation *> &opsToEraseSet) {
+  for (Value operand : op->getOperands()) {
+    if (isDefinedByErasedOp(operand, opsToEraseSet)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static void populateSynchronizedRegion(OpBuilder &builder, ValueRange blockArgs,
+                                       ValueRange consumers,
+                                       ValueRange producers,
+                                       Block::iterator start,
+                                       Block::iterator end) {
+  IRMapping mapping;
+  for (size_t i = 0; i < consumers.size(); i++) {
+    mapping.map(consumers[i], blockArgs[i]);
+  }
+  for (size_t i = 0; i < producers.size(); i++) {
+    mapping.map(producers[i], blockArgs[i + consumers.size()]);
+  }
+
+  for (Operation &op : llvm::make_range(start, end)) {
+    builder.clone(op, mapping);
+  }
+}
+
 // Wraps a range of ops in a SynchronizedRegionOp and returns the latter.
 // This is to be used to wrap a region of non-synchronized ops into an op that
 // generically implements SynchronizableOpInterface (e.g. wrapping
@@ -85,10 +167,10 @@ bool isPurelyDerivedOp(Operation *op,
 //
 // PRECONDITION: No op in [start, end) that is not purely derived may
 // produce SSA results that are used outside of [start, end).
-Operation *wrapInSynchronizedRegion(RewriterBase &rewriter,
-                                    Block::iterator start, Block::iterator end,
-                                    const SmallVector<Value> &consumers,
-                                    const SmallVector<Value> &producers) {
+FailureOr<Operation *> wrapInSynchronizedRegion(
+    RewriterBase &rewriter, Block::iterator start, Block::iterator end,
+    const SmallVector<Value> &consumers, const SmallVector<Value> &producers,
+    std::string *failureMessage) {
   assert(start != end && "Cannot wrap an empty range in SynchronizedRegionOp");
 
   // Verify no results are used outside the wrapped range.
@@ -98,51 +180,56 @@ Operation *wrapInSynchronizedRegion(RewriterBase &rewriter,
   }
 
   DenseMap<Operation *, bool> purelyDerivedOps;
-  SmallVector<Operation *> opsToErase;
+  llvm::DenseSet<Operation *> opsToEraseSet;
   for (Operation &op : llvm::make_range(start, end)) {
     if (!isPurelyDerivedOp(&op, purelyDerivedOps)) {
-      opsToErase.push_back(&op);
-      for (Value result : op.getResults()) {
-        for (Operation *user : result.getUsers()) {
-          if (!llvm::any_of(opsInRange, [&](Operation *op) {
-                return op->isAncestor(user);
-              })) {
-            std::string msg;
-            llvm::raw_string_ostream os(msg);
-            os << "Found use of non-pure op result outside the range of ops "
-                  "being wrapped: "
-               << *user;
-            llvm::report_fatal_error(llvm::StringRef(os.str()));
-          }
-        }
+      opsToEraseSet.insert(&op);
+      if (failed(verifyNoOutsideUses(&op, opsInRange, failureMessage))) {
+        return failure();
       }
+    }
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (Operation &op : llvm::make_range(start, end)) {
+      if (opsToEraseSet.contains(&op) ||
+          !isPurelyDerivedOp(&op, purelyDerivedOps)) {
+        continue;
+      }
+      if (!hasOperandDefinedByErasedOp(&op, opsToEraseSet)) {
+        continue;
+      }
+      if (failed(verifyNoOutsideUses(&op, opsInRange, failureMessage))) {
+        return failure();
+      }
+      opsToEraseSet.insert(&op);
+      changed = true;
     }
   }
 
   rewriter.setInsertionPoint(&*start);
   auto newSynchronizedRegionOp = rewriter.create<d2m::SynchronizedRegionOp>(
       start->getLoc(), TypeRange(), consumers, producers,
-      [&](mlir::OpBuilder &bbBuilder, mlir::Location bbLoc,
-          mlir::ValueRange bbArgs) {
-        IRMapping bbMapping;
-        for (size_t i = 0; i < consumers.size(); i++) {
-          bbMapping.map(consumers[i], bbArgs[i]);
-        }
-        for (size_t i = 0; i < producers.size(); i++) {
-          bbMapping.map(producers[i], bbArgs[i + consumers.size()]);
-        }
-
-        for (Operation &op : llvm::make_range(start, end)) {
-          bbBuilder.clone(op, bbMapping);
-        }
+      [&](mlir::OpBuilder &bbBuilder, mlir::Location, mlir::ValueRange bbArgs) {
+        populateSynchronizedRegion(bbBuilder, bbArgs, consumers, producers,
+                                   start, end);
       });
 
-  // Erase only the non-pure ops
-  for (Operation *op : llvm::reverse(opsToErase)) {
+  // Erase wrapped ops in reverse program order so nested uses in later
+  // compute ops are removed before their view-like producers.
+  SmallVector<Operation *> opsToEraseInBlockOrder;
+  for (Operation &op : llvm::make_range(start, end)) {
+    if (opsToEraseSet.contains(&op)) {
+      opsToEraseInBlockOrder.push_back(&op);
+    }
+  }
+  for (Operation *op : llvm::reverse(opsToEraseInBlockOrder)) {
     rewriter.eraseOp(op);
   }
 
-  return newSynchronizedRegionOp;
+  return newSynchronizedRegionOp.getOperation();
 }
 
 // This is used to remove SynchronizedRegionOps and hoist their ops up parent

--- a/test/ttmlir/Conversion/D2MToTTKernel/cb_port_custom_ports.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/cb_port_custom_ports.mlir
@@ -38,4 +38,18 @@ module {
     memref.store %t, %out[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
     return
   }
+  // CHECK-LABEL: func.func @physical_cb_port_map
+  // Logical d2m.get_cb indices stay untouched, but CBPort args use the
+  // physical port map when present.
+  // CHECK-SAME: rt_args = [<arg_type = cb_port, operand_index = 2>]
+  func.func @physical_cb_port_map() attributes {d2m.physical_cb_ports = array<i64: 0, 1, 2, 2>, d2m.thread = #d2m.thread<compute>} {
+    %c0 = arith.constant 0 : index
+    %cb0 = d2m.get_cb(3) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>
+    // CHECK: ttkernel.get_common_arg_val
+    %in = d2m.wait %cb0 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+    %t = memref.load %in[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+    memref.store %t, %in[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+    return
+  }
+
 }

--- a/test/ttmlir/Conversion/D2MToTTMetal/generic_scalar_additional_arg.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/generic_scalar_additional_arg.mlir
@@ -16,6 +16,7 @@ module {
     %alloc = memref.alloc() {alignment = 64 : i64, address = 0x1000} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>
     %cb_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>
     %cb_1 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>
+    %cb_unused = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>
 
     // CHECK: "ttmetal.enqueue_program"
     // CHECK-SAME: cb_ports = array<i64: 0, 1>
@@ -24,14 +25,14 @@ module {
     d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<compute, @compute_kernel>]}
         ins(%arg0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)
         outs(%alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)
-        additionalArgs(%cb_0, %cb_1, %scalar : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>, i32)
+        additionalArgs(%cb_0, %cb_1, %cb_unused, %scalar : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>, i32)
     return %alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>
   }
 
   func.func private @compute_kernel() attributes {d2m.thread = #d2m.thread<compute>} {
     %cb0 = d2m.get_cb(2) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>>
     %cb1 = d2m.get_cb(3) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 1>, #l1_>>
-    %s = d2m.get_arg(4) : i32
+    %s = d2m.get_arg(5) : i32
     return
   }
 }

--- a/test/ttmlir/Dialect/D2M/Transforms/hoist_cb_allocs.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/hoist_cb_allocs.mlir
@@ -56,3 +56,26 @@ func.func @hoist_multiple_cbs_dealloc(
   }
   return
 }
+
+// Verify that compute intermediate synchronized buffers with concrete addresses
+// are real CB-backed buffers and are hoisted like other synchronized buffers.
+func.func @hoist_compute_intermediate_cb_dealloc(
+    %stream: memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>,
+    %out: memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+  // CHECK-LABEL: func @hoist_compute_intermediate_cb_dealloc
+  // CHECK: %[[CB:.*]] = memref.alloc() {address = 4096 : i64{{.*}}d2m.compute_intermediate{{.*}}cb_layout
+  // CHECK: d2m.generic
+  // CHECK: additionalArgs(%[[CB]]
+  // CHECK: memref.dealloc %[[CB]]
+  d2m.generic {block_factors = [], grid = #ttcore.grid<2x2>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+      ins(%stream : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>)
+      outs(%out : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+  ^unified0():
+    %c0 = d2m.core_index(0) : index
+    %c1 = d2m.core_index(1) : index
+    %alloc_cb = memref.alloc() {address = 4096 : i64, alignment = 16 : i64, d2m.compute_intermediate, d2m.synchronized_buffer = 2} : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    d2m.remote_load %alloc_cb %stream[%c0, %c1] : memref<4x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    d2m.remote_store %out[%c0, %c1] %alloc_cb : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+  }
+  return
+}

--- a/test/ttmlir/Dialect/D2M/arguments/normalize_thread_args_cb_reuse.mlir
+++ b/test/ttmlir/Dialect/D2M/arguments/normalize_thread_args_cb_reuse.mlir
@@ -1,0 +1,212 @@
+// RUN: ttmlir-opt --split-input-file --d2m-normalize-thread-args %s | FileCheck %s
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --d2m-normalize-thread-args --d2m-generic-regions-to-funcs --convert-d2m-to-ttkernel %s | FileCheck %s --check-prefix=KERNEL
+
+#l1 = #ttcore.memory_space<l1>
+
+module {
+  // CHECK-LABEL: func.func @reuse_get_cb_ports_counts_fixed_io
+  // KERNEL-LABEL: func.func private @compute_kernel0
+  // KERNEL-SAME: operand_index = 31>]
+  // CHECK: d2m.physical_cb_ports = array<i64: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 2>
+  // CHECK: d2m.get_cb(31)
+  // CHECK: d2m.get_cb(32)
+  func.func @reuse_get_cb_ports_counts_fixed_io(
+      %in: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %out: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a0: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a1: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a2: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a3: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a4: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a5: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a6: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a7: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a8: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a9: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a10: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a11: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a12: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a13: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a14: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a15: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a16: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a17: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a18: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a19: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a20: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a21: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a22: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a23: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a24: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a25: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a26: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a27: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a28: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a29: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a30: memref<1x1x!ttcore.tile<32x32, f32>, #l1>) {
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<compute>]}
+        ins(%in : memref<1x1x!ttcore.tile<32x32, f32>, #l1>)
+        outs(%out : memref<1x1x!ttcore.tile<32x32, f32>, #l1>)
+        additionalArgs(%a0, %a1, %a2, %a3, %a4, %a5, %a6, %a7, %a8, %a9, %a10, %a11, %a12, %a13, %a14, %a15, %a16, %a17, %a18, %a19, %a20, %a21, %a22, %a23, %a24, %a25, %a26, %a27, %a28, %a29, %a30 : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) {
+    ^compute0:
+      %cb0 = d2m.get_cb(0) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb0 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb1 = d2m.get_cb(1) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb1 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb2 = d2m.get_cb(2) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb2 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb3 = d2m.get_cb(3) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb3 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb4 = d2m.get_cb(4) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb4 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb5 = d2m.get_cb(5) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb5 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb6 = d2m.get_cb(6) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb6 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb7 = d2m.get_cb(7) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb7 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb8 = d2m.get_cb(8) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb8 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb9 = d2m.get_cb(9) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb9 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb10 = d2m.get_cb(10) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb10 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb11 = d2m.get_cb(11) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb11 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb12 = d2m.get_cb(12) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb12 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb13 = d2m.get_cb(13) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb13 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb14 = d2m.get_cb(14) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb14 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb15 = d2m.get_cb(15) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb15 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb16 = d2m.get_cb(16) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb16 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb17 = d2m.get_cb(17) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb17 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb18 = d2m.get_cb(18) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb18 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb19 = d2m.get_cb(19) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb19 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb20 = d2m.get_cb(20) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb20 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb21 = d2m.get_cb(21) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb21 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb22 = d2m.get_cb(22) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb22 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb23 = d2m.get_cb(23) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb23 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb24 = d2m.get_cb(24) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb24 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb25 = d2m.get_cb(25) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb25 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb26 = d2m.get_cb(26) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb26 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb27 = d2m.get_cb(27) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb27 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb28 = d2m.get_cb(28) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb28 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb29 = d2m.get_cb(29) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb29 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb30 = d2m.get_cb(30) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb30 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb31 = d2m.get_cb(31) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb31 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb32 = d2m.get_cb(32) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb32 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    return
+  }
+}
+
+// -----
+
+#l1 = #ttcore.memory_space<l1>
+
+module {
+  // CHECK-LABEL: func.func @reuse_cb_backed_get_arg_ports
+  // KERNEL-LABEL: func.func private @compute_kernel0
+  // KERNEL-SAME: operand_index = 2>, <arg_type = cb_port, operand_index = 4>
+  // CHECK: d2m.physical_cb_ports = array<i64: 0, 1, 2, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32>
+  // CHECK: d2m.get_arg(32)
+  // CHECK: d2m.get_arg(31)
+  func.func @reuse_cb_backed_get_arg_ports(
+      %in: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %out: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a0: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a1: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a2: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a3: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a4: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a5: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a6: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a7: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a8: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a9: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a10: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a11: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a12: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a13: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a14: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a15: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a16: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a17: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a18: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a19: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a20: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a21: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a22: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a23: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a24: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a25: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a26: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a27: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a28: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a29: memref<1x1x!ttcore.tile<32x32, f32>, #l1>,
+      %a30: memref<1x1x!ttcore.tile<32x32, f32>, #l1>) {
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<compute>]}
+        ins(%in : memref<1x1x!ttcore.tile<32x32, f32>, #l1>)
+        outs(%out : memref<1x1x!ttcore.tile<32x32, f32>, #l1>)
+        additionalArgs(%a0, %a1, %a2, %a3, %a4, %a5, %a6, %a7, %a8, %a9, %a10, %a11, %a12, %a13, %a14, %a15, %a16, %a17, %a18, %a19, %a20, %a21, %a22, %a23, %a24, %a25, %a26, %a27, %a28, %a29, %a30 : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) {
+    ^compute0:
+      %c0 = arith.constant 0 : index
+      %cb0 = d2m.get_cb(0) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb0 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb1 = d2m.get_cb(1) : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      d2m.push %cb1 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %v0 = memref.load %a0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v1 = memref.load %a1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v2 = memref.load %a2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v3 = memref.load %a3[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v4 = memref.load %a4[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v5 = memref.load %a5[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v6 = memref.load %a6[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v7 = memref.load %a7[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v8 = memref.load %a8[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v9 = memref.load %a9[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v10 = memref.load %a10[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v11 = memref.load %a11[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v12 = memref.load %a12[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v13 = memref.load %a13[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v14 = memref.load %a14[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v15 = memref.load %a15[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v16 = memref.load %a16[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v17 = memref.load %a17[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v18 = memref.load %a18[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v19 = memref.load %a19[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v20 = memref.load %a20[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v21 = memref.load %a21[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v22 = memref.load %a22[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v23 = memref.load %a23[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v24 = memref.load %a24[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v25 = memref.load %a25[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v26 = memref.load %a26[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v27 = memref.load %a27[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v28 = memref.load %a28[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v29 = memref.load %a29[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %v30 = memref.load %a30[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    }
+    return
+  }
+}

--- a/test/unittests/D2MGenericAnalysis/TestD2MGenericAnalysis.cpp
+++ b/test/unittests/D2MGenericAnalysis/TestD2MGenericAnalysis.cpp
@@ -1013,11 +1013,12 @@ func.func @test(
   }
   ASSERT_EQ(opsBeforeWrap, 8u);
   IRRewriter rewriter(&context);
-  Operation *synchronizedOp = d2m::utils::wrapInSynchronizedRegion(
+  FailureOr<Operation *> synchronizedOp = d2m::utils::wrapInSynchronizedRegion(
       rewriter, start, end, consumers, producers);
-  ASSERT_NE(synchronizedOp, nullptr);
-  ASSERT_TRUE(mlir::isa<d2m::SynchronizedRegionOp>(synchronizedOp));
-  auto syncOp = mlir::cast<d2m::SynchronizedRegionOp>(synchronizedOp);
+  ASSERT_TRUE(succeeded(synchronizedOp));
+  ASSERT_NE(*synchronizedOp, nullptr);
+  ASSERT_TRUE(mlir::isa<d2m::SynchronizedRegionOp>(*synchronizedOp));
+  auto syncOp = mlir::cast<d2m::SynchronizedRegionOp>(*synchronizedOp);
   // Verify the synchronized region has a body with ops
   // and consumer/producer operands are set correctly.
   ASSERT_EQ(syncOp.getRegion().getBlocks().size(), 1u);


### PR DESCRIPTION
## Summary
- add conservative D2M CB-port reuse after thread arg normalization
- represent reuse with an optional `d2m.physical_cb_ports` logical operand index -> physical CB port map, so `d2m.get_cb` / `d2m.get_arg` stay logical
- model CB reuse lifetimes as `Operation *` use windows, using MLIR block ordering instead of synthetic integer positions
- centralize physical CB port lookup in D2M CB utilities and consume it at the D2M-to-TTKernel arg-spec boundary
- compact TTMetal CB configs to only referenced physical CB operands
- hoist addressed compute-intermediate synchronized buffers and fix synchronized-region wrapping for derived pure/view-like ops
- add lit coverage for >32 logical CB ports, logical-index preservation, TTKernel physical arg specs, TTMetal CB compaction, and compute-intermediate CB hoisting

## Testing
- `cmake --build build --target ttmlir-opt d2m-jit TTMLIRPythonModules.extension._ttmlir.dso`
- `llvm-lit -a test/ttmlir/Dialect/D2M/arguments/normalize_thread_args_cb_reuse.mlir test/ttmlir/Dialect/D2M/arguments/normalize_thread_args.mlir test/ttmlir/Conversion/D2MToTTKernel/cb_port_custom_ports.mlir test/ttmlir/Conversion/D2MToTTMetal/generic_scalar_additional_arg.mlir`
- `llvm-lit -a test/ttmlir/Dialect/D2M test/ttmlir/Conversion/D2MToTTKernel test/ttmlir/Conversion/D2MToTTMetal test/ttmlir/Conversion/D2MToTTNN` (185 passed, 1 unsupported)
- `pytest -q test/d2m-jit -s` (114 passed)
- `git diff --check`