### PR TITLE
Add native conv1d op and route framework-lowered 1D convolutions to it

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -2308,6 +2308,53 @@ public:
       return conv2dExpr;
     }
 
+    // Special handling for Conv1dOp. Like Conv2dOp, `ttnn::conv1d` returns a
+    // variant (`Conv1dResult`) rather than a bare `ttnn::Tensor`, so we unwrap
+    // the first alternative via `std::get<0>`. Using an ExpressionOp built from
+    // `adaptor.getOperands()` (original operand order) is also required here:
+    // Conv1dOp has an optional `bias` operand that precedes `device` in the
+    // op's operand list, but the conversion pattern emits `device` before
+    // `bias`. The generic path below would mismatch the operand indices
+    // (swapping `device` and `bias`), so we must reference the block arguments,
+    // which follow the original operand order.
+    if constexpr (std::is_same_v<TTNNOp, tt::ttnn::Conv1dOp>) {
+      using OutputLength = std::uint32_t;
+      using ReturnTy = std::variant<
+          ::ttnn::Tensor, std::tuple<::ttnn::Tensor, OutputLength>,
+          std::tuple<::ttnn::Tensor,
+                     std::tuple<::ttnn::Tensor, std::optional<::ttnn::Tensor>>>,
+          std::tuple<
+              ::ttnn::Tensor, OutputLength,
+              std::tuple<::ttnn::Tensor, std::optional<::ttnn::Tensor>>>>;
+
+      emitc::ExpressionOp conv1dExpr = rewriter.create<emitc::ExpressionOp>(
+          op.getLoc(),
+          rewriter.getType<emitc::OpaqueType>(TypeNameV<::ttnn::Tensor>),
+          adaptor.getOperands());
+
+      mlir::Block &bodyBlock = conv1dExpr.createBody();
+      rewriter.setInsertionPointToStart(&bodyBlock);
+
+      auto conv1dOp = rewriter.create<emitc::CallOpaqueOp>(
+          op.getLoc(), rewriter.getType<emitc::OpaqueType>(TypeNameV<ReturnTy>),
+          opConversionPattern.convertOpName(op), rewriter.getArrayAttr(args),
+          /*template_args=*/nullptr, bodyBlock.getArguments());
+      auto getTensorOp = rewriter.create<emitc::CallOpaqueOp>(
+          op.getLoc(),
+          rewriter.getType<emitc::OpaqueType>(TypeNameV<::ttnn::Tensor>),
+          "::std::get", /*args=*/nullptr,
+          /*template_args=*/
+          rewriter.getArrayAttr({rewriter.getI32IntegerAttr(0)}),
+          conv1dOp.getResult(0));
+      rewriter.create<emitc::YieldOp>(op.getLoc(), getTensorOp.getResult(0));
+
+      rewriter.replaceOp(op, conv1dExpr);
+
+      rewriter.setInsertionPointAfter(conv1dExpr);
+
+      return conv1dExpr;
+    }
+
     // MaxPool2dOp return a std::vector<ttnn::Tensor> containing a single
     // element. We can guarantee this because MaxPool2dOp always has
     // `return_indices=false` - otherwise it would be MaxPool2dWithIndicesOp.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -3752,6 +3752,86 @@ def TTIR_BroadcastOp : TTIR_NamedOp<"broadcast"> {
     let hasFolder = 1;
 }
 
+def TTIR_Conv1dOp : TTIR_NamedOp<"conv1d"> {
+    let summary = "Conv1d operation.";
+    let description = [{
+      Applies a 1D convolution over an input signal composed of several input planes.
+
+      This operation performs a 1D convolution on the input tensor using the provided weight tensor
+      and optional bias. It supports configurable stride, padding, dilation, and grouping parameters
+      to control the convolution behavior.
+
+      Example:
+      ```mlir
+      // Basic 1D convolution
+      %input = ... : tensor<1x32x32xf32>    // Batch size 1, length 32, 32 channels
+      %weight = ... : tensor<32x32x3xf32>   // 32 output channels, 32 input channels, kernel 3
+      %bias = ... : tensor<1x1x32xf32>      // Bias for 32 output channels
+      %result = ttir.conv1d(%input, %weight, %bias) {
+          stride = 1,
+          padding = 1,
+          dilation = 1,
+          groups = 1
+      } : (tensor<1x32x32xf32>, tensor<32x32x3xf32>, tensor<1x1x32xf32>) -> tensor<1x32x32xf32>
+      ```
+
+      Inputs:
+      - `input` (AnyRankedTensor): 3D tensor where dimension indices are controlled by `batch_dim`,
+        `length_dim`, and `channel_dim` attributes. Default layout is NLC (N, L_in, C) where:
+        - N is the batch size
+        - L_in is the length of the input signal
+        - C is the number of channels
+      - `weight` (AnyRankedTensor): expected in the following format (O, C/G, K) where:
+        - C is the number of input channels
+        - O is the number of output channels
+        - G is the number of groups
+        - K is the length of the kernel
+      - `bias` Optional<AnyRankedTensor>: bias tensor with output channels at position specified by `channel_dim`.
+        Default format is (1, 1, O).
+
+      Attributes:
+      - `stride` (i32 | array<1xi32>): The stride of the kernel window.
+      - `padding` (i32 | array<1xi32> | array<2xi32>):
+        - i32: Same padding for both sides (pL = pR = value).
+        - array<1xi32>: [p] symmetric padding (pL = pR = p).
+        - array<2xi32>: [pL, pR] for left and right padding respectively.
+      - `dilation` (i32 | array<1xi32>): Spacing between kernel elements.
+      - `groups` (i32): Number of blocked connections from input channels to output channels. Input and output channels must both be divisible by groups.
+      - `batch_dim` (i64): Index of the batch dimension in input/output tensors. Default: 0.
+      - `length_dim` (i64): Index of the length dimension in input/output tensors. Default: 1.
+      - `channel_dim` (i64): Index of the channel dimension in input/output tensors. Default: 2.
+
+      Output:
+      - `result` AnyRankedTensor: 3D tensor with same layout as input (controlled by dimension attributes).
+        Default format is (N, L_out, O) where:
+        - `L_out = (L_in + pL + pR - dilation * (K - 1) - 1) / stride + 1`
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$weight,
+                         Optional<AnyRankedTensor>:$bias,
+                         AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$stride,
+                         AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$padding,
+                         AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$dilation,
+                         I32Attr:$groups,
+                         DefaultValuedAttr<I64Attr, "0">:$batch_dim,
+                         DefaultValuedAttr<I64Attr, "1">:$length_dim,
+                         DefaultValuedAttr<I64Attr, "2">:$channel_dim);
+
+    let extraClassDeclaration = [{
+      // Get number of output channels
+      int64_t getOutputChannelSize();
+      bool isNLC() {
+        return getBatchDim() == 0 && getLengthDim() == 1 &&
+               getChannelDim() == 2;
+      }
+    }];
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTIR_Conv2dOp : TTIR_NamedOp<"conv2d", [DeclareOpInterfaceMethods<TTIR_QuantizableOpInterface, ["isQuantizedRewriteFavorable", "rewriteWithQuantizedInputs"]>]> {
     let summary = "Conv2d operation.";
     let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2075,6 +2075,78 @@ def TTNN_PrepareConvTranspose2dBiasOp : TTNN_Op<"prepare_conv_transpose2d_bias",
     let hasVerifier = 1;
 }
 
+def TTNN_Conv1dOp : TTNN_Op<"conv1d", [TTNN_ComputeKernelConfigOpInterface]> {
+    let summary = "Conv1d operation.";
+    let description = [{
+      Applies a 1D convolution over an input signal composed of several input planes.
+
+      This op models the `ttnn::conv1d` library function, which is itself a thin wrapper
+      around `ttnn::conv2d` (the input is reshaped to a height-1 image and the 1D
+      parameters are mapped to their 2D equivalents).
+
+      Inputs:
+      - `input` (AnyRankedTensor): expected in the following channels-last format (N, L_in, C) where:
+        - N is the batch size
+        - L_in is the length of the input signal
+        - C is the number of input channels
+      - `weight` (AnyRankedTensor): expected in the following format (O, C/G, K) where:
+        - O is the number of output channels
+        - C is the number of input channels
+        - G is the number of groups
+        - K is the length of the kernel
+      - `bias` (Optional<AnyRankedTensor>): expected in the following format (1, 1, 1, O)
+        (matching `ttnn::conv2d`, which `ttnn::conv1d` delegates to).
+
+      Attributes:
+      - `in_channels` (i32): The number of input channels.
+      - `out_channels` (i32): The number of output channels.
+      - `batch_size` (i32): The batch size.
+      - `input_length` (i32): The length of the input signal.
+      - `kernel_size` (i32): The length of the kernel K.
+      - `stride` (i32): The stride of the kernel window.
+      - `padding` (array<2xi32>): [pL, pR] padding added to the left and right of the input.
+      - `dilation` (i32): The spacing between kernel elements.
+      - `groups` (i32): Number of blocked connections from input channels to output channels. Input and output channels must both be divisible by groups.
+
+      Outputs:
+      - `result` (AnyRankedTensor): returned in `ttnn::conv2d`'s flattened layout
+        (1, 1, N * L_out, O) where:
+        - `L_out = (L_in + pL + pR - dilation * (K - 1) - 1) / stride + 1`
+        A reshape back to (N, L_out, O) is inserted during lowering from TTIR.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$weight,
+                         Optional<AnyRankedTensor>:$bias,
+                         TTNN_Device:$device,
+                         I32Attr:$in_channels,
+                         I32Attr:$out_channels,
+                         I32Attr:$batch_size,
+                         I32Attr:$input_length,
+                         I32Attr:$kernel_size,
+                         I32Attr:$stride,
+                         DenseI32ArrayAttr:$padding,
+                         I32Attr:$dilation,
+                         I32Attr:$groups,
+                         OptionalAttr<TTNN_Conv2dConfigAttr>:$conv2d_config,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config,
+                         OptionalAttr<TTNN_Conv2dSliceConfigAttr>:$conv2d_slice_config);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+
+    let extraClassDeclaration = [{
+      // Get number of output channels.
+      int64_t getOutputChannelSize();
+      // conv1d wraps conv2d, so it has the same operand-layout constraint:
+      // the input must be on device in row-major layout.
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(*this);
+      }
+    }];
+}
+
 def TTNN_Conv2dOp : TTNN_Op<"conv2d", [TTNN_ComputeKernelConfigOpInterface]> {
     let summary = "Conv2d operation.";
     let description = [{

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -36,6 +36,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/operations/ccl/mesh_partition/mesh_partition.hpp"
+#include "ttnn/operations/conv/conv1d/conv1d.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1261,6 +1261,44 @@ struct OpModel<Conv2dOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// Conv1dOp
+//===----------------------------------------------------------------------===//
+
+// `ttnn::conv1d` is a thin wrapper around `ttnn::conv2d` (it reshapes the input
+// to a height-1 image and maps the 1D parameters to their 2D equivalents). This
+// model mirrors the runtime path by querying `::ttnn::conv1d` directly with the
+// native 1D parameters, while reusing the conv2d weight/bias prepare helpers
+// (conv1d weights/biases are conv2d weights/biases).
+template <>
+struct OpModel<Conv1dOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_length,
+      uint32_t kernel_size, uint32_t stride, llvm::ArrayRef<int32_t> padding,
+      uint32_t dilation, uint32_t groups,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_length,
+      uint32_t kernel_size, uint32_t stride, llvm::ArrayRef<int32_t> padding,
+      uint32_t dilation, uint32_t groups,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // Conv3dOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/Target/TTNN/operations/conv.fbs
+++ b/include/ttmlir/Target/TTNN/operations/conv.fbs
@@ -152,6 +152,27 @@ table PrepareConvTranspose2dBiasOp {
   conv2d_slice_config: tt.target.ttnn.Conv2dSliceConfig;
 }
 
+table Conv1dOp {
+  input: tt.target.ttnn.TensorRef;
+  weight: tt.target.ttnn.TensorRef;
+  bias: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
+  device: tt.target.DeviceRef;
+  in_channels: uint32;
+  out_channels: uint32;
+  batch_size: uint32;
+  input_length: uint32;
+  kernel_size: uint32;
+  stride: uint32;
+  padding: [int32];
+  dilation: uint32;
+  groups: uint32;
+  output_dtype: tt.target.DataType = null;
+  conv2d_config: tt.target.ttnn.Conv2dConfig;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
+  conv2d_slice_config: tt.target.ttnn.Conv2dSliceConfig;
+}
+
 table Conv2dOp {
   input: tt.target.ttnn.TensorRef;
   weight: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -55,6 +55,7 @@ union OpType {
   NLPCreateQKVHeadsDecodeOp,
   NLPConcatHeadsOp,
   ConstantOp,
+  Conv1dOp,
   Conv2dOp,
   ConvTranspose2dOp,
   Conv3dOp,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -1821,6 +1821,19 @@ public:
       return failure();
     }
 
+    // Frameworks (e.g. torch-xla) lower a conv1d to a 2D convolution with a
+    // size-1 spatial dim. Route that back to a native ttir.conv1d (which lowers
+    // to ttnn.conv1d and can use an L1 config), avoiding the in-DRAM depthwise
+    // conv2d hang (tt-metal #45075) that the DRAM conv2d config hits. Only
+    // non-transposed, batchGroupCount==1 convs; genuine 2D convs fall through.
+    if (!tt::stablehlo::utils::isTransposedConv(op) &&
+        adaptor.getBatchGroupCount() == 1) {
+      if (Value conv1d = tryEmitDegenerate2dAsConv1d(rewriter, op, adaptor)) {
+        rewriter.replaceOp(op, conv1d);
+        return success();
+      }
+    }
+
     uint64_t batchGroupCount = adaptor.getBatchGroupCount();
     uint64_t featureGroupCount = adaptor.getFeatureGroupCount();
 
@@ -1894,6 +1907,155 @@ public:
   }
 
 private:
+  // If the framework lowered a conv1d to a 2D convolution (one spatial dim has
+  // extent 1 in both input and kernel), emit a native ttir.conv1d instead of a
+  // conv2d by squeezing that degenerate spatial dim. Returns a null Value for a
+  // genuine 2D conv (caller falls back to conv2d).
+  Value tryEmitDegenerate2dAsConv1d(ConversionPatternRewriter &rewriter,
+                                    mlir::stablehlo::ConvolutionOp op,
+                                    OpAdaptor adaptor) const {
+    // Local semantic tags for permutation layouts. BATCH/FEATURE are negative
+    // in the ConvolutionDimension enum, so 0/1 here cannot collide.
+    constexpr int64_t REAL = 0, DEG = 1;
+
+    const auto &dn = adaptor.getDimensionNumbers();
+    auto inputType = mlir::cast<RankedTensorType>(adaptor.getLhs().getType());
+    auto weightType = mlir::cast<RankedTensorType>(adaptor.getRhs().getType());
+    auto inputSpatialDims = dn.getInputSpatialDimensions();
+    auto kernelSpatialDims = dn.getKernelSpatialDimensions();
+    auto outputSpatialDims = dn.getOutputSpatialDimensions();
+
+    // Find the degenerate spatial index (input and kernel extent both 1).
+    int degIdx = -1;
+    for (int i = 0; i < static_cast<int>(NUM_SPATIAL_DIMS); ++i) {
+      if (inputType.getShape()[inputSpatialDims[i]] == 1 &&
+          weightType.getShape()[kernelSpatialDims[i]] == 1) {
+        degIdx = i;
+        break;
+      }
+    }
+    if (degIdx < 0) {
+      return Value(); // genuine 2D conv.
+    }
+    int realIdx = 1 - degIdx; // the other of the two spatial dims.
+
+    auto outputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(op.getType()));
+    llvm::ArrayRef<int64_t> expectedOutputShape = outputType.getShape();
+
+    // 1D attributes come from the real spatial dim only. Any padding on the
+    // degenerate dim is ignored (it is [0,0] for a genuine 1D conv).
+    auto windowStrides = getI64ArrayOrDefault(adaptor.getWindowStridesAttr(),
+                                              NUM_SPATIAL_DIMS, 1);
+    auto rhsDilation =
+        getI64ArrayOrDefault(adaptor.getRhsDilationAttr(), NUM_SPATIAL_DIMS, 1);
+    auto padding =
+        getPaddingOrDefault(adaptor.getPaddingAttr(), NUM_SPATIAL_DIMS);
+    auto paddingMatrix = getPaddingMatrix<NUM_SPATIAL_DIMS>(padding);
+
+    auto strideAttr = rewriter.getI32IntegerAttr(
+        static_cast<int32_t>(windowStrides[realIdx]));
+    auto dilationAttr =
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(rhsDilation[realIdx]));
+    auto paddingAttr = rewriter.getDenseI32ArrayAttr(
+        {static_cast<int32_t>(paddingMatrix[realIdx][0]),
+         static_cast<int32_t>(paddingMatrix[realIdx][1])});
+    auto groupsAttr = rewriter.getI32IntegerAttr(
+        static_cast<int32_t>(adaptor.getFeatureGroupCount()));
+
+    // Permute the 4D input to [batch, real, feature, deg], then reshape to NLC
+    // (dropping the trailing size-1 spatial dim).
+    llvm::SmallVector<int64_t> inputLayout(4);
+    inputLayout[dn.getInputBatchDimension()] = ConvolutionDimension::BATCH;
+    inputLayout[dn.getInputFeatureDimension()] = ConvolutionDimension::FEATURE;
+    inputLayout[inputSpatialDims[realIdx]] = REAL;
+    inputLayout[inputSpatialDims[degIdx]] = DEG;
+    llvm::SmallVector<int64_t> nlcdLayout = {
+        ConvolutionDimension::BATCH, REAL, ConvolutionDimension::FEATURE, DEG};
+    auto inputPerm = ttmlir::utils::generatePermutation(
+        llvm::ArrayRef(inputLayout), llvm::ArrayRef(nlcdLayout));
+    auto permutedInputShape =
+        ttmlir::utils::applyPermutation(inputType.getShape(), inputPerm);
+    Value permutedInput = rewriter.create<ttir::PermuteOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_conv1dInput"),
+        RankedTensorType::get(permutedInputShape, inputType.getElementType(),
+                              inputType.getEncoding()),
+        adaptor.getLhs(), inputPerm);
+    llvm::SmallVector<int64_t> nlcInputShape(permutedInputShape.begin(),
+                                             permutedInputShape.end() - 1);
+    Value nlcInput = ttir::utils::createReshapeOp(
+        rewriter,
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_conv1dInputSqueeze"),
+        permutedInput, nlcInputShape);
+
+    // Permute the 4D weight to (O, I/G, K_real, K_deg), then reshape to
+    // (O, I/G, K) by dropping the trailing size-1 kernel dim.
+    llvm::SmallVector<int64_t> kernelLayout(4);
+    kernelLayout[dn.getKernelOutputFeatureDimension()] =
+        ConvolutionKernelDimension::OUTPUT_FEATURES;
+    kernelLayout[dn.getKernelInputFeatureDimension()] =
+        ConvolutionKernelDimension::INPUT_FEATURES;
+    kernelLayout[kernelSpatialDims[realIdx]] = REAL;
+    kernelLayout[kernelSpatialDims[degIdx]] = DEG;
+    llvm::SmallVector<int64_t> oikdLayout = {
+        ConvolutionKernelDimension::OUTPUT_FEATURES,
+        ConvolutionKernelDimension::INPUT_FEATURES, REAL, DEG};
+    auto kernelPerm = ttmlir::utils::generatePermutation(
+        llvm::ArrayRef(kernelLayout), llvm::ArrayRef(oikdLayout));
+    auto permutedWeightShape =
+        ttmlir::utils::applyPermutation(weightType.getShape(), kernelPerm);
+    Value permutedWeight = rewriter.create<ttir::PermuteOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_conv1dWeight"),
+        RankedTensorType::get(permutedWeightShape, weightType.getElementType(),
+                              weightType.getEncoding()),
+        adaptor.getRhs(), kernelPerm);
+    llvm::SmallVector<int64_t> oikWeightShape(permutedWeightShape.begin(),
+                                              permutedWeightShape.end() - 1);
+    Value oikWeight =
+        ttir::utils::createReshapeOp(rewriter,
+                                     ttmlir::utils::appendLocationSuffix(
+                                         op.getLoc(), "_conv1dWeightSqueeze"),
+                                     permutedWeight, oikWeightShape);
+
+    // conv1d output is NLC.
+    llvm::SmallVector<int64_t> nlcOutputShape = {
+        expectedOutputShape[dn.getOutputBatchDimension()],
+        expectedOutputShape[outputSpatialDims[realIdx]],
+        expectedOutputShape[dn.getOutputFeatureDimension()]};
+    auto conv1dResultType = RankedTensorType::get(
+        nlcOutputShape, outputType.getElementType(), outputType.getEncoding());
+
+    Value conv1d = rewriter.create<ttir::Conv1dOp>(
+        op.getLoc(), conv1dResultType, nlcInput, oikWeight, /*bias=*/Value(),
+        strideAttr, paddingAttr, dilationAttr, groupsAttr,
+        /*batch_dim=*/rewriter.getI64IntegerAttr(0),
+        /*length_dim=*/rewriter.getI64IntegerAttr(1),
+        /*channel_dim=*/rewriter.getI64IntegerAttr(2));
+
+    // Re-add the size-1 spatial dim (NLC -> [batch, real, feature, deg]) then
+    // permute to the StableHLO output layout.
+    llvm::SmallVector<int64_t> nlcdOutputShape(nlcOutputShape.begin(),
+                                               nlcOutputShape.end());
+    nlcdOutputShape.push_back(1);
+    Value conv1dExpanded = ttir::utils::createReshapeOp(
+        rewriter,
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_conv1dOutputExpand"),
+        conv1d, nlcdOutputShape);
+    llvm::SmallVector<int64_t> outputLayout(4);
+    outputLayout[dn.getOutputBatchDimension()] = ConvolutionDimension::BATCH;
+    outputLayout[dn.getOutputFeatureDimension()] =
+        ConvolutionDimension::FEATURE;
+    outputLayout[outputSpatialDims[realIdx]] = REAL;
+    outputLayout[outputSpatialDims[degIdx]] = DEG;
+    auto outputPerm = ttmlir::utils::generatePermutation(
+        llvm::ArrayRef(nlcdLayout), llvm::ArrayRef(outputLayout));
+    return rewriter.create<ttir::PermuteOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_conv1dOutput"),
+        RankedTensorType::get(expectedOutputShape, outputType.getElementType(),
+                              outputType.getEncoding()),
+        conv1dExpanded, outputPerm);
+  }
+
   // Create a Conv2d or ConvTranspose2d operation for a single slice.
   Value createConv2dForSlice(ConversionPatternRewriter &rewriter,
                              mlir::stablehlo::ConvolutionOp op,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1864,6 +1864,131 @@ public:
 } // namespace
 
 namespace {
+class Conv1dOpConversionPattern : public OpConversionPattern<ttir::Conv1dOp> {
+public:
+  using OpConversionPattern<ttir::Conv1dOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::Conv1dOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
+
+    auto inputTy = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
+    auto weightTy = mlir::cast<RankedTensorType>(adaptor.getWeight().getType());
+    auto inputShape = inputTy.getShape();
+
+    int64_t batchDim = op.getBatchDim();
+    int64_t lengthDim = op.getLengthDim();
+    int64_t channelDim = op.getChannelDim();
+
+    auto batchSizeAttr = rewriter.getI32IntegerAttr(inputShape[batchDim]);
+    auto inputLengthAttr = rewriter.getI32IntegerAttr(inputShape[lengthDim]);
+    auto inChannelsAttr = rewriter.getI32IntegerAttr(inputShape[channelDim]);
+    auto outChannelsAttr = rewriter.getI32IntegerAttr(
+        op.getResult().getType().getDimSize(channelDim));
+
+    // Weight is (O, C/G, K); the kernel length is the last dimension.
+    auto kernelSizeAttr = rewriter.getI32IntegerAttr(weightTy.getDimSize(2));
+
+    // stride and dilation are scalars in the TTNN op. The TTIR op allows them
+    // to be either a scalar integer or a 1-element array.
+    auto scalarAttr =
+        [&](mlir::Attribute attr) -> std::optional<mlir::IntegerAttr> {
+      if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(attr)) {
+        return rewriter.getI32IntegerAttr(intAttr.getInt());
+      }
+      if (auto arrAttr = mlir::dyn_cast<DenseI32ArrayAttr>(attr)) {
+        if (arrAttr.size() != 1) {
+          return std::nullopt;
+        }
+        return rewriter.getI32IntegerAttr(arrAttr[0]);
+      }
+      return std::nullopt;
+    };
+
+    auto strideAttr = scalarAttr(adaptor.getStride());
+    if (!strideAttr) {
+      return rewriter.notifyMatchFailure(
+          op, "conv1d stride must be a scalar or a 1-element array");
+    }
+    auto dilationAttr = scalarAttr(adaptor.getDilation());
+    if (!dilationAttr) {
+      return rewriter.notifyMatchFailure(
+          op, "conv1d dilation must be a scalar or a 1-element array");
+    }
+
+    // padding is normalized to a 2-element [pL, pR] array in the TTNN op.
+    DenseI32ArrayAttr paddingAttr;
+    mlir::Attribute padding = adaptor.getPadding();
+    if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(padding)) {
+      int32_t p = static_cast<int32_t>(intAttr.getInt());
+      paddingAttr = rewriter.getDenseI32ArrayAttr({p, p});
+    } else if (auto arrAttr = mlir::dyn_cast<DenseI32ArrayAttr>(padding)) {
+      if (arrAttr.size() == 1) {
+        paddingAttr = rewriter.getDenseI32ArrayAttr({arrAttr[0], arrAttr[0]});
+      } else if (arrAttr.size() == 2) {
+        paddingAttr = arrAttr;
+      } else {
+        return rewriter.notifyMatchFailure(
+            op, "conv1d padding must be a scalar, 1-element, or 2-element "
+                "array");
+      }
+    } else {
+      return rewriter.notifyMatchFailure(op,
+                                         "unexpected conv1d padding attribute");
+    }
+
+    auto groupsAttr = rewriter.getI32IntegerAttr(adaptor.getGroups());
+
+    // ttnn::conv1d forwards the bias unchanged to ttnn::conv2d, which expects a
+    // 4D (1, 1, 1, O) bias. The conv1d bias is (1, 1, O), so unsqueeze a height
+    // dimension before handing it off.
+    Value bias = adaptor.getBias();
+    if (bias) {
+      auto biasTy = mlir::cast<RankedTensorType>(bias.getType());
+      llvm::SmallVector<int64_t> biasShape(biasTy.getShape());
+      biasShape.insert(biasShape.begin() + 2, 1);
+      bias = mlir::tt::ttir_to_ttnn::utils::generateReshape(
+          mlir::cast<TypedValue<RankedTensorType>>(bias), biasShape, rewriter,
+          ttmlir::utils::appendLocationSuffix(op.getLoc(), "_bias_unsqueeze"));
+    }
+
+    // Keep conv1d config tensors in L1 (the Metal default). ttnn::conv1d wraps
+    // conv2d, and the in-DRAM depthwise conv2d path hangs in tt-metal (#45075),
+    // so we must not force DRAM here as the general conv2d path does.
+    auto conv2dConfigAttr = ttnn::Conv2dConfigAttr::get(rewriter.getContext())
+                                .withConfigTensorsInDram(false);
+
+    // ttnn::conv1d delegates to ttnn::conv2d and returns the output in conv2d's
+    // flattened layout (1, 1, N * L_out, O). Create the op with that flattened
+    // result type and reshape back to the original (N, L_out, O) shape.
+    auto resultTy = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(op.getResult().getType()));
+    int64_t outLength = resultTy.getDimSize(lengthDim);
+    llvm::SmallVector<int64_t> flattenedShape = {
+        1, 1, inputShape[batchDim] * outLength,
+        resultTy.getDimSize(channelDim)};
+    RankedTensorType flattenedResultTy =
+        ttnn::utils::RankedTensorTypeFactory::create(resultTy, flattenedShape);
+
+    auto convOp = rewriter.create<ttnn::Conv1dOp>(
+        op.getLoc(), flattenedResultTy, adaptor.getInput(), adaptor.getWeight(),
+        bias, device, inChannelsAttr, outChannelsAttr, batchSizeAttr,
+        inputLengthAttr, kernelSizeAttr, *strideAttr, paddingAttr,
+        *dilationAttr, groupsAttr, conv2dConfigAttr, /*compute_config=*/nullptr,
+        /*conv2d_slice_config=*/nullptr);
+
+    Value output = mlir::tt::ttir_to_ttnn::utils::generateReshape(
+        mlir::cast<TypedValue<RankedTensorType>>(convOp.getResult()),
+        llvm::SmallVector<int64_t>(resultTy.getShape()), rewriter,
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_unflatten"));
+
+    rewriter.replaceOp(op, output);
+
+    return success();
+  }
+};
+
 class Conv2dOpConversionPattern : public OpConversionPattern<ttir::Conv2dOp> {
 public:
   using OpConversionPattern<ttir::Conv2dOp>::OpConversionPattern;
@@ -3671,6 +3796,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            MoeExpertTokenRemapOpConversionPattern,
            MoeGptOpConversionPattern,
            MoeComputeOpConversionPattern,
+           Conv1dOpConversionPattern,
            Conv2dOpConversionPattern,
            Conv3dOpConversionPattern,
            ConvTranspose2dOpConversionPattern,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1635,6 +1635,50 @@ public:
 // Conv2d op conversion pattern
 //
 namespace {
+class Conv1dOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::Conv1dOp> {
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::Conv1dOp>::TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::Conv1dOp srcOp,
+                  mlir::tt::ttnn::Conv1dOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::Conv1dOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getWeight()),
+        emitter.emit(srcOp.getDevice()),
+        emitter.emit(srcOp.getInChannels()),
+        emitter.emit(srcOp.getOutChannels()),
+        emitter.emit(srcOp.getBatchSize()),
+        emitter.emit(srcOp.getInputLength()),
+        emitter.emit(srcOp.getKernelSize()),
+        emitter.emit(srcOp.getStride()),
+        emitter.emit<std::array<uint32_t, 2>>(srcOp.getPaddingAttr()),
+        emitter.emit(srcOp.getDilation()),
+        emitter.emit(srcOp.getGroups()),
+        emitter.emit(srcOp.getDtypeAttr()),
+        emitter.emit(srcOp.getBias()),
+        emitter.emit(srcOp.getConv2dConfig()),
+        emitter.emit(srcOp.getComputeConfig()),
+        emitter.emit(srcOp.getMemoryConfigAttr()),
+        emitter.emit(srcOp.getConv2dSliceConfigAttr()),
+        emitter.emit(false), // return_output_dim
+        emitter.emit(false), // return_weights_and_bias
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+
 class Conv2dOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::Conv2dOp> {
 
@@ -5663,6 +5707,7 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
                                                                  ctx);
   patterns.add<PrepareConvTranspose2dBiasOpConversionPattern>(typeConverter,
                                                               ctx);
+  patterns.add<Conv1dOpConversionPattern>(typeConverter, ctx);
   patterns.add<Conv2dOpConversionPattern>(typeConverter, ctx);
   patterns.add<Conv3dOpConversionPattern>(typeConverter, ctx);
   patterns.add<ConvTranspose2dOpConversionPattern>(typeConverter, ctx);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1643,6 +1643,55 @@ public:
 };
 } // namespace
 
+// Conv1dOp conversion pattern
+//
+namespace {
+class Conv1dOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<mlir::tt::ttnn::Conv1dOp> {
+
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::Conv1dOp>::TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::Conv1dOp conv1dOp,
+                  mlir::tt::ttnn::Conv1dOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::Conv1dOp> emitter(
+        conv1dOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(conv1dOp.getInput(), "input_tensor"),
+        emitter.emit(conv1dOp.getWeight(), "weight_tensor"),
+        emitter.emit(conv1dOp.getDevice(), "device"),
+        emitter.emit(conv1dOp.getInChannels(), "in_channels"),
+        emitter.emit(conv1dOp.getOutChannels(), "out_channels"),
+        emitter.emit(conv1dOp.getBatchSize(), "batch_size"),
+        emitter.emit(conv1dOp.getInputLength(), "input_length"),
+        emitter.emit(conv1dOp.getKernelSize(), "kernel_size"),
+        emitter.emit(conv1dOp.getStride(), "stride"),
+        emitter.template emit<std::vector<uint32_t>>(conv1dOp.getPaddingAttr(),
+                                                     "padding"),
+        emitter.emit(conv1dOp.getDilation(), "dilation"),
+        emitter.emit(conv1dOp.getGroups(), "groups"),
+        emitter.emit(conv1dOp.getDtypeAttr(), "dtype"),
+        emitter.emit(conv1dOp.getBias(), "bias_tensor"),
+        emitter.emit(conv1dOp.getConv2dConfig(), "conv_config"),
+        emitter.emit(conv1dOp.getComputeConfig(), "compute_config"),
+        emitter.emit(conv1dOp.getMemoryConfigAttr(), "memory_config"),
+        emitter.emit(conv1dOp.getConv2dSliceConfig(), "slice_config"),
+        emitter.emit(false, "return_output_dim"),
+        emitter.emit(false, "return_weights_and_bias"),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // Conv2dOp conversion pattern
 //
 namespace {
@@ -5440,7 +5489,8 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
 
   // Convolution ops
   //
-  patterns.add<Conv2dOpConversionPattern, ConvTranspose2dOpConversionPattern,
+  patterns.add<Conv1dOpConversionPattern, Conv2dOpConversionPattern,
+               ConvTranspose2dOpConversionPattern,
                PrepareConv2dWeightsOpConversionPattern,
                PrepareConv2dBiasOpConversionPattern,
                PrepareConv3dWeightsOpConversionPattern,

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1554,6 +1554,67 @@ mlir::Operation *mlir::tt::ttir::Conv2dOp::rewriteWithQuantizedInputs(
   return quantConv.getOperation();
 }
 
+//===----------------------------------------------------------------------===//
+// Conv1dOp
+//===----------------------------------------------------------------------===//
+
+// Get number of output channels
+int64_t mlir::tt::ttir::Conv1dOp::getOutputChannelSize() {
+  RankedTensorType weightTy = getWeight().getType();
+  return weightTy.getShape()[0];
+}
+
+// Conv1dOp verification
+::mlir::LogicalResult mlir::tt::ttir::Conv1dOp::verify() {
+  if (getInput().getType().getRank() != 3) {
+    return emitOpError("input must be a 3D tensor");
+  }
+  if (getWeight().getType().getRank() != 3) {
+    return emitOpError("weight must be a 3D tensor (O, C/G, K)");
+  }
+  if (getBias() && getBias().getType().getRank() != 3) {
+    return emitOpError("bias must be a 3D tensor (1, 1, O)");
+  }
+  if (getResult().getType().getRank() != 3) {
+    return emitOpError("output must be a 3D tensor");
+  }
+
+  RankedTensorType inputType = getInput().getType();
+  RankedTensorType weightType = getWeight().getType();
+  RankedTensorType outputType = getResult().getType();
+
+  int64_t inChannels = inputType.getDimSize(getChannelDim());
+  int64_t outChannels = outputType.getDimSize(getChannelDim());
+  uint32_t groups = getGroups();
+
+  if (groups == 0) {
+    return emitOpError("groups must be a positive integer");
+  }
+  if (inChannels % groups != 0) {
+    return emitOpError("number of input channels (")
+           << inChannels << ") must be divisible by groups (" << groups << ")";
+  }
+  if (outChannels % groups != 0) {
+    return emitOpError("number of output channels (")
+           << outChannels << ") must be divisible by groups (" << groups << ")";
+  }
+
+  // weight is (O, C/G, K).
+  if (weightType.getDimSize(0) != outChannels) {
+    return emitOpError("expected weight's output channel dimension (")
+           << weightType.getDimSize(0)
+           << ") to match the output tensor's channel dimension ("
+           << outChannels << ")";
+  }
+  if (weightType.getDimSize(1) != inChannels / groups) {
+    return emitOpError("expected weight's input channel dimension (")
+           << weightType.getDimSize(1) << ") to match in_channels / groups ("
+           << inChannels / groups << ")";
+  }
+
+  return mlir::success();
+}
+
 // Conv2dOp verification
 ::mlir::LogicalResult mlir::tt::ttir::Conv2dOp::verify() {
   // Verify tensor ranks.

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -615,6 +615,48 @@ static bool isDefinedByOp(mlir::Value value) {
   return foundDefinedByOp;
 }
 
+// Conv1dOp verification
+int64_t mlir::tt::ttnn::Conv1dOp::getOutputChannelSize() {
+  RankedTensorType weightTy = getWeight().getType();
+  return weightTy.getShape()[0];
+}
+
+::mlir::LogicalResult mlir::tt::ttnn::Conv1dOp::verify() {
+  if (getInput().getType().getRank() != 3) {
+    return emitOpError("input must be a 3D tensor (N, L_in, C)");
+  }
+  if (getWeight().getType().getRank() != 3) {
+    return emitOpError("weight must be a 3D tensor (O, C/G, K)");
+  }
+  // ttnn::conv1d forwards the bias to ttnn::conv2d, which expects a 4D
+  // (1, 1, 1, O) bias.
+  if (getBias() && getBias().getType().getRank() != 4) {
+    return emitOpError("bias must be a 4D tensor (1, 1, 1, O)");
+  }
+  // ttnn::conv1d returns the output in ttnn::conv2d's flattened layout
+  // (1, 1, N * L_out, O).
+  if (getResult().getType().getRank() != 4) {
+    return emitOpError("output must be a 4D tensor (1, 1, N * L_out, O)");
+  }
+
+  if (getPadding().size() != 2) {
+    return emitOpError(
+        "padding attribute must have exactly 2 elements ([pL, pR])");
+  }
+
+  if (getGroups() <= 0) {
+    return emitOpError("groups must be a positive integer");
+  }
+  if (getInChannels() % getGroups() != 0) {
+    return emitOpError("in_channels must be divisible by groups");
+  }
+  if (getOutChannels() % getGroups() != 0) {
+    return emitOpError("out_channels must be divisible by groups");
+  }
+
+  return mlir::success();
+}
+
 // Conv2dOp verification
 ::mlir::LogicalResult mlir::tt::ttnn::Conv2dOp::verify() {
   using namespace mlir::tt::ttnn::utils::verification_utils::conv2d;

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1742,6 +1742,9 @@ TTNNOperandsWorkaroundsFactory::createTopKRouterGptOpOperandsWorkarounds() {
 
 template TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(
+    ttnn::Conv1dOp op);
+template TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(
     ttnn::Conv2dOp op);
 template TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3374,6 +3374,82 @@ SamplingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// Conv1dOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+// If a config has been specified, use that. Otherwise, use the op property.
+// Conv1dOp carries a conv2d config/compute config (it delegates to conv2d), so
+// the conv2d attrs bundle is reused verbatim.
+static Conv2dAttrs unpackConv1dAttrs(const OpConfig::OpSpecificAttrs &attrs,
+                                     Conv1dOp op) {
+  assert((std::holds_alternative<Conv2dAttrs>(attrs) ||
+          std::holds_alternative<UninitializedAttrs>(attrs)) &&
+         "Please create a Conv2dAttrs or leave it to be uninitialized.");
+
+  if (std::holds_alternative<UninitializedAttrs>(attrs)) {
+    return Conv2dAttrs{op.getConv2dConfig(), op.getComputeConfig()};
+  }
+
+  Conv2dAttrs conv2dAttrs = std::get<Conv2dAttrs>(attrs);
+
+  return Conv2dAttrs{conv2dAttrs.conv2dConfig ? conv2dAttrs.conv2dConfig
+                                              : op.getConv2dConfig(),
+                     conv2dAttrs.deviceComputeKernelConfig
+                         ? conv2dAttrs.deviceComputeKernelConfig
+                         : op.getComputeConfig()};
+}
+
+llvm::Expected<op_model::OpConstraints>
+Conv1dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<TTNNLayoutAttr> biasLayout;
+  if (inputs.size() == 3) {
+    biasShape = getBias().getType().getShape();
+    biasLayout = inputs[2];
+  }
+
+  Conv2dAttrs attr = unpackConv1dAttrs(opConfig.opSpecificAttrs, *this);
+
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<Conv1dOp>::getOpConstraints, getOperation(), inputShape,
+      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
+      getOutChannels(), getBatchSize(), getInputLength(), getKernelSize(),
+      getStride(), getPadding(), getDilation(), getGroups(), attr.conv2dConfig,
+      attr.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+Conv1dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<TTNNLayoutAttr> biasLayout;
+  if (inputs.size() == 3) {
+    biasShape = getBias().getType().getShape();
+    biasLayout = inputs[2];
+  }
+
+  Conv2dAttrs attr = unpackConv1dAttrs(opConfig.opSpecificAttrs, *this);
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<Conv1dOp>::getOpRuntime, getOperation(), inputShape,
+      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
+      getOutChannels(), getBatchSize(), getInputLength(), getKernelSize(),
+      getStride(), getPadding(), getDilation(), getGroups(), attr.conv2dConfig,
+      attr.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
+      opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // Conv2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -648,6 +648,7 @@ public:
               ttnn::FillCacheOp>,
           workarounds::decomposition::FillCacheInputPadRewritePattern<
               ttnn::PagedFillCacheOp>,
+          workarounds::decomposition::Conv2dRewritePattern<Conv1dOp>,
           workarounds::decomposition::Conv2dRewritePattern<Conv2dOp>,
           workarounds::decomposition::Conv2dRewritePattern<ConvTranspose2dOp>,
           workarounds::decomposition::

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -5032,6 +5032,223 @@ llvm::Expected<size_t> OpModel<Conv2dOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// Conv1dOp
+//===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+namespace {
+// Builds the 2D-equivalent parameters `ttnn::conv1d` uses internally, for the
+// shared conv2d weight/bias prepare step:
+//   input   (N, L_in, C) -> (N, 1, L_in, C)
+//   weight  (O, C/G, K)  -> (O, C/G, 1, K)  ("OIHW")
+//   kernel/stride/dilation gain a leading 1; padding [pL, pR] ->
+//     {top=0, left=pL, bottom=0, right=pR} (the order reorderPool2dPadding
+//     consumes for a 4-element padding).
+struct Conv1dConv2dPrepParams {
+  llvm::SmallVector<int64_t, 4> inputShape;
+  llvm::SmallVector<int64_t, 4> weightShape;
+  llvm::SmallVector<int32_t, 2> kernelSize;
+  llvm::SmallVector<int32_t, 2> stride;
+  llvm::SmallVector<int32_t, 4> padding;
+  llvm::SmallVector<int32_t, 2> dilation;
+};
+
+Conv1dConv2dPrepParams
+getConv1dConv2dPrepParams(llvm::ArrayRef<int64_t> inputShape,
+                          llvm::ArrayRef<int64_t> weightShape,
+                          uint32_t kernel_size, uint32_t stride,
+                          llvm::ArrayRef<int32_t> padding, uint32_t dilation) {
+  return Conv1dConv2dPrepParams{
+      /*inputShape=*/{inputShape[0], 1, inputShape[1], inputShape[2]},
+      /*weightShape=*/{weightShape[0], weightShape[1], 1, weightShape[2]},
+      /*kernelSize=*/{1, static_cast<int32_t>(kernel_size)},
+      /*stride=*/{1, static_cast<int32_t>(stride)},
+      /*padding=*/{0, padding[0], 0, padding[1]},
+      /*dilation=*/{1, static_cast<int32_t>(dilation)}};
+}
+
+// `ttnn::conv1d` forces L1_FULL slicing when no slice config is provided;
+// return that effective config so the weight prepare and the query match
+// runtime.
+Conv2dSliceConfigAttr getConv1dEffectiveSliceConfig(
+    mlir::MLIRContext *ctx, std::optional<Conv2dSliceConfigAttr> sliceConfig) {
+  if (sliceConfig && *sliceConfig) {
+    return *sliceConfig;
+  }
+  return Conv2dSliceConfigAttr::get(ctx, Conv2dSliceType::L1Full,
+                                    /*num_slices=*/0);
+}
+} // namespace
+#endif // TTMLIR_ENABLE_OPMODEL
+
+llvm::Expected<OpConstraints> OpModel<Conv1dOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_length,
+    uint32_t kernel_size, uint32_t stride, llvm::ArrayRef<int32_t> padding,
+    uint32_t dilation, uint32_t groups,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  Conv1dConv2dPrepParams prep = getConv1dConv2dPrepParams(
+      inputShape, weightShape, kernel_size, stride, padding, dilation);
+  Conv2dSliceConfigAttr sliceConfig = getConv1dEffectiveSliceConfig(
+      inputLayout.getContext(), conv2dSliceConfig);
+
+  // Prepare weight tensor first (shared conv2d prepare helper).
+  llvm::Expected<::ttnn::TensorSpec> preparedWeightExp =
+      getPrepareConv2dWeightsOpOutputTensorSpec(
+          prep.inputShape, inputLayout, prep.weightShape, weightLayout,
+          in_channels, out_channels, batch_size, /*input_height=*/1,
+          /*input_width=*/input_length, prep.kernelSize, prep.stride,
+          prep.padding, prep.dilation, groups, conv2dConfig, sliceConfig,
+          biasLayout.has_value(), /*transpose*/ false);
+  if (!preparedWeightExp) {
+    return preparedWeightExp.takeError();
+  }
+  ::ttnn::TensorSpec weightSpec = preparedWeightExp.get();
+
+  // Prepare bias tensor if present.
+  std::optional<::ttnn::TensorSpec> biasSpec;
+  if (biasShape && biasLayout) {
+    llvm::Expected<::ttnn::TensorSpec> preparedBiasExp =
+        getPrepareConv2dBiasOpOutputTensorSpec(
+            prep.inputShape, inputLayout, *biasShape, *biasLayout,
+            weightSpec.data_type(), in_channels, out_channels, batch_size,
+            /*input_height=*/1, /*input_width=*/input_length, prep.kernelSize,
+            prep.stride, prep.padding, prep.dilation, groups, conv2dConfig,
+            /*transpose*/ false);
+    if (!preparedBiasExp) {
+      return preparedBiasExp.takeError();
+    }
+    biasSpec = preparedBiasExp.get();
+  }
+
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+
+  std::optional<::tt::tt_metal::DataType> outputDtype =
+      detail::getNullableDataType(outputLayout);
+  std::optional<::ttnn::Conv2dConfig> conv2dConfigConverted =
+      conversion::getConv2dConfig(conv2dConfig);
+  std::optional<::ttnn::DeviceComputeKernelConfig>
+      deviceComputeKernelConfigConverted =
+          conversion::getDeviceComputeKernelConfig(deviceComputeKernelConfig);
+  std::optional<::ttnn::Conv2dSliceConfig> sliceConfigConverted =
+      conversion::getConv2dSliceConfig(sliceConfig);
+
+  // conv1d padding is std::variant<std::array<uint32_t, 2>, uint32_t>; use the
+  // (left, right) array alternative, matching the runtime op.
+  std::variant<std::array<uint32_t, 2>, uint32_t> conv1dPadding =
+      conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding);
+
+  auto conv1dOpQuery = [=]() {
+    return QUERY_OP_CONSTRAINTS(
+        ::ttnn::conv1d, device, inputSpec, weightSpec, device, in_channels,
+        out_channels, batch_size, input_length, kernel_size, stride,
+        conv1dPadding, dilation, groups, outputDtype, biasSpec,
+        conv2dConfigConverted, deviceComputeKernelConfigConverted,
+        detail::getNullableMemoryConfig(outputLayout), sliceConfigConverted,
+        /*return_output_dim=*/false,
+        /*return_weights_and_bias=*/false);
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), conv1dOpQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<Conv1dOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_length,
+    uint32_t kernel_size, uint32_t stride, llvm::ArrayRef<int32_t> padding,
+    uint32_t dilation, uint32_t groups,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  Conv1dConv2dPrepParams prep = getConv1dConv2dPrepParams(
+      inputShape, weightShape, kernel_size, stride, padding, dilation);
+  Conv2dSliceConfigAttr sliceConfig = getConv1dEffectiveSliceConfig(
+      inputLayout.getContext(), conv2dSliceConfig);
+
+  llvm::Expected<::ttnn::TensorSpec> preparedWeightExp =
+      getPrepareConv2dWeightsOpOutputTensorSpec(
+          prep.inputShape, inputLayout, prep.weightShape, weightLayout,
+          in_channels, out_channels, batch_size, /*input_height=*/1,
+          /*input_width=*/input_length, prep.kernelSize, prep.stride,
+          prep.padding, prep.dilation, groups, conv2dConfig, sliceConfig,
+          biasLayout.has_value(), /*transpose*/ false);
+  if (!preparedWeightExp) {
+    return preparedWeightExp.takeError();
+  }
+  ::ttnn::TensorSpec weightSpec = preparedWeightExp.get();
+
+  std::optional<::ttnn::TensorSpec> biasSpec;
+  if (biasShape && biasLayout) {
+    llvm::Expected<::ttnn::TensorSpec> preparedBiasExp =
+        getPrepareConv2dBiasOpOutputTensorSpec(
+            prep.inputShape, inputLayout, *biasShape, *biasLayout,
+            weightSpec.data_type(), in_channels, out_channels, batch_size,
+            /*input_height=*/1, /*input_width=*/input_length, prep.kernelSize,
+            prep.stride, prep.padding, prep.dilation, groups, conv2dConfig,
+            /*transpose*/ false);
+    if (!preparedBiasExp) {
+      return preparedBiasExp.takeError();
+    }
+    biasSpec = preparedBiasExp.get();
+  }
+
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+
+  std::optional<::tt::tt_metal::DataType> outputDtype =
+      detail::getNullableDataType(outputLayout);
+  std::optional<::ttnn::Conv2dConfig> conv2dConfigConverted =
+      conversion::getConv2dConfig(conv2dConfig);
+  std::optional<::ttnn::DeviceComputeKernelConfig>
+      deviceComputeKernelConfigConverted =
+          conversion::getDeviceComputeKernelConfig(deviceComputeKernelConfig);
+  std::optional<::ttnn::Conv2dSliceConfig> sliceConfigConverted =
+      conversion::getConv2dSliceConfig(sliceConfig);
+
+  std::variant<std::array<uint32_t, 2>, uint32_t> conv1dPadding =
+      conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding);
+
+  auto conv1dOpQuery = [=]() {
+    return QUERY_OP_RUNTIME(
+        ::ttnn::conv1d, device, inputSpec, weightSpec, device, in_channels,
+        out_channels, batch_size, input_length, kernel_size, stride,
+        conv1dPadding, dilation, groups, outputDtype, biasSpec,
+        conv2dConfigConverted, deviceComputeKernelConfigConverted,
+        detail::getNullableMemoryConfig(outputLayout), sliceConfigConverted,
+        /*return_output_dim=*/false,
+        /*return_weights_and_bias=*/false);
+  };
+
+  return operation::getOpRuntime(conv1dOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // Conv3dOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -893,6 +893,46 @@ createOp(FlatbufferObjectCache &cache, PrepareConvTranspose2dBiasOp op) {
       computeConfig.value_or(0), sliceConfig.value_or(0));
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::Conv1dOp>
+createOp(FlatbufferObjectCache &cache, Conv1dOp op) {
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto weight = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getWeight()));
+  auto bias = op.getBias()
+                  ? cache.at<::tt::target::ttnn::TensorRef>(
+                        getOperandThroughDPSOps(op.getBias()))
+                  : flatbuffers::Offset<::tt::target::ttnn::TensorRef>();
+  auto output =
+      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
+                                  /*local_shape*/ std::nullopt);
+
+  auto device = getOperandThroughDPSOps(op.getDevice());
+
+  ::flatbuffers::Offset<::flatbuffers::Vector<int32_t>> padding =
+      toFlatbuffer(cache, op.getPadding());
+
+  auto outputDtype = toFlatbuffer(cache, op.getDtypeAttr());
+
+  std::optional<::flatbuffers::Offset<::tt::target::ttnn::Conv2dConfig>>
+      conv2dConfig = toFlatbuffer(cache, op.getConv2dConfig());
+
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
+  std::optional<::flatbuffers::Offset<::tt::target::ttnn::Conv2dSliceConfig>>
+      sliceConfig = toFlatbuffer(cache, op.getConv2dSliceConfig());
+
+  return ::tt::target::ttnn::CreateConv1dOp(
+      *cache.fbb, input, weight, bias, output,
+      cache.at<::tt::target::DeviceRef>(device), op.getInChannels(),
+      op.getOutChannels(), op.getBatchSize(), op.getInputLength(),
+      op.getKernelSize(), op.getStride(), padding, op.getDilation(),
+      op.getGroups(), outputDtype, conv2dConfig.value_or(0),
+      computeConfig.value_or(0), sliceConfig.value_or(0));
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::Conv2dOp>
 createOp(FlatbufferObjectCache &cache, Conv2dOp op) {
   auto input = cache.at<::tt::target::ttnn::TensorRef>(
@@ -4614,6 +4654,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
       prepareConvTranspose2dBiasOp) {
     return createOperation(cache, createOp(cache, prepareConvTranspose2dBiasOp),
                            debugString, locInfo);
+  }
+  if (auto conv1dOp = dyn_cast<Conv1dOp>(op); conv1dOp) {
+    return createOperation(cache, createOp(cache, conv1dOp), debugString,
+                           locInfo);
   }
   if (auto conv2dOp = dyn_cast<Conv2dOp>(op); conv2dOp) {
     return createOperation(cache, createOp(cache, conv2dOp), debugString,

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -16,6 +16,7 @@
 #include "ttnn/device.hpp"
 #include "ttnn/events.hpp"
 #include "ttnn/global_semaphore.hpp"
+#include "ttnn/operations/conv/conv1d/conv1d.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/core/core.hpp"

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/point_to_point.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/reduce_scatter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/context/get_device.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv1d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv_transpose2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/prepare_conv2d_weights.cpp

--- a/runtime/lib/ttnn/operations/conv/conv1d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv1d.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/conv/conv1d.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
+
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+#include "ttnn/types.hpp"
+
+#include <array>
+#include <variant>
+
+namespace tt::runtime::ttnn::operations::conv {
+using ::ttnn::Conv1dResult;
+void run(const ::tt::target::ttnn::Conv1dOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
+  const ::ttnn::Tensor &weight =
+      tensorPool.getTTNNTensorAndValidate(op->weight());
+
+  std::optional<::ttnn::Tensor> bias =
+      op->bias()
+          ? std::make_optional(tensorPool.getTTNNTensorAndValidate(op->bias()))
+          : std::nullopt;
+
+  LOG_ASSERT(op->padding()->size() == 2,
+             "Padding expected to have 2 elements ([pL, pR])");
+
+  // conv1d padding is a (left, right) pair, mapped to the std::array<2>
+  // alternative of the TTNN variant.
+  std::variant<std::array<uint32_t, 2>, uint32_t> padding;
+  std::array<uint32_t, 2> lrPadding;
+  std::copy_n(op->padding()->begin(), 2, lrPadding.begin());
+  padding = lrPadding;
+
+  std::optional<::ttnn::DataType> outputDtype;
+  if (op->output_dtype()) {
+    outputDtype =
+        ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->output_dtype()));
+  }
+
+  ::ttnn::Conv1dConfig conv1dConfig;
+  if (op->conv2d_config()) {
+    conv1dConfig = utils::createConv2dConfig(op->conv2d_config());
+  }
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
+                 outputMemoryConfig.has_value(),
+             "Memory config must exist for device tensors");
+
+  std::optional<::ttnn::Conv1dSliceConfig> sliceConfig;
+  if (op->conv2d_slice_config()) {
+    sliceConfig = utils::createConv2dSliceConfig(op->conv2d_slice_config());
+  }
+
+  Conv1dResult result = ::ttnn::conv1d(
+      input, weight, &targetDevice, op->in_channels(), op->out_channels(),
+      op->batch_size(), op->input_length(), op->kernel_size(), op->stride(),
+      padding, op->dilation(), op->groups(), outputDtype, bias, conv1dConfig,
+      computeConfig, outputMemoryConfig, sliceConfig,
+      /*return_output_dim=*/false, /*return_weights_and_bias=*/false);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result));
+
+  ::ttnn::Tensor out = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+} // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/conv/conv1d.h
+++ b/runtime/lib/ttnn/operations/conv/conv1d.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CONV_CONV1D_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CONV_CONV1D_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::conv {
+void run(const ::tt::target::ttnn::Conv1dOp *op, ProgramContext &context);
+
+} // namespace tt::runtime::ttnn::operations::conv
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -29,6 +29,7 @@
 #include "operations/ccl/reduce_scatter.h"
 #include "operations/ccl/selective_reduce_combine.h"
 #include "operations/context/get_device.h"
+#include "operations/conv/conv1d.h"
 #include "operations/conv/conv2d.h"
 #include "operations/conv/conv3d.h"
 #include "operations/conv/conv_transpose2d.h"
@@ -506,6 +507,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   case ::tt::target::ttnn::OpType::PrepareConvTranspose2dBiasOp: {
     return operations::conv::run(op->type_as_PrepareConvTranspose2dBiasOp(),
                                  getContext());
+  }
+  case ::tt::target::ttnn::OpType::Conv1dOp: {
+    return operations::conv::run(op->type_as_Conv1dOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::Conv2dOp: {
     return operations::conv::run(op->type_as_Conv2dOp(), getContext());

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1310,6 +1310,10 @@ std::vector<tt::runtime::TensorRef> getOpOutputRefs(OpContext opContextHandle) {
     tensorRefs = {opContext.type_as_RepeatInterleaveOp()->out()};
     break;
   }
+  case ::tt::target::ttnn::OpType::Conv1dOp: {
+    tensorRefs = {opContext.type_as_Conv1dOp()->out()};
+    break;
+  }
   case ::tt::target::ttnn::OpType::Conv2dOp: {
     tensorRefs = {opContext.type_as_Conv2dOp()->out()};
     break;
@@ -1840,6 +1844,14 @@ std::vector<tt::runtime::TensorRef> getOpInputRefs(OpContext opContextHandle) {
   }
   case ::tt::target::ttnn::OpType::RepeatInterleaveOp: {
     tensorRefs = {opContext.type_as_RepeatInterleaveOp()->input()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::Conv1dOp: {
+    auto *op = opContext.type_as_Conv1dOp();
+    tensorRefs = {op->input(), op->weight()};
+    if (op->bias()) {
+      tensorRefs.push_back(op->bias());
+    }
     break;
   }
   case ::tt::target::ttnn::OpType::Conv2dOp: {

--- a/test/python/golden/ttir_ops/convolution/test_conv1d.py
+++ b/test/python/golden/ttir_ops/convolution/test_conv1d.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import sys
+import torch
+from typing import List, Optional, Tuple, Union
+from builder.base.builder_utils import Operand, Shape
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_and_execute_ttir
+from conftest import get_request_kwargs
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+# TODO: Remove this fixture once we support config tensors in dram for conv1d
+# (mirrors the conv2d behaviour, see https://github.com/tenstorrent/tt-mlir/issues/6105).
+@pytest.fixture(autouse=True)
+def clear_program_cache_after_test(device):
+    """Clear program cache after each conv1d test to free L1 memory."""
+    yield
+    conftest = sys.modules.get("conftest")
+    if conftest and conftest._current_device is not None:
+        conftest._current_device.clear_program_cache()
+
+
+@pytest.mark.parametrize(
+    "input_shape, weight_shape, bias_shape, stride, padding, dilation, groups",
+    [
+        # input: (N, L, C); weight: (O, C/G, K); bias: (1, 1, O)
+        # Basic kernel=3, same length via padding=1
+        ((1, 32, 64), (64, 64, 3), (1, 1, 64), 1, 1, 1, 1),
+        # No bias, valid padding (length shrinks)
+        ((1, 32, 64), (128, 64, 3), None, 1, 0, 1, 1),
+        # Stride=2 downsample
+        ((1, 32, 16), (32, 16, 3), (1, 1, 32), 2, 0, 1, 1),
+        # Dilation=2 atrous conv
+        ((1, 64, 32), (32, 32, 3), (1, 1, 32), 1, 2, 2, 1),
+        # Asymmetric padding [left, right]
+        ((1, 32, 16), (16, 16, 3), (1, 1, 16), 1, (0, 1), 1, 1),
+        # Grouped / depthwise conv
+        ((1, 32, 64), (64, 1, 3), (1, 1, 64), 1, 1, 1, 64),
+        # Batched
+        ((4, 32, 32), (64, 32, 3), (1, 1, 64), 1, 1, 1, 1),
+    ],
+    ids=[
+        "basic_k3_pad1",
+        "valid_no_bias",
+        "stride2",
+        "dilation2",
+        "asymmetric_pad",
+        "depthwise",
+        "batched",
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_conv1d(
+    input_shape: Shape,
+    weight_shape: Shape,
+    bias_shape: Optional[Shape],
+    stride: int,
+    padding: Union[int, Tuple[int, int]],
+    dilation: int,
+    groups: int,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    if bias_shape:
+        input_shapes = [input_shape, weight_shape, bias_shape]
+        input_types = [dtype, dtype, dtype]
+
+        def module(builder: TTIRBuilder):
+            @builder.func(input_shapes, input_types)
+            def conv1d_wrapper(
+                in0: Operand,
+                weight: Operand,
+                bias: Operand,
+                builder: TTIRBuilder,
+                unit_attrs: Optional[List[str]] = None,
+            ):
+                return builder.conv1d(
+                    in0,
+                    weight,
+                    bias,
+                    stride=stride,
+                    padding=padding,
+                    dilation=dilation,
+                    groups=groups,
+                    unit_attrs=unit_attrs,
+                )
+
+    else:
+        input_shapes = [input_shape, weight_shape]
+        input_types = [dtype, dtype]
+
+        def module(builder: TTIRBuilder):
+            @builder.func(input_shapes, input_types)
+            def conv1d_wrapper(
+                in0: Operand,
+                weight: Operand,
+                builder: TTIRBuilder,
+                unit_attrs: Optional[List[str]] = None,
+            ):
+                return builder.conv1d(
+                    in0,
+                    weight,
+                    None,
+                    stride=stride,
+                    padding=padding,
+                    dilation=dilation,
+                    groups=groups,
+                    unit_attrs=unit_attrs,
+                )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target=target,
+    )

--- a/test/ttmlir/Conversion/StableHLOToTTIR/conv2d_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/conv2d_op.mlir
@@ -17,10 +17,10 @@ module @jit_convolution attributes {} {
     return %0 : tensor<1x128x128x64xf32>
   }
 
-  // Tests 1d convolution that gets translated to 2d.
+  // Tests 1d convolution, which is routed to a native ttir.conv1d.
   func.func @test_convolution_1d(%arg0: tensor<1x256x512xf32>, %arg1: tensor<1024x256x1xf32>) -> tensor<1x1024x512xf32> {
     // CHECK-COUNT-2: = "ttir.reshape"
-    // CHECK: = "ttir.conv2d"
+    // CHECK: = "ttir.conv1d"
     // CHECK: = "ttir.reshape"
     %0 = stablehlo.convolution(%arg0, %arg1)
       dim_numbers = [b, f, 0]x[o, i, 0]->[b, f, 0],

--- a/test/ttmlir/Conversion/StableHLOToTTIR/convolution_decomposition.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/convolution_decomposition.mlir
@@ -3,10 +3,11 @@
 // RUN: FileCheck %s --input-file=%t
 
 module @test_convolution {
-  // Test 1D convolution sliced with batch_group_count > 1
+  // Test 1D convolution sliced with batch_group_count > 1. Each slice is a 1D
+  // conv, so it is routed to ttir.conv1d.
   func.func @test_conv_sliced(%arg0: tensor<1x9x3072xbf16>, %arg1: tensor<1x9x768xbf16>) -> tensor<1x768x768xbf16> {
     // CHECK-COUNT-8: "ttir.slice_static"
-    // CHECK-COUNT-4: "ttir.conv2d"
+    // CHECK-COUNT-4: "ttir.conv1d"
     // CHECK: "ttir.concat"
     %0 = stablehlo.convolution(%arg0, %arg1)
       dim_numbers = [f, 0, b]x[i, 0, o]->[0, b, f],
@@ -37,8 +38,10 @@ module @test_convolution {
     return %0 : tensor<1x16x32x32xbf16>
   }
 
-  // Test depthwise convolution (feature_group_count > 1, not transposed)
+  // Test depthwise convolution (feature_group_count > 1, not transposed).
+  // Genuine 2D (both spatial dims > 1) must stay conv2d.
   func.func @test_conv_not_transposed(%arg0: tensor<1x2048x16x16xbf16>, %arg1: tensor<2048x1x3x3xbf16>) -> tensor<1x2048x16x16xbf16> {
+    // CHECK-LABEL: @test_conv_not_transposed
     // CHECK: "ttir.conv2d"
     %0 = stablehlo.convolution(%arg0, %arg1)
       dim_numbers = [b, f, 0, 1]x[o, i, 0, 1]->[b, f, 0, 1],
@@ -50,5 +53,25 @@ module @test_convolution {
         batch_group_count = 1 : i64
       } : (tensor<1x2048x16x16xbf16>, tensor<2048x1x3x3xbf16>) -> tensor<1x2048x16x16xbf16>
     return %0 : tensor<1x2048x16x16xbf16>
+  }
+
+  // Test a conv1d that the framework (e.g. torch-xla) lowered to a 2D
+  // convolution with a size-1 spatial dim. It must be routed to ttir.conv1d
+  // (so it lowers to ttnn.conv1d and can use an L1 config, avoiding the
+  // in-DRAM depthwise conv2d hang).
+  func.func @test_degenerate_2d_to_conv1d(%arg0: tensor<1x8x1x20xbf16>, %arg1: tensor<8x1x1x4xbf16>) -> tensor<1x8x1x23xbf16> {
+    // CHECK-LABEL: @test_degenerate_2d_to_conv1d
+    // CHECK: "ttir.conv1d"
+    // CHECK-NOT: "ttir.conv2d"
+    %0 = stablehlo.convolution(%arg0, %arg1)
+      dim_numbers = [b, f, 0, 1]x[o, i, 0, 1]->[b, f, 0, 1],
+      window = {
+        stride = [1, 1],
+        pad = [[0, 0], [3, 3]]
+      } {
+        feature_group_count = 8 : i64,
+        batch_group_count = 1 : i64
+      } : (tensor<1x8x1x20xbf16>, tensor<8x1x1x4xbf16>) -> tensor<1x8x1x23xbf16>
+    return %0 : tensor<1x8x1x23xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/conv/conv1d/simple_conv1d.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv/conv1d/simple_conv1d.mlir
@@ -1,0 +1,39 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  func.func @conv1d_simple(%arg0: tensor<1x32x64xbf16>, %arg1: tensor<64x64x3xbf16>, %arg2: tensor<1x1x64xbf16>) -> tensor<1x30x64xbf16> {
+    // CHECK: "ttnn.conv1d"
+    %0 = "ttir.conv1d"(%arg0, %arg1, %arg2)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x64xbf16>, tensor<64x64x3xbf16>, tensor<1x1x64xbf16>) -> tensor<1x30x64xbf16>
+    return %0 : tensor<1x30x64xbf16>
+  }
+
+  func.func @conv1d_no_bias(%arg0: tensor<1x32x64xbf16>, %arg1: tensor<64x64x3xbf16>) -> tensor<1x32x64xbf16> {
+    // CHECK: "ttnn.conv1d"
+    %0 = "ttir.conv1d"(%arg0, %arg1)
+            <{
+              stride = 1: i32,
+              padding = 1: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x64xbf16>, tensor<64x64x3xbf16>) -> tensor<1x32x64xbf16>
+    return %0 : tensor<1x32x64xbf16>
+  }
+
+  func.func @conv1d_stride(%arg0: tensor<3x32x8xbf16>, %arg1: tensor<16x8x3xbf16>, %arg2: tensor<1x1x16xbf16>) -> tensor<3x15x16xbf16> {
+    // CHECK: "ttnn.conv1d"
+    %0 = "ttir.conv1d"(%arg0, %arg1, %arg2)
+            <{
+              stride = 2: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<3x32x8xbf16>, tensor<16x8x3xbf16>, tensor<1x1x16xbf16>) -> tensor<3x15x16xbf16>
+    return %0 : tensor<3x15x16xbf16>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/conv/conv1d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv1d.mlir
@@ -1,0 +1,20 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
+
+module {
+  func.func @conv1d_with_bias(%arg0: tensor<1x32x64xbf16>, %arg1: tensor<64x64x3xbf16>, %arg2: tensor<1x1x64xbf16>) -> tensor<1x30x64xbf16> {
+    %0 = "ttir.conv1d"(%arg0, %arg1, %arg2)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x64xbf16>, tensor<64x64x3xbf16>, tensor<1x1x64xbf16>) -> tensor<1x30x64xbf16>
+    return %0 : tensor<1x30x64xbf16>
+  }
+}

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -2813,6 +2813,115 @@ INSTANTIATE_TEST_SUITE_P(
                         llvm::SmallVector<int32_t>{1, 1}, 1,
                         detail::ExpectedResult{true})));
 
+// conv1d shares the conv2d op model path (it queries ::ttnn::conv1d, which
+// wraps
+// ::ttnn::conv2d). Parameters are the native 1D form: input (N, L_in, C),
+// weight (O, C/G, K), and scalar kernel/stride/dilation with [pL, pR] padding.
+class OpModelConv1dParam : public OpModelTest,
+                           public testing::WithParamInterface<
+                               std::tuple<detail::TestTensor, // input
+                                          detail::TestTensor, // weight
+                                          detail::TestTensor, // output
+                                          uint32_t,           // in_channels
+                                          uint32_t,           // out_channels
+                                          uint32_t,           // batch_size
+                                          uint32_t,           // input_length
+                                          uint32_t,           // kernel_size
+                                          uint32_t,           // stride
+                                          llvm::SmallVector<int32_t>, // padding
+                                          uint32_t, // dilation
+                                          uint32_t, // groups
+                                          detail::ExpectedResult>> {};
+
+TEST_P(OpModelConv1dParam, Conv1d) {
+  auto params = GetParam();
+  const auto [inputShape, inputTensorLayout, inputBufferType,
+              inputVirtualGrid] = std::get<0>(params);
+  const auto [weightShape, weightTensorLayout, weightBufferType,
+              weightVirtualGrid] = std::get<1>(params);
+  const auto [outputShape, outputTensorLayout, outputBufferType,
+              outputVirtualGrid] = std::get<2>(params);
+  const auto in_channels = std::get<3>(params);
+  const auto out_channels = std::get<4>(params);
+  const auto batch_size = std::get<5>(params);
+  const auto input_length = std::get<6>(params);
+  const auto kernel_size = std::get<7>(params);
+  const auto stride = std::get<8>(params);
+  const auto padding = std::get<9>(params);
+  const auto dilation = std::get<10>(params);
+  const auto groups = std::get<11>(params);
+  const auto expectedLegal = std::get<12>(params).expectedLegal;
+
+  const TTNNLayoutAttr inputLayout = CreateRowMajorLayout(
+      inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid,
+      GetPhysicalGridSize(), builder.getF32Type());
+  const TTNNLayoutAttr weightLayout = CreateRowMajorLayout(
+      weightShape, weightBufferType, weightTensorLayout, weightVirtualGrid,
+      GetPhysicalGridSize(), builder.getF32Type());
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+  auto constraintsExp = OpModel<Conv1dOp>::getOpConstraints(
+      inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
+      std::nullopt, in_channels, out_channels, batch_size, input_length,
+      kernel_size, stride, padding, dilation, groups, std::nullopt,
+      std::nullopt, std::nullopt, outputLayout);
+  // Manually cast to bool because EXPECT_TRUE requires a const bool operator
+  // which llvm::Expected<T> does not have
+  EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+  if (constraintsExp) {
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+                outputLayoutReadBacks] = constraintsExp.get();
+    EXPECT_GT(cbSize, 0);
+    EXPECT_GT(l1PeakSize, 0);
+    EXPECT_GT(totalPeakSize, 0);
+  } else {
+    // Must clean up the error
+    llvm::consumeError(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = OpModel<Conv1dOp>::getOpRuntime(
+      inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
+      std::nullopt, in_channels, out_channels, batch_size, input_length,
+      kernel_size, stride, padding, dilation, groups, std::nullopt,
+      std::nullopt, std::nullopt, outputLayout);
+  EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
+  if (runtimeExp) {
+    EXPECT_GT(runtimeExp.get(), 0);
+  } else {
+    // Must clean up the error
+    llvm::consumeError(runtimeExp.takeError());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Conv1dTests, OpModelConv1dParam,
+    ::testing::Values(
+        // symmetric (zero) padding: L_out = 30
+        std::make_tuple(detail::TestTensor{{1, 32, 64},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{64, 64, 3},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::SystemMemory},
+                        detail::TestTensor{{1, 1, 30, 64},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        64, 64, 1, 32, 3, 1, llvm::SmallVector<int32_t>{0, 0},
+                        1, 1, detail::ExpectedResult{true}),
+        // asymmetric padding [pL=1, pR=2]: L_out = 33
+        std::make_tuple(detail::TestTensor{{1, 32, 64},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{64, 64, 3},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::SystemMemory},
+                        detail::TestTensor{{1, 1, 33, 64},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        64, 64, 1, 32, 3, 1, llvm::SmallVector<int32_t>{1, 2},
+                        1, 1, detail::ExpectedResult{true})));
+
 class OpModelConvTranspose2dParam
     : public OpModelTest,
       public testing::WithParamInterface<

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -2786,6 +2786,198 @@ TEST_F(OpModelBase, Conv2dInterface) {
   }
 }
 
+TEST_F(OpModelBase, Conv1dInterface) {
+  // conv1d is modeled by reusing the conv2d op model path. Input is (N, L_in,
+  // C) and weight is (O, C/G, K); the op model maps these to their height-1
+  // conv2d equivalents internally.
+  llvm::SmallVector<int64_t> inputShape = {1, 32, 64};
+  llvm::SmallVector<int64_t> weightShape = {64, 64, 3};
+  // conv2d flattened output layout (1, 1, N * L_out, O); L_out = 30.
+  llvm::SmallVector<int64_t> outputShape = {1, 1, 30, 64};
+
+  auto input = createEmptyTensor(inputShape);
+  Type weightElementType = builder.getBF16Type();
+  auto weightLayout =
+      TTNNLayoutAttr::Builder(&context, weightShape, weightElementType)
+          .setBufferType(BufferType::SystemMemory)
+          .setGridShape(llvm::ArrayRef<int64_t>{1, 1})
+          .buildWithCanonicalCorePlacement(CreateDeviceAttr());
+  auto weight = createEmptyTensor(weightShape, weightElementType, weightLayout);
+  auto outputType = createRankedTensorType(outputShape);
+
+  GetDeviceOp deviceOp = builder.create<GetDeviceOp>(
+      builder.getUnknownLoc(), builder.getType<DeviceType>(),
+      MeshShapeAttr::get(builder.getContext(), 1, 1),
+      MeshOffsetAttr::get(builder.getContext(), 0, 0));
+
+  Conv1dOp conv1d = builder.create<Conv1dOp>(
+      builder.getUnknownLoc(),         // Location
+      outputType,                      // Output type
+      input,                           // Input tensor
+      weight,                          // Weight tensor
+      nullptr,                         // Bias tensor (optional)
+      deviceOp,                        // Device operation
+      64,                              // Input channels
+      64,                              // Output channels
+      1,                               // Batch size
+      32,                              // Input length
+      3,                               // Kernel size
+      1,                               // Stride
+      llvm::ArrayRef<int32_t>({0, 0}), // Padding [pL, pR]
+      1,                               // Dilation
+      1,                               // Groups
+      nullptr,                         // Conv2dConfig (optional)
+      nullptr,                         // ComputeKernelConfig (optional)
+      nullptr                          // Conv2dSliceConfig (optional)
+  );
+
+  // test Conv1dOp interface
+  auto constraintsExp = getOpConstraints(conv1d.getOperation());
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
+      constraintsExp.get();
+  EXPECT_GT(cbSize, 0);
+  EXPECT_GE(l1PeakSize, 0);
+  EXPECT_GT(outputSize, 0);
+
+  auto runtimeExp = getOpRuntime(conv1d.getOperation());
+  EXPECT_TRUE(static_cast<bool>(runtimeExp));
+  if (runtimeExp) {
+    EXPECT_GT(runtimeExp.get(), 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, Conv1dMatchesEquivalentConv2d) {
+  // conv1d is modeled by delegating to the conv2d op model with a height-1
+  // mapping. Verify the delegation is exact: a conv1d and its explicit conv2d
+  // equivalent must produce identical constraints AND the same output layout
+  // (the flattened (1, 1, N * L_out, O) conv2d layout that conv1d lowers to
+  // downstream). Uses asymmetric padding [pL=1, pR=2] to also lock the padding
+  // mapping [pL, pR] -> {top=0, left=pL, bottom=0, right=pR}.
+  GetDeviceOp deviceOp = builder.create<GetDeviceOp>(
+      builder.getUnknownLoc(), builder.getType<DeviceType>(),
+      MeshShapeAttr::get(builder.getContext(), 1, 1),
+      MeshOffsetAttr::get(builder.getContext(), 0, 0));
+
+  Type bf16 = builder.getBF16Type();
+  auto makeHostWeight = [&](llvm::ArrayRef<int64_t> shape) {
+    auto layout = TTNNLayoutAttr::Builder(&context, shape, bf16)
+                      .setBufferType(BufferType::SystemMemory)
+                      .setGridShape(llvm::ArrayRef<int64_t>{1, 1})
+                      .buildWithCanonicalCorePlacement(CreateDeviceAttr());
+    return createEmptyTensor(shape, bf16, layout);
+  };
+
+  // conv1d: input (N, L_in, C) = (1, 32, 64), weight (O, C/G, K) = (64, 64, 3).
+  // L_out = (32 + 1 + 2 - 1 * (3 - 1) - 1) / 1 + 1 = 33; flattened output is
+  // (1, 1, N * L_out, O) = (1, 1, 33, 64).
+  Conv1dOp conv1d = builder.create<Conv1dOp>(
+      builder.getUnknownLoc(), createRankedTensorType({1, 1, 33, 64}),
+      createEmptyTensor({1, 32, 64}), makeHostWeight({64, 64, 3}),
+      /*bias=*/nullptr, deviceOp,
+      /*in_channels=*/64, /*out_channels=*/64, /*batch_size=*/1,
+      /*input_length=*/32, /*kernel_size=*/3, /*stride=*/1,
+      /*padding=*/llvm::ArrayRef<int32_t>({1, 2}), /*dilation=*/1, /*groups=*/1,
+      /*conv2d_config=*/nullptr, /*compute_config=*/nullptr,
+      /*conv2d_slice_config=*/nullptr);
+
+  // Explicit conv2d equivalent: input (1, 1, 32, 64), weight (64, 64, 1, 3),
+  // kernel {1, 3}, stride {1, 1}, dilation {1, 1}, padding {0, 1, 0, 2} (the
+  // [top, left, bottom, right] form conv2d's interface feeds through
+  // reorderPool2dPadding), and the L1_FULL slicing conv1d forces by default.
+  Conv2dSliceConfigAttr l1Full = Conv2dSliceConfigAttr::get(
+      &context, Conv2dSliceType::L1Full, /*num_slices=*/0);
+  Conv2dOp conv2d = builder.create<Conv2dOp>(
+      builder.getUnknownLoc(), createRankedTensorType({1, 1, 33, 64}),
+      createEmptyTensor({1, 1, 32, 64}), makeHostWeight({64, 64, 1, 3}),
+      /*bias=*/nullptr, deviceOp,
+      /*in_channels=*/64, /*out_channels=*/64, /*batch_size=*/1,
+      /*input_height=*/1, /*input_width=*/32, llvm::ArrayRef<int32_t>({1, 3}),
+      llvm::ArrayRef<int32_t>({1, 1}), llvm::ArrayRef<int32_t>({0, 1, 0, 2}),
+      llvm::ArrayRef<int32_t>({1, 1}), /*groups=*/1, /*conv2d_config=*/nullptr,
+      /*compute_config=*/nullptr, l1Full);
+
+  auto c1 = getOpConstraints(conv1d.getOperation());
+  auto c2 = getOpConstraints(conv2d.getOperation());
+  ASSERT_TRUE(static_cast<bool>(c1)) << llvm::toString(c1.takeError());
+  ASSERT_TRUE(static_cast<bool>(c2)) << llvm::toString(c2.takeError());
+
+  EXPECT_EQ(c1->cbL1PeakSize, c2->cbL1PeakSize);
+  EXPECT_EQ(c1->tensorL1PeakSize, c2->tensorL1PeakSize);
+  EXPECT_EQ(c1->peakL1MemorySize, c2->peakL1MemorySize);
+  EXPECT_EQ(c1->outputL1BufferSize, c2->outputL1BufferSize);
+  ASSERT_EQ(c1->outputLayouts.size(), c2->outputLayouts.size());
+  ASSERT_FALSE(c1->outputLayouts.empty());
+  EXPECT_EQ(c1->outputLayouts[0], c2->outputLayouts[0]);
+
+  auto r1 = getOpRuntime(conv1d.getOperation());
+  auto r2 = getOpRuntime(conv2d.getOperation());
+  ASSERT_TRUE(static_cast<bool>(r1)) << llvm::toString(r1.takeError());
+  ASSERT_TRUE(static_cast<bool>(r2)) << llvm::toString(r2.takeError());
+  EXPECT_GT(r1.get(), 0u);
+}
+
+TEST_F(OpModelBase, Conv1dWithBiasMatchesEquivalentConv2d) {
+  // Same delegation check as Conv1dMatchesEquivalentConv2d, but exercising the
+  // optional bias operand (conv1d bias is (1, 1, 1, O), identical to conv2d, so
+  // it is forwarded unchanged). This is the shape the motivating conv1d IR
+  // uses.
+  GetDeviceOp deviceOp = builder.create<GetDeviceOp>(
+      builder.getUnknownLoc(), builder.getType<DeviceType>(),
+      MeshShapeAttr::get(builder.getContext(), 1, 1),
+      MeshOffsetAttr::get(builder.getContext(), 0, 0));
+
+  Type bf16 = builder.getBF16Type();
+  auto makeHostTensor = [&](llvm::ArrayRef<int64_t> shape) {
+    auto layout = TTNNLayoutAttr::Builder(&context, shape, bf16)
+                      .setBufferType(BufferType::SystemMemory)
+                      .setGridShape(llvm::ArrayRef<int64_t>{1, 1})
+                      .buildWithCanonicalCorePlacement(CreateDeviceAttr());
+    return createEmptyTensor(shape, bf16, layout);
+  };
+
+  Conv1dOp conv1d = builder.create<Conv1dOp>(
+      builder.getUnknownLoc(), createRankedTensorType({1, 1, 30, 64}),
+      createEmptyTensor({1, 32, 64}), makeHostTensor({64, 64, 3}),
+      /*bias=*/makeHostTensor({1, 1, 1, 64}), deviceOp,
+      /*in_channels=*/64, /*out_channels=*/64, /*batch_size=*/1,
+      /*input_length=*/32, /*kernel_size=*/3, /*stride=*/1,
+      /*padding=*/llvm::ArrayRef<int32_t>({0, 0}), /*dilation=*/1, /*groups=*/1,
+      /*conv2d_config=*/nullptr, /*compute_config=*/nullptr,
+      /*conv2d_slice_config=*/nullptr);
+
+  Conv2dSliceConfigAttr l1Full = Conv2dSliceConfigAttr::get(
+      &context, Conv2dSliceType::L1Full, /*num_slices=*/0);
+  Conv2dOp conv2d = builder.create<Conv2dOp>(
+      builder.getUnknownLoc(), createRankedTensorType({1, 1, 30, 64}),
+      createEmptyTensor({1, 1, 32, 64}), makeHostTensor({64, 64, 1, 3}),
+      /*bias=*/makeHostTensor({1, 1, 1, 64}), deviceOp,
+      /*in_channels=*/64, /*out_channels=*/64, /*batch_size=*/1,
+      /*input_height=*/1, /*input_width=*/32, llvm::ArrayRef<int32_t>({1, 3}),
+      llvm::ArrayRef<int32_t>({1, 1}), llvm::ArrayRef<int32_t>({0, 0, 0, 0}),
+      llvm::ArrayRef<int32_t>({1, 1}), /*groups=*/1, /*conv2d_config=*/nullptr,
+      /*compute_config=*/nullptr, l1Full);
+
+  auto c1 = getOpConstraints(conv1d.getOperation());
+  auto c2 = getOpConstraints(conv2d.getOperation());
+  ASSERT_TRUE(static_cast<bool>(c1)) << llvm::toString(c1.takeError());
+  ASSERT_TRUE(static_cast<bool>(c2)) << llvm::toString(c2.takeError());
+
+  EXPECT_EQ(c1->cbL1PeakSize, c2->cbL1PeakSize);
+  EXPECT_EQ(c1->tensorL1PeakSize, c2->tensorL1PeakSize);
+  EXPECT_EQ(c1->peakL1MemorySize, c2->peakL1MemorySize);
+  EXPECT_EQ(c1->outputL1BufferSize, c2->outputL1BufferSize);
+  ASSERT_FALSE(c1->outputLayouts.empty());
+  ASSERT_EQ(c1->outputLayouts.size(), c2->outputLayouts.size());
+  EXPECT_EQ(c1->outputLayouts[0], c2->outputLayouts[0]);
+
+  auto r1 = getOpRuntime(conv1d.getOperation());
+  ASSERT_TRUE(static_cast<bool>(r1)) << llvm::toString(r1.takeError());
+  EXPECT_GT(r1.get(), 0u);
+}
+
 TEST_F(OpModelBase, Conv2dInterfaceNullOutput) {
   // create Conv2dOp
   llvm::SmallVector<int64_t> inputShape = {1, 1, 50176, 3};

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -14472,6 +14472,132 @@ class TTIRBuilder(Builder):
 
         return csdpa_module, csdpa_builder
 
+    @tag(ttir.Conv1dOp)
+    def conv1d(
+        self,
+        in0: Operand,
+        weight: Operand,
+        bias: Optional[Operand],
+        stride: Union[int, List[int]],
+        padding: Union[int, List[int]],
+        dilation: Union[int, List[int]],
+        groups: int,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        """
+        Creates ``ttir.conv1d``.
+
+        *Conv1d operation.*
+
+        Applies a 1D convolution over an input signal composed of several input planes.
+
+        Parameters
+        ----------
+        in0 : Operand
+            Input tensor in (N, L_in, C) format
+        weight : Operand
+            Weight tensor in (O, C/G, K) format
+        bias : *Optional[Operand]*
+            Optional bias tensor in (1, 1, O) format
+        stride : *Union[int, List[int]]*, optional
+            Stride of the kernel window (default: 1)
+        padding : *Union[int, List[int]]*, optional
+            Padding for both sides or [left, right] (default: 0)
+        dilation : *Union[int, List[int]]*, optional
+            Spacing between kernel elements (default: 1)
+        groups : int, optional
+            Number of blocked connections from input to output channels (default: 1)
+        output_type : *Optional[torch.dtype]*, optional
+            Optional output data type (default: None, uses input type)
+        loc : *Optional[str]*, optional
+            Optional location string for debugging
+        unit_attrs : *Optional[List[str]]*, optional
+            Optional list of unit attributes
+
+        Returns
+        -------
+        (*OpResult*)
+            Output tensor after convolution
+        """
+        ttir_op = self.get_opview_from_method(TTIRBuilder.conv1d)
+
+        if not bias:
+            bias = None
+
+        stride_attr = (
+            IntegerAttr.get(IntegerType.get_signless(32), stride)
+            if isinstance(stride, int)
+            else DenseI32ArrayAttr.get(stride)
+        )
+        padding_attr = (
+            IntegerAttr.get(IntegerType.get_signless(32), padding)
+            if isinstance(padding, int)
+            else DenseI32ArrayAttr.get(padding)
+        )
+        dilation_attr = (
+            IntegerAttr.get(IntegerType.get_signless(32), dilation)
+            if isinstance(dilation, int)
+            else DenseI32ArrayAttr.get(dilation)
+        )
+
+        groups_attr = IntegerAttr.get(IntegerType.get_signless(32), groups)
+
+        # Default dimension attributes (NLC layout)
+        batch_dim_attr = IntegerAttr.get(IntegerType.get_signless(32), 0)
+        length_dim_attr = IntegerAttr.get(IntegerType.get_signless(32), 1)
+        channel_dim_attr = IntegerAttr.get(IntegerType.get_signless(32), 2)
+
+        if output_type is None:
+            mlir_output_type = self.get_type(in0)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        input0 = self._get_golden_tensor(in0)
+        weight0 = self._get_golden_tensor(weight)
+        bias0 = self._get_golden_tensor(bias) if bias is not None else None
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(
+            input0,
+            weight0,
+            bias0,
+            stride_attr,
+            padding_attr,
+            dilation_attr,
+            groups_attr,
+            batch_dim_attr,
+            length_dim_attr,
+            channel_dim_attr,
+        )
+        result = self._create_ranked_tensor_type(golden_output.shape, mlir_output_type)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = ttir_op(
+            result,
+            in0,
+            weight,
+            stride_attr,
+            padding_attr,
+            dilation_attr,
+            groups_attr,
+            bias=bias,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
     @tag(ttir.Conv2dOp)
     def conv2d(
         self,

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -499,6 +499,87 @@ def cbrt_golden(x: GoldenMapTensor) -> GoldenMapTensor:
     return torch.mul(golden_sign, golden_cbrt)
 
 
+def conv1d_golden(
+    input_tensor: GoldenMapTensor,
+    weight: GoldenMapTensor,
+    bias: Optional[GoldenMapTensor],
+    stride: Union[IntegerAttr, DenseI32ArrayAttr],
+    padding: Union[IntegerAttr, DenseI32ArrayAttr],
+    dilation: Union[IntegerAttr, DenseI32ArrayAttr],
+    groups: IntegerAttr,
+    batch_dim: IntegerAttr,
+    length_dim: IntegerAttr,
+    channel_dim: IntegerAttr,
+) -> GoldenMapTensor:
+    """
+    Custom golden function for conv1d with layout transformation.
+
+    The TTIR op uses an NLC layout (batch, length, channel) while
+    ``torch.nn.functional.conv1d`` expects NCL (batch, channel, length).
+    """
+    if bias is not None:
+        bias = bias.squeeze()  # Removes all dims of size 1
+
+    stride = unpack_mlir_attr(stride)
+    padding = unpack_mlir_attr(padding)
+    dilation = unpack_mlir_attr(dilation)
+    groups = unpack_mlir_attr(groups)
+
+    batch_dim = unpack_mlir_attr(batch_dim)
+    length_dim = unpack_mlir_attr(length_dim)
+    channel_dim = unpack_mlir_attr(channel_dim)
+
+    # Permute any layout to NCL (batch=0, channel=1, length=2).
+    to_ncl_perm = [batch_dim, channel_dim, length_dim]
+    is_ncl = to_ncl_perm == [0, 1, 2]
+
+    copied_input_tensor = input_tensor.clone()
+    if not is_ncl:
+        copied_input_tensor = copied_input_tensor.permute(to_ncl_perm)
+
+    # Normalize stride/dilation to scalars.
+    if isinstance(stride, (list, tuple)):
+        stride = int(stride[0])
+    if isinstance(dilation, (list, tuple)):
+        dilation = int(dilation[0])
+
+    # Handle padding: int, [p] (symmetric), or [pL, pR] (asymmetric).
+    if isinstance(padding, (list, tuple)):
+        padding = [int(p) for p in padding]
+        if len(padding) == 1:
+            padding = padding[0]
+        elif len(padding) == 2:
+            left, right = padding
+            if left == right:
+                padding = left
+            else:
+                copied_input_tensor = torch.nn.functional.pad(
+                    copied_input_tensor,
+                    [left, right],
+                    mode="constant",
+                    value=0,
+                )
+                padding = 0
+
+    result = torch.nn.functional.conv1d(
+        copied_input_tensor,
+        weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+    )
+
+    # Permute output back to original layout if we permuted the input.
+    if not is_ncl:
+        from_ncl_perm = [0] * 3
+        for i, p in enumerate(to_ncl_perm):
+            from_ncl_perm[p] = i
+        result = result.permute(from_ncl_perm)
+    return result
+
+
 def conv2d_golden(
     input_tensor: GoldenMapTensor,
     weight: GoldenMapTensor,
@@ -8937,6 +9018,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     # Complex operations
     ttir.CbrtOp: cbrt_golden,
     ttir.ConcatenateHeadsOp: ttir_concatenate_heads_golden,
+    ttir.Conv1dOp: conv1d_golden,
     ttir.Conv2dOp: conv2d_golden,
     ttir.Conv3dOp: conv3d_golden,
     ttir.ConvTranspose2dOp: conv_transpose2d_golden,
@@ -9788,6 +9870,25 @@ def chisel_ttnn_max_pool2d_with_indices(op, inputs):
     )
 
 
+def chisel_ttnn_conv1d(op, inputs):
+    # TTNN conv1d keeps the input in NLC layout and the weight in (O, C/G, K)
+    # format (the same as TTIR), so the golden can be reused directly. The TTNN
+    # op returns the output in conv2d's flattened layout (1, 1, N * L_out, O).
+    result = conv1d_golden(
+        input_tensor=inputs["input"],
+        weight=inputs["weight"],
+        bias=inputs["bias"],
+        stride=op.attributes["stride"],
+        padding=op.attributes["padding"],
+        dilation=op.attributes["dilation"],
+        groups=op.attributes["groups"],
+        batch_dim=0,
+        length_dim=1,
+        channel_dim=2,
+    )
+    return result.reshape(1, 1, -1, result.shape[-1])
+
+
 def chisel_ttnn_conv2d(op, inputs):
     # TTNN input/output is flat [1, 1, N*H*W, C]; unflatten to NHWC, run conv, re-flatten.
     batch_size = unpack_mlir_attr(op.attributes["batch_size"])
@@ -10387,6 +10488,7 @@ CHISEL_GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.MaxPool2dOp: chisel_ttnn_max_pool2d,
     ttnn.AvgPool2dOp: chisel_ttnn_avg_pool2d,
     ttnn.MaxPool2dWithIndicesOp: chisel_ttnn_max_pool2d_with_indices,
+    ttnn.Conv1dOp: chisel_ttnn_conv1d,
     ttnn.Conv2dOp: chisel_ttnn_conv2d,
     ttnn.Conv3dOp: chisel_ttnn_conv3d,
     ttnn.ConvTranspose2dOp: chisel_ttnn_conv_transpose2d,

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -10,6 +10,7 @@
 #include "operations/ccl/all_to_all_combine/all_to_all_combine.hpp"
 #include "operations/ccl/all_to_all_dispatch/all_to_all_dispatch.hpp"
 #include "operations/ccl/ccl_host_types.hpp"
+#include "operations/conv/conv1d/conv1d.hpp"
 #include "operations/conv/conv2d/conv2d.hpp"
 #include "operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "operations/conv/conv_transpose2d/conv_transpose2d.hpp"


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/47799)

### Problem description
torch-xla lower nn.Conv1d to a 2D stablehlo.convolution with a size-1 spatial dim, so it previously lowered to ttnn.conv2d. For depthwise 1D convs, the conv2d path with config_tensors_in_dram=true hangs in tt-metal ([#47799](https://github.com/tenstorrent/tt-metal/issues/47799)). Surfaced by the Qwen3.5 gated-delta depthwise causal conv.

### What's changed

- New conv1d op across the stack (TTIR + TTNN defs/verifiers, TTIR→TTNN, EmitC/EmitPy, flatbuffer schema + serialization, runtime execution, TTIRBuilder/golden, tests), modeling ttnn::conv1d.
- Routing: tryEmitDegenerate2dAsConv1d detects a 2D conv with one spatial dim of extent 1 in both input and kernel, squeezes it, and emits ttir.conv1d. Genuine 2D convs are untouched.
- Config: conv1d uses an L1 config (config_tensors_in_dram=false) to avoid the hang; conv2d/conv_transpose2d stay in DRAM.
- Layout workarounds (mirroring conv2d): input forced row-major, weight/bias moved to host row-major - ttnn::conv1d does its own runtime weight-prep and requires a row-major host weight.

### Checklist
- [ ] New/Existing tests provide coverage for changes
