### PR TITLE
Fix argmax regression 

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -788,5 +788,11 @@ const std::set<mlir::StringRef>
         ttnn::AllToAllCombineOp::getOperationName(),
         ttnn::MoeExpertTokenRemapOp::getOperationName(),
         ttnn::SparseMatmulOp::getOperationName(),
+        // ArgMax's operands workaround forces ROW_MAJOR input/output. Since
+        // tt-metal #46340 the multicore argmax kernel is only selected for a
+        // ROW_MAJOR input (TILE silently falls back to single-core, ~100ms for
+        // a full-vocab reduction). Without this, opt_level>=1 layout
+        // propagation leaves the input TILE and we lose the multicore path.
+        ttnn::ArgMaxOp::getOperationName(),
 };
 } // namespace mlir::tt::ttnn


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/5390

### Problem description
New tt-metal argmax path selected single-core argmax kernel for argmax in our benchmark LLMs: https://github.com/tenstorrent/tt-metal/commit/6008ff55566970d844d621b8e7cd31a5b87cd71a

This caused a massive perf regression and failure of ministral_8b on tt-xla benchmarks.

### What's changed
Enable argmax workaround that forces ROW_MAJOR inputs/output so mutlicore argmax kernel is selected.