### PR TITLE
Add RMS fusing different version.

### DIFF
--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -19,7 +19,9 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include <cmath>
 #include <cstdint>
+#include <optional>
 
 #include <type_traits>
 
@@ -3022,6 +3024,309 @@ public:
   }
 };
 
+// Reads a splat scalar value from a constant-like value, tracing back through
+// layout ops (typecast/reshape/broadcast/repeat_interleave). Handles
+// ttir.full, ttir.constant (splat) and ttir.zeros. Returns std::nullopt if the
+// value is not a recognizable scalar constant.
+static std::optional<double> getSplatConstantValue(mlir::Value value) {
+  value = utils::lookThroughLayoutOps(value);
+  mlir::Operation *op = value.getDefiningOp();
+  if (!op) {
+    return std::nullopt;
+  }
+  if (mlir::isa<ZerosOp>(op)) {
+    return 0.0;
+  }
+  if (auto fullOp = mlir::dyn_cast<FullOp>(op)) {
+    mlir::Attribute fill = fullOp.getFillValue();
+    if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(fill)) {
+      return floatAttr.getValue().convertToDouble();
+    }
+    if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(fill)) {
+      return static_cast<double>(intAttr.getValue().getSExtValue());
+    }
+    return std::nullopt;
+  }
+  if (auto constOp = mlir::dyn_cast<ConstantOp>(op)) {
+    auto elements = mlir::dyn_cast<mlir::ElementsAttr>(constOp.getValue());
+    if (!elements || !elements.isSplat()) {
+      return std::nullopt;
+    }
+    mlir::Type elemType = elements.getElementType();
+    if (mlir::isa<mlir::FloatType>(elemType)) {
+      return elements.getSplatValue<mlir::APFloat>().convertToDouble();
+    }
+    if (mlir::isa<mlir::IntegerType>(elemType)) {
+      return static_cast<double>(
+          elements.getSplatValue<llvm::APInt>().getSExtValue());
+    }
+  }
+  return std::nullopt;
+}
+
+// Returns true if `value` is a splat scalar constant approximately equal to
+// `expected` within the given relative tolerance.
+static bool isApproxScalarConstant(mlir::Value value, double expected,
+                                   double relTol) {
+  std::optional<double> actual = getSplatConstantValue(value);
+  if (!actual) {
+    return false;
+  }
+  double denom = std::max(std::abs(expected), 1.0);
+  return std::abs(*actual - expected) / denom <= relTol;
+}
+
+// Fuses the `torch.nn.functional.normalize`-style RMS norm decomposition into a
+// ttir.rms_norm op. Frontends that export an RMS norm as an L2 normalize scaled
+// by sqrt(D) produce:
+//
+//   s = sum(|x|^2, dim=d)              // sum of squares over dim d (size D)
+//   n = clamp_min(sqrt(s), eps)        // F.normalize denominator guard
+//   y = (x / n) * sqrt(D) * gamma      // rescale + per-channel weight
+//
+// Multiplying the unit-norm (L2) result by sqrt(D) turns it into a mean-square
+// (RMS) normalized tensor, since
+//   x / sqrt(sum(x^2)) * sqrt(D) == x / sqrt(mean(x^2)).
+// The sqrt(D) factor is therefore required: it is what distinguishes an RMS
+// norm from a plain L2 normalization (which is not an rms_norm).
+//
+// ttir.rms_norm (and the TTNN kernel behind it) only normalizes over the
+// trailing dimension. When the reduced dim `d` is not the last one, the input
+// is permuted so `d` becomes last, normalized, then permuted back.
+//
+// If the sqrt(D) scale is followed by a per-channel `gamma` multiply, gamma is
+// folded into the rms_norm weight. When there is no such multiply, only the
+// normalization core (up to and including the sqrt(D) scale) is fused.
+class NormalizeRMSNormFusionPattern
+    : public mlir::OpRewritePattern<MultiplyOp> {
+  using mlir::OpRewritePattern<MultiplyOp>::OpRewritePattern;
+
+public:
+  mlir::LogicalResult
+  matchAndRewrite(MultiplyOp scaleMul,
+                  mlir::PatternRewriter &rewriter) const final {
+    if (utils::isInsideCompositeDecomposition(scaleMul)) {
+      return mlir::failure();
+    }
+
+    // The anchor multiply is `normalize_core * sqrt(D)`. Identify which operand
+    // is the DivOp (looking through typecasts) and which is the scalar scale.
+    DivOp divOp =
+        ttmlir::utils::findOpThrough<DivOp, TypecastOp>(scaleMul.getLhs());
+    mlir::Value scaleRaw = scaleMul.getRhs();
+    if (!divOp) {
+      divOp =
+          ttmlir::utils::findOpThrough<DivOp, TypecastOp>(scaleMul.getRhs());
+      scaleRaw = scaleMul.getLhs();
+    }
+    if (!divOp) {
+      return mlir::failure();
+    }
+
+    // Numerator of the division is the tensor being normalized.
+    mlir::Value x = utils::lookThroughLayoutOps(divOp.getLhs());
+
+    // Denominator: optional clamp_min(sqrt(sum(x^2)), eps).
+    double epsGuard = 0.0;
+    mlir::Value sqrtSource = divOp.getRhs();
+    if (auto clampOp =
+            utils::findOpThroughLayoutOps<ClampTensorOp>(divOp.getRhs())) {
+      std::optional<double> minVal = getSplatConstantValue(clampOp.getMin());
+      if (!minVal) {
+        return mlir::failure();
+      }
+      // Only fold the clamp when it acts as a small numerical-stability eps
+      // guard (as in F.normalize). A larger floor would be a meaningful clamp
+      // whose behavior is not captured by an rms_norm epsilon.
+      constexpr double kMaxNormEpsGuard = 1e-3;
+      if (*minVal < 0.0 || *minVal > kMaxNormEpsGuard) {
+        return mlir::failure();
+      }
+      epsGuard = *minVal;
+      sqrtSource = clampOp.getInput();
+    }
+
+    // sqrt expressed as either ttir.sqrt or pow(_, 0.5).
+    mlir::Value sumSource;
+    if (auto sqrtOp = utils::findOpThroughLayoutOps<SqrtOp>(sqrtSource)) {
+      sumSource = sqrtOp.getInput();
+    } else if (auto powOp = utils::findOpThroughLayoutOps<PowOp>(sqrtSource)) {
+      if (!isApproxScalarConstant(powOp.getRhs(), 0.5, 1e-3)) {
+        return mlir::failure();
+      }
+      sumSource = powOp.getLhs();
+    } else {
+      return mlir::failure();
+    }
+
+    // Reduction: sum over a single dimension.
+    auto sumOp = utils::findOpThroughLayoutOps<SumOp>(sumSource);
+    if (!sumOp) {
+      return mlir::failure();
+    }
+    std::optional<mlir::ArrayAttr> dimArg = sumOp.getDimArg();
+    if (!dimArg || dimArg->size() != 1) {
+      return mlir::failure();
+    }
+    int64_t rank =
+        mlir::cast<mlir::RankedTensorType>(sumOp.getInput().getType())
+            .getRank();
+    int64_t reduceDim = mlir::cast<mlir::IntegerAttr>((*dimArg)[0]).getInt();
+    if (reduceDim < 0) {
+      reduceDim += rank;
+    }
+
+    // The summand must be x^2, expressed as pow(_, 2) or mul(v, v), optionally
+    // wrapped in abs (|x|^2 == x^2).
+    mlir::Value squareBase;
+    if (auto powOp = utils::findOpThroughLayoutOps<PowOp>(sumOp.getInput())) {
+      if (!isApproxScalarConstant(powOp.getRhs(), 2.0, 1e-3)) {
+        return mlir::failure();
+      }
+      squareBase = powOp.getLhs();
+    } else if (auto mulOp = utils::findOpThroughLayoutOps<MultiplyOp>(
+                   sumOp.getInput())) {
+      if (mulOp.getLhs() != mulOp.getRhs()) {
+        return mlir::failure();
+      }
+      squareBase = mulOp.getLhs();
+    } else {
+      return mlir::failure();
+    }
+
+    mlir::Value squareSrc = utils::lookThroughLayoutOps(squareBase);
+    if (auto absOp = squareSrc.getDefiningOp<AbsOp>()) {
+      squareSrc = utils::lookThroughLayoutOps(absOp.getInput());
+    }
+    // The squared tensor must be the same value that is being normalized.
+    if (squareSrc != x) {
+      return mlir::failure();
+    }
+
+    // The scale factor must be sqrt(D), where D is the size of the reduced dim.
+    auto xType = mlir::cast<mlir::RankedTensorType>(x.getType());
+    if (reduceDim < 0 || reduceDim >= xType.getRank()) {
+      return mlir::failure();
+    }
+    int64_t reduceDimSize = xType.getShape()[reduceDim];
+    if (reduceDimSize <= 1) {
+      return mlir::failure();
+    }
+    if (!isApproxScalarConstant(scaleRaw,
+                                std::sqrt(static_cast<double>(reduceDimSize)),
+                                /*relTol=*/0.02)) {
+      return mlir::failure();
+    }
+
+    // rms_norm's internal mean divides by reduceDimSize, which is exactly what
+    // the sqrt(D) scale accounts for. The clamp guard on the norm (denominator
+    // floored at `epsGuard`) maps to an additive epsilon under the mean of
+    // epsGuard^2 / D.
+    float epsilon = static_cast<float>((epsGuard * epsGuard) /
+                                       static_cast<double>(reduceDimSize));
+    llvm::SmallVector<int64_t> normalizedShape{reduceDimSize};
+
+    // If the scale multiply feeds a per-channel gamma multiply, fold gamma into
+    // the rms_norm weight. gamma qualifies when it is a per-channel vector,
+    // i.e. it holds exactly `reduceDimSize` elements (broadcast across the
+    // other dims). The scale multiply must have a single use so that folding
+    // the gamma multiply leaves it dead. Otherwise the (absent) weight stays
+    // null and only the normalization core is fused.
+    MultiplyOp gammaMul;
+    mlir::Value gammaSrc;
+    if (scaleMul->hasOneUse()) {
+      if (auto userMul =
+              mlir::dyn_cast<MultiplyOp>(*scaleMul->getUsers().begin())) {
+        mlir::Value other = userMul.getLhs() == scaleMul.getResult()
+                                ? userMul.getRhs()
+                                : userMul.getLhs();
+        mlir::Value src = utils::lookThroughLayoutOps(other);
+        if (auto srcType =
+                mlir::dyn_cast<mlir::RankedTensorType>(src.getType())) {
+          int64_t total = 1;
+          for (int64_t d : srcType.getShape()) {
+            total *= d;
+          }
+          if (src != scaleMul.getResult() && total == reduceDimSize) {
+            gammaMul = userMul;
+            gammaSrc = src;
+          }
+        }
+      }
+    }
+
+    mlir::Operation *replaceTarget =
+        gammaMul ? gammaMul.getOperation() : scaleMul.getOperation();
+    auto targetType = mlir::cast<mlir::RankedTensorType>(
+        replaceTarget->getResult(0).getType());
+
+    rewriter.setInsertionPoint(replaceTarget);
+    mlir::Location loc = scaleMul.getLoc();
+
+    // Build the optional rms_norm weight from gamma: reshape to the 1-D
+    // normalized_shape and match the input's element type.
+    mlir::Value weight;
+    if (gammaMul) {
+      weight = gammaSrc;
+      auto gammaType = mlir::cast<mlir::RankedTensorType>(weight.getType());
+      if (gammaType.getShape() != llvm::ArrayRef(normalizedShape)) {
+        weight = utils::createReshapeOp(rewriter, loc, weight, normalizedShape)
+                     .getResult();
+      }
+      auto weightType = mlir::cast<mlir::RankedTensorType>(weight.getType());
+      if (weightType.getElementType() != xType.getElementType()) {
+        auto castType = mlir::RankedTensorType::get(
+            normalizedShape, xType.getElementType(), weightType.getEncoding());
+        weight = rewriter.create<TypecastOp>(loc, castType, weight);
+      }
+    }
+
+    mlir::Value rmsResult;
+    if (reduceDim == xType.getRank() - 1) {
+      rmsResult =
+          rewriter
+              .create<RMSNormOp>(loc, xType, x, weight,
+                                 /*bias=*/mlir::Value(),
+                                 rewriter.getDenseI64ArrayAttr(normalizedShape),
+                                 rewriter.getF32FloatAttr(epsilon))
+              .getResult();
+    } else {
+      // Move the reduced dim to the last position, normalize, then restore.
+      // The weight is 1-D over the reduced (now last) dim, so it needs no
+      // permutation.
+      llvm::SmallVector<int64_t> perm;
+      for (int64_t i = 0; i < xType.getRank(); ++i) {
+        if (i != reduceDim) {
+          perm.push_back(i);
+        }
+      }
+      perm.push_back(reduceDim);
+      llvm::SmallVector<int64_t> invPerm =
+          ttmlir::utils::inversePermutation(perm);
+      llvm::SmallVector<int64_t> permShape = ttmlir::utils::applyPermutation(
+          xType.getShape(), llvm::ArrayRef(perm));
+      auto permType = mlir::RankedTensorType::get(
+          permShape, xType.getElementType(), xType.getEncoding());
+      mlir::Value permX = rewriter.create<PermuteOp>(
+          loc, permType, x, rewriter.getDenseI64ArrayAttr(perm));
+      mlir::Value rms =
+          rewriter
+              .create<RMSNormOp>(loc, permType, permX, weight,
+                                 /*bias=*/mlir::Value(),
+                                 rewriter.getDenseI64ArrayAttr(normalizedShape),
+                                 rewriter.getF32FloatAttr(epsilon))
+              .getResult();
+      rmsResult = rewriter.create<PermuteOp>(
+          loc, xType, rms, rewriter.getDenseI64ArrayAttr(invPerm));
+    }
+
+    mlir::Value result =
+        utils::reshapeAndCastToType(rewriter, loc, rmsResult, targetType);
+    rewriter.replaceOp(replaceTarget, result);
+    return mlir::success();
+  }
+};
+
 // If value is defined by PermuteOp with permute dimensions
 // (..., rank - 2, rank - 1), return the input of the PermuteOp, otherwise
 // return std::nullopt. This is used for fusing permute into MatmulOp and
@@ -3362,6 +3667,7 @@ public:
         patterns.add<PermuteSliceAfterMatmulPattern>(&getContext());
       }
       patterns.add<RMSNormFusionPattern>(&getContext());
+      patterns.add<NormalizeRMSNormFusionPattern>(&getContext());
 
       patterns.add<GeluFusionPattern>(&getContext());
       patterns.add<Relu6FusionPattern>(&getContext());

--- a/test/ttmlir/Dialect/TTIR/fusing/normalize_rms_norm_fusion.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/normalize_rms_norm_fusion.mlir
@@ -1,0 +1,120 @@
+// RUN: ttmlir-opt --ttir-fusing %s | FileCheck %s
+
+module {
+  // F.normalize-style RMS norm over a non-last (channel) dim:
+  //   (x / clamp_min(sqrt(sum(x^2, dim=1)), eps)) * sqrt(4)
+  // The reduced dim (1) is permuted to last, normalized, then permuted back.
+  // CHECK-LABEL: func.func @fuse_channel_rms
+  func.func @fuse_channel_rms(%arg0: tensor<2x4x8xf32>) -> tensor<2x4x8xf32> {
+    // CHECK: "ttir.permute"
+    // CHECK: "ttir.rms_norm"
+    // CHECK-SAME: normalized_shape = array<i64: 4>
+    // CHECK: "ttir.permute"
+    // CHECK-NOT: "ttir.div"
+    %two = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 2.0 : f32}> : () -> tensor<2x4x8xf32>
+    %sq = "ttir.pow"(%arg0, %two) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %sum = "ttir.sum"(%sq) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x4x8xf32>) -> tensor<2x1x8xf32>
+    %half = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 0.5 : f32}> : () -> tensor<2x1x8xf32>
+    %sqrt = "ttir.pow"(%sum, %half) : (tensor<2x1x8xf32>, tensor<2x1x8xf32>) -> tensor<2x1x8xf32>
+    %min = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 1.000000e-12 : f32}> : () -> tensor<2x1x8xf32>
+    %max = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 3.40282347E+38 : f32}> : () -> tensor<2x1x8xf32>
+    %clamp = "ttir.clamp_tensor"(%sqrt, %min, %max) : (tensor<2x1x8xf32>, tensor<2x1x8xf32>, tensor<2x1x8xf32>) -> tensor<2x1x8xf32>
+    %bcast = "ttir.broadcast"(%clamp) <{broadcast_dimensions = array<i64: 1, 4, 1>}> : (tensor<2x1x8xf32>) -> tensor<2x4x8xf32>
+    %div = "ttir.div"(%arg0, %bcast) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %scale = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 2.0 : f32}> : () -> tensor<2x4x8xf32>
+    %out = "ttir.multiply"(%div, %scale) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    return %out : tensor<2x4x8xf32>
+  }
+
+  // Same as above but with a trailing per-channel gamma multiply, which is
+  // folded into the rms_norm weight operand.
+  // CHECK-LABEL: func.func @fuse_channel_rms_with_gamma
+  func.func @fuse_channel_rms_with_gamma(%arg0: tensor<2x4x8xf32>, %g: tensor<4xf32>) -> tensor<2x4x8xf32> {
+    // CHECK: "ttir.permute"
+    // CHECK: "ttir.rms_norm"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}})
+    // CHECK-SAME: normalized_shape = array<i64: 4>
+    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0>
+    // CHECK: "ttir.permute"
+    // CHECK-NOT: "ttir.div"
+    %two = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 2.0 : f32}> : () -> tensor<2x4x8xf32>
+    %sq = "ttir.pow"(%arg0, %two) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %sum = "ttir.sum"(%sq) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x4x8xf32>) -> tensor<2x1x8xf32>
+    %half = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 0.5 : f32}> : () -> tensor<2x1x8xf32>
+    %sqrt = "ttir.pow"(%sum, %half) : (tensor<2x1x8xf32>, tensor<2x1x8xf32>) -> tensor<2x1x8xf32>
+    %min = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 1.000000e-12 : f32}> : () -> tensor<2x1x8xf32>
+    %max = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 3.40282347E+38 : f32}> : () -> tensor<2x1x8xf32>
+    %clamp = "ttir.clamp_tensor"(%sqrt, %min, %max) : (tensor<2x1x8xf32>, tensor<2x1x8xf32>, tensor<2x1x8xf32>) -> tensor<2x1x8xf32>
+    %bcast = "ttir.broadcast"(%clamp) <{broadcast_dimensions = array<i64: 1, 4, 1>}> : (tensor<2x1x8xf32>) -> tensor<2x4x8xf32>
+    %div = "ttir.div"(%arg0, %bcast) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %scale = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 2.0 : f32}> : () -> tensor<2x4x8xf32>
+    %scaled = "ttir.multiply"(%div, %scale) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %gr = "ttir.reshape"(%g) <{shape = [1 : i32, 4 : i32, 1 : i32]}> : (tensor<4xf32>) -> tensor<1x4x1xf32>
+    %gb = "ttir.broadcast"(%gr) <{broadcast_dimensions = array<i64: 2, 1, 8>}> : (tensor<1x4x1xf32>) -> tensor<2x4x8xf32>
+    %out = "ttir.multiply"(%scaled, %gb) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    return %out : tensor<2x4x8xf32>
+  }
+
+  // Same decomposition but over the last dim (with keep_dim=false + reshape).
+  // No permutes are needed. The scale is sqrt(8).
+  // CHECK-LABEL: func.func @fuse_last_dim_rms
+  func.func @fuse_last_dim_rms(%arg0: tensor<2x4x8xf32>) -> tensor<2x4x8xf32> {
+    // CHECK: "ttir.rms_norm"
+    // CHECK-SAME: normalized_shape = array<i64: 8>
+    // CHECK-NOT: "ttir.permute"
+    // CHECK-NOT: "ttir.div"
+    %two = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 2.0 : f32}> : () -> tensor<2x4x8xf32>
+    %sq = "ttir.pow"(%arg0, %two) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %sum = "ttir.sum"(%sq) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<2x4x8xf32>) -> tensor<2x4xf32>
+    %rs = "ttir.reshape"(%sum) <{shape = [2 : i32, 4 : i32, 1 : i32]}> : (tensor<2x4xf32>) -> tensor<2x4x1xf32>
+    %half = "ttir.full"() <{shape = array<i32: 2, 4, 1>, fill_value = 0.5 : f32}> : () -> tensor<2x4x1xf32>
+    %sqrt = "ttir.pow"(%rs, %half) : (tensor<2x4x1xf32>, tensor<2x4x1xf32>) -> tensor<2x4x1xf32>
+    %min = "ttir.full"() <{shape = array<i32: 2, 4, 1>, fill_value = 1.000000e-12 : f32}> : () -> tensor<2x4x1xf32>
+    %max = "ttir.full"() <{shape = array<i32: 2, 4, 1>, fill_value = 3.40282347E+38 : f32}> : () -> tensor<2x4x1xf32>
+    %clamp = "ttir.clamp_tensor"(%sqrt, %min, %max) : (tensor<2x4x1xf32>, tensor<2x4x1xf32>, tensor<2x4x1xf32>) -> tensor<2x4x1xf32>
+    %bcast = "ttir.broadcast"(%clamp) <{broadcast_dimensions = array<i64: 1, 1, 8>}> : (tensor<2x4x1xf32>) -> tensor<2x4x8xf32>
+    %div = "ttir.div"(%arg0, %bcast) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %scale = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 2.828427 : f32}> : () -> tensor<2x4x8xf32>
+    %out = "ttir.multiply"(%div, %scale) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    return %out : tensor<2x4x8xf32>
+  }
+
+  // A large clamp floor is a meaningful clamp, not an eps guard, so it must not
+  // be reinterpreted as an rms_norm epsilon.
+  // CHECK-LABEL: func.func @no_fuse_large_clamp
+  func.func @no_fuse_large_clamp(%arg0: tensor<2x4x8xf32>) -> tensor<2x4x8xf32> {
+    // CHECK-NOT: "ttir.rms_norm"
+    %two = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 2.0 : f32}> : () -> tensor<2x4x8xf32>
+    %sq = "ttir.pow"(%arg0, %two) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %sum = "ttir.sum"(%sq) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x4x8xf32>) -> tensor<2x1x8xf32>
+    %half = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 0.5 : f32}> : () -> tensor<2x1x8xf32>
+    %sqrt = "ttir.pow"(%sum, %half) : (tensor<2x1x8xf32>, tensor<2x1x8xf32>) -> tensor<2x1x8xf32>
+    %min = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 5.000000e-01 : f32}> : () -> tensor<2x1x8xf32>
+    %max = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 3.40282347E+38 : f32}> : () -> tensor<2x1x8xf32>
+    %clamp = "ttir.clamp_tensor"(%sqrt, %min, %max) : (tensor<2x1x8xf32>, tensor<2x1x8xf32>, tensor<2x1x8xf32>) -> tensor<2x1x8xf32>
+    %bcast = "ttir.broadcast"(%clamp) <{broadcast_dimensions = array<i64: 1, 4, 1>}> : (tensor<2x1x8xf32>) -> tensor<2x4x8xf32>
+    %div = "ttir.div"(%arg0, %bcast) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %scale = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 2.0 : f32}> : () -> tensor<2x4x8xf32>
+    %out = "ttir.multiply"(%div, %scale) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    return %out : tensor<2x4x8xf32>
+  }
+
+  // Plain L2 normalization: the rescale factor is NOT sqrt(D) (here 3.0 while
+  // sqrt(4) = 2.0), so this must remain unfused (it is not an RMS norm).
+  // CHECK-LABEL: func.func @no_fuse_plain_l2
+  func.func @no_fuse_plain_l2(%arg0: tensor<2x4x8xf32>) -> tensor<2x4x8xf32> {
+    // CHECK-NOT: "ttir.rms_norm"
+    %two = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 2.0 : f32}> : () -> tensor<2x4x8xf32>
+    %sq = "ttir.pow"(%arg0, %two) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %sum = "ttir.sum"(%sq) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x4x8xf32>) -> tensor<2x1x8xf32>
+    %half = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 0.5 : f32}> : () -> tensor<2x1x8xf32>
+    %sqrt = "ttir.pow"(%sum, %half) : (tensor<2x1x8xf32>, tensor<2x1x8xf32>) -> tensor<2x1x8xf32>
+    %min = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 1.000000e-12 : f32}> : () -> tensor<2x1x8xf32>
+    %max = "ttir.full"() <{shape = array<i32: 2, 1, 8>, fill_value = 3.40282347E+38 : f32}> : () -> tensor<2x1x8xf32>
+    %clamp = "ttir.clamp_tensor"(%sqrt, %min, %max) : (tensor<2x1x8xf32>, tensor<2x1x8xf32>, tensor<2x1x8xf32>) -> tensor<2x1x8xf32>
+    %bcast = "ttir.broadcast"(%clamp) <{broadcast_dimensions = array<i64: 1, 4, 1>}> : (tensor<2x1x8xf32>) -> tensor<2x4x8xf32>
+    %div = "ttir.div"(%arg0, %bcast) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    %scale = "ttir.full"() <{shape = array<i32: 2, 4, 8>, fill_value = 3.0 : f32}> : () -> tensor<2x4x8xf32>
+    %out = "ttir.multiply"(%div, %scale) : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+    return %out : tensor<2x4x8xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
Part of https://github.com/tenstorrent/tt-xla/discussions/5377

### Problem description
RMS norm can come in different form: `abs(x) → pow(·,2) → sum(channel) → sqrt → clamp(ε) → div(x, ·) → ·(√D·γ)`
Fusing pattern for this version is currently not present.

### What's changed
Added fusing pattern for this case. This is mathematically equivalent to the RMS norm:

A = sum(abs(x)^2) along channel dim
RMS norm: y = (x / (√(ε + A/D)))*γ

This pattern:
abs(x) → pow(·,2) → sum(channel) = A
after sqrt: √A

If ε is just stabilization factor and in rms norm it is usually a number close to 0, but greater to avoid division by zero. Clamp(ε, √A) is just √A but it also retains the property of always being greater than 0. Also in rms norm ε + A/D can be approximated as just A/D if  ε << A/D. This step is here to avoid division by zero.

after div: x/√A

after multiple: x*√D*γ/√A which can be rewritten to (x/√(A/D))*γ that is what RMS norm is computing.

Multiple guards are present to fuse only if approximations are valid.

### Checklist
- [x] New/Existing tests provide coverage for changes
