### PR TITLE
[TTNN] Make compute-kernel-config bool knobs tri-state and expose them

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -10,8 +10,8 @@
 #include "ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h"
 #include "ttmlir/Dialect/TTNN/Utils/BFPDtypeParser.h"
 #include "ttmlir/Dialect/TTNN/Utils/CompositeResolution.h"
-#include "ttmlir/Dialect/TTNN/Utils/MathFidelityParser.h"
 #include "ttmlir/Dialect/TTNN/Utils/MemoryLayoutAnalysisParams.h"
+#include "ttmlir/Dialect/TTNN/Utils/PassOptionParsers.h"
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 
 #include "mlir/Pass/PassManager.h"
@@ -471,8 +471,13 @@ struct TTIRToTTNNCommonPipelineOptions
   // This is done as part of generality effort,
   // to boost accuracy on all operations exposing compute kernel config by
   // default. At optimization levels > 0, these are overridden to
-  // Undefined/false to defer to runtime defaults (see
+  // Undefined/unset to defer to runtime defaults (see
   // resolveOptimizationLevelOptions).
+  // The remaining bool knobs (math_approx_mode, packer_l1_acc,
+  // dst_full_sync_en) default to unset (std::nullopt) at every optimization
+  // level, so TTNN decides unless a frontend explicitly overrides them. All
+  // bool knobs are tri-state (true / false / unset) so a frontend can force a
+  // knob OFF as distinct from leaving it to TTNN.
   mutable Option<OptionalMathFidelity> computeCfgMathFidelity{
       *this, "compute-cfg-math-fidelity",
       llvm::cl::desc("Set math fidelity for all ttnn operations exposing "
@@ -486,11 +491,30 @@ struct TTIRToTTNNCommonPipelineOptions
                      "Undefined math fidelity")),
       llvm::cl::init(OptionalMathFidelity::HiFi4)};
 
-  mutable Option<bool> computeCfgFp32DestAccEn{
+  mutable Option<std::optional<bool>> computeCfgFp32DestAccEn{
       *this, "compute-cfg-fp32-dest-acc-en",
       llvm::cl::desc("Set fp32 destination accumulation for all ttnn "
-                     "operations exposing compute kernel config."),
-      llvm::cl::init(true)};
+                     "operations exposing compute kernel config "
+                     "(true, false, unset)."),
+      llvm::cl::init(std::optional<bool>(true))};
+
+  mutable Option<std::optional<bool>> computeCfgMathApproxMode{
+      *this, "compute-cfg-math-approx-mode",
+      llvm::cl::desc("Set math approx mode for all ttnn operations exposing "
+                     "compute kernel config (true, false, unset)."),
+      llvm::cl::init(std::optional<bool>(std::nullopt))};
+
+  mutable Option<std::optional<bool>> computeCfgPackerL1Acc{
+      *this, "compute-cfg-packer-l1-acc",
+      llvm::cl::desc("Set packer L1 accumulation for all ttnn operations "
+                     "exposing compute kernel config (true, false, unset)."),
+      llvm::cl::init(std::optional<bool>(std::nullopt))};
+
+  mutable Option<std::optional<bool>> computeCfgDstFullSyncEn{
+      *this, "compute-cfg-dst-full-sync-en",
+      llvm::cl::desc("Set dst full sync enable for all ttnn operations "
+                     "exposing compute kernel config (true, false, unset)."),
+      llvm::cl::init(std::optional<bool>(std::nullopt))};
 
   Option<bool> ttnnPerfMetricsEnabled{
       *this, "ttnn-perf-metrics-enabled",
@@ -596,7 +620,7 @@ struct TTIRToTTNNCommonPipelineOptions
     }
     if (computeCfgFp32DestAccEn.getNumOccurrences() == 0 &&
         optimizationLevel > 0) {
-      computeCfgFp32DestAccEn = false;
+      computeCfgFp32DestAccEn = std::optional<bool>(std::nullopt);
     }
   }
 };

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.h
@@ -16,8 +16,8 @@
 #include "ttmlir/Dialect/TTNN/Transforms/GreedyMemoryLayoutPropagation.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Optimizer.h"
 #include "ttmlir/Dialect/TTNN/Utils/CompositeResolution.h"
-#include "ttmlir/Dialect/TTNN/Utils/MathFidelityParser.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h"
+#include "ttmlir/Dialect/TTNN/Utils/PassOptionParsers.h"
 
 namespace mlir::tt::ttnn {
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -633,8 +633,11 @@ def TTNNSetComputeKernelConfig: Pass<"ttnn-set-compute-kernel-config", "::mlir::
       option values are applied.
     - If a parameter is already set on the operation's compute_config, pipeline options do
       not override it.
-    - If a parameter is unset (std::nullopt for math_fidelity, false for bool options),
-      the corresponding pipeline option is applied.
+    - If a pipeline option is unset (std::nullopt / OptionalMathFidelity::Undefined), the
+      corresponding op parameter is left untouched (TTNN decides at runtime).
+    - If a pipeline option is set (including bool options explicitly set to false), it is
+      applied to ops that do not already set that parameter. This makes true / false /
+      unset a genuine tri-state for the bool options.
 
     Large-inner-dimension bf16 matmul/linear correctness fix (tenstorrent/tt-metal#46101):
     For `ttnn.matmul` and `ttnn.linear` with inner dimension > 50000 and bf16 output,
@@ -645,19 +648,20 @@ def TTNNSetComputeKernelConfig: Pass<"ttnn-set-compute-kernel-config", "::mlir::
     Example usage:
     ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=hifi4" input.mlir
     ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=lofi fp32-dest-acc-en=true" input.mlir
+    ttmlir-opt --ttnn-set-compute-kernel-config="fp32-dest-acc-en=false packer-l1-acc=true" input.mlir
   }];
 
   let options = [
     Option<"mathFidelity", "math-fidelity", "::mlir::tt::ttnn::OptionalMathFidelity", /*default=*/"::mlir::tt::ttnn::OptionalMathFidelity::HiFi4",
-           "Set default math_fidelity (lofi, hifi2, hifi3, hifi4)">,
-    Option<"mathApproxMode", "math-approx-mode", "bool", /*default=*/"false",
-           "Set default math_approx_mode">,
-    Option<"fp32DestAccEn", "fp32-dest-acc-en", "bool", /*default=*/"true",
-           "Set default fp32_dest_acc_en">,
-    Option<"packerL1Acc", "packer-l1-acc", "bool", /*default=*/"false",
-           "Set default packer_l1_acc">,
-    Option<"dstFullSyncEn", "dst-full-sync-en", "bool", /*default=*/"false",
-           "Set default dst_full_sync_en">
+           "Set default math_fidelity (lofi, hifi2, hifi3, hifi4, undefined)">,
+    Option<"mathApproxMode", "math-approx-mode", "std::optional<bool>", /*default=*/"std::optional<bool>(std::nullopt)",
+           "Set default math_approx_mode (true, false, unset)">,
+    Option<"fp32DestAccEn", "fp32-dest-acc-en", "std::optional<bool>", /*default=*/"std::optional<bool>(true)",
+           "Set default fp32_dest_acc_en (true, false, unset)">,
+    Option<"packerL1Acc", "packer-l1-acc", "std::optional<bool>", /*default=*/"std::optional<bool>(std::nullopt)",
+           "Set default packer_l1_acc (true, false, unset)">,
+    Option<"dstFullSyncEn", "dst-full-sync-en", "std::optional<bool>", /*default=*/"std::optional<bool>(std::nullopt)",
+           "Set default dst_full_sync_en (true, false, unset)">
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOptionParsers.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOptionParsers.h
@@ -2,11 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TTMLIR_DIALECT_TTNN_UTILS_MATHFIDELITYPARSER_H
-#define TTMLIR_DIALECT_TTNN_UTILS_MATHFIDELITYPARSER_H
+#ifndef TTMLIR_DIALECT_TTNN_UTILS_PASSOPTIONPARSERS_H
+#define TTMLIR_DIALECT_TTNN_UTILS_PASSOPTIONPARSERS_H
+
+// llvm::cl::parser specializations that let custom types be used as MLIR
+// pass / pipeline options. Grouped here so each new option type does not need
+// its own header.
 
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include <optional>
 
 namespace llvm::cl {
@@ -127,6 +135,65 @@ public:
   }
 };
 
+// Template specialization of llvm::cl::parser for std::optional<bool>.
+//
+// This enables MLIR pass / pipeline options to express a tri-state boolean:
+//   - "true"  -> std::optional<bool>(true)
+//   - "false" -> std::optional<bool>(false)
+//   - "unset" -> std::nullopt (defer to the downstream default)
+//
+// The tri-state is required so a frontend can force a knob OFF (false) as
+// distinct from leaving it unset (let TTNN decide). Mirrors the
+// parser<std::optional<mlir::tt::ttnn::MathFidelity>> specialization above.
+template <>
+class parser<std::optional<bool>> : public basic_parser<std::optional<bool>> {
+public:
+  parser(Option &opt) : basic_parser<std::optional<bool>>(opt) {}
+
+  bool parse(Option &opt, StringRef argName, StringRef arg,
+             std::optional<bool> &value) {
+    StringRef trimmed = arg.trim();
+    if (trimmed.equals_insensitive("true")) {
+      value = true;
+      return false; // Success
+    }
+    if (trimmed.equals_insensitive("false")) {
+      value = false;
+      return false; // Success
+    }
+    if (trimmed.equals_insensitive("unset")) {
+      value = std::nullopt;
+      return false; // Success
+    }
+
+    return opt.error("Invalid value '" + arg.str() +
+                     "'. Valid values are: true, false, unset");
+  }
+
+  static StringRef toString(const std::optional<bool> &value) {
+    if (!value.has_value()) {
+      return "unset";
+    }
+    return *value ? "true" : "false";
+  }
+
+  void print(raw_ostream &os, const std::optional<bool> &value) {
+    os << toString(value);
+  }
+
+  void printOptionDiff(const Option &opt,
+                       const OptionValue<std::optional<bool>> &value,
+                       const OptionValue<std::optional<bool>> &defaultValue,
+                       size_t globalWidth) const {
+    printOptionName(opt, globalWidth);
+    outs() << "= " << toString(value.getValue());
+    if (defaultValue.getValue() != value.getValue()) {
+      outs() << " (default: " << toString(defaultValue.getValue()) << ")";
+    }
+    outs() << "\n";
+  }
+};
+
 } // namespace llvm::cl
 
-#endif // TTMLIR_DIALECT_TTNN_UTILS_MATHFIDELITYPARSER_H
+#endif // TTMLIR_DIALECT_TTNN_UTILS_PASSOPTIONPARSERS_H

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -457,11 +457,14 @@ void createTTIRToTTNNCommonPipeline(
 
     // Apply ComputeKernelConfig settings before analysis passes.
     // Always run: large-K matmul/linear packer_l1_acc logic runs even when
-    // pipeline options leave math_fidelity undefined and fp32_dest_acc_en
-    // false.
+    // pipeline options leave every compute-kernel-config knob unset.
     TTNNSetComputeKernelConfigOptions setConfigOptions;
     setConfigOptions.mathFidelity = options.computeCfgMathFidelity.getValue();
+    setConfigOptions.mathApproxMode =
+        options.computeCfgMathApproxMode.getValue();
     setConfigOptions.fp32DestAccEn = options.computeCfgFp32DestAccEn.getValue();
+    setConfigOptions.packerL1Acc = options.computeCfgPackerL1Acc.getValue();
+    setConfigOptions.dstFullSyncEn = options.computeCfgDstFullSyncEn.getValue();
     devicePm.addPass(createTTNNSetComputeKernelConfig(setConfigOptions));
 
     if (options.enableCreateD2MSubgraphs) {

--- a/lib/Dialect/TTNN/Transforms/TTNNSetComputeKernelConfig.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNSetComputeKernelConfig.cpp
@@ -96,30 +96,64 @@ public:
         config = DeviceComputeKernelConfigAttr::get(context);
       }
 
-      // Apply overrides only for parameters that are not already set.
+      // Apply overrides only for parameters that are not already set on the op.
       // Each withX() method returns a new attribute, so we chain them.
+      // A pipeline option that is unset (std::nullopt for the bool options,
+      // Undefined for math fidelity) is never applied, so the op parameter is
+      // left for TTNN to decide. A bool option that is explicitly set - even to
+      // false - is applied, giving a genuine true / false / unset tri-state.
+      //
+      // When a global override is available but the op already sets that knob,
+      // we keep the op's value and emit a debug log so the user is aware the
+      // global compute-kernel-config was not applied for that parameter.
+      auto logSkippedOverride = [&](llvm::StringRef knob) {
+        TTMLIR_DEBUG(ttmlir::LogComponent::General,
+                     "  Skipping global {0} override on {1}: op already sets "
+                     "this knob, keeping its value",
+                     knob, op->getName().getStringRef());
+      };
 
       // Math fidelity: only override if not already set and we have a value.
-      if (!config.getMathFidelity().has_value() &&
-          mathFidelityOverride.has_value()) {
-        config = config.withMathFidelity(*mathFidelityOverride);
+      if (mathFidelityOverride.has_value()) {
+        if (!config.getMathFidelity().has_value()) {
+          config = config.withMathFidelity(*mathFidelityOverride);
+        } else {
+          logSkippedOverride("math_fidelity");
+        }
       }
 
-      // Bool options: only override if not already set and option is true.
-      if (!config.getMathApproxMode() && mathApproxMode) {
-        config = config.withMathApproxMode(mathApproxMode);
+      // Bool options: only override if not already set on the op and the
+      // pipeline option carries a value (true or false).
+      if (mathApproxMode.has_value()) {
+        if (!config.getMathApproxMode()) {
+          config = config.withMathApproxMode(*mathApproxMode);
+        } else {
+          logSkippedOverride("math_approx_mode");
+        }
       }
 
-      if (!config.getFp32DestAccEn() && fp32DestAccEn) {
-        config = config.withFp32DestAccEn(fp32DestAccEn);
+      if (fp32DestAccEn.has_value()) {
+        if (!config.getFp32DestAccEn()) {
+          config = config.withFp32DestAccEn(*fp32DestAccEn);
+        } else {
+          logSkippedOverride("fp32_dest_acc_en");
+        }
       }
 
-      if (!config.getPackerL1Acc() && packerL1Acc) {
-        config = config.withPackerL1Acc(packerL1Acc);
+      if (packerL1Acc.has_value()) {
+        if (!config.getPackerL1Acc()) {
+          config = config.withPackerL1Acc(*packerL1Acc);
+        } else {
+          logSkippedOverride("packer_l1_acc");
+        }
       }
 
-      if (!config.getDstFullSyncEn() && dstFullSyncEn) {
-        config = config.withDstFullSyncEn(dstFullSyncEn);
+      if (dstFullSyncEn.has_value()) {
+        if (!config.getDstFullSyncEn()) {
+          config = config.withDstFullSyncEn(*dstFullSyncEn);
+        } else {
+          logSkippedOverride("dst_full_sync_en");
+        }
       }
 
       // This fix is required for correctness of large matmuls/linears.

--- a/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/conv2d_packer_l1_acc_tristate.mlir
+++ b/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/conv2d_packer_l1_acc_tristate.mlir
@@ -1,0 +1,38 @@
+// Tri-state test for a single bool compute-kernel-config knob (packer_l1_acc):
+// the pipeline option can force it ON (true), force it OFF (false), or be left
+// UNSET (leave the op untouched so TTNN decides). math_fidelity and
+// fp32_dest_acc_en are pinned to undefined/unset here so only packer_l1_acc is
+// under test.
+
+// RUN: ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=undefined fp32-dest-acc-en=unset packer-l1-acc=true" %s | FileCheck %s --check-prefix=TRUE
+// RUN: ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=undefined fp32-dest-acc-en=unset packer-l1-acc=false" %s | FileCheck %s --check-prefix=FALSE
+// RUN: ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=undefined fp32-dest-acc-en=unset packer-l1-acc=unset" %s | FileCheck %s --check-prefix=UNSET
+
+// TRUE-LABEL: func @test_packer_l1_acc_tristate
+// FALSE-LABEL: func @test_packer_l1_acc_tristate
+// UNSET-LABEL: func @test_packer_l1_acc_tristate
+func.func @test_packer_l1_acc_tristate(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %device: !ttnn.device) -> tensor<1x1x900x64xbf16> {
+  // TRUE: ttnn.conv2d
+  // TRUE-SAME: compute_config = #ttnn.device_compute_kernel_config<packer_l1_acc = true>
+
+  // FALSE: ttnn.conv2d
+  // FALSE-SAME: compute_config = #ttnn.device_compute_kernel_config<packer_l1_acc = false>
+
+  // UNSET: ttnn.conv2d
+  // UNSET-NOT: compute_config
+  // UNSET-NOT: device_compute_kernel_config
+  %result = "ttnn.conv2d"(%arg0, %arg1, %device) {
+    in_channels = 64: i32,
+    out_channels = 64: i32,
+    batch_size = 1: i32,
+    input_height = 32: i32,
+    input_width = 32: i32,
+    kernel_size = array<i32: 3, 3>,
+    stride = array<i32: 1, 1>,
+    padding = array<i32: 0, 0>,
+    dilation = array<i32: 1, 1>,
+    groups = 1: i32
+  } : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+
+  return %result : tensor<1x1x900x64xbf16>
+}

--- a/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/conv2d_preserve_existing_bool_knobs.mlir
+++ b/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/conv2d_preserve_existing_bool_knobs.mlir
@@ -1,0 +1,30 @@
+// RUN: ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=undefined fp32-dest-acc-en=unset math-approx-mode=false packer-l1-acc=true" %s | FileCheck %s
+// Test tri-state handling of the new bool knobs:
+//   - packer_l1_acc is already set to false on the op, so the pass must NOT
+//     override it to true (existing op value wins).
+//   - math_approx_mode is unset on the op, so the pass applies its value (false).
+//   - fp32_dest_acc_en pipeline option is unset, so it is left untouched.
+//   - math_fidelity is undefined, so it is left untouched.
+
+// CHECK-LABEL: func @test_preserve_bool_knobs
+func.func @test_preserve_bool_knobs(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %device: !ttnn.device) -> tensor<1x1x900x64xbf16> {
+  // CHECK: ttnn.conv2d
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_approx_mode = false, packer_l1_acc = false>
+  // CHECK-NOT: packer_l1_acc = true
+  // CHECK-NOT: fp32_dest_acc_en
+  %result = "ttnn.conv2d"(%arg0, %arg1, %device) {
+    in_channels = 64: i32,
+    out_channels = 64: i32,
+    batch_size = 1: i32,
+    input_height = 32: i32,
+    input_width = 32: i32,
+    kernel_size = array<i32: 3, 3>,
+    stride = array<i32: 1, 1>,
+    padding = array<i32: 0, 0>,
+    dilation = array<i32: 1, 1>,
+    groups = 1: i32,
+    compute_config = #ttnn.device_compute_kernel_config<packer_l1_acc = false>
+  } : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+
+  return %result : tensor<1x1x900x64xbf16>
+}

--- a/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/conv2d_set_all_knobs.mlir
+++ b/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/conv2d_set_all_knobs.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=lofi math-approx-mode=true fp32-dest-acc-en=false packer-l1-acc=true dst-full-sync-en=false" %s | FileCheck %s
+// Test that the pass can set every compute-kernel-config knob at once, including
+// bool knobs forced explicitly to false.
+
+// CHECK-LABEL: func @test_set_all_knobs
+func.func @test_set_all_knobs(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %device: !ttnn.device) -> tensor<1x1x900x64xbf16> {
+  // CHECK: ttnn.conv2d
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = lofi, math_approx_mode = true, fp32_dest_acc_en = false, packer_l1_acc = true, dst_full_sync_en = false>
+  %result = "ttnn.conv2d"(%arg0, %arg1, %device) {
+    in_channels = 64: i32,
+    out_channels = 64: i32,
+    batch_size = 1: i32,
+    input_height = 32: i32,
+    input_width = 32: i32,
+    kernel_size = array<i32: 3, 3>,
+    stride = array<i32: 1, 1>,
+    padding = array<i32: 0, 0>,
+    dilation = array<i32: 1, 1>,
+    groups = 1: i32
+  } : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+
+  return %result : tensor<1x1x900x64xbf16>
+}

--- a/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/conv2d_set_fp32_dest_acc.mlir
+++ b/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/conv2d_set_fp32_dest_acc.mlir
@@ -1,10 +1,11 @@
 // RUN: ttmlir-opt --ttnn-set-compute-kernel-config="fp32-dest-acc-en=false" %s | FileCheck %s
-// Test that the pass can set fp32_dest_acc_en parameter to false (override the default true)
+// Test that the pass can force fp32_dest_acc_en OFF (explicitly false), which is
+// distinct from leaving it unset. math_fidelity keeps its pass default (hifi4).
 
 // CHECK-LABEL: func @test_set_fp32_dest_acc
 func.func @test_set_fp32_dest_acc(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %device: !ttnn.device) -> tensor<1x1x900x64xbf16> {
   // CHECK: ttnn.conv2d
-  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi4>
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi4, fp32_dest_acc_en = false>
   %result = "ttnn.conv2d"(%arg0, %arg1, %device) {
     in_channels = 64: i32,
     out_channels = 64: i32,


### PR DESCRIPTION
### Ticket
Closes #8946

### Problem description
The TTNNSetComputeKernelConfig pass and TTIRToTTNNCommonPipelineOptions previously modeled the bool compute-kernel-config knobs (math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en) as plain `bool`, where the apply logic could only ever force a knob ON. `false` was indistinguishable from "unset", so a frontend could not force a knob OFF, and only fp32_dest_acc_en was plumbed through the pipeline. Rest of the knobs were unavailable to frontend to override. This was done intentionally.
Now, training team needs these knobs exposed in tt-xla. Therefore this PR.

### What's changed
- Add an `llvm::cl::parser<std::optional<bool>>` specialization accepting exactly `true` / `false` / `unset`, mirroring the existing `parser<std::optional<MathFidelity>>`. It lives in a new `PassOptionParsers.h`, which also absorbs the former `MathFidelityParser.h` — one header for the `llvm::cl::parser` specializations that let custom types be used as pass/pipeline options, instead of one header per type (`BFPDtypeParser.h` left separate for now, can fold in later).
- Convert the four bool pass options to `std::optional<bool>` and update the apply logic to `has_value()`, so an explicit `false` is applied while `unset` is left for TTNN to decide (genuine true / false / unset tri-state).
- Add the three missing pipeline options (compute-cfg-math-approx-mode, compute-cfg-packer-l1-acc, compute-cfg-dst-full-sync-en) and wire all four bool knobs through to the pass. `fp32_dest_acc_en` keeps its default of `true` at optimization_level 0 and is reset to `unset` (not `false`) at higher levels.
- Emit a per-knob DEBUG log when a global override is skipped because the op already sets that knob, so users can see which ops did not pick up the global config.
- Update / add lit tests: forcing `false`, setting all knobs at once, preserving existing op values for the new knobs, and a focused tri-state (true/false/unset) test for a single knob.
