### PR TITLE
Incrementally update EraseInverseOps const-trace cache

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ConstevalForwardAnalysis.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ConstevalForwardAnalysis.h
@@ -6,9 +6,12 @@
 #define TTMLIR_DIALECT_TTIR_TRANSFORMS_ERASEINVERSEOPS_CONSTEVALFORWARDANALYSIS_H
 
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/DenseMap.h"
+
+#include <optional>
 
 namespace mlir::tt::ttir {
 
@@ -17,9 +20,13 @@ namespace mlir::tt::ttir {
 // attempt; without caching the pass is O(num_ops^2). One forward walk
 // per FuncOp populates the cache; subsequent queries are O(1).
 //
-// Acts as a RewriterBase::Listener: any IR mutation flips a dirty flag
-// and the next query rebuilds from scratch, so cached Value pointers
-// never go stale.
+// Acts as a RewriterBase::Listener. Const-ness flows strictly forward along
+// the use-def chain, so each IR mutation can only change the touched op's
+// results and their transitive users. The listener updates exactly those
+// entries incrementally instead of dropping the whole cache. Any situation
+// the incremental path cannot reason about (an operand not yet cached, an
+// uncertain notification ordering) falls back to `dirty_ = true`, so the next
+// query rebuilds from scratch and correctness is never sacrificed.
 class ConstevalForwardAnalysis : public mlir::RewriterBase::Listener {
 public:
   explicit ConstevalForwardAnalysis(mlir::Operation *root);
@@ -29,29 +36,96 @@ public:
   // function block argument and no non-CONST/PARAM block argument.
   bool valueTracesToConstantArgs(mlir::Value value);
 
-  // Listener overrides: any IR mutation invalidates the cache.
-  void notifyOperationInserted(mlir::Operation *,
+  // Listener overrides. Const-ness only propagates forward, so each hook
+  // re-derives the affected entries and pushes the change to downstream
+  // users. If anything is uncertain the hook sets `dirty_` and the next
+  // query rebuilds.
+  void notifyOperationInserted(mlir::Operation *op,
                                mlir::OpBuilder::InsertPoint) override {
-    dirty_ = true;
+    if (dirty_) {
+      return;
+    }
+    // Operands are pre-existing (already cached); seed from this op's
+    // results. A missing operand makes propagateFrom set dirty_.
+    for (mlir::Value result : op->getResults()) {
+      propagateFrom(result);
+    }
   }
-  void notifyOperationModified(mlir::Operation *) override { dirty_ = true; }
-  void notifyOperationReplaced(mlir::Operation *, mlir::Operation *) override {
-    dirty_ = true;
+  void notifyOperationModified(mlir::Operation *op) override {
+    if (dirty_) {
+      return;
+    }
+    // Operands may have been rewired; recompute results and propagate.
+    for (mlir::Value result : op->getResults()) {
+      propagateFrom(result);
+    }
   }
-  void notifyOperationReplaced(mlir::Operation *, mlir::ValueRange) override {
-    dirty_ = true;
+  void notifyOperationReplaced(mlir::Operation *op,
+                               mlir::Operation *newOp) override {
+    if (dirty_) {
+      return;
+    }
+    // Old results are RAUW'd to the new op's results; drop the stale
+    // entries and re-derive from the replacements.
+    for (mlir::Value result : op->getResults()) {
+      cache_.erase(result);
+    }
+    for (mlir::Value result : newOp->getResults()) {
+      propagateFrom(result);
+    }
   }
-  void notifyOperationErased(mlir::Operation *) override { dirty_ = true; }
+  void notifyOperationReplaced(mlir::Operation *op,
+                               mlir::ValueRange newValues) override {
+    if (dirty_) {
+      return;
+    }
+    for (mlir::Value result : op->getResults()) {
+      cache_.erase(result);
+    }
+    for (mlir::Value newValue : newValues) {
+      propagateFrom(newValue);
+    }
+  }
+  void notifyOperationErased(mlir::Operation *op) override {
+    if (dirty_) {
+      return;
+    }
+    // No users remain on an erased op's results.
+    for (mlir::Value result : op->getResults()) {
+      cache_.erase(result);
+    }
+  }
 
 private:
-  void rebuild();
-
   // Tracks both bits: a value traces to constant args iff its use-def chain
   // reaches at least one CONST/PARAM arg and no non-CONST/PARAM arg.
   struct Reachability {
     bool hasConstOrParamArg = false;
     bool hasNonConstOrParamArg = false;
+
+    bool operator==(const Reachability &other) const {
+      return hasConstOrParamArg == other.hasConstOrParamArg &&
+             hasNonConstOrParamArg == other.hasNonConstOrParamArg;
+    }
+    bool operator!=(const Reachability &other) const {
+      return !(*this == other);
+    }
   };
+
+  void rebuild();
+
+  // Computes the Reachability for `op`'s results from its operands' cached
+  // entries -- identical logic to the rebuild() inner loop, so there is
+  // exactly one definition of the rule. Also seeds nested-region block args
+  // (never function CONST/PARAM args). Returns std::nullopt if any operand is
+  // not yet cached, so the incremental caller can fall back to rebuild().
+  std::optional<Reachability> computeFromOperands(mlir::Operation *op);
+
+  // Recomputes `seed`'s defining op entry; if it changed, pushes its users.
+  // Const-ness flows strictly forward, so the frontier is bounded by the
+  // touched value's downstream users. Sets `dirty_` (full rebuild next query)
+  // if it hits an operand that is not cached.
+  void propagateFrom(mlir::Value seed);
 
   mlir::Operation *root_;
   bool dirty_ = true;

--- a/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ConstevalForwardAnalysis.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ConstevalForwardAnalysis.h
@@ -121,10 +121,13 @@ private:
   // not yet cached, so the incremental caller can fall back to rebuild().
   std::optional<Reachability> computeFromOperands(mlir::Operation *op);
 
-  // Recomputes `seed`'s defining op entry; if it changed, pushes its users.
-  // Const-ness flows strictly forward, so the frontier is bounded by the
-  // touched value's downstream users. Sets `dirty_` (full rebuild next query)
-  // if it hits an operand that is not cached.
+  // Worklist that re-syncs the cache after a local IR change. Starting from
+  // `seed`, recomputes each value's Reachability from its operands; if the
+  // entry changed, enqueues that value's users and repeats, so the update flows
+  // downstream to a fixpoint. Only affected values are touched (a change can't
+  // reach anything upstream), leaving the cache as a full rebuild would.
+  // Skips block args (seeded by rebuild(), never change mid-pass); on an
+  // operand missing from the cache, sets `dirty_` to force a full rebuild.
   void propagateFrom(mlir::Value seed);
 
   mlir::Operation *root_;

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ConstevalForwardAnalysis.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ConstevalForwardAnalysis.cpp
@@ -99,10 +99,8 @@ void ConstevalForwardAnalysis::rebuild() {
 
       std::optional<Reachability> r = computeFromOperands(op);
       // Pre-order guarantees operands are cached, so r always has a value.
-      // Defensively treat an out-of-region operand pessimistically as
-      // non-const so callers skip the optimization rather than apply an
-      // incorrect one.
-      Reachability reachability = r ? *r : Reachability{false, true};
+      assert(r.has_value() && "rebuild: operands must be cached in pre-order");
+      Reachability reachability = *r;
 
       for (mlir::Value result : op->getResults()) {
         cache_[result] = reachability;

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ConstevalForwardAnalysis.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ConstevalForwardAnalysis.cpp
@@ -8,11 +8,74 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Operation.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
 
 namespace mlir::tt::ttir {
 
 ConstevalForwardAnalysis::ConstevalForwardAnalysis(mlir::Operation *root)
     : root_(root) {}
+
+std::optional<ConstevalForwardAnalysis::Reachability>
+ConstevalForwardAnalysis::computeFromOperands(mlir::Operation *op) {
+  // Nested-region block args (scf.for iter_args, linalg.generic, ...)
+  // are never function-level CONST/PARAM args.
+  for (mlir::Region &region : op->getRegions()) {
+    for (mlir::Block &block : region.getBlocks()) {
+      for (mlir::BlockArgument innerArg : block.getArguments()) {
+        cache_[innerArg] = {false, true};
+      }
+    }
+  }
+
+  Reachability r;
+  for (mlir::Value operand : op->getOperands()) {
+    auto it = cache_.find(operand);
+    if (it == cache_.end()) {
+      // Operand not cached: in rebuild() this never happens (pre-order
+      // caches operands first); in the incremental path it means we cannot
+      // reason about this op, so the caller must fall back to a full
+      // rebuild rather than risk a wrong (favorable) answer.
+      return std::nullopt;
+    }
+    r.hasConstOrParamArg |= it->second.hasConstOrParamArg;
+    r.hasNonConstOrParamArg |= it->second.hasNonConstOrParamArg;
+  }
+  return r;
+}
+
+void ConstevalForwardAnalysis::propagateFrom(mlir::Value seed) {
+  llvm::SmallVector<mlir::Value> work{seed};
+  while (!work.empty()) {
+    mlir::Value v = work.pop_back_val();
+    mlir::Operation *def = v.getDefiningOp();
+    if (!def) {
+      // Block args are seeded separately and never change during rewriting.
+      continue;
+    }
+
+    std::optional<Reachability> r = computeFromOperands(def);
+    if (!r) {
+      // Safe fallback: an operand is not cached, so rebuild on next query.
+      dirty_ = true;
+      return;
+    }
+
+    for (mlir::Value result : def->getResults()) {
+      auto it = cache_.find(result);
+      if (it == cache_.end() || it->second != *r) {
+        cache_[result] = *r;
+        // Const-ness flows strictly forward: only downstream users can flip.
+        for (mlir::Operation *user : result.getUsers()) {
+          for (mlir::Value userResult : user->getResults()) {
+            work.push_back(userResult);
+          }
+        }
+      }
+    }
+  }
+}
 
 void ConstevalForwardAnalysis::rebuild() {
   cache_.clear();
@@ -34,32 +97,15 @@ void ConstevalForwardAnalysis::rebuild() {
         return;
       }
 
-      // Nested-region block args (scf.for iter_args, linalg.generic, ...)
-      // are never function-level CONST/PARAM args.
-      for (mlir::Region &region : op->getRegions()) {
-        for (mlir::Block &block : region.getBlocks()) {
-          for (mlir::BlockArgument innerArg : block.getArguments()) {
-            cache_[innerArg] = {false, true};
-          }
-        }
-      }
-
-      Reachability r;
-      for (mlir::Value operand : op->getOperands()) {
-        auto it = cache_.find(operand);
-        if (it == cache_.end()) {
-          // Operand defined outside the walked region. Treat
-          // pessimistically as non-const; callers will skip the
-          // optimization rather than apply an incorrect one.
-          r.hasNonConstOrParamArg = true;
-          continue;
-        }
-        r.hasConstOrParamArg |= it->second.hasConstOrParamArg;
-        r.hasNonConstOrParamArg |= it->second.hasNonConstOrParamArg;
-      }
+      std::optional<Reachability> r = computeFromOperands(op);
+      // Pre-order guarantees operands are cached, so r always has a value.
+      // Defensively treat an out-of-region operand pessimistically as
+      // non-const so callers skip the optimization rather than apply an
+      // incorrect one.
+      Reachability reachability = r ? *r : Reachability{false, true};
 
       for (mlir::Value result : op->getResults()) {
-        cache_[result] = r;
+        cache_[result] = reachability;
       }
     });
   });


### PR DESCRIPTION
### Ticket
None

### Problem description
`ConstevalForwardAnalysis` (added in [here](https://github.com/tenstorrent/tt-mlir/pull/8288)) makes `valueTracesToConstantArgs` an O(1) cache lookup, but every successful commute flips `dirty_` and forces the next query to rebuild the entire cache with a full O(N) walk. Across a pass with many rewrites that is O(N × edits) so the cache's O(1)-query benefit only holds between edits, not during active rewriting.

### What's changed
The listener now updates the cache incrementally instead of dropping it: since const-ness flows strictly forward, each mutation re-derives only the touched op's results and propagates to their downstream users (`propagateFrom` + the extracted `computeFromOperands` rule). Anything the incremental path can't reason about (uncached operand, uncertain notification ordering) still falls back to `dirty_ = true` + full rebuild, so answers are identical and the produced IR is unchanged just without the repeated full rebuilds.

This change lowers EIO pass time of one Wan 2.2 5b train step from ~570s to 4.4s, measured with this [flag](https://github.com/tenstorrent/tt-xla/pull/5492).

### Checklist
- [ ] New/Existing tests provide coverage for changes
