### PR TITLE
[Codegen] Add TTNNForceFinalDeallocs pass

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -489,6 +489,17 @@ def TTNNAdjustDeallocs: Pass<"ttnn-adjust-deallocs", "::mlir::ModuleOp"> {
   }];
 }
 
+def TTNNForceFinalDeallocs: Pass<"ttnn-force-final-deallocs", "::mlir::ModuleOp"> {
+  let summary = "Force the final deallocation of each aliased device buffer.";
+  let description = [{
+    This pass walks the deallocation ops of each buffer from bottom to top and
+    sets the force flag to true on the last one in program order (the true final
+    use of that memory), so the buffer is freed properly. Exceptions are
+    variables that escape the function (returned values) or activations that are
+    deallocated by a conv op.
+  }];
+}
+
 def TTNNWeightDtypeConversion: Pass<"ttnn-weight-dtype-conversion", "::mlir::ModuleOp"> {
   let summary = "Convert weight tensors to a specified dtype in matmul, linear, and sparse_matmul operations.";
   let description = [{

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -494,9 +494,11 @@ def TTNNForceFinalDeallocs: Pass<"ttnn-force-final-deallocs", "::mlir::ModuleOp"
   let description = [{
     This pass walks the deallocation ops of each buffer from bottom to top and
     sets the force flag to true on the last one in program order (the true final
-    use of that memory), so the buffer is freed properly. Exceptions are
-    variables that escape the function (returned values) or activations that are
-    deallocated by a conv op.
+    use of that memory), so the buffer is freed properly. The remaining
+    deallocations of that buffer are no-ops and are removed. For buffers that are
+    freed elsewhere (variables that escape the function that are freed by the caller
+    or conv activations the conv op force-deallocates itself), no deallocation
+    is forced and all of their (no-op) deallocations are removed.
   }];
 }
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -605,6 +605,8 @@ void createTTNNCommonToEmitCPipeline(
   if (options.tryRecoverStructure) {
     createRecoverStructureXLATorchPipeline(
         pm, RecoverStructureXLATorchPipelineOptions());
+  } else {
+    pm.addPass(createTTNNForceFinalDeallocs());
   }
 
   if (options.targetDylib) {
@@ -647,6 +649,8 @@ void createTTNNCommonToEmitPyPipeline(
   if (options.tryRecoverStructure) {
     createRecoverStructureXLATorchPipeline(
         devicePm, RecoverStructureXLATorchPipelineOptions());
+  } else {
+    devicePm.addPass(createTTNNForceFinalDeallocs());
   }
 
   // Apply EmitPy-specific workarounds before conversion

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -51,6 +51,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         OptimizerPasses/TTNNDeduceMoEComputeLayouts.cpp
         OptimizerPasses/TTNNPrepareConv3dWeights.cpp
         TTNNAdjustDeallocs.cpp
+        TTNNForceFinalDeallocs.cpp
         TTNNAllocateDistributedOpBuffers.cpp
         TTNNAllocateDistributedOpSemaphores.cpp
         TTNNCollaspeD2M.cpp

--- a/lib/Dialect/TTNN/Transforms/TTNNForceFinalDeallocs.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNForceFinalDeallocs.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNFORCEFINALDEALLOCS
@@ -92,9 +93,10 @@ Value canonicalRoot(Value value, llvm::DenseMap<Value, Value> &valueToRoot) {
 // For each underlying buffer, this pass walks that buffer's deallocate ops from
 // bottom to top and sets the force flag to true on the last one in program
 // order (the true final use of that buffer), so the buffer is properly freed.
-// The remaining deallocates of that buffer are left as force=false no-ops.
-// Buffers that escape the function (returned variables) or activations that a
-// conv op deallocates itself are left untouched.
+// For buffers that are freed elsewhere (variables that escape the function that
+// are freed by the caller or conv activations the conv op force-deallocates
+// itself), no deallocation is forced and all of their (no-op) deallocations are
+// removed.
 class TTNNForceFinalDeallocs
     : public impl::TTNNForceFinalDeallocsBase<TTNNForceFinalDeallocs> {
 public:
@@ -121,12 +123,12 @@ private:
         return WalkResult::advance();
       }
 
-      Value convActivation;
-      if (auto convOp = mlir::dyn_cast<Conv2dOp>(op)) {
-        convActivation = getConvDeallocatedActivation(convOp);
-      } else if (auto convOp = mlir::dyn_cast<ConvTranspose2dOp>(op)) {
-        convActivation = getConvDeallocatedActivation(convOp);
-      }
+      Value convActivation =
+          llvm::TypeSwitch<Operation *, Value>(op)
+              .Case<Conv2dOp, ConvTranspose2dOp>([](auto convOp) {
+                return getConvDeallocatedActivation(convOp);
+              })
+              .Default(Value());
       if (convActivation) {
         doNotForceRoots.insert(canonicalRoot(convActivation, valueToRoot));
       }
@@ -156,21 +158,38 @@ private:
       deallocCountByRoot[canonicalRoot(deallocOp.getInput(), valueToRoot)]++;
     });
 
-    // Walk deallocations bottom-to-top. The first deallocate in order for the
-    // given buffer is the last in program order.
+    // Walk deallocations bottom-to-top and decide, per buffer, which single
+    // deallocate (if any) should free it. All other deallocations of that
+    // buffer are no-ops and are removed.
     llvm::DenseSet<Value> forcedRoots;
+    llvm::SmallVector<DeallocateOp> redundantDeallocs;
     for (auto deallocOp : llvm::reverse(deallocs)) {
       Value root = canonicalRoot(deallocOp.getInput(), valueToRoot);
+
+      // The buffer is freed elsewhere: escapes the function (freed by the
+      // caller) or is a conv activation the conv force-deallocates itself.
       if (doNotForceRoots.contains(root)) {
+        redundantDeallocs.push_back(deallocOp);
         continue;
       }
+
+      // A single deallocate already frees the buffer (its input variable is the
+      // sole reference), so leave it as is.
       if (deallocCountByRoot.lookup(root) < 2) {
         continue;
       }
-      if (!forcedRoots.insert(root).second) {
-        continue;
+
+      // Multiple aliasing deallocations: the first one seen is the last in
+      // program order, so force it. The rest are no-ops and are removed.
+      if (forcedRoots.insert(root).second) {
+        deallocOp.setForce(true);
+      } else {
+        redundantDeallocs.push_back(deallocOp);
       }
-      deallocOp.setForce(true);
+    }
+
+    for (DeallocateOp deallocOp : redundantDeallocs) {
+      deallocOp->erase();
     }
   }
 };

--- a/lib/Dialect/TTNN/Transforms/TTNNForceFinalDeallocs.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNForceFinalDeallocs.cpp
@@ -104,7 +104,14 @@ public:
       TTNNForceFinalDeallocs>::TTNNForceFinalDeallocsBase;
 
   void runOnOperation() final {
-    getOperation()->walk([&](func::FuncOp funcOp) { processFunc(funcOp); });
+    getOperation()->walk([&](func::FuncOp funcOp) {
+      if (funcOp.isDeclaration()) {
+        return;
+      }
+      assert(funcOp.getBody().hasOneBlock() &&
+             "found func that didn't have one block!");
+      processFunc(funcOp);
+    });
   }
 
 private:

--- a/lib/Dialect/TTNN/Transforms/TTNNForceFinalDeallocs.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNForceFinalDeallocs.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttnn {
+#define GEN_PASS_DEF_TTNNFORCEFINALDEALLOCS
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+namespace {
+
+// Returns the input value whose device buffer op's result aliases, or a null
+// Value if op allocates its own buffer (i.e. is not acting as a view).
+//
+// Today, only view-eligible reshapes alias their input. This helper is the
+// single place that knowledge lives so that the rest of the pass is decoupled
+// from it. A future ViewOpInterface can replace the body without touching the
+// pass logic.
+Value getViewSource(Operation *op) {
+  if (canReshapeBeView(op)) {
+    return op->getOperand(0);
+  }
+  return Value();
+}
+
+// Returns the activation of the given conv op if the conv deallocates it
+// itself, or a null value otherwise.
+template <typename ConvOpTy>
+Value getConvDeallocatedActivation(ConvOpTy conv) {
+  auto config = conv.getConv2dConfigAttr();
+  Value input = conv.getInput();
+  auto inputType = mlir::cast<RankedTensorType>(input.getType());
+
+  // The conv deallocates its activation when the flag is set and the
+  // activation is in L1 memory.
+  bool deallocatesActivation =
+      config && config.getDeallocateActivation() &&
+      config.getDeallocateActivation().getValue() &&
+      utils::getBufferTypeFromTensor(inputType) == BufferType::L1;
+
+  return deallocatesActivation ? input : Value();
+}
+
+// Walks up the chain of view ops until reaching the value that produces the
+// underlying buffer, caching the result for every value on the path.
+Value canonicalRoot(Value value, llvm::DenseMap<Value, Value> &valueToRoot) {
+  llvm::SmallVector<Value, 4> path;
+  Value current = value;
+  while (true) {
+    auto it = valueToRoot.find(current);
+    if (it != valueToRoot.end()) {
+      current = it->second;
+      break;
+    }
+    Operation *defOp = current.getDefiningOp();
+    Value source = defOp ? getViewSource(defOp) : Value();
+    if (!source) {
+      break;
+    }
+    path.push_back(current);
+    current = source;
+  }
+  Value root = current;
+  for (Value aliased : path) {
+    valueToRoot[aliased] = root;
+  }
+  valueToRoot[root] = root;
+  return root;
+}
+
+} // namespace
+
+// A `ttnn.deallocate` with the force flag set to false frees the buffer only
+// when its input variable is the last one referencing that buffer. This
+// becomes a problem when several handles alias one buffer: e.g. a
+// view-eligible reshape op returns a tensor that points to its input's device
+// buffer. Deallocate ops are inserted in the IR per SSA value by the
+// `TTNNDeallocate` pass. However, in the mentioned case, they act as no-ops,
+// so the buffer is never freed. This can result in L1 allocation failure.
+//
+// For each underlying buffer, this pass walks that buffer's deallocate ops from
+// bottom to top and sets the force flag to true on the last one in program
+// order (the true final use of that buffer), so the buffer is properly freed.
+// The remaining deallocates of that buffer are left as force=false no-ops.
+// Buffers that escape the function (returned variables) or activations that a
+// conv op deallocates itself are left untouched.
+class TTNNForceFinalDeallocs
+    : public impl::TTNNForceFinalDeallocsBase<TTNNForceFinalDeallocs> {
+public:
+  using impl::TTNNForceFinalDeallocsBase<
+      TTNNForceFinalDeallocs>::TTNNForceFinalDeallocsBase;
+
+  void runOnOperation() final {
+    getOperation()->walk([&](func::FuncOp funcOp) { processFunc(funcOp); });
+  }
+
+private:
+  // Collects the roots that must never be force-freed. These are either
+  // variables returned from the function, or conv activations that the conv op
+  // deallocates itself.
+  llvm::DenseSet<Value>
+  collectDoNotForceRoots(func::FuncOp funcOp,
+                         llvm::DenseMap<Value, Value> &valueToRoot) {
+    llvm::DenseSet<Value> doNotForceRoots;
+    funcOp.walk([&](Operation *op) {
+      if (auto returnOp = mlir::dyn_cast<func::ReturnOp>(op)) {
+        for (Value operand : returnOp.getOperands()) {
+          doNotForceRoots.insert(canonicalRoot(operand, valueToRoot));
+        }
+        return WalkResult::advance();
+      }
+
+      Value convActivation;
+      if (auto convOp = mlir::dyn_cast<Conv2dOp>(op)) {
+        convActivation = getConvDeallocatedActivation(convOp);
+      } else if (auto convOp = mlir::dyn_cast<ConvTranspose2dOp>(op)) {
+        convActivation = getConvDeallocatedActivation(convOp);
+      }
+      if (convActivation) {
+        doNotForceRoots.insert(canonicalRoot(convActivation, valueToRoot));
+      }
+      return WalkResult::advance();
+    });
+    return doNotForceRoots;
+  }
+
+  // Forces the last deallocation of each buffer that has more than one
+  // (aliasing) deallocations.
+  void processFunc(func::FuncOp funcOp) {
+    // Resolves each value to the root value identifying its underlying
+    // buffer.
+    llvm::DenseMap<Value, Value> valueToRoot;
+
+    // Buffers that are used outside the function (returned variables) or
+    // deallocated by a conv op (conv op L1 activations) cannot be force-freed.
+    llvm::DenseSet<Value> doNotForceRoots =
+        collectDoNotForceRoots(funcOp, valueToRoot);
+
+    // Count deallocations per buffer so we only touch buffers that
+    // actually have multiple (aliasing) deallocations.
+    llvm::SmallVector<DeallocateOp> deallocs;
+    llvm::DenseMap<Value, unsigned> deallocCountByRoot;
+    funcOp.walk([&](DeallocateOp deallocOp) {
+      deallocs.push_back(deallocOp);
+      deallocCountByRoot[canonicalRoot(deallocOp.getInput(), valueToRoot)]++;
+    });
+
+    // Walk deallocations bottom-to-top. The first deallocate in order for the
+    // given buffer is the last in program order.
+    llvm::DenseSet<Value> forcedRoots;
+    for (auto deallocOp : llvm::reverse(deallocs)) {
+      Value root = canonicalRoot(deallocOp.getInput(), valueToRoot);
+      if (doNotForceRoots.contains(root)) {
+        continue;
+      }
+      if (deallocCountByRoot.lookup(root) < 2) {
+        continue;
+      }
+      if (!forcedRoots.insert(root).second) {
+        continue;
+      }
+      deallocOp.setForce(true);
+    }
+  }
+};
+
+} // namespace mlir::tt::ttnn

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_force_final_deallocs.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_force_final_deallocs.mlir
@@ -1,0 +1,55 @@
+// RUN: ttmlir-opt --ttnn-force-final-deallocs -o %t %s
+// RUN: FileCheck %s --input-file=%t
+//
+// Test for the --ttnn-force-final-deallocs pass.
+// A view-eligible ttnn.reshape aliases its input's buffer, so the input and the
+// reshape result get separate ttnn.deallocate ops that both target one buffer.
+// The pass forces the last deallocation (bottom-most in program order) of each
+// such buffer so the memory is actually freed, while leaving buffers that
+// escape the function untouched.
+
+#dram = #ttnn.buffer_type<dram>
+#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#l3 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#l4 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 64 + d1 * 64 + d2, d3), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // %0 and its view %1 share one buffer; the last deallocate (%1's) is forced,
+  // the earlier one (%0's) stays a no-op.
+  // CHECK-LABEL: func.func @aliased
+  func.func @aliased(%arg0: tensor<64x128xbf16, #l>) -> tensor<1x64x128xbf16, #l3> {
+    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<64x128xbf16, #l>, tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l>
+    %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 64 : i32, 128 : i32]}> : (tensor<64x128xbf16, #l>) -> tensor<1x64x128xbf16, #l3>
+    %2 = "ttnn.add"(%1, %1) : (tensor<1x64x128xbf16, #l3>, tensor<1x64x128xbf16, #l3>) -> tensor<1x64x128xbf16, #l3>
+    // CHECK: "ttnn.deallocate"(%0) <{force = false}>
+    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l>) -> ()
+    // CHECK: "ttnn.deallocate"(%1) <{force = true}>
+    "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x64x128xbf16, #l3>) -> ()
+    return %2 : tensor<1x64x128xbf16, #l3>
+  }
+
+  // A view of the buffer is returned, so the buffer escapes the function and
+  // must not be force-freed: every deallocate stays force = false.
+  // CHECK-LABEL: func.func @returned_aliased
+  func.func @returned_aliased(%arg0: tensor<64x128xbf16, #l>) -> tensor<1x1x64x128xbf16, #l4> {
+    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<64x128xbf16, #l>, tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l>
+    %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 64 : i32, 128 : i32]}> : (tensor<64x128xbf16, #l>) -> tensor<1x64x128xbf16, #l3>
+    %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 1 : i32, 64 : i32, 128 : i32]}> : (tensor<1x64x128xbf16, #l3>) -> tensor<1x1x64x128xbf16, #l4>
+    // CHECK: "ttnn.deallocate"(%0) <{force = false}>
+    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l>) -> ()
+    // CHECK: "ttnn.deallocate"(%1) <{force = false}>
+    "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x64x128xbf16, #l3>) -> ()
+    return %2 : tensor<1x1x64x128xbf16, #l4>
+  }
+
+  // No aliasing: a single deallocate per buffer already frees with force = false
+  // (refcount 1), so the pass leaves it untouched.
+  // CHECK-LABEL: func.func @single
+  func.func @single(%arg0: tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l> {
+    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<64x128xbf16, #l>, tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l>
+    %1 = "ttnn.add"(%0, %0) : (tensor<64x128xbf16, #l>, tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l>
+    // CHECK: "ttnn.deallocate"(%0) <{force = false}>
+    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l>) -> ()
+    return %1 : tensor<64x128xbf16, #l>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_force_final_deallocs.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_force_final_deallocs.mlir
@@ -6,38 +6,39 @@
 // reshape result get separate ttnn.deallocate ops that both target one buffer.
 // The pass forces the last deallocation (bottom-most in program order) of each
 // such buffer so the memory is actually freed, while leaving buffers that
-// escape the function untouched.
+// escape the function untouched. All other deallocations of that buffer are no-ops
+// and are removed.
 
 #dram = #ttnn.buffer_type<dram>
-#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#l2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #l3 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #l4 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 64 + d1 * 64 + d2, d3), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
 module {
   // %0 and its view %1 share one buffer; the last deallocate (%1's) is forced,
-  // the earlier one (%0's) stays a no-op.
+  // the earlier one (%0's) is a redundant no-op and is removed.
   // CHECK-LABEL: func.func @aliased
-  func.func @aliased(%arg0: tensor<64x128xbf16, #l>) -> tensor<1x64x128xbf16, #l3> {
-    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<64x128xbf16, #l>, tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l>
-    %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 64 : i32, 128 : i32]}> : (tensor<64x128xbf16, #l>) -> tensor<1x64x128xbf16, #l3>
+  func.func @aliased(%arg0: tensor<64x128xbf16, #l2>) -> tensor<1x64x128xbf16, #l3> {
+    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<64x128xbf16, #l2>, tensor<64x128xbf16, #l2>) -> tensor<64x128xbf16, #l2>
+    %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 64 : i32, 128 : i32]}> : (tensor<64x128xbf16, #l2>) -> tensor<1x64x128xbf16, #l3>
     %2 = "ttnn.add"(%1, %1) : (tensor<1x64x128xbf16, #l3>, tensor<1x64x128xbf16, #l3>) -> tensor<1x64x128xbf16, #l3>
-    // CHECK: "ttnn.deallocate"(%0) <{force = false}>
-    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l>) -> ()
+    // CHECK-NOT: "ttnn.deallocate"
     // CHECK: "ttnn.deallocate"(%1) <{force = true}>
+    // CHECK-NOT: "ttnn.deallocate"
+    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l2>) -> ()
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x64x128xbf16, #l3>) -> ()
     return %2 : tensor<1x64x128xbf16, #l3>
   }
 
-  // A view of the buffer is returned, so the buffer escapes the function and
-  // must not be force-freed: every deallocate stays force = false.
+  // A view of the buffer is returned, so the buffer escapes the function and is
+  // freed by the caller. All of its (no-op) deallocates are removed.
   // CHECK-LABEL: func.func @returned_aliased
-  func.func @returned_aliased(%arg0: tensor<64x128xbf16, #l>) -> tensor<1x1x64x128xbf16, #l4> {
-    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<64x128xbf16, #l>, tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l>
-    %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 64 : i32, 128 : i32]}> : (tensor<64x128xbf16, #l>) -> tensor<1x64x128xbf16, #l3>
+  func.func @returned_aliased(%arg0: tensor<64x128xbf16, #l2>) -> tensor<1x1x64x128xbf16, #l4> {
+    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<64x128xbf16, #l2>, tensor<64x128xbf16, #l2>) -> tensor<64x128xbf16, #l2>
+    %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 64 : i32, 128 : i32]}> : (tensor<64x128xbf16, #l2>) -> tensor<1x64x128xbf16, #l3>
     %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 1 : i32, 64 : i32, 128 : i32]}> : (tensor<1x64x128xbf16, #l3>) -> tensor<1x1x64x128xbf16, #l4>
-    // CHECK: "ttnn.deallocate"(%0) <{force = false}>
-    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l>) -> ()
-    // CHECK: "ttnn.deallocate"(%1) <{force = false}>
+    // CHECK-NOT: "ttnn.deallocate"
+    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l2>) -> ()
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x64x128xbf16, #l3>) -> ()
     return %2 : tensor<1x1x64x128xbf16, #l4>
   }
@@ -45,11 +46,11 @@ module {
   // No aliasing: a single deallocate per buffer already frees with force = false
   // (refcount 1), so the pass leaves it untouched.
   // CHECK-LABEL: func.func @single
-  func.func @single(%arg0: tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l> {
-    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<64x128xbf16, #l>, tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l>
-    %1 = "ttnn.add"(%0, %0) : (tensor<64x128xbf16, #l>, tensor<64x128xbf16, #l>) -> tensor<64x128xbf16, #l>
+  func.func @single(%arg0: tensor<64x128xbf16, #l2>) -> tensor<64x128xbf16, #l2> {
+    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<64x128xbf16, #l2>, tensor<64x128xbf16, #l2>) -> tensor<64x128xbf16, #l2>
+    %1 = "ttnn.add"(%0, %0) : (tensor<64x128xbf16, #l2>, tensor<64x128xbf16, #l2>) -> tensor<64x128xbf16, #l2>
     // CHECK: "ttnn.deallocate"(%0) <{force = false}>
-    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l>) -> ()
-    return %1 : tensor<64x128xbf16, #l>
+    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l2>) -> ()
+    return %1 : tensor<64x128xbf16, #l2>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_force_final_deallocs.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_force_final_deallocs.mlir
@@ -5,14 +5,23 @@
 // A view-eligible ttnn.reshape aliases its input's buffer, so the input and the
 // reshape result get separate ttnn.deallocate ops that both target one buffer.
 // The pass forces the last deallocation (bottom-most in program order) of each
-// such buffer so the memory is actually freed, while leaving buffers that
-// escape the function untouched. All other deallocations of that buffer are no-ops
-// and are removed.
+// such buffer so the memory is actually freed. Other deallocations of that buffer
+// are no-ops and are removed. Buffers freed elsewhere (returned values that are
+// freed by the caller or conv activations the conv op force-deallocates itself)
+// are never forced and all of their no-op deallocations are removed.
 
 #dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+#system_memory = #ttnn.buffer_type<system_memory>
 #l2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #l3 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #l4 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 64 + d1 * 64 + d2, d3), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// Conv activation (L1) and a view of it, plus weight/bias/output layouts.
+#conv_in = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 852800 + d1 * 852800 + d2, d3), <1x1>, memref<26650x1x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#conv_in_view = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 852800 + d1, d2), <1x1>, memref<26650x1x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#weight = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 21 + d1 * 7 + d2, d3), <1x1>, memref<1344x7xbf16, #system_memory>>
+#bias = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 + d1 + d2, d3), <1x1>, memref<1x64xbf16, #system_memory>>
+#conv_out = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 213216 + d1 * 213216 + d2, d3), <1x1>, memref<6663x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
 module {
   // %0 and its view %1 share one buffer; the last deallocate (%1's) is forced,
@@ -41,6 +50,20 @@ module {
     "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xbf16, #l2>) -> ()
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x64x128xbf16, #l3>) -> ()
     return %2 : tensor<1x1x64x128xbf16, #l4>
+  }
+
+  // The conv2d has deallocate_activation=true and an L1 input, so the conv frees
+  // that buffer itself. All of its (no-op) deallocates are removed.
+  // CHECK-LABEL: func.func @conv_activation
+  func.func @conv_activation(%arg0: tensor<1x1x852800x3xbf16, #conv_in>, %arg1: tensor<64x3x7x7xbf16, #weight>, %arg2: tensor<1x1x1x64xbf16, #bias>) -> tensor<1x1x213200x64xbf16, #conv_out> {
+    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %view = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 852800 : i32, 3 : i32]}> : (tensor<1x1x852800x3xbf16, #conv_in>) -> tensor<1x852800x3xbf16, #conv_in_view>
+    // CHECK: "ttnn.conv2d"
+    %result = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0) <{batch_size = 1 : i32, conv2d_config = #ttnn.conv2d_config<weights_dtype = bf16, deallocate_activation = true, enable_kernel_stride_folding = false>, dilation = array<i32: 1, 1>, dtype = #ttcore.supportedDataTypes<bf16>, groups = 1 : i32, in_channels = 3 : i32, input_height = 800 : i32, input_width = 1066 : i32, kernel_size = array<i32: 7, 7>, out_channels = 64 : i32, padding = array<i32: 3, 3, 3, 3>, stride = array<i32: 2, 2>}> : (tensor<1x1x852800x3xbf16, #conv_in>, tensor<64x3x7x7xbf16, #weight>, tensor<1x1x1x64xbf16, #bias>, !ttnn.device) -> tensor<1x1x213200x64xbf16, #conv_out>
+    // CHECK-NOT: "ttnn.deallocate"
+    "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<1x1x852800x3xbf16, #conv_in>) -> ()
+    "ttnn.deallocate"(%view) <{force = false}> : (tensor<1x852800x3xbf16, #conv_in_view>) -> ()
+    return %result : tensor<1x1x213200x64xbf16, #conv_out>
   }
 
   // No aliasing: a single deallocate per buffer already frees with force = false


### PR DESCRIPTION
### Ticket
Closes #8942
### Problem description
`TTNNDeallocate` inserts one deallocate op per SSA value with the default `force=false`. `ttnn.deallocate(force=false)` frees the buffer only when its input variable is the last one referencing it. When several variables alias one underlying buffer (e.g., a view-eligible reshape op returns a tensor that points to its input's device buffer), each of the per-variable deallocations is a no-op, so the buffer is never freed. This caused L1 allocation failures.

### What's changed
Added `TTNNForceFinalDeallocs` pass that walks deallocations of each buffer bottom-to-top and sets `force=true` on the last one in program order (the true final use of that buffer). Exceptions are buffers that must not be force-freed:
- values returned from the function (escape the function), and
- conv activations that conv op deallocates itself ( when `deallocate_activation=true` and activation is in L1).
Last deallocates in such cases and other no-op deallocates are removed completely from the emitted code.

#### Current scope/limitations:
- View detection is currently done only for the reshape op (`canReshapeBeView` is used). This can be further improved by implementing`ViewOpInterface`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
