### PR TITLE
[TTIR] Replace 1x1x1 conv3d with matmul/linear

### DIFF
--- a/include/ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h
+++ b/include/ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h
@@ -15,6 +15,12 @@ enum class DecompMode { TTNN, TTMetal, CPUFallback };
 #define GEN_PASS_DECL_TTIRTOTTIRDECOMPOSITION
 #include "ttmlir/Conversion/Passes.h.inc"
 
+namespace ttir {
+class Conv3dOp;
+} // namespace ttir
+
+bool isConv3dPointwiseLinearEligible(ttir::Conv3dOp op);
+
 void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
                                              RewritePatternSet &patterns,
                                              TypeConverter &typeConverter,

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -276,6 +276,8 @@ def TTIR_WhereOp: TTIR_ElementwiseTernaryOp<"where"> {
       This operation is equivalent to the ternary conditional operator (`condition ? true_value : false_value`)
       in many programming languages, applied elementwise across tensors.
     }];
+
+    let hasFolder = 1;
 }
 
 class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1581,6 +1581,85 @@ struct Conv3dChannelLastDecompositionPattern
     return success();
   }
 };
+
+// A 1x1x1 conv3d is just a matmul, so rewrite it to matmul (or linear, when a
+// bias is present) to avoid the conv3d blocking machinery. Requires NDHWC
+// layout, where the reshapes below move no data:
+//   input  (N,D,H,W,Cin)   -> reshape -> (N*D*H*W, Cin)
+//   weight (Cout,Cin,1,1,1) -> reshape -> (Cout, Cin)
+//   matmul (M,Cin) x (Cout,Cin)^T (transpose_b) -> (M, Cout)
+//   result (M,Cout)        -> reshape -> (N,D,H,W,Cout)
+struct Conv3dPointwiseToLinearPattern
+    : public OpConversionPattern<ttir::Conv3dOp> {
+  using OpConversionPattern<ttir::Conv3dOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::Conv3dOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!isConv3dPointwiseLinearEligible(op)) {
+      return failure();
+    }
+
+    auto inputType = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
+    auto weightType =
+        mlir::cast<RankedTensorType>(adaptor.getWeight().getType());
+    auto outputType = mlir::cast<RankedTensorType>(op.getResult().getType());
+
+    ArrayRef<int64_t> inputShape = inputType.getShape();   // (N, D, H, W, Cin)
+    ArrayRef<int64_t> weightShape = weightType.getShape(); // (Cout, Cin, 1,1,1)
+
+    int64_t rows =
+        inputShape[0] * inputShape[1] * inputShape[2] * inputShape[3];
+    int64_t cIn = inputShape[4];
+    int64_t cOut = weightShape[0];
+
+    // Build a ttir.reshape of `value` to `shape`.
+    auto reshapeTo = [&](Value value, ArrayRef<int64_t> shape, Type elementType,
+                         StringRef suffix) -> Value {
+      SmallVector<int32_t> shapeI32(shape.begin(), shape.end());
+      return rewriter.create<ttir::ReshapeOp>(
+          ttmlir::utils::appendLocationSuffix(op.getLoc(), suffix),
+          RankedTensorType::get(shape, elementType), value,
+          rewriter.getI32ArrayAttr(shapeI32));
+    };
+
+    // Collapse the input's spatial/temporal dims into matmul rows, and drop the
+    // singleton kernel dims from the weight.
+    Value inputMatrix = reshapeTo(adaptor.getInput(), {rows, cIn},
+                                  inputType.getElementType(), "_reshapeInput");
+    Value weightMatrix =
+        reshapeTo(adaptor.getWeight(), {cOut, cIn}, weightType.getElementType(),
+                  "_reshapeWeight");
+
+    auto matmulResultType =
+        RankedTensorType::get({rows, cOut}, outputType.getElementType());
+
+    // weight is (Cout, Cin); transpose_b makes the contraction
+    // (M,Cin)x(Cin,Cout).
+    Value contraction;
+    if (Value bias = adaptor.getBias()) {
+      Value biasVector = reshapeTo(
+          bias, {cOut},
+          mlir::cast<RankedTensorType>(bias.getType()).getElementType(),
+          "_reshapeBias");
+      contraction = rewriter.create<ttir::LinearOp>(
+          op.getLoc(), matmulResultType, inputMatrix, weightMatrix, biasVector,
+          /*transpose_a=*/false, /*transpose_b=*/true);
+    } else {
+      contraction = rewriter.create<ttir::MatmulOp>(
+          op.getLoc(), matmulResultType, inputMatrix, weightMatrix,
+          /*transpose_a=*/false, /*transpose_b=*/true);
+    }
+
+    // Restore the NDHWC output shape. Reuse the op's result type so the
+    // replacement type matches (D_out/H_out/W_out == D/H/W here).
+    SmallVector<int32_t> outShapeI32(outputType.getShape().begin(),
+                                     outputType.getShape().end());
+    rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
+        op, outputType, contraction, rewriter.getI32ArrayAttr(outShapeI32));
+    return success();
+  }
+};
 } // namespace
 
 namespace {
@@ -1998,6 +2077,38 @@ struct NegativePadOpDecompositionPattern
 };
 } // namespace
 
+bool isConv3dPointwiseLinearEligible(ttir::Conv3dOp op) {
+  // Only handle the canonical NDHWC layout; other layouts are normalized to
+  // NDHWC first by Conv3dChannelLastDecompositionPattern.
+  if (!op.isNDHWC()) {
+    return false;
+  }
+  if (op.getGroups() != 1) {
+    return false;
+  }
+
+  // Kernel must be 1x1x1. Weight is (Cout, Cin, K_D, K_H, K_W).
+  auto weightType = mlir::cast<RankedTensorType>(op.getWeight().getType());
+  ArrayRef<int64_t> weightShape = weightType.getShape();
+  if (weightShape.size() != 5 || weightShape[2] != 1 || weightShape[3] != 1 ||
+      weightShape[4] != 1) {
+    return false;
+  }
+
+  // Unit stride and no padding, otherwise the op is a strided/padded gather
+  // rather than a plain matmul or linear.
+  auto stride = ttmlir::utils::getTripleOfInteger<int32_t>(op.getStride());
+  auto padding = ttmlir::utils::getTripleOfInteger<int32_t>(op.getPadding());
+  if (!stride || !padding) {
+    llvm::consumeError(stride.takeError());
+    llvm::consumeError(padding.takeError());
+    return false;
+  }
+  auto [sD, sH, sW] = *stride;
+  auto [pD, pH, pW] = *padding;
+  return sD == 1 && sH == 1 && sW == 1 && pD == 0 && pH == 0 && pW == 0;
+}
+
 void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
                                              RewritePatternSet &patterns,
                                              TypeConverter &typeConverter,
@@ -2036,6 +2147,7 @@ void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
   patterns.add<ConvChannelLastDecompositionPattern<ttir::ConvTranspose2dOp>>(
       typeConverter, ctx);
   patterns.add<Conv3dChannelLastDecompositionPattern>(typeConverter, ctx);
+  patterns.add<Conv3dPointwiseToLinearPattern>(typeConverter, ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -80,8 +80,11 @@ struct TTIRToTTIRDecompositionPass
       // Non-channel-last ops will be decomposed with permutes.
       target.addDynamicallyLegalOp<ttir::Conv2dOp>(
           [](ttir::Conv2dOp op) { return op.isNHWC(); });
-      target.addDynamicallyLegalOp<ttir::Conv3dOp>(
-          [](ttir::Conv3dOp op) { return op.isNDHWC(); });
+      // A conv3d is legal only if it is channel-last (NDHWC) and is not a
+      // pointwise (1x1x1) conv, which is rewritten to a matmul/linear.
+      target.addDynamicallyLegalOp<ttir::Conv3dOp>([](ttir::Conv3dOp op) {
+        return op.isNDHWC() && !isConv3dPointwiseLinearEligible(op);
+      });
       target.addDynamicallyLegalOp<ttir::ConvTranspose2dOp>(
           [](ttir::ConvTranspose2dOp op) { return op.isNHWC(); });
       break;

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -695,8 +695,7 @@ static mlir::Attribute makeScalarAttr(mlir::Type elemType, double val) {
   llvm_unreachable("Expected a FloatType or IntegerType");
 }
 
-// Extract constant fill value from FullOp, ZerosOp, OnesOp,
-//  or a splat ConstantOp.
+// Extract constant fill value from FullOp, ZerosOp, or OnesOp.
 static mlir::Attribute getConstantValue(mlir::Value value) {
   mlir::Operation *op = value.getDefiningOp();
 
@@ -715,17 +714,6 @@ static mlir::Attribute getConstantValue(mlir::Value value) {
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType())
             .getElementType(),
         1.0);
-  }
-
-  // A splat constant (an all-ones/all-zeros mask that is folded to a single
-  // repeated value)
-  if (auto constantOp =
-          mlir::dyn_cast_if_present<mlir::tt::ttir::ConstantOp>(op)) {
-    auto elements =
-        mlir::dyn_cast<mlir::DenseElementsAttr>(constantOp.getValueAttr());
-    if (elements && elements.isSplat()) {
-      return elements.getSplatValue<mlir::Attribute>();
-    }
   }
 
   return {};
@@ -922,7 +910,7 @@ constantFoldLogicalOr(mlir::tt::ttir::LogicalOrOp op,
 ::mlir::OpFoldResult mlir::tt::ttir::WhereOp::fold(FoldAdaptor adaptor) {
   auto resultType = getResult().getType();
 
-  if (isConstantOne(getFirst()) && getSecond().getType() == resultType) {
+  if (isConstantNonZero(getFirst()) && getSecond().getType() == resultType) {
     return getSecond();
   }
   if (isConstantZero(getFirst()) && getThird().getType() == resultType) {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -695,7 +695,8 @@ static mlir::Attribute makeScalarAttr(mlir::Type elemType, double val) {
   llvm_unreachable("Expected a FloatType or IntegerType");
 }
 
-// Extract constant fill value from FullOp, ZerosOp, or OnesOp.
+// Extract constant fill value from FullOp, ZerosOp, OnesOp,
+//  or a splat ConstantOp.
 static mlir::Attribute getConstantValue(mlir::Value value) {
   mlir::Operation *op = value.getDefiningOp();
 
@@ -714,6 +715,17 @@ static mlir::Attribute getConstantValue(mlir::Value value) {
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType())
             .getElementType(),
         1.0);
+  }
+
+  // A splat constant (an all-ones/all-zeros mask that is folded to a single
+  // repeated value)
+  if (auto constantOp =
+          mlir::dyn_cast_if_present<mlir::tt::ttir::ConstantOp>(op)) {
+    auto elements =
+        mlir::dyn_cast<mlir::DenseElementsAttr>(constantOp.getValueAttr());
+    if (elements && elements.isSplat()) {
+      return elements.getSplatValue<mlir::Attribute>();
+    }
   }
 
   return {};
@@ -896,6 +908,25 @@ constantFoldLogicalOr(mlir::tt::ttir::LogicalOrOp op,
   }
   if (auto foldResult = constantFoldLogicalOr(*this, adaptor)) {
     return foldResult;
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// WhereOp
+//===----------------------------------------------------------------------===//
+
+// WhereOp folder:
+//   where(ones,  x, y) -> x
+//   where(zeros, x, y) -> y
+::mlir::OpFoldResult mlir::tt::ttir::WhereOp::fold(FoldAdaptor adaptor) {
+  auto resultType = getResult().getType();
+
+  if (isConstantOne(getFirst()) && getSecond().getType() == resultType) {
+    return getSecond();
+  }
+  if (isConstantZero(getFirst()) && getThird().getType() == resultType) {
+    return getThird();
   }
   return nullptr;
 }

--- a/test/python/golden/ttir_ops/convolution/test_conv3d.py
+++ b/test/python/golden/ttir_ops/convolution/test_conv3d.py
@@ -260,3 +260,85 @@ def test_conv3d_c_in_block_divergent(dtype, target, request, device):
         device=device,
         target=target,
     )
+
+
+@pytest.mark.parametrize(
+    "input_shape, weight_shape, bias_shape",
+    [
+        # 1x1x1 pointwise conv3d, no bias -> rewritten to ttir.matmul by
+        # Conv3dPointwiseToMatmulPattern.
+        ((1, 8, 16, 16, 64), (128, 64, 1, 1, 1), None),
+        # 1x1x1 pointwise conv3d, with bias -> rewritten to ttir.linear.
+        ((1, 8, 16, 16, 64), (128, 64, 1, 1, 1), (1, 1, 1, 1, 128)),
+    ],
+    ids=["pointwise_1x1x1_no_bias", "pointwise_1x1x1_with_bias"],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_conv3d_pointwise_to_linear(
+    input_shape: Shape,
+    weight_shape: Shape,
+    bias_shape: Optional[Shape],
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    """Golden coverage for the 1x1x1 conv3d -> matmul/linear rewrite.
+
+    A pointwise (1x1x1) conv3d in NDHWC layout with unit stride, no padding and
+    groups==1 is mathematically a matmul, so the decomposition pass rewrites it
+    to ttir.matmul (no bias) or ttir.linear (bias) instead of lowering it as a
+    conv3d.
+    """
+    if bias_shape:
+        input_shapes = [input_shape, weight_shape, bias_shape]
+        input_types = [dtype, dtype, dtype]
+
+        def module(builder: TTIRBuilder):
+            @builder.func(input_shapes, input_types)
+            def conv3d_wrapper(
+                in0: Operand,
+                weight: Operand,
+                bias: Operand,
+                builder: TTIRBuilder,
+                unit_attrs: Optional[List[str]] = None,
+            ):
+                return builder.conv3d(
+                    in0,
+                    weight,
+                    bias,
+                    stride=[1, 1, 1],
+                    padding=[0, 0, 0],
+                    groups=1,
+                    unit_attrs=unit_attrs,
+                )
+
+    else:
+        input_shapes = [input_shape, weight_shape]
+        input_types = [dtype, dtype]
+
+        def module(builder: TTIRBuilder):
+            @builder.func(input_shapes, input_types)
+            def conv3d_wrapper(
+                in0: Operand,
+                weight: Operand,
+                builder: TTIRBuilder,
+                unit_attrs: Optional[List[str]] = None,
+            ):
+                return builder.conv3d(
+                    in0,
+                    weight,
+                    None,
+                    stride=[1, 1, 1],
+                    padding=[0, 0, 0],
+                    groups=1,
+                    unit_attrs=unit_attrs,
+                )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target=target,
+    )

--- a/test/ttmlir/Dialect/TTIR/Decomposition/conv3d_pointwise_to_linear.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/conv3d_pointwise_to_linear.mlir
@@ -1,0 +1,146 @@
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttir-decomposition -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verifies Conv3dPointwiseToMatmulPattern: a 1x1x1 conv3d in NDHWC layout with
+// unit stride, no padding and groups==1 is mathematically a matmul, so the
+// decomposition pass rewrites it to ttir.matmul (no bias) / ttir.linear (bias)
+// instead of lowering it as a conv3d. Anything failing the eligibility gate
+// (isConv3dPointwiseMatmulEligible) must stay a ttir.conv3d.
+
+// -----
+
+// Pointwise 1x1x1 conv3d, no bias -> ttir.matmul, conv3d eliminated.
+// input  (N=1, D=8, H=16, W=16, Cin=64)
+// weight (Cout=128, Cin=64, 1, 1, 1)  -> output (1, 8, 16, 16, 128)
+func.func @pointwise_no_bias(%input: tensor<1x8x16x16x64xbf16>,
+                             %weight: tensor<128x64x1x1x1xbf16>) -> tensor<1x8x16x16x128xbf16> {
+  // CHECK-LABEL: @pointwise_no_bias
+  // CHECK: "ttir.matmul"
+  // CHECK-NOT: "ttir.linear"
+  // CHECK-NOT: "ttir.conv3d"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x1x1x1xbf16>) -> tensor<1x8x16x16x128xbf16>
+  return %0 : tensor<1x8x16x16x128xbf16>
+}
+
+// -----
+
+// Pointwise 1x1x1 conv3d, with bias -> ttir.linear, conv3d eliminated.
+// bias (1, 1, 1, 1, Cout=128)
+func.func @pointwise_with_bias(%input: tensor<1x8x16x16x64xbf16>,
+                               %weight: tensor<128x64x1x1x1xbf16>,
+                               %bias: tensor<1x1x1x1x128xbf16>) -> tensor<1x8x16x16x128xbf16> {
+  // CHECK-LABEL: @pointwise_with_bias
+  // CHECK: "ttir.linear"
+  // CHECK-NOT: "ttir.conv3d"
+  %0 = "ttir.conv3d"(%input, %weight, %bias)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x1x1x1xbf16>, tensor<1x1x1x1x128xbf16>) -> tensor<1x8x16x16x128xbf16>
+  return %0 : tensor<1x8x16x16x128xbf16>
+}
+
+// -----
+
+// Multi-frame batch (N>1, D>1) must still fold: the rewrite collapses
+// N*D*H*W into the matmul row dim, so this guards that reshape.
+// input (N=2, D=4, H=8, W=8, Cin=64) -> output (2, 4, 8, 8, 128)
+func.func @pointwise_multiframe(%input: tensor<2x4x8x8x64xbf16>,
+                                %weight: tensor<128x64x1x1x1xbf16>) -> tensor<2x4x8x8x128xbf16> {
+  // CHECK-LABEL: @pointwise_multiframe
+  // CHECK: "ttir.matmul"
+  // CHECK-NOT: "ttir.conv3d"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<2x4x8x8x64xbf16>, tensor<128x64x1x1x1xbf16>) -> tensor<2x4x8x8x128xbf16>
+  return %0 : tensor<2x4x8x8x128xbf16>
+}
+
+// -----
+
+// Negative: 3x3x3 kernel is a real convolution, must NOT be rewritten.
+// output (1, 6, 14, 14, 128) from D_out=(8-3)+1, H/W_out=(16-3)+1.
+func.func @negative_non_pointwise_kernel(%input: tensor<1x8x16x16x64xbf16>,
+                                         %weight: tensor<128x64x3x3x3xbf16>) -> tensor<1x6x14x14x128xbf16> {
+  // CHECK-LABEL: @negative_non_pointwise_kernel
+  // CHECK: "ttir.conv3d"
+  // CHECK-NOT: "ttir.matmul"
+  // CHECK-NOT: "ttir.linear"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x3x3x3xbf16>) -> tensor<1x6x14x14x128xbf16>
+  return %0 : tensor<1x6x14x14x128xbf16>
+}
+
+// -----
+
+// Negative: 1x1x1 kernel but non-unit stride is a strided gather, not a matmul.
+// stride 2 -> D_out=(8-1)/2+1=4, H/W_out=(16-1)/2+1=8 -> output (1, 4, 8, 8, 128).
+func.func @negative_strided(%input: tensor<1x8x16x16x64xbf16>,
+                            %weight: tensor<128x64x1x1x1xbf16>) -> tensor<1x4x8x8x128xbf16> {
+  // CHECK-LABEL: @negative_strided
+  // CHECK: "ttir.conv3d"
+  // CHECK-NOT: "ttir.matmul"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 2, 2, 2>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x1x1x1xbf16>) -> tensor<1x4x8x8x128xbf16>
+  return %0 : tensor<1x4x8x8x128xbf16>
+}
+
+// -----
+
+// Negative: 1x1x1 kernel but non-zero padding, must NOT be rewritten.
+// padding 1 -> D_out=(8+2-1)+1=10, H/W_out=(16+2-1)+1=18 -> output (1, 10, 18, 18, 128).
+func.func @negative_padded(%input: tensor<1x8x16x16x64xbf16>,
+                           %weight: tensor<128x64x1x1x1xbf16>) -> tensor<1x10x18x18x128xbf16> {
+  // CHECK-LABEL: @negative_padded
+  // CHECK: "ttir.conv3d"
+  // CHECK-NOT: "ttir.matmul"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 1, 1, 1>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x1x1x1xbf16>) -> tensor<1x10x18x18x128xbf16>
+  return %0 : tensor<1x10x18x18x128xbf16>
+}
+
+// -----
+
+// Negative: grouped conv (groups != 1), must NOT be rewritten.
+// groups=2 -> weight C_in dim is Cin/groups = 32.
+func.func @negative_grouped(%input: tensor<1x8x16x16x64xbf16>,
+                            %weight: tensor<128x32x1x1x1xbf16>) -> tensor<1x8x16x16x128xbf16> {
+  // CHECK-LABEL: @negative_grouped
+  // CHECK: "ttir.conv3d"
+  // CHECK-NOT: "ttir.matmul"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 2 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x32x1x1x1xbf16>) -> tensor<1x8x16x16x128xbf16>
+  return %0 : tensor<1x8x16x16x128xbf16>
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/where_op_folds_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/where_op_folds_tests.mlir
@@ -1,0 +1,73 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verifies WhereOp::fold: a where with a constant-splat condition folds to the
+// selected branch:
+//   where(ones,  x, y) -> x
+//   where(zeros, x, y) -> y
+// The condition may come from ttir.ones/ttir.zeros/ttir.full or a splat
+// ttir.constant (getConstantValue looks through all of them). This is the GLM
+// 4.7 router group mask when n_group == 1, where the mask is statically all
+// ones (see tenstorrent/tt-mlir#8928, tenstorrent/tt-xla#5427).
+
+module {
+  // where(ones, x, y) -> x
+  func.func @where_ones_folds_to_true(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_ones_folds_to_true
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg0
+    %cond = "ttir.ones"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xbf16>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // where(zeros, x, y) -> y
+  func.func @where_zeros_folds_to_false(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_zeros_folds_to_false
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg1
+    %cond = "ttir.zeros"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xbf16>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Splat ttir.constant condition (the GLM n_group==1 mask form) -> x.
+  func.func @where_splat_constant_ones_folds_to_true(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_splat_constant_ones_folds_to_true
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg0
+    %cond = "ttir.constant"() <{value = dense<true> : tensor<4x4xi1>}> : () -> tensor<4x4xi1>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xi1>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Negative: a non-constant condition must NOT fold.
+  func.func @where_dynamic_condition_not_folded(%cond: tensor<4x4xi1>, %x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_dynamic_condition_not_folded
+    // CHECK: "ttir.where"
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xi1>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Negative: a constant condition whose value is neither 0 nor 1 must NOT
+  // fold. This pins the fold to the exact 1/0 predicate values rather than
+  // "any constant condition".
+  func.func @where_constant_nonbinary_not_folded(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_constant_nonbinary_not_folded
+    // CHECK: "ttir.where"
+    %cond = "ttir.full"() <{shape = array<i32: 4, 4>, fill_value = 5.0 : f32}> : () -> tensor<4x4xf32>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Integer-typed splat condition (all ones) -> x. Exercises the IntegerAttr
+  // path of isConstantOne (getSplatValue -> isOneAttr), not just i1/float.
+  func.func @where_int_splat_ones_folds_to_true(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_int_splat_ones_folds_to_true
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg0
+    %cond = "ttir.constant"() <{value = dense<1> : tensor<4x4xi32>}> : () -> tensor<4x4xi32>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xi32>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/where_op_folds_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/where_op_folds_tests.mlir
@@ -3,7 +3,7 @@
 
 // Verifies WhereOp::fold: a where with a constant-splat condition folds to the
 // selected branch:
-//   where(ones,  x, y) -> x
+//   where(nonzero,  x, y) -> x
 //   where(zeros, x, y) -> y
 // The condition may come from ttir.ones/ttir.zeros/ttir.full or a splat
 // ttir.constant (getConstantValue looks through all of them). This is the GLM
@@ -49,12 +49,12 @@ module {
     return %0 : tensor<4x4xf32>
   }
 
-  // Negative: a constant condition whose value is neither 0 nor 1 must NOT
-  // fold. This pins the fold to the exact 1/0 predicate values rather than
-  // "any constant condition".
-  func.func @where_constant_nonbinary_not_folded(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
-    // CHECK-LABEL: @where_constant_nonbinary_not_folded
-    // CHECK: "ttir.where"
+  // A non-zero constant condition (any value, not just 1) selects the
+  // true branch, matching where's non-zero=true predicate semantics.
+  func.func @where_constant_nonzero_folds_to_true(%x: tensor<4x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_constant_nonzero_folds_to_true
+    // CHECK-NOT: "ttir.where"
+    // CHECK: return %arg0
     %cond = "ttir.full"() <{shape = array<i32: 4, 4>, fill_value = 5.0 : f32}> : () -> tensor<4x4xf32>
     %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %0 : tensor<4x4xf32>
@@ -68,6 +68,16 @@ module {
     // CHECK: return %arg0
     %cond = "ttir.constant"() <{value = dense<1> : tensor<4x4xi32>}> : () -> tensor<4x4xi32>
     %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xi32>, tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Constant-true but broadcasting condition: folding to x would change the
+  // result type, so the guard declines the fold.
+  func.func @where_broadcast_condition_not_folded(%x: tensor<1x4xf32>, %y: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: @where_broadcast_condition_not_folded
+    // CHECK: "ttir.where"
+    %cond = "ttir.ones"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+    %0 = "ttir.where"(%cond, %x, %y) : (tensor<4x4xbf16>, tensor<1x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %0 : tensor<4x4xf32>
   }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/discussions/5377 — 6th entry

### Problem description
A 1x1x1 conv3d in NDHWC layout with unit stride, no padding and groups==1 is essentially a matmul (or linear, with bias), so it can be replaced using reshapes and matmul.

matmul case:
  input  (N, D, H, W, Cin) -> reshape -> (N * D * H * W, Cin) = (M, Cin)
  weight (Cout, Cin, 1, 1, 1) -> reshape -> (Cout, Cin)
  matmul (M, Cin) x (Cout, Cin) ^ T -> (M, Cout)
  result (M, Cout) -> reshape -> (N, D, H, W, Cout)

linear case:
  input  (N, D, H, W, Cin)    -> reshape -> (N * D * H * W, Cin) = (M, Cin)
  weight (Cout, Cin, 1, 1, 1) -> reshape -> (Cout, Cin)
  bias   (1, 1, 1, 1, Cout)   -> reshape -> (Cout, )
  linear (M, Cin) x (Cout, Cin)^T + bias-> (M, Cout)
  result (M, Cout) -> reshape -> (N, D, H, W, Cout)

### What's changed
`isConv3dPointwiseMatmulEligible` checks if the rewrite (NDHWC, 1x1x1 kernel, unit stride, no padding, groups==1) is eligible.
Non-NDHWC convs are normalized by the channel-last decomposition first, then become eligible.
`Conv3dPointwiseToMatmulPattern` rewrites eligible convs to ttir.matmul (no bias) / ttir.linear (bias), wrapped in reshapes.

Tested with lit tests, a golden test, and end-to-end through tt-xla on the Wan decoder to confirm pointwise conv3ds were replaced by ttnn.linear + reshapes.

### Checklist
- [x] New/Existing tests provide coverage for changes