### PR TITLE
[Optimizer] Dedup reshards across consumers of the same producer

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
@@ -85,6 +85,12 @@ private:
   /// Maps op -> index into beamState[op]. For K=1, always 0.
   llvm::DenseMap<Operation *, size_t> finalChoice;
 
+  /// Reshard dedup cache for one applyToIR run: (producer value, target layout)
+  /// -> the shared ToMemoryConfigOp result. Lets consumers requesting the same
+  /// reshard (e.g. q/k/v slices off a fused-QKV matmul) reuse one op.
+  llvm::DenseMap<std::pair<mlir::Value, mlir::Attribute>, mlir::Value>
+      reshardCache;
+
   /// Observer (NullObject pattern: always non-null, no-op when tracing
   /// disabled).
   std::unique_ptr<LayoutPropagationObserver> observer;

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
@@ -85,9 +85,10 @@ private:
   /// Maps op -> index into beamState[op]. For K=1, always 0.
   llvm::DenseMap<Operation *, size_t> finalChoice;
 
-  /// Reshard dedup cache for one applyToIR run: (producer value, target layout)
-  /// -> the shared ToMemoryConfigOp result. Lets consumers requesting the same
-  /// reshard (e.g. q/k/v slices off a fused-QKV matmul) reuse one op.
+  /// Reshard dedup cache for the reshard pass in applyToIR: (producer value,
+  /// target layout) -> the shared ToMemoryConfigOp result. Lets consumers
+  /// requesting the same reshard (e.g. q/k/v slices off a fused-QKV matmul)
+  /// reuse one op. Empty by construction: run() executes once per instance.
   llvm::DenseMap<std::pair<mlir::Value, mlir::Attribute>, mlir::Value>
       reshardCache;
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
@@ -86,13 +86,17 @@ private:
   llvm::DenseMap<Operation *, size_t> finalChoice;
 
   /// Reshard dedup cache for the reshard pass in applyToIR: (producer value,
-  /// target layout) -> the shared reshard result (a ToMemoryConfigOp, or a
-  /// ToLayoutOp when the page layout changes). Lets consumers requesting the
-  /// same reshard (e.g. q/k/v slices off a fused-QKV matmul) reuse one op.
-  /// Keying on the target layout is what keeps the op kind consistent per
-  /// entry: whether a retile is needed is a pure function of the producer
-  /// layout and the target layout. Empty by construction: run() executes once
-  /// per instance.
+  /// target layout) -> the shared ToMemoryConfigOp result. Lets consumers
+  /// requesting the same reshard (e.g. q/k/v slices off a fused-QKV matmul)
+  /// reuse one op.
+  ///
+  /// ToMemoryConfigOp only. A page-layout change emits a ToTensorSpecOp, which
+  /// L1SpillManagement keeps out of liveValues when its result is in L1 -- see
+  /// insertReshardOp for why sharing one would leave that L1 uncounted. Keying
+  /// on the target layout is what makes the exclusion decidable per entry:
+  /// whether a retile is needed is a pure function of the producer layout and
+  /// the target layout, so an entry is never half one op kind and half the
+  /// other. Empty by construction: run() executes once per instance.
   llvm::DenseMap<std::pair<mlir::Value, mlir::Attribute>, mlir::Value>
       reshardCache;
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
@@ -85,6 +85,17 @@ private:
   /// Maps op -> index into beamState[op]. For K=1, always 0.
   llvm::DenseMap<Operation *, size_t> finalChoice;
 
+  /// Reshard dedup cache for the reshard pass in applyToIR: (producer value,
+  /// target layout) -> the shared reshard result (a ToMemoryConfigOp, or a
+  /// ToLayoutOp when the page layout changes). Lets consumers requesting the
+  /// same reshard (e.g. q/k/v slices off a fused-QKV matmul) reuse one op.
+  /// Keying on the target layout is what keeps the op kind consistent per
+  /// entry: whether a retile is needed is a pure function of the producer
+  /// layout and the target layout. Empty by construction: run() executes once
+  /// per instance.
+  llvm::DenseMap<std::pair<mlir::Value, mlir::Attribute>, mlir::Value>
+      reshardCache;
+
   /// Observer (NullObject pattern: always non-null, no-op when tracing
   /// disabled).
   std::unique_ptr<LayoutPropagationObserver> observer;

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1390,7 +1390,6 @@ void MemoryLayoutPropagation::applyToIR() {
   });
 
   // Second pass: insert reshard ops (deduped per producer via reshardCache).
-  reshardCache.clear();
   func->walk([&](Operation *op) {
     const BeamCandidate *chosen = getChosenCandidate(op);
     if (!chosen) {

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1389,7 +1389,8 @@ void MemoryLayoutPropagation::applyToIR() {
     applyOpConfig(op, *chosen);
   });
 
-  // Second pass: insert reshard ops.
+  // Second pass: insert reshard ops (deduped per producer via reshardCache).
+  reshardCache.clear();
   func->walk([&](Operation *op) {
     const BeamCandidate *chosen = getChosenCandidate(op);
     if (!chosen) {
@@ -1503,6 +1504,23 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
   RankedTensorType newTensorType =
       utils::RankedTensorTypeFactory::create(producerTensorType, outputLayout);
 
+  // Dedup: reuse a shared reshard for consumers of the same producer requesting
+  // the same target layout.
+  // Stays correct downstream: TTNNDeallocate frees it after its last consumer,
+  // and if the L1 spill pass evicts it for space it re-splits into per-consumer
+  // reshards.
+  std::pair<mlir::Value, mlir::Attribute> cacheKey{operand, reshardLayout};
+  if (auto it = reshardCache.find(cacheKey); it != reshardCache.end()) {
+    if (Operation *cachedOp = it->second.getDefiningOp();
+        cachedOp && cachedOp->getBlock() == consumerOp->getBlock() &&
+        cachedOp->isBeforeInBlock(consumerOp)) {
+      consumerOp->setOperand(operandIndex, it->second);
+      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                   "Reused shared memory reconfig op: {0}", cachedOp);
+      return;
+    }
+  }
+
   OpBuilder builder(consumerOp);
   Location loc = ttmlir::utils::appendLocationSuffix(consumerOp->getLoc(),
                                                      "_mem_reconfig");
@@ -1522,6 +1540,7 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
                 .getOperation();
 
   consumerOp->setOperand(operandIndex, reshardOp->getResult(0));
+  reshardCache[cacheKey] = reshardOp->getResult(0);
 
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                "Inserted reshard op: {0}", *reshardOp);

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1443,7 +1443,7 @@ void MemoryLayoutPropagation::applyToIR() {
     applyOpConfig(op, *getChosenCandidate(op));
   }
 
-  // Second pass: insert reshard ops.
+  // Second pass: insert reshard ops (deduped per producer via reshardCache).
   func->walk([&](Operation *op) {
     const BeamCandidate *chosen = getChosenCandidate(op);
     if (!chosen) {
@@ -1585,6 +1585,23 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
   RankedTensorType newTensorType =
       utils::RankedTensorTypeFactory::create(producerTensorType, outputLayout);
 
+  // Dedup: reuse a shared reshard for consumers of the same producer requesting
+  // the same target layout.
+  // Stays correct downstream: TTNNDeallocate frees it after its last consumer,
+  // and if the L1 spill pass evicts it for space it re-splits into per-consumer
+  // reshards.
+  std::pair<mlir::Value, mlir::Attribute> cacheKey{operand, reshardLayout};
+  if (auto it = reshardCache.find(cacheKey); it != reshardCache.end()) {
+    if (Operation *cachedOp = it->second.getDefiningOp();
+        cachedOp && cachedOp->getBlock() == consumerOp->getBlock() &&
+        cachedOp->isBeforeInBlock(consumerOp)) {
+      consumerOp->setOperand(operandIndex, it->second);
+      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                   "Reused shared memory reconfig op: {0}", cachedOp);
+      return;
+    }
+  }
+
   OpBuilder builder(consumerOp);
   Location loc = ttmlir::utils::appendLocationSuffix(consumerOp->getLoc(),
                                                      "_mem_reconfig");
@@ -1604,6 +1621,7 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
                 .getOperation();
 
   consumerOp->setOperand(operandIndex, reshardOp->getResult(0));
+  reshardCache[cacheKey] = reshardOp->getResult(0);
 
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                "Inserted reshard op: {0}", *reshardOp);

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1585,20 +1585,36 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
   RankedTensorType newTensorType =
       utils::RankedTensorTypeFactory::create(producerTensorType, outputLayout);
 
+  // A tile <-> row-major page-layout change (RowMajor input siblings) is a
+  // retile, which ttnn.to_memory_config does not do -- emit a
+  // ttnn.to_tensor_spec, which TTNNDecomposeLayouts lowers into the
+  // untilize/tilize + memory-config sequence. Pure memory-config reshards stay
+  // ttnn.to_memory_config.
+  bool pageLayoutChanges =
+      producerLayout.getLayout() != outputLayout.getLayout();
+
   // Dedup: reuse a shared reshard for consumers of the same producer requesting
-  // the same target layout.
-  // Stays correct downstream: TTNNDeallocate frees it after its last consumer,
-  // and if the L1 spill pass evicts it for space it re-splits into per-consumer
-  // reshards.
+  // the same target layout. Only the ttnn.to_memory_config path is shared.
+  //
+  // Sharing a ToMemoryConfigOp is safe downstream: it carries an ordinary
+  // allocation record, so L1SpillManagement tracks it in liveValues and can
+  // evict it, and TTNNDeallocate frees it after its last consumer.
+  //
+  // A ToTensorSpecOp is deliberately left out. L1SpillManagement makes room
+  // for an L1 ToTensorSpecOp result but does not add it to liveValues, on the
+  // stated assumption that such a result is "always immediately consumed by
+  // the target op".
   std::pair<mlir::Value, mlir::Attribute> cacheKey{operand, reshardLayout};
-  if (auto it = reshardCache.find(cacheKey); it != reshardCache.end()) {
-    if (Operation *cachedOp = it->second.getDefiningOp();
-        cachedOp && cachedOp->getBlock() == consumerOp->getBlock() &&
-        cachedOp->isBeforeInBlock(consumerOp)) {
-      consumerOp->setOperand(operandIndex, it->second);
-      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
-                   "Reused shared memory reconfig op: {0}", cachedOp);
-      return;
+  if (!pageLayoutChanges) {
+    if (auto it = reshardCache.find(cacheKey); it != reshardCache.end()) {
+      if (Operation *cachedOp = it->second.getDefiningOp();
+          cachedOp && cachedOp->getBlock() == consumerOp->getBlock() &&
+          cachedOp->isBeforeInBlock(consumerOp)) {
+        consumerOp->setOperand(operandIndex, it->second);
+        TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                     "Reused shared memory reconfig op: {0}", cachedOp);
+        return;
+      }
     }
   }
 
@@ -1606,13 +1622,6 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
   Location loc = ttmlir::utils::appendLocationSuffix(consumerOp->getLoc(),
                                                      "_mem_reconfig");
 
-  // A tile <-> row-major page-layout change (RowMajor input siblings) is a
-  // retile, which ttnn.to_memory_config does not do -- emit a ttnn.to_layout,
-  // which TTNNDecomposeLayouts lowers into the untilize/tilize + memory-config
-  // sequence. Pure memory-config reshards stay ttnn.to_memory_config.
-  bool pageLayoutChanges =
-      utils::getLayoutAttrFromTensor(producerTensorType).getLayout() !=
-      outputLayout.getLayout();
   Operation *reshardOp =
       pageLayoutChanges
           ? builder.create<ToTensorSpecOp>(loc, newTensorType, operand)
@@ -1621,7 +1630,9 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
                 .getOperation();
 
   consumerOp->setOperand(operandIndex, reshardOp->getResult(0));
-  reshardCache[cacheKey] = reshardOp->getResult(0);
+  if (!pageLayoutChanges) {
+    reshardCache[cacheKey] = reshardOp->getResult(0);
+  }
 
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                "Inserted reshard op: {0}", *reshardOp);

--- a/test/ttmlir/Dialect/TTNN/optimizer/shared_reshard_across_consumers.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/shared_reshard_across_consumers.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" -o %t %s --mlir-print-local-scope
+// RUN: FileCheck %s --input-file=%t
+
+// Consumers that ask the same producer for the same target layout share one
+// reshard op rather than getting one each. The canonical shape is the q/k/v
+// slices off a fused-QKV matmul: three consumers, one producer, and a single
+// layout requirement between them.
+//
+// The slices carry different offsets so CSE cannot collapse them, which is what
+// makes the operand of each one meaningful: all three must read the *same*
+// reshard result. Without the dedup this lowers to three separate
+// ttnn.to_memory_config ops, each consuming the matmul directly.
+
+module {
+  func.func @fused_qkv_slices(
+      %a: tensor<32x512xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %w: tensor<512x384xbf16> {ttcore.argument_type = #ttcore.argument_type<input>})
+      -> tensor<32x128xbf16> {
+    // CHECK-LABEL: func.func @fused_qkv_slices
+    // CHECK: %[[QKV:[0-9]+]] = "ttnn.matmul"
+    // CHECK: %[[RESHARD:[0-9]+]] = "ttnn.to_memory_config"(%[[QKV]])
+    // CHECK: "ttnn.slice_static"(%[[RESHARD]])
+    // CHECK: "ttnn.slice_static"(%[[RESHARD]])
+    // CHECK: "ttnn.slice_static"(%[[RESHARD]])
+    %0 = "ttir.matmul"(%a, %w) : (tensor<32x512xbf16>, tensor<512x384xbf16>) -> tensor<32x384xbf16>
+    %q = "ttir.slice_static"(%0) <{begins = [0 : i32, 0 : i32], ends = [32 : i32, 128 : i32], step = [1 : i32, 1 : i32]}> : (tensor<32x384xbf16>) -> tensor<32x128xbf16>
+    %k = "ttir.slice_static"(%0) <{begins = [0 : i32, 128 : i32], ends = [32 : i32, 256 : i32], step = [1 : i32, 1 : i32]}> : (tensor<32x384xbf16>) -> tensor<32x128xbf16>
+    %v = "ttir.slice_static"(%0) <{begins = [0 : i32, 256 : i32], ends = [32 : i32, 384 : i32], step = [1 : i32, 1 : i32]}> : (tensor<32x384xbf16>) -> tensor<32x128xbf16>
+    %1 = "ttir.add"(%q, %k) : (tensor<32x128xbf16>, tensor<32x128xbf16>) -> tensor<32x128xbf16>
+    %2 = "ttir.add"(%1, %v) : (tensor<32x128xbf16>, tensor<32x128xbf16>) -> tensor<32x128xbf16>
+    return %2 : tensor<32x128xbf16>
+  }
+}


### PR DESCRIPTION
### Summary of changes
In MemoryLayoutPropagation, when several consumers of the same producer value request an identical reshard (same target layout), reuse one shared ToMemoryConfigOp instead of emitting one per consumer. The canonical case is the q/k/v slices off a fused-QKV matmul output, which each request the same layout conversion.

Implemented as a small per-run cache in applyToIR's reshard pass, keyed on (producer value, target layout). A cached reshard is only reused when it dominates the consumer (same block(should be guaranteed but checked just in case), defined earlier); otherwise a fresh one is emitted.

**ToMemoryConfigOp only.** A reshard that also changes page layout (tile <-> row-major, the RowMajor input sibling case) is emitted as a ToTensorSpecOp, and those are never cached. L1SpillManagement makes room for an L1 ToTensorSpecOp result but deliberately does not add it to `liveValues`, on the stated assumption that such a result is "always immediately consumed by the target op". Sharing one breaks that assumption: it then spans other ops while absent from `liveValues`, so its L1 goes uncounted in every later occupancy and eviction decision, and it cannot be evicted to recover the space. Keying the cache on the target layout is what makes the exclusion decidable per entry — whether a retile is needed is a pure function of the producer layout and the target layout, so an entry is never half one op kind and half the other.

The dedup composes with the downstream passes without either needing to know about it:
- Deallocation: TTNNDeallocate is liveness-based, so the shared reshard is freed after its last consumer automatically.
- L1 spill: a shared ToMemoryConfigOp is a normal evictable value — it carries an ordinary allocation record, so GreedyL1SpillManagement tracks it in `liveValues` and can evict it. If it does evict it to reclaim space, it re-splits back into per-consumer reshards (only for consumers that actually need L1; DRAM-tolerant ones read the spill directly). ToTensorSpecOp is excluded precisely because it has no such allocation record pre-decomposition, so none of that applies to it.

### Why excluding the page-layout path costs nothing

Reshard results with more than one consuming use, counted in the decode graph of every model in three benchmark fleets, before and after this dedup landed (as a740187cf9, carried in the DRAM-sharded series):

| part | to_memory_config shared | to_tensor_spec shared | models gaining |
|---|---|---|---|
| n150 | 2635 -> 3400 (+765) | 2 -> 2 (+0) | 27/40 |
| p150 | 2189 -> 2931 (+742) | 2 -> 2 (+0) | 27/42 |
| qb2 | 90 -> 677 (+587) | 0 -> 0 (+0) | 13/15 |

The page-layout path is never shared in any of them. The only page-layout reshards with two consumers are in bge_m3 and flux2, they predate the dedup, and they are in DRAM. Shared ToMemoryConfigOp results in L1 are by contrast routine — 39 of 40 on qwen_2_5_3b's decode step — which is what the exclusion protects.

Counting notes: uses are counted per function (these dumps carry ~143 func.func each and SSA names restart per function) and exclude ttnn.deallocate operands (every value has one). The before runs already show thousands of shared ToMemoryConfigOp because CSE merges identical reshards on its own, so the feature's contribution is the delta, not the total.

### Perf impact

Runtime impact is roughly neutral for now — on Llama 3.1 8B decode it drops reshard ops 360 → 201 but the e2e latency delta is within measurement noise (~1% on a single warm trace replay), since these particular reshards are cheap and largely overlapped.

The point is enabling if for future gains on #9247 : DRAM-sharded matmul incorporation emits many near-identical reshards on shared operands, and deduping them avoids redundant data movement and L1 pressure that would otherwise scale with consumer count. This lands the mechanism ahead of that work.

### Checklist
- [x] Slight perf gains, negligible for now, no regressions
- before: https://github.com/tenstorrent/tt-xla/actions/runs/28677307742
- after: https://github.com/tenstorrent/tt-xla/actions/runs/28676930272
