### PR TITLE
[TTIR] Fold constant splat sum reduction eq and neq

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -2677,6 +2677,8 @@ def TTIR_SumOp : TTIR_ReductionOp<"sum"> {
       Output:
       - `result` (Tensor): The result tensor after applying the reduction.
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_MeanOp : TTIR_ReductionOp<"mean"> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -6483,6 +6483,48 @@ verifyReduceOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
                         getDimArg(), getKeepDim(), getType().getShape());
 }
 
+// SumOp folder
+::mlir::OpFoldResult mlir::tt::ttir::SumOp::fold(FoldAdaptor adaptor) {
+  // estricting to splats keeps the fold cheap and avoids
+  // materializing large (non-splat) constants.
+  auto input =
+      mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(adaptor.getInput());
+  if (!input || !input.isSplat()) {
+    return nullptr;
+  }
+
+  auto resultType = mlir::cast<ShapedType>(getResult().getType());
+  if (input.getElementType() != resultType.getElementType()) {
+    return nullptr;
+  }
+
+  int64_t resultElements = resultType.getNumElements();
+  if (resultElements == 0) {
+    return nullptr;
+  }
+  int64_t reductionCount = input.getNumElements() / resultElements;
+
+  mlir::Type elementType = resultType.getElementType();
+  if (auto floatType = mlir::dyn_cast<mlir::FloatType>(elementType)) {
+    llvm::APFloat value = input.getSplatValue<llvm::APFloat>();
+    llvm::APFloat scale(floatType.getFloatSemantics());
+    scale.convertFromAPInt(llvm::APInt(64, reductionCount, /*isSigned=*/true),
+                           /*IsSigned=*/true,
+                           llvm::APFloat::rmNearestTiesToEven);
+    value.multiply(scale, llvm::APFloat::rmNearestTiesToEven);
+    return SplatElementsAttr::get(resultType,
+                                  mlir::FloatAttr::get(elementType, value));
+  }
+  if (mlir::isa<mlir::IntegerType>(elementType)) {
+    llvm::APInt value = input.getSplatValue<llvm::APInt>();
+    value *= llvm::APInt(value.getBitWidth(), reductionCount);
+    return SplatElementsAttr::get(resultType,
+                                  mlir::IntegerAttr::get(elementType, value));
+  }
+
+  return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 // Reduce MinOp
 //===----------------------------------------------------------------------===//
@@ -8456,11 +8498,65 @@ static bool anyZero(mlir::ElementsAttr elems) {
       });
 }
 
+// Fold a self-comparison `x <cmp> x` (same SSA value): `eq` is all-true and
+// `ne` is all-false. Note that for floating-point operands this assumes the
+// value is not NaN (`NaN == NaN` is false, `NaN != NaN` is true).
+static mlir::OpFoldResult foldSelfComparison(mlir::Operation *op,
+                                             mlir::Value lhs, mlir::Value rhs,
+                                             bool foldToTrue) {
+  if (lhs != rhs) {
+    return nullptr;
+  }
+  auto resultType = mlir::cast<ShapedType>(op->getResult(0).getType());
+  return SplatElementsAttr::get(
+      resultType,
+      makeScalarAttr(resultType.getElementType(), foldToTrue ? 1.0 : 0.0));
+}
+
+// Fold a comparison of two splat constants. Restricted to splats so we never
+// compare large tensors, and it works even though comparisons change the
+// element type, which the generic elementwise-binary folder rejects.
+template <typename Predicate>
+static mlir::OpFoldResult
+foldSplatComparison(mlir::Operation *op, mlir::Attribute lhsAttr,
+                    mlir::Attribute rhsAttr, Predicate predicate) {
+  auto lhs = mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(lhsAttr);
+  auto rhs = mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(rhsAttr);
+  if (!lhs || !rhs || !lhs.isSplat() || !rhs.isSplat() ||
+      lhs.getElementType() != rhs.getElementType()) {
+    return nullptr;
+  }
+
+  bool result;
+  if (mlir::isa<mlir::FloatType>(lhs.getElementType())) {
+    result = predicate(lhs.getSplatValue<llvm::APFloat>(),
+                       rhs.getSplatValue<llvm::APFloat>());
+  } else if (mlir::isa<mlir::IntegerType>(lhs.getElementType())) {
+    result = predicate(lhs.getSplatValue<llvm::APInt>(),
+                       rhs.getSplatValue<llvm::APInt>());
+  } else {
+    return nullptr;
+  }
+
+  auto resultType = mlir::cast<ShapedType>(op->getResult(0).getType());
+  return SplatElementsAttr::get(
+      resultType,
+      makeScalarAttr(resultType.getElementType(), result ? 1.0 : 0.0));
+}
+
 //===----------------------------------------------------------------------===//
 // EqualOp
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::EqualOp::fold(FoldAdaptor adaptor) {
+  if (mlir::OpFoldResult result =
+          foldSelfComparison(*this, getLhs(), getRhs(), /*foldToTrue=*/true)) {
+    return result;
+  }
+  if (mlir::OpFoldResult result = foldSplatComparison(
+          *this, adaptor.getLhs(), adaptor.getRhs(), std::equal_to<>())) {
+    return result;
+  }
   auto eq = PredicateToNumericAdapter(std::equal_to<>());
   return constantFoldEltwiseBinary(*this, adaptor.getLhs(), adaptor.getRhs(),
                                    eq, eq);
@@ -8471,6 +8567,14 @@ static bool anyZero(mlir::ElementsAttr elems) {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::NotEqualOp::fold(FoldAdaptor adaptor) {
+  if (mlir::OpFoldResult result =
+          foldSelfComparison(*this, getLhs(), getRhs(), /*foldToTrue=*/false)) {
+    return result;
+  }
+  if (mlir::OpFoldResult result = foldSplatComparison(
+          *this, adaptor.getLhs(), adaptor.getRhs(), std::not_equal_to<>())) {
+    return result;
+  }
   auto ne = PredicateToNumericAdapter(std::not_equal_to<>());
   return constantFoldEltwiseBinary(*this, adaptor.getLhs(), adaptor.getRhs(),
                                    ne, ne);

--- a/test/ttmlir/Dialect/TTIR/canonicalize/splat_comparison_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/splat_comparison_fold_tests.mlir
@@ -1,0 +1,84 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  // eq of two equal integer splats -> all-true (ones), despite i64 -> i1.
+  func.func @eq_equal_int() -> tensor<4x4xi1> {
+    // CHECK-LABEL: @eq_equal_int
+    // CHECK: "ttir.ones"
+    // CHECK-NOT: "ttir.eq"
+    %0 = "ttir.constant"() <{value = dense<7> : tensor<4x4xi64>}> : () -> tensor<4x4xi64>
+    %1 = "ttir.constant"() <{value = dense<7> : tensor<4x4xi64>}> : () -> tensor<4x4xi64>
+    %2 = "ttir.eq"(%0, %1) : (tensor<4x4xi64>, tensor<4x4xi64>) -> tensor<4x4xi1>
+    return %2 : tensor<4x4xi1>
+  }
+
+  // eq of two different integer splats -> all-false (zeros).
+  func.func @eq_different_int() -> tensor<4x4xi1> {
+    // CHECK-LABEL: @eq_different_int
+    // CHECK: "ttir.zeros"
+    // CHECK-NOT: "ttir.eq"
+    %0 = "ttir.constant"() <{value = dense<7> : tensor<4x4xi64>}> : () -> tensor<4x4xi64>
+    %1 = "ttir.constant"() <{value = dense<9> : tensor<4x4xi64>}> : () -> tensor<4x4xi64>
+    %2 = "ttir.eq"(%0, %1) : (tensor<4x4xi64>, tensor<4x4xi64>) -> tensor<4x4xi1>
+    return %2 : tensor<4x4xi1>
+  }
+
+  // ne of two different float splats -> all-true (ones), despite f32 -> i1.
+  func.func @ne_different_float() -> tensor<3xi1> {
+    // CHECK-LABEL: @ne_different_float
+    // CHECK: "ttir.ones"
+    // CHECK-NOT: "ttir.ne"
+    %0 = "ttir.constant"() <{value = dense<1.5> : tensor<3xf32>}> : () -> tensor<3xf32>
+    %1 = "ttir.constant"() <{value = dense<2.5> : tensor<3xf32>}> : () -> tensor<3xf32>
+    %2 = "ttir.ne"(%0, %1) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
+    return %2 : tensor<3xi1>
+  }
+
+  // ne of two equal float splats -> all-false (zeros).
+  func.func @ne_equal_float() -> tensor<3xi1> {
+    // CHECK-LABEL: @ne_equal_float
+    // CHECK: "ttir.zeros"
+    // CHECK-NOT: "ttir.ne"
+    %0 = "ttir.constant"() <{value = dense<2.5> : tensor<3xf32>}> : () -> tensor<3xf32>
+    %1 = "ttir.constant"() <{value = dense<2.5> : tensor<3xf32>}> : () -> tensor<3xf32>
+    %2 = "ttir.ne"(%0, %1) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
+    return %2 : tensor<3xi1>
+  }
+
+  // Comparison of a value with itself folds even for non-constant operands.
+  func.func @eq_self(%arg0: tensor<16x1x1xi64>) -> tensor<16x1x1xi1> {
+    // CHECK-LABEL: @eq_self
+    // CHECK: "ttir.ones"
+    // CHECK-NOT: "ttir.eq"
+    %0 = "ttir.eq"(%arg0, %arg0) : (tensor<16x1x1xi64>, tensor<16x1x1xi64>) -> tensor<16x1x1xi1>
+    return %0 : tensor<16x1x1xi1>
+  }
+
+  func.func @ne_self(%arg0: tensor<16x1x1xi64>) -> tensor<16x1x1xi1> {
+    // CHECK-LABEL: @ne_self
+    // CHECK: "ttir.zeros"
+    // CHECK-NOT: "ttir.ne"
+    %0 = "ttir.ne"(%arg0, %arg0) : (tensor<16x1x1xi64>, tensor<16x1x1xi64>) -> tensor<16x1x1xi1>
+    return %0 : tensor<16x1x1xi1>
+  }
+
+  // Distinct non-constant operands are not folded.
+  func.func @ne_non_constant(%arg0: tensor<3xf32>) -> tensor<3xi1> {
+    // CHECK-LABEL: @ne_non_constant
+    // CHECK: "ttir.ne"
+    %0 = "ttir.constant"() <{value = dense<2.5> : tensor<3xf32>}> : () -> tensor<3xf32>
+    %1 = "ttir.ne"(%arg0, %0) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
+    return %1 : tensor<3xi1>
+  }
+
+  // Distinct non-splat constant operands are not folded (avoids large
+  // comparisons).
+  func.func @eq_non_splat() -> tensor<3xi1> {
+    // CHECK-LABEL: @eq_non_splat
+    // CHECK: "ttir.eq"
+    %0 = "ttir.constant"() <{value = dense<[1, 2, 3]> : tensor<3xi64>}> : () -> tensor<3xi64>
+    %1 = "ttir.constant"() <{value = dense<[4, 5, 6]> : tensor<3xi64>}> : () -> tensor<3xi64>
+    %2 = "ttir.eq"(%0, %1) : (tensor<3xi64>, tensor<3xi64>) -> tensor<3xi1>
+    return %2 : tensor<3xi1>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/sum_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/sum_fold_tests.mlir
@@ -1,0 +1,71 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  // Reduction over a unit dimension leaves the values unchanged.
+  func.func @sum_unit_dim() -> tensor<16x1xbf16> {
+    // CHECK-LABEL: @sum_unit_dim
+    // CHECK: "ttir.ones"() <{shape = array<i32: 16, 1>}>
+    // CHECK-NOT: "ttir.sum"
+    %0 = "ttir.ones"() <{shape = array<i32: 16, 1, 1>}> : () -> tensor<16x1x1xbf16>
+    %1 = "ttir.sum"(%0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<16x1x1xbf16>) -> tensor<16x1xbf16>
+    return %1 : tensor<16x1xbf16>
+  }
+
+  // Reduction of a splat integer constant.
+  func.func @sum_splat_int() -> tensor<2xsi32> {
+    // CHECK-LABEL: @sum_splat_int
+    // CHECK: "ttir.full"() <{fill_value = 12 : i32
+    // CHECK-NOT: "ttir.sum"
+    %0 = "ttir.constant"() <{value = dense<3> : tensor<2x4xsi32>}> : () -> tensor<2x4xsi32>
+    %1 = "ttir.sum"(%0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<2x4xsi32>) -> tensor<2xsi32>
+    return %1 : tensor<2xsi32>
+  }
+
+  // Reduction of a splat float constant.
+  func.func @sum_splat_float() -> tensor<2xf32> {
+    // CHECK-LABEL: @sum_splat_float
+    // CHECK: "ttir.full"() <{fill_value = 1.000000e+01 : f32
+    // CHECK-NOT: "ttir.sum"
+    %0 = "ttir.constant"() <{value = dense<2.5> : tensor<2x4xf32>}> : () -> tensor<2x4xf32>
+    %1 = "ttir.sum"(%0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<2x4xf32>) -> tensor<2xf32>
+    return %1 : tensor<2xf32>
+  }
+
+  // keep_dim = true retains the reduced dimension as size 1.
+  func.func @sum_keepdim_splat() -> tensor<2x1xsi32> {
+    // CHECK-LABEL: @sum_keepdim_splat
+    // CHECK: "ttir.full"() <{fill_value = 12 : i32, shape = array<i32: 2, 1>}>
+    // CHECK-NOT: "ttir.sum"
+    %0 = "ttir.constant"() <{value = dense<3> : tensor<2x4xsi32>}> : () -> tensor<2x4xsi32>
+    %1 = "ttir.sum"(%0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x4xsi32>) -> tensor<2x1xsi32>
+    return %1 : tensor<2x1xsi32>
+  }
+
+  // keep_dim = true over a unit dimension is a no-op on both values and shape.
+  func.func @sum_keepdim_unit() -> tensor<16x1x1xbf16> {
+    // CHECK-LABEL: @sum_keepdim_unit
+    // CHECK: "ttir.ones"() <{shape = array<i32: 16, 1, 1>}>
+    // CHECK-NOT: "ttir.sum"
+    %0 = "ttir.ones"() <{shape = array<i32: 16, 1, 1>}> : () -> tensor<16x1x1xbf16>
+    %1 = "ttir.sum"(%0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<16x1x1xbf16>) -> tensor<16x1x1xbf16>
+    return %1 : tensor<16x1x1xbf16>
+  }
+
+  // A non-splat real reduction is not folded.
+  func.func @sum_nonsplat(%arg0: tensor<2x4xf32>) -> tensor<2xf32> {
+    // CHECK-LABEL: @sum_nonsplat
+    // CHECK: "ttir.sum"
+    %1 = "ttir.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<2x4xf32>) -> tensor<2xf32>
+    return %1 : tensor<2xf32>
+  }
+
+  // A non-splat constant is not folded even over a unit dimension: folding is
+  // restricted to splats to avoid materializing large constants.
+  func.func @sum_nonsplat_unit_dim() -> tensor<3xsi32> {
+    // CHECK-LABEL: @sum_nonsplat_unit_dim
+    // CHECK: "ttir.sum"
+    %0 = "ttir.constant"() <{value = dense<[[1], [2], [3]]> : tensor<3x1xsi32>}> : () -> tensor<3x1xsi32>
+    %1 = "ttir.sum"(%0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<3x1xsi32>) -> tensor<3xsi32>
+    return %1 : tensor<3xsi32>
+  }
+}


### PR DESCRIPTION
This change adds folding of splat tensors which are used by `sum` reduction or `eq`/`neq` ops. Currently
there is folder for `eq` and `neq` constants but it's but it has guards which prevent folding of these constructions:

`ttir.neq(float32, float32) -> bf16`

also sum reduction folder wasn't added.
We are adding basic support for folding of these 3 ops:

eq/neq -> allow folding only if lhs and rhs are splat constants of same type
sum -> allow folding for splat constants only

related to #8928

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
