### PR TITLE
Fix fill_cache golden function

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -1014,7 +1014,6 @@ def prod(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = N
     return builder.prod(in0, [1], False, unit_attrs=unit_attrs)
 
 
-@pytest.mark.xfail(reason="Fails Golden")
 @pytest.mark.parametrize(
     "shapes", [[(1, 32, 64, 512), (1, 32, 3, 512)] | SkipIf("sim")], ids=shapes_list_str
 )

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3606,9 +3606,15 @@ def fill_cache_golden(
         Filled cache tensor
     """
     result = cache_tensor.clone()
+    seq_len = input_tensor.shape[2]
+    tile_height = 32
+    padded_seq_len = ((seq_len + tile_height - 1) // tile_height) * tile_height
+    padded_seq_len = min(padded_seq_len, cache_tensor.shape[2])
 
     for device_id, shard in result.shard_map.items():
-        shard[:, :, : input_tensor.shape[2], :] = input_tensor.shard_at(device_id)
+        shard[:, :, :seq_len, :] = input_tensor.shard_at(device_id)
+        if padded_seq_len > seq_len:
+            shard[:, :, seq_len:padded_seq_len, :] = 0
     return result
 
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3609,11 +3609,10 @@ def fill_cache_golden(
     seq_len = input_tensor.shape[2]
     tile_height = 32
     padded_seq_len = ((seq_len + tile_height - 1) // tile_height) * tile_height
-    padded_seq_len = min(padded_seq_len, cache_tensor.shape[2])
 
     for device_id, shard in result.shard_map.items():
         shard[:, :, :seq_len, :] = input_tensor.shard_at(device_id)
-        if padded_seq_len > seq_len:
+        if seq_len < padded_seq_len <= cache_tensor.shape[2]:
             shard[:, :, seq_len:padded_seq_len, :] = 0
     return result
 


### PR DESCRIPTION
### Ticket
Closes [#2883](https://github.com/tenstorrent/tt-mlir/issues/2883)

### Problem description
The fill cache golden doesn't handle padding correctly. 

### What's changed
Added padding handling to match `FillCacheInputPadRewritePattern`

### Checklist
- [ ] New/Existing tests provide coverage for changes
