### PR TITLE
[d2m-jit] add RoPE support

### DIFF
--- a/test/d2m-jit/lit/rope.py
+++ b/test/d2m-jit/lit/rope.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR-shape coverage for the d2m-jit RoPE prefill helper."""
+
+import torch
+
+import d2m_jit as d2m
+from d2m_jit.prefill.rope import apply_rope, build_rope_tables
+from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise
+
+
+L = d2m.Layout(
+    shape=(64, 64),
+    dtype=d2m.float32,
+    block_shape=[2, 2],
+    grid_shape=[1, 1],
+)
+
+x = torch.randn(64, 64, dtype=torch.float32)
+cos, sin_signed = build_rope_tables(64, 64, dtype=torch.float32)
+out = apply_rope(
+    d2m.to_layout(x, L),
+    d2m.to_layout(cos, L),
+    d2m.to_layout(sin_signed, L),
+    L,
+    grid=(1, 1),
+    m_blocks=1,
+    n_blocks=1,
+)
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [out])
+builder.module.operation.verify()
+print(builder.module)
+_Builder.reset()
+
+
+# CHECK-DAG:   affine_map<{{.*}}mod{{.*}}>
+# CHECK-LABEL: func.func @main
+# CHECK:       d2m.view_layout
+# CHECK:       d2m.generic
+# CHECK:       d2m.remote_load
+# CHECK:       "d2m.tile_mul"
+# CHECK:       "d2m.tile_add"

--- a/test/d2m-jit/lit/view_layout_affine.py
+++ b/test/d2m-jit/lit/view_layout_affine.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR-shape coverage for affine-arithmetic d2m-jit view_layout lambdas."""
+
+import d2m_jit as d2m
+from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise
+
+
+L = d2m.Layout(shape=(64, 64), dtype=d2m.float32, block_shape=[2, 2], grid_shape=[1, 1])
+inp = d2m.empty(L)
+
+
+def remap(d0, d1, d2, d3):
+    feature = d1 * 2 + d3 + 1
+    shifted = d1 * 2 - d3 + 3
+    return (d0, (feature % 2) // 2, d2, shifted % 2)
+
+
+view = d2m.view_layout(inp, remap)
+out = d2m.to_layout(view, view.layout)
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [out])
+builder.module.operation.verify()
+print(builder.module)
+_Builder.reset()
+
+
+# CHECK:       affine_map<
+# CHECK-SAME:  mod
+# CHECK-SAME:  floordiv
+# CHECK-SAME:  - d3
+# CHECK-LABEL: func.func @main
+# CHECK:       d2m.view_layout

--- a/test/d2m-jit/test_rope.py
+++ b/test/d2m-jit/test_rope.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import d2m_jit as d2m
+from d2m_jit.prefill.rope import apply_rope, build_rope_tables
+from utils import assert_pcc
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _unsigned_sin(sin_signed):
+    half = sin_signed.shape[-1] // 2
+    return torch.cat([-sin_signed[..., :half], sin_signed[..., half:]], dim=-1)
+
+
+@pytest.mark.parametrize(
+    "seq_len,head_dim,block_shape,grid_shape,grid",
+    [
+        (64, 64, [2, 2], [1, 1], (1, 1)),
+        (64, 128, [2, 2], [1, 2], (1, 2)),
+    ],
+)
+def test_rope_matches_torch(seq_len, head_dim, block_shape, grid_shape, grid):
+    x = torch.randn(seq_len, head_dim, dtype=torch.float32)
+    cos, sin_signed = build_rope_tables(
+        seq_len, head_dim, start_pos=7, dtype=torch.float32
+    )
+    sin = _unsigned_sin(sin_signed)
+
+    layout = d2m.Layout(
+        shape=x.shape,
+        dtype=x.dtype,
+        block_shape=block_shape,
+        grid_shape=grid_shape,
+    )
+    x_lt = d2m.to_layout(x, layout)
+    cos_lt = d2m.to_layout(cos, layout)
+    sin_signed_lt = d2m.to_layout(sin_signed, layout)
+
+    out = apply_rope(
+        x_lt,
+        cos_lt,
+        sin_signed_lt,
+        layout,
+        grid,
+        m_blocks=1,
+        n_blocks=1,
+    ).to_host()
+
+    golden = x * cos + rotate_half(x) * sin
+    assert_pcc(golden, out)
+    assert torch.allclose(golden, out, atol=0.05, rtol=0.05)
+
+
+def test_build_rope_tables_start_pos_and_signed_sin():
+    cos, sin_signed = build_rope_tables(
+        seq_len=2, head_dim=4, start_pos=3, theta=10000.0, dtype=torch.float32
+    )
+
+    inv_freq = 1.0 / (10000.0 ** (torch.arange(0, 4, 2).float() / 4))
+    angles = torch.outer(torch.arange(3, 5, dtype=torch.float32), inv_freq)
+    cos_half = torch.cos(angles)
+    sin_half = torch.sin(angles)
+
+    assert torch.allclose(cos, torch.cat([cos_half, cos_half], dim=-1))
+    assert torch.allclose(sin_signed, torch.cat([-sin_half, sin_half], dim=-1))

--- a/tools/d2m-jit/CMakeLists.txt
+++ b/tools/d2m-jit/CMakeLists.txt
@@ -20,6 +20,8 @@ declare_mlir_python_sources(TTD2MJitSources
         patterns/_template.py
         patterns/eltwise_add_exp_to_kernel.py
         patterns/eltwise_exp_to_kernel.py
+        prefill/__init__.py
+        prefill/rope.py
 )
 
 add_mlir_python_modules(TTD2MJitModules

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -172,7 +172,7 @@ kernel body.
 | `d2m.tilize(lt, dtype=None)` | Convert a `LazyTensor` to a tile-typed (`tiled=True`) layout; optional dtype override. |
 | `d2m.untilize(lt, dtype=None)` | Convert a `LazyTensor` to row-major (`tiled=False`); optional dtype override. |
 | `d2m.view(lt, lambda d0, d1: ...)` | Logical-rank permutation. The lambda's parameter count matches the source's logical rank. Result is a view (`is_view=True`). |
-| `d2m.view_layout(lt, lambda d0, d1, d2, d3: ...)` | Low-level: lambda parameter count matches the source's MLIR rank (typically `2 * logical_rank` for tiled tensors). Each result expression may be a parameter or the literal `0`. |
+| `d2m.view_layout(lt, lambda d0, d1, d2, d3: ...)` | Low-level: lambda parameter count matches the source's MLIR rank (typically `2 * logical_rank` for tiled tensors). Each result expression may be a parameter, literal `0`, or affine arithmetic with integer constants (`+`, `-`, `*`, `//`, `%`). Arithmetic remappings preserve the source physical shape. |
 | `d2m.permute(lt, *dims)` | `torch.permute`-style positional permutation. |
 | `d2m.to_host(*lts)` | Compile and execute; return a tuple of `torch.Tensor`s. Resets the builder. |
 | `LazyTensor.to_host()` | Sugar for `to_host(self)[0]`. |

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -672,9 +672,23 @@ def _emit_view_layout(lt: LazyTensor, affine_map, spec) -> LazyTensor:
                 f"view_layout: lambda takes {affine_map.n_dims} args but "
                 f"source MLIR rank is {len(src_shape)}"
             )
-        dst_shape = []
-        for tag, val in spec:
-            dst_shape.append(src_shape[val] if tag == "dim" else 1)
+        simple_dim_or_const = all(tag in {"dim", "const"} for tag, _ in spec)
+        if simple_dim_or_const:
+            dst_shape = []
+            for tag, val in spec:
+                dst_shape.append(src_shape[val] if tag == "dim" else 1)
+        else:
+            # For now, affine-arithmetic view_layout lambdas are remappings over
+            # the same physical shape. If future users need arithmetic maps that
+            # also change shape/rank, add an explicit shape= parameter rather
+            # than trying to infer bounds from arbitrary affine expressions.
+            if len(spec) != len(src_shape):
+                raise ValueError(
+                    "view_layout: affine-arithmetic remappings currently "
+                    "preserve source rank and shape; got "
+                    f"{len(spec)} results for source rank {len(src_shape)}"
+                )
+            dst_shape = src_shape
         dst_ty = RankedTensorType.get(
             dst_shape, src_type.element_type, encoding=src_type.encoding
         )
@@ -690,14 +704,13 @@ def view_layout(lt: LazyTensor, remapping_fn) -> LazyTensor:
     source value's MLIR rank (typically 2N for an N-dim logical tiled
     tensor: the first N dims are grid, the trailing N are per-grid tile
     indices). Each result expression may reference a parameter (perm /
-    passthrough) or be the literal 0 (broadcast-to-1).
+    passthrough), be the literal 0 (broadcast-to-1), or use affine arithmetic
+    with integer constants (`+`, `-`, `*`, `//`, `%`).
 
     The result LazyTensor's Layout is derived from the source by
     permuting logical_shape/block_shape/grid_shape if the lambda is a
-    paired (grid, tile) permutation. Otherwise it inherits the source
-    Layout unchanged -- callers that immediately consume the view in a
-    kernel should make sure their lambda corresponds to a valid layout
-    permutation.
+    paired (grid, tile) permutation. Arithmetic remappings preserve the source
+    physical shape and inherit the source Layout unchanged.
     """
     lt = lt._resolve()
     b = _get_scope()
@@ -985,23 +998,76 @@ def _affine_map_from_lambda(fn):
     """Build an MLIR AffineMap by running `fn` with sentinel dim objects.
 
     Returns `(AffineMap, spec)` where `spec` is a list of one tag per
-    result expression: either `("dim", i)` for AffineDimExpr referencing
-    input dim `i`, or `("const", v)` for an AffineConstantExpr. Callers
-    that don't need the spec can take `[0]`.
+    result expression: `("dim", i)` for a bare input dim, `("const", 0)` for
+    literal zero, or `("expr", None)` for affine arithmetic.
     """
 
-    class _Dim:
+    class _AffineExprProxy:
+        def __init__(self, expr, spec=("expr", None)):
+            self.expr = expr
+            self.spec = spec
+
+        @staticmethod
+        def _constant(value):
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(
+                    "view_layout affine expressions only support integer constants"
+                )
+            return AffineConstantExpr.get(value)
+
+        @classmethod
+        def _expr(cls, value):
+            if isinstance(value, _AffineExprProxy):
+                return value.expr
+            return cls._constant(value)
+
+        def _new(self, expr):
+            return _AffineExprProxy(expr)
+
+        def __add__(self, rhs):
+            return self._new(self.expr + self._expr(rhs))
+
+        def __radd__(self, lhs):
+            return self._new(self._expr(lhs) + self.expr)
+
+        def __sub__(self, rhs):
+            return self._new(self.expr - self._expr(rhs))
+
+        def __rsub__(self, lhs):
+            return self._new(self._expr(lhs) - self.expr)
+
+        def __mul__(self, rhs):
+            self._constant(rhs)
+            return self._new(self.expr * rhs)
+
+        def __rmul__(self, lhs):
+            self._constant(lhs)
+            return self._new(self.expr * lhs)
+
+        def __floordiv__(self, rhs):
+            return self._new(AffineFloorDivExpr.get(self.expr, self._constant(rhs)))
+
+        def __mod__(self, rhs):
+            return self._new(AffineModExpr.get(self.expr, self._constant(rhs)))
+
+        def __rfloordiv__(self, lhs):
+            raise TypeError("view_layout does not support int // affine_expr")
+
+        def __rmod__(self, lhs):
+            raise TypeError("view_layout does not support int % affine_expr")
+
+    class _Dim(_AffineExprProxy):
         def __init__(self, position):
-            self.position = position
+            super().__init__(AffineDimExpr.get(position), ("dim", position))
 
     dims = tuple(_Dim(i) for i, _ in enumerate(inspect.signature(fn).parameters))
     results = fn(*dims)
     exprs = []
     spec = []
     for r in results:
-        if isinstance(r, _Dim):
-            exprs.append(AffineDimExpr.get(r.position))
-            spec.append(("dim", r.position))
+        if isinstance(r, _AffineExprProxy):
+            exprs.append(r.expr)
+            spec.append(r.spec)
         elif isinstance(r, int):
             assert r == 0, "Only 0 is allowed as an integer constant in indexing_map"
             exprs.append(AffineConstantExpr.get(r))

--- a/tools/d2m-jit/prefill/__init__.py
+++ b/tools/d2m-jit/prefill/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prefill kernels and runnable helper specs.
+"""

--- a/tools/d2m-jit/prefill/rope.py
+++ b/tools/d2m-jit/prefill/rope.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rotary position embedding (RoPE) prefill kernel.
+
+    rope(x) = x * cos + rotate_half(x) * sin
+
+`rotate_half` is expressed as a *view-roll* of x plus a precomputed sign tile,
+so no `concat` primitive is needed:
+
+    rotate_half(x) = roll_view(x) * sign        # sign = [-1...,+1...]
+    rope(x)        = x * cos + roll_view(x) * (sign * sin)
+
+cos / (sign*sin) are precomputed host-side and passed as input tiles. The roll
+is a free `view_layout` (metadata, no data movement).
+
+The first implementation only supports tile-aligned half-split RoPE. The final
+logical dimension must be a multiple of 64 so the half-roll boundary never cuts
+through a 32-wide tile.
+"""
+
+import torch
+
+import d2m_jit as d2m
+
+
+def _feature_half_roll_view(x_lt):
+    """Return RoPE's tile-level half-roll view over the final dimension."""
+    layout = x_lt.layout
+    head_dim = layout.logical_shape[-1]
+    src_shape = list(x_lt.value.type.shape)
+    if len(src_shape) != 4:
+        raise ValueError(
+            "RoPE half-roll expects physical rank 4 "
+            f"[grid_y, grid_x, block_y, block_x], got shape {src_shape}"
+        )
+
+    grid_x = src_shape[1]
+    block_x = src_shape[3]
+    total_feature_tiles = grid_x * block_x
+    expected_feature_tiles = head_dim // 32
+    if total_feature_tiles != expected_feature_tiles:
+        raise ValueError(
+            "RoPE half-roll expected physical feature tiles "
+            f"{expected_feature_tiles}, got {total_feature_tiles} from shape "
+            f"{src_shape}"
+        )
+    if total_feature_tiles % 2 != 0:
+        raise ValueError(
+            "RoPE half-roll requires an even number of feature tiles, "
+            f"got {total_feature_tiles}"
+        )
+
+    def roll_dim(d1, d3):
+        feature_tile = d1 * block_x + d3 + (total_feature_tiles // 2)
+        rolled = feature_tile % total_feature_tiles
+        return rolled // block_x, rolled % block_x
+
+    return d2m.view_layout(
+        x_lt,
+        lambda d0, d1, d2, d3: (d0, roll_dim(d1, d3)[0], d2, roll_dim(d1, d3)[1]),
+    )
+
+
+def _validate_rope_layouts(x_lt, cos_lt, sin_signed_lt, out_layout):
+    x_shape = list(x_lt.layout.logical_shape)
+    if len(x_shape) != 2:
+        raise ValueError(f"RoPE expects a 2D layout, got shape {x_shape}")
+    if x_shape[-1] % 64 != 0:
+        raise ValueError(
+            "RoPE requires the final logical dimension to be a multiple of 64, "
+            f"got {x_shape[-1]}"
+        )
+
+    for name, lt in (("cos", cos_lt), ("sin_signed", sin_signed_lt)):
+        if list(lt.layout.logical_shape) != x_shape:
+            raise ValueError(
+                f"{name} layout shape {lt.layout.logical_shape} must match x shape "
+                f"{x_shape}"
+            )
+        if lt.layout.tiled != x_lt.layout.tiled:
+            raise ValueError(f"{name} layout tiled flag must match x layout")
+
+    if list(out_layout.logical_shape) != x_shape:
+        raise ValueError(
+            f"output layout shape {out_layout.logical_shape} must match x shape {x_shape}"
+        )
+    if out_layout.tiled != x_lt.layout.tiled:
+        raise ValueError("output layout tiled flag must match x layout")
+    if not x_lt.layout.tiled:
+        raise ValueError("RoPE requires tiled input layouts")
+
+
+def build_rope_tables(
+    seq_len,
+    head_dim,
+    *,
+    start_pos=0,
+    theta=10000.0,
+    dtype=torch.float32,
+    device=None,
+):
+    """Build row-major host tables for half-split RoPE prefill.
+
+    Returns `(cos, sin_signed)` with shape `[seq_len, head_dim]`. `sin_signed`
+    folds rotate_half's `[-x_hi, x_lo]` sign into the sine table so the kernel
+    can use only multiply/add tile ops.
+    """
+    if head_dim % 2 != 0:
+        raise ValueError(f"head_dim must be even, got {head_dim}")
+
+    freqs = 1.0 / (
+        theta
+        ** (torch.arange(0, head_dim, 2, dtype=torch.float32, device=device) / head_dim)
+    )
+    positions = torch.arange(
+        start_pos, start_pos + seq_len, dtype=torch.float32, device=device
+    )
+    angles = torch.outer(positions, freqs)
+    cos_half = torch.cos(angles)
+    sin_half = torch.sin(angles)
+
+    cos = torch.cat([cos_half, cos_half], dim=-1)
+    sin_signed = torch.cat([-sin_half, sin_half], dim=-1)
+    return cos.to(dtype=dtype), sin_signed.to(dtype=dtype)
+
+
+@d2m.kernel
+def rope(x, x_rolled, cos, sin_signed, out, m_blocks, n_blocks):
+    # x_rolled: a view of x produced host-side via d2m.view_layout (the
+    #           half-rotation index permutation). Passed in so the kernel
+    #           body stays a pure eltwise pass.
+    # cos:        precomputed cos table tile(s).
+    # sin_signed: precomputed (sign * sin) so rotate_half's negate folds in.
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            xx = remote_load(x, [m_off + m, n_off + n])
+            xr = remote_load(x_rolled, [m_off + m, n_off + n])
+            c = remote_load(cos, [m_off + m, n_off + n])
+            s = remote_load(sin_signed, [m_off + m, n_off + n])
+            remote_store(out, [m_off + m, n_off + n], xx * c + xr * s)
+
+
+def apply_rope(x_lt, cos_lt, sin_signed_lt, L_io, grid, m_blocks, n_blocks):
+    """Host driver: build the half-rotation view, dispatch the kernel."""
+    _validate_rope_layouts(x_lt, cos_lt, sin_signed_lt, L_io)
+    x_rolled = _feature_half_roll_view(x_lt)
+    out = d2m.empty(L_io)
+    rope(x_lt, x_rolled, cos_lt, sin_signed_lt, out, m_blocks, n_blocks, grid=grid)
+    return out


### PR DESCRIPTION
### What's changed

Adds first-pass RoPE support in d2m-jit, choosing the half-split (GPT-NeoX or Huggingface) flavor of `rotate_half` defined as:

```python
rotate_half(x) = concat(-x[..., D/2:], x[..., :D/2])
rope(x) = x * cos + rotate_half(x) * sin
```

- The lambda parser `_affine_map_from_lambda()` is extended to support lambdas with `+ - * // %` arithmetics, required by the following `grid x shard` roll-view:
  - `feature_tile = d1 * block_x + d3`.
  - `rolled = (feature_tile + total_feature_tiles / 2) % total_feature_tiles`.
  - `result = (d0, rolled // block_x, d2, rolled % block_x)`.
- The RoPE implementation:
  - Referenced `tt-metal/models/tt_transformers/tt/rope.py`.
  - The inputs are checked in `_validate_rope_layouts()`: dimensions, divisibility, layout, etc.
  - The roll-view is created by `_feature_half_roll_view(x_lt)`.
  - The `build_rope_tables()` function builds the tables where the rows are `[cos(0 .. H-1) | cos(0 .. H-1)]` and `[-sin(0 .. H-1) | sin(0 .. H-1)]`.
    - The sign from `rotate_half` is folded into the sine table so the RoPE kernel only does eltwise addition & multiplication, saving the negation.
    - The tables stay row-major on the host, sharding & tilization is handled by `d2m.to_layout`.
    - The `start_pos` parameter makes the generated rows correspond to actual prefill positions, instead of assuming every prefill starts at 0.
- Added lit tests for the affine map extension, and added both lit & device tests for RoPE with golden comparision.

Limitations:
- Support only tile-aligned half-rolls for now. When the innermost dimension is a multiple of 64, the `rotate_half` boundary will fall between the tiles and so the roll-view can be represented by a "free" tile-level index manipulation.
  - Non-tile-aligned inputs need a materializing implementation (slice-then-concat in row-major).
- Like the simple dim/const remappings, the new affine-arithmetic remappings also preserve the source physical shape. Usage that deviates from this should probably add an explicit `shape=` parameter to specify the output shape.