### PR TITLE
[TTIR] Relax paged SDPA decode verifier for higher precision query over BFP8 KV cache

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7459,14 +7459,11 @@ mlir::tt::ttir::PagedScaledDotProductAttentionDecodeOp::verify() {
   auto numKVHeads = keyShape[1];
   auto blockSize = keyShape[2];
 
-  // Verify element types.
-  if (queryType.getElementType() != keyType.getElementType() ||
-      queryType.getElementType() != valueType.getElementType()) {
-    return emitOpError(
-        "Query, key, and value must have the same element type.");
-  }
-
-  if (!queryType.getElementType().isFloat()) {
+  // Query may be higher precision than a BFP8/BFP4 KV cache (mirrors the TTNN
+  // verifier relaxed in #8668); K == V is still enforced below.
+  if (!queryType.getElementType().isFloat() ||
+      !keyType.getElementType().isFloat() ||
+      !valueType.getElementType().isFloat()) {
     return emitOpError("Query, key, and value must be float tensors.");
   }
 


### PR DESCRIPTION
### Ticket
Closes #8988

### Problem
`ttir.paged_scaled_dot_product_attention_decode` still enforces a strict Q == K == V element type in its verifier. The TTNN verifier for the same op was relaxed in #8668 so a bf16 query can run over a BFP8/BFP4 paged KV cache (the tt-metal decode kernel supports this; a typecast reconciles late in the pipeline). Because TTIR runs first during `TTIRToTTNNCommon`, a legal graph is rejected before it reaches the relaxed TTNN check:

```
'ttnn.paged_scaled_dot_product_attention_decode' op Query, key, and value must have the same element type
Failed to run TTIRToTTNNCommon pipeline
```

This started firing once #8931 (decode RoPE/QKV fusion) began routing a bf16 query into the BFP8 cache at the TTIR level; before that the pattern never reached this verifier.

### Fix
Mirror #8668 in the TTIR verifier: require query, key, and value to be float rather than identical. The existing K == V check below still enforces the cache invariant, so the only newly allowed case is a higher precision query over a lower precision (BFP8/BFP4) KV cache, exactly what TTNN already accepts.

### Testing
The existing paged_sdpa_decode_bfp8.mlir builds the op at the TTNN level only, so it never exercised this TTIR verifier (which is why the gap went unnoticed).
- [x] Local ttmlir-opt check on a paged decode op with a higher precision query (f32) over lower precision K == V (bf16), the same verifier branch as bf16 query over a BFP8 cache: before this change: error: 'ttir.paged_scaled_dot_product_attention_decode' op Query, key, and value must have the same element type after this change:  parses and verifies cleanly (exit 0)
- [x] End to end validation via tt-xla CI with this verifier relaxation as mlir_override (tt-xla run https://github.com/tenstorrent/tt-xla/actions/runs/29043024978). Both target tests passed: the chunked prefill test (bf16 query + BFP8 KV, n150) and the Llama 3.2 3B tensor parallel test (n300). The override was built from a pin-based branch carrying only this change, since tt-xla cannot yet compile against tt-mlir main (an unrelated symbol rename).
