### PR TITLE
Skip nlp_concat_heads_decode fusion when batch exceeds worker grid

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Utils.h"
@@ -280,6 +281,16 @@ public:
     // volume mismatch in the subsequent reshape at runtime.
     constexpr int64_t kTileSize = 32;
     if (headDim % kTileSize != 0 || batchSize % kTileSize != 0) {
+      return failure();
+    }
+
+    // The op height-shards the batch one shard per core, so batchSize must fit
+    // the worker grid; beyond that the sharded layout built below asserts in
+    // deriveCanonicalL1CoreRangeSet.
+    ttcore::DeviceAttr device = ttcore::lookupDevice(reshapeOp);
+    int64_t workerGridVolume =
+        ttmlir::utils::volume(device.getWorkerGrid().getShape());
+    if (batchSize > workerGridVolume) {
       return failure();
     }
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/nlp_concat_heads_decode/nlp_concat_heads_decode.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/nlp_concat_heads_decode/nlp_concat_heads_decode.mlir
@@ -6,6 +6,7 @@
 //   1. Basic decode pattern: permute + reshape fuses to nlp_concat_heads_decode
 //   2. Negative: wrong permutation (should not fuse)
 //   3. Negative: non-decode seq_len > 1 (should not fuse)
+//   4. Negative: batch exceeds worker grid volume (should not fuse)
 
 // REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% optimization-level=1" %s | FileCheck %s
@@ -36,5 +37,15 @@ module {
   func.func @nlp_concat_heads_not_decode(%arg0: tensor<128x32x8x64xbf16>) -> tensor<32x8x128x64xbf16> {
     %0 = "ttir.permute"(%arg0) <{permutation = array<i64: 1, 2, 0, 3>}> : (tensor<128x32x8x64xbf16>) -> tensor<32x8x128x64xbf16>
     return %0 : tensor<32x8x128x64xbf16>
+  }
+
+  // Negative: batch (256) exceeds worker grid volume must not fuse (would assert
+  // in deriveCanonicalL1CoreRangeSet). Canonicalized reshape form. Mochi
+  // [1, 256, H, D] text-stream misfire.
+  // CHECK-LABEL: @nlp_concat_heads_batch_exceeds_grid
+  // CHECK-NOT: "ttnn.nlp_concat_heads_decode"
+  func.func @nlp_concat_heads_batch_exceeds_grid(%arg0: tensor<1x256x8x128xbf16>) -> tensor<256x1024xbf16> {
+    %0 = "ttir.reshape"(%arg0) <{shape = [256 : i32, 1024 : i32]}> : (tensor<1x256x8x128xbf16>) -> tensor<256x1024xbf16>
+    return %0 : tensor<256x1024xbf16>
   }
 }


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4651

### Problem description

- At opt-0, Mochi OOMs on the `softmax` produced by the native SDPA decomposition at TTNN level — a `~22516×22516` f32 score matrix (~6 GB/device).
- Fusing SDPA avoids materializing that matrix, but the fusion only runs at `optimization_level >= 1`.
- At opt-1, the model instead hits this crash:
```
third_party/tt-mlir/src/tt-mlir/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp:1327: CoreRangeSetAttr mlir::tt::ttnn::deriveCanonicalL1CoreRangeSet(...): Assertion `gridShape[0] <= workerGridVolume` failed, was `256 <= 64`, HeightSharded shard count 256 exceeds worker grid volume 64
Fatal Python error: Aborted
```
- Root cause: a fusion meant only for single-token LLM decode wrongly fires on Mochi's `[1, 256, …]` text tensor (its leading dim happens to be `1`), mistakes the 256 text tokens for 256 batch items, and tries to spread them across 256 cores — but the chip has only 64, so it crashes. More context [here](https://github.com/tenstorrent/tt-xla/issues/4651#issuecomment-4927957860).

### What's changed

- Guard `NLPConcatHeadsDecodeFusing` (tt-mlir `TTNNFusing.cpp`): skip the fusion when `batch > worker-grid volume`, so the decode-only concat-heads pattern no longer misfires on the `[1, 256, …]` text stream and no longer builds an invalid 256-shard layout — the reshape falls back to a plain reshape.
- Added regression lit test `nlp_concat_heads_batch_exceeds_grid`.
- Result: at opt-1 the SDPA now fuses to `ttnn.scaled_dot_product_attention` and the softmax OOM is eliminated and now it faces OOM from downstream ops

### Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [jul8_mochi_transformer_opt1_before_fix.log](https://github.com/user-attachments/files/29860072/jul8_mochi_transformer_opt1_before_fix.log)
- [jul9_mochi_sanity_before_fix.log](https://github.com/user-attachments/files/29860075/jul9_mochi_sanity_before_fix.log)
- [jul9_mochi_sanity_after_fix.log](https://github.com/user-attachments/files/29860073/jul9_mochi_sanity_after_fix.log)
- [jul9_mochi_transformer_opt1_after_fix.log](https://github.com/user-attachments/files/29860076/jul9_mochi_transformer_opt1_after_fix.log)
