### PR TITLE
[d2m] added fix for single core arange

### DIFF
--- a/lib/Dialect/D2M/Transforms/DecomposeArange.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeArange.cpp
@@ -19,6 +19,34 @@ namespace mlir::tt::d2m {
 
 namespace {
 
+// Walk up from `op` collecting IVs of enclosing blocking loops (tagged
+// `d2m.blocking_loop = <dim>` by D2MGenerateOuterLoops) into `rowBlockIV` and
+// `colBlockIV`. These must be folded into the arange offset so each shard
+// computes its correct slice rather than identical values. Either IV is null
+// if the corresponding blocking loop is absent.
+static void collectBlockingLoopIVs(Operation *op, int64_t rank,
+                                   Value &rowBlockIV, Value &colBlockIV) {
+  rowBlockIV = nullptr;
+  colBlockIV = nullptr;
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    auto forOp = dyn_cast<scf::ForOp>(parent);
+    if (!forOp) {
+      continue;
+    }
+    auto dimAttr = forOp->getAttrOfType<IntegerAttr>("d2m.blocking_loop");
+    if (!dimAttr) {
+      continue;
+    }
+    int64_t dim = dimAttr.getInt();
+    if (dim == rank - 1) {
+      colBlockIV = forOp.getInductionVar();
+    } else if (dim == rank - 2) {
+      rowBlockIV = forOp.getInductionVar();
+    }
+  }
+}
+
 /// Decompose ArangeBlockOp into low-level tile operations.
 ///
 /// The arange_block op generates values: output[i] = start + step * i
@@ -134,14 +162,30 @@ struct DecomposeArangeBlockPattern : OpRewritePattern<ArangeBlockOp> {
     Value totalTileRowsIdx =
         rewriter.create<arith::ConstantIndexOp>(loc, totalTileRows);
     Value const32Idx = rewriter.create<arith::ConstantIndexOp>(loc, 32);
-    // globalTileRow = coreY * shardTileRows + localTileRow
+    Value rowBlockIV, colBlockIV;
+    collectBlockingLoopIVs(op, static_cast<int64_t>(outputShape.size()),
+                           rowBlockIV, colBlockIV);
+
+    // globalTileRow = coreY * shardTileRows + rowBlockIV * shardTileRows
+    //               + localTileRow
     Value globalTileRow = rewriter.create<arith::AddIOp>(
         loc, rewriter.create<arith::MulIOp>(loc, coreY, shardTileRowsIdx),
         tileRowIdx);
-    // globalTileCol = coreX * shardTileCols + localTileCol
+    if (rowBlockIV) {
+      globalTileRow = rewriter.create<arith::AddIOp>(
+          loc, globalTileRow,
+          rewriter.create<arith::MulIOp>(loc, rowBlockIV, shardTileRowsIdx));
+    }
+    // globalTileCol = coreX * shardTileCols + colBlockIV * shardTileCols
+    //               + localTileCol
     Value globalTileCol = rewriter.create<arith::AddIOp>(
         loc, rewriter.create<arith::MulIOp>(loc, coreX, shardTileColsIdx),
         tileColIdx);
+    if (colBlockIV) {
+      globalTileCol = rewriter.create<arith::AddIOp>(
+          loc, globalTileCol,
+          rewriter.create<arith::MulIOp>(loc, colBlockIV, shardTileColsIdx));
+    }
 
     Value tileOffsetIdx;
     if (colMajor) {

--- a/test/python/golden/d2m/test_tms.py
+++ b/test/python/golden/d2m/test_tms.py
@@ -497,6 +497,63 @@ def test_arange(
     )
 
 
+@pytest.mark.parametrize(
+    "shape,start,step,dtype,arange_dimension",
+    [
+        pytest.param((1, 128), 0, 1, torch.float32, 1, id="1x128_s0_step1_f32_dim1"),
+        pytest.param((32, 256), 0, 1, torch.float32, 1, id="32x256_s0_step1_f32_dim1"),
+        pytest.param(
+            (32, 1024), 0, 1, torch.float32, 1, id="32x1024_s0_step1_f32_dim1"
+        ),
+        pytest.param((32, 256), 0, 1, torch.float32, 0, id="32x256_s0_step1_f32_dim0"),
+        pytest.param(
+            (1024, 32), 0, 1, torch.float32, 0, id="1024x32_s0_step1_f32_dim0"
+        ),
+    ],
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_arange_single_core(
+    shape: tuple,
+    start: int,
+    step: int,
+    dtype: torch.dtype,
+    arange_dimension: int,
+    target: str,
+    request,
+    device,
+):
+    num_elements = shape[arange_dimension]
+    end = start + num_elements * step
+
+    def arange_module(builder: TTIRBuilder):
+        @builder.func([shape], [dtype])
+        def arange(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.arange(
+                shape=list(shape),
+                dtype=dtype,
+                start=start,
+                end=end,
+                step=step,
+                arange_dimension=arange_dimension,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttir(
+        arange_module,
+        target=target,
+        device=device,
+        custom_pipeline="ttir-to-ttmetal-pipeline",
+        pipeline_options=["override-device-shape=1,1"],
+        **get_request_kwargs(request),
+        atol=1e-6,
+        check_atol=True,
+    )
+
+
 # ==================== EMBEDDING TESTS ====================
 
 

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_arange.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_arange.mlir
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttcore-register-device --d2m-decompose-arange -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verify that d2m-decompose-arange expands arange_block into tile loops.
+// All tests operate on pre-bufferized memref IR (as seen after ttcore-one-shot-bufferize).
+
+#l1_ = #ttcore.memory_space<l1>
+#shard_1x1 = #ttcore.shard<4096x4096, 1>
+#shard_1x4 = #ttcore.shard<4096x16384, 1>
+#shard_4x1 = #ttcore.shard<16384x4096, 1>
+
+// ---- Row-major single tile (1x1 grid, 1x1 shard) ----
+// Verifies fill_arange_tile, two nested scf.for loops, and no tile_transpose.
+
+// CHECK-LABEL: func.func @row_major_single_tile
+func.func @row_major_single_tile(
+    %scratch: memref<1x1x!ttcore.tile<32x32, f32>>,
+    %out: memref<1x1x!ttcore.tile<32x32, f32>>) {
+  d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>,
+               indexing_maps = [], iterator_types = [],
+               threads = [#d2m.thread<unified>]}
+      ins(%scratch : memref<1x1x!ttcore.tile<32x32, f32>>)
+      outs(%out : memref<1x1x!ttcore.tile<32x32, f32>>) {
+    // CHECK-NOT: d2m.arange_block
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: scf.for
+    // CHECK:   scf.for
+    // CHECK-NOT: d2m.tile_transpose
+    // CHECK: d2m.tile_add
+    %0 = "d2m.arange_block"(%scratch, %out)
+        <{colMajor = false, num_elements = 32 : i64, start = 0 : i64, step = 1 : i64}>
+        : (memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x1x!ttcore.tile<32x32, f32>>)
+        -> memref<1x1x!ttcore.tile<32x32, f32>>
+  }
+  return
+}
+
+// ---- Row-major multi-tile (1x1 grid, 1x4 shard) ----
+// Verifies the inner loop runs numTileCols=4 times and no tile_transpose is emitted.
+
+// CHECK-LABEL: func.func @row_major_multi_tile
+func.func @row_major_multi_tile(
+    %scratch: memref<1x1x!ttcore.tile<32x32, f32>>,
+    %out: memref<1x4x!ttcore.tile<32x32, f32>>) {
+  d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>,
+               indexing_maps = [], iterator_types = [],
+               threads = [#d2m.thread<unified>]}
+      ins(%scratch : memref<1x1x!ttcore.tile<32x32, f32>>)
+      outs(%out : memref<1x4x!ttcore.tile<32x32, f32>>) {
+    // CHECK-NOT: d2m.arange_block
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: scf.for
+    // CHECK:   scf.for
+    // CHECK-NOT: d2m.tile_transpose
+    // CHECK: d2m.tile_add
+    %0 = "d2m.arange_block"(%scratch, %out)
+        <{colMajor = false, num_elements = 128 : i64, start = 0 : i64, step = 1 : i64}>
+        : (memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x4x!ttcore.tile<32x32, f32>>)
+        -> memref<1x4x!ttcore.tile<32x32, f32>>
+  }
+  return
+}
+
+// ---- Col-major (1x1 grid, 4x1 shard) ----
+// Verifies that colMajor=true emits tile_transpose before arithmetic.
+
+// CHECK-LABEL: func.func @col_major
+func.func @col_major(
+    %scratch: memref<1x1x!ttcore.tile<32x32, f32>>,
+    %out: memref<4x1x!ttcore.tile<32x32, f32>>) {
+  d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>,
+               indexing_maps = [], iterator_types = [],
+               threads = [#d2m.thread<unified>]}
+      ins(%scratch : memref<1x1x!ttcore.tile<32x32, f32>>)
+      outs(%out : memref<4x1x!ttcore.tile<32x32, f32>>) {
+    // CHECK-NOT: d2m.arange_block
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: scf.for
+    // CHECK:   scf.for
+    // CHECK: d2m.tile_transpose
+    // CHECK: d2m.tile_add
+    %0 = "d2m.arange_block"(%scratch, %out)
+        <{colMajor = true, num_elements = 128 : i64, start = 0 : i64, step = 1 : i64}>
+        : (memref<1x1x!ttcore.tile<32x32, f32>>, memref<4x1x!ttcore.tile<32x32, f32>>)
+        -> memref<4x1x!ttcore.tile<32x32, f32>>
+  }
+  return
+}
+
+// ---- Blocking loop IV folding ----
+// Verifies that a col-blocking IV (d2m.blocking_loop = 1) is folded into
+// globalTileCol as colBlockIV * shardTileCols.
+
+// CHECK-LABEL: func.func @blocking_loop_col_iv
+func.func @blocking_loop_col_iv(
+    %scratch: memref<1x1x!ttcore.tile<32x32, f32>>,
+    %out: memref<1x4x!ttcore.tile<32x32, f32>>) {
+  d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>,
+               indexing_maps = [], iterator_types = [],
+               threads = [#d2m.thread<unified>]}
+      ins(%scratch : memref<1x1x!ttcore.tile<32x32, f32>>)
+      outs(%out : memref<1x4x!ttcore.tile<32x32, f32>>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    // CHECK: scf.for
+    // CHECK:   d2m.fill_arange_tile
+    // CHECK:   scf.for
+    // CHECK:     scf.for
+    // The inner loop body emits 4 muli: coreX*shardTileCols,
+    // colBlockIV*shardTileCols, and the three-multiply row-major rowContrib
+    // (globalTileRow * totalTileCols * 32 * 32), plus globalTileCol * 32.
+    // CHECK:       arith.muli
+    // CHECK:       arith.muli
+    // CHECK:       arith.muli
+    // CHECK:       arith.muli
+    // CHECK:       arith.addi
+    scf.for %blk = %c0 to %c2 step %c1 {
+      %0 = "d2m.arange_block"(%scratch, %out)
+          <{colMajor = false, num_elements = 128 : i64, start = 0 : i64, step = 1 : i64}>
+          : (memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x4x!ttcore.tile<32x32, f32>>)
+          -> memref<1x4x!ttcore.tile<32x32, f32>>
+    } {d2m.blocking_loop = 1 : i64}
+  }
+  return
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Existing arange implementation had an issue when the target dimension was > 4 tiles. It would repeat the same values across 4-tile increments because it wasn't taking the outer blocking loop into account during calculations. This was likely due to an assumption that arange with more than 4 tiles would be distributed across multiple cores, so an outer blocking loop would not be needed.

### What's changed
Improved handling of arange operations in the D2M dialect by ensuring correct computation of global indices when blocking loops are present

**Core logic improvements:**

* Added the `collectBlockingLoopIVs` helper function to traverse parent operations and collect induction variables (IVs) from enclosing blocking loops, which are tagged with `d2m.blocking_loop` attributes.
* Updated the decomposition logic in `DecomposeArangeBlockPattern` to use the collected IVs, folding them into the calculation of `globalTileRow` and `globalTileCol`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
