### PR TITLE
[TTNN] Force fp32 accumulation on the lm_head (large output dim) matmul

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNSetComputeKernelConfig.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNSetComputeKernelConfig.cpp
@@ -11,12 +11,18 @@
 namespace mlir::tt::ttnn {
 namespace {
 
-// During training backward run we have observed matmuls with inner dimension
-// equal to vocab size fail due to precision issues. Upon inspection, we have
-// not found a model that has vocab size smaller than this threshold. Fix is
-// only applied to these types of matmuls, as we do not expect other matmuls to
-// have this type of inner dimension.
-constexpr int64_t kLargeInnerDimThreshold = 50000;
+// bf16 matmuls with a vocab-sized dimension accumulate too coarsely and hit
+// precision issues, so we force fp32 destination accumulation on them:
+//   * large *inner* (contraction) dim: observed in the training backward run,
+//     where grad flows through a matmul whose inner dim equals vocab size;
+//   * large *output* dim: the forward lm_head / vocab projection
+//     ([.., hidden] x [hidden, vocab]). On multi-chip TP its logits feed greedy
+//     argmax, where coarse bf16 accumulation lets a near-tie logit flip
+//     run-to-run, breaking greedy determinism (tt-xla #5520).
+// We have not found a model with a vocab smaller than this threshold, and we do
+// not expect other matmuls to have an inner or output dim this large, so the
+// fix stays scoped to matmuls that cross it.
+constexpr int64_t kLargeDimThreshold = 50000;
 
 static bool hasSetComputeConfigFields(DeviceComputeKernelConfigAttr config) {
   return config.getMathFidelity().has_value() || config.getMathApproxMode() ||
@@ -25,16 +31,23 @@ static bool hasSetComputeConfigFields(DeviceComputeKernelConfigAttr config) {
 }
 
 template <typename OpTy>
-void applyLargeInnerDimBf16MatmulConfig(OpTy op,
-                                        DeviceComputeKernelConfigAttr &config) {
+void applyLargeDimBf16MatmulConfig(OpTy op,
+                                   DeviceComputeKernelConfigAttr &config) {
+  auto outputType = mlir::cast<RankedTensorType>(op.getResult().getType());
+
   std::optional<int64_t> innerDim =
       getMatmulInnerDim(op.getA().getType(), op.getB().getType(),
                         op.getTransposeA(), op.getTransposeB());
-  if (!innerDim || *innerDim <= kLargeInnerDimThreshold) {
+  bool largeInnerDim = innerDim && *innerDim > kLargeDimThreshold;
+
+  auto outputShape = outputType.getShape();
+  bool largeOutputDim =
+      !outputShape.empty() && outputShape.back() > kLargeDimThreshold;
+
+  if (!largeInnerDim && !largeOutputDim) {
     return;
   }
 
-  auto outputType = mlir::cast<RankedTensorType>(op.getResult().getType());
   if (ttcore::elementTypeToDataType(outputType.getElementType()) !=
       ttcore::DataType::BFloat16) {
     return;
@@ -158,9 +171,9 @@ public:
 
       // This fix is required for correctness of large matmuls/linears.
       if (auto matmulOp = dyn_cast<MatmulOp>(op)) {
-        applyLargeInnerDimBf16MatmulConfig(matmulOp, config);
+        applyLargeDimBf16MatmulConfig(matmulOp, config);
       } else if (auto linearOp = dyn_cast<LinearOp>(op)) {
-        applyLargeInnerDimBf16MatmulConfig(linearOp, config);
+        applyLargeDimBf16MatmulConfig(linearOp, config);
       }
 
       // Log config after applying overrides

--- a/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/matmul_large_n_lm_head.mlir
+++ b/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/matmul_large_n_lm_head.mlir
@@ -1,0 +1,26 @@
+// RUN: ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=undefined fp32-dest-acc-en=false" %s | FileCheck %s
+
+// The forward lm_head / vocab projection: [.., hidden] x [hidden, vocab].
+// Inner (contraction) dim = hidden (small), output dim = vocab (> threshold).
+// A vocab-sized *output* dim must force fp32 dest-acc + packer_l1_acc on the
+// bf16 matmul so greedy argmax over these logits is reproducible (tt-xla #5520).
+
+// CHECK-LABEL: func @test_large_n_lm_head_matmul
+func.func @test_large_n_lm_head_matmul(%arg0: tensor<1x128xbf16>, %arg1: tensor<128x50001xbf16>) -> tensor<1x50001xbf16> {
+  // CHECK: "ttnn.matmul"
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<fp32_dest_acc_en = true, packer_l1_acc = true>
+  %0 = "ttnn.matmul"(%arg0, %arg1) <{transpose_a = false, transpose_b = false}> : (tensor<1x128xbf16>, tensor<128x50001xbf16>) -> tensor<1x50001xbf16>
+  return %0 : tensor<1x50001xbf16>
+}
+
+// A small output dim (typical hidden/intermediate matmul) must be left alone:
+// no fp32 dest-acc, no packer_l1_acc.
+
+// CHECK-LABEL: func @test_small_n_matmul
+func.func @test_small_n_matmul(%arg0: tensor<1x128xbf16>, %arg1: tensor<128x256xbf16>) -> tensor<1x256xbf16> {
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: fp32_dest_acc_en = true
+  // CHECK-NOT: packer_l1_acc = true
+  %0 = "ttnn.matmul"(%arg0, %arg1) <{transpose_a = false, transpose_b = false}> : (tensor<1x128xbf16>, tensor<128x256xbf16>) -> tensor<1x256xbf16>
+  return %0 : tensor<1x256xbf16>
+}


### PR DESCRIPTION
### Ticket
Relates to tenstorrent/tt-xla#5520

### Problem description
On multi chip tensor parallel inference, greedy decoding (temperature 0) is not reproducible run to run when the top two logits at a position are near tied. The forward lm_head projection is a bf16 matmul, and bf16 destination accumulation is coarse enough that a near tie can resolve differently across two otherwise identical runs, so argmax picks a different token. On the tt-xla side this shows up as flaky greedy tests on n300_llmbox (test_stop_token_ids, test_min_tokens, test_greedy_determinism).

`TTNNSetComputeKernelConfig` already forces fp32 destination accumulation on bf16 matmuls whose inner (contraction) dimension exceeds a vocab sized threshold. That path was added for the training backward pass, where the gradient matmul has an inner dimension equal to vocab size. The forward lm_head has the opposite shape: a small inner dimension (hidden) and a large output dimension (vocab), so it was never covered and kept accumulating in bf16.

### What's changed
`applyLargeInnerDimBf16MatmulConfig` is generalized to `applyLargeDimBf16MatmulConfig` and now fires on either a large inner dimension or a large output dimension, both compared against `kLargeDimThreshold` (unchanged at 50000). A bf16 matmul or linear with a vocab sized output (the forward lm_head) now gets `fp32_dest_acc_en` and `packer_l1_acc`, matching the existing large inner dim behavior.

No other matmul in a transformer is expected to have an inner or output dimension above the threshold (hidden and intermediate sizes stay well below it), so the fix stays scoped to the vocab projection.

#### Compiler side changes
`lib/Dialect/TTNN/Transforms/TTNNSetComputeKernelConfig.cpp`: rename and extend the helper, add the large output dimension check, update the two call sites and the comment.

### Checklist
* [x] Large output dim bf16 matmul gets `fp32_dest_acc_en` + `packer_l1_acc`
* [x] Existing large inner dim behavior preserved
* [x] Small output dim matmul left untouched
* [x] Lit test added (`matmul_large_n_lm_head.mlir`)

### Validation

- [x]  Lit: matmul_large_n_lm_head.mlir added; the full set_compute_kernel_config suite passes locally (16/16, ttmlir- opt built from this branch), covering the new large output dim case, the preserved large inner dim behavior, and a small output dim left untouched.
- [x] On silicon (n300_llmbox): toggling fp32_dest_acc_en on an lm_head shaped bf16 matmul ([32,4096] x [4096,8192]) raises PCC against the fp32 golden from 0.99900 to 0.99998 (about 40x lower error), and the exported TTNN IR shows fp32_dest_acc_en = true landing on the matmul, the same attribute this PR auto applies to vocab output matmuls. Mechanism level evidence that fp32 destination accumulation materially increases lm_head logit precision, which is what shrinks the near tie flip window. (Repro note: run the flag off vs on in separate processes; torch_xla caches the compiled executable by graph shape, not by compile options, so both arms in one process reuse the first binary and show a misleading identical PCC.)
- [x] End to end (n300_llmbox, this commit as the tt-xla mlir version): the three greedy tests test_stop_token_ids, test_min_tokens, test_greedy_determinism pass on real silicon, confirming the fixed plugin runs with no regression and coherent output.