### PR TITLE
[Optimizer] Whitelist workarounds needed for glm 4.7

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -767,6 +767,15 @@ const std::set<mlir::StringRef>
         ttnn::PrepareMoEComputeW0W1WeightsOp::getOperationName(),
         ttnn::PrepareMoEComputeW2WeightsOp::getOperationName(),
         ttnn::MoeComputeOp::getOperationName(),
+        // MoE all-to-all CCL ops: workaround forces ROW_MAJOR + bf16/ui16.
+        ttnn::AllToAllDispatchOp::getOperationName(),
+        ttnn::AllToAllDispatchMetadataOp::getOperationName(),
+        ttnn::AllToAllCombineOp::getOperationName(),
+        ttnn::MoeExpertTokenRemapOp::getOperationName(),
+        ttnn::MoeGptOp::getOperationName(),
+        ttnn::SelectiveReduceCombineOp::getOperationName(),
+        // sparse_matmul: workaround forces sparsity operand ROW_MAJOR + bf16.
+        ttnn::SparseMatmulOp::getOperationName(),
         // Conv3d's runtime kernel hard-rejects Tile input
         // (TT_FATAL @ conv3d_device_operation.cpp:49); without the
         // workaround running here, the optimizer's layout propagation
@@ -779,5 +788,7 @@ const std::set<mlir::StringRef>
         // index/param tensors, UINT32 dtype on k, and ROW_MAJOR+UINT32 on
         // the result (the kernel hard-rejects anything else and produces
         // UINT32).
-        ttnn::SamplingOp::getOperationName()};
+        ttnn::SamplingOp::getOperationName(),
+        // argmax: workaround forces ROW_MAJOR + ui32 result, typecast to signed.
+        ttnn::ArgMaxOp::getOperationName()};
 } // namespace mlir::tt::ttnn


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5357)

### Problem description
During bringup of moe models some workarounds were added that were not whitelisted in the optimizer.

### What's changed
Whitelist all the workarounds needed for glm 4.7 to work with opt level 1. 

### Checklist
| Check | Config | Run |
|-------|--------|-----|
| GLM-4.7 opt=1 (4 layers) | `galaxy-wh-6u`, `optimization_level=1` | [28590325689](https://github.com/tenstorrent/tt-xla/actions/runs/28590325689) |
| Regression — with this change | `qb2-blackhole`, opt=2, `regression_check`; gpt_oss_20b, qwen_3_8b, falcon3_7b | [28589380843](https://github.com/tenstorrent/tt-xla/actions/runs/28589380843) |
| Regression — baseline (no change) | same, `mlir_override=ba8aa2ac` | [28589791624](https://github.com/tenstorrent/tt-xla/actions/runs/28589791624) |
