### PR TITLE
Clarify semantics of tensor global ID to be auto-initialized at construction and rebindable once

### DIFF
--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -420,8 +420,17 @@ struct Tensor : public detail::RuntimeCheckedObjectImpl {
         event(eventHandle.value_or(nullptr), runtime),
         globalId(nextTensorGlobalId()) {}
 
-  void setGlobalId(std::uint64_t id) { globalId = id; }
   std::uint64_t getGlobalId() const { return globalId; }
+
+  // Returns a copy of `tensor` that shares the same underlying handle/data
+  // but is labeled with `globalId`. Used to bind runtime tensors to the
+  // caller-assigned (e.g. controller) global id at construction time, since
+  // the id is otherwise immutable after a Tensor is created.
+  static Tensor withGlobalId(const Tensor &tensor, std::uint64_t globalId) {
+    Tensor copy = tensor;
+    copy.globalId = globalId;
+    return copy;
+  }
 
 private:
   std::uint64_t nextTensorGlobalId();

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -422,19 +422,17 @@ struct Tensor : public detail::RuntimeCheckedObjectImpl {
 
   std::uint64_t getGlobalId() const { return globalId; }
 
-  // Returns a copy of `tensor` that shares the same underlying handle/data
-  // but is labeled with `globalId`. Used to bind runtime tensors to the
-  // caller-assigned (e.g. controller) global id at construction time, since
-  // the id is otherwise immutable after a Tensor is created.
-  static Tensor withGlobalId(const Tensor &tensor, std::uint64_t globalId) {
-    Tensor copy = tensor;
-    copy.globalId = globalId;
-    return copy;
-  }
+  // Binds the canonical (e.g. controller-assigned) global id that correlates
+  // this tensor across the controller/worker IPC boundary. May be called at
+  // most once: the id is frozen afterward and any attempt to rebind it to a
+  // different value is a fatal error. This keeps globalId a stable correlation
+  // key that cannot be silently reconfigured at runtime.
+  void bindGlobalId(std::uint64_t id);
 
 private:
   std::uint64_t nextTensorGlobalId();
   std::uint64_t globalId;
+  bool globalIdBound_ = false;
 };
 
 struct GlobalSemaphore : public detail::RuntimeCheckedObjectImpl {

--- a/runtime/lib/common/types.cpp
+++ b/runtime/lib/common/types.cpp
@@ -210,6 +210,14 @@ std::uint64_t Tensor::nextTensorGlobalId() {
   return globalId.fetch_add(1, std::memory_order_relaxed);
 }
 
+void Tensor::bindGlobalId(std::uint64_t id) {
+  LOG_ASSERT(!globalIdBound_ || globalId == id,
+             "Tensor globalId is already bound to ", globalId,
+             " and cannot be rebound to ", id);
+  globalId = id;
+  globalIdBound_ = true;
+}
+
 std::uint64_t GlobalSemaphore::nextGlobalSemaphoreGlobalId() {
   static std::atomic<std::uint64_t> globalId = 0;
   return globalId.fetch_add(1, std::memory_order_relaxed);

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -370,7 +370,7 @@ void CommandExecutor::execute(uint64_t commandId,
   ::tt::runtime::Tensor tensor = ::tt::runtime::createOwnedHostTensor(
       tensorData, shape, stride, itemSize, dataType);
 
-  tensor = ::tt::runtime::Tensor::withGlobalId(tensor, tensorGlobalId);
+  tensor.bindGlobalId(tensorGlobalId);
 
   tensorPool_.insert_or_assign(tensorGlobalId, tensor);
 
@@ -400,8 +400,7 @@ void CommandExecutor::execute(
       ::tt::runtime::createMultiDeviceHostTensor(tensorShards, strategy,
                                                  meshShape);
 
-  multiDeviceHostTensor = ::tt::runtime::Tensor::withGlobalId(
-      multiDeviceHostTensor, command->output_global_id());
+  multiDeviceHostTensor.bindGlobalId(command->output_global_id());
   tensorPool_.insert_or_assign(command->output_global_id(),
                                multiDeviceHostTensor);
 
@@ -426,8 +425,7 @@ void CommandExecutor::execute(
   ::tt::runtime::Tensor sourceTensor = tensorPool_.at(sourceGlobalId);
   ::tt::runtime::Tensor borrowedTensor =
       ::tt::runtime::createUnsafeBorrowedHostTensor(sourceTensor);
-  borrowedTensor =
-      ::tt::runtime::Tensor::withGlobalId(borrowedTensor, outputGlobalId);
+  borrowedTensor.bindGlobalId(outputGlobalId);
   tensorPool_.insert_or_assign(outputGlobalId, borrowedTensor);
 
   std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
@@ -533,8 +531,7 @@ void CommandExecutor::execute(uint64_t commandId,
   ::tt::runtime::Tensor resultTensor =
       ::tt::runtime::toLayout(inputTensor, device, layout, retain);
 
-  resultTensor =
-      ::tt::runtime::Tensor::withGlobalId(resultTensor, outputGlobalId);
+  resultTensor.bindGlobalId(outputGlobalId);
 
   tensorPool_.insert_or_assign(outputGlobalId, resultTensor);
 
@@ -567,8 +564,7 @@ void CommandExecutor::execute(uint64_t commandId,
              " != ", command->output_global_ids()->size());
 
   for (size_t i = 0; i < outputTensors.size(); i++) {
-    outputTensors[i] = ::tt::runtime::Tensor::withGlobalId(
-        outputTensors[i], command->output_global_ids()->Get(i));
+    outputTensors[i].bindGlobalId(command->output_global_ids()->Get(i));
     tensorPool_.insert_or_assign(command->output_global_ids()->Get(i),
                                  outputTensors[i]);
   }
@@ -613,8 +609,7 @@ void CommandExecutor::execute(uint64_t commandId,
              " != ", command->output_global_ids()->size());
 
   for (size_t i = 0; i < outputTensors.size(); i++) {
-    outputTensors[i] = ::tt::runtime::Tensor::withGlobalId(
-        outputTensors[i], command->output_global_ids()->Get(i));
+    outputTensors[i].bindGlobalId(command->output_global_ids()->Get(i));
     tensorPool_.insert_or_assign(command->output_global_ids()->Get(i),
                                  outputTensors[i]);
   }

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -370,7 +370,7 @@ void CommandExecutor::execute(uint64_t commandId,
   ::tt::runtime::Tensor tensor = ::tt::runtime::createOwnedHostTensor(
       tensorData, shape, stride, itemSize, dataType);
 
-  tensor.setGlobalId(tensorGlobalId);
+  tensor = ::tt::runtime::Tensor::withGlobalId(tensor, tensorGlobalId);
 
   tensorPool_.insert_or_assign(tensorGlobalId, tensor);
 
@@ -400,7 +400,8 @@ void CommandExecutor::execute(
       ::tt::runtime::createMultiDeviceHostTensor(tensorShards, strategy,
                                                  meshShape);
 
-  multiDeviceHostTensor.setGlobalId(command->output_global_id());
+  multiDeviceHostTensor = ::tt::runtime::Tensor::withGlobalId(
+      multiDeviceHostTensor, command->output_global_id());
   tensorPool_.insert_or_assign(command->output_global_id(),
                                multiDeviceHostTensor);
 
@@ -425,7 +426,8 @@ void CommandExecutor::execute(
   ::tt::runtime::Tensor sourceTensor = tensorPool_.at(sourceGlobalId);
   ::tt::runtime::Tensor borrowedTensor =
       ::tt::runtime::createUnsafeBorrowedHostTensor(sourceTensor);
-  borrowedTensor.setGlobalId(outputGlobalId);
+  borrowedTensor =
+      ::tt::runtime::Tensor::withGlobalId(borrowedTensor, outputGlobalId);
   tensorPool_.insert_or_assign(outputGlobalId, borrowedTensor);
 
   std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
@@ -531,7 +533,8 @@ void CommandExecutor::execute(uint64_t commandId,
   ::tt::runtime::Tensor resultTensor =
       ::tt::runtime::toLayout(inputTensor, device, layout, retain);
 
-  resultTensor.setGlobalId(outputGlobalId);
+  resultTensor =
+      ::tt::runtime::Tensor::withGlobalId(resultTensor, outputGlobalId);
 
   tensorPool_.insert_or_assign(outputGlobalId, resultTensor);
 
@@ -564,7 +567,8 @@ void CommandExecutor::execute(uint64_t commandId,
              " != ", command->output_global_ids()->size());
 
   for (size_t i = 0; i < outputTensors.size(); i++) {
-    outputTensors[i].setGlobalId(command->output_global_ids()->Get(i));
+    outputTensors[i] = ::tt::runtime::Tensor::withGlobalId(
+        outputTensors[i], command->output_global_ids()->Get(i));
     tensorPool_.insert_or_assign(command->output_global_ids()->Get(i),
                                  outputTensors[i]);
   }
@@ -609,7 +613,8 @@ void CommandExecutor::execute(uint64_t commandId,
              " != ", command->output_global_ids()->size());
 
   for (size_t i = 0; i < outputTensors.size(); i++) {
-    outputTensors[i].setGlobalId(command->output_global_ids()->Get(i));
+    outputTensors[i] = ::tt::runtime::Tensor::withGlobalId(
+        outputTensors[i], command->output_global_ids()->Get(i));
     tensorPool_.insert_or_assign(command->output_global_ids()->Get(i),
                                  outputTensors[i]);
   }


### PR DESCRIPTION
### Ticket
Related to allocation tracking / observability

### Problem description
The primary way to correlate controller and worker tensors is by global ID, which we assume is a stable identity but do not guarantee well. If we want to do things like allocation tracking or deallocate / cache tensors by global ID it is very unsafe to expose a public API that lets runtime arbitrarily mutate that global ID.

### What's changed
Clarify semantics of tensorID to be created at construction + rebindable once (which is only used in distributed context right after construction), instead of arbitrarily rebindable at runtime. 

- Add a bindTensorId API that can only be called once per tensor, allowing a one-time rebind of tensor global IDs
- Call bindTensorId at callsites that used to use setGlobalId; i.e. ones where the worker generated new tensors

This slightly leaks the distributed bind-once concern to the core runtime type, though the original API did that as well but in a more unclear way (via general setter).


### Alternatives considered
- Removing rebinding altogether. Because controller and worker auto-set tensor IDs at construction they will become desynchronized - controller will not construct intermediates during submit() but workers do - so we need some kind of rebinding or a set-at-construction for all the APIs that construct tensors (see below)
- Const-ifying the globalID and setting it at construction - This would require all tensor construction APIs to have an interface for passing one (or for submit - many) tensor IDs which would pollute those APIs much more heavily for distributed case

### Checklist
- [ ] New/Existing tests provide coverage for changes
