### PR TITLE
Fold where when condition is all ones or zeroes

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -276,6 +276,8 @@ def TTIR_WhereOp: TTIR_ElementwiseTernaryOp<"where"> {
       This operation is equivalent to the ternary conditional operator (`condition ? true_value : false_value`)
       in many programming languages, applied elementwise across tensors.
     }];
+
+    let hasFolder = 1;
 }
 
 class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -695,8 +695,7 @@ static mlir::Attribute makeScalarAttr(mlir::Type elemType, double val) {
   llvm_unreachable("Expected a FloatType or IntegerType");
 }
 
-// Extract constant fill value from FullOp, ZerosOp, OnesOp,
-//  or a splat ConstantOp.
+// Extract constant fill value from FullOp, ZerosOp, or OnesOp.
 static mlir::Attribute getConstantValue(mlir::Value value) {
   mlir::Operation *op = value.getDefiningOp();
 
@@ -715,17 +714,6 @@ static mlir::Attribute getConstantValue(mlir::Value value) {
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType())
             .getElementType(),
         1.0);
-  }
-
-  // A splat constant (an all-ones/all-zeros mask that is folded to a single
-  // repeated value)
-  if (auto constantOp =
-          mlir::dyn_cast_if_present<mlir::tt::ttir::ConstantOp>(op)) {
-    auto elements =
-        mlir::dyn_cast<mlir::DenseElementsAttr>(constantOp.getValueAttr());
-    if (elements && elements.isSplat()) {
-      return elements.getSplatValue<mlir::Attribute>();
-    }
   }
 
   return {};
@@ -922,7 +910,7 @@ constantFoldLogicalOr(mlir::tt::ttir::LogicalOrOp op,
 ::mlir::OpFoldResult mlir::tt::ttir::WhereOp::fold(FoldAdaptor adaptor) {
   auto resultType = getResult().getType();
 
-  if (isConstantOne(getFirst()) && getSecond().getType() == resultType) {
+  if (isConstantNonZero(getFirst()) && getSecond().getType() == resultType) {
     return getSecond();
   }
   if (isConstantZero(getFirst()) && getThird().getType() == resultType) {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -695,7 +695,8 @@ static mlir::Attribute makeScalarAttr(mlir::Type elemType, double val) {
   llvm_unreachable("Expected a FloatType or IntegerType");
 }
 
-// Extract constant fill value from FullOp, ZerosOp, or OnesOp.
+// Extract constant fill value from FullOp, ZerosOp, OnesOp,
+//  or a splat ConstantOp.
 static mlir::Attribute getConstantValue(mlir::Value value) {
   mlir::Operation *op = value.getDefiningOp();
 
@@ -714,6 +715,17 @@ static mlir::Attribute getConstantValue(mlir::Value value) {
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType())
             .getElementType(),
         1.0);
+  }
+
+  // A splat constant (an all-ones/all-zeros mask that is folded to a single
+  // repeated value)
+  if (auto constantOp =
+          mlir::dyn_cast_if_present<mlir::tt::ttir::ConstantOp>(op)) {
+    auto elements =
+        mlir::dyn_cast<mlir::DenseElementsAttr>(constantOp.getValueAttr());
+    if (elements && elements.isSplat()) {
+      return elements.getSplatValue<mlir::Attribute>();
+    }
   }
 
   return {};
@@ -896,6 +908,25 @@ constantFoldLogicalOr(mlir::tt::ttir::LogicalOrOp op,
   }
   if (auto foldResult = constantFoldLogicalOr(*this, adaptor)) {
     return foldResult;
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// WhereOp
+//===----------------------------------------------------------------------===//
+
+// WhereOp folder:
+//   where(ones,  x, y) -> x
+//   where(zeros, x, y) -> y
+::mlir::OpFoldResult mlir::tt::ttir::WhereOp::fold(FoldAdaptor adaptor) {
+  auto resultType = getResult().getType();
+
+  if (isConstantOne(getFirst()) && getSecond().getType() == resultType) {
+    return getSecond();
+  }
+  if (isConstantZero(getFirst()) && getThird().getType() == resultType) {
+    return getThird();
   }
   return nullptr;
 }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/where_op_folds_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/where_op_folds_tests.mlir
@@ -1,0 +1,73 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verifies WhereOp::fold: a where with a constant-splat condition folds to the
+// selected branch:
+//   where(ones,  x, y) -> x
+//   where(zeros, x, y) -> y
+// The condition may come from ttir.ones/ttir.zeros/ttir.full or a splat
+// ttir.constant (getConstantValue looks through all of them). This is the GLM
+// 4.7 router group mask when n_group == 1, where the mask is statically all
+// ones (see tenstorrent/tt-mlir#8928, tenstorrent/tt-xla#5427).
+
+module {
+  // where(ones, x, y) -> x
+  func.func @where_ones_folds_to_true(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_ones_folds_to_true
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg0
+    %cond = "ttir.ones"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xbf16>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // where(zeros, x, y) -> y
+  func.func @where_zeros_folds_to_false(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_zeros_folds_to_false
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg1
+    %cond = "ttir.zeros"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xbf16>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Splat ttir.constant condition (the GLM n_group==1 mask form) -> x.
+  func.func @where_splat_constant_ones_folds_to_true(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_splat_constant_ones_folds_to_true
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg0
+    %cond = "ttir.constant"() <{value = dense<true> : tensor<4x4xi1>}> : () -> tensor<4x4xi1>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xi1>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Negative: a non-constant condition must NOT fold.
+  func.func @where_dynamic_condition_not_folded(%cond: tensor<4x4xi1>, %x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_dynamic_condition_not_folded
+    // CHECK: "ttir.where"
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xi1>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Negative: a constant condition whose value is neither 0 nor 1 must NOT
+  // fold. This pins the fold to the exact 1/0 predicate values rather than
+  // "any constant condition".
+  func.func @where_constant_nonbinary_not_folded(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_constant_nonbinary_not_folded
+    // CHECK: "ttir.where"
+    %cond = "ttir.full"() <{shape = array<i32: 4, 4>, fill_value = 5.0 : f32}> : () -> tensor<4x4xf32>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Integer-typed splat condition (all ones) -> x. Exercises the IntegerAttr
+  // path of isConstantOne (getSplatValue -> isOneAttr), not just i1/float.
+  func.func @where_int_splat_ones_folds_to_true(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_int_splat_ones_folds_to_true
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg0
+    %cond = "ttir.constant"() <{value = dense<1> : tensor<4x4xi32>}> : () -> tensor<4x4xi32>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xi32>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/where_op_folds_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/where_op_folds_tests.mlir
@@ -3,7 +3,7 @@
 
 // Verifies WhereOp::fold: a where with a constant-splat condition folds to the
 // selected branch:
-//   where(ones,  x, y) -> x
+//   where(nonzero,  x, y) -> x
 //   where(zeros, x, y) -> y
 // The condition may come from ttir.ones/ttir.zeros/ttir.full or a splat
 // ttir.constant (getConstantValue looks through all of them). This is the GLM
@@ -49,12 +49,12 @@ module {
     return %0 : tensor<4x4xf32>
   }
 
-  // Negative: a constant condition whose value is neither 0 nor 1 must NOT
-  // fold. This pins the fold to the exact 1/0 predicate values rather than
-  // "any constant condition".
-  func.func @where_constant_nonbinary_not_folded(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
-    // CHECK-LABEL: @where_constant_nonbinary_not_folded
-    // CHECK: "ttir.where"
+  // A non-zero constant condition (any value, not just 1) selects the
+  // true branch, matching where's non-zero=true predicate semantics.
+  func.func @where_constant_nonzero_folds_to_true(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_constant_nonzero_folds_to_true
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg0
     %cond = "ttir.full"() <{shape = array<i32: 4, 4>, fill_value = 5.0 : f32}> : () -> tensor<4x4xf32>
     %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %0 : tensor<4x4xf32>
@@ -68,6 +68,16 @@ module {
     // CHECK: return %arg0
     %cond = "ttir.constant"() <{value = dense<1> : tensor<4x4xi32>}> : () -> tensor<4x4xi32>
     %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xi32>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Constant-true but broadcasting condition: folding to x would change the
+  // result type, so the guard declines the fold.
+  func.func @where_broadcast_condition_not_folded(%x: tensor<1x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_broadcast_condition_not_folded
+    // CHECK: "ttir.where"
+    %cond = "ttir.ones"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xbf16>, tensor<1x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %0 : tensor<4x4xf32>
   }
 }


### PR DESCRIPTION
### Ticket
Resolves #8928

### Problem description
This change adds a fold to where, when we have condition that is constant (first parameter of where).

### What's changed
Added WhereOp::fold
where(nonzero, x, y) -> x,
where(zeros, x, y) -> y.

### Checklist
- [x] New/Existing tests provide coverage for changes
