### PR TITLE
[TTIR] Replace 1x1x1 Conv3d with matmul/linear

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -3972,6 +3972,7 @@ def TTIR_Conv3dOp : TTIR_NamedOp<"conv3d"> {
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
+    let hasCanonicalizer = 1;
 }
 
 def TTIR_ConvTranspose2dOp : TTIR_NamedOp<"conv_transpose2d", [DeclareOpInterfaceMethods<TTIR_QuantizableOpInterface, ["isQuantizedRewriteFavorable", "rewriteWithQuantizedInputs"]>]> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1696,6 +1696,117 @@ bool mlir::tt::ttir::Conv2dOp::isBiasCompatible(llvm::ArrayRef<int64_t> bias) {
   return mlir::success();
 }
 
+// A 1x1x1 conv3d is just a matmul (or linear, when a bias is present), so it
+// can be rewritten to avoid the conv3d. This is only eligible for the canonical
+// NDHWC layout; other layouts are normalized to NDHWC first by the
+// decomposition pass.
+static bool isConv3dPointwiseLinearEligible(mlir::tt::ttir::Conv3dOp op) {
+  if (!op.isNDHWC()) {
+    return false;
+  }
+  if (op.getGroups() != 1) {
+    return false;
+  }
+
+  // Kernel must be 1x1x1. Weight is (Cout, Cin, K_D, K_H, K_W).
+  auto weightType = mlir::cast<RankedTensorType>(op.getWeight().getType());
+  ArrayRef<int64_t> weightShape = weightType.getShape();
+  if (weightShape.size() != 5 || weightShape[2] != 1 || weightShape[3] != 1 ||
+      weightShape[4] != 1) {
+    return false;
+  }
+
+  // Unit stride and no padding, otherwise the op is a strided/padded gather
+  // rather than a plain matmul or linear.
+  auto stride = ttmlir::utils::getTripleOfInteger<int32_t>(op.getStride());
+  auto padding = ttmlir::utils::getTripleOfInteger<int32_t>(op.getPadding());
+  if (!stride || !padding) {
+    llvm::consumeError(stride.takeError());
+    llvm::consumeError(padding.takeError());
+    return false;
+  }
+  auto [sD, sH, sW] = *stride;
+  auto [pD, pH, pW] = *padding;
+  return sD == 1 && sH == 1 && sW == 1 && pD == 0 && pH == 0 && pW == 0;
+}
+
+// Conv3dOp canonicalization
+void mlir::tt::ttir::Conv3dOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  // Rewrite a pointwise (1x1x1) conv3d to matmul (or linear, when a bias is
+  // present).
+  //   input  (N,D,H,W,Cin) ->  reshape  -> (N*D*H*W, Cin)
+  //   weight (Cout,Cin,1,1,1)  ->  reshape ->  (Cout, Cin)
+  //   matmul (M,Cin) x (Cout,Cin)^T (transpose_b)  ->  (M, Cout) // no bias
+  //   linear (M,Cin) x (Cout,Cin)^T (transpose_b) + bias ->  (M, Cout) // bias
+  //   bias (1,1,1,1,Cout)  ->  reshape ->  (Cout,) // with bias
+  //   (M,Cout)  ->  reshape ->  (N,D,H,W,Cout)
+  patterns.add(+[](mlir::tt::ttir::Conv3dOp op,
+                   mlir::PatternRewriter &rewriter) {
+    if (!isConv3dPointwiseLinearEligible(op)) {
+      return mlir::failure();
+    }
+
+    auto inputType = mlir::cast<RankedTensorType>(op.getInput().getType());
+    auto weightType = mlir::cast<RankedTensorType>(op.getWeight().getType());
+    auto outputType = mlir::cast<RankedTensorType>(op.getResult().getType());
+
+    ArrayRef<int64_t> inputShape = inputType.getShape();   // (N, D, H, W, Cin)
+    ArrayRef<int64_t> weightShape = weightType.getShape(); // (Cout, Cin, 1,1,1)
+
+    int64_t rows =
+        inputShape[0] * inputShape[1] * inputShape[2] * inputShape[3];
+    int64_t cIn = inputShape[4];
+    int64_t cOut = weightShape[0];
+
+    // Build a ttir.reshape of `value` to `shape`.
+    auto reshapeTo = [&](Value value, ArrayRef<int64_t> shape, Type elementType,
+                         StringRef suffix) -> Value {
+      SmallVector<int32_t> shapeI32(shape.begin(), shape.end());
+      return rewriter.create<ttir::ReshapeOp>(
+          ttmlir::utils::appendLocationSuffix(op.getLoc(), suffix),
+          RankedTensorType::get(shape, elementType), value,
+          rewriter.getI32ArrayAttr(shapeI32));
+    };
+
+    // Collapse the input's spatial/temporal dims into matmul rows, and drop the
+    // singleton kernel dims from the weight.
+    Value inputMatrix = reshapeTo(op.getInput(), {rows, cIn},
+                                  inputType.getElementType(), "_reshapeInput");
+    Value weightMatrix =
+        reshapeTo(op.getWeight(), {cOut, cIn}, weightType.getElementType(),
+                  "_reshapeWeight");
+
+    auto matmulResultType =
+        RankedTensorType::get({rows, cOut}, outputType.getElementType());
+
+    // weight is (Cout, Cin); transpose_b makes the contraction
+    // (M,Cin)x(Cin,Cout).
+    Value contraction;
+    if (Value bias = op.getBias()) {
+      Value biasVector = reshapeTo(
+          bias, {cOut},
+          mlir::cast<RankedTensorType>(bias.getType()).getElementType(),
+          "_reshapeBias");
+      contraction = rewriter.create<ttir::LinearOp>(
+          op.getLoc(), matmulResultType, inputMatrix, weightMatrix, biasVector,
+          /*transpose_a=*/false, /*transpose_b=*/true);
+    } else {
+      contraction = rewriter.create<ttir::MatmulOp>(
+          op.getLoc(), matmulResultType, inputMatrix, weightMatrix,
+          /*transpose_a=*/false, /*transpose_b=*/true);
+    }
+
+    // Restore the NDHWC output shape. Reuse the op's result type so the
+    // replacement type matches (D_out/H_out/W_out == D/H/W here).
+    SmallVector<int32_t> outShapeI32(outputType.getShape().begin(),
+                                     outputType.getShape().end());
+    rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
+        op, outputType, contraction, rewriter.getI32ArrayAttr(outShapeI32));
+    return mlir::success();
+  });
+}
+
 //===----------------------------------------------------------------------===//
 // Quantize ops
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1719,9 +1719,12 @@ static bool isConv3dPointwiseLinearEligible(mlir::tt::ttir::Conv3dOp op) {
   // Unit stride and no padding, otherwise the op is a strided/padded gather
   // rather than a plain matmul or linear.
   auto stride = ttmlir::utils::getTripleOfInteger<int32_t>(op.getStride());
-  auto padding = ttmlir::utils::getTripleOfInteger<int32_t>(op.getPadding());
-  if (!stride || !padding) {
+  if (!stride) {
     llvm::consumeError(stride.takeError());
+    return false;
+  }
+  auto padding = ttmlir::utils::getTripleOfInteger<int32_t>(op.getPadding());
+  if (!padding) {
     llvm::consumeError(padding.takeError());
     return false;
   }

--- a/test/python/golden/ttir_ops/convolution/test_conv3d.py
+++ b/test/python/golden/ttir_ops/convolution/test_conv3d.py
@@ -13,6 +13,15 @@ from conftest import get_request_kwargs
 pytestmark = pytest.mark.frontend("ttir")
 
 
+def check_op(mlir_file: str, op_name: str) -> bool:
+    op_name = "ttnn." + op_name
+    with open(mlir_file, "r") as f:
+        for line in f:
+            if op_name in line:
+                return True
+    return False
+
+
 @pytest.fixture(autouse=True)
 def clear_program_cache_after_test(device):
     """Clear program cache after each conv3d test to free L1 memory.
@@ -260,3 +269,92 @@ def test_conv3d_c_in_block_divergent(dtype, target, request, device):
         device=device,
         target=target,
     )
+
+
+@pytest.mark.parametrize(
+    "input_shape, weight_shape, bias_shape",
+    [
+        # 1x1x1 pointwise conv3d, no bias -> rewritten to ttir.matmul by
+        # the Conv3dOp canonicalizer.
+        ((1, 8, 16, 16, 64), (128, 64, 1, 1, 1), None),
+        # 1x1x1 pointwise conv3d, with bias -> rewritten to ttir.linear.
+        ((1, 8, 16, 16, 64), (128, 64, 1, 1, 1), (1, 1, 1, 1, 128)),
+    ],
+    ids=["pointwise_1x1x1_no_bias", "pointwise_1x1x1_with_bias"],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_conv3d_pointwise_to_linear(
+    input_shape: Shape,
+    weight_shape: Shape,
+    bias_shape: Optional[Shape],
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    """Golden coverage for the 1x1x1 conv3d -> matmul/linear rewrite.
+
+    A pointwise (1x1x1) conv3d in NDHWC layout with unit stride, no padding and
+    groups==1 is mathematically a matmul, so the decomposition pass rewrites it
+    to ttir.matmul (no bias) or ttir.linear (bias) instead of lowering it as a
+    conv3d.
+    """
+    if bias_shape:
+        input_shapes = [input_shape, weight_shape, bias_shape]
+        input_types = [dtype, dtype, dtype]
+
+        def module(builder: TTIRBuilder):
+            @builder.func(input_shapes, input_types)
+            def conv3d_wrapper(
+                in0: Operand,
+                weight: Operand,
+                bias: Operand,
+                builder: TTIRBuilder,
+                unit_attrs: Optional[List[str]] = None,
+            ):
+                return builder.conv3d(
+                    in0,
+                    weight,
+                    bias,
+                    stride=[1, 1, 1],
+                    padding=[0, 0, 0],
+                    groups=1,
+                    unit_attrs=unit_attrs,
+                )
+
+    else:
+        input_shapes = [input_shape, weight_shape]
+        input_types = [dtype, dtype]
+
+        def module(builder: TTIRBuilder):
+            @builder.func(input_shapes, input_types)
+            def conv3d_wrapper(
+                in0: Operand,
+                weight: Operand,
+                builder: TTIRBuilder,
+                unit_attrs: Optional[List[str]] = None,
+            ):
+                return builder.conv3d(
+                    in0,
+                    weight,
+                    None,
+                    stride=[1, 1, 1],
+                    padding=[0, 0, 0],
+                    groups=1,
+                    unit_attrs=unit_attrs,
+                )
+
+    output = compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target=target,
+        save_artifacts=True,
+    )
+
+    if target == "ttnn":
+        expected_op = "linear" if bias_shape else "matmul"
+        assert check_op(
+            output, expected_op
+        ), f"Pointwise conv3d should be rewritten to ttnn.{expected_op}"

--- a/test/python/golden/ttir_ops/convolution/test_conv3d.py
+++ b/test/python/golden/ttir_ops/convolution/test_conv3d.py
@@ -296,8 +296,8 @@ def test_conv3d_pointwise_to_linear(
     """Golden coverage for the 1x1x1 conv3d -> matmul/linear rewrite.
 
     A pointwise (1x1x1) conv3d in NDHWC layout with unit stride, no padding and
-    groups==1 is mathematically a matmul, so the decomposition pass rewrites it
-    to ttir.matmul (no bias) or ttir.linear (bias) instead of lowering it as a
+    groups==1 is mathematically a matmul, so the Conv3dOp canonicalizer rewrites
+    it to ttir.matmul (no bias) or ttir.linear (bias) instead of lowering it as a
     conv3d.
     """
     if bias_shape:

--- a/test/ttmlir/Dialect/TTIR/canonicalize/conv3d_pointwise_to_linear.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/conv3d_pointwise_to_linear.mlir
@@ -1,0 +1,173 @@
+// RUN: ttmlir-opt --split-input-file --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verifies the Conv3dOp canonicalizer: a 1x1x1 conv3d in NDHWC layout with
+// unit stride, no padding and groups==1 is mathematically a matmul, so the
+// canonicalizer rewrites it to ttir.matmul (no bias) / ttir.linear (bias)
+// instead of lowering it as a conv3d. Anything failing the eligibility gate
+// (isConv3dPointwiseLinearEligible) must stay a ttir.conv3d.
+
+// -----
+
+// Pointwise 1x1x1 conv3d, no bias -> ttir.matmul, conv3d eliminated.
+// input  (N=1, D=8, H=16, W=16, Cin=64)
+// weight (Cout=128, Cin=64, 1, 1, 1)  -> output (1, 8, 16, 16, 128)
+func.func @pointwise_no_bias(%input: tensor<1x8x16x16x64xbf16>,
+                             %weight: tensor<128x64x1x1x1xbf16>) -> tensor<1x8x16x16x128xbf16> {
+  // CHECK-LABEL: @pointwise_no_bias
+  // CHECK: "ttir.matmul"
+  // CHECK-NOT: "ttir.linear"
+  // CHECK-NOT: "ttir.conv3d"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x1x1x1xbf16>) -> tensor<1x8x16x16x128xbf16>
+  return %0 : tensor<1x8x16x16x128xbf16>
+}
+
+// -----
+
+// Pointwise 1x1x1 conv3d, with bias -> ttir.linear, conv3d eliminated.
+// bias (1, 1, 1, 1, Cout=128)
+func.func @pointwise_with_bias(%input: tensor<1x8x16x16x64xbf16>,
+                               %weight: tensor<128x64x1x1x1xbf16>,
+                               %bias: tensor<1x1x1x1x128xbf16>) -> tensor<1x8x16x16x128xbf16> {
+  // CHECK-LABEL: @pointwise_with_bias
+  // CHECK: "ttir.linear"
+  // CHECK-NOT: "ttir.conv3d"
+  %0 = "ttir.conv3d"(%input, %weight, %bias)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x1x1x1xbf16>, tensor<1x1x1x1x128xbf16>) -> tensor<1x8x16x16x128xbf16>
+  return %0 : tensor<1x8x16x16x128xbf16>
+}
+
+// -----
+
+// Multi-frame batch (N>1, D>1) must still fold: the rewrite collapses
+// N*D*H*W into the matmul row dim, so this guards that reshape.
+// input (N=2, D=4, H=8, W=8, Cin=64) -> output (2, 4, 8, 8, 128)
+func.func @pointwise_multiframe(%input: tensor<2x4x8x8x64xbf16>,
+                                %weight: tensor<128x64x1x1x1xbf16>) -> tensor<2x4x8x8x128xbf16> {
+  // CHECK-LABEL: @pointwise_multiframe
+  // CHECK: "ttir.matmul"
+  // CHECK-NOT: "ttir.conv3d"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<2x4x8x8x64xbf16>, tensor<128x64x1x1x1xbf16>) -> tensor<2x4x8x8x128xbf16>
+  return %0 : tensor<2x4x8x8x128xbf16>
+}
+
+// -----
+
+// Negative: 3x3x3 kernel is a real convolution, must NOT be rewritten.
+// output (1, 6, 14, 14, 128) from D_out=(8-3)+1, H/W_out=(16-3)+1.
+func.func @negative_non_pointwise_kernel(%input: tensor<1x8x16x16x64xbf16>,
+                                         %weight: tensor<128x64x3x3x3xbf16>) -> tensor<1x6x14x14x128xbf16> {
+  // CHECK-LABEL: @negative_non_pointwise_kernel
+  // CHECK: "ttir.conv3d"
+  // CHECK-NOT: "ttir.matmul"
+  // CHECK-NOT: "ttir.linear"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x3x3x3xbf16>) -> tensor<1x6x14x14x128xbf16>
+  return %0 : tensor<1x6x14x14x128xbf16>
+}
+
+// -----
+
+// Negative: 1x1x1 kernel but non-unit stride is a strided gather, not a matmul.
+// stride 2 -> D_out=(8-1)/2+1=4, H/W_out=(16-1)/2+1=8 -> output (1, 4, 8, 8, 128).
+func.func @negative_strided(%input: tensor<1x8x16x16x64xbf16>,
+                            %weight: tensor<128x64x1x1x1xbf16>) -> tensor<1x4x8x8x128xbf16> {
+  // CHECK-LABEL: @negative_strided
+  // CHECK: "ttir.conv3d"
+  // CHECK-NOT: "ttir.matmul"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 2, 2, 2>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x1x1x1xbf16>) -> tensor<1x4x8x8x128xbf16>
+  return %0 : tensor<1x4x8x8x128xbf16>
+}
+
+// -----
+
+// Negative: 1x1x1 kernel but non-zero padding, must NOT be rewritten.
+// padding 1 -> D_out=(8+2-1)+1=10, H/W_out=(16+2-1)+1=18 -> output (1, 10, 18, 18, 128).
+func.func @negative_padded(%input: tensor<1x8x16x16x64xbf16>,
+                           %weight: tensor<128x64x1x1x1xbf16>) -> tensor<1x10x18x18x128xbf16> {
+  // CHECK-LABEL: @negative_padded
+  // CHECK: "ttir.conv3d"
+  // CHECK-NOT: "ttir.matmul"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 1, 1, 1>,
+            padding_mode = "zeros",
+            groups = 1 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x64x1x1x1xbf16>) -> tensor<1x10x18x18x128xbf16>
+  return %0 : tensor<1x10x18x18x128xbf16>
+}
+
+// -----
+
+// Negative: grouped conv (groups != 1), must NOT be rewritten.
+// groups=2 -> weight C_in dim is Cin/groups = 32.
+func.func @negative_grouped(%input: tensor<1x8x16x16x64xbf16>,
+                            %weight: tensor<128x32x1x1x1xbf16>) -> tensor<1x8x16x16x128xbf16> {
+  // CHECK-LABEL: @negative_grouped
+  // CHECK: "ttir.conv3d"
+  // CHECK-NOT: "ttir.matmul"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 2 : i32
+          }> : (tensor<1x8x16x16x64xbf16>, tensor<128x32x1x1x1xbf16>) -> tensor<1x8x16x16x128xbf16>
+  return %0 : tensor<1x8x16x16x128xbf16>
+}
+
+// -----
+
+// Negative: non-NDHWC (NCDHW) layout fails the isNDHWC() gate, so the
+// canonicalizer leaves it as conv3d. Layout normalization to NDHWC is a
+// separate decomposition pass, not the canonicalizer's job.
+// NCDHW input (N=1, Cin=64, D=8, H=16, W=16), weight (Cout=128, Cin=64, 1,1,1).
+func.func @negative_non_ndhwc(%input: tensor<1x64x8x16x16xbf16>,
+                              %weight: tensor<128x64x1x1x1xbf16>) -> tensor<1x128x8x16x16xbf16> {
+  // CHECK-LABEL: @negative_non_ndhwc
+  // CHECK: "ttir.conv3d"
+  // CHECK-NOT: "ttir.matmul"
+  // CHECK-NOT: "ttir.linear"
+  %0 = "ttir.conv3d"(%input, %weight)
+          <{
+            stride = array<i32: 1, 1, 1>,
+            padding = array<i32: 0, 0, 0>,
+            padding_mode = "zeros",
+            groups = 1 : i32,
+            batch_dim = 0 : i64,
+            channel_dim = 1 : i64,
+            depth_dim = 2 : i64,
+            height_dim = 3 : i64,
+            width_dim = 4 : i64
+          }> : (tensor<1x64x8x16x16xbf16>, tensor<128x64x1x1x1xbf16>) -> tensor<1x128x8x16x16xbf16>
+  return %0 : tensor<1x128x8x16x16xbf16>
+}


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-xla/discussions/5377 — 6th entry

### Problem description
A 1x1x1 conv3d in NDHWC layout with unit stride, no padding and groups==1 is essentially a matmul (or linear, with bias), so it can be replaced using reshapes and matmul.

matmul case:
input (N, D, H, W, Cin) is reshaped to (N * D * H * W, Cin), which is (M, Cin)
weight (Cout, Cin, 1, 1, 1) is reshaped to (Cout, Cin)
then we have matmul of input and transposed weight (M, Cin) x (Cout, Cin) ^ T = (M, Cout)
the result is (M, Cout) and is reshaped back to (N, D, H, W, Cout)

linear case (when we have bias):
input (N, D, H, W, Cin) is reshaped to (N * D * H * W, Cin) which is (M, Cin)
weight (Cout, Cin, 1, 1, 1) is reshaped to (Cout, Cin)
bias (1, 1, 1, 1, Cout) is reshaped to (Cout, )
then we have matmul of input and transposed weight and we add bias (M, Cin) x (Cout, Cin)^T + bias = (M, Cout)
the result is (M, Cout) and is reshaped back to (N, D, H, W, Cout)

### What's changed

`isConv3dPointwiseMatmulEligible` checks if the rewrite (NDHWC, 1x1x1 kernel, unit stride, no padding, groups==1) is eligible.
`Conv3dPointwiseToMatmulPattern` rewrites eligible convs to ttir.matmul (no bias) / ttir.linear (bias), wrapped in reshapes.
Tested with lit tests, a golden test, and end-to-end through tt-xla on the Wan decoder to confirm conv3d was replaced.

### Checklist
- [x] New/Existing tests provide coverage for changes
