### PR TITLE
[Shardy] Add custom sharding rule support on stablehlo.custom_call

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -65,6 +65,32 @@ def RegisterCustomShardingRulePass : Pass<"register-custom-sharding-rule", "::ml
     "::mlir::sdy::SdyDialect"
   ];
 }
+
+def RegisterUserShardingRulePass : Pass<"register-user-sharding-rule", "::mlir::ModuleOp">
+{
+  let summary = "Promote user-provided xla.sdy.custom_sharding_rule frontend attributes to sdy.sharding_rule op attributes.";
+
+  let description = [{
+    Promotes a user-specified custom sharding rule, carried on a
+    stablehlo.custom_call as the "xla.sdy.custom_sharding_rule" frontend
+    attribute, into a real #sdy.op_sharding_rule set under the standard
+    sdy.sharding_rule op attribute. Promoting it to a first-class,
+    Shardy-recognized attribute lets Shardy propagate it directly and run
+    its always-on verifier on it.
+
+    If "xla.sdy.custom_sharding_rule" is absent or an empty string, the op
+    has no custom rule and falls back to Shardy's default replication. If it
+    is present and non-empty but does not parse into an #sdy.op_sharding_rule,
+    the pass fails with an error.
+
+    This pass is intended to run before any Shardy sharding propagation passes.
+  }];
+
+  let dependentDialects = [
+    "::mlir::sdy::SdyDialect"
+  ];
+}
+
 def ApplyArgumentShardStatusPass : Pass<"apply-argument-shard-status", "::mlir::ModuleOp">
 {
   let summary = "Annotate arguments with their shard status.";

--- a/include/ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h
@@ -14,6 +14,8 @@ namespace mlir::tt::sharding_utils {
 // SDY sharding related string definitions.
 inline constexpr llvm::StringRef kXlaSdyShardingAttr = "xla.sdy.sharding";
 inline constexpr llvm::StringRef kXlaSdyMeshesAttr = "xla.sdy.meshes";
+inline constexpr llvm::StringRef kXlaSdyCustomShardingRuleAttr =
+    "xla.sdy.custom_sharding_rule";
 inline constexpr llvm::StringRef kDefaultMeshName = "mesh";
 inline constexpr llvm::StringRef kTTShardingConstraintTargetName =
     "tt.sharding_constraint";

--- a/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
+++ b/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
@@ -75,6 +75,10 @@ void createStableHLOPipeline(OpPassManager &pm,
   // Register custom sharding rules for unsupported ops in Shardy.
   pm.addPass(createRegisterCustomShardingRulePass());
 
+  // Promote user-provided xla.sdy.custom_sharding_rule frontend attributes to
+  // sdy.sharding_rule op attributes. Must run before propagation.
+  pm.addPass(createRegisterUserShardingRulePass());
+
   // Apply sharding constraints.
   pm.addPass(mlir::sdy::createApplyShardingConstraintsPass());
 

--- a/lib/Dialect/StableHLO/Transforms/AutoSharding.cpp
+++ b/lib/Dialect/StableHLO/Transforms/AutoSharding.cpp
@@ -286,6 +286,7 @@ static void addRemainingStableHLOPasses(OpPassManager &pm) {
   pm.addPass(createDecoupleConstFanoutPass());
   pm.addPass(createFlattenOrConvertCompositesPass());
   pm.addPass(createRegisterCustomShardingRulePass());
+  pm.addPass(createRegisterUserShardingRulePass());
 
   mlir::sdy::PropagationOptions propagationOptions;
   propagationOptions.conservativePropagation = true;

--- a/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
+++ b/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_dialect_library(MLIRStableHLOTransforms
   InsertReshardsForUnpropagatedOps.cpp
   PartiallyConvertSdyToStableHLO.cpp
   RegisterCustomShardingRule.cpp
+  RegisterUserShardingRule.cpp
   ReoutlineComposite.cpp
   ReplicateNonSplittableConstants.cpp
   ShardyCCLCanonicalization.cpp

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
 #include "ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h"
 
+#include "mlir/IR/BuiltinAttributes.h"
 #include "llvm/Support/Error.h"
 #include <shardy/dialect/sdy/ir/enums.h>
 
@@ -1700,6 +1701,9 @@ struct StablehloCustomCallShardingModel
 private:
   mlir::sdy::OpShardingRuleAttr
   getCustomCallShardingRule(mlir::stablehlo::CustomCallOp op) const {
+    // NOTE: User-provided rules (xla.sdy.custom_sharding_rule) are promoted to
+    // the sdy.sharding_rule op attribute by the RegisterUserShardingRulePass.
+    // This pass only serves the C++-defined built-in rules below.
     llvm::StringRef target = op.getCallTargetName();
 
     auto shardOpFunc = customCallShardingRules.lookup(target);

--- a/lib/Dialect/StableHLO/Transforms/RegisterUserShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterUserShardingRule.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "shardy/dialect/sdy/ir/constants.h"
+#include "shardy/dialect/sdy/ir/dialect.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
+#include "ttmlir/Dialect/StableHLO/Utils/GSPMDUtils.h"
+#include "ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h"
+
+#include "mlir/AsmParser/AsmParser.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+namespace mlir::tt::stablehlo {
+#define GEN_PASS_DEF_REGISTERUSERSHARDINGRULEPASS
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
+
+class RegisterUserShardingRulePass
+    : public impl::RegisterUserShardingRulePassBase<
+          RegisterUserShardingRulePass> {
+public:
+  using impl::RegisterUserShardingRulePassBase<
+      RegisterUserShardingRulePass>::RegisterUserShardingRulePassBase;
+
+  void runOnOperation() final {
+    getOperation().walk([&](mlir::stablehlo::CustomCallOp op) {
+      auto frontendAttrs = op->getAttrOfType<mlir::DictionaryAttr>(
+          gspmd_utils::kFrontendAttributesAttr);
+      if (!frontendAttrs) {
+        return;
+      }
+
+      // If attribute is defined but empty, fall back to Shardy's default
+      // handling (replication)
+      auto ruleStrAttr = frontendAttrs.getAs<mlir::StringAttr>(
+          sharding_utils::kXlaSdyCustomShardingRuleAttr);
+      if (!ruleStrAttr || ruleStrAttr.getValue().trim().empty()) {
+        return;
+      }
+
+      auto rule = mlir::dyn_cast_or_null<mlir::sdy::OpShardingRuleAttr>(
+          mlir::parseAttribute(ruleStrAttr.getValue(), &getContext()));
+      if (!rule) {
+        op.emitError() << "failed to parse '"
+                       << sharding_utils::kXlaSdyCustomShardingRuleAttr
+                       << "' frontend attribute as an #sdy.op_sharding_rule";
+        signalPassFailure();
+        return;
+      }
+
+      op->setAttr(mlir::sdy::kShardingRuleAttr, rule);
+    });
+  }
+};
+
+} // namespace mlir::tt::stablehlo

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/tt_lang_custom_rule.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/tt_lang_custom_rule.mlir
@@ -1,0 +1,108 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline -o %t.mlir %s 2>%t.err
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: FileCheck %s --check-prefix=ERR --input-file=%t.err
+
+// End-to-end coverage for user-provided `xla.sdy.custom_sharding_rule` rules on a
+// `tt.tt_lang_op` custom_call, exercised through the full stablehlo pipeline:
+//   * @with_rule      -- a valid rule is parsed into a typed
+//                        `sdy.op_sharding_rule`, honored by Shardy propagation,
+//                        and reflected in the local shapes produced by
+//                        UpdateGlobalToLocalShapes.
+//   * @without_rule   -- no rule: Shardy has no built-in rule for tt.tt_lang_op,
+//                        so the result is left replicated.
+//
+// A malformed or semantically invalid rule is a hard error and is covered
+// separately in tt_lang_custom_rule_invalid.mlir.
+//
+// `tt.tt_lang_op` has no built-in sharding rule, so the custom rule is the only
+// thing that can shard the result: the sharded (4x16) result in @with_rule is
+// what makes the test discriminating.
+
+sdy.mesh @mesh = <["x"=2]>
+
+// With the rule, dim 0 is a shared factor ([i, j], [i, j]) -> ([i, j]): the
+// operands' "x" sharding on dim 0 propagates to the result, so every tensor
+// inside the manual_computation body is local-shaped 4x16 (8 / 2).
+//
+// CHECK-LABEL: func.func @with_rule
+// The rule propagates the operand sharding to the result...
+// CHECK: sdy.manual_computation(%arg0, %arg1)
+// CHECK-SAME: in_shardings=[<@mesh, [{"x"}, {}]>, <@mesh, [{"x"}, {}]>]
+// CHECK-SAME: out_shardings=[<@mesh, [{"x"}, {}]>]
+// ...the string rule was parsed into a typed, reprinted sdy.op_sharding_rule...
+// CHECK: stablehlo.custom_call @tt.tt_lang_op
+// CHECK-SAME: sdy.sharding_rule = #sdy.op_sharding_rule<([i, j], [i, j])->([i, j]) {i=8, j=16}, custom>
+// ...and UpdateGlobalToLocalShapes halves dim 0 (8 -> 4) on operands AND result.
+// CHECK-SAME: (tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK: sdy.return %{{.*}} : tensor<4x16xf32>
+func.func @with_rule(
+    %arg0: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>},
+    %arg1: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>})
+    -> tensor<8x16xf32> {
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      kernel_id = "pkg.add::v1",
+      version_tag = "1.0",
+      arg_roles = "in,out",
+      "xla.sdy.custom_sharding_rule" = "#sdy.op_sharding_rule<([i, j], [i, j]) -> ([i, j]) {i=8, j=16}, custom>"
+    }
+  } : (tensor<8x16xf32>, tensor<8x16xf32>) -> tensor<8x16xf32>
+  return %0 : tensor<8x16xf32>
+}
+
+// Without a rule there is nothing to relate operands and result: Shardy leaves
+// the result unconstrained (replicated), so UpdateGlobalToLocalShapes keeps the
+// result at its full 8x16 shape even though the operands are local 4x16.
+//
+// CHECK-LABEL: func.func @without_rule
+// Result sharding is empty (replicated), not {"x"}.
+// CHECK: out_shardings=[<@mesh, [{}, {}]>]
+// Operands are local 4x16 but the result stays full 8x16.
+// CHECK: stablehlo.custom_call @tt.tt_lang_op
+// CHECK-SAME: (tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<8x16xf32>
+// CHECK: sdy.return %{{.*}} : tensor<8x16xf32>
+//
+// With no rule and no built-in rule for tt.tt_lang_op, Shardy warns loudly.
+// ERR-DAG: warning: StableHLO CustomCallOp sharding rule is not defined for target 'tt.tt_lang_op'
+func.func @without_rule(
+    %arg0: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>},
+    %arg1: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>})
+    -> tensor<8x16xf32> {
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      kernel_id = "pkg.add::v1",
+      version_tag = "1.0",
+      arg_roles = "in,out"
+    }
+  } : (tensor<8x16xf32>, tensor<8x16xf32>) -> tensor<8x16xf32>
+  return %0 : tensor<8x16xf32>
+}
+
+// An empty (or whitespace-only) rule string is treated exactly like no rule: it
+// is NOT a hard parse error, and the op falls back to replication just like
+// @without_rule (result stays full 8x16, operands local 4x16). This guards the
+// empty-string fallback in the promote pass.
+//
+// CHECK-LABEL: func.func @empty_rule
+// CHECK: out_shardings=[<@mesh, [{}, {}]>]
+// CHECK: stablehlo.custom_call @tt.tt_lang_op
+// CHECK-SAME: (tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<8x16xf32>
+// CHECK: sdy.return %{{.*}} : tensor<8x16xf32>
+func.func @empty_rule(
+    %arg0: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>},
+    %arg1: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>})
+    -> tensor<8x16xf32> {
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      kernel_id = "pkg.add::v1",
+      version_tag = "1.0",
+      arg_roles = "in,out",
+      "xla.sdy.custom_sharding_rule" = ""
+    }
+  } : (tensor<8x16xf32>, tensor<8x16xf32>) -> tensor<8x16xf32>
+  return %0 : tensor<8x16xf32>
+}

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/tt_lang_custom_rule_invalid.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/tt_lang_custom_rule_invalid.mlir
@@ -1,0 +1,119 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline -verify-diagnostics=only-expected -split-input-file %s
+
+// An invalid `xla.sdy.custom_sharding_rule` frontend attribute is a hard error, not a
+// silent fallback to replication. There are two distinct failure points:
+//
+//   * A rule string that does not parse into an #sdy.op_sharding_rule is caught
+//     by RegisterUserShardingRulePass, which fails before propagation runs
+//     (see @not_a_rule / @wrong_attribute_kind).
+//
+//   * A rule that parses but is semantically inconsistent with the op it is
+//     attached to (operand/result arity, per-tensor rank, or factor reuse) is
+//     caught by Shardy's own always-on op-attribute verifier: once the pass
+//     promotes the rule to the `sdy.sharding_rule` op attribute, MLIR operation
+//     verification runs SdyDialect::verifyOperationAttribute ->
+//     verifyOpShardingRuleAttr, which rejects it with a clear diagnostic in
+//     every build (see @arity_mismatch / @rank_mismatch / @duplicate_factor).
+//     These diagnostics are emitted by Shardy, so we match Shardy's wording.
+//
+// `only-expected` is used because the full pipeline also emits unrelated
+// module-level warnings (e.g. missing argument type map / result shard status)
+// and the MLIR parser emits its own sub-diagnostic for an unparseable rule; we
+// only want to assert on the error under test here.
+
+sdy.mesh @mesh = <["x"=2]>
+
+func.func @not_a_rule(
+    %arg0: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>},
+    %arg1: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>})
+    -> tensor<8x16xf32> {
+  // expected-error @+1 {{failed to parse 'xla.sdy.custom_sharding_rule' frontend attribute as an #sdy.op_sharding_rule}}
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      arg_roles = "in,out",
+      "xla.sdy.custom_sharding_rule" = "not a valid rule"
+    }
+  } : (tensor<8x16xf32>, tensor<8x16xf32>) -> tensor<8x16xf32>
+  return %0 : tensor<8x16xf32>
+}
+
+// -----
+
+sdy.mesh @mesh = <["x"=2]>
+
+func.func @wrong_attribute_kind(
+    %arg0: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>},
+    %arg1: tensor<8x16xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>})
+    -> tensor<8x16xf32> {
+  // A syntactically valid attribute that is not an #sdy.op_sharding_rule.
+  // expected-error @+1 {{failed to parse 'xla.sdy.custom_sharding_rule' frontend attribute as an #sdy.op_sharding_rule}}
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      arg_roles = "in,out",
+      "xla.sdy.custom_sharding_rule" = "42 : i32"
+    }
+  } : (tensor<8x16xf32>, tensor<8x16xf32>) -> tensor<8x16xf32>
+  return %0 : tensor<8x16xf32>
+}
+
+// -----
+
+sdy.mesh @mesh = <["x"=2]>
+
+// Op has 2 operands but the rule only maps 1 operand. Caught by Shardy's
+// verifyOpShardingRuleAttr once the rule is promoted to the op attribute.
+func.func @arity_mismatch(
+    %arg0: tensor<8x4xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>},
+    %arg1: tensor<8x4xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>})
+    -> tensor<8x4xf32> {
+  // expected-error @+1 {{'stablehlo.custom_call' op number of operands and mappings must match: 2 != 1}}
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      arg_roles = "in,out",
+      "xla.sdy.custom_sharding_rule" = "#sdy.op_sharding_rule<([i, j])->([i, j]) {i=8, j=4}, custom>"
+    }
+  } : (tensor<8x4xf32>, tensor<8x4xf32>) -> tensor<8x4xf32>
+  return %0 : tensor<8x4xf32>
+}
+
+// -----
+
+sdy.mesh @mesh = <["x"=2]>
+
+// Op operand is rank 2 but the rule's operand mapping is rank 3.
+func.func @rank_mismatch(
+    %arg0: tensor<8x4xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>})
+    -> tensor<8x4xf32> {
+  // expected-error @+1 {{'stablehlo.custom_call' op operand - mapping rank must match: 3 != 2}}
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      arg_roles = "in,out",
+      "xla.sdy.custom_sharding_rule" = "#sdy.op_sharding_rule<([i, j, k])->([i, j]) {i=8, j=4, k=1}, custom>"
+    }
+  } : (tensor<8x4xf32>) -> tensor<8x4xf32>
+  return %0 : tensor<8x4xf32>
+}
+
+// -----
+
+sdy.mesh @mesh = <["x"=2]>
+
+// Factor `i` is mapped to both dim 0 and dim 1 of the same tensor.
+func.func @duplicate_factor(
+    %arg0: tensor<8x8xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>})
+    -> tensor<8x8xf32> {
+  // expected-error @+1 {{'stablehlo.custom_call' op operand - cannot reuse factors for the same tensor value}}
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      arg_roles = "in,out",
+      "xla.sdy.custom_sharding_rule" = "#sdy.op_sharding_rule<([i, i])->([i, i]) {i=8}, custom>"
+    }
+  } : (tensor<8x8xf32>) -> tensor<8x8xf32>
+  return %0 : tensor<8x8xf32>
+}


### PR DESCRIPTION
Add support for a `xla.sdy.custom_sharding_rule` frontend attribute that carries a serialized `#sdy.op_sharding_rule<...>`. A new `register-user-sharding-rule` pass reads this attribute off `stablehlo.custom_call` ops and promotes it to a first-class `sdy.sharding_rule` op attribute, so frontends can describe sharding for arbitrary custom_calls (e.g. tt-lang ops) that have no built-in rule.

Because the rule becomes a real `sdy.sharding_rule` attribute (rather than being served lazily through the `ShardingRuleOpInterface`), Shardy propagates it directly and runs its always-on verifier (`verifyOpShardingRuleAttr`) on it, giving clean diagnostics in every build without a hand-rolled validator.

Error handling:
- Absent or empty/whitespace-only attribute: the op has no custom rule and
  falls back to Shardy's default (replication).
- Present, non-empty, but unparseable into an `#sdy.op_sharding_rule`: a
  hard error that fails the pass (it can never become a valid attribute).
- Parses but is semantically inconsistent with the op (operand/result
  arity, per-tensor rank, or factor reuse): rejected by Shardy's op-attribute
  verifier once promoted.

### Ticket
[Link to Github
Issue](https://github.com/tenstorrent/tt-xla/issues/4708)

### Problem description
Currently the XLA to SDY import only consumes three `xla.sdy.*` frontend attributes (`xla.sdy.sharding`, `xla.sdy.meshes`, and `xla.sdy.FuncResultSharding`); any other `xla.sdy.*` attribute is ignored. And for `stablehlo.custom_call` ops, the only available `sdy.op_sharding_rule`s are the per-target ones hardcoded in `RegisterCustomShardingRule.cpp`, attached via `ShardingRuleOpInterface`. There is no way for a frontend to supply its own sharding rule for a custom_call, and rules provided through the interface bypass Shardy's op-attribute verifier.

### What's changed
- Adds a new `xla.sdy.custom_sharding_rule` frontend attribute for
  user-supplied custom sharding rules.
- Adds a dedicated `register-user-sharding-rule` pass
  (`RegisterUserShardingRulePass`) that parses the attribute and sets it as
  the `sdy.sharding_rule` op attribute, wired into the StableHLO and
  auto-sharding pipelines ahead of propagation.
- Leaves `RegisterCustomShardingRule.cpp` responsible only for the
  C++-defined built-in rules.
- Adds lit tests for the happy path / empty-string fallback
  (`tt_lang_custom_rule.mlir`) and for parse + semantic failures
  (`tt_lang_custom_rule_invalid.mlir`), plus a Python builder
  (`make_sharding_rule`) and an end-to-end hardware test.

### Checklist
- [x] New/Existing tests provide coverage for changes