### PR TITLE
[d2m] extending shapes that topk supports and fixing index output

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -3325,7 +3325,7 @@ def D2M_TopkBlockOp : D2M_GenericRegionComputeOp<"topk_block",
       The scratch_idx_tile is a pre-filled full-shape index buffer containing
       the arange of original element indices (generated upstream in TTIRToD2M
       via arange + broadcast generics). `d2m-decompose-topk` consumes this
-      buffer directly; it no longer emits `arange_block`.
+      buffer directly.
   }];
 
   let arguments = (ins

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -3320,11 +3320,12 @@ def D2M_TopkBlockOp : D2M_GenericRegionComputeOp<"topk_block",
 
       This op operates at the block level (memref of tiles) and is
       decomposed post-bufferization by `d2m-decompose-topk` into
-      `arange_block`, `tile_topk_local_sort`, `tile_topk_merge`, and
-      `tile_topk_rebuild`.
+      `tile_topk_local_sort`, `tile_topk_merge`, and `tile_topk_rebuild`.
 
-      The scratch_idx_tile is a single-tile scratch buffer used by the
-      internal arange_block operation.
+      The scratch_idx_tile is a pre-filled full-shape index buffer containing
+      the arange of original element indices (generated upstream in TTIRToD2M
+      via arange + broadcast generics). `d2m-decompose-topk` consumes this
+      buffer directly; it no longer emits `arange_block`.
   }];
 
   let arguments = (ins

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1083,8 +1083,7 @@ def D2M_TileUntilizeBlockOp : D2M_GenericRegionComputeOp<"tile_untilize_block",
 
 def D2M_TileTopkLocalSortOp : D2M_GenericRegionComputeOp<"tile_topk_local_sort",
   [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-   D2M_SkipOpEltwiseFusionTrait,
-   D2M_SynchronizableOpInterface]> {
+   D2M_SkipOpEltwiseFusionTrait]> {
     let summary = "D2M Tile TopK Local Sort Block Op";
     let description = [{
         The `tile_topk_local_sort` operation bitonically sorts the input value block and its paired index block in place.
@@ -1094,14 +1093,14 @@ def D2M_TileTopkLocalSortOp : D2M_GenericRegionComputeOp<"tile_topk_local_sort",
                          AnyRankedTensorOrMemRef:$indices,
                          AnyRankedTensorOrMemRef:$out_values,
                          AnyRankedTensorOrMemRef:$out_indices,
-                         I32Attr:$idir,
+                         I32:$idir,
                          I32Attr:$i_end_phase,
                          I32Attr:$i_start_phase,
-                         I64Attr:$tile_a,
-                         I64Attr:$tile_b,
+                         Index:$tile_a,
+                         Index:$tile_b,
                          BoolAttr:$is_group_start,
-                         BoolAttr:$is_group_end,
-                         BoolAttr:$read_from_output);
+                         I1:$is_group_end,
+                         I1:$read_from_output);
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() {
@@ -1123,8 +1122,7 @@ def D2M_TileTopkLocalSortOp : D2M_GenericRegionComputeOp<"tile_topk_local_sort",
 
 def D2M_TileTopkMergeOp : D2M_GenericRegionComputeOp<"tile_topk_merge",
   [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-   D2M_SkipOpEltwiseFusionTrait,
-   D2M_SynchronizableOpInterface]> {
+   D2M_SkipOpEltwiseFusionTrait]> {
     let summary = "D2M Tile TopK Merge Block Op";
     let description = [{
         The `tile_topk_merge` operation merges length-K subsequences so the top-K values land in the first subsequence.
@@ -1134,13 +1132,13 @@ def D2M_TileTopkMergeOp : D2M_GenericRegionComputeOp<"tile_topk_merge",
                          AnyRankedTensorOrMemRef:$indices,
                          AnyRankedTensorOrMemRef:$out_values,
                          AnyRankedTensorOrMemRef:$out_indices,
-                         I32Attr:$m_iter,
+                         I32:$m_iter,
                          I32Attr:$k,
-                         I64Attr:$tile_a,
-                         I64Attr:$tile_b,
+                         Index:$tile_a,
+                         Index:$tile_b,
                          BoolAttr:$is_group_start,
-                         BoolAttr:$is_group_end,
-                         BoolAttr:$read_from_output);
+                         I1:$is_group_end,
+                         I1:$read_from_output);
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() {
@@ -1162,8 +1160,7 @@ def D2M_TileTopkMergeOp : D2M_GenericRegionComputeOp<"tile_topk_merge",
 
 def D2M_TileTopkRebuildOp : D2M_GenericRegionComputeOp<"tile_topk_rebuild",
   [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-   D2M_SkipOpEltwiseFusionTrait,
-   D2M_SynchronizableOpInterface]> {
+   D2M_SkipOpEltwiseFusionTrait]> {
     let summary = "D2M Tile TopK Rebuild Block Op";
     let description = [{
         The `tile_topk_rebuild` operation re-sorts the surviving length-K subsequences into final order.
@@ -1174,15 +1171,15 @@ def D2M_TileTopkRebuildOp : D2M_GenericRegionComputeOp<"tile_topk_rebuild",
                          AnyRankedTensorOrMemRef:$out_values,
                          AnyRankedTensorOrMemRef:$out_indices,
                          I32Attr:$idir,
-                         I32Attr:$m_iter,
+                         I32:$m_iter,
                          I32Attr:$k,
                          I32Attr:$logk,
                          I32Attr:$skip_second,
-                         I64Attr:$tile_a,
-                         I64Attr:$tile_b,
+                         Index:$tile_a,
+                         Index:$tile_b,
                          BoolAttr:$is_group_start,
-                         BoolAttr:$is_group_end,
-                         BoolAttr:$read_from_output);
+                         I1:$is_group_end,
+                         I1:$read_from_output);
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() {

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1106,15 +1106,6 @@ def D2M_TileTopkLocalSortOp : D2M_GenericRegionComputeOp<"tile_topk_local_sort",
       MutableOperandRange getDpsInitsMutable() {
         return MutableOperandRange(getOperation(), 2, 2);
       }
-
-      bool isProducer(mlir::OpOperand &operand) {
-        return &getOutValuesMutable() == &operand ||
-               &getOutIndicesMutable() == &operand;
-      }
-      bool isConsumer(mlir::OpOperand &operand) {
-        return &getValuesMutable() == &operand ||
-               &getIndicesMutable() == &operand;
-      }
     }];
 
     let hasVerifier = 1;
@@ -1143,15 +1134,6 @@ def D2M_TileTopkMergeOp : D2M_GenericRegionComputeOp<"tile_topk_merge",
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() {
         return MutableOperandRange(getOperation(), 2, 2);
-      }
-
-      bool isProducer(mlir::OpOperand &operand) {
-        return &getOutValuesMutable() == &operand ||
-               &getOutIndicesMutable() == &operand;
-      }
-      bool isConsumer(mlir::OpOperand &operand) {
-        return &getValuesMutable() == &operand ||
-               &getIndicesMutable() == &operand;
       }
     }];
 
@@ -1184,15 +1166,6 @@ def D2M_TileTopkRebuildOp : D2M_GenericRegionComputeOp<"tile_topk_rebuild",
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() {
         return MutableOperandRange(getOperation(), 2, 2);
-      }
-
-      bool isProducer(mlir::OpOperand &operand) {
-        return &getOutValuesMutable() == &operand ||
-               &getOutIndicesMutable() == &operand;
-      }
-      bool isConsumer(mlir::OpOperand &operand) {
-        return &getValuesMutable() == &operand ||
-               &getIndicesMutable() == &operand;
       }
     }];
 

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1086,16 +1086,39 @@ def D2M_TileTopkLocalSortOp : D2M_GenericRegionComputeOp<"tile_topk_local_sort",
    D2M_SkipOpEltwiseFusionTrait]> {
     let summary = "D2M Tile TopK Local Sort Block Op";
     let description = [{
-        The `tile_topk_local_sort` operation bitonically sorts the input value block and its paired index block in place.
+        Runs a bitonic sort in place over the concatenated 2-tile sequence
+        formed by `tile_a` and `tile_b` (each a value tile paired with an
+        index tile), leaving each tile as a sorted run forming one bitonic
+        sequence across both. Maps onto the ttkernel `topk_local_sort` LLK
+        call.
+
+        - `values`/`indices`: input value/index tensors or memrefs.
+        - `out_values`/`out_indices`: output value/index tensors or memrefs;
+          the op's DPS inits (`getDpsInitsMutable` = operands 2-3).
+        - `idir`: sort direction (0 = descending).
+        - `i_end_phase`: last bitonic-network phase (0-indexed) to run; a full
+          64-element sort runs phases 0..5.
+        - `i_start_phase`: first bitonic-network phase (0-indexed) to run;
+          nonzero values resume a partially-sorted tile pair rather than
+          re-sorting from scratch.
+        - `tile_a`, `tile_b`: flat tile indices of the pair being sorted.
+        - `is_group_start`: whether this op is responsible for acquiring the
+          DST tile registers and copying `tile_a`/`tile_b` (values and
+          indices) in from the source CB.
+        - `is_group_end`: whether this op is responsible for packing the
+          resulting DST tiles back to the output CB and releasing the DST
+          tile registers.
+        - `read_from_output`: whether `tile_a`/`tile_b` are read from the
+          output value/index buffers instead of the input buffers.
     }];
 
     let arguments = (ins AnyRankedTensorOrMemRef:$values,
                          AnyRankedTensorOrMemRef:$indices,
                          AnyRankedTensorOrMemRef:$out_values,
                          AnyRankedTensorOrMemRef:$out_indices,
-                         I32:$idir,
+                         I32Attr:$idir,
                          I32Attr:$i_end_phase,
-                         I32Attr:$i_start_phase,
+                         I32:$i_start_phase,
                          Index:$tile_a,
                          Index:$tile_b,
                          BoolAttr:$is_group_start,
@@ -1116,7 +1139,28 @@ def D2M_TileTopkMergeOp : D2M_GenericRegionComputeOp<"tile_topk_merge",
    D2M_SkipOpEltwiseFusionTrait]> {
     let summary = "D2M Tile TopK Merge Block Op";
     let description = [{
-        The `tile_topk_merge` operation merges length-K subsequences so the top-K values land in the first subsequence.
+        Given two bitonic length-K subsequences held in `tile_a` and
+        `tile_b`, merges them so the top-K values/indices across both land in
+        `tile_a`; `tile_b` is left holding the complementary "losers". Maps
+        onto the ttkernel `topk_merge` LLK call.
+
+        - `values`/`indices`: input value/index tensors or memrefs.
+        - `out_values`/`out_indices`: output value/index tensors or memrefs;
+          the op's DPS inits (`getDpsInitsMutable` = operands 2-3).
+        - `m_iter`: merge-tree level (0-indexed) being merged; determines
+          which stride/shape of length-K runs the LLK merges.
+        - `k`: number of top elements tracked per subsequence.
+        - `tile_a`, `tile_b`: flat tile indices of the pair being merged;
+          after the merge, `tile_a` holds the combined top-K result, `tile_b`
+          the losers.
+        - `is_group_start`: whether this op is responsible for acquiring the
+          DST tile registers and copying `tile_a`/`tile_b` in from the source
+          CB.
+        - `is_group_end`: whether this op is responsible for packing the
+          resulting DST tiles back to the output CB and releasing the DST
+          tile registers.
+        - `read_from_output`: whether `tile_a`/`tile_b` are read from the
+          output value/index buffers instead of the input buffers.
     }];
 
     let arguments = (ins AnyRankedTensorOrMemRef:$values,
@@ -1145,7 +1189,32 @@ def D2M_TileTopkRebuildOp : D2M_GenericRegionComputeOp<"tile_topk_rebuild",
    D2M_SkipOpEltwiseFusionTrait]> {
     let summary = "D2M Tile TopK Rebuild Block Op";
     let description = [{
-        The `tile_topk_rebuild` operation re-sorts the surviving length-K subsequences into final order.
+        Re-sorts the length-K sequence held across `tile_a`/`tile_b` into
+        fully-ordered order (a merge only guarantees the top-K values landed
+        in `tile_a`, not that they're sorted). Maps onto the ttkernel
+        `topk_rebuild` LLK call.
+
+        - `values`/`indices`: input value/index tensors or memrefs.
+        - `out_values`/`out_indices`: output value/index tensors or memrefs;
+          the op's DPS inits (`getDpsInitsMutable` = operands 2-3).
+        - `idir`: sort direction (0 = descending).
+        - `m_iter`: merge-tree level (0-indexed) whose result is being
+          rebuilt.
+        - `k`: number of top elements retained in the rebuilt sequence.
+        - `logk`: `floor(log2(k))`; number of bitonic-network phases the
+          rebuild runs to fully re-sort the length-K sequence.
+        - `skip_second`: whether the rebuild's second sub-pass (over the
+          second half of the sequence) is skipped.
+        - `tile_a`, `tile_b`: flat tile indices of the pair being rebuilt;
+          after rebuild hold the fully sorted top-K result.
+        - `is_group_start`: whether this op is responsible for acquiring the
+          DST tile registers and copying `tile_a`/`tile_b` in from the source
+          CB.
+        - `is_group_end`: whether this op is responsible for packing the
+          resulting DST tiles back to the output CB and releasing the DST
+          tile registers.
+        - `read_from_output`: whether `tile_a`/`tile_b` are read from the
+          output value/index buffers instead of the input buffers.
     }];
 
     let arguments = (ins AnyRankedTensorOrMemRef:$values,

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -971,7 +971,8 @@ def D2MDecomposeTopk : Pass<"d2m-decompose-topk", "::mlir::ModuleOp"> {
   let dependentDialects = [
     "::mlir::tt::d2m::D2MDialect",
     "::mlir::memref::MemRefDialect",
-    "::mlir::arith::ArithDialect"
+    "::mlir::arith::ArithDialect",
+    "::mlir::scf::SCFDialect"
   ];
 }
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2148,15 +2148,15 @@ static void emitTopkGroupStartIfNeeded(ConversionPatternRewriter &rewriter,
   // all pack_tile L1 writes before copy_tile executes.
   Value rfo = op.getReadFromOutput();
   std::optional<int64_t> rfoConst = getConstantIntValue(rfo);
+  if (rfoConst && *rfoConst != 0) {
+    rewriter.create<ttkernel::UnpackStallOnPackOp>(loc);
+    emitTopkGroupStart(rewriter, loc, cbOutVals, cbOutIdx, cbOutVals, tileA,
+                       tileB);
+    return;
+  }
   if (rfoConst) {
-    if (*rfoConst) {
-      rewriter.create<ttkernel::UnpackStallOnPackOp>(loc);
-      emitTopkGroupStart(rewriter, loc, cbOutVals, cbOutIdx, cbOutVals, tileA,
-                         tileB);
-    } else {
-      emitTopkGroupStart(rewriter, loc, cbInVals, cbInIdx, cbOutVals, tileA,
-                         tileB);
-    }
+    emitTopkGroupStart(rewriter, loc, cbInVals, cbInIdx, cbOutVals, tileA,
+                       tileB);
     return;
   }
   rewriter.create<scf::IfOp>(
@@ -2180,11 +2180,12 @@ static void emitTopkGroupEndIfNeeded(ConversionPatternRewriter &rewriter,
                                      Value tileB) {
   Value isGroupEnd = op.getIsGroupEnd();
   std::optional<int64_t> isGroupEndConst = getConstantIntValue(isGroupEnd);
+  if (isGroupEndConst && *isGroupEndConst != 0) {
+    emitTopkGroupEnd(rewriter, loc, getCB(rewriter, op.getOutValues()),
+                     getCB(rewriter, op.getOutIndices()), tileA, tileB);
+    return;
+  }
   if (isGroupEndConst) {
-    if (*isGroupEndConst) {
-      emitTopkGroupEnd(rewriter, loc, getCB(rewriter, op.getOutValues()),
-                       getCB(rewriter, op.getOutIndices()), tileA, tileB);
-    }
     return;
   }
   rewriter.create<scf::IfOp>(

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2093,82 +2093,88 @@ namespace {
 
 static void emitTopkGroupStart(OpBuilder &rewriter, Location loc,
                                Value cbSrcVals, Value cbSrcIdx, Value cbOutVals,
-                               int64_t tileA, int64_t tileB) {
+                               Value tileA, Value tileB) {
   Value dst0 = index(rewriter, loc, 0);
   Value dst1 = index(rewriter, loc, 1);
   Value dst2 = index(rewriter, loc, 2);
   Value dst3 = index(rewriter, loc, 3);
-  Value tA = index(rewriter, loc, tileA);
-  Value tB = index(rewriter, loc, tileB);
 
   rewriter.create<ttkernel::TileRegsAcquireOp>(loc);
   rewriter.create<ttkernel::TopkTileInitOp>(loc);
   rewriter.create<ttkernel::InitSFPUOp>(loc, cbSrcVals, cbOutVals);
   rewriter.create<ttkernel::CopyTileInitOp>(loc, cbSrcVals);
-  rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcVals, tA, dst0);
-  rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcVals, tB, dst1);
+  rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcVals, tileA, dst0);
+  rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcVals, tileB, dst1);
   rewriter.create<ttkernel::CopyTileInitOp>(loc, cbSrcIdx);
-  rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcIdx, tA, dst2);
-  rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcIdx, tB, dst3);
+  rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcIdx, tileA, dst2);
+  rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcIdx, tileB, dst3);
 }
 
 static void emitTopkGroupEnd(OpBuilder &rewriter, Location loc, Value cbOutVals,
-                             Value cbOutIdx, int64_t tileA, int64_t tileB) {
+                             Value cbOutIdx, Value tileA, Value tileB) {
   Value dst0 = index(rewriter, loc, 0);
   Value dst1 = index(rewriter, loc, 1);
   Value dst2 = index(rewriter, loc, 2);
   Value dst3 = index(rewriter, loc, 3);
-  Value tA = index(rewriter, loc, tileA);
-  Value tB = index(rewriter, loc, tileB);
 
   rewriter.create<ttkernel::TileRegsCommitOp>(loc);
   rewriter.create<ttkernel::TileRegsWaitOp>(loc);
   rewriter.create<ttkernel::PackReconfigDataFormatOp>(loc, cbOutVals);
-  rewriter.create<ttkernel::PackTileOp>(loc, dst0, cbOutVals, tA,
+  rewriter.create<ttkernel::PackTileOp>(loc, dst0, cbOutVals, tileA,
                                         rewriter.getBoolAttr(true));
-  rewriter.create<ttkernel::PackTileOp>(loc, dst1, cbOutVals, tB,
+  rewriter.create<ttkernel::PackTileOp>(loc, dst1, cbOutVals, tileB,
                                         rewriter.getBoolAttr(true));
   rewriter.create<ttkernel::PackReconfigDataFormatOp>(loc, cbOutIdx);
-  rewriter.create<ttkernel::PackTileOp>(loc, dst2, cbOutIdx, tA,
+  rewriter.create<ttkernel::PackTileOp>(loc, dst2, cbOutIdx, tileA,
                                         rewriter.getBoolAttr(true));
-  rewriter.create<ttkernel::PackTileOp>(loc, dst3, cbOutIdx, tB,
+  rewriter.create<ttkernel::PackTileOp>(loc, dst3, cbOutIdx, tileB,
                                         rewriter.getBoolAttr(true));
   rewriter.create<ttkernel::TileRegsReleaseOp>(loc);
 }
 
 template <typename OpTy>
 static void emitTopkGroupStartIfNeeded(ConversionPatternRewriter &rewriter,
-                                       Location loc, OpTy op, int64_t tileA,
-                                       int64_t tileB) {
+                                       Location loc, OpTy op, Value tileA,
+                                       Value tileB) {
   if (!op.getIsGroupStart()) {
     return;
   }
   Value cbOutVals = getCB(rewriter, op.getOutValues());
   Value cbOutIdx = getCB(rewriter, op.getOutIndices());
-  Value cbSrcVals =
-      op.getReadFromOutput() ? cbOutVals : getCB(rewriter, op.getValues());
-  Value cbSrcIdx =
-      op.getReadFromOutput() ? cbOutIdx : getCB(rewriter, op.getIndices());
+  Value cbInVals = getCB(rewriter, op.getValues());
+  Value cbInIdx = getCB(rewriter, op.getIndices());
 
   // rfo=true: T0 reads output CB tiles that T2 just wrote. Fence so T0 sees
   // all pack_tile L1 writes before copy_tile executes.
-  if (op.getReadFromOutput()) {
-    rewriter.create<ttkernel::UnpackStallOnPackOp>(loc);
-  }
-
-  emitTopkGroupStart(rewriter, loc, cbSrcVals, cbSrcIdx, cbOutVals, tileA,
-                     tileB);
+  Value rfo = op.getReadFromOutput();
+  rewriter.create<scf::IfOp>(
+      loc, rfo,
+      /*thenBuilder=*/
+      [&](OpBuilder &b, Location l) {
+        b.create<ttkernel::UnpackStallOnPackOp>(l);
+        emitTopkGroupStart(b, l, cbOutVals, cbOutIdx, cbOutVals, tileA, tileB);
+        b.create<scf::YieldOp>(l);
+      },
+      /*elseBuilder=*/
+      [&](OpBuilder &b, Location l) {
+        emitTopkGroupStart(b, l, cbInVals, cbInIdx, cbOutVals, tileA, tileB);
+        b.create<scf::YieldOp>(l);
+      });
 }
 
 template <typename OpTy>
 static void emitTopkGroupEndIfNeeded(ConversionPatternRewriter &rewriter,
-                                     Location loc, OpTy op, int64_t tileA,
-                                     int64_t tileB) {
-  if (!op.getIsGroupEnd()) {
-    return;
-  }
-  emitTopkGroupEnd(rewriter, loc, getCB(rewriter, op.getOutValues()),
-                   getCB(rewriter, op.getOutIndices()), tileA, tileB);
+                                     Location loc, OpTy op, Value tileA,
+                                     Value tileB) {
+  Value isGroupEnd = op.getIsGroupEnd();
+  rewriter.create<scf::IfOp>(
+      loc, isGroupEnd,
+      /*thenBuilder=*/
+      [&](OpBuilder &b, Location l) {
+        emitTopkGroupEnd(b, l, getCB(rewriter, op.getOutValues()),
+                         getCB(rewriter, op.getOutIndices()), tileA, tileB);
+        b.create<scf::YieldOp>(l);
+      });
 }
 
 class D2MTopkLocalSortRewriter
@@ -2181,12 +2187,12 @@ public:
                   d2m::TileTopkLocalSortOp::Adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     Location loc = op->getLoc();
-    int64_t tileA = op.getTileA(), tileB = op.getTileB();
+    Value tileA = op.getTileA(), tileB = op.getTileB();
     auto i32 = [&](auto v) { return intConstant<int32_t>(rewriter, loc, v); };
 
     emitTopkGroupStartIfNeeded(rewriter, loc, op, tileA, tileB);
     rewriter.create<ttkernel::TopkLocalSortOp>(
-        loc, index(rewriter, loc, 0), i32(op.getIdir()), i32(op.getIEndPhase()),
+        loc, index(rewriter, loc, 0), op.getIdir(), i32(op.getIEndPhase()),
         i32(op.getIStartPhase()));
     emitTopkGroupEndIfNeeded(rewriter, loc, op, tileA, tileB);
 
@@ -2203,12 +2209,12 @@ public:
   matchAndRewrite(d2m::TileTopkMergeOp op, d2m::TileTopkMergeOp::Adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     Location loc = op->getLoc();
-    int64_t tileA = op.getTileA(), tileB = op.getTileB();
+    Value tileA = op.getTileA(), tileB = op.getTileB();
     auto i32 = [&](auto v) { return intConstant<int32_t>(rewriter, loc, v); };
 
     emitTopkGroupStartIfNeeded(rewriter, loc, op, tileA, tileB);
     rewriter.create<ttkernel::TopkMergeOp>(loc, index(rewriter, loc, 0),
-                                           i32(op.getMIter()), i32(op.getK()));
+                                           op.getMIter(), i32(op.getK()));
     emitTopkGroupEndIfNeeded(rewriter, loc, op, tileA, tileB);
 
     rewriter.eraseOp(op);
@@ -2225,12 +2231,12 @@ public:
   matchAndRewrite(d2m::TileTopkRebuildOp op, d2m::TileTopkRebuildOp::Adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     Location loc = op->getLoc();
-    int64_t tileA = op.getTileA(), tileB = op.getTileB();
+    Value tileA = op.getTileA(), tileB = op.getTileB();
     auto i32 = [&](auto v) { return intConstant<int32_t>(rewriter, loc, v); };
 
     emitTopkGroupStartIfNeeded(rewriter, loc, op, tileA, tileB);
     rewriter.create<ttkernel::TopkRebuildOp>(
-        loc, index(rewriter, loc, 0), i32(op.getIdir()), i32(op.getMIter()),
+        loc, index(rewriter, loc, 0), i32(op.getIdir()), op.getMIter(),
         i32(op.getK()), i32(op.getLogk()), i32(op.getSkipSecond()));
     emitTopkGroupEndIfNeeded(rewriter, loc, op, tileA, tileB);
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2105,11 +2105,6 @@ static void emitTopkGroupStart(OpBuilder &rewriter, Location loc,
   rewriter.create<ttkernel::CopyTileInitOp>(loc, cbSrcVals);
   rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcVals, tileA, dst0);
   rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcVals, tileB, dst1);
-  // The index tiles are si32 while the value tiles are f32. copy_tile_init
-  // does NOT reconfigure the unpacker data format, so the unpacker is still
-  // set up for the f32 value CB. Without re-running init_sfpu for the index
-  // CB, the si32 index tiles get unpacked as f32 and decay to all zeros.
-  rewriter.create<ttkernel::InitSFPUOp>(loc, cbSrcIdx, cbOutVals);
   rewriter.create<ttkernel::CopyTileInitOp>(loc, cbSrcIdx);
   rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcIdx, tileA, dst2);
   rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcIdx, tileB, dst3);

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2192,8 +2192,8 @@ public:
 
     emitTopkGroupStartIfNeeded(rewriter, loc, op, tileA, tileB);
     rewriter.create<ttkernel::TopkLocalSortOp>(
-        loc, index(rewriter, loc, 0), op.getIdir(), i32(op.getIEndPhase()),
-        i32(op.getIStartPhase()));
+        loc, index(rewriter, loc, 0), i32(op.getIdir()), i32(op.getIEndPhase()),
+        op.getIStartPhase());
     emitTopkGroupEndIfNeeded(rewriter, loc, op, tileA, tileB);
 
     rewriter.eraseOp(op);

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2105,6 +2105,11 @@ static void emitTopkGroupStart(OpBuilder &rewriter, Location loc,
   rewriter.create<ttkernel::CopyTileInitOp>(loc, cbSrcVals);
   rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcVals, tileA, dst0);
   rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcVals, tileB, dst1);
+  // The index tiles are si32 while the value tiles are f32. copy_tile_init
+  // does NOT reconfigure the unpacker data format, so the unpacker is still
+  // set up for the f32 value CB. Without re-running init_sfpu for the index
+  // CB, the si32 index tiles get unpacked as f32 and decay to all zeros.
+  rewriter.create<ttkernel::InitSFPUOp>(loc, cbSrcIdx, cbOutVals);
   rewriter.create<ttkernel::CopyTileInitOp>(loc, cbSrcIdx);
   rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcIdx, tileA, dst2);
   rewriter.create<ttkernel::CopyTileOp>(loc, cbSrcIdx, tileB, dst3);

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2159,19 +2159,6 @@ static void emitTopkGroupStartIfNeeded(ConversionPatternRewriter &rewriter,
                        tileB);
     return;
   }
-  rewriter.create<scf::IfOp>(
-      loc, rfo,
-      /*thenBuilder=*/
-      [&](OpBuilder &b, Location l) {
-        b.create<ttkernel::UnpackStallOnPackOp>(l);
-        emitTopkGroupStart(b, l, cbOutVals, cbOutIdx, cbOutVals, tileA, tileB);
-        b.create<scf::YieldOp>(l);
-      },
-      /*elseBuilder=*/
-      [&](OpBuilder &b, Location l) {
-        emitTopkGroupStart(b, l, cbInVals, cbInIdx, cbOutVals, tileA, tileB);
-        b.create<scf::YieldOp>(l);
-      });
 }
 
 template <typename OpTy>
@@ -2188,14 +2175,6 @@ static void emitTopkGroupEndIfNeeded(ConversionPatternRewriter &rewriter,
   if (isGroupEndConst) {
     return;
   }
-  rewriter.create<scf::IfOp>(
-      loc, isGroupEnd,
-      /*thenBuilder=*/
-      [&](OpBuilder &b, Location l) {
-        emitTopkGroupEnd(b, l, getCB(rewriter, op.getOutValues()),
-                         getCB(rewriter, op.getOutIndices()), tileA, tileB);
-        b.create<scf::YieldOp>(l);
-      });
 }
 
 class D2MTopkLocalSortRewriter

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2147,6 +2147,18 @@ static void emitTopkGroupStartIfNeeded(ConversionPatternRewriter &rewriter,
   // rfo=true: T0 reads output CB tiles that T2 just wrote. Fence so T0 sees
   // all pack_tile L1 writes before copy_tile executes.
   Value rfo = op.getReadFromOutput();
+  std::optional<int64_t> rfoConst = getConstantIntValue(rfo);
+  if (rfoConst) {
+    if (*rfoConst) {
+      rewriter.create<ttkernel::UnpackStallOnPackOp>(loc);
+      emitTopkGroupStart(rewriter, loc, cbOutVals, cbOutIdx, cbOutVals, tileA,
+                         tileB);
+    } else {
+      emitTopkGroupStart(rewriter, loc, cbInVals, cbInIdx, cbOutVals, tileA,
+                         tileB);
+    }
+    return;
+  }
   rewriter.create<scf::IfOp>(
       loc, rfo,
       /*thenBuilder=*/
@@ -2167,6 +2179,14 @@ static void emitTopkGroupEndIfNeeded(ConversionPatternRewriter &rewriter,
                                      Location loc, OpTy op, Value tileA,
                                      Value tileB) {
   Value isGroupEnd = op.getIsGroupEnd();
+  std::optional<int64_t> isGroupEndConst = getConstantIntValue(isGroupEnd);
+  if (isGroupEndConst) {
+    if (*isGroupEndConst) {
+      emitTopkGroupEnd(rewriter, loc, getCB(rewriter, op.getOutValues()),
+                       getCB(rewriter, op.getOutIndices()), tileA, tileB);
+    }
+    return;
+  }
   rewriter.create<scf::IfOp>(
       loc, isGroupEnd,
       /*thenBuilder=*/

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3734,8 +3734,9 @@ public:
           op,
           "D2M topk requires at least 2 tiles along the reduction dimension");
     }
-    // For k>32, the reduction dim is padded to a power-of-2 tile count, so
-    // lastStride must use the padded count (not numReductionTiles/2).
+    // For k>32 with a non-pow2 tile count, the reduction dim is padded to the
+    // next power of 2, so lastStride must use the padded count (not
+    // numReductionTiles/2).
     int64_t p = 1;
     while (p < numReductionTiles) {
       p <<= 1;
@@ -3748,7 +3749,7 @@ public:
     int64_t paddedNumReductionTiles = (k > 32) ? nextPow2 : numReductionTiles;
     int64_t lastStride = paddedNumReductionTiles / 2;
 
-    // For large-k with a non-pow2 tile count, pad the logical input shape to
+    // For k>32 with a non-pow2 tile count, pad the logical input shape to
     // paddedNumReductionTiles*32 so GridSelection derives the correct tile
     // count, then mask the padding region with -inf so those tiles are never
     // top-k.
@@ -3897,9 +3898,6 @@ public:
                                   arangeScratchTileType, arangeScratchLayout)
             .getResult();
 
-    // Compute numElements from the padded logical shape: for C (column
-    // reduction), all output columns; for R (row reduction), all output rows.
-    // Padded positions are never selected since the value side is -inf.
     int64_t numElements =
         (dim == 0) ? topkLogicalShape[rank - 2] : topkLogicalShape[rank - 1];
 
@@ -4085,11 +4083,9 @@ public:
         rewriter, loc, ctx, topkIdxRelayouted, extractIdxLayout,
         extractProjectDim, outputReductionTiles, lastStride, dim);
 
-    // Typecast extracted fp32 indices to the output element type (uint16).
-    // Untilize is a pure layout op with no narrowing, so width must match;
-    // fp32 untilized into uint16 drops the high half. One tile op per region
-    // so D2M->TTKernel store/DST-index lookup finds a single terminal compute
-    // op.
+    // Typecast extracted fp32 indices to the output element type (uint16)
+    // before untilize. One tile op per region so D2M->TTKernel store/DST-index
+    // lookup finds a single terminal compute op.
     Value extractedIdx = extractIdxGeneric->getResult(0);
     auto extractedIdxType = cast<RankedTensorType>(extractedIdx.getType());
     Type idxOutElemType = indicesType.getElementType();

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3699,6 +3699,7 @@ public:
     assert(k <= 64 && "D2M topk only supports k <= 64");
     int32_t dim = op.getDim();
     int64_t rank = inputType.getRank();
+    const bool noCollapse = rank > 2;
     if (dim < 0) {
       dim += rank;
     }
@@ -3794,15 +3795,6 @@ public:
     auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
         loc, deviceShape, si32TileType, metalLayout);
 
-    ArrayRef<int64_t> gridShape = metalLayout.getGridShape(layoutedType);
-    SmallVector<int64_t> scratchShape(gridShape.begin(), gridShape.end());
-    scratchShape.append({1, 1});
-    auto scratchLayout = ttcore::MetalLayoutAttr::get(
-        ctx, SmallVector<int64_t>{1, 1}, ttcore::MemorySpace::DeviceL1,
-        ttcore::TensorMemoryLayout::Sharded);
-    auto scratchIdx = rewriter.create<d2m::EmptyOp>(
-        loc, scratchShape, si32TileType, scratchLayout);
-
     auto wrapInToLayout = [&](Value genericResult) -> Value {
       auto resultType = cast<RankedTensorType>(genericResult.getType());
       auto emptyOp = rewriter.create<d2m::EmptyOp>(loc, resultType.getShape(),
@@ -3817,13 +3809,16 @@ public:
     SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
     AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
 
-    // When dim=1, the sort dimension falls along tile rows, but TopkBlockOp
-    // operates on tile columns, so we transpose the tiles first.
-    Value topkInput = layoutedInput;
-    if (dim == 1) {
+    // Per-tile transpose helper: emits a generic whose region applies
+    // TileTransposeOp to every tile in the shard. Used for both the value input
+    // and the index buffer when dim==1 so the two stay in the same orientation.
+    auto transposeTiles = [&](Value src) -> Value {
+      auto srcType = cast<RankedTensorType>(src.getType());
+      auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
+      auto srcLayout = cast<ttcore::MetalLayoutAttr>(srcType.getEncoding());
       auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, deviceShape, f32TileType, metalLayout);
-      SmallVector<Value> transposeInputs = {layoutedInput};
+          loc, srcType.getShape(), srcTileType, srcLayout);
+      SmallVector<Value> transposeInputs = {src};
       SmallVector<Value> transposeOutputs = {transposeEmpty.getResult()};
       auto transposeGeneric = rewriter.create<d2m::GenericOp>(
           loc, transposeInputs, transposeOutputs,
@@ -3857,20 +3852,178 @@ public:
             return {linalgOp->getResult(0)};
           });
 
-      topkInput = wrapInToLayout(transposeGeneric->getResult(0));
+      return wrapInToLayout(transposeGeneric->getResult(0));
+    };
+
+    // When dim=1, the sort dimension falls along tile rows, but TopkBlockOp
+    // operates on tile columns, so we transpose the tiles first.
+    Value topkInput = layoutedInput;
+    if (dim == 1) {
+      topkInput = transposeTiles(layoutedInput);
     }
 
-    SmallVector<AffineExpr> zeroExprs(physicalRank,
-                                      rewriter.getAffineConstantExpr(0));
-    AffineMap constantMap = AffineMap::get(physicalRank, 0, zeroExprs, ctx);
+    // Setting up the arange op.
 
-    SmallVector<Value> topkInputs = {topkInput, scratchIdx.getResult()};
+    auto si32InputType = RankedTensorType::get(inputType.getShape(), si32Type,
+                                               inputType.getEncoding());
+    auto arangeOrigOutputs = createDpsOutputs(loc, rewriter, {si32InputType});
+    auto [arangeins, arangeOutputs] = toLayoutOperandsAndResults(
+        rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true, noCollapse);
+
+    // Create a scratch tile (copied from D2MArangeOpRewriter).
+    auto arangeOutput = arangeOutputs[0];
+    auto arangeTensorType =
+        mlir::cast<RankedTensorType>(arangeOutput.getType());
+    auto arangeLayout =
+        mlir::cast<ttcore::MetalLayoutAttr>(arangeTensorType.getEncoding());
+    auto arangeTileType =
+        mlir::cast<ttcore::TileType>(arangeTensorType.getElementType());
+    Type arangeElemType = arangeTileType.getElementType();
+    ArrayRef<int64_t> arangeGridShape =
+        arangeLayout.getGridShape(arangeTensorType);
+    SmallVector<int64_t> arangeScratchShape(arangeGridShape.begin(),
+                                            arangeGridShape.end());
+    arangeScratchShape.append({1, 1});
+    auto arangeScratchTileType = ttcore::TileType::get(arangeElemType);
+    auto arangeScratchLayout = ttcore::MetalLayoutAttr::get(
+        ctx, SmallVector<int64_t>{1, 1}, ttcore::MemorySpace::DeviceL1,
+        ttcore::TensorMemoryLayout::Sharded);
+    Value indexTileTensor =
+        rewriter
+            .create<d2m::EmptyOp>(loc, arangeScratchShape,
+                                  arangeScratchTileType, arangeScratchLayout)
+            .getResult();
+
+    // Compute numElements: for C (column reduction), we need all output
+    // columns; for R (row reduction), we need all output rows.
+    int64_t numElements = (dim == 0) ? inputType.getDimSize(rank - 2)
+                                     : inputType.getDimSize(rank - 1);
+
+    // Build affine maps: scratch input always at (0,0), output is identity.
+    AffineExpr zero = rewriter.getAffineConstantExpr(0);
+    AffineMap arangeConstMap =
+        AffineMap::get(physicalRank, 0, {zero, zero}, ctx);
+    AffineMap arangeIdentMap = rewriter.getMultiDimIdentityMap(physicalRank);
+    SmallVector<AffineMap> arangeMaps = {arangeConstMap, arangeIdentMap};
+
+    // All iterators are parallel for arange.
+    SmallVector<Attribute> arangeIters(
+        physicalRank,
+        ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
+
+    SmallVector<Value> arangeGenericInputs = {indexTileTensor};
+    auto arange = rewriter.create<d2m::GenericOp>(
+        loc, arangeGenericInputs, arangeOutputs,
+        /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(arangeMaps),
+        rewriter.getArrayAttr(arangeIters));
+
+    withD2MGenericRegion(
+        rewriter, loc, arange, arangeGenericInputs, arangeOutputs,
+        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+          Value idxTile = blockArgs[0];
+          Value outTile = blockArgs[1];
+          Value result = rewriter
+                             .create<d2m::ArangeBlockOp>(
+                                 loc, idxTile, outTile, numElements,
+                                 /*start=*/0,
+                                 /*step=*/1,
+                                 /*colMajor=*/(dim == 0))
+                             .getResult();
+          return {result};
+        });
+
+    // Setting up the broadcast after arange.
+
+    // Broadcast first row or column to full shape.
+    d2m::TileBcastType postArangeBcastType =
+        (dim == 1) ? d2m::TileBcastType::Row : d2m::TileBcastType::Col;
+    d2m::TileBcastTypeAttr postArangeBcastTypeAttr =
+        d2m::TileBcastTypeAttr::get(ctx, postArangeBcastType);
+    SmallVector<Value> postArangeBcastInputs(arange.getResults().begin(),
+                                             arange.getResults().end());
+    auto postArangeBcastOrigOutputs =
+        createDpsOutputs(loc, rewriter, {si32InputType});
+    auto [postArangeBcastins, postArangeBcastOutputs] =
+        toLayoutOperandsAndResults(
+            rewriter, {SmallVector<Value>{}, postArangeBcastOrigOutputs}, true,
+            noCollapse);
+
+    // Build affine maps: input is reduced, output is identity.
+    mlir::MutableAffineMap postArangeInMap(
+        rewriter.getMultiDimIdentityMap(physicalRank));
+    switch (postArangeBcastType) {
+    case d2m::TileBcastType::Row:
+      postArangeInMap.setResult(physicalRank - 2, zero);
+      break;
+    case d2m::TileBcastType::Col:
+      postArangeInMap.setResult(physicalRank - 1, zero);
+      break;
+    default:
+      break;
+    }
+    AffineMap postArangeBcastInputMap = postArangeInMap.getAffineMap();
+    AffineMap postArangeBcastOutputMap =
+        rewriter.getMultiDimIdentityMap(physicalRank);
+    SmallVector<AffineMap> postArangeBcastMaps = {postArangeBcastInputMap,
+                                                  postArangeBcastOutputMap};
+
+    SmallVector<Attribute> postArangeBcastIters(
+        physicalRank,
+        ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
+
+    d2m::GenericOp postArangeBcast = rewriter.create<d2m::GenericOp>(
+        loc, postArangeBcastInputs, postArangeBcastOutputs,
+        /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(postArangeBcastMaps),
+        rewriter.getArrayAttr(postArangeBcastIters));
+
+    withD2MGenericRegion(
+        rewriter, loc, postArangeBcast, postArangeBcastInputs,
+        postArangeBcastOutputs,
+        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+          Value input = blockArgs[0];
+          Value output = blockArgs[1];
+          std::size_t shardRank =
+              cast<RankedTensorType>(input.getType()).getRank();
+          AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
+          SmallVector<mlir::utils::IteratorType> linalgIters(
+              shardRank, mlir::utils::IteratorType::parallel);
+          auto linalgOp = rewriter.create<linalg::GenericOp>(
+              loc, output.getType(), input, output,
+              SmallVector<AffineMap>{shardIdentity, shardIdentity}, linalgIters,
+              [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                Value bcast = b.create<d2m::TileBcastOp>(
+                    bodyLoc, args[1].getType(), args[0],
+                    postArangeBcastTypeAttr);
+                b.create<linalg::YieldOp>(bodyLoc, bcast);
+              });
+          return {linalgOp->getResult(0)};
+        });
+
+    Value indexOperand = postArangeBcast->getResult(0);
+    Value idxBuf = wrapInToLayout(indexOperand);
+
+    // The value input is transposed per-tile for dim==1 (see topkInput above).
+    // TopkBlockOp reads the value tile and index tile in lockstep, element for
+    // element, so the index buffer must be in the SAME orientation as the value
+    // tiles. Apply the identical per-tile transpose to keep them aligned.
+    //
+    // For dim==1: arange+bcast yields idxBuf[row][col] = col (constant down
+    // each column). After the per-tile transpose, idxBufT_tile[i][j] =
+    // col_of(i) = tileCol*32 + i, i.e. the source column index now varies along
+    // the tile's row axis, matching where the transposed value tile expects it.
+    if (dim == 1) {
+      idxBuf = transposeTiles(idxBuf);
+    }
+
+    SmallVector<Value> topkInputs = {topkInput, idxBuf};
     SmallVector<Value> topkOutputs = {topkValsEmpty.getResult(),
                                       topkIdxEmpty.getResult()};
     auto topkGeneric = rewriter.create<d2m::GenericOp>(
         loc, topkInputs, topkOutputs, /*additionalArgs=*/ValueRange(),
         rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
-            identityMap, constantMap, identityMap, identityMap}),
+            identityMap, identityMap, identityMap, identityMap}),
         rewriter.getArrayAttr(iteratorTypes));
 
     withD2MGenericRegion(

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3710,15 +3710,16 @@ public:
 
     int64_t reductionDimSize = inputType.getShape()[dim];
 
-    // The value input's logical shape. When large-k pads the reduction dim to
-    // a power-of-2 tile count, this grows to match the arange/index buffer,
-    // since topk d2m.generic requires both operands to share a shard shape.
+    // Logical shape for the value input. When the reduction dim is padded to a
+    // power-of-2 tile count (for large-k cases), this shape grows to match the
+    // arange/index buffer, since topk d2m.generic requires compatible operand
+    // shapes.
     SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
                                           inputType.getShape().end());
 
-    Value layoutedInput = createOptimalLayoutOp(adaptor.getInputTensor(),
-                                                memorySpaces[0], /*tiled=*/true,
-                                                /*noCollapse=*/false, rewriter);
+    Value layoutedInput = createOptimalLayoutOp(
+        adaptor.getInputTensor(), memorySpaces[0], /*tiled=*/true,
+        /*noCollapse=*/false, rewriter, ttcore::OOBVal::NegInf);
     auto layoutedType = cast<RankedTensorType>(layoutedInput.getType());
     auto metalLayout =
         cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3699,7 +3699,6 @@ public:
     assert(k <= 64 && "D2M topk only supports k <= 64");
     int32_t dim = op.getDim();
     int64_t rank = inputType.getRank();
-    const bool noCollapse = rank > 2;
     if (dim < 0) {
       dim += rank;
     }
@@ -3710,6 +3709,12 @@ public:
     }
 
     int64_t reductionDimSize = inputType.getShape()[dim];
+
+    // The value input's logical shape. When large-k pads the reduction dim to
+    // a power-of-2 tile count, this grows to match the arange/index buffer,
+    // since topk d2m.generic requires both operands to share a shard shape.
+    SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
+                                          inputType.getShape().end());
 
     Value layoutedInput = createOptimalLayoutOp(adaptor.getInputTensor(),
                                                 memorySpaces[0], /*tiled=*/true,
@@ -3785,7 +3790,7 @@ public:
       layoutedType = cast<RankedTensorType>(layoutedInput.getType());
       metalLayout = cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
       deviceShape = layoutedType.getShape();
-      numReductionTiles = paddedNumReductionTiles;
+      topkLogicalShape[dim] = paddedDimElems;
     }
 
     Type si32Type = IntegerType::get(ctx, 32, IntegerType::Signed);
@@ -3809,9 +3814,9 @@ public:
     SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
     AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
 
-    // Per-tile transpose helper: emits a generic whose region applies
-    // TileTransposeOp to every tile in the shard. Used for both the value input
-    // and the index buffer when dim==1 so the two stay in the same orientation.
+    // Emits a generic that applies TileTransposeOp to every tile in the shard.
+    // Used for both value and index when dim==1 to keep them in the same
+    // orientation.
     auto transposeTiles = [&](Value src) -> Value {
       auto srcType = cast<RankedTensorType>(src.getType());
       auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
@@ -3864,11 +3869,12 @@ public:
 
     // Setting up the arange op.
 
-    auto si32InputType = RankedTensorType::get(inputType.getShape(), si32Type,
+    auto si32InputType = RankedTensorType::get(topkLogicalShape, si32Type,
                                                inputType.getEncoding());
     auto arangeOrigOutputs = createDpsOutputs(loc, rewriter, {si32InputType});
     auto [arangeins, arangeOutputs] = toLayoutOperandsAndResults(
-        rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true, noCollapse);
+        rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true,
+        /*noCollapse=*/false);
 
     // Create a scratch tile (copied from D2MArangeOpRewriter).
     auto arangeOutput = arangeOutputs[0];
@@ -3894,10 +3900,11 @@ public:
                                   arangeScratchTileType, arangeScratchLayout)
             .getResult();
 
-    // Compute numElements: for C (column reduction), we need all output
-    // columns; for R (row reduction), we need all output rows.
-    int64_t numElements = (dim == 0) ? inputType.getDimSize(rank - 2)
-                                     : inputType.getDimSize(rank - 1);
+    // Compute numElements from the padded logical shape: for C (column
+    // reduction), all output columns; for R (row reduction), all output rows.
+    // Padded positions are never selected since the value side is -inf.
+    int64_t numElements =
+        (dim == 0) ? topkLogicalShape[rank - 2] : topkLogicalShape[rank - 1];
 
     // Build affine maps: scratch input always at (0,0), output is identity.
     AffineExpr zero = rewriter.getAffineConstantExpr(0);
@@ -3947,7 +3954,7 @@ public:
     auto [postArangeBcastins, postArangeBcastOutputs] =
         toLayoutOperandsAndResults(
             rewriter, {SmallVector<Value>{}, postArangeBcastOrigOutputs}, true,
-            noCollapse);
+            /*noCollapse=*/false);
 
     // Build affine maps: input is reduced, output is identity.
     mlir::MutableAffineMap postArangeInMap(
@@ -3985,13 +3992,33 @@ public:
           Value input = blockArgs[0];
           Value output = blockArgs[1];
           std::size_t shardRank =
-              cast<RankedTensorType>(input.getType()).getRank();
+              cast<RankedTensorType>(output.getType()).getRank();
+          // Reuse the outer d2m.generic's projecting maps (input map zeroes the
+          // broadcast axis). An identity map would make linalg infer the
+          // broadcast-axis extent from the iteration domain, mismatching the
+          // collapsed input shard when the non-target dim spans >1 tile (e.g.
+          // ht=2 for dim=1).
+          mlir::MutableAffineMap shardInMap(
+              rewriter.getMultiDimIdentityMap(shardRank));
+          switch (postArangeBcastType) {
+          case d2m::TileBcastType::Row:
+            shardInMap.setResult(shardRank - 2,
+                                 rewriter.getAffineConstantExpr(0));
+            break;
+          case d2m::TileBcastType::Col:
+            shardInMap.setResult(shardRank - 1,
+                                 rewriter.getAffineConstantExpr(0));
+            break;
+          default:
+            break;
+          }
+          AffineMap shardInputMap = shardInMap.getAffineMap();
           AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
           SmallVector<mlir::utils::IteratorType> linalgIters(
               shardRank, mlir::utils::IteratorType::parallel);
           auto linalgOp = rewriter.create<linalg::GenericOp>(
               loc, output.getType(), input, output,
-              SmallVector<AffineMap>{shardIdentity, shardIdentity}, linalgIters,
+              SmallVector<AffineMap>{shardInputMap, shardIdentity}, linalgIters,
               [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
                 Value bcast = b.create<d2m::TileBcastOp>(
                     bodyLoc, args[1].getType(), args[0],
@@ -4004,15 +4031,10 @@ public:
     Value indexOperand = postArangeBcast->getResult(0);
     Value idxBuf = wrapInToLayout(indexOperand);
 
-    // The value input is transposed per-tile for dim==1 (see topkInput above).
-    // TopkBlockOp reads the value tile and index tile in lockstep, element for
-    // element, so the index buffer must be in the SAME orientation as the value
-    // tiles. Apply the identical per-tile transpose to keep them aligned.
-    //
-    // For dim==1: arange+bcast yields idxBuf[row][col] = col (constant down
-    // each column). After the per-tile transpose, idxBufT_tile[i][j] =
-    // col_of(i) = tileCol*32 + i, i.e. the source column index now varies along
-    // the tile's row axis, matching where the transposed value tile expects it.
+    // TopkBlockOp reads value and index tiles in lockstep, so transpose the
+    // index buffer the same way as the value input for dim==1. For dim==1,
+    // arange+bcast yields idxBuf[row][col] = col, so after transpose the
+    // column index varies along the tile's row axis, matching the value tile.
     if (dim == 1) {
       idxBuf = transposeTiles(idxBuf);
     }
@@ -4038,10 +4060,9 @@ public:
     Value topkValsRelayouted = wrapInToLayout(topkGeneric->getResult(0));
     Value topkIdxRelayouted = wrapInToLayout(topkGeneric->getResult(1));
 
-    // The index extract operates on the si32 topk index tiles; a typecast
-    // generic below converts the extracted si32 indices to the user index
-    // output element type (e.g. ui16) so the final untilize is
-    // width-preserving.
+    // Index extract uses si32 topk tiles; a typecast generic below converts
+    // to the user index output element type (uint16) for width-preserving
+    // untilize.
     auto si32IndicesType =
         RankedTensorType::get(indicesType.getShape(), si32Type);
 
@@ -4067,14 +4088,11 @@ public:
         rewriter, loc, ctx, topkIdxRelayouted, extractIdxLayout,
         extractProjectDim, outputReductionTiles, lastStride, dim);
 
-    // Typecast the extracted si32 indices to the user index output element type
-    // (e.g. ui16). The element width MUST match the output: the final untilize
-    // is a pure layout op (tiled->row-major) with no numeric narrowing, so an
-    // si32 index tile untilized into a ui16 buffer drops the high half and
-    // zeroes small indices. Casting to the output width here keeps untilize a
-    // width-preserving copy. Modeled on the standalone transpose generic above:
-    // one tile op per region so the D2M->TTKernel store/DST-index lookup finds
-    // a single terminal compute op.
+    // Typecast extracted si32 indices to the output element type (uint16).
+    // Untilize is a pure layout op with no narrowing, so width must match;
+    // si32 untilized into uint16 drops the high half. One tile op per region
+    // so D2M->TTKernel store/DST-index lookup finds a single terminal compute
+    // op.
     Value extractedIdx = extractIdxGeneric->getResult(0);
     auto extractedIdxType = cast<RankedTensorType>(extractedIdx.getType());
     Type idxOutElemType = indicesType.getElementType();

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3738,14 +3738,9 @@ public:
     // For k>32 with a non-pow2 tile count, the reduction dim is padded to the
     // next power of 2, so lastStride must use the padded count (not
     // numReductionTiles/2).
-    int64_t p = 1;
-    while (p < numReductionTiles) {
-      p <<= 1;
-    }
-    int64_t nextPow2 = p;
-    if (numReductionTiles <= 0 ||
-        (numReductionTiles & (numReductionTiles - 1)) == 0) {
-      nextPow2 = numReductionTiles;
+    int64_t nextPow2 = 1;
+    while (nextPow2 < numReductionTiles) {
+      nextPow2 <<= 1;
     }
     int64_t paddedNumReductionTiles = (k > 32) ? nextPow2 : numReductionTiles;
     int64_t lastStride = paddedNumReductionTiles / 2;

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3736,16 +3736,14 @@ public:
     }
     // For k>32, the reduction dim is padded to a power-of-2 tile count, so
     // lastStride must use the padded count (not numReductionTiles/2).
-    int64_t nextPow2;
+    int64_t p = 1;
+    while (p < numReductionTiles) {
+      p <<= 1;
+    }
+    int64_t nextPow2 = p;
     if (numReductionTiles <= 0 ||
         (numReductionTiles & (numReductionTiles - 1)) == 0) {
       nextPow2 = numReductionTiles;
-    } else {
-      int64_t p = 1;
-      while (p < numReductionTiles) {
-        p <<= 1;
-      }
-      nextPow2 = p;
     }
     int64_t paddedNumReductionTiles = (k > 32) ? nextPow2 : numReductionTiles;
     int64_t lastStride = paddedNumReductionTiles / 2;
@@ -3793,12 +3791,11 @@ public:
       topkLogicalShape[dim] = paddedDimElems;
     }
 
-    Type si32Type = IntegerType::get(ctx, 32, IntegerType::Signed);
-    auto si32TileType = ttcore::TileType::get(si32Type, f32TileType.getShape());
+    Type f32Type = f32TileType.getElementType();
     auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(
         loc, deviceShape, f32TileType, metalLayout);
-    auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
-        loc, deviceShape, si32TileType, metalLayout);
+    auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(loc, deviceShape,
+                                                      f32TileType, metalLayout);
 
     auto wrapInToLayout = [&](Value genericResult) -> Value {
       auto resultType = cast<RankedTensorType>(genericResult.getType());
@@ -3869,9 +3866,9 @@ public:
 
     // Setting up the arange op.
 
-    auto si32InputType = RankedTensorType::get(topkLogicalShape, si32Type,
-                                               inputType.getEncoding());
-    auto arangeOrigOutputs = createDpsOutputs(loc, rewriter, {si32InputType});
+    auto f32InputType = RankedTensorType::get(topkLogicalShape, f32Type,
+                                              inputType.getEncoding());
+    auto arangeOrigOutputs = createDpsOutputs(loc, rewriter, {f32InputType});
     auto [arangeins, arangeOutputs] = toLayoutOperandsAndResults(
         rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true,
         /*noCollapse=*/false);
@@ -3950,7 +3947,7 @@ public:
     SmallVector<Value> postArangeBcastInputs(arange.getResults().begin(),
                                              arange.getResults().end());
     auto postArangeBcastOrigOutputs =
-        createDpsOutputs(loc, rewriter, {si32InputType});
+        createDpsOutputs(loc, rewriter, {f32InputType});
     auto [postArangeBcastins, postArangeBcastOutputs] =
         toLayoutOperandsAndResults(
             rewriter, {SmallVector<Value>{}, postArangeBcastOrigOutputs}, true,
@@ -4060,16 +4057,16 @@ public:
     Value topkValsRelayouted = wrapInToLayout(topkGeneric->getResult(0));
     Value topkIdxRelayouted = wrapInToLayout(topkGeneric->getResult(1));
 
-    // Index extract uses si32 topk tiles; a typecast generic below converts
+    // Index extract uses fp32 topk tiles; a typecast generic below converts
     // to the user index output element type (uint16) for width-preserving
     // untilize.
-    auto si32IndicesType =
-        RankedTensorType::get(indicesType.getShape(), si32Type);
+    auto f32IndicesType =
+        RankedTensorType::get(indicesType.getShape(), f32Type);
 
     SmallVector<Value> origValOutputs =
         createDpsOutputs(loc, rewriter, {valuesType});
     SmallVector<Value> origIdxOutputs =
-        createDpsOutputs(loc, rewriter, {si32IndicesType});
+        createDpsOutputs(loc, rewriter, {f32IndicesType});
     Value extractValsLayout = createOptimalLayoutOp(
         origValOutputs[0], memorySpaces[1], /*tiled=*/true,
         /*noCollapse=*/false, rewriter);
@@ -4088,9 +4085,9 @@ public:
         rewriter, loc, ctx, topkIdxRelayouted, extractIdxLayout,
         extractProjectDim, outputReductionTiles, lastStride, dim);
 
-    // Typecast extracted si32 indices to the output element type (uint16).
+    // Typecast extracted fp32 indices to the output element type (uint16).
     // Untilize is a pure layout op with no narrowing, so width must match;
-    // si32 untilized into uint16 drops the high half. One tile op per region
+    // fp32 untilized into uint16 drops the high half. One tile op per region
     // so D2M->TTKernel store/DST-index lookup finds a single terminal compute
     // op.
     Value extractedIdx = extractIdxGeneric->getResult(0);

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3737,16 +3737,64 @@ public:
           op,
           "D2M topk requires at least 2 tiles along the reduction dimension");
     }
-    auto isPowerOfTwo = [](int64_t x) { return x > 0 && (x & (x - 1)) == 0; };
-    if (!isPowerOfTwo(numReductionTiles)) {
-      return rewriter.notifyMatchFailure(
-          op, "D2M topk requires reduction dim tile count to be a power of 2");
+    // For k>32, the reduction dim is padded to a power-of-2 tile count, so
+    // lastStride must use the padded count (not numReductionTiles/2).
+    int64_t nextPow2;
+    if (numReductionTiles <= 0 ||
+        (numReductionTiles & (numReductionTiles - 1)) == 0) {
+      nextPow2 = numReductionTiles;
+    } else {
+      int64_t p = 1;
+      while (p < numReductionTiles) {
+        p <<= 1;
+      }
+      nextPow2 = p;
     }
-    // After the merge tree, the top-k result occupies tile 0 (winner) and,
-    // for k>32, tile numReductionTiles/2 (the last loser tile, which holds the
-    // second half of the top-k). The lastStride variable stores the index of
-    // that second tile.
-    int64_t lastStride = numReductionTiles / 2;
+    int64_t paddedNumReductionTiles = (k > 32) ? nextPow2 : numReductionTiles;
+    int64_t lastStride = paddedNumReductionTiles / 2;
+
+    // For large-k with a non-pow2 tile count, pad the logical input shape to
+    // paddedNumReductionTiles*32 so GridSelection derives the correct tile
+    // count, then mask the padding region with -inf so those tiles are never
+    // top-k.
+    if (paddedNumReductionTiles != numReductionTiles) {
+      constexpr int64_t kTileDim = 32;
+      int64_t paddedDimElems = paddedNumReductionTiles * kTileDim;
+
+      // Build a padded logical type with the reduction dim grown to
+      // paddedDimElems.
+      SmallVector<int64_t> paddedLogicalShape(inputType.getShape().begin(),
+                                              inputType.getShape().end());
+      paddedLogicalShape[dim] = paddedDimElems;
+      auto paddedLogicalType =
+          RankedTensorType::get(paddedLogicalShape, inputType.getElementType());
+
+      Value paddedLayouted = createOptimalLayoutOp(
+          adaptor.getInputTensor(), memorySpaces[0], /*tiled=*/true,
+          /*noCollapse=*/false, rewriter, ttcore::OOBVal::Undef,
+          paddedLogicalType);
+
+      // Mask with the real logical shape so padding cols/rows get -inf.
+      auto paddedLayoutedType =
+          cast<RankedTensorType>(paddedLayouted.getType());
+      auto maskOutput =
+          rewriter.create<d2m::EmptyOp>(loc, paddedLayoutedType.getShape(),
+                                        paddedLayoutedType.getElementType(),
+                                        paddedLayoutedType.getEncoding());
+      SmallVector<int64_t> realLogicalShape(inputType.getShape().begin(),
+                                            inputType.getShape().end());
+      paddedLayouted =
+          rewriter
+              .create<d2m::MaskOp>(loc, paddedLayouted, maskOutput,
+                                   realLogicalShape, ttcore::OOBVal::NegInf)
+              .getResult();
+
+      layoutedInput = paddedLayouted;
+      layoutedType = cast<RankedTensorType>(layoutedInput.getType());
+      metalLayout = cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
+      deviceShape = layoutedType.getShape();
+      numReductionTiles = paddedNumReductionTiles;
+    }
 
     Type si32Type = IntegerType::get(ctx, 32, IntegerType::Signed);
     auto si32TileType = ttcore::TileType::get(si32Type, f32TileType.getShape());

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3722,15 +3722,6 @@ public:
 
     int64_t ht = deviceShape[deviceShape.size() - 2];
     int64_t wt = deviceShape[deviceShape.size() - 1];
-    if (dim == 1 && ht != 1) {
-      return rewriter.notifyMatchFailure(
-          op, "D2M topk dim=1 requires input height = 32 (Ht=1)");
-    }
-    if (dim == 0 && wt != 1) {
-      return rewriter.notifyMatchFailure(
-          op, "D2M topk dim=0 requires input width = 32 (Wt=1)");
-    }
-
     int64_t numReductionTiles = (dim == 1) ? wt : ht;
     if (numReductionTiles < 2) {
       return rewriter.notifyMatchFailure(
@@ -3894,10 +3885,17 @@ public:
     Value topkValsRelayouted = wrapInToLayout(topkGeneric->getResult(0));
     Value topkIdxRelayouted = wrapInToLayout(topkGeneric->getResult(1));
 
+    // The index extract operates on the si32 topk index tiles; a typecast
+    // generic below converts the extracted si32 indices to the user index
+    // output element type (e.g. ui16) so the final untilize is
+    // width-preserving.
+    auto si32IndicesType =
+        RankedTensorType::get(indicesType.getShape(), si32Type);
+
     SmallVector<Value> origValOutputs =
         createDpsOutputs(loc, rewriter, {valuesType});
     SmallVector<Value> origIdxOutputs =
-        createDpsOutputs(loc, rewriter, {indicesType});
+        createDpsOutputs(loc, rewriter, {si32IndicesType});
     Value extractValsLayout = createOptimalLayoutOp(
         origValOutputs[0], memorySpaces[1], /*tiled=*/true,
         /*noCollapse=*/false, rewriter);
@@ -3916,10 +3914,61 @@ public:
         rewriter, loc, ctx, topkIdxRelayouted, extractIdxLayout,
         extractProjectDim, outputReductionTiles, lastStride, dim);
 
+    // Typecast the extracted si32 indices to the user index output element type
+    // (e.g. ui16). The element width MUST match the output: the final untilize
+    // is a pure layout op (tiled->row-major) with no numeric narrowing, so an
+    // si32 index tile untilized into a ui16 buffer drops the high half and
+    // zeroes small indices. Casting to the output width here keeps untilize a
+    // width-preserving copy. Modeled on the standalone transpose generic above:
+    // one tile op per region so the D2M->TTKernel store/DST-index lookup finds
+    // a single terminal compute op.
+    Value extractedIdx = extractIdxGeneric->getResult(0);
+    auto extractedIdxType = cast<RankedTensorType>(extractedIdx.getType());
+    Type idxOutElemType = indicesType.getElementType();
+    auto extractIdxTileType =
+        cast<ttcore::TileType>(extractedIdxType.getElementType());
+    auto idxCastTileType =
+        ttcore::TileType::get(idxOutElemType, extractIdxTileType.getShape());
+    auto idxCastEmpty = rewriter.create<d2m::EmptyOp>(
+        loc, extractedIdxType.getShape(), idxCastTileType,
+        extractedIdxType.getEncoding());
+    SmallVector<Value> castInputs = {extractedIdx};
+    SmallVector<Value> castOutputs = {idxCastEmpty.getResult()};
+    std::size_t castRank = extractedIdxType.getShape().size() / 2;
+    AffineMap castIdentity = rewriter.getMultiDimIdentityMap(castRank);
+    SmallVector<Attribute> castIters(
+        castRank,
+        ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
+    auto idxCastGeneric = rewriter.create<d2m::GenericOp>(
+        loc, castInputs, castOutputs, /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(
+            SmallVector<AffineMap>{castIdentity, castIdentity}),
+        rewriter.getArrayAttr(castIters));
+    withD2MGenericRegion(
+        rewriter, loc, idxCastGeneric, castInputs, castOutputs,
+        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+          Value input = blockArgs[0];
+          Value output = blockArgs[1];
+          std::size_t shardRank =
+              cast<RankedTensorType>(input.getType()).getRank();
+          AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
+          SmallVector<mlir::utils::IteratorType> linalgIters(
+              shardRank, mlir::utils::IteratorType::parallel);
+          auto linalgOp = rewriter.create<linalg::GenericOp>(
+              loc, output.getType(), input, output,
+              SmallVector<AffineMap>{shardIdentity, shardIdentity}, linalgIters,
+              [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                Value casted = b.create<d2m::TileTypecastOp>(
+                    bodyLoc, args[1].getType(), args[0]);
+                b.create<linalg::YieldOp>(bodyLoc, casted);
+              });
+          return {linalgOp->getResult(0)};
+        });
+
     Operation *valResult =
         unLayoutResult(rewriter, extractValsGeneric->getResult(0), valuesType);
     Operation *idxResult =
-        unLayoutResult(rewriter, extractIdxGeneric->getResult(0), indicesType);
+        unLayoutResult(rewriter, idxCastGeneric->getResult(0), indicesType);
 
     rewriter.replaceOp(op, {valResult->getResult(0), idxResult->getResult(0)});
     return success();

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -79,7 +79,8 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     // The reduction dim is padded to a power-of-2 tile count in TTIRToD2M
     // (-inf fill), so the large-k path always sees a power-of-2 tile count.
     bool useLargeK = (k > 32);
-    int64_t numTilesInner = inputShape[op.getDim()];
+    int64_t dimIdx = op.getDim();
+    int64_t numTilesInner = inputShape[dimIdx];
     // logWt is the merge-tree depth; ceilLog2 ensures the final fold always
     // runs for non-power-of-2 tile counts.
     bool numTilesPow2 =
@@ -87,6 +88,18 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     int32_t fl = floorLog2(numTilesInner);
     int32_t logWt = numTilesPow2 ? fl : fl + 1;
     bool ragged = !numTilesPow2;
+
+    // The shard is row-major [htShard, wtShard]; flat(nt, r) =
+    // r*reductionStride
+    // + nt*ntStride, where strides depend on which dim is the reduction dim.
+    int64_t ntDimIdx = (dimIdx == (int64_t)inputShape.size() - 1)
+                           ? (int64_t)inputShape.size() - 2
+                           : (int64_t)inputShape.size() - 1;
+    int64_t nonTargetCount = inputShape[ntDimIdx];
+    int64_t reductionStride =
+        (dimIdx == (int64_t)inputShape.size() - 1) ? 1 : nonTargetCount;
+    int64_t ntStride =
+        (dimIdx == (int64_t)inputShape.size() - 1) ? numTilesInner : 1;
 
     auto i32Attr = [&](int32_t v) { return rewriter.getI32IntegerAttr(v); };
     auto boolAttr = [&](bool v) { return rewriter.getBoolAttr(v); };
@@ -104,6 +117,30 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     auto i1Val = [&](bool v) -> Value {
       return rewriter.create<arith::ConstantOp>(
           loc, rewriter.getIntegerAttr(rewriter.getI1Type(), v ? 1 : 0));
+    };
+
+    Value zeroIdx = idxVal(0);
+    Value oneIdx = idxVal(1);
+    Value zeroI32 = i32Val(0);
+    Value trueVal = i1Val(true);
+    Value falseVal = i1Val(false);
+    Value numTilesIdx = idxVal(numTilesInner);
+    Value logWtIdx = idxVal(logWt);
+
+    Value reductionStrideIdx = idxVal(reductionStride);
+    Value ntStrideIdx = idxVal(ntStride);
+
+    // Each non-target row runs an independent merge tree with its tile indices
+    // offset by ntOffset.
+    auto ntLoop = rewriter.create<scf::ForOp>(loc, zeroIdx,
+                                              idxVal(nonTargetCount), oneIdx);
+    rewriter.setInsertionPointToStart(ntLoop.getBody());
+    Value ntIdxVar = ntLoop.getInductionVar();
+    Value ntOffset = rewriter.create<arith::MulIOp>(loc, ntIdxVar, ntStrideIdx);
+
+    auto flat = [&](Value r) -> Value {
+      Value scaled = rewriter.create<arith::MulIOp>(loc, r, reductionStrideIdx);
+      return rewriter.create<arith::AddIOp>(loc, scaled, ntOffset);
     };
 
     // Emit local_sort + merge + rebuild for the large-k path. The rebuild
@@ -128,14 +165,6 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
           tB, boolAttr(false), /*is_group_end=*/i1Val(true), rfo);
     };
 
-    Value zeroIdx = idxVal(0);
-    Value oneIdx = idxVal(1);
-    Value zeroI32 = i32Val(0);
-    Value trueVal = i1Val(true);
-    Value falseVal = i1Val(false);
-    Value numTilesIdx = idxVal(numTilesInner);
-    Value logWtIdx = idxVal(logWt);
-
     auto outerLoop =
         rewriter.create<scf::ForOp>(loc, zeroIdx, logWtIdx, oneIdx);
     rewriter.setInsertionPointToStart(outerLoop.getBody());
@@ -153,9 +182,13 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
         rewriter.create<scf::ForOp>(loc, zeroIdx, innerUB, innerStep);
     rewriter.setInsertionPointToStart(innerLoop.getBody());
 
+    // rA/rB are raw reduction indices; tileA/tileB are flat after adding
+    // ntOffset.
     Value baseIdx = innerLoop.getInductionVar();
-    Value tileA = baseIdx;
-    Value tileB = rewriter.create<arith::AddIOp>(loc, baseIdx, distanceIdx);
+    Value rA = baseIdx;
+    Value rB = rewriter.create<arith::AddIOp>(loc, baseIdx, distanceIdx);
+    Value tileA = flat(rA);
+    Value tileB = flat(rB);
 
     if (useLargeK) {
       // The first iteration performs a single sort-merge-rebuild. In later
@@ -179,6 +212,12 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
       Value prevDistIdx =
           rewriter.create<arith::ShRUIOp>(loc, distanceIdx, oneIdx);
 
+      // Loser indices derive from rA/rB to avoid double-applying the ntOffset.
+      Value rALoser = rewriter.create<arith::AddIOp>(loc, rA, prevDistIdx);
+      Value rBLoser = rewriter.create<arith::AddIOp>(loc, rB, prevDistIdx);
+      Value tileALoser = flat(rALoser);
+      Value tileBLoser = flat(rBLoser);
+
       // Step 1: Merge the winner tiles (tileA, tileB) from the previous
       // iteration; tileA holds the best-k across both afterward.
       emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
@@ -186,12 +225,8 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
                            /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
                            /*skipSecond=*/0, /*rfo=*/trueVal);
 
-      // Step 2: Merge the loser tiles; (tileA+prevDist) holds the best-k
+      // Step 2: Merge the loser tiles; (tileALoser) holds the best-k
       // across both losers afterward.
-      Value tileALoser =
-          rewriter.create<arith::AddIOp>(loc, tileA, prevDistIdx);
-      Value tileBLoser =
-          rewriter.create<arith::AddIOp>(loc, tileB, prevDistIdx);
       emitSortMergeRebuild(tileALoser, tileBLoser, /*mergeK=*/k, /*rebuildK=*/k,
                            logk, /*sortStartPhase=*/zeroI32,
                            /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
@@ -225,10 +260,9 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
           rewriter.create<arith::XOrIOp>(loc, needsRebuild, trueVal);
 
       // For ragged N, tileB may be out of bounds at the last level, so guard
-      // the sort+merge+rebuild with a bounds check; unpaired tiles are carried
-      // forward from the previous level. On the ragged path, always use
-      // sortStartPhase=0 since carried tiles may have skipped levels and need a
-      // full sort.
+      // the sort+merge+rebuild with a bounds check on rB (not the flat tileB).
+      // On the ragged path, always use sortStartPhase=0 since carried tiles may
+      // have skipped levels and need a full sort.
       Value sortStartPhase = ragged ? i32Val(0) : mIterI32;
 
       auto emitSortMergeRebuildSmallK = [&]() {
@@ -256,9 +290,11 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
       };
 
       if (ragged) {
-        Value tileBInBounds = rewriter.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::ult, tileB, numTilesIdx);
-        auto mergeIf = rewriter.create<scf::IfOp>(loc, tileBInBounds,
+        // Guard on rB (the raw reduction index) rather than the flat tile
+        // index.
+        Value rBInBounds = rewriter.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::ult, rB, numTilesIdx);
+        auto mergeIf = rewriter.create<scf::IfOp>(loc, rBInBounds,
                                                   /*withElseRegion=*/false);
         rewriter.setInsertionPointToStart(mergeIf.thenBlock());
         emitSortMergeRebuildSmallK();
@@ -275,7 +311,8 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     // using tileB=tileA (sorts the same tile twice, harmlessly) so it is a
     // valid sorted run before level 1 tries to pair it.
     if (ragged && (numTilesInner % 2 == 1) && !useLargeK) {
-      Value tailTileIdx = idxVal(numTilesInner - 1);
+      Value tailRawIdx = idxVal(numTilesInner - 1);
+      Value tailTileIdx = flat(tailRawIdx);
       Value isLevelZero = rewriter.create<arith::CmpIOp>(
           loc, arith::CmpIPredicate::eq, mIterIdx, zeroIdx);
       auto tailSortIf = rewriter.create<scf::IfOp>(loc, isLevelZero,
@@ -291,6 +328,7 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     }
 
     rewriter.setInsertionPointAfter(outerLoop);
+    rewriter.setInsertionPointAfter(ntLoop);
 
     rewriter.replaceOp(op, {outValues, outIndices});
     return success();

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -9,6 +9,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -27,8 +28,8 @@ static int32_t floorLog2(T n) {
   return result;
 }
 
-// Decomposes TopkBlockOp into arange_block and
-// tile_topk_{local_sort,merge,rebuild} ops.
+// Decomposes TopkBlockOp into arange_block +
+// tile_topk_{local_sort,merge,rebuild} ops with scf.for loops over tile pairs.
 struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
   using OpRewritePattern<TopkBlockOp>::OpRewritePattern;
 
@@ -48,7 +49,6 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
                "input must have at least 2 dimensions");
 
     int64_t numElements = op.getNumElements();
-    int32_t dim = op.getDim();
     int32_t k = op.getK();
 
     auto tileType = cast<ttcore::TileType>(inputType.getElementType());
@@ -75,7 +75,7 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
 
     int32_t logk = floorLog2(k);
 
-    int64_t numTilesInner = inputShape[dim];
+    int64_t numTilesInner = inputShape[op.getDim()];
     // logWt is the number of merge-tree iterations. Each iteration doubles the
     // distance between paired tiles, so numTilesInner must be a power of 2.
     int32_t logWt = floorLog2(numTilesInner);
@@ -84,93 +84,164 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     bool useLargeK = (k > 32);
 
     auto i32Attr = [&](int32_t v) { return rewriter.getI32IntegerAttr(v); };
-    auto i64Attr = [&](int64_t v) { return rewriter.getI64IntegerAttr(v); };
     auto boolAttr = [&](bool v) { return rewriter.getBoolAttr(v); };
 
-    // Emit the local_sort, merge, and rebuild stages.
-    auto emitSortMergeRebuild = [&](int64_t tA, int64_t tB, int32_t mK,
-                                    int32_t mLogk, int32_t mIter,
-                                    int32_t skipSecond, bool rfo) {
-      rewriter.create<TileTopkLocalSortOp>(
-          loc, inputValues, bufIdxFilled, outValues, outIndices, i32Attr(0),
-          i32Attr(mLogk - 1), i32Attr(0), i64Attr(tA), i64Attr(tB),
-          boolAttr(true), boolAttr(false), boolAttr(rfo));
-      rewriter.create<TileTopkMergeOp>(
-          loc, inputValues, bufIdxFilled, outValues, outIndices, i32Attr(mIter),
-          i32Attr(mK), i64Attr(tA), i64Attr(tB), boolAttr(false),
-          boolAttr(false), boolAttr(rfo));
-      rewriter.create<TileTopkRebuildOp>(
-          loc, inputValues, bufIdxFilled, outValues, outIndices, i32Attr(0),
-          i32Attr(mIter), i32Attr(mK), i32Attr(mLogk), i32Attr(skipSecond),
-          i64Attr(tA), i64Attr(tB), boolAttr(false), boolAttr(true),
-          boolAttr(rfo));
+    // Helper to create index-typed SSA constants.
+    auto idxVal = [&](int64_t v) -> Value {
+      return rewriter.create<arith::ConstantIndexOp>(loc, v);
+    };
+    // Helper to create i32-typed SSA constants.
+    auto i32Val = [&](int32_t v) -> Value {
+      return rewriter.create<arith::ConstantOp>(loc,
+                                                rewriter.getI32IntegerAttr(v));
+    };
+    // Helper to create i1-typed SSA constants.
+    auto i1Val = [&](bool v) -> Value {
+      return rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getIntegerAttr(rewriter.getI1Type(), v ? 1 : 0));
     };
 
-    for (int32_t mIter = 0; mIter < logWt; ++mIter) {
-      bool isFirst = (mIter == 0);
-      bool isLast = (mIter == logWt - 1);
-      int64_t distance = 1LL << mIter;
-      bool readFromOutput = !isFirst;
+    // Emit local_sort + merge + rebuild for the large-k path. The rebuild
+    // always runs here (is_group_end=true), so the merge never packs
+    // (is_group_end=false).
+    auto emitSortMergeRebuild = [&](Value tA, Value tB, int32_t mergeK,
+                                    int32_t rebuildK, int32_t mLogk,
+                                    Value sortStartPhase, int32_t sortEndPhase,
+                                    Value mergeIter, int32_t skipSecond,
+                                    Value rfo) {
+      rewriter.create<TileTopkLocalSortOp>(
+          loc, inputValues, bufIdxFilled, outValues, outIndices, sortStartPhase,
+          i32Attr(sortEndPhase), i32Attr(0), tA, tB, boolAttr(true),
+          i1Val(false), rfo);
+      rewriter.create<TileTopkMergeOp>(loc, inputValues, bufIdxFilled,
+                                       outValues, outIndices, mergeIter,
+                                       i32Attr(mergeK), tA, tB, boolAttr(false),
+                                       /*is_group_end=*/i1Val(false), rfo);
+      rewriter.create<TileTopkRebuildOp>(
+          loc, inputValues, bufIdxFilled, outValues, outIndices, i32Attr(0),
+          mergeIter, i32Attr(rebuildK), i32Attr(mLogk), i32Attr(skipSecond), tA,
+          tB, boolAttr(false), /*is_group_end=*/i1Val(true), rfo);
+    };
 
-      for (int64_t base = 0; base + distance < numTilesInner;
-           base += 2 * distance) {
-        int64_t tileA = base;
-        int64_t tileB = base + distance;
+    Value zeroIdx = idxVal(0);
+    Value oneIdx = idxVal(1);
+    Value zeroI32 = i32Val(0);
+    Value trueVal = i1Val(true);
+    Value falseVal = i1Val(false);
+    Value numTilesIdx = idxVal(numTilesInner);
+    Value logWtIdx = idxVal(logWt);
 
-        if (useLargeK) {
-          if (isFirst) {
-            emitSortMergeRebuild(tileA, tileB, k, logk, /*mIter=*/mIter,
-                                 /*skipSecond=*/0, /*rfo=*/false);
-          } else {
-            // DST only holds 2 tiles at a time, so we cannot merge all 4 tiles
-            // directly. Instead, we use 3 sub-merges to compute the top-k.
-            int64_t prevDist = distance / 2;
+    auto outerLoop =
+        rewriter.create<scf::ForOp>(loc, zeroIdx, logWtIdx, oneIdx);
+    rewriter.setInsertionPointToStart(outerLoop.getBody());
 
-            // Step 1: Merge the winner tiles (tileA, tileB) from the previous
-            // iteration; tileA holds the best-k across both afterward.
-            emitSortMergeRebuild(tileA, tileB, k, logk, /*mIter=*/0,
-                                 /*skipSecond=*/0, /*rfo=*/true);
+    Value mIterIdx = outerLoop.getInductionVar();
+    Value mIterI32 = rewriter.create<arith::IndexCastOp>(
+        loc, rewriter.getI32Type(), mIterIdx);
 
-            // Step 2: Merge the loser tiles; (tileA+prevDist) holds the best-k
-            // across both losers afterward.
-            emitSortMergeRebuild(tileA + prevDist, tileB + prevDist, k, logk,
-                                 /*mIter=*/0, /*skipSecond=*/0, /*rfo=*/true);
+    Value distanceIdx = rewriter.create<arith::ShLIOp>(loc, oneIdx, mIterIdx);
+    Value innerUB =
+        rewriter.create<arith::SubIOp>(loc, numTilesIdx, distanceIdx);
+    Value innerStep =
+        rewriter.create<arith::MulIOp>(loc, distanceIdx, idxVal(2));
+    auto innerLoop =
+        rewriter.create<scf::ForOp>(loc, zeroIdx, innerUB, innerStep);
+    rewriter.setInsertionPointToStart(innerLoop.getBody());
 
-            // Step 3: Merge winners against losers; tileB holds the final top-k
-            // across all four tiles afterward.
-            emitSortMergeRebuild(tileB, tileA + prevDist, k, logk,
-                                 /*mIter=*/0, /*skipSecond=*/0, /*rfo=*/true);
-          }
-        } else {
-          // K=32/logk=5 is used so that sorting spans both tiles; a smaller K
-          // would confine it to a single tile, preventing cross-tile merges.
+    Value baseIdx = innerLoop.getInductionVar();
+    Value tileA = baseIdx;
+    Value tileB = rewriter.create<arith::AddIOp>(loc, baseIdx, distanceIdx);
 
-          // Rebuild only on the last iteration. Skip it when k==32 with a
-          // single iteration since the merge output is already exactly k
-          // elements. The !isFirst check handles the case when logWt = 1.
-          bool needsRebuild = isLast && (!isFirst || k < 32);
+    if (useLargeK) {
+      // First iteration: a single sort-merge-rebuild. Later iterations: DST
+      // only holds 2 tiles at a time, so we cannot merge all 4 tiles directly;
+      // instead we use 3 sub-merges to compute the top-k.
+      Value isFirst = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, mIterIdx, zeroIdx);
+      auto ifOp = rewriter.create<scf::IfOp>(loc, isFirst,
+                                             /*withElseRegion=*/true);
 
-          rewriter.create<TileTopkLocalSortOp>(
-              loc, inputValues, bufIdxFilled, outValues, outIndices,
-              i32Attr(mIter), i32Attr(4), i32Attr(0), i64Attr(tileA),
-              i64Attr(tileB), boolAttr(true), boolAttr(false),
-              boolAttr(readFromOutput));
-          rewriter.create<TileTopkMergeOp>(
-              loc, inputValues, bufIdxFilled, outValues, outIndices,
-              i32Attr(mIter), i32Attr(32), i64Attr(tileA), i64Attr(tileB),
-              boolAttr(false), boolAttr(!needsRebuild),
-              boolAttr(readFromOutput));
+      // then: single sort-merge-rebuild.
+      rewriter.setInsertionPointToStart(ifOp.thenBlock());
+      emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
+                           /*sortStartPhase=*/zeroI32,
+                           /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                           /*skipSecond=*/0, /*rfo=*/falseVal);
 
-          if (needsRebuild) {
-            rewriter.create<TileTopkRebuildOp>(
-                loc, inputValues, bufIdxFilled, outValues, outIndices,
-                i32Attr(0), i32Attr(mIter), i32Attr(k), i32Attr(5), i32Attr(1),
-                i64Attr(tileA), i64Attr(tileB), boolAttr(false), boolAttr(true),
-                boolAttr(readFromOutput));
-          }
-        }
-      }
+      // else: 3-sub-merge tree.
+      rewriter.setInsertionPointToStart(ifOp.elseBlock());
+      // prevDist = distance / 2 = 1 << (mIter - 1).
+      Value prevDistIdx =
+          rewriter.create<arith::ShRUIOp>(loc, distanceIdx, oneIdx);
+
+      // Step 1: merge the winner tiles; tileA holds the best-k afterward.
+      emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
+                           /*sortStartPhase=*/zeroI32,
+                           /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                           /*skipSecond=*/0, /*rfo=*/trueVal);
+
+      // Step 2: merge the loser tiles; (tileA+prevDist) holds the best-k across
+      // both losers afterward.
+      Value tileALoser =
+          rewriter.create<arith::AddIOp>(loc, tileA, prevDistIdx);
+      Value tileBLoser =
+          rewriter.create<arith::AddIOp>(loc, tileB, prevDistIdx);
+      emitSortMergeRebuild(tileALoser, tileBLoser, /*mergeK=*/k, /*rebuildK=*/k,
+                           logk, /*sortStartPhase=*/zeroI32,
+                           /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                           /*skipSecond=*/0, /*rfo=*/trueVal);
+
+      // Step 3: merge winners against losers; tileB holds the final top-k
+      // across all four tiles afterward.
+      emitSortMergeRebuild(tileB, tileALoser, /*mergeK=*/k, /*rebuildK=*/k,
+                           logk, /*sortStartPhase=*/zeroI32,
+                           /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                           /*skipSecond=*/0, /*rfo=*/trueVal);
+    } else {
+      // K=32/logk=5 is used so that sorting spans both tiles; a smaller K would
+      // confine it to a single tile, preventing cross-tile merges.
+      Value readFromOutput = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::ne, mIterIdx, zeroIdx);
+      Value lastIterIdx = idxVal(logWt - 1);
+      Value isLast = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, mIterIdx, lastIterIdx);
+      Value needsRebuild =
+          (k < 32) ? isLast
+                   : rewriter.create<arith::AndIOp>(loc, isLast, readFromOutput)
+                         .getResult();
+
+      // The merge packs the tiles only when no rebuild follows, so its
+      // is_group_end is the complement of needsRebuild.
+      Value mergeGroupEnd =
+          rewriter.create<arith::XOrIOp>(loc, needsRebuild, trueVal);
+      rewriter.create<TileTopkLocalSortOp>(
+          loc, inputValues, bufIdxFilled, outValues, outIndices,
+          /*sortStartPhase=*/mIterI32, /*sortEndPhase=*/i32Attr(4), i32Attr(0),
+          tileA, tileB, boolAttr(true), i1Val(false),
+          /*rfo=*/readFromOutput);
+      rewriter.create<TileTopkMergeOp>(
+          loc, inputValues, bufIdxFilled, outValues, outIndices,
+          /*mergeIter=*/mIterI32, i32Attr(32), tileA, tileB, boolAttr(false),
+          mergeGroupEnd, /*rfo=*/readFromOutput);
+
+      // The rebuild only runs on the last iteration (and is skipped when k==32
+      // with a single iteration, where the merge output is already exactly k
+      // elements). Emit it inside an scf.if guarded on needsRebuild. Its
+      // is_group_end is always true since the rebuild, when present, ends the
+      // group and packs the tiles.
+      auto rebuildIf = rewriter.create<scf::IfOp>(loc, needsRebuild,
+                                                  /*withElseRegion=*/false);
+      rewriter.setInsertionPointToStart(rebuildIf.thenBlock());
+      rewriter.create<TileTopkRebuildOp>(
+          loc, inputValues, bufIdxFilled, outValues, outIndices, i32Attr(0),
+          /*mergeIter=*/mIterI32, i32Attr(k), i32Attr(5), i32Attr(1), tileA,
+          tileB, boolAttr(false), /*is_group_end=*/trueVal,
+          /*rfo=*/readFromOutput);
+      rewriter.setInsertionPointAfter(rebuildIf);
     }
+
+    rewriter.setInsertionPointAfter(innerLoop);
+    rewriter.setInsertionPointAfter(outerLoop);
 
     rewriter.replaceOp(op, {outValues, outIndices});
     return success();

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -148,105 +148,129 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
           tB, boolAttr(false), /*is_group_end=*/i1Val(true), rfo);
     };
 
-    auto outerLoop =
-        rewriter.create<scf::ForOp>(loc, zeroIdx, logWtIdx, oneIdx);
-    rewriter.setInsertionPointToStart(outerLoop.getBody());
-
-    Value mIterIdx = outerLoop.getInductionVar();
-    Value mIterI32 = rewriter.create<arith::IndexCastOp>(
-        loc, rewriter.getI32Type(), mIterIdx);
-
-    Value distanceIdx = rewriter.create<arith::ShLIOp>(loc, oneIdx, mIterIdx);
-    Value innerUB =
-        rewriter.create<arith::SubIOp>(loc, numTilesIdx, distanceIdx);
-    Value innerStep =
-        rewriter.create<arith::MulIOp>(loc, distanceIdx, idxVal(2));
-    auto innerLoop =
-        rewriter.create<scf::ForOp>(loc, zeroIdx, innerUB, innerStep);
-    rewriter.setInsertionPointToStart(innerLoop.getBody());
-
-    // rA/rB are raw reduction indices; tileA/tileB are flat after adding
-    // ntOffset.
-    Value baseIdx = innerLoop.getInductionVar();
-    Value rA = baseIdx;
-    Value rB = rewriter.create<arith::AddIOp>(loc, baseIdx, distanceIdx);
-    Value tileA = flat(rA);
-    Value tileB = flat(rB);
-
+    // useLargeK is fixed per rewrite (derived from k), so the large-k and
+    // small-k paths are emitted as two independent loop structures.
     if (useLargeK) {
-      // The first iteration performs a single sort-merge-rebuild. In later
-      // iterations, DST only holds 2 tiles at a time, so we cannot merge all 4
-      // tiles directly; instead, we use 3 sub-merges to compute the top-k.
-      Value isFirst = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::eq, mIterIdx, zeroIdx);
-      auto ifOp = rewriter.create<scf::IfOp>(loc, isFirst,
-                                             /*withElseRegion=*/true);
+      // Level 0 is emitted unrolled, then levels [1,logWt) are emitted in a
+      // single scf.for loop, each with a fixed body.
+      auto emitInnerBody = [&](Value mIterIdx, bool isFirstLevel) {
+        Value distanceIdx =
+            rewriter.create<arith::ShLIOp>(loc, oneIdx, mIterIdx);
+        Value innerUB =
+            rewriter.create<arith::SubIOp>(loc, numTilesIdx, distanceIdx);
+        Value innerStep =
+            rewriter.create<arith::MulIOp>(loc, distanceIdx, idxVal(2));
+        auto innerLoop =
+            rewriter.create<scf::ForOp>(loc, zeroIdx, innerUB, innerStep);
+        rewriter.setInsertionPointToStart(innerLoop.getBody());
 
-      // Iteration 0: emit a single sort-merge-rebuild.
-      rewriter.setInsertionPointToStart(ifOp.thenBlock());
-      emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
-                           /*sortStartPhase=*/zeroI32,
-                           /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
-                           /*skipSecond=*/0, /*rfo=*/falseVal);
+        // rA/rB are raw reduction indices; tileA/tileB are flat after adding
+        // ntOffset.
+        Value baseIdx = innerLoop.getInductionVar();
+        Value rA = baseIdx;
+        Value rB = rewriter.create<arith::AddIOp>(loc, baseIdx, distanceIdx);
+        Value tileA = flat(rA);
+        Value tileB = flat(rB);
 
-      // Iterations > 0: emit a 3-sub-merge tree.
-      rewriter.setInsertionPointToStart(ifOp.elseBlock());
-      // prevDist is the stride from the previous level: distance / 2.
-      Value prevDistIdx =
-          rewriter.create<arith::ShRUIOp>(loc, distanceIdx, oneIdx);
+        if (isFirstLevel) {
+          // Level 0: emit a single sort-merge-rebuild.
+          emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
+                               /*sortStartPhase=*/zeroI32,
+                               /*sortEndPhase=*/logk - 1,
+                               /*mergeIter=*/zeroI32, /*skipSecond=*/0,
+                               /*rfo=*/falseVal);
+        } else {
+          // Levels > 0: DST only holds 2 tiles at a time, so we cannot merge
+          // all 4 tiles directly; instead, we use 3 sub-merges.
+          // prevDist is the stride from the previous level: distance / 2.
+          Value prevDistIdx =
+              rewriter.create<arith::ShRUIOp>(loc, distanceIdx, oneIdx);
 
-      // Loser indices derive from rA/rB to avoid double-applying the ntOffset.
-      Value rALoser = rewriter.create<arith::AddIOp>(loc, rA, prevDistIdx);
-      Value rBLoser = rewriter.create<arith::AddIOp>(loc, rB, prevDistIdx);
-      Value tileALoser = flat(rALoser);
-      Value tileBLoser = flat(rBLoser);
+          // Loser indices derive from rA/rB to avoid double-applying the
+          // ntOffset.
+          Value rALoser = rewriter.create<arith::AddIOp>(loc, rA, prevDistIdx);
+          Value rBLoser = rewriter.create<arith::AddIOp>(loc, rB, prevDistIdx);
+          Value tileALoser = flat(rALoser);
+          Value tileBLoser = flat(rBLoser);
 
-      // Step 1: Merge the winner tiles (tileA, tileB) from the previous
-      // iteration; tileA holds the best-k across both afterward.
-      emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
-                           /*sortStartPhase=*/zeroI32,
-                           /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
-                           /*skipSecond=*/0, /*rfo=*/trueVal);
+          // Step 1: Merge the winner tiles (tileA, tileB) from the previous
+          // iteration; tileA holds the best-k across both afterward.
+          emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
+                               /*sortStartPhase=*/zeroI32,
+                               /*sortEndPhase=*/logk - 1,
+                               /*mergeIter=*/zeroI32, /*skipSecond=*/0,
+                               /*rfo=*/trueVal);
 
-      // Step 2: Merge the loser tiles; (tileALoser) holds the best-k
-      // across both losers afterward.
-      emitSortMergeRebuild(tileALoser, tileBLoser, /*mergeK=*/k, /*rebuildK=*/k,
-                           logk, /*sortStartPhase=*/zeroI32,
-                           /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
-                           /*skipSecond=*/0, /*rfo=*/trueVal);
+          // Step 2: Merge the loser tiles; (tileALoser) holds the best-k
+          // across both losers afterward.
+          emitSortMergeRebuild(tileALoser, tileBLoser, /*mergeK=*/k,
+                               /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
+                               /*sortEndPhase=*/logk - 1,
+                               /*mergeIter=*/zeroI32, /*skipSecond=*/0,
+                               /*rfo=*/trueVal);
 
-      // Step 3: Merge winners against losers; tileB holds the final top-k
-      // across all four tiles afterward.
-      emitSortMergeRebuild(tileB, tileALoser, /*mergeK=*/k, /*rebuildK=*/k,
-                           logk, /*sortStartPhase=*/zeroI32,
-                           /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
-                           /*skipSecond=*/0, /*rfo=*/trueVal);
+          // Step 3: Merge winners against losers; tileB holds the final
+          // top-k across all four tiles afterward.
+          emitSortMergeRebuild(tileB, tileALoser, /*mergeK=*/k,
+                               /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
+                               /*sortEndPhase=*/logk - 1,
+                               /*mergeIter=*/zeroI32, /*skipSecond=*/0,
+                               /*rfo=*/trueVal);
+        }
+
+        rewriter.setInsertionPointAfter(innerLoop);
+      };
+
+      // Level 0 loop: exactly one iteration (mIterIdx == 0), run unrolled.
+      emitInnerBody(zeroIdx, /*isFirstLevel=*/true);
+
+      // Levels [1, logWt): outer loop with fixed body.
+      auto outerLoop =
+          rewriter.create<scf::ForOp>(loc, oneIdx, logWtIdx, oneIdx);
+      rewriter.setInsertionPointToStart(outerLoop.getBody());
+      emitInnerBody(outerLoop.getInductionVar(), /*isFirstLevel=*/false);
+      rewriter.setInsertionPointAfter(outerLoop);
     } else {
-      // K=32/logk=5 ensures sorting spans both tiles for cross-tile merges.
-      Value readFromOutput = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::ne, mIterIdx, zeroIdx);
-      Value lastIterIdx = idxVal(logWt - 1);
-      Value isLast = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::eq, mIterIdx, lastIterIdx);
+      // Level 0 is emitted unrolled, levels [1,logWt-1) run in a middle
+      // scf.for loop (if logWt > 1), and level logWt-1 is emitted unrolled
+      // (if logWt > 1). Each level's behavior is determined by the isLevelZero
+      // and isLastLevel parameters.
+      bool tailSortNeeded = ragged && (numTilesInner % 2 == 1);
 
-      // Rebuild only on the last iteration. Skip it when k==32 with a
-      // single iteration since the merge output is already exactly k
-      // elements. The !isFirst check handles the case when logWt = 1.
-      Value needsRebuild =
-          (k < 32) ? isLast
-                   : rewriter.create<arith::AndIOp>(loc, isLast, readFromOutput)
-                         .getResult();
+      auto emitLevelBody = [&](Value mIterIdx, bool isLevelZero,
+                               bool isLastLevel) {
+        Value mIterI32 = rewriter.create<arith::IndexCastOp>(
+            loc, rewriter.getI32Type(), mIterIdx);
 
-      // The merge packs the tiles only when no rebuild follows, so its
-      // is_group_end is the complement of needsRebuild.
-      Value mergeGroupEnd =
-          rewriter.create<arith::XOrIOp>(loc, needsRebuild, trueVal);
+        Value distanceIdx =
+            rewriter.create<arith::ShLIOp>(loc, oneIdx, mIterIdx);
+        Value innerUB =
+            rewriter.create<arith::SubIOp>(loc, numTilesIdx, distanceIdx);
+        Value innerStep =
+            rewriter.create<arith::MulIOp>(loc, distanceIdx, idxVal(2));
+        auto innerLoop =
+            rewriter.create<scf::ForOp>(loc, zeroIdx, innerUB, innerStep);
+        rewriter.setInsertionPointToStart(innerLoop.getBody());
 
-      // On the ragged path, always use sortStartPhase=0 since carried tiles may
-      // have skipped levels and need a full sort.
-      Value sortStartPhase = ragged ? i32Val(0) : mIterI32;
+        // rA/rB are raw reduction indices; tileA/tileB are flat after adding
+        // ntOffset.
+        Value baseIdx = innerLoop.getInductionVar();
+        Value rA = baseIdx;
+        Value rB = rewriter.create<arith::AddIOp>(loc, baseIdx, distanceIdx);
+        Value tileA = flat(rA);
+        Value tileB = flat(rB);
 
-      auto emitSortMergeRebuildSmallK = [&]() {
+        // K=32/logk=5 ensures sorting spans both tiles for cross-tile merges.
+        Value readFromOutput = isLevelZero ? falseVal : trueVal;
+
+        // Rebuild only on the last level. Skip it when k==32 with a single
+        // level since the merge output is already exactly k elements.
+        bool needsRebuild = isLastLevel && ((k < 32) || !isLevelZero);
+
+        // On the ragged path, always use sortStartPhase=0 since carried
+        // tiles may have skipped levels and need a full sort.
+        Value sortStartPhase = ragged ? i32Val(0) : mIterI32;
+
         rewriter.create<TileTopkLocalSortOp>(
             loc, inputValues, bufIdxFilled, outValues, outIndices,
             /*sortStartPhase=*/sortStartPhase, /*sortEndPhase=*/i32Attr(4),
@@ -255,48 +279,53 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
         rewriter.create<TileTopkMergeOp>(
             loc, inputValues, bufIdxFilled, outValues, outIndices,
             /*mergeIter=*/mIterI32, i32Attr(32), tileA, tileB, boolAttr(false),
-            mergeGroupEnd, /*rfo=*/readFromOutput);
+            /*is_group_end=*/i1Val(!needsRebuild), /*rfo=*/readFromOutput);
 
-        // Rebuild runs only on the last iteration; k==32 with one iteration
-        // skips it since the merge already produces exactly k elements.
-        auto rebuildIf = rewriter.create<scf::IfOp>(loc, needsRebuild,
-                                                    /*withElseRegion=*/false);
-        rewriter.setInsertionPointToStart(rebuildIf.thenBlock());
-        rewriter.create<TileTopkRebuildOp>(
-            loc, inputValues, bufIdxFilled, outValues, outIndices, i32Attr(0),
-            /*mergeIter=*/mIterI32, i32Attr(k), i32Attr(5), i32Attr(1), tileA,
-            tileB, boolAttr(false), /*is_group_end=*/trueVal,
-            /*rfo=*/readFromOutput);
-        rewriter.setInsertionPointAfter(rebuildIf);
+        if (needsRebuild) {
+          rewriter.create<TileTopkRebuildOp>(
+              loc, inputValues, bufIdxFilled, outValues, outIndices, i32Attr(0),
+              /*mergeIter=*/mIterI32, i32Attr(k), i32Attr(5), i32Attr(1), tileA,
+              tileB, boolAttr(false), /*is_group_end=*/trueVal,
+              /*rfo=*/readFromOutput);
+        }
+
+        // For ragged N with an odd tile count, tile (N-1) is skipped by the
+        // even-indexed level-0 loop. Emit a standalone local_sort for it at
+        // level 0 using tileB=tileA (sorts the same tile twice, harmlessly)
+        // so it is a valid sorted run before level 1 tries to pair it.
+        if (isLevelZero && tailSortNeeded) {
+          Value tailRawIdx = idxVal(numTilesInner - 1);
+          Value tailTileIdx = flat(tailRawIdx);
+          rewriter.create<TileTopkLocalSortOp>(
+              loc, inputValues, bufIdxFilled, outValues, outIndices,
+              /*sortStartPhase=*/i32Val(0), /*sortEndPhase=*/i32Attr(4),
+              /*idir=*/i32Attr(0), /*tileA=*/tailTileIdx,
+              /*tileB=*/tailTileIdx, /*is_group_start=*/boolAttr(true),
+              /*is_group_end=*/i1Val(true), /*rfo=*/falseVal);
+        }
+
+        rewriter.setInsertionPointAfter(innerLoop);
       };
 
-      emitSortMergeRebuildSmallK();
+      // Level 0: exactly one iteration, run unrolled.
+      emitLevelBody(zeroIdx, /*isLevelZero=*/true,
+                    /*isLastLevel=*/(logWt == 1));
+
+      if (logWt > 1) {
+        // Middle levels [1, logWt-1): no rebuild, no tail-sort.
+        auto midLoop =
+            rewriter.create<scf::ForOp>(loc, oneIdx, idxVal(logWt - 1), oneIdx);
+        rewriter.setInsertionPointToStart(midLoop.getBody());
+        emitLevelBody(midLoop.getInductionVar(), /*isLevelZero=*/false,
+                      /*isLastLevel=*/false);
+        rewriter.setInsertionPointAfter(midLoop);
+
+        // Last level: exactly one iteration, run unrolled.
+        emitLevelBody(idxVal(logWt - 1), /*isLevelZero=*/false,
+                      /*isLastLevel=*/true);
+      }
     }
 
-    rewriter.setInsertionPointAfter(innerLoop);
-
-    // For ragged N with an odd tile count, tile (N-1) is skipped by the
-    // even-indexed level-0 loop. Emit a standalone local_sort for it at level 0
-    // using tileB=tileA (sorts the same tile twice, harmlessly) so it is a
-    // valid sorted run before level 1 tries to pair it.
-    if (ragged && (numTilesInner % 2 == 1) && !useLargeK) {
-      Value tailRawIdx = idxVal(numTilesInner - 1);
-      Value tailTileIdx = flat(tailRawIdx);
-      Value isLevelZero = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::eq, mIterIdx, zeroIdx);
-      auto tailSortIf = rewriter.create<scf::IfOp>(loc, isLevelZero,
-                                                   /*withElseRegion=*/false);
-      rewriter.setInsertionPointToStart(tailSortIf.thenBlock());
-      rewriter.create<TileTopkLocalSortOp>(
-          loc, inputValues, bufIdxFilled, outValues, outIndices,
-          /*sortStartPhase=*/i32Val(0), /*sortEndPhase=*/i32Attr(4),
-          /*idir=*/i32Attr(0), /*tileA=*/tailTileIdx, /*tileB=*/tailTileIdx,
-          /*is_group_start=*/boolAttr(true), /*is_group_end=*/i1Val(true),
-          /*rfo=*/falseVal);
-      rewriter.setInsertionPointAfter(tailSortIf);
-    }
-
-    rewriter.setInsertionPointAfter(outerLoop);
     rewriter.setInsertionPointAfter(ntLoop);
 
     rewriter.replaceOp(op, {outValues, outIndices});

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -28,8 +28,8 @@ static int32_t floorLog2(T n) {
   return result;
 }
 
-// Decomposes TopkBlockOp into arange_block +
-// tile_topk_{local_sort,merge,rebuild} ops with scf.for loops over tile pairs.
+// Decomposes TopkBlockOp into tile_topk_{local_sort,merge,rebuild} ops with
+// scf.for loops over tile pairs.
 struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
   using OpRewritePattern<TopkBlockOp>::OpRewritePattern;
 
@@ -57,8 +57,8 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     int32_t logk = floorLog2(k);
 
     // When k>32 the result spans 2 tiles, requiring a 3-sub-merge reduction.
-    // The reduction dim is padded to a power-of-2 tile count in TTIRToD2M
-    // (-inf fill), so the large-k path always sees a power-of-2 tile count.
+    // TTIRToD2M pads the reduction dim to a power-of-2 tile count (-inf fill),
+    // so the large-k path always sees a power-of-2 tile count.
     bool useLargeK = (k > 32);
     int64_t dimIdx = op.getDim();
     int64_t numTilesInner = inputShape[dimIdx];
@@ -70,17 +70,19 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     int32_t logWt = numTilesPow2 ? fl : fl + 1;
     bool ragged = !numTilesPow2;
 
-    // The shard is row-major [htShard, wtShard]; flat(nt, r) =
-    // r*reductionStride
-    // + nt*ntStride, where strides depend on which dim is the reduction dim.
-    int64_t ntDimIdx = (dimIdx == (int64_t)inputShape.size() - 1)
-                           ? (int64_t)inputShape.size() - 2
-                           : (int64_t)inputShape.size() - 1;
+    // Shard is row-major [htShard, wtShard] with flat index r*reductionStride +
+    // nt*ntStride; strides depend on which dim is the reduction dim.
+    int64_t ntDimIdx = (dimIdx == static_cast<int64_t>(inputShape.size()) - 1)
+                           ? static_cast<int64_t>(inputShape.size()) - 2
+                           : static_cast<int64_t>(inputShape.size()) - 1;
     int64_t nonTargetCount = inputShape[ntDimIdx];
     int64_t reductionStride =
-        (dimIdx == (int64_t)inputShape.size() - 1) ? 1 : nonTargetCount;
-    int64_t ntStride =
-        (dimIdx == (int64_t)inputShape.size() - 1) ? numTilesInner : 1;
+        (dimIdx == static_cast<int64_t>(inputShape.size()) - 1)
+            ? 1
+            : nonTargetCount;
+    int64_t ntStride = (dimIdx == static_cast<int64_t>(inputShape.size()) - 1)
+                           ? numTilesInner
+                           : 1;
 
     auto i32Attr = [&](int32_t v) { return rewriter.getI32IntegerAttr(v); };
     auto boolAttr = [&](bool v) { return rewriter.getBoolAttr(v); };
@@ -240,8 +242,6 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
       Value mergeGroupEnd =
           rewriter.create<arith::XOrIOp>(loc, needsRebuild, trueVal);
 
-      // For ragged N, tileB may be out of bounds at the last level, so guard
-      // the sort+merge+rebuild with a bounds check on rB (not the flat tileB).
       // On the ragged path, always use sortStartPhase=0 since carried tiles may
       // have skipped levels and need a full sort.
       Value sortStartPhase = ragged ? i32Val(0) : mIterI32;
@@ -270,19 +270,7 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
         rewriter.setInsertionPointAfter(rebuildIf);
       };
 
-      if (ragged) {
-        // Guard on rB (the raw reduction index) rather than the flat tile
-        // index.
-        Value rBInBounds = rewriter.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::ult, rB, numTilesIdx);
-        auto mergeIf = rewriter.create<scf::IfOp>(loc, rBInBounds,
-                                                  /*withElseRegion=*/false);
-        rewriter.setInsertionPointToStart(mergeIf.thenBlock());
-        emitSortMergeRebuildSmallK();
-        rewriter.setInsertionPointAfter(mergeIf);
-      } else {
-        emitSortMergeRebuildSmallK();
-      }
+      emitSortMergeRebuildSmallK();
     }
 
     rewriter.setInsertionPointAfter(innerLoop);

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -48,30 +48,11 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     TT_assertv(inputShape.size() >= 2ul,
                "input must have at least 2 dimensions");
 
-    int64_t numElements = op.getNumElements();
     int32_t k = op.getK();
 
-    auto tileType = cast<ttcore::TileType>(inputType.getElementType());
-    Type si32Type =
-        IntegerType::get(rewriter.getContext(), 32, IntegerType::Signed);
-    auto idxTileType = ttcore::TileType::get(si32Type, tileType.getShape());
-    auto l1MemorySpace = ttcore::MemorySpaceAttr::get(
-        rewriter.getContext(), ttcore::MemorySpace::DeviceL1);
-
-    auto allocScratch = [&](ArrayRef<int64_t> shape,
-                            ttcore::TileType elemType) -> Value {
-      auto memrefType = MemRefType::get(
-          shape, elemType, MemRefLayoutAttrInterface{}, l1MemorySpace);
-      return rewriter.create<memref::AllocOp>(loc, memrefType).getResult();
-    };
-
-    Value bufIdx = allocScratch(inputShape, idxTileType);
-    Value bufIdxFilled =
-        rewriter
-            .create<ArangeBlockOp>(loc, scratchIdxTile, bufIdx, numElements,
-                                   /*start=*/0,
-                                   /*step=*/1)
-            .getResult();
+    // The index buffer is pre-filled upstream (in TTIRToD2M via arange +
+    // broadcast generics) and passed in as scratch_idx_tile.
+    Value bufIdxFilled = scratchIdxTile;
 
     int32_t logk = floorLog2(k);
 

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -135,8 +135,9 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
                                     Value mergeIter, int32_t skipSecond,
                                     Value rfo) {
       rewriter.create<TileTopkLocalSortOp>(
-          loc, inputValues, bufIdxFilled, outValues, outIndices, sortStartPhase,
-          i32Attr(sortEndPhase), i32Attr(0), tA, tB, boolAttr(true),
+          loc, inputValues, bufIdxFilled, outValues, outIndices,
+          /*idir=*/i32Attr(0), /*i_end_phase=*/i32Attr(sortEndPhase),
+          /*i_start_phase=*/sortStartPhase, tA, tB, boolAttr(true),
           i1Val(false), rfo);
       rewriter.create<TileTopkMergeOp>(loc, inputValues, bufIdxFilled,
                                        outValues, outIndices, mergeIter,
@@ -273,9 +274,9 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
 
         rewriter.create<TileTopkLocalSortOp>(
             loc, inputValues, bufIdxFilled, outValues, outIndices,
-            /*sortStartPhase=*/sortStartPhase, /*sortEndPhase=*/i32Attr(4),
-            i32Attr(0), tileA, tileB, boolAttr(true), i1Val(false),
-            /*rfo=*/readFromOutput);
+            /*idir=*/i32Attr(0), /*i_end_phase=*/i32Attr(4),
+            /*i_start_phase=*/sortStartPhase, tileA, tileB, boolAttr(true),
+            i1Val(false), /*rfo=*/readFromOutput);
         rewriter.create<TileTopkMergeOp>(
             loc, inputValues, bufIdxFilled, outValues, outIndices,
             /*mergeIter=*/mIterI32, i32Attr(32), tileA, tileB, boolAttr(false),
@@ -298,8 +299,8 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
           Value tailTileIdx = flat(tailRawIdx);
           rewriter.create<TileTopkLocalSortOp>(
               loc, inputValues, bufIdxFilled, outValues, outIndices,
-              /*sortStartPhase=*/i32Val(0), /*sortEndPhase=*/i32Attr(4),
-              /*idir=*/i32Attr(0), /*tileA=*/tailTileIdx,
+              /*idir=*/i32Attr(0), /*i_end_phase=*/i32Attr(4),
+              /*i_start_phase=*/i32Val(0), /*tileA=*/tailTileIdx,
               /*tileB=*/tailTileIdx, /*is_group_start=*/boolAttr(true),
               /*is_group_end=*/i1Val(true), /*rfo=*/falseVal);
         }

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -75,13 +75,18 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
 
     int32_t logk = floorLog2(k);
 
-    int64_t numTilesInner = inputShape[op.getDim()];
-    // logWt is the number of merge-tree iterations. Each iteration doubles the
-    // distance between paired tiles, so numTilesInner must be a power of 2.
-    int32_t logWt = floorLog2(numTilesInner);
-
     // When k>32 the result spans 2 tiles, requiring a 3-sub-merge reduction.
+    // The reduction dim is padded to a power-of-2 tile count in TTIRToD2M
+    // (-inf fill), so the large-k path always sees a power-of-2 tile count.
     bool useLargeK = (k > 32);
+    int64_t numTilesInner = inputShape[op.getDim()];
+    // logWt is the merge-tree depth; ceilLog2 ensures the final fold always
+    // runs for non-power-of-2 tile counts.
+    bool numTilesPow2 =
+        (numTilesInner > 0 && (numTilesInner & (numTilesInner - 1)) == 0);
+    int32_t fl = floorLog2(numTilesInner);
+    int32_t logWt = numTilesPow2 ? fl : fl + 1;
+    bool ragged = !numTilesPow2;
 
     auto i32Attr = [&](int32_t v) { return rewriter.getI32IntegerAttr(v); };
     auto boolAttr = [&](bool v) { return rewriter.getBoolAttr(v); };
@@ -153,35 +158,36 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     Value tileB = rewriter.create<arith::AddIOp>(loc, baseIdx, distanceIdx);
 
     if (useLargeK) {
-      // First iteration: a single sort-merge-rebuild. Later iterations: DST
-      // only holds 2 tiles at a time, so we cannot merge all 4 tiles directly;
-      // instead we use 3 sub-merges to compute the top-k.
+      // The first iteration performs a single sort-merge-rebuild. In later
+      // iterations, DST only holds 2 tiles at a time, so we cannot merge all 4
+      // tiles directly; instead, we use 3 sub-merges to compute the top-k.
       Value isFirst = rewriter.create<arith::CmpIOp>(
           loc, arith::CmpIPredicate::eq, mIterIdx, zeroIdx);
       auto ifOp = rewriter.create<scf::IfOp>(loc, isFirst,
                                              /*withElseRegion=*/true);
 
-      // then: single sort-merge-rebuild.
+      // Iteration 0: emit a single sort-merge-rebuild.
       rewriter.setInsertionPointToStart(ifOp.thenBlock());
       emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
                            /*sortStartPhase=*/zeroI32,
                            /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
                            /*skipSecond=*/0, /*rfo=*/falseVal);
 
-      // else: 3-sub-merge tree.
+      // Iterations > 0: emit a 3-sub-merge tree.
       rewriter.setInsertionPointToStart(ifOp.elseBlock());
-      // prevDist = distance / 2 = 1 << (mIter - 1).
+      // prevDist is the stride from the previous level: distance / 2.
       Value prevDistIdx =
           rewriter.create<arith::ShRUIOp>(loc, distanceIdx, oneIdx);
 
-      // Step 1: merge the winner tiles; tileA holds the best-k afterward.
+      // Step 1: Merge the winner tiles (tileA, tileB) from the previous
+      // iteration; tileA holds the best-k across both afterward.
       emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
                            /*sortStartPhase=*/zeroI32,
                            /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
                            /*skipSecond=*/0, /*rfo=*/trueVal);
 
-      // Step 2: merge the loser tiles; (tileA+prevDist) holds the best-k across
-      // both losers afterward.
+      // Step 2: Merge the loser tiles; (tileA+prevDist) holds the best-k
+      // across both losers afterward.
       Value tileALoser =
           rewriter.create<arith::AddIOp>(loc, tileA, prevDistIdx);
       Value tileBLoser =
@@ -191,20 +197,23 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
                            /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
                            /*skipSecond=*/0, /*rfo=*/trueVal);
 
-      // Step 3: merge winners against losers; tileB holds the final top-k
+      // Step 3: Merge winners against losers; tileB holds the final top-k
       // across all four tiles afterward.
       emitSortMergeRebuild(tileB, tileALoser, /*mergeK=*/k, /*rebuildK=*/k,
                            logk, /*sortStartPhase=*/zeroI32,
                            /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
                            /*skipSecond=*/0, /*rfo=*/trueVal);
     } else {
-      // K=32/logk=5 is used so that sorting spans both tiles; a smaller K would
-      // confine it to a single tile, preventing cross-tile merges.
+      // K=32/logk=5 ensures sorting spans both tiles for cross-tile merges.
       Value readFromOutput = rewriter.create<arith::CmpIOp>(
           loc, arith::CmpIPredicate::ne, mIterIdx, zeroIdx);
       Value lastIterIdx = idxVal(logWt - 1);
       Value isLast = rewriter.create<arith::CmpIOp>(
           loc, arith::CmpIPredicate::eq, mIterIdx, lastIterIdx);
+
+      // Rebuild only on the last iteration. Skip it when k==32 with a
+      // single iteration since the merge output is already exactly k
+      // elements. The !isFirst check handles the case when logWt = 1.
       Value needsRebuild =
           (k < 32) ? isLast
                    : rewriter.create<arith::AndIOp>(loc, isLast, readFromOutput)
@@ -214,33 +223,73 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
       // is_group_end is the complement of needsRebuild.
       Value mergeGroupEnd =
           rewriter.create<arith::XOrIOp>(loc, needsRebuild, trueVal);
-      rewriter.create<TileTopkLocalSortOp>(
-          loc, inputValues, bufIdxFilled, outValues, outIndices,
-          /*sortStartPhase=*/mIterI32, /*sortEndPhase=*/i32Attr(4), i32Attr(0),
-          tileA, tileB, boolAttr(true), i1Val(false),
-          /*rfo=*/readFromOutput);
-      rewriter.create<TileTopkMergeOp>(
-          loc, inputValues, bufIdxFilled, outValues, outIndices,
-          /*mergeIter=*/mIterI32, i32Attr(32), tileA, tileB, boolAttr(false),
-          mergeGroupEnd, /*rfo=*/readFromOutput);
 
-      // The rebuild only runs on the last iteration (and is skipped when k==32
-      // with a single iteration, where the merge output is already exactly k
-      // elements). Emit it inside an scf.if guarded on needsRebuild. Its
-      // is_group_end is always true since the rebuild, when present, ends the
-      // group and packs the tiles.
-      auto rebuildIf = rewriter.create<scf::IfOp>(loc, needsRebuild,
+      // For ragged N, tileB may be out of bounds at the last level, so guard
+      // the sort+merge+rebuild with a bounds check; unpaired tiles are carried
+      // forward from the previous level. On the ragged path, always use
+      // sortStartPhase=0 since carried tiles may have skipped levels and need a
+      // full sort.
+      Value sortStartPhase = ragged ? i32Val(0) : mIterI32;
+
+      auto emitSortMergeRebuildSmallK = [&]() {
+        rewriter.create<TileTopkLocalSortOp>(
+            loc, inputValues, bufIdxFilled, outValues, outIndices,
+            /*sortStartPhase=*/sortStartPhase, /*sortEndPhase=*/i32Attr(4),
+            i32Attr(0), tileA, tileB, boolAttr(true), i1Val(false),
+            /*rfo=*/readFromOutput);
+        rewriter.create<TileTopkMergeOp>(
+            loc, inputValues, bufIdxFilled, outValues, outIndices,
+            /*mergeIter=*/mIterI32, i32Attr(32), tileA, tileB, boolAttr(false),
+            mergeGroupEnd, /*rfo=*/readFromOutput);
+
+        // Rebuild runs only on the last iteration; k==32 with one iteration
+        // skips it since the merge already produces exactly k elements.
+        auto rebuildIf = rewriter.create<scf::IfOp>(loc, needsRebuild,
+                                                    /*withElseRegion=*/false);
+        rewriter.setInsertionPointToStart(rebuildIf.thenBlock());
+        rewriter.create<TileTopkRebuildOp>(
+            loc, inputValues, bufIdxFilled, outValues, outIndices, i32Attr(0),
+            /*mergeIter=*/mIterI32, i32Attr(k), i32Attr(5), i32Attr(1), tileA,
+            tileB, boolAttr(false), /*is_group_end=*/trueVal,
+            /*rfo=*/readFromOutput);
+        rewriter.setInsertionPointAfter(rebuildIf);
+      };
+
+      if (ragged) {
+        Value tileBInBounds = rewriter.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::ult, tileB, numTilesIdx);
+        auto mergeIf = rewriter.create<scf::IfOp>(loc, tileBInBounds,
                                                   /*withElseRegion=*/false);
-      rewriter.setInsertionPointToStart(rebuildIf.thenBlock());
-      rewriter.create<TileTopkRebuildOp>(
-          loc, inputValues, bufIdxFilled, outValues, outIndices, i32Attr(0),
-          /*mergeIter=*/mIterI32, i32Attr(k), i32Attr(5), i32Attr(1), tileA,
-          tileB, boolAttr(false), /*is_group_end=*/trueVal,
-          /*rfo=*/readFromOutput);
-      rewriter.setInsertionPointAfter(rebuildIf);
+        rewriter.setInsertionPointToStart(mergeIf.thenBlock());
+        emitSortMergeRebuildSmallK();
+        rewriter.setInsertionPointAfter(mergeIf);
+      } else {
+        emitSortMergeRebuildSmallK();
+      }
     }
 
     rewriter.setInsertionPointAfter(innerLoop);
+
+    // For ragged N with an odd tile count, tile (N-1) is skipped by the
+    // even-indexed level-0 loop. Emit a standalone local_sort for it at level 0
+    // using tileB=tileA (sorts the same tile twice, harmlessly) so it is a
+    // valid sorted run before level 1 tries to pair it.
+    if (ragged && (numTilesInner % 2 == 1) && !useLargeK) {
+      Value tailTileIdx = idxVal(numTilesInner - 1);
+      Value isLevelZero = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, mIterIdx, zeroIdx);
+      auto tailSortIf = rewriter.create<scf::IfOp>(loc, isLevelZero,
+                                                   /*withElseRegion=*/false);
+      rewriter.setInsertionPointToStart(tailSortIf.thenBlock());
+      rewriter.create<TileTopkLocalSortOp>(
+          loc, inputValues, bufIdxFilled, outValues, outIndices,
+          /*sortStartPhase=*/i32Val(0), /*sortEndPhase=*/i32Attr(4),
+          /*idir=*/i32Attr(0), /*tileA=*/tailTileIdx, /*tileB=*/tailTileIdx,
+          /*is_group_start=*/boolAttr(true), /*is_group_end=*/i1Val(true),
+          /*rfo=*/falseVal);
+      rewriter.setInsertionPointAfter(tailSortIf);
+    }
+
     rewriter.setInsertionPointAfter(outerLoop);
 
     rewriter.replaceOp(op, {outValues, outIndices});

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -267,10 +267,11 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
            !opsWithSynchronizableOps.contains(outermostOp->getParentOp())) {
       outermostOp = outermostOp->getParentOp();
       if (!mlir::isa<scf::ForOp>(outermostOp) &&
+          !mlir::isa<scf::IfOp>(outermostOp) &&
           !mlir::isa<linalg::GenericOp>(outermostOp)) {
-        (void)rewriter.notifyMatchFailure(
-            genericOp, "parent ops containing compute ops must be scf.for or "
-                       "linalg.generic");
+        outermostOp->emitOpError(
+            "Parent ops containing compute ops must be scf.for, scf.if, or "
+            "linalg.generic");
         walkFailed = true;
         return WalkResult::interrupt();
       }
@@ -691,6 +692,13 @@ static void collectOpsToErase(Block *block, DenseSet<Operation *> &eraseSet,
     }
     if (auto forOp = dyn_cast<scf::ForOp>(&op)) {
       collectOpsToErase(forOp.getBody(), eraseSet, isDatamovementThread);
+      continue;
+    }
+    if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
+      collectOpsToErase(ifOp.thenBlock(), eraseSet, isDatamovementThread);
+      if (Block *elseBlock = ifOp.elseBlock()) {
+        collectOpsToErase(elseBlock, eraseSet, isDatamovementThread);
+      }
       continue;
     }
 

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -267,11 +267,10 @@ LogicalResult wrapComputeInSynchronizedRegion(GenericOp genericOp,
            !opsWithSynchronizableOps.contains(outermostOp->getParentOp())) {
       outermostOp = outermostOp->getParentOp();
       if (!mlir::isa<scf::ForOp>(outermostOp) &&
-          !mlir::isa<scf::IfOp>(outermostOp) &&
           !mlir::isa<linalg::GenericOp>(outermostOp)) {
-        outermostOp->emitOpError(
-            "Parent ops containing compute ops must be scf.for, scf.if, or "
-            "linalg.generic");
+        (void)rewriter.notifyMatchFailure(
+            genericOp, "parent ops containing compute ops must be scf.for or "
+                       "linalg.generic");
         walkFailed = true;
         return WalkResult::interrupt();
       }

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -694,13 +694,6 @@ static void collectOpsToErase(Block *block, DenseSet<Operation *> &eraseSet,
       collectOpsToErase(forOp.getBody(), eraseSet, isDatamovementThread);
       continue;
     }
-    if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
-      collectOpsToErase(ifOp.thenBlock(), eraseSet, isDatamovementThread);
-      if (Block *elseBlock = ifOp.elseBlock()) {
-        collectOpsToErase(elseBlock, eraseSet, isDatamovementThread);
-      }
-      continue;
-    }
 
     bool isDMAOp = isa<ShardDMAOpInterface, DeviceSynchronizeOp>(&op);
     bool isReplicated = isa<SemaphoreWaitOp>(&op);

--- a/lib/Dialect/TTKernel/Transforms/ControlDstSection.cpp
+++ b/lib/Dialect/TTKernel/Transforms/ControlDstSection.cpp
@@ -30,9 +30,9 @@ static Block *findBlockContaining(Operation *op) {
 }
 
 // Returns true if `op` is a pack_tile that already lives inside a
-// self-managed DST section. Topk group ops emit a complete
-// commit/wait/pack/release sequence in the same block as the pack_tile, so
-// this pass must not wrap them again.
+// self-managed DST section. Some group ops emit a complete
+// commit/wait/pack/release sequence in the same block, so this pass must
+// not wrap them again.
 static bool isSelfManagedPackTile(Operation *op) {
   return !op->getBlock()->getOps<ttkernel::TileRegsReleaseOp>().empty();
 }
@@ -80,7 +80,7 @@ public:
         return;
       }
 
-      // Topk group ops self-manage their DST section; don't wrap them.
+      // When group ops self-manage their DST section, don't wrap them.
       if (isSelfManagedPackTile(op)) {
         return;
       }

--- a/lib/Dialect/TTKernel/Transforms/ControlDstSection.cpp
+++ b/lib/Dialect/TTKernel/Transforms/ControlDstSection.cpp
@@ -29,6 +29,14 @@ static Block *findBlockContaining(Operation *op) {
   return block;
 }
 
+// Returns true if `op` is a pack_tile that already lives inside a
+// self-managed DST section. Topk group ops emit a complete
+// commit/wait/pack/release sequence in the same block as the pack_tile, so
+// this pass must not wrap them again.
+static bool isSelfManagedPackTile(Operation *op) {
+  return !op->getBlock()->getOps<ttkernel::TileRegsReleaseOp>().empty();
+}
+
 static Operation *parentOpAtBlock(Operation *child, Block *atBlock) {
   Operation *parent = child;
   while (parent->getBlock() != atBlock) {
@@ -69,6 +77,11 @@ public:
 
     getOperation()->walk([&](Operation *op) {
       if (!isa<ttkernel::PackTileOp, ttkernel::PackTileBlockOp>(op)) {
+        return;
+      }
+
+      // Topk group ops self-manage their DST section; don't wrap them.
+      if (isSelfManagedPackTile(op)) {
         return;
       }
 

--- a/lib/Dialect/TTKernel/Transforms/ControlDstSection.cpp
+++ b/lib/Dialect/TTKernel/Transforms/ControlDstSection.cpp
@@ -30,11 +30,37 @@ static Block *findBlockContaining(Operation *op) {
 }
 
 // Returns true if `op` is a pack_tile that already lives inside a
-// self-managed DST section. Some group ops emit a complete
+// self-managed DST section: a TileRegsAcquireOp precedes it and a
+// TileRegsReleaseOp follows it in the same block, with no intervening
+// acquire/release breaking that pairing. Some group ops emit a complete
 // commit/wait/pack/release sequence in the same block, so this pass must
 // not wrap them again.
 static bool isSelfManagedPackTile(Operation *op) {
-  return !op->getBlock()->getOps<ttkernel::TileRegsReleaseOp>().empty();
+  bool precededByAcquire = false;
+  for (Operation *it = op->getPrevNode(); it != nullptr;
+       it = it->getPrevNode()) {
+    if (isa<ttkernel::TileRegsAcquireOp>(it)) {
+      precededByAcquire = true;
+      break;
+    }
+    if (isa<ttkernel::TileRegsReleaseOp>(it)) {
+      break;
+    }
+  }
+  if (!precededByAcquire) {
+    return false;
+  }
+
+  for (Operation *it = op->getNextNode(); it != nullptr;
+       it = it->getNextNode()) {
+    if (isa<ttkernel::TileRegsReleaseOp>(it)) {
+      return true;
+    }
+    if (isa<ttkernel::TileRegsAcquireOp>(it)) {
+      return false;
+    }
+  }
+  return false;
 }
 
 static Operation *parentOpAtBlock(Operation *child, Block *atBlock) {

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -28,12 +28,16 @@ torch.manual_seed(0)
     [
         pytest.param((32, 64), 16, -1, id="32x64_k16_dim1"),
         pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
-        pytest.param((32, 256), 32, -1, id="32x256_k32_dim1"),
         pytest.param((64, 32), 16, 0, id="64x32_k16_dim0"),
         pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
-        pytest.param((256, 32), 32, 0, id="256x32_k32_dim0"),
         pytest.param((32, 64), 64, -1, id="32x64_k64_dim1"),
         pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
+        pytest.param((64, 32), 64, 0, id="64x32_k64_dim0"),
+        pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
+        pytest.param((32, 1024), 16, -1, id="32x1024_k16_dim1"),
+        pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
+        pytest.param((1024, 32), 16, 0, id="1024x32_k16_dim0"),
+        pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
     ],
 )
 def test_topk(shape, k, dim, target, request, device):
@@ -122,10 +126,13 @@ def _build_tile_distribution_input(
     "shape,k,dim",
     [
         pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
-        pytest.param((32, 256), 32, -1, id="32x256_k32_dim1"),
         pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
-        pytest.param((256, 32), 32, 0, id="256x32_k32_dim0"),
+        pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
         pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
+        pytest.param((32, 1024), 16, -1, id="32x1024_k16_dim1"),
+        pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
+        pytest.param((1024, 32), 16, 0, id="1024x32_k16_dim0"),
+        pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
     ],
 )
 def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device):

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -26,9 +26,8 @@ torch.manual_seed(0)
 def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors):
     """PCC-checks topk device outputs against the golden.
 
-    Device output order and tie-breaking can differ from the golden.
     Values are compared order-robustly. Indices are validated on the values
-    they point to, gathered from the input, rather than on raw positions.
+    they point to, gathered from the input, rather than raw positions.
     """
     d = dim % input_tensor.ndim
     prog = output_tensors["program_0"]
@@ -61,14 +60,14 @@ def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors):
         pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
         pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
         # Large target dim (many tiles in reduction)
-        pytest.param((32, 1024), 16, -1, id="32x1024_k16_dim1"),
+        pytest.param((32, 1376), 16, -1, id="32x1376_k16_dim1"),
         pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
         # Ragged (non-power-of-2 tile count)
         pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
-        pytest.param((544, 32), 16, 0, id="544x32_k16_dim0"),
+        pytest.param((1536, 32), 16, 0, id="1536x32_k16_dim0"),
         # Multi-tile non-target dim (ht>1 for dim=1, wt>1 for dim=0)
-        pytest.param((128, 384), 32, -1, id="128x384_k32_dim1"),
-        pytest.param((384, 96), 64, 0, id="384x96_k64_dim0"),
+        pytest.param((96, 446), 32, -1, id="96x446_k32_dim1"),
+        pytest.param((383, 96), 63, 0, id="383x96_k63_dim0"),
     ],
 )
 def test_topk(shape, k, dim, target, request, device):
@@ -79,7 +78,7 @@ def test_topk(shape, k, dim, target, request, device):
             builder: TTIRBuilder,
             unit_attrs: Optional[List[str]] = None,
         ):
-            return builder.topk(
+            values = builder.topk(
                 in0,
                 k=k,
                 dim=dim,
@@ -87,6 +86,8 @@ def test_topk(shape, k, dim, target, request, device):
                 sorted=False,
                 unit_attrs=unit_attrs,
             )
+            indices = builder.topk_indices(values)
+            return values, indices
 
     kwargs = get_request_kwargs(request)
     artifact_dir = get_artifact_dir(
@@ -107,8 +108,8 @@ def test_topk(shape, k, dim, target, request, device):
         save_artifacts=True,
     )
 
-    # Recompute the golden from a fresh random input so the comparison is valid.
-    input_tensor = torch.randn(shape)
+    # Recompute golden from a fresh random input for a valid comparison.
+    input_tensor = torch.randn(shape) * 50
     golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
 
     mesh_shape = (1, 1)
@@ -116,14 +117,12 @@ def test_topk(shape, k, dim, target, request, device):
     io_goldens[0]["output_0"] = GoldenMapTensor(
         {0: golden_topk.values}, mesh_shape=mesh_shape
     )
-    # Match the device index output dtype so execute_fb's built-in comparison
-    # doesn't hit a dtype mismatch; the raw-index result itself is ignored.
+    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
     io_goldens[0]["output_1"] = GoldenMapTensor(
         {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
     )
 
-    # Raw index comparison is unstable on ties, so we PCC-check both outputs
-    # ourselves in _verify_topk_outputs instead.
+    # Raw index comparison is unstable on ties; PCC-check both in _verify_topk_outputs.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,
@@ -138,68 +137,23 @@ def test_topk(shape, k, dim, target, request, device):
     _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors)
 
 
-# Materializes just the arange index tensor to verify the arange/tilize/untilize
-# round-trip. For dim=1, element [i, j] should equal the global column index j.
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize(
-    "shape,dim",
-    [
-        pytest.param((32, 256), 1, id="32x256_dim1"),
-        pytest.param((32, 1024), 1, id="32x1024_dim1"),
-    ],
-)
-def test_arange_index_tensor(shape, dim, target, request, device):
-    # Disable truncation and line wrapping so the comparison message shows
-    # every element of each row.
-    torch.set_printoptions(threshold=1_000_000, linewidth=1_000_000)
-    end = shape[dim]
-
-    def module(builder: TTIRBuilder):
-        @builder.func([shape], [torch.float32])
-        def arange_index(
-            in0: Operand,
-            builder: TTIRBuilder,
-            unit_attrs: Optional[List[str]] = None,
-        ):
-            # in0 is a dummy operand; only the arange output is inspected.
-            idx = builder.arange(
-                shape=list(shape),
-                dtype=torch.int32,
-                start=0,
-                end=end,
-                step=1,
-                arange_dimension=dim,
-                unit_attrs=unit_attrs,
-            )
-            return idx
-
-    compile_and_execute_ttir(
-        module,
-        **get_request_kwargs(request),
-        target=target,
-        device=device,
-        pipeline_options=["override-device-shape=1,1"],
-        save_artifacts=True,
-    )
-
-
 def _build_tile_distribution_input(
     shape: Tuple[int, ...], k: int, dim: int, pattern: str
 ) -> torch.Tensor:
-    """Builds an input tensor whose top-k values are concentrated in specific tiles.
+    """Build an input tensor where top-k values are concentrated in specific tiles.
 
-    Placing large values in only certain 32-element tiles forces the merge
-    tree to propagate them correctly.
+    Each tile is 32 elements along the topk dim.  By placing large values only
+    in certain tiles we force the merge tree to propagate them correctly.
     """
     # Normalize negative dim so index comparisons work correctly.
     if dim < 0:
         dim = len(shape) + dim
-    tensor = torch.randn(shape) * 50  # Near-zero baseline.
+    tensor = torch.randn(shape) * 0.01  # near-zero baseline.
     tile_size = 32
     num_tiles = shape[dim] // tile_size
 
     if pattern == "first_tiles":
-        # Concentrates top values in the first 2 tiles.
+        # Top values in the first 2 tiles.
         slices = [slice(None)] * len(shape)
         slices[dim] = slice(0, min(2 * tile_size, shape[dim]))
         tensor[tuple(slices)] = (
@@ -213,7 +167,7 @@ def _build_tile_distribution_input(
         )
 
     elif pattern == "last_tiles":
-        # Concentrates top values in the last 2 tiles.
+        # Top values concentrated in the last 2 tiles.
         slices = [slice(None)] * len(shape)
         start = max(0, shape[dim] - 2 * tile_size)
         slices[dim] = slice(start, shape[dim])
@@ -225,8 +179,8 @@ def _build_tile_distribution_input(
         )
 
     elif pattern == "strided":
-        # Places top values in every other tile, forcing the merge to pull
-        # from non-adjacent tiles at every level of the reduction tree.
+        # Top values in every other tile — forces merge to pull from
+        # non-adjacent tiles at every level of the reduction tree.
         for t in range(0, num_tiles, 2):
             slices = [slice(None)] * len(shape)
             slices[dim] = slice(t * tile_size, (t + 1) * tile_size)
@@ -254,7 +208,8 @@ def _build_tile_distribution_input(
     ],
 )
 def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device):
-    """Runs topk on hand-crafted inputs that stress the merge-tree reduction logic."""
+    """Run topk with hand-crafted inputs that concentrate top values in
+    specific tiles, stressing the merge-tree reduction logic."""
 
     def module(builder: TTIRBuilder):
         @builder.func([shape], [torch.float32])
@@ -263,7 +218,7 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
             builder: TTIRBuilder,
             unit_attrs: Optional[List[str]] = None,
         ):
-            return builder.topk(
+            values = builder.topk(
                 in0,
                 k=k,
                 dim=dim,
@@ -271,6 +226,8 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
                 sorted=False,
                 unit_attrs=unit_attrs,
             )
+            indices = builder.topk_indices(values)
+            return values, indices
 
     kwargs = get_request_kwargs(request)
     artifact_dir = get_artifact_dir(
@@ -291,7 +248,8 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
         save_artifacts=True,
     )
 
-    # Recompute the golden from the adversarial tensor so the comparison is valid.
+    # Replace the random input with our adversarial tensor and recompute the
+    # expected output so the golden comparison is valid.
     adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
     golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
 
@@ -302,14 +260,12 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
     io_goldens[0]["output_0"] = GoldenMapTensor(
         {0: golden_topk.values}, mesh_shape=mesh_shape
     )
-    # Match the device index output dtype so execute_fb's built-in comparison
-    # doesn't hit a dtype mismatch; the raw-index result itself is ignored.
+    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
     io_goldens[0]["output_1"] = GoldenMapTensor(
         {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
     )
 
-    # Raw index comparison is unstable on ties, so we PCC-check both outputs
-    # ourselves in _verify_topk_outputs instead.
+    # Raw index comparison is unstable on ties; PCC-check both in _verify_topk_outputs.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -7,10 +7,7 @@ import torch
 
 from builder.base.builder_utils import Operand
 from builder.ttir.ttir_builder import TTIRBuilder
-from builder.base.builder_apis import (
-    compile_and_execute_ttir,
-    compile_ttir_to_flatbuffer,
-)
+from builder.base.builder_apis import compile_ttir_to_flatbuffer
 from builder.base.builder_runtime import execute_fb
 from builder.base.builder_apis import get_artifact_dir
 from golden import get_atol_rtol_pcc
@@ -71,6 +68,9 @@ def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors):
     ],
 )
 def test_topk(shape, k, dim, target, request, device):
+    input_tensor = torch.randn(shape) * 50
+    golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
+
     def module(builder: TTIRBuilder):
         @builder.func([shape], [torch.float32])
         def topk(
@@ -87,6 +87,13 @@ def test_topk(shape, k, dim, target, request, device):
                 unit_attrs=unit_attrs,
             )
             indices = builder.topk_indices(values)
+            builder.set_goldens(
+                {in0: input_tensor},
+                {
+                    values: golden_topk.values,
+                    indices: golden_topk.indices.to(torch.uint16),
+                },
+            )
             return values, indices
 
     kwargs = get_request_kwargs(request)
@@ -108,21 +115,6 @@ def test_topk(shape, k, dim, target, request, device):
         save_artifacts=True,
     )
 
-    # Recompute golden from a fresh random input for a valid comparison.
-    input_tensor = torch.randn(shape) * 50
-    golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
-
-    mesh_shape = (1, 1)
-    io_goldens[0]["input_0"] = GoldenMapTensor({0: input_tensor}, mesh_shape=mesh_shape)
-    io_goldens[0]["output_0"] = GoldenMapTensor(
-        {0: golden_topk.values}, mesh_shape=mesh_shape
-    )
-    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
-    io_goldens[0]["output_1"] = GoldenMapTensor(
-        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
-    )
-
-    # Raw index comparison is unstable on ties; PCC-check both in _verify_topk_outputs.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,
@@ -211,6 +203,9 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
     """Run topk with hand-crafted inputs that concentrate top values in
     specific tiles, stressing the merge-tree reduction logic."""
 
+    adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
+    golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
+
     def module(builder: TTIRBuilder):
         @builder.func([shape], [torch.float32])
         def topk(
@@ -227,6 +222,13 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
                 unit_attrs=unit_attrs,
             )
             indices = builder.topk_indices(values)
+            builder.set_goldens(
+                {in0: adversarial_input},
+                {
+                    values: golden_topk.values,
+                    indices: golden_topk.indices.to(torch.uint16),
+                },
+            )
             return values, indices
 
     kwargs = get_request_kwargs(request)
@@ -248,24 +250,6 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
         save_artifacts=True,
     )
 
-    # Replace the random input with our adversarial tensor and recompute the
-    # expected output so the golden comparison is valid.
-    adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
-    golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
-
-    mesh_shape = (1, 1)
-    io_goldens[0]["input_0"] = GoldenMapTensor(
-        {0: adversarial_input}, mesh_shape=mesh_shape
-    )
-    io_goldens[0]["output_0"] = GoldenMapTensor(
-        {0: golden_topk.values}, mesh_shape=mesh_shape
-    )
-    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
-    io_goldens[0]["output_1"] = GoldenMapTensor(
-        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
-    )
-
-    # Raw index comparison is unstable on ties; PCC-check both in _verify_topk_outputs.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -38,6 +38,13 @@ torch.manual_seed(0)
         pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
         pytest.param((1024, 32), 16, 0, id="1024x32_k16_dim0"),
         pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
+        # Non-power-of-2 tile counts
+        pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
+        pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
+        pytest.param((32, 192), 16, -1, id="32x192_k16_dim1"),
+        pytest.param((96, 32), 16, 0, id="96x32_k16_dim0"),
+        pytest.param((544, 32), 16, 0, id="544x32_k16_dim0"),
+        pytest.param((32, 1536), 32, 1, id="32x1536_k32_dim1"),
     ],
 )
 def test_topk(shape, k, dim, target, request, device):
@@ -133,6 +140,13 @@ def _build_tile_distribution_input(
         pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
         pytest.param((1024, 32), 16, 0, id="1024x32_k16_dim0"),
         pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
+        # Non-power-of-2 tile counts (ragged), k<=32. The strided/last_tiles
+        # patterns stress odd-tail propagation and carried-tile correctness.
+        pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),  # 3 tiles, odd
+        pytest.param((32, 192), 16, -1, id="32x192_k16_dim1"),  # 6 tiles, even
+        pytest.param((32, 1013), 64, -1, id="32x1013_k64_dim1"),  # 36 tiles, even
+        pytest.param((96, 32), 16, 0, id="96x32_k16_dim0"),  # 3 tiles, odd
+        pytest.param((544, 32), 16, 0, id="544x32_k16_dim0"),  # 17 tiles, odd
     ],
 )
 def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device):

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -26,25 +26,20 @@ torch.manual_seed(0)
 @pytest.mark.parametrize(
     "shape,k,dim",
     [
-        pytest.param((32, 64), 16, -1, id="32x64_k16_dim1"),
+        # Single-tile target dim, dim=1 and dim=0
         pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
-        pytest.param((64, 32), 16, 0, id="64x32_k16_dim0"),
-        pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
-        pytest.param((32, 64), 64, -1, id="32x64_k64_dim1"),
         pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
-        pytest.param((64, 32), 64, 0, id="64x32_k64_dim0"),
+        pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
         pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
+        # Large target dim (many tiles in reduction)
         pytest.param((32, 1024), 16, -1, id="32x1024_k16_dim1"),
-        pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
-        pytest.param((1024, 32), 16, 0, id="1024x32_k16_dim0"),
         pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
-        # Non-power-of-2 tile counts
+        # Ragged (non-power-of-2 tile count)
         pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
-        pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
-        pytest.param((32, 192), 16, -1, id="32x192_k16_dim1"),
-        pytest.param((96, 32), 16, 0, id="96x32_k16_dim0"),
         pytest.param((544, 32), 16, 0, id="544x32_k16_dim0"),
-        pytest.param((32, 1536), 32, 1, id="32x1536_k32_dim1"),
+        # Multi-tile non-target dim (ht>1 for dim=1, wt>1 for dim=0)
+        pytest.param((128, 384), 32, -1, id="128x384_k32_dim1"),
+        pytest.param((511, 96), 64, 0, id="384x128_k64_dim0"),
     ],
 )
 def test_topk(shape, k, dim, target, request, device):
@@ -63,6 +58,57 @@ def test_topk(shape, k, dim, target, request, device):
                 sorted=False,
                 unit_attrs=unit_attrs,
             )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        pipeline_options=["override-device-shape=1,1"],
+        save_artifacts=True,
+    )
+
+
+# Debug: materialize just the arange index tensor (no topk) to verify what the
+# arange->tilize->untilize round-trip produces at every element. For dim=1 the
+# expected value at [i, j] is j == tileColIdx*32 + withinTileColIdx (the global
+# column index, constant across rows).
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize(
+    "shape,dim",
+    [
+        pytest.param((32, 256), 1, id="32x256_dim1"),
+        pytest.param((32, 1024), 1, id="32x1024_dim1"),
+    ],
+)
+def test_arange_index_tensor(shape, dim, target, request, device):
+    # Print full tensors (no ... truncation, no line wrapping) so the
+    # golden-vs-output comparison message shows every element of each row.
+    torch.set_printoptions(threshold=1_000_000, linewidth=1_000_000)
+    end = shape[dim]
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [torch.float32])
+        def arange_index(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            # Take a dummy input so the function has an operand; the arange is
+            # what we actually inspect. Add input*0 (as f32) to keep the arange
+            # from being folded into a pure host constant, forcing the real
+            # tilize/untilize device round-trip. Cast to f32 to add, then the
+            # golden comparison checks the index pattern.
+            idx = builder.arange(
+                shape=list(shape),
+                dtype=torch.int32,
+                start=0,
+                end=end,
+                step=1,
+                arange_dimension=dim,
+                unit_attrs=unit_attrs,
+            )
+            return idx
 
     compile_and_execute_ttir(
         module,
@@ -132,21 +178,16 @@ def _build_tile_distribution_input(
 @pytest.mark.parametrize(
     "shape,k,dim",
     [
+        # pow2 tile count, dim=1 and dim=0
         pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
-        pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
-        pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
         pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
-        pytest.param((32, 1024), 16, -1, id="32x1024_k16_dim1"),
+        # Large reduction dim
         pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
-        pytest.param((1024, 32), 16, 0, id="1024x32_k16_dim0"),
-        pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
-        # Non-power-of-2 tile counts (ragged), k<=32. The strided/last_tiles
-        # patterns stress odd-tail propagation and carried-tile correctness.
+        # Ragged (non-power-of-2): odd tile count, even tile count
         pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),  # 3 tiles, odd
-        pytest.param((32, 192), 16, -1, id="32x192_k16_dim1"),  # 6 tiles, even
-        pytest.param((32, 1013), 64, -1, id="32x1013_k64_dim1"),  # 36 tiles, even
-        pytest.param((96, 32), 16, 0, id="96x32_k16_dim0"),  # 3 tiles, odd
         pytest.param((544, 32), 16, 0, id="544x32_k16_dim0"),  # 17 tiles, odd
+        # Multi-tile non-target dim
+        pytest.param((64, 256), 64, -1, id="64x256_k64_dim1"),  # ht=2, large-k
     ],
 )
 def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device):
@@ -191,14 +232,17 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
     # Replace the random input with our adversarial tensor and recompute the
     # expected output so the golden comparison is valid.
     adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
-    golden_output = torch.topk(adversarial_input, k=k, dim=dim, largest=True).values
+    golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
 
     mesh_shape = (1, 1)
     io_goldens[0]["input_0"] = GoldenMapTensor(
         {0: adversarial_input}, mesh_shape=mesh_shape
     )
     io_goldens[0]["output_0"] = GoldenMapTensor(
-        {0: golden_output}, mesh_shape=mesh_shape
+        {0: golden_topk.values}, mesh_shape=mesh_shape
+    )
+    io_goldens[0]["output_1"] = GoldenMapTensor(
+        {0: golden_topk.indices}, mesh_shape=mesh_shape
     )
 
     execute_fb(

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -13,6 +13,7 @@ from builder.base.builder_apis import (
 )
 from builder.base.builder_runtime import execute_fb
 from builder.base.builder_apis import get_artifact_dir
+from golden import get_atol_rtol_pcc
 from golden.mapping import GoldenMapTensor
 from conftest import get_request_kwargs
 from typing import Optional, List, Tuple
@@ -20,6 +21,34 @@ from typing import Optional, List, Tuple
 
 pytestmark = pytest.mark.frontend("ttir")
 torch.manual_seed(0)
+
+
+def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors):
+    """PCC-checks topk device outputs against the golden.
+
+    Device output order and tie-breaking can differ from the golden.
+    Values are compared order-robustly. Indices are validated on the values
+    they point to, gathered from the input, rather than on raw positions.
+    """
+    d = dim % input_tensor.ndim
+    prog = output_tensors["program_0"]
+    device_values = prog["device_output_0"][0]
+    device_indices = prog["device_output_1"][0].long()
+
+    dv_sorted, _ = torch.sort(device_values, dim=d)
+    gv_sorted, _ = torch.sort(golden_topk.values, dim=d)
+    _, _, values_pcc = get_atol_rtol_pcc(gv_sorted, dv_sorted, 1e-08, 1e-05)
+    assert values_pcc >= 0.99, f"values PCC {values_pcc} < 0.99"
+
+    # The pointed-to values are compared in bf16.
+    device_gathered = torch.gather(input_tensor, d, device_indices).to(torch.bfloat16)
+    golden_gathered = torch.gather(input_tensor, d, golden_topk.indices).to(
+        torch.bfloat16
+    )
+    dg_sorted, _ = torch.sort(device_gathered, dim=d)
+    gg_sorted, _ = torch.sort(golden_gathered, dim=d)
+    _, _, index_value_pcc = get_atol_rtol_pcc(gg_sorted, dg_sorted, 1e-08, 1e-05)
+    assert index_value_pcc >= 0.99, f"index-value PCC {index_value_pcc} < 0.99"
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -39,7 +68,7 @@ torch.manual_seed(0)
         pytest.param((544, 32), 16, 0, id="544x32_k16_dim0"),
         # Multi-tile non-target dim (ht>1 for dim=1, wt>1 for dim=0)
         pytest.param((128, 384), 32, -1, id="128x384_k32_dim1"),
-        pytest.param((511, 96), 64, 0, id="384x128_k64_dim0"),
+        pytest.param((384, 96), 64, 0, id="384x96_k64_dim0"),
     ],
 )
 def test_topk(shape, k, dim, target, request, device):
@@ -59,20 +88,58 @@ def test_topk(shape, k, dim, target, request, device):
                 unit_attrs=unit_attrs,
             )
 
-    compile_and_execute_ttir(
+    kwargs = get_request_kwargs(request)
+    artifact_dir = get_artifact_dir(
+        kwargs["output_root"], "TTIRBuilder", kwargs["test_base"], make_dir=True
+    )
+
+    (
+        builder,
+        compiled_bin,
+        io_goldens,
+        intermediate_goldens,
+    ) = compile_ttir_to_flatbuffer(
         module,
-        **get_request_kwargs(request),
+        system_desc_path=kwargs["system_desc_path"],
+        artifact_dir=artifact_dir,
         target=target,
-        device=device,
         pipeline_options=["override-device-shape=1,1"],
         save_artifacts=True,
     )
 
+    # Recompute the golden from a fresh random input so the comparison is valid.
+    input_tensor = torch.randn(shape)
+    golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
 
-# Debug: materialize just the arange index tensor (no topk) to verify what the
-# arange->tilize->untilize round-trip produces at every element. For dim=1 the
-# expected value at [i, j] is j == tileColIdx*32 + withinTileColIdx (the global
-# column index, constant across rows).
+    mesh_shape = (1, 1)
+    io_goldens[0]["input_0"] = GoldenMapTensor({0: input_tensor}, mesh_shape=mesh_shape)
+    io_goldens[0]["output_0"] = GoldenMapTensor(
+        {0: golden_topk.values}, mesh_shape=mesh_shape
+    )
+    # Match the device index output dtype so execute_fb's built-in comparison
+    # doesn't hit a dtype mismatch; the raw-index result itself is ignored.
+    io_goldens[0]["output_1"] = GoldenMapTensor(
+        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
+    )
+
+    # Raw index comparison is unstable on ties, so we PCC-check both outputs
+    # ourselves in _verify_topk_outputs instead.
+    _, output_tensors = execute_fb(
+        compiled_bin,
+        input_output_goldens=io_goldens,
+        intermediate_goldens=intermediate_goldens,
+        device=device,
+        pcc=0.99,
+        check_pcc=False,
+        save_artifacts=True,
+        artifact_dir=artifact_dir,
+    )
+
+    _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors)
+
+
+# Materializes just the arange index tensor to verify the arange/tilize/untilize
+# round-trip. For dim=1, element [i, j] should equal the global column index j.
 @pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.parametrize(
     "shape,dim",
@@ -82,8 +149,8 @@ def test_topk(shape, k, dim, target, request, device):
     ],
 )
 def test_arange_index_tensor(shape, dim, target, request, device):
-    # Print full tensors (no ... truncation, no line wrapping) so the
-    # golden-vs-output comparison message shows every element of each row.
+    # Disable truncation and line wrapping so the comparison message shows
+    # every element of each row.
     torch.set_printoptions(threshold=1_000_000, linewidth=1_000_000)
     end = shape[dim]
 
@@ -94,11 +161,7 @@ def test_arange_index_tensor(shape, dim, target, request, device):
             builder: TTIRBuilder,
             unit_attrs: Optional[List[str]] = None,
         ):
-            # Take a dummy input so the function has an operand; the arange is
-            # what we actually inspect. Add input*0 (as f32) to keep the arange
-            # from being folded into a pure host constant, forcing the real
-            # tilize/untilize device round-trip. Cast to f32 to add, then the
-            # golden comparison checks the index pattern.
+            # in0 is a dummy operand; only the arange output is inspected.
             idx = builder.arange(
                 shape=list(shape),
                 dtype=torch.int32,
@@ -123,20 +186,20 @@ def test_arange_index_tensor(shape, dim, target, request, device):
 def _build_tile_distribution_input(
     shape: Tuple[int, ...], k: int, dim: int, pattern: str
 ) -> torch.Tensor:
-    """Build an input tensor where top-k values are concentrated in specific tiles.
+    """Builds an input tensor whose top-k values are concentrated in specific tiles.
 
-    Each tile is 32 elements along the topk dim.  By placing large values only
-    in certain tiles we force the merge tree to propagate them correctly.
+    Placing large values in only certain 32-element tiles forces the merge
+    tree to propagate them correctly.
     """
     # Normalize negative dim so index comparisons work correctly.
     if dim < 0:
         dim = len(shape) + dim
-    tensor = torch.randn(shape) * 0.01  # near-zero baseline
+    tensor = torch.randn(shape) * 50  # Near-zero baseline.
     tile_size = 32
     num_tiles = shape[dim] // tile_size
 
     if pattern == "first_tiles":
-        # Top values concentrated in the first 2 tiles (indices 0..63).
+        # Concentrates top values in the first 2 tiles.
         slices = [slice(None)] * len(shape)
         slices[dim] = slice(0, min(2 * tile_size, shape[dim]))
         tensor[tuple(slices)] = (
@@ -150,7 +213,7 @@ def _build_tile_distribution_input(
         )
 
     elif pattern == "last_tiles":
-        # Top values concentrated in the last 2 tiles.
+        # Concentrates top values in the last 2 tiles.
         slices = [slice(None)] * len(shape)
         start = max(0, shape[dim] - 2 * tile_size)
         slices[dim] = slice(start, shape[dim])
@@ -162,8 +225,8 @@ def _build_tile_distribution_input(
         )
 
     elif pattern == "strided":
-        # Top values in every other tile — forces merge to pull from
-        # non-adjacent tiles at every level of the reduction tree.
+        # Places top values in every other tile, forcing the merge to pull
+        # from non-adjacent tiles at every level of the reduction tree.
         for t in range(0, num_tiles, 2):
             slices = [slice(None)] * len(shape)
             slices[dim] = slice(t * tile_size, (t + 1) * tile_size)
@@ -191,8 +254,7 @@ def _build_tile_distribution_input(
     ],
 )
 def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device):
-    """Run topk with hand-crafted inputs that concentrate top values in
-    specific tiles, stressing the merge-tree reduction logic."""
+    """Runs topk on hand-crafted inputs that stress the merge-tree reduction logic."""
 
     def module(builder: TTIRBuilder):
         @builder.func([shape], [torch.float32])
@@ -229,8 +291,7 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
         save_artifacts=True,
     )
 
-    # Replace the random input with our adversarial tensor and recompute the
-    # expected output so the golden comparison is valid.
+    # Recompute the golden from the adversarial tensor so the comparison is valid.
     adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
     golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
 
@@ -241,17 +302,23 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
     io_goldens[0]["output_0"] = GoldenMapTensor(
         {0: golden_topk.values}, mesh_shape=mesh_shape
     )
+    # Match the device index output dtype so execute_fb's built-in comparison
+    # doesn't hit a dtype mismatch; the raw-index result itself is ignored.
     io_goldens[0]["output_1"] = GoldenMapTensor(
-        {0: golden_topk.indices}, mesh_shape=mesh_shape
+        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
     )
 
-    execute_fb(
+    # Raw index comparison is unstable on ties, so we PCC-check both outputs
+    # ourselves in _verify_topk_outputs instead.
+    _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,
         intermediate_goldens=intermediate_goldens,
         device=device,
         pcc=0.99,
-        check_pcc=True,
+        check_pcc=False,
         save_artifacts=True,
         artifact_dir=artifact_dir,
     )
+
+    _verify_topk_outputs(adversarial_input, golden_topk, dim, output_tensors)

--- a/test/ttmlir/Conversion/D2MToTTKernel/topk.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/topk.mlir
@@ -24,7 +24,7 @@ func.func @topk_dim1_k16(%arg0: tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor
 
 // -----
 
-// ---- dim=1, k=32, 2-tile input: no rebuild ----
+// ---- dim=1, k=32, 2-tile input ----
 
 // 32x64 with k=32: the merge output is exactly k elements, so no rebuild is emitted.
 // CHECK-LABEL: func.func @topk_k32_no_rebuild

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -169,9 +169,4 @@ module {
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
   }
-
-  // Note: k>32 with non-pow2 reduction tiles is still rejected by the gate
-  // ("D2M topk requires a power-of-2 reduction tile count when k > 32").
-  // That negative case is not exercised here to avoid an unconverted op in the
-  // output; it can be tested via a separate -verify-diagnostics run.
 }

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -146,4 +146,29 @@ module {
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>)
     return %values, %indices : tensor<16x32xf32>, tensor<16x32xsi32>
   }
+
+  // ---- Non-power-of-2 tile counts (ragged), k<=32 ----
+
+  // 32x544 with k=16: Wt=17 (non-pow2) now converts successfully.
+  // CHECK-LABEL: func @topk_dim1_k16_nonpow2
+  func.func @topk_dim1_k16_nonpow2(%arg0: tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
+    // Pre-transpose and topk_block emit normally.
+    // CHECK: d2m.generic
+    // CHECK: d2m.tile_transpose
+    // CHECK: d2m.generic
+    // CHECK: d2m.topk_block
+    // CHECK-SAME: k = 16
+    // CHECK-SAME: num_elements = 544
+    // CHECK: d2m.generic
+    // CHECK: d2m.tile_transpose
+    // CHECK: d2m.generic
+    // CHECK: d2m.tile_transpose
+    %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
+    return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
+  }
+
+  // Note: k>32 with non-pow2 reduction tiles is still rejected by the gate
+  // ("D2M topk requires a power-of-2 reduction tile count when k > 32").
+  // That negative case is not exercised here to avoid an unconverted op in the
+  // output; it can be tested via a separate -verify-diagnostics run.
 }

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -130,8 +130,9 @@ module {
     // CHECK-SAME: tensor<1x1x1x2x!ttcore.tile<32x32, f32>
     // The TopK values output is 1x2 tiles (full reduction shape before extract).
     // CHECK: d2m.empty() : tensor<1x1x1x2x!ttcore.tile<32x32, f32>
-    // The TopK indices output is 1x2 tiles of si32.
-    // CHECK: d2m.empty() : tensor<1x1x1x2x!ttcore.tile<32x32, si32>
+    // The TopK indices output is 1x2 tiles of f32 (index buffer carried as
+    // fp32; typecast to the si32 user output happens after extract).
+    // CHECK: d2m.empty() : tensor<1x1x1x2x!ttcore.tile<32x32, f32>
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
   }
@@ -142,7 +143,9 @@ module {
     // CHECK: d2m.to_layout
     // CHECK-SAME: tensor<1x1x2x1x!ttcore.tile<32x32, f32>
     // CHECK: d2m.empty() : tensor<1x1x2x1x!ttcore.tile<32x32, f32>
-    // CHECK: d2m.empty() : tensor<1x1x2x1x!ttcore.tile<32x32, si32>
+    // Index buffer is carried as fp32 (typecast to si32 user output after
+    // extract).
+    // CHECK: d2m.empty() : tensor<1x1x2x1x!ttcore.tile<32x32, f32>
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>)
     return %values, %indices : tensor<16x32xf32>, tensor<16x32xsi32>
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
@@ -161,4 +161,98 @@ module {
     %values, %indices = "ttir.topk"(%arg0) <{k = 32 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x64xf32>) -> (tensor<32x32xf32>, tensor<32x32xsi32>)
     return %values, %indices : tensor<32x32xf32>, tensor<32x32xsi32>
   }
+
+  // ---- Non-power-of-2 tile counts (ragged merge tree) ----
+
+  // 32x96 with k=16: Wt=3 (odd, ragged), ceilLog2=2 iterations.
+  // Level 0 pairs (0,1); tile 2 is odd tail → standalone local_sort at level 0.
+  // Level 1 pairs (0,2).
+  // CHECK-LABEL: func @decompose_k16_3tiles
+  func.func @decompose_k16_3tiles(%arg0: tensor<32x96xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
+    // CHECK-NOT: d2m.topk_block
+    // CHECK: d2m.arange_block
+    // CHECK-SAME: num_elements = 96
+    // Outer scf.for (ceilLog2(3)=2 iterations), inner scf.for over tile pairs.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // Ragged guard: merge only when tileB < numTiles.
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
+    // Odd-tail standalone sort for tile 2 (emitted at level 0).
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_local_sort
+
+    %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x96xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
+    return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
+  }
+
+  // 32x192 with k=16: Wt=6 (even, ragged), ceilLog2=3 iterations.
+  // All tiles paired at level 0 (no odd tail). Ragged merge guard present.
+  // CHECK-LABEL: func @decompose_k16_6tiles
+  func.func @decompose_k16_6tiles(%arg0: tensor<32x192xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
+    // CHECK-NOT: d2m.topk_block
+    // CHECK: d2m.arange_block
+    // CHECK-SAME: num_elements = 192
+    // Outer scf.for (ceilLog2(6)=3 iterations), inner scf.for over tile pairs.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // Ragged guard present (tileB < numTiles check wrapping merge).
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
+
+    %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x192xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
+    return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
+  }
+
+  // 32x544 with k=16: Wt=17 (odd, ragged), ceilLog2=5 iterations. Headline case.
+  // CHECK-LABEL: func @decompose_k16_17tiles
+  func.func @decompose_k16_17tiles(%arg0: tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
+    // CHECK-NOT: d2m.topk_block
+    // CHECK: d2m.arange_block
+    // CHECK-SAME: num_elements = 544
+    // Outer scf.for (ceilLog2(17)=5 iterations), inner scf.for over tile pairs.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // Ragged merge guard.
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
+    // Odd-tail standalone sort for tile 16 at level 0.
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_local_sort
+
+    %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
+    return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
+  }
+
+  // dim=0 non-pow2: 96x32 with k=16, Ht=3 (odd, ragged), ceilLog2=2.
+  // CHECK-LABEL: func @decompose_k16_3tiles_dim0
+  func.func @decompose_k16_3tiles_dim0(%arg0: tensor<96x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
+    // CHECK-NOT: d2m.topk_block
+    // CHECK: d2m.arange_block
+    // CHECK-SAME: num_elements = 96
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // Ragged merge guard.
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
+    // Odd-tail standalone sort for tile 2 at level 0.
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_local_sort
+
+    %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<96x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>)
+    return %values, %indices : tensor<16x32xf32>, tensor<16x32xsi32>
+  }
+
 }

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
@@ -20,13 +20,13 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 64
 
-    // Outer scf.for over mIter, inner scf.for over tile pairs. The rebuild is
-    // guarded by an scf.if on needsRebuild.
+    // logWt=1, so level 0 is also the last level: emitted unrolled (no outer
+    // scf.for), with an inner scf.for over tile pairs and an unconditional
+    // rebuild.
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
-    // CHECK: scf.if
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
@@ -44,13 +44,22 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 256
 
-    // Outer scf.for over mIter [0, 3), inner scf.for over tile pairs. The
-    // rebuild is guarded by an scf.if on needsRebuild.
+    // Level 0 is emitted unrolled, levels [1,logWt-1) run in a
+    // middle scf.for with no rebuild, and the last level is emitted unrolled
+    // with an unconditional rebuild.
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
-    // CHECK: scf.if
+    // Middle level(s): plain scf.for, no rebuild.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // Last level: unrolled, unconditional rebuild.
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x256xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
@@ -91,16 +100,16 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 128
 
-    // Outer loop over logWt=2 merge iterations; inner loop over tile pairs.
+    // Level 0 is emitted unrolled: direct sort-merge-rebuild.
     // CHECK: scf.for
     // CHECK: scf.for
-    // scf.if dispatches iter 0 (then-block) vs later iters (else-block).
-    // CHECK: scf.if
-    // Iter 0 (then-block): direct sort-merge-rebuild.
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 64
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
-    // Iter 1 (else-block): 3-sub-merge (winners, losers, winners-vs-losers).
+    // Levels [1, logWt) run in a separate scf.for: 3-sub-merge (winners,
+    // losers, winners-vs-losers).
+    // CHECK: scf.for
+    // CHECK: scf.for
     // Sub 1: merge winner tiles.
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 64
@@ -128,12 +137,12 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 64
 
-    // The rebuild is guarded by an scf.if on needsRebuild.
+    // logWt=1: level 0 is also the last level, so rebuild is emitted
+    // unconditionally.
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
-    // CHECK: scf.if
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>)
@@ -144,8 +153,8 @@ module {
 
   // 32x64 with k=32: Wt=2, logWt=1.
   // Only 1 iteration and k==32, so the merge output is already exactly k
-  // elements. The rebuild is guarded by an scf.if whose condition is false at
-  // runtime, so it is skipped and the merge packs the tiles instead.
+  // elements: needsRebuild is false at compile time, so no rebuild op
+  // is emitted at all, and the merge packs the tiles instead.
   // CHECK-LABEL: func @decompose_k32_2tiles
   func.func @decompose_k32_2tiles(%arg0: tensor<32x64xf32>) -> (tensor<32x32xf32>, tensor<32x32xsi32>) {
     // CHECK-NOT: d2m.topk_block
@@ -155,8 +164,7 @@ module {
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
-    // CHECK: scf.if
-    // CHECK: d2m.tile_topk_rebuild
+    // CHECK-NOT: d2m.tile_topk_rebuild
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 32 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x64xf32>) -> (tensor<32x32xf32>, tensor<32x32xsi32>)
     return %values, %indices : tensor<32x32xf32>, tensor<32x32xsi32>
@@ -172,17 +180,18 @@ module {
     // CHECK-NOT: d2m.topk_block
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 96
-    // Outer scf.for (ceilLog2(3)=2 iterations), inner scf.for over tile pairs.
+    // Level 0 (unrolled): local_sort+merge, plus the odd-tail standalone sort
+    // for tile 2 (emitted unconditionally at level 0).
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
-    // Rebuild only on the last iteration.
-    // CHECK: scf.if
-    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
-    // Odd-tail standalone sort for tile 2 (emitted at level 0).
-    // CHECK: scf.if
     // CHECK: d2m.tile_topk_local_sort
+    // Last level (logWt-1, unrolled): rebuild is unconditional.
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x96xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
@@ -195,13 +204,20 @@ module {
     // CHECK-NOT: d2m.topk_block
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 192
-    // Outer scf.for (ceilLog2(6)=3 iterations), inner scf.for over tile pairs.
+    // Level 0 (unrolled).
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
-    // Rebuild only on the last iteration.
-    // CHECK: scf.if
+    // Middle level(s) [1, logWt-1): plain scf.for, no rebuild.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // Last level (unrolled): rebuild is unconditional.
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x192xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
@@ -214,17 +230,22 @@ module {
     // CHECK-NOT: d2m.topk_block
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 544
-    // Outer scf.for (ceilLog2(17)=5 iterations), inner scf.for over tile pairs.
+    // Level 0 (unrolled), plus odd-tail standalone sort for tile 16.
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
-    // Rebuild only on the last iteration.
-    // CHECK: scf.if
-    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
-    // Odd-tail standalone sort for tile 16 at level 0.
-    // CHECK: scf.if
     // CHECK: d2m.tile_topk_local_sort
+    // Middle level(s) [1, logWt-1): plain scf.for, no rebuild.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // Last level (unrolled): rebuild is unconditional.
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
@@ -236,16 +257,17 @@ module {
     // CHECK-NOT: d2m.topk_block
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 96
+    // Level 0 (unrolled), plus odd-tail standalone sort for tile 2.
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
-    // Rebuild only on the last iteration.
-    // CHECK: scf.if
-    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
-    // Odd-tail standalone sort for tile 2 at level 0.
-    // CHECK: scf.if
     // CHECK: d2m.tile_topk_local_sort
+    // Last level (unrolled): rebuild is unconditional.
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<96x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>)
     return %values, %indices : tensor<16x32xf32>, tensor<16x32xsi32>

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
@@ -2,14 +2,15 @@
 // RUN: FileCheck %s --input-file=%t
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline -o %t.ttmetal %s
 
-// Verify that d2m-decompose-topk replaces topk_block with the decomposed
-// arange_block + tile_topk_{local_sort,merge,rebuild} sequence.
+// Verify that d2m-decompose-topk replaces topk_block with arange_block +
+// scf.for loops (one per merge iteration) containing
+// tile_topk_{local_sort,merge,rebuild} ops.
 
 module {
 
   // ---- Small k (k<=32), 2 tiles: 1 merge iteration ----
 
-  // 32x64 with k=16: Wt=2, logWt=1 yields 1 iteration of sort+merge+rebuild.
+  // 32x64 with k=16: Wt=2, logWt=1 → outer scf.for with nested inner scf.for.
   // CHECK-LABEL: func @decompose_k16_2tiles
   func.func @decompose_k16_2tiles(%arg0: tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // The topk_block must be fully replaced.
@@ -19,13 +20,15 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 64
 
-    // Iteration 0 (only iteration) contains sort, merge, and rebuild.
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_merge{{.*}}k = 32{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5{{.*}}skip_second = 1{{.*}}tile_a = 0{{.*}}tile_b = 1
+    // Outer scf.for over mIter, inner scf.for over tile pairs. The rebuild is
+    // guarded by an scf.if on needsRebuild.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
-    // No extra iterations should be emitted.
-    // CHECK-NOT: d2m.tile_topk_local_sort
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
   }
@@ -33,9 +36,7 @@ module {
   // ---- Small k (k<=32), 8 tiles: 3 merge iterations ----
 
   // 32x256 with k=16: Wt=8, logWt=3.
-  // Iter 0: 4 pairs (0,1)(2,3)(4,5)(6,7) contain sort+merge only (no rebuild).
-  // Iter 1: 2 pairs (0,2)(4,6) contain sort+merge only.
-  // Iter 2: 1 pair (0,4) contains sort+merge+rebuild (last iteration, k<32).
+  // Single outer scf.for (3 iterations) with nested inner scf.for.
   // CHECK-LABEL: func @decompose_k16_8tiles
   func.func @decompose_k16_8tiles(%arg0: tensor<32x256xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
@@ -43,26 +44,14 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 256
 
-    // ---- Iteration 0: 4 pairs with sort+merge and no rebuild ----
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_merge{{.*}}m_iter = 0{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 2{{.*}}tile_b = 3
-    // CHECK: d2m.tile_topk_merge{{.*}}tile_a = 2{{.*}}tile_b = 3
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 4{{.*}}tile_b = 5
-    // CHECK: d2m.tile_topk_merge{{.*}}tile_a = 4{{.*}}tile_b = 5
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 6{{.*}}tile_b = 7
-    // CHECK: d2m.tile_topk_merge{{.*}}tile_a = 6{{.*}}tile_b = 7
-
-    // ---- Iteration 1: 2 pairs with sort+merge and read_from_output ----
-    // CHECK: d2m.tile_topk_local_sort{{.*}}read_from_output = true{{.*}}tile_a = 0{{.*}}tile_b = 2
-    // CHECK: d2m.tile_topk_merge{{.*}}m_iter = 1{{.*}}tile_a = 0{{.*}}tile_b = 2
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 4{{.*}}tile_b = 6
-    // CHECK: d2m.tile_topk_merge{{.*}}tile_a = 4{{.*}}tile_b = 6
-
-    // ---- Iteration 2 (last): 1 pair with sort+merge+rebuild ----
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 0{{.*}}tile_b = 4
-    // CHECK: d2m.tile_topk_merge{{.*}}m_iter = 2{{.*}}tile_a = 0{{.*}}tile_b = 4
-    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5{{.*}}m_iter = 2{{.*}}skip_second = 1{{.*}}tile_a = 0{{.*}}tile_b = 4
+    // Outer scf.for over mIter [0, 3), inner scf.for over tile pairs. The
+    // rebuild is guarded by an scf.if on needsRebuild.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x256xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
@@ -80,9 +69,11 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 128
 
-    // CHECK: d2m.tile_topk_local_sort{{.*}}read_from_output = false{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_merge{{.*}}k = 64{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64{{.*}}logk = 6{{.*}}skip_second = 0{{.*}}tile_a = 0{{.*}}tile_b = 1
+    // Single scf.for with sort-merge-rebuild.
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64{{.*}}logk = 6
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 64 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x128xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>)
     return %values, %indices : tensor<32x64xf32>, tensor<32x64xsi32>
@@ -91,11 +82,8 @@ module {
   // ---- Large k (k>32), 4 tiles: 3-sub-merge tree on later iterations ----
 
   // 32x128 with k=64: Wt=4, logWt=2.
-  // Iter 0: pairs (0,1)(2,3) use direct sort-merge-rebuild (isFirst).
-  // Iter 1: pair (0,2) uses a 3-sub-merge tree:
-  //   Sub 1: merge winners (0,2)
-  //   Sub 2: merge losers (1,3)
-  //   Sub 3: merge winners vs losers (2,1)
+  // Iter 0: pairs (0,1)(2,3) — direct sort-merge-rebuild (isFirst).
+  // Iter 1: pair (0,2) — 3-sub-merge tree.
   // CHECK-LABEL: func @decompose_k64_4tiles
   func.func @decompose_k64_4tiles(%arg0: tensor<32x128xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
@@ -103,29 +91,28 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 128
 
-    // ---- Iter 0: 2 pairs with direct sort-merge-rebuild ----
-    // Pair (0,1):
-    // CHECK: d2m.tile_topk_local_sort{{.*}}read_from_output = false{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_merge{{.*}}k = 64{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // Pair (2,3):
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 2{{.*}}tile_b = 3
-    // CHECK: d2m.tile_topk_merge{{.*}}k = 64{{.*}}tile_a = 2{{.*}}tile_b = 3
-    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64{{.*}}tile_a = 2{{.*}}tile_b = 3
-
-    // ---- Iter 1: 3-sub-merge tree for pair (0,2) ----
-    // Sub 1 merges winner tiles (0,2).
-    // CHECK: d2m.tile_topk_local_sort{{.*}}read_from_output = true{{.*}}tile_a = 0{{.*}}tile_b = 2
-    // CHECK: d2m.tile_topk_merge{{.*}}tile_a = 0{{.*}}tile_b = 2
-    // CHECK: d2m.tile_topk_rebuild{{.*}}tile_a = 0{{.*}}tile_b = 2
-    // Sub 2 merges loser tiles (1,3).
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 1{{.*}}tile_b = 3
-    // CHECK: d2m.tile_topk_merge{{.*}}tile_a = 1{{.*}}tile_b = 3
-    // CHECK: d2m.tile_topk_rebuild{{.*}}tile_a = 1{{.*}}tile_b = 3
-    // Sub 3 merges winners vs losers (2,1).
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 2{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_merge{{.*}}tile_a = 2{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_rebuild{{.*}}tile_a = 2{{.*}}tile_b = 1
+    // Outer loop over logWt=2 merge iterations; inner loop over tile pairs.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // scf.if dispatches iter 0 (then-block) vs later iters (else-block).
+    // CHECK: scf.if
+    // Iter 0 (then-block): direct sort-merge-rebuild.
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // Iter 1 (else-block): 3-sub-merge (winners, losers, winners-vs-losers).
+    // Sub 1: merge winner tiles.
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // Sub 2: merge loser tiles.
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // Sub 3: merge winners vs losers.
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 64 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x128xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>)
     return %values, %indices : tensor<32x64xf32>, tensor<32x64xsi32>
@@ -134,21 +121,20 @@ module {
   // ---- dim=0 decomposition ----
 
   // 64x32 with k=16, dim=0: Ht=2, logWt=1.
-  // The key difference from dim=1 is the shard layout: tiles are 2x1 (tall)
-  // rather than 1x2 (wide), since the reduction runs along tile rows.
-  // No pre-transpose is needed; extract uses tile_typecast instead.
   // CHECK-LABEL: func @decompose_dim0_k16
   func.func @decompose_dim0_k16(%arg0: tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // The shard shape is 2x1 (2 tiles tall, 1 tile wide).
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 64
 
-    // The single iteration has tiles indexed in the height dimension.
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_merge{{.*}}k = 32{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5{{.*}}skip_second = 1{{.*}}tile_a = 0{{.*}}tile_b = 1
+    // The rebuild is guarded by an scf.if on needsRebuild.
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>)
     return %values, %indices : tensor<16x32xf32>, tensor<16x32xsi32>
@@ -157,18 +143,20 @@ module {
   // ---- k=32 special case: no rebuild on single iteration ----
 
   // 32x64 with k=32: Wt=2, logWt=1.
-  // Only 1 iteration and k==32, so the merge output is already exactly k elements.
-  // No rebuild is emitted.
+  // Only 1 iteration and k==32, so the merge output is already exactly k
+  // elements. The rebuild is guarded by an scf.if whose condition is false at
+  // runtime, so it is skipped and the merge packs the tiles instead.
   // CHECK-LABEL: func @decompose_k32_2tiles
   func.func @decompose_k32_2tiles(%arg0: tensor<32x64xf32>) -> (tensor<32x32xf32>, tensor<32x32xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
     // CHECK: d2m.arange_block
-    // CHECK: d2m.tile_topk_local_sort{{.*}}tile_a = 0{{.*}}tile_b = 1
-    // CHECK: d2m.tile_topk_merge{{.*}}k = 32{{.*}}tile_a = 0{{.*}}tile_b = 1
-
-    // No rebuild is emitted when k==32 and there is only 1 iteration.
-    // CHECK-NOT: d2m.tile_topk_rebuild
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // CHECK: scf.if
+    // CHECK: d2m.tile_topk_rebuild
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 32 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x64xf32>) -> (tensor<32x32xf32>, tensor<32x32xsi32>)
     return %values, %indices : tensor<32x32xf32>, tensor<32x32xsi32>

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
@@ -175,10 +175,9 @@ module {
     // Outer scf.for (ceilLog2(3)=2 iterations), inner scf.for over tile pairs.
     // CHECK: scf.for
     // CHECK: scf.for
-    // Ragged guard: merge only when tileB < numTiles.
-    // CHECK: scf.if
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // Rebuild only on the last iteration.
     // CHECK: scf.if
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
     // Odd-tail standalone sort for tile 2 (emitted at level 0).
@@ -190,7 +189,7 @@ module {
   }
 
   // 32x192 with k=16: Wt=6 (even, ragged), ceilLog2=3 iterations.
-  // All tiles paired at level 0 (no odd tail). Ragged merge guard present.
+  // All tiles paired at level 0 (no odd tail).
   // CHECK-LABEL: func @decompose_k16_6tiles
   func.func @decompose_k16_6tiles(%arg0: tensor<32x192xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
@@ -199,10 +198,9 @@ module {
     // Outer scf.for (ceilLog2(6)=3 iterations), inner scf.for over tile pairs.
     // CHECK: scf.for
     // CHECK: scf.for
-    // Ragged guard present (tileB < numTiles check wrapping merge).
-    // CHECK: scf.if
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // Rebuild only on the last iteration.
     // CHECK: scf.if
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
 
@@ -219,10 +217,9 @@ module {
     // Outer scf.for (ceilLog2(17)=5 iterations), inner scf.for over tile pairs.
     // CHECK: scf.for
     // CHECK: scf.for
-    // Ragged merge guard.
-    // CHECK: scf.if
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // Rebuild only on the last iteration.
     // CHECK: scf.if
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
     // Odd-tail standalone sort for tile 16 at level 0.
@@ -241,10 +238,9 @@ module {
     // CHECK-SAME: num_elements = 96
     // CHECK: scf.for
     // CHECK: scf.for
-    // Ragged merge guard.
-    // CHECK: scf.if
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 32
+    // Rebuild only on the last iteration.
     // CHECK: scf.if
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 16{{.*}}logk = 5
     // Odd-tail standalone sort for tile 2 at level 0.

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -19238,14 +19238,16 @@ class TTIRBuilder(Builder):
             loc=loc,
         )
         op_values = op.values
+        op_indices = op.indices
 
         if unit_attrs is not None:
             for attr_name in unit_attrs:
                 op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
 
         self._set_golden_tensor(op_values, golden_values)
+        self._set_golden_tensor(op_indices, golden_indices)
 
-        return op_values
+        return op_values, op_indices
 
     @parse(ttir.TopKOp)
     def topk_parser(

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -19199,7 +19199,7 @@ class TTIRBuilder(Builder):
         output_type: Optional[torch.dtype] = None,
         loc: Optional[str] = None,
         unit_attrs: Optional[List[str]] = None,
-    ) -> Tuple[OpResult, OpResult]:
+    ) -> OpResult:
         ttir_op = self.get_opview_from_method(TTIRBuilder.topk)
 
         if output_type is None:
@@ -19238,16 +19238,34 @@ class TTIRBuilder(Builder):
             loc=loc,
         )
         op_values = op.values
-        op_indices = op.indices
 
         if unit_attrs is not None:
             for attr_name in unit_attrs:
                 op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
 
+        # The ttir.topk op is dual-result: it produces both values and indices.
+        # topk() returns only the values result; topk_indices() recovers the
+        # indices result of the same op without emitting a duplicate op.
         self._set_golden_tensor(op_values, golden_values)
-        self._set_golden_tensor(op_indices, golden_indices)
+        self._set_golden_tensor(op.indices, golden_indices)
 
-        return op_values, op_indices
+        return op_values
+
+    def topk_indices(self, topk_values: OpResult) -> OpResult:
+        """Return the indices result of the ttir.topk op that produced ``topk_values``.
+
+        ``topk`` yields only the values result; the op itself is dual-result
+        (values, indices). This recovers the sibling indices result from the
+        same op, so no second topk op is emitted.
+        """
+        owner = topk_values.owner
+        op_view = owner.opview if isinstance(owner, Operation) else owner
+        if not isinstance(op_view, ttir.TopKOp):
+            raise TypeError(
+                "topk_indices expects a value produced by builder.topk; got "
+                f"{type(op_view).__name__}"
+            )
+        return op_view.indices
 
     @parse(ttir.TopKOp)
     def topk_parser(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Topk was very restricted on the size and shape of both dimensions. Also, the index output was untested and resulting in all 0s due to a datatype issue. Correcting the index output also required fixing arange (#8967) because this is still a single core implementation.

### What's changed

**Extended Shape Support**
* Emitted `scf.for` and `scf.if` ops instead of unrolling entire reduction tree to decrease the size of the generated kernel
* Arbitrary target dimension support using a ragged merge loop for k <=32 and `-inf` padding to nearest power-of-2 tile count for k > 32
* Arbitrary non-target dim support using a loop to index over the tiles in the non-target dim

**Corrected Index Output**
* Refactored builder to also check index output. `torch.topk` is not stable in its tie breaking decisions so index output is measured on what values they point to rather than comparing the actual indices
* Utilized `arange` + `broadcast` to generate initial index buffer
* Emitted index generation in `TTIRToD2M` instead of in topk block op decomposition to simplify logic

**Current Capabilities**
* Target dim must be at least 2 tiles
* Total input can be a total of 48 tiles for dim 0 and 43 tiles for dim 1
* Still only supports k <= 64
* Single core implementation

**Future Work**
* Extend to arbitrary k based on real model requirements
* Multi-core to all for much larger shapes because L1 memory is being exceeded right now on a single core
* Get real shapes from a real model working with topk

### Checklist
- [ ] New/Existing tests provide coverage for changes
