### PR TITLE
D2M: add TensorAccessor DMA lowering

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1449,7 +1449,8 @@ def D2M_DMAWriteOp : D2M_GenericRegionDatamovementOp<"dma_write",
                          AnyRankedTensorOrMemRef:$dst, Variadic<Index>:$dstIndices,
                          I64Attr:$numElems,
                          Variadic<Index>:$mcastStartIndex, Variadic<Index>:$mcastShape,
-                         Variadic<Index>:$startDevice, Variadic<Index>:$deviceMcastShape);
+                         Variadic<Index>:$startDevice, Variadic<Index>:$deviceMcastShape,
+                         OptionalAttr<AffineMapAttr>:$tensorAccessorPageMap);
     let results = (outs D2M_MemTx:$result);
 
     let builders =
@@ -1457,37 +1458,37 @@ def D2M_DMAWriteOp : D2M_GenericRegionDatamovementOp<"dma_write",
       // Fully indexed unicast - multicast args are defaulted
       OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "size_t": $numElems),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Write), src, srcIndices, dst, dstIndices, $_builder.getI64IntegerAttr(numElems), ValueRange(), ValueRange(), /*startDevice=*/ValueRange(), /*deviceMcastShape=*/ValueRange());
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Write), src, srcIndices, dst, dstIndices, $_builder.getI64IntegerAttr(numElems), ValueRange(), ValueRange(), /*startDevice=*/ValueRange(), /*deviceMcastShape=*/ValueRange(), /*tensorAccessorPageMap=*/AffineMapAttr());
       }]>,
 
       // Fully indexed multicast - multicast args must be provided
       OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "ValueRange": $mcastStartIndex, "ValueRange": $mcastShape, "size_t": $numElems),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::McastWrite), src, srcIndices, dst, dstIndices, $_builder.getI64IntegerAttr(numElems), mcastStartIndex, mcastShape, /*startDevice=*/ValueRange(), /*deviceMcastShape=*/ValueRange());
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::McastWrite), src, srcIndices, dst, dstIndices, $_builder.getI64IntegerAttr(numElems), mcastStartIndex, mcastShape, /*startDevice=*/ValueRange(), /*deviceMcastShape=*/ValueRange(), /*tensorAccessorPageMap=*/AffineMapAttr());
       }]>,
 
       // Fully indexed unicast, with destination device range
       OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "size_t": $numElems, "ValueRange": $startDevice, "ValueRange": $deviceMcastShape),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Write), src, srcIndices, dst, dstIndices, $_builder.getI64IntegerAttr(numElems), ValueRange(), ValueRange(), startDevice, deviceMcastShape);
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Write), src, srcIndices, dst, dstIndices, $_builder.getI64IntegerAttr(numElems), ValueRange(), ValueRange(), startDevice, deviceMcastShape, /*tensorAccessorPageMap=*/AffineMapAttr());
       }]>,
 
       // Shard-level unicast (no src indices, grid indices on dst, numElems = 0)
       OpBuilder<(ins "Value": $src, "Value": $dst, "ValueRange": $dstIndices),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Write), src, ValueRange(), dst, dstIndices, $_builder.getI64IntegerAttr(0), ValueRange(), ValueRange(), /*startDevice=*/ValueRange(), /*deviceMcastShape=*/ValueRange());
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Write), src, ValueRange(), dst, dstIndices, $_builder.getI64IntegerAttr(0), ValueRange(), ValueRange(), /*startDevice=*/ValueRange(), /*deviceMcastShape=*/ValueRange(), /*tensorAccessorPageMap=*/AffineMapAttr());
       }]>,
 
       // Shard-level multicast (no indices on either, numElems = 0)
       OpBuilder<(ins "Value": $src, "Value": $dst, "ValueRange": $mcastStartIndex, "ValueRange": $mcastShape),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::McastWrite), src, ValueRange(), dst, ValueRange(), $_builder.getI64IntegerAttr(0), mcastStartIndex, mcastShape, /*startDevice=*/ValueRange(), /*deviceMcastShape=*/ValueRange());
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::McastWrite), src, ValueRange(), dst, ValueRange(), $_builder.getI64IntegerAttr(0), mcastStartIndex, mcastShape, /*startDevice=*/ValueRange(), /*deviceMcastShape=*/ValueRange(), /*tensorAccessorPageMap=*/AffineMapAttr());
       }]>,
 
       // Shard-level unicast (no src indices, grid indices on dst, numElems = 0), with destination device range
       OpBuilder<(ins "Value": $src, "Value": $dst, "ValueRange": $dstIndices, "ValueRange": $startDevice, "ValueRange": $deviceMcastShape),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Write), src, ValueRange(), dst, dstIndices, $_builder.getI64IntegerAttr(0), ValueRange(), ValueRange(), startDevice, deviceMcastShape);
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Write), src, ValueRange(), dst, dstIndices, $_builder.getI64IntegerAttr(0), ValueRange(), ValueRange(), startDevice, deviceMcastShape, /*tensorAccessorPageMap=*/AffineMapAttr());
       }]>
     ];
 
@@ -1566,19 +1567,20 @@ def D2M_DMAReadOp : D2M_GenericRegionDatamovementOp<"dma_read",
 
     let arguments = (ins AnyRankedTensorOrMemRef:$src, Variadic<Index>:$srcIndices,
                          AnyRankedTensorOrMemRef:$dst, Variadic<Index>:$dstIndices,
-                         I64Attr:$numElems);
+                         I64Attr:$numElems,
+                         OptionalAttr<AffineMapAttr>:$tensorAccessorPageMap);
     let results = (outs D2M_MemTx:$result);
 
     let builders = [
       // Shard-level form (grid indices on src, no indices on dst, numElems = 0)
       OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, ValueRange(), $_builder.getI64IntegerAttr(0));
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, ValueRange(), $_builder.getI64IntegerAttr(0), /*tensorAccessorPageMap=*/AffineMapAttr());
       }]>,
       // Fully indexed form
       OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "IntegerAttr": $numElems),
       [{
-        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, dstIndices, numElems);
+        build($_builder, $_state, MemTxType::get($_builder.getContext(), DMAType::Read), src, srcIndices, dst, dstIndices, numElems, /*tensorAccessorPageMap=*/AffineMapAttr());
       }]>,
     ];
 

--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -230,6 +230,12 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
                      "prints debug output comparing them."),
       llvm::cl::init(false)};
 
+  Option<bool> useTensorAccessorDMA{
+      *this, "use-tensor-accessor-dma",
+      llvm::cl::desc(
+          "Use TensorAccessor for eligible page-granular D2M DMA operations."),
+      llvm::cl::init(false)};
+
   Option<bool> disableL1Acc{
       *this, "disable-l1-acc",
       llvm::cl::desc("Disable L1 accumulation (force reloading from L1 to DST "

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -1247,6 +1247,10 @@ def D2MLowerDMAToFullyIndexedForm : Pass<"d2m-lower-dma-to-fully-indexed-form", 
            /*default=*/"false",
            "Enable debug mode for coalescing inference. Runs both analytical and "
            "sampling-based coalescing checks and prints debug output comparing them.">,
+    Option<"useTensorAccessorDMA", "use-tensor-accessor-dma", "bool",
+           /*default=*/"false",
+           "Preserve eligible tiled shard-level DMA operations for "
+           "TensorAccessor lowering.">,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4547,11 +4547,13 @@ def TTKernel_TensorAccessorOp : TTKernel_Op<"TensorAccessor"> {
     TensorAccessor constructor.
   }];
 
-  let arguments = (ins TTKernel_TensorAccessorArgs:$args, I32:$bank_base_address_in, I32:$page_size_in);
+  let arguments = (ins TTKernel_TensorAccessorArgs:$args,
+                       I32:$bank_base_address_in,
+                       Optional<I32>:$page_size_in);
   let results = (outs TTKernel_TensorAccessor:$result);
 
   let assemblyFormat = [{
-    `(` $args `,` $bank_base_address_in `,` $page_size_in `)` attr-dict `:` functional-type(operands, results)
+    `(` $args `,` $bank_base_address_in (`,` $page_size_in^)? `)` attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -70,6 +70,7 @@ def TTKernel_ArgTypeLocalSemaphore : I32EnumAttrCase<"LocalSemaphore", 2, "local
 def TTKernel_ArgTypeNamedArgument : I32EnumAttrCase<"NamedArgument", 3, "named_argument">;
 def TTKernel_ArgTypeGlobalSemaphore : I32EnumAttrCase<"GlobalSemaphore", 4, "global_semaphore">;
 def TTKernel_ArgTypeScalar : I32EnumAttrCase<"Scalar", 5, "scalar">;
+def TTKernel_ArgTypeTensorAccessorArgs : I32EnumAttrCase<"TensorAccessorArgs", 6, "tensor_accessor_args">;
 
 def TTKernel_ArgType : I32EnumAttr<"ArgType", "TTKernel Argument Types",
                          [
@@ -78,7 +79,8 @@ def TTKernel_ArgType : I32EnumAttr<"ArgType", "TTKernel Argument Types",
                            TTKernel_ArgTypeLocalSemaphore,
                            TTKernel_ArgTypeNamedArgument,
                            TTKernel_ArgTypeGlobalSemaphore,
-                           TTKernel_ArgTypeScalar
+                           TTKernel_ArgTypeScalar,
+                           TTKernel_ArgTypeTensorAccessorArgs
                          ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt::ttkernel";

--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -86,6 +86,10 @@ table KernelArgScalar {
   operand_idx: uint32;
 }
 
+table KernelArgTensorAccessorArgs {
+  operand_idx: uint32;
+}
+
 union KernelArgType {
   KernelArgCBPort,
   KernelArgBufferAddress,
@@ -93,6 +97,7 @@ union KernelArgType {
   KernelArgNamedArgument,
   KernelArgGlobalSemaphore,
   KernelArgScalar,
+  KernelArgTensorAccessorArgs,
 }
 
 table KernelArg {

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -27,10 +27,12 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 #include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -2569,6 +2571,147 @@ static Value buildL1Address(OpBuilder &rewriter, Location loc, Value cb,
   return rewriter.create<arith::AddIOp>(loc, baseAddr, offset);
 }
 
+// Stores the chain of TensorAccessorArgs for all FuncOps.
+class TensorAccessorArgsChains {
+public:
+  void bind(func::FuncOp func, const size_t operandIndex, Value args) {
+    accessorArgs[func.getOperation()][operandIndex] = args;
+  }
+
+  Value lookup(func::FuncOp func, const size_t operandIndex) const {
+    auto funcIt = accessorArgs.find(func.getOperation());
+    if (funcIt == accessorArgs.end()) {
+      return {};
+    }
+    auto argIt = funcIt->second.find(operandIndex);
+    return argIt == funcIt->second.end() ? Value{} : argIt->second;
+  }
+
+private:
+  DenseMap<Operation *, DenseMap<size_t, Value>> accessorArgs;
+};
+
+template <typename DMAOp>
+class D2MDMAViaTensorAccessorRewriter : public OpConversionPattern<DMAOp> {
+  static constexpr bool isRead = std::is_same_v<DMAOp, d2m::DMAReadOp>;
+  static_assert(std::is_same_v<DMAOp, d2m::DMAReadOp> ||
+                std::is_same_v<DMAOp, d2m::DMAWriteOp>);
+
+public:
+  D2MDMAViaTensorAccessorRewriter(
+      TypeConverter &typeConverter, MLIRContext *context,
+      std::shared_ptr<TensorAccessorArgsChains> tensorAccessorArgsChains,
+      const d2m::CBProducerConsumer *cbProducerConsumer)
+      : OpConversionPattern<DMAOp>(typeConverter, context),
+        tensorAccessorArgsChains(std::move(tensorAccessorArgsChains)),
+        cbProducerConsumer(cbProducerConsumer) {}
+
+  LogicalResult
+  matchAndRewrite(DMAOp op, typename DMAOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    AffineMapAttr pageMapAttr = op.getTensorAccessorPageMapAttr();
+    if (!pageMapAttr) {
+      return failure();
+    }
+    TT_assertv(op.isShardLevel(),
+               "TensorAccessor lowering requires shard-level DMA");
+
+    Value remoteMemref = isRead ? op.getSrc() : op.getDst();
+    auto getArg = remoteMemref.template getDefiningOp<d2m::GetArgOp>();
+    TT_assertv(getArg, "remote TensorAccessor operand must be a d2m.get_arg");
+
+    func::FuncOp func = op->template getParentOfType<func::FuncOp>();
+    Value tensorAccessorArgs =
+        tensorAccessorArgsChains->lookup(func, getArg.getOperandIndex());
+    TT_assertv(tensorAccessorArgs,
+               "TensorAccessorArgs binding was not materialized");
+
+    auto remoteType = mlir::cast<MemRefType>(remoteMemref.getType());
+    auto remoteLayout =
+        mlir::cast<ttcore::DeviceLayoutInterface>(remoteType.getLayout());
+    ArrayRef<int64_t> shardShape = remoteLayout.getShardShape(remoteType);
+
+    SmallVector<Value> remoteGridIndices;
+    Value remoteBaseAddress = nullptr;
+    Value localCB = nullptr;
+    Value localBaseAddress = nullptr;
+    if constexpr (isRead) {
+      auto dstCBMapping = cbProducerConsumer->get(op.getDst());
+      TT_assertv((dstCBMapping == d2m::ThreadCBOrientation::Producer ||
+                  dstCBMapping == d2m::ThreadCBOrientation::Default),
+                 "DMARead's dst CB must be the producer/default orientation.");
+      remoteGridIndices.assign(adaptor.getSrcIndices().begin(),
+                               adaptor.getSrcIndices().end());
+      remoteBaseAddress = adaptor.getSrc();
+      localCB = adaptor.getDst();
+      localBaseAddress =
+          rewriter.create<ttkernel::GetWritePtrOp>(op.getLoc(), localCB);
+    } else {
+      remoteGridIndices.assign(adaptor.getDstIndices().begin(),
+                               adaptor.getDstIndices().end());
+      remoteBaseAddress = adaptor.getDst();
+      localCB = adaptor.getSrc();
+      localBaseAddress =
+          rewriter.create<ttkernel::GetReadPtrOp>(op.getLoc(), localCB);
+    }
+
+    Value tensorAccessor = rewriter.create<ttkernel::TensorAccessorOp>(
+        op.getLoc(), tensorAccessorArgs, remoteBaseAddress,
+        /*page_size_in=*/Value{});
+    Value nocId = materializeKernelNocId(rewriter, op.getOperation());
+    const int64_t pageSize =
+        ttcore::getElementSizeBytes(remoteType.getElementType());
+
+    auto [lbs, ubs, steps] =
+        d2m::utils::getLoopBounds(rewriter, op.getLoc(), shardShape);
+    scf::buildLoopNest(
+        rewriter, op.getLoc(), lbs, ubs, steps,
+        [&](OpBuilder &loopBuilder, Location loc, ValueRange shardIndices) {
+          SmallVector<Value> remotePageCoordinates(remoteGridIndices);
+          remotePageCoordinates.append(shardIndices.begin(),
+                                       shardIndices.end());
+          SmallVector<Value> pageIds =
+              d2m::utils::applyMap(loopBuilder, loc, pageMapAttr.getValue(),
+                                   remotePageCoordinates, /*isRemote=*/false);
+          Value pageId = loopBuilder.create<arith::IndexCastOp>(
+              loc, loopBuilder.getI32Type(), pageIds.front());
+
+          Value localPage = loopBuilder.create<arith::ConstantIndexOp>(loc, 0);
+          for (auto [shardIndex, dimSize] :
+               llvm::zip_equal(shardIndices, shardShape)) {
+            Value dim =
+                loopBuilder.create<arith::ConstantIndexOp>(loc, dimSize);
+            localPage = loopBuilder.create<arith::AddIOp>(
+                loc, loopBuilder.create<arith::MulIOp>(loc, localPage, dim),
+                shardIndex);
+          }
+          Value pageSizeValue =
+              loopBuilder.create<arith::ConstantIndexOp>(loc, pageSize);
+          Value localOffset =
+              loopBuilder.create<arith::MulIOp>(loc, localPage, pageSizeValue);
+          Value localOffsetI32 = loopBuilder.create<arith::IndexCastOp>(
+              loc, loopBuilder.getI32Type(), localOffset);
+          Value localAddress = loopBuilder.create<arith::AddIOp>(
+              loc, localBaseAddress, localOffsetI32);
+
+          if constexpr (isRead) {
+            loopBuilder.create<ttkernel::NocAsyncReadTileOp>(
+                loc, pageId, tensorAccessor, localAddress, nocId);
+          } else {
+            loopBuilder.create<ttkernel::NocAsyncWriteTileOp>(
+                loc, pageId, tensorAccessor, localAddress, nocId);
+          }
+        });
+
+    rewriter.replaceOpWithNewOp<d2m::NullTxOp>(op, op.getResult().getType());
+    return success();
+  }
+
+private:
+  std::shared_ptr<TensorAccessorArgsChains> tensorAccessorArgsChains;
+  const d2m::CBProducerConsumer *cbProducerConsumer;
+};
+
 class D2MDMAReadRewriter : public OpConversionPattern<d2m::DMAReadOp> {
 public:
   D2MDMAReadRewriter(TypeConverter &typeConverter, MLIRContext *context,
@@ -2579,6 +2722,9 @@ public:
   LogicalResult
   matchAndRewrite(d2m::DMAReadOp op, d2m::DMAReadOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    if (!op.isFullyIndexed()) {
+      return failure();
+    }
 
     auto chipDesc = ttcore::getOpChipDescAttr(op);
     Location loc = op.getLoc();
@@ -2631,6 +2777,9 @@ public:
   LogicalResult
   matchAndRewrite(d2m::DMAWriteOp op, d2m::DMAWriteOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    if (!op.isFullyIndexed()) {
+      return failure();
+    }
 
     auto chipDesc = ttcore::getOpChipDescAttr(op);
 
@@ -3280,10 +3429,13 @@ public:
 namespace {
 class D2MKernelFunctionArgsRewriter : public OpConversionPattern<func::FuncOp> {
 public:
-  D2MKernelFunctionArgsRewriter(TypeConverter &typeConverter,
-                                MLIRContext *context, bool forceCompileTimeArgs)
+  D2MKernelFunctionArgsRewriter(
+      TypeConverter &typeConverter, MLIRContext *context,
+      bool forceCompileTimeArgs,
+      std::shared_ptr<TensorAccessorArgsChains> tensorAccessorArgsChains)
       : OpConversionPattern<func::FuncOp>(typeConverter, context),
-        forceCompileTimeArgs(forceCompileTimeArgs) {}
+        forceCompileTimeArgs(forceCompileTimeArgs),
+        tensorAccessorArgsChains(std::move(tensorAccessorArgsChains)) {}
 
   static ThreadType getTTKernelThreadType(func::FuncOp op) {
     d2m::ThreadAttr threadAttr =
@@ -3383,6 +3535,72 @@ public:
         insertKernelArg(rtArgs, ctArgs, arg);
       }
     });
+
+    auto collectTensorAccessorArg = [&](Value remoteMemref) {
+      auto getArg = remoteMemref.getDefiningOp<d2m::GetArgOp>();
+      if (!getArg) {
+        return;
+      }
+      insertSortedUnique(ctArgs,
+                         builder.getAttr<ArgAttr>(ArgType::TensorAccessorArgs,
+                                                  getArg.getOperandIndex()));
+    };
+    op.walk([&](d2m::DMAReadOp dmaRead) {
+      if (dmaRead.getTensorAccessorPageMapAttr()) {
+        collectTensorAccessorArg(dmaRead.getSrc());
+      }
+    });
+    op.walk([&](d2m::DMAWriteOp dmaWrite) {
+      if (dmaWrite.getTensorAccessorPageMapAttr()) {
+        collectTensorAccessorArg(dmaWrite.getDst());
+      }
+    });
+  }
+
+  void formTensorAccessorArgsChain(ConversionPatternRewriter &rewriter,
+                                   func::FuncOp op,
+                                   ArrayRef<ArgAttr> ctArgs) const {
+    const auto *firstTensorAccessorArgs =
+        llvm::find_if(ctArgs, [](ArgAttr arg) {
+          return arg.getArgType() == ArgType::TensorAccessorArgs;
+        });
+    if (firstTensorAccessorArgs == ctArgs.end()) {
+      return;
+    }
+
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(&op.getBody().front());
+
+    const size_t ctaBase = static_cast<size_t>(
+        std::distance(ctArgs.begin(), firstTensorAccessorArgs));
+    ArrayRef<ArgAttr> allTensorAccessorArgs = ctArgs.drop_front(ctaBase);
+    Value previousArgs = nullptr;
+    for (ArgAttr ctArg : allTensorAccessorArgs) {
+      TT_assertv(ctArg.getArgType() == ArgType::TensorAccessorArgs,
+                 "TensorAccessorArgs must be the last in the CTA list");
+      Value args = nullptr;
+      if (!previousArgs) {
+        Value ctaBaseValue =
+            intConstant<int32_t>(rewriter, op.getLoc(), ctaBase);
+        Value zero = intConstant<int32_t>(rewriter, op.getLoc(), 0);
+        args = rewriter
+                   .create<ttkernel::TensorAccessorArgsOp>(
+                       op.getLoc(), ctaBaseValue, zero,
+                       /*prev_args=*/Value{}, /*cta_expr=*/StringAttr{},
+                       /*crta_expr=*/StringAttr{})
+                   .getResult();
+      } else {
+        args = rewriter
+                   .create<ttkernel::TensorAccessorArgsOp>(
+                       op.getLoc(), /*cta_base=*/Value{},
+                       /*crta_base=*/Value{}, previousArgs,
+                       /*cta_expr=*/StringAttr{},
+                       /*crta_expr=*/StringAttr{})
+                   .getResult();
+      }
+      tensorAccessorArgsChains->bind(op, ctArg.getOperandIndex(), args);
+      previousArgs = args;
+    }
   }
 
   LogicalResult
@@ -3401,11 +3619,13 @@ public:
       op.setType(rewriter.getFunctionType(TypeRange(), TypeRange()));
       convertFunctionAttrs(rewriter, op, rtArgSpecVector, ctArgSpecVector);
     });
+    formTensorAccessorArgsChain(rewriter, op, ctArgSpecVector);
     return success();
   }
 
 private:
   bool forceCompileTimeArgs;
+  std::shared_ptr<TensorAccessorArgsChains> tensorAccessorArgsChains;
 };
 } // namespace
 
@@ -3657,9 +3877,11 @@ void populateD2MToTTKernelPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
     const d2m::CBProducerConsumer &cbProducerConsumer,
     bool forceCompileTimeArgs) {
+  auto tensorAccessorArgsChains =
+      std::make_shared<ttkernel::TensorAccessorArgsChains>();
   // clang-format off
   patterns.add<ttkernel::D2MKernelFunctionArgsRewriter>(
-      typeConverter, ctx, forceCompileTimeArgs);
+      typeConverter, ctx, forceCompileTimeArgs, tensorAccessorArgsChains);
   patterns.add<ttkernel::PassthroughRewriter<memref::CastOp>,
                ttkernel::MemRefSubviewRewriter,
 
@@ -3786,6 +4008,10 @@ void populateD2MToTTKernelPatterns(
                                             forceCompileTimeArgs);
   patterns.add<ttkernel::D2MGetCBRewriter>(typeConverter, ctx,
                                            forceCompileTimeArgs);
+  patterns.add<
+      ttkernel::D2MDMAViaTensorAccessorRewriter<d2m::DMAReadOp>,
+      ttkernel::D2MDMAViaTensorAccessorRewriter<d2m::DMAWriteOp>>(
+      typeConverter, ctx, tensorAccessorArgsChains, &cbProducerConsumer);
   patterns.add<ttkernel::D2MDMAReadRewriter>(typeConverter, ctx, &cbProducerConsumer);
   patterns.add<ttkernel::D2MDMAWriteRewriter>(typeConverter, ctx, &cbProducerConsumer);
 

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -782,7 +782,8 @@ private:
                                       size_t mergedCbSlotBase) {
     size_t operandIndex = kernelArg.getOperandIndex();
     if (kernelArg.getType() == ttkernel::ArgType::BufferAddress ||
-        kernelArg.getType() == ttkernel::ArgType::Scalar) {
+        kernelArg.getType() == ttkernel::ArgType::Scalar ||
+        kernelArg.getType() == ttkernel::ArgType::TensorAccessorArgs) {
       if (auto unified = remapTable.lookupIO(enqueueProgram, operandIndex)) {
         operandIndex = *unified;
       }

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -231,6 +231,10 @@ convertKernelArg(Builder &builder, const ttkernel::ArgAttr &arg,
     return builder.getAttr<ttnn::KernelArgScalarAttr>(
         additionalArgMapping.at(arg.getOperandIndex()));
   }
+  case ttkernel::ArgType::TensorAccessorArgs: {
+    return builder.getAttr<ttnn::KernelArgTensorAccessorArgsAttr>(
+        arg.getOperandIndex());
+  }
   }
   llvm_unreachable("Invalid ArgType");
 }
@@ -858,6 +862,12 @@ remapSpatialKernelArgs(MLIRContext *ctx, ArrayRef<Attribute> args,
       if (auto unified =
               remapTable.lookupIO(generic, tensor.getTensorIndex())) {
         mapped = ttnn::KernelArgAddressOfTensorAttr::get(ctx, *unified);
+      }
+    } else if (auto tensorAccessor =
+                   mlir::dyn_cast<ttnn::KernelArgTensorAccessorArgsAttr>(arg)) {
+      if (auto unified =
+              remapTable.lookupIO(generic, tensorAccessor.getOperandIndex())) {
+        mapped = ttnn::KernelArgTensorAccessorArgsAttr::get(ctx, *unified);
       }
     } else if (auto globalSem =
                    mlir::dyn_cast<ttnn::KernelArgGlobalSemaphoreAttr>(arg)) {

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1740,20 +1740,31 @@ public:
       return failure();
     }
 
-    SmallVector<Value, 4> operands;
+    std::string pageIdVarName =
+        getResultVariableName(op.getId(), state, "page_id_");
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(),
+                                       "const uint32_t " + pageIdVarName +
+                                           " = static_cast<uint32_t>({});",
+                                       ValueRange{adaptor.getId()});
+
+    SmallVector<Value, 3> operands;
     std::string callStr;
     if constexpr (isRead) {
       operands.append({adaptor.getAddrGenStruct(), adaptor.getDstLocalL1Addr(),
-                       adaptor.getAddrGenStruct(), adaptor.getId()});
-      callStr = *nocName + ".async_read({}, CoreLocalMem<uint32_t>({}), "
-                           "{}.get_aligned_page_size(), "
-                           "{{.page_id = static_cast<uint32_t>({})}, {{});";
+                       adaptor.getAddrGenStruct()});
+      callStr = *nocName +
+                ".async_read({}, CoreLocalMem<uint32_t>({}), "
+                "{}.get_aligned_page_size(), "
+                "{{.page_id = " +
+                pageIdVarName + "}, {{});";
     } else {
       operands.append({adaptor.getSrcLocalL1Addr(), adaptor.getAddrGenStruct(),
-                       adaptor.getAddrGenStruct(), adaptor.getId()});
-      callStr = *nocName + ".async_write(CoreLocalMem<uint32_t>({}), {}, "
-                           "{}.get_aligned_page_size(), {{} , "
-                           "{{.page_id = static_cast<uint32_t>({})});";
+                       adaptor.getAddrGenStruct()});
+      callStr = *nocName +
+                ".async_write(CoreLocalMem<uint32_t>({}), {}, "
+                "{}.get_aligned_page_size(), {{} , "
+                "{{.page_id = " +
+                pageIdVarName + "});";
     }
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
@@ -2117,10 +2128,10 @@ public:
     std::string crtaArg = buildArgExpr(op.getCrtaExprAttr(), op.getCrtaBase(),
                                        "next_common_runtime_args_offset");
 
-    // Emit: auto tensor_accessor_args_N = TensorAccessorArgs<ctaArg,
-    // crtaArg>();
-    std::string code = "auto " + varName + " = TensorAccessorArgs<" + ctaArg +
-                       ", " + crtaArg + ">();";
+    // Emit: constexpr auto tensor_accessor_args_N =
+    // TensorAccessorArgs<ctaArg, crtaArg>();
+    std::string code = "constexpr auto " + varName + " = TensorAccessorArgs<" +
+                       ctaArg + ", " + crtaArg + ">();";
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), code);
 
     auto resultType =

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -66,6 +66,29 @@ static mlir::ConstantIntRanges getIndexRange(uint64_t umin, uint64_t umax) {
 // DMA Operations
 //===----------------------------------------------------------------------===//
 
+static LogicalResult verifyTensorAccessorPageMap(Operation *op,
+                                                 AffineMapAttr pageMapAttr,
+                                                 ShapedType remoteType,
+                                                 const bool isShardLevel) {
+  if (!pageMapAttr) {
+    return success();
+  }
+  if (!isShardLevel) {
+    return op->emitOpError("TensorAccessor page map requires shard-level DMA");
+  }
+
+  AffineMap pageMap = pageMapAttr.getValue();
+  if (pageMap.getNumDims() != static_cast<unsigned>(remoteType.getRank()) ||
+      pageMap.getNumSymbols() != 0 || pageMap.getNumResults() != 1) {
+    return op->emitOpError(
+               "TensorAccessor page map must be single-result, no symbols, and "
+               "one input per remote memref dim; expected ")
+           << remoteType.getRank() << " inputs, got "
+           << AffineMapAttr::get(pageMap);
+  }
+  return success();
+}
+
 // Comprehensive verifiers matching D2M
 ::mlir::LogicalResult DMAWriteOp::verify() {
   ShapedType srcType = mlir::cast<ShapedType>(getSrc().getType());
@@ -81,6 +104,12 @@ static mlir::ConstantIntRanges getIndexRange(uint64_t umin, uint64_t umax) {
 
   if (srcType.getElementType() != dstType.getElementType()) {
     return emitOpError("Operands to DMAWrite must have the same element type");
+  }
+
+  if (failed(verifyTensorAccessorPageMap(getOperation(),
+                                         getTensorAccessorPageMapAttr(),
+                                         dstType, isShardLevel()))) {
+    return failure();
   }
 
   if (isDstRemote() && isMcast()) {
@@ -138,6 +167,11 @@ static mlir::ConstantIntRanges getIndexRange(uint64_t umin, uint64_t umax) {
   }
   if (srcType.getElementType() != dstType.getElementType()) {
     return emitOpError("Operands to DMARead must have the same element type");
+  }
+  if (failed(verifyTensorAccessorPageMap(getOperation(),
+                                         getTensorAccessorPageMapAttr(),
+                                         srcType, isShardLevel()))) {
+    return failure();
   }
   int64_t numDstIndices = getDstIndices().size();
   int64_t numSrcIndices = getSrcIndices().size();

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -255,7 +255,12 @@ void createD2MBackendPipeline(OpPassManager &pm,
   pm.addPass(d2m::createD2MLowerLoadStoreOpsToDMA());
   pm.addPass(d2m::createD2MOptimizeDMA());
   pm.addPass(d2m::createD2MExpandDMAReadCompositeView());
-  pm.addPass(d2m::createD2MLowerDMAToFullyIndexedForm());
+  d2m::D2MLowerDMAToFullyIndexedFormOptions dmaOptions;
+  {
+    dmaOptions.debugCoalescingInference = options.debugD2mCoalescingInference;
+    dmaOptions.useTensorAccessorDMA = options.useTensorAccessorDMA;
+  }
+  pm.addPass(d2m::createD2MLowerDMAToFullyIndexedForm(dmaOptions));
 
   // Normalize thread argument access by inserting d2m.get_arg ops for any
   // remaining additional arguments and setting resolution_stage on

--- a/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/AffineMapAnalysis.h"
 #include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+#include "ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Utils.h"
@@ -16,6 +17,11 @@
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#include <optional>
+#include <type_traits>
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MLOWERDMATOFULLYINDEXEDFORM
@@ -75,6 +81,149 @@ static size_t getElementSizeBytes(MemRefType memref) {
   auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType);
   return tileType ? tileType.getSizeBytes()
                   : elementType.getIntOrFloatBitWidth() / 8;
+}
+
+static std::optional<AffineMap> buildTensorAccessorPageMap(Value remoteMemref) {
+  MemRefType remoteType = mlir::cast<MemRefType>(remoteMemref.getType());
+  MemRefType baseType = remoteType;
+
+  AffineMap viewMap = AffineMap::getMultiDimIdentityMap(
+      remoteType.getRank(), remoteType.getContext());
+  if (Operation *definingOp = remoteMemref.getDefiningOp()) {
+    if (auto viewOp = mlir::dyn_cast<ViewOpInterface>(definingOp)) {
+      if (viewOp.isComposite()) {
+        return std::nullopt;
+      }
+      std::tie(baseType, viewMap) = applyViews(definingOp);
+    }
+  }
+
+  if (!baseType.hasStaticShape() ||
+      !mlir::isa<ttcore::TileType>(baseType.getElementType())) {
+    return std::nullopt;
+  }
+
+  auto baseLayout = mlir::dyn_cast_if_present<ttcore::DeviceLayoutInterface>(
+      baseType.getLayout());
+  if (!baseLayout ||
+      !mlir::isa<ttcore::ShardLayoutAttr, ttcore::InterleavedLayoutAttr>(
+          baseType.getLayout())) {
+    return std::nullopt;
+  }
+
+  ttcore::MemorySpace memorySpace = ttcore::getMemorySpace(baseType);
+  if (memorySpace != ttcore::MemorySpace::DeviceL1 &&
+      memorySpace != ttcore::MemorySpace::DeviceDRAM) {
+    return std::nullopt;
+  }
+  if (mlir::isa<ttcore::InterleavedLayoutAttr>(baseType.getLayout()) &&
+      memorySpace != ttcore::MemorySpace::DeviceDRAM) {
+    return std::nullopt;
+  }
+
+  ArrayRef<int64_t> gridShape = baseLayout.getGridShape(baseType);
+  ArrayRef<int64_t> shardShape = baseLayout.getShardShape(baseType);
+  const size_t rank = gridShape.size();
+  static constexpr size_t kTensorAccessorMaxRank = 8;
+  if (rank == 0 || rank != shardShape.size() || rank > kTensorAccessorMaxRank) {
+    return std::nullopt;
+  }
+  if (viewMap.getNumDims() != static_cast<unsigned>(remoteType.getRank()) ||
+      viewMap.getNumSymbols() != 0 ||
+      viewMap.getNumResults() != static_cast<unsigned>(baseType.getRank())) {
+    return std::nullopt;
+  }
+
+  SmallVector<int64_t> tensorShape;
+  tensorShape.reserve(rank);
+  for (auto [gridDim, shardDim] : llvm::zip_equal(gridShape, shardShape)) {
+    tensorShape.push_back(gridDim * shardDim);
+  }
+
+  SmallVector<int64_t> tensorStrides(tensorShape.size());
+  int64_t stride = 1;
+  for (int64_t dim = static_cast<int64_t>(rank) - 1; dim >= 0; dim--) {
+    tensorStrides[dim] = stride;
+    stride *= tensorShape[dim];
+  }
+
+  MLIRContext *ctx = remoteType.getContext();
+  AffineExpr pageId = getAffineConstantExpr(0, ctx);
+  for (unsigned dim = 0; dim < rank; dim++) {
+    AffineExpr gridIndex = getAffineDimExpr(dim, ctx);
+    AffineExpr shardIndex = getAffineDimExpr(rank + dim, ctx);
+    AffineExpr absolutePage = gridIndex * shardShape[dim] + shardIndex;
+    pageId = pageId + absolutePage * tensorStrides[dim];
+  }
+
+  AffineMap basePageMap = AffineMap::get(baseType.getRank(), 0, pageId, ctx);
+  return simplifyAffineMap(basePageMap.compose(viewMap));
+}
+
+template <typename DMAOp>
+static std::optional<AffineMap> getEligibleTensorAccessorPageMap(DMAOp op) {
+  static_assert(std::is_same_v<DMAOp, DMAReadOp> ||
+                std::is_same_v<DMAOp, DMAWriteOp>);
+
+  if (!op.isShardLevel()) {
+    return std::nullopt;
+  }
+
+  Value remoteMemref = nullptr;
+  Value localMemref = nullptr;
+  ValueRange remoteGridIndices;
+  if constexpr (std::is_same_v<DMAOp, DMAReadOp>) {
+    if (!op.isSrcRemote()) {
+      return std::nullopt;
+    }
+    remoteMemref = op.getSrc();
+    localMemref = op.getDst();
+    remoteGridIndices = op.getSrcIndices();
+  } else {
+    if (!op.isDstRemote() || op.isMcast() || !op.getStartDevice().empty() ||
+        !op.getDeviceMcastShape().empty()) {
+      return std::nullopt;
+    }
+    remoteMemref = op.getDst();
+    localMemref = op.getSrc();
+    remoteGridIndices = op.getDstIndices();
+  }
+
+  GenericOp generic = op->template getParentOfType<GenericOp>();
+  if (!generic || !llvm::is_contained(generic.getOperands(), remoteMemref)) {
+    return std::nullopt;
+  }
+
+  auto remoteType = mlir::dyn_cast<MemRefType>(remoteMemref.getType());
+  auto localType = mlir::dyn_cast<MemRefType>(localMemref.getType());
+  if (!remoteType || !localType || !remoteType.hasStaticShape() ||
+      !localType.hasStaticShape() ||
+      !mlir::isa<ttcore::TileType>(remoteType.getElementType()) ||
+      remoteType.getElementType() != localType.getElementType()) {
+    return std::nullopt;
+  }
+
+  int64_t pageSize = ttcore::getElementSizeBytes(remoteType.getElementType());
+  if (pageSize % utils::getNocAddressAlignmentBytes(
+                     op, ttcore::getMemorySpace(remoteType)) !=
+          0 ||
+      pageSize % utils::getNocAddressAlignmentBytes(
+                     op, ttcore::MemorySpace::DeviceL1) !=
+          0) {
+    return std::nullopt;
+  }
+
+  auto remoteLayout = mlir::dyn_cast_if_present<ttcore::DeviceLayoutInterface>(
+      remoteType.getLayout());
+  if (!remoteLayout ||
+      remoteGridIndices.size() !=
+          remoteLayout.getGridShape(remoteType).size() ||
+      ttmlir::utils::volume(remoteLayout.getShardShape(remoteType)) !=
+          localType.getNumElements()) {
+    return std::nullopt;
+  }
+
+  return buildTensorAccessorPageMap(remoteMemref);
 }
 
 // Calculates coalescing factor using analytical method with sampling fallback.
@@ -279,6 +428,9 @@ public:
     if (op.isFullyIndexed()) {
       return failure();
     }
+    if (op.getTensorAccessorPageMapAttr()) {
+      return failure();
+    }
 
     Location loc = op.getLoc();
     Value remoteMemref = op.getSrc();
@@ -348,6 +500,9 @@ public:
   LogicalResult matchAndRewrite(DMAWriteOp op,
                                 PatternRewriter &rewriter) const final {
     if (op.isFullyIndexed()) {
+      return failure();
+    }
+    if (op.getTensorAccessorPageMapAttr()) {
       return failure();
     }
 
@@ -565,6 +720,30 @@ public:
       D2MLowerDMAToFullyIndexedForm>::D2MLowerDMAToFullyIndexedFormBase;
 
   void runOnOperation() final {
+    WalkResult walkResult = getOperation()->walk([&](Operation *op) {
+      return llvm::TypeSwitch<Operation *, WalkResult>(op)
+          .Case<DMAReadOp, DMAWriteOp>([&](auto dmaOp) {
+            if (dmaOp.getTensorAccessorPageMapAttr()) {
+              dmaOp.emitOpError(
+                  "unexpected pre-existing TensorAccessor page map");
+              return WalkResult::interrupt();
+            }
+            if (useTensorAccessorDMA) {
+              if (std::optional<AffineMap> pageMap =
+                      getEligibleTensorAccessorPageMap(dmaOp)) {
+                dmaOp.setTensorAccessorPageMapAttr(
+                    AffineMapAttr::get(*pageMap));
+              }
+            }
+            return WalkResult::advance();
+          })
+          .Default([](Operation *) { return WalkResult::advance(); });
+    });
+    if (walkResult.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+
     CoalescingFactorCache coalescingCache;
     RewritePatternSet dmaPatterns(&getContext());
     dmaPatterns.add<D2MLowerDMAReadToFullyIndexed>(

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
@@ -471,29 +471,67 @@ public:
            currentInverse == spec.vgmInverse;
   }
 
+  OutputBufferSpec
+  inferRequiredVirtualGridMapping(const OutputBufferSpec &spec) const {
+    TT_assertv(static_cast<bool>(spec.vgmForward) ==
+                   static_cast<bool>(spec.vgmInverse),
+               "Expected virtual-grid forward and inverse maps to be set "
+               "together");
+    if (spec.vgmForward) {
+      return spec;
+    }
+
+    auto layout = mlir::dyn_cast_if_present<ttcore::MetalLayoutAttr>(
+        spec.type.getEncoding());
+    if (!layout) {
+      return spec;
+    }
+
+    ArrayRef<int64_t> gridShape = layout.getGridShape(spec.type);
+    if (!ttmlir::d2m::utils::grids::requiresVirtualGrid(gridShape,
+                                                        targetGridShape)) {
+      return spec;
+    }
+
+    SmallVector<int64_t> physicalGridShape =
+        ttmlir::d2m::utils::grids::getPhysicalGridExtent(gridShape,
+                                                         targetGridShape);
+    auto [forwardMap, inverseMap] =
+        ttmlir::d2m::utils::grids::createCoreVirtMaps(
+            spec.type.getContext(), gridShape, physicalGridShape);
+
+    OutputBufferSpec mappedSpec = spec;
+    mappedSpec.vgmForward = forwardMap;
+    mappedSpec.vgmInverse = inverseMap;
+    return mappedSpec;
+  }
+
   Value createEmpty(PatternRewriter &rewriter, Location loc,
                     const OutputBufferSpec &spec, Value reusableOutput = {},
                     bool allowReuse = true) const {
-    if (allowReuse && matchesOutputSpec(reusableOutput, spec)) {
+    OutputBufferSpec mappedSpec = inferRequiredVirtualGridMapping(spec);
+    if (allowReuse && matchesOutputSpec(reusableOutput, mappedSpec)) {
       return reusableOutput;
     }
 
-    AffineMapAttr invAttr =
-        spec.vgmInverse ? AffineMapAttr::get(spec.vgmInverse) : nullptr;
-    AffineMapAttr fwdAttr =
-        spec.vgmForward ? AffineMapAttr::get(spec.vgmForward) : nullptr;
+    AffineMapAttr invAttr = mappedSpec.vgmInverse
+                                ? AffineMapAttr::get(mappedSpec.vgmInverse)
+                                : nullptr;
+    AffineMapAttr fwdAttr = mappedSpec.vgmForward
+                                ? AffineMapAttr::get(mappedSpec.vgmForward)
+                                : nullptr;
     if (!invAttr && !fwdAttr) {
       if (auto layout = mlir::dyn_cast_if_present<ttcore::MetalLayoutAttr>(
-              spec.type.getEncoding())) {
+              mappedSpec.type.getEncoding())) {
         return rewriter
-            .create<d2m::EmptyOp>(loc, spec.type.getShape(),
-                                  spec.type.getElementType(), layout,
+            .create<d2m::EmptyOp>(loc, mappedSpec.type.getShape(),
+                                  mappedSpec.type.getElementType(), layout,
                                   targetGridShape)
             .getResult();
       }
     }
 
-    return rewriter.create<d2m::EmptyOp>(loc, spec.type, invAttr, fwdAttr)
+    return rewriter.create<d2m::EmptyOp>(loc, mappedSpec.type, invAttr, fwdAttr)
         .getResult();
   }
 

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -39,6 +39,7 @@
 #include "mlir/IR/Matchers.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
@@ -234,12 +235,14 @@ createShardedBufferConfigForDRAMMemref(FlatbufferObjectCache &cache,
                                        MemRefType memref,
                                        ttcore::DeviceAttr device,
                                        ttcore::SystemDescAttr systemDesc) {
+  const bool isTiled = mlir::isa<ttcore::TileType>(memref.getElementType());
+
   // D2M DRAM shard-to-bank placement is cyclic. Use the same page granularity
   // as L1 (one element-row per page) so that the host-side read reassembles
   // data in the row-major order.
   target::Dim2d elementShape(1, 1);
-  if (auto tileType =
-          mlir::dyn_cast<ttcore::TileType>(memref.getElementType())) {
+  if (isTiled) {
+    auto tileType = mlir::cast<ttcore::TileType>(memref.getElementType());
     elementShape = target::Dim2d(tileType.getHeight(), tileType.getWidth());
   }
 
@@ -256,18 +259,23 @@ createShardedBufferConfigForDRAMMemref(FlatbufferObjectCache &cache,
       (memrefShardShape[0] * stride[0] / elementSize) / shardXElements;
   TT_assert(collapsedShardYElements * shardXElements ==
             ttmlir::utils::volume(memrefShardShape));
+  // In scalar-space.
   target::Dim2d shardShape(collapsedShardYElements * elementShape.y() *
                                shardLayout.getBuffers(),
                            shardXElements * elementShape.x());
 
-  // The page's width is the same as the memref's element's row width.
-  target::Dim2d pageShape(elementShape.y(), shardShape.x());
+  // For tiled DRAM tensors, always use one tile as one page (for
+  // TensorAccessor). For row-major DRAM tensors, one page is one
+  // full-shard-row.
+  target::Dim2d pageShape =
+      isTiled ? elementShape : target::Dim2d(elementShape.y(), shardShape.x());
 
   // Determine how many DRAM banks are actually used by D2M.
   uint64_t numDramBanks =
       systemDesc.getChipDescs().front().getNumDramChannels();
   uint64_t numDRAMBanksUsed = std::min(numDramBanks, gridVolume);
   // Important: the DRAM cores are distributed along the X dim on WH & BH.
+  // CoreRange(Set) is inclusive, but Dim2dRange is exclusive.
   std::vector<target::Dim2dRange> coreRangeSet = {target::Dim2dRange(
       target::Dim2d(0, 0), target::Dim2d(1, numDRAMBanksUsed))};
 
@@ -316,6 +324,10 @@ createShardedBufferConfigForDRAMMemref(FlatbufferObjectCache &cache,
                                     pageShape.x() / elementShape.x()};
   const uint64_t pageSize =
       pageShapeInElements[0] * pageShapeInElements[1] * elementSize;
+  if (isTiled) {
+    TT_assert(pageSize % systemDesc.getNocL1AddressAlignBytes() == 0u);
+    TT_assert(pageSize % systemDesc.getNocDRAMAddressAlignBytes() == 0u);
+  }
   const uint64_t shardSize =
       device.getMemrefSizeBytes(memref, pageSize, /*includeBuffers=*/true);
   const uint64_t totalSize = gridVolume * shardSize;
@@ -367,50 +379,65 @@ getPhysicalGridShapeForVirtualGrid(ttcore::ShardLayoutAttr shardLayout,
 }
 
 static flatbuffers::Offset<target::metal::BufferDistributionSpec>
-createBufferDistributionSpecForVirtualGrid(
-    FlatbufferObjectCache &cache, ttcore::ShardLayoutAttr shardLayout,
-    MemRefType memref, target::Dim2d elementShape, target::Dim2d pageShape,
-    bool hasVirtualGridMapping,
+createBufferDistributionSpec(
+    FlatbufferObjectCache &cache, ttcore::DeviceAttr device,
+    ttcore::ShardLayoutAttr shardLayout, MemRefType memref,
+    target::Dim2d elementShape, target::Dim2d pageShape,
     std::optional<AffineMap> virtualGridForwardMapping) {
-  if (!hasVirtualGridMapping) {
-    return 0;
-  }
-  TT_assertv(virtualGridForwardMapping.has_value(),
-             "Expected virtual-grid forward mapping");
-
-  ArrayRef<int64_t> virtualGridShape = shardLayout.getGridShape(memref);
-  ArrayRef<int64_t> memrefShardShape = shardLayout.getShardShape(memref);
-  TT_assertv(virtualGridShape.size() == memrefShardShape.size(),
-             "Expected grid rank to match shard rank");
+  ArrayRef<int64_t> gridShape = shardLayout.getGridShape(memref);
+  ArrayRef<int64_t> shardShape = shardLayout.getShardShape(memref);
+  TT_assertv(gridShape.size() == shardShape.size(),
+             "Grid rank must match shard rank");
 
   std::vector<uint32_t> shardShapeInPages =
-      computeShardPageShapeForDistributionSpec(memrefShardShape, elementShape,
+      computeShardPageShapeForDistributionSpec(shardShape, elementShape,
                                                pageShape);
   std::vector<uint32_t> tensorShapeInPages;
   tensorShapeInPages.reserve(shardShapeInPages.size());
-  for (size_t i = 0; i < shardShapeInPages.size(); ++i) {
-    tensorShapeInPages.push_back(static_cast<uint32_t>(virtualGridShape[i]) *
+  for (size_t i = 0; i < shardShapeInPages.size(); i++) {
+    tensorShapeInPages.push_back(static_cast<uint32_t>(gridShape[i]) *
                                  shardShapeInPages[i]);
   }
 
-  AffineMap forwardMap = *virtualGridForwardMapping;
-  TT_assertv(forwardMap.getNumDims() >= virtualGridShape.size(),
-             "Expected forward virtual-grid map to accept grid dimensions");
-  std::vector<target::Dim2d> cores;
-  cores.reserve(ttmlir::utils::volume<int64_t>(virtualGridShape));
-  ttmlir::utils::sample(
-      virtualGridShape, [&](ArrayRef<int64_t> virtualCoreCoord) {
-        SmallVector<int64_t> operands(forwardMap.getNumDims(), 0);
-        for (size_t i = 0; i < virtualCoreCoord.size(); ++i) {
-          operands[i] = virtualCoreCoord[i];
-        }
+  AffineMap coreMapping;
+  int64_t coreYResult = -1;
+  int64_t coreXResult = -1;
+  if (virtualGridForwardMapping.has_value()) {
+    coreMapping = *virtualGridForwardMapping;
+    coreYResult = 0;
+    coreXResult = 1;
+  } else {
+    coreMapping = extendMappingForHigherDimGrid(
+        device.getWorkerGrid().getVirtToPhysicalMap(), gridShape.size());
+    coreYResult = ttcore::PhysGridResultIdx::CoreCoordY;
+    coreXResult = ttcore::PhysGridResultIdx::CoreCoordX;
+  }
 
-        SmallVector<int64_t> physicalCoord = forwardMap.compose(operands);
-        TT_assertv(physicalCoord.size() >= 2u,
-                   "Expected forward virtual-grid map to produce a 2D core");
-        cores.emplace_back(static_cast<int32_t>(physicalCoord[0]),
-                           static_cast<int32_t>(physicalCoord[1]));
-      });
+  TT_assertv(coreMapping.getNumDims() >= gridShape.size(),
+             "Expected core mapping to accept grid dimensions");
+  TT_assertv(coreMapping.getNumResults() > coreXResult,
+             "Expected core mapping to produce worker coordinates");
+
+  std::vector<target::Dim2d> cores;
+  cores.reserve(ttmlir::utils::volume<int64_t>(gridShape));
+  llvm::DenseSet<std::pair<int64_t, int64_t>> seenCores;
+  ttmlir::utils::sample(gridShape, [&](ArrayRef<int64_t> logicalCoreCoord) {
+    SmallVector<int64_t> operands(coreMapping.getNumDims(), 0);
+    for (size_t i = 0; i < logicalCoreCoord.size(); i++) {
+      operands[i] = logicalCoreCoord[i];
+    }
+
+    SmallVector<int64_t> mappedCoord = coreMapping.compose(operands);
+    const int64_t coreY = mappedCoord[coreYResult];
+    const int64_t coreX = mappedCoord[coreXResult];
+    TT_assertv(seenCores.insert({coreY, coreX}).second,
+               "Core mapping must be one-to-one");
+    cores.emplace_back(static_cast<int32_t>(coreY),
+                       static_cast<int32_t>(coreX));
+  });
+  TT_assertv(static_cast<int64_t>(cores.size()) ==
+                 ttmlir::utils::volume<int64_t>(gridShape),
+             "Core mapping must be onto");
 
   return target::metal::CreateBufferDistributionSpecDirect(
       *cache.fbb, &tensorShapeInPages, &shardShapeInPages, &cores);
@@ -419,7 +446,8 @@ createBufferDistributionSpecForVirtualGrid(
 static flatbuffers::Offset<target::metal::ShardedBufferConfig>
 createShardedBufferConfigForL1Memref(
     FlatbufferObjectCache &cache, MemRefType memref, ttcore::DeviceAttr device,
-    target::Dim2d elementShape, bool hasVirtualGridMapping,
+    target::Dim2d elementShape, ttcore::SystemDescAttr systemDesc,
+    bool hasVirtualGridMapping,
     std::optional<AffineMap> virtualGridForwardMapping) {
   auto deviceLayout = mlir::dyn_cast_if_present<ttcore::DeviceLayoutInterface>(
       memref.getLayout());
@@ -457,7 +485,9 @@ createShardedBufferConfigForL1Memref(
   auto shardSpec = target::metal::CreateShardSpecDirect(
       *cache.fbb, &coreRangeSet, &shardShape);
 
-  target::Dim2d pageShape(elementShape.y(), shardShape.x());
+  const bool isTiled = mlir::isa<ttcore::TileType>(memref.getElementType());
+  target::Dim2d pageShape =
+      isTiled ? elementShape : target::Dim2d(elementShape.y(), shardShape.x());
   std::array<int32_t, 2> tensorShape = {gridShapeExtents[0] * shardShape.y(),
                                         gridShapeExtents[1] * shardShape.x()};
   assert(tensorShape[0] % pageShape.y() == 0);
@@ -466,9 +496,9 @@ createShardedBufferConfigForL1Memref(
                                    tensorShape[1] / pageShape.x());
   auto shardSpecBuffer = target::metal::CreateShardSpecBuffer(
       *cache.fbb, shardSpec, &pageShape, &tensorShapeInPages);
-  auto bufferDistributionSpec = createBufferDistributionSpecForVirtualGrid(
-      cache, shardLayout, memref, elementShape, pageShape,
-      hasVirtualGridMapping, virtualGridForwardMapping);
+  auto bufferDistributionSpec = createBufferDistributionSpec(
+      cache, device, shardLayout, memref, elementShape, pageShape,
+      virtualGridForwardMapping);
 
   assert(pageShape.y() % elementShape.y() == 0);
   assert(pageShape.x() % elementShape.x() == 0);
@@ -476,6 +506,11 @@ createShardedBufferConfigForL1Memref(
       pageShape.y() / elementShape.y(), pageShape.x() / elementShape.x()};
   uint64_t pageSize =
       pageShapeInElements[0] * pageShapeInElements[1] * elementSize;
+  if (isTiled) {
+    TT_assert(pageSize % systemDesc.getNocL1AddressAlignBytes() == 0u);
+    TT_assertv(pageSize == device.getMemrefCBPageSizeBytes(memref),
+               "Tiled MeshBuffer and CB page sizes must match");
+  }
   uint64_t shardSize =
       device.getMemrefSizeBytes(memref, pageSize, /*includeBuffers=*/true);
   uint64_t size = gridShapeExtents[0] * gridShapeExtents[1] * shardSize;
@@ -496,7 +531,7 @@ memrefTypeToShardedBufferConfigFlatbuffer(
         cache, memref, device, systemDesc);
   } else if (isMemrefDeviceL1Memspace(memref)) {
     sharded_buffer_config = createShardedBufferConfigForL1Memref(
-        cache, memref, device, elementShape, hasVirtualGridMapping,
+        cache, memref, device, elementShape, systemDesc, hasVirtualGridMapping,
         virtualGridForwardMapping);
   } else {
     assert(false &&
@@ -627,13 +662,17 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
                        ttcore::SystemDescAttr systemDesc,
                        std::optional<AffineMap> virtualGridInverseMapping,
                        std::optional<AffineMap> virtualGridForwardMapping) {
-  bool hasVirtualGridMapping = hasVirtualGridMappingPair(
-      virtualGridInverseMapping, virtualGridForwardMapping);
+  const Type elementType = memref.getElementType();
+  target::Dim2d elementShape(0, 0);
+  ttcore::DataType dtype = ttcore::DataType::Bool;
 
-  std::vector<int32_t> shape =
-      ttmlir::utils::castContainer<std::vector<int32_t>>(memref.getShape());
-  target::Dim2d elementShape(1, 1);
-  ttcore::DataType dtype = ttcore::DataType::Float32;
+  if (auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType)) {
+    dtype = tileType.getDataType();
+    elementShape = target::Dim2d(tileType.getHeight(), tileType.getWidth());
+  } else {
+    dtype = ttcore::elementTypeToDataType(elementType);
+    elementShape = target::Dim2d(1, 1);
+  }
 
   target::metal::BufferDetail bufferDetailType;
   flatbuffers::Offset<void> bufferDetail;
@@ -653,13 +692,16 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
     bufferDetailType = target::metal::BufferDetail::MetalBuffer;
     bool isSharded = mlir::isa<ttcore::ShardLayoutAttr>(memref.getLayout());
 
+    bool hasVirtualGridMapping = hasVirtualGridMappingPair(
+        virtualGridInverseMapping, virtualGridForwardMapping);
+
     if (isSharded) {
       flatbuffers::Offset<target::metal::ShardedBufferConfig>
           shardedBufferConfig = memrefTypeToShardedBufferConfigFlatbuffer(
               cache, memref, device, elementShape, systemDesc,
               hasVirtualGridMapping, virtualGridForwardMapping);
 
-      // only generate CircularBufferConfig for L1 memspace
+      // Only generate CircularBufferConfig for L1 memspace.
       flatbuffers::Offset<target::metal::CircularBufferConfig>
           circularBufferConfig =
               isMemrefDeviceL1Memspace(memref)
@@ -674,7 +716,7 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
                          shardedBufferConfig.Union(), circularBufferConfig)
                          .Union();
     } else {
-      // must be interleaved if not sharded
+      // Must be interleaved if not sharded.
       flatbuffers::Offset<target::metal::InterleavedBufferConfig>
           interleavedBufferConfig =
               memrefTypeToInterleavedBufferConfigFlatbuffer(
@@ -685,14 +727,6 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
                          interleavedBufferConfig.Union(), 0)
                          .Union();
     }
-  }
-
-  Type elementType = memref.getElementType();
-  if (auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType)) {
-    dtype = tileType.getDataType();
-    elementShape = target::Dim2d(tileType.getHeight(), tileType.getWidth());
-  } else {
-    dtype = ttcore::elementTypeToDataType(elementType);
   }
 
   std::vector<int32_t> hostStrides{};
@@ -720,6 +754,8 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
     }
   }
 
+  const auto shape =
+      ttmlir::utils::castContainer<std::vector<int32_t>>(memref.getShape());
   return target::metal::CreateBufferDescDirect(
       *cache.fbb, &shape, &hostStrides, hostVolume, toFlatbuffer(cache, dtype),
       &elementShape, bufferDetailType, bufferDetail,
@@ -894,6 +930,13 @@ toFlatbuffer(FlatbufferObjectCache &cache, KernelArgAttr kernelArg) {
     argType = target::metal::KernelArgType::KernelArgScalar;
     arg = target::metal::CreateKernelArgScalar(*cache.fbb,
                                                kernelArg.getOperandIndex())
+              .Union();
+    break;
+  }
+  case ttkernel::ArgType::TensorAccessorArgs: {
+    argType = target::metal::KernelArgType::KernelArgTensorAccessorArgs;
+    arg = target::metal::CreateKernelArgTensorAccessorArgs(
+              *cache.fbb, kernelArg.getOperandIndex())
               .Union();
     break;
   }

--- a/python/ttmlir/dialects/ttkernel.py
+++ b/python/ttmlir/dialects/ttkernel.py
@@ -5,3 +5,22 @@
 from ._ttkernel_ops_gen import *
 from ._ttkernel_enum_gen import *
 from .._mlir_libs._ttmlir import ttkernel_ir as ir
+
+
+def TensorAccessor(
+    args,
+    bank_base_address_in,
+    page_size_in=None,
+    *,
+    results=None,
+    loc=None,
+    ip=None,
+):
+    return TensorAccessorOp(
+        args=args,
+        bank_base_address_in=bank_base_address_in,
+        page_size_in=page_size_in,
+        results=results,
+        loc=loc,
+        ip=ip,
+    ).result

--- a/runtime/lib/ttmetal/arguments.h
+++ b/runtime/lib/ttmetal/arguments.h
@@ -15,6 +15,8 @@
 #include "ttmlir/Target/TTMetal/Target.h"
 #include "ttmlir/Target/TTMetal/types_generated.h"
 
+#include "tt-metalium/tensor_accessor_args.hpp"
+
 #include <cstring>
 
 namespace tt::runtime::ttmetal {
@@ -136,6 +138,29 @@ std::vector<std::uint32_t> processKernelArgs(
               .as<MetalTensor>(DeviceRuntime::TTMetal);
       std::uint32_t scalarValue = std::get<std::uint32_t>(metalTensor);
       argsVec.push_back(scalarValue);
+      break;
+    }
+    case target::metal::KernelArgType::KernelArgTensorAccessorArgs: {
+      LOG_ASSERT(isCompileTime,
+                 "TensorAccessorArgs are only supported as compile-time args");
+      const auto *arg = kernelArg->arg_as_KernelArgTensorAccessorArgs();
+      LOG_ASSERT(arg->operand_idx() < argRefsType->size(),
+                 "TensorAccessorArgs operand_idx out of bounds ",
+                 arg->operand_idx());
+      LOG_ASSERT(argRefsType->Get(arg->operand_idx()) ==
+                 target::metal::ArgRef::BufferRef);
+      const target::metal::BufferRef *buffer =
+          reinterpret_cast<const target::metal::BufferRef *>(
+              argRefs->Get(arg->operand_idx()));
+      auto meshBufferIt = meshBuffers.find(buffer->global_id());
+      LOG_ASSERT(meshBufferIt != meshBuffers.end(),
+                 "Buffer referenced by TensorAccessorArgs is no longer alive "
+                 "or was never created ",
+                 logger::Buffer(buffer->global_id()));
+      std::vector<uint32_t> accessorArgs =
+          tt_metal::TensorAccessorArgs(*meshBufferIt->second)
+              .get_compile_time_args();
+      argsVec.insert(argsVec.end(), accessorArgs.begin(), accessorArgs.end());
       break;
     }
     case target::metal::KernelArgType::NONE:

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -141,14 +141,8 @@ createMeshBufferForShardedMetalBuffer(
                                              : tt_metal::BufferType::L1;
   uint32_t address = deviceAddressValidator(refAddress, bufferType);
 
-  auto localShardShape = tt_metal::Shape2D{shardShape[0], shardShape[1]};
-  auto distributedBufferShape =
-      tt_metal::Shape2D{localShardShape.height() * meshDevice->num_rows(),
-                        localShardShape.width() * meshDevice->num_cols()};
-  auto distributedBufferSizeBytes = meshDevice->num_rows() *
-                                    meshDevice->num_cols() *
-                                    shardedBufferConfig->size();
-
+  // BufferShardingArgs describes buffer distribution across worker cores within
+  // each device.
   auto createBufferShardingArgs = [&]() {
     const target::metal::BufferDistributionSpec *distributionSpec =
         shardedBufferConfig->buffer_distribution_spec();
@@ -190,10 +184,36 @@ createMeshBufferForShardedMetalBuffer(
       .bottom_up = std::nullopt,
       .sub_device_id = std::nullopt};
 
+  // ShardedBufferConfig describes buffer distribution across mesh devices.
+  const uint64_t devLocalSize = shardedBufferConfig->size();
+  const uint64_t pageSize = shardedBufferConfig->page_size();
+  LOG_ASSERT(devLocalSize % pageSize == 0,
+             "Sharded buffer size must be divisible by its page size: ",
+             devLocalSize, " % ", pageSize);
+
+  const size_t devLocalPageH = tensorShapeInPages[0];
+  const size_t devLocalPageW = tensorShapeInPages[1];
+  const uint64_t devLocalPages = devLocalSize / pageSize;
+  LOG_ASSERT(devLocalPageH * devLocalPageW == devLocalPages,
+             "Device-local page shape volume must match buffer page count: ",
+             devLocalPageH, " * ", devLocalPageW, " != ", devLocalPages);
+
+  // While global_size is the size of the full tensor in bytes, the two shapes
+  // are unit-agnostic: only the shapes and the inferred datum size are used to
+  // partition byte ranges across mesh devices.
+  //
+  // Here, we model the mesh-level shape using the full device-local tensor
+  // shape in the page-space instead of the scalar-space.
+  // - In the scalar-space, the inferred datum size might be truncated for BFP
+  //   data formats since their tile sizes are not powers-of-two.
+  // - In the page-space, inferred datum size is always equal to the page size
+  //   for every data format.
+  const size_t meshH = meshDevice->num_rows();
+  const size_t meshW = meshDevice->num_cols();
   auto distributedBufferConfig = distributed::ShardedBufferConfig{
-      .global_size = distributedBufferSizeBytes,
-      .global_buffer_shape = distributedBufferShape,
-      .shard_shape = localShardShape,
+      .global_size = meshH * meshW * devLocalSize,
+      .global_buffer_shape = {meshH * devLocalPageH, meshW * devLocalPageW},
+      .shard_shape = {devLocalPageH, devLocalPageW},
       .shard_orientation = tt_metal::ShardOrientation::ROW_MAJOR};
 
   return distributed::MeshBuffer::create(

--- a/test/python/golden/d2m/test_dma.py
+++ b/test/python/golden/d2m/test_dma.py
@@ -2,37 +2,54 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import List, Optional
+
 import pytest
 import torch
-from typing import Callable, List, Optional
 
-from ttmlir.dialects import ttir, ttcore
+from ttmlir.dialects import ttcore
 from ttmlir.ir import *
 
 from builder.base.builder_utils import Operand, Shape
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir
 from conftest import get_request_kwargs
+from test_utils import SkipIf
 
 pytestmark = pytest.mark.frontend("ttir")
 
 
-def compile_dma_test(test_func, request, device):
-
+def get_dma_pipeline(
+    use_tensor_accessor_dma: bool,
+    force_compile_time_args: bool = False,
+) -> str:
     # Back to back tolayout ops are normally folded during canonicalization into
     # a single ToLayoutOp representing the final result. The option
     # 'disable-tolayout-folding' prevents this
-    pipeline_options = "{disable-tolayout-folding=1}"
-    pipeline = ",".join(
-        [
-            f"ttir-to-ttmetal-pipeline{pipeline_options}",
-        ]
+    pipeline_options = (
+        "{disable-tolayout-folding=1 "
+        f"use-tensor-accessor-dma={int(use_tensor_accessor_dma)}"
+        f" force-compile-time-args={int(force_compile_time_args)}"
+        "}"
     )
+    return f"ttir-to-ttmetal-pipeline{pipeline_options}"
+
+
+def compile_dma_test(
+    test_func,
+    target,
+    request,
+    device,
+    use_tensor_accessor_dma: bool = False,
+    force_compile_time_args: bool = False,
+):
     compile_and_execute_ttir(
         test_func,
-        target="ttmetal",
+        target=target,
         device=device,
-        custom_pipeline=pipeline,
+        custom_pipeline=get_dma_pipeline(
+            use_tensor_accessor_dma, force_compile_time_args
+        ),
         **get_request_kwargs(request),
     )
 
@@ -74,7 +91,7 @@ def test_host_interop_single_bank_dram_dma(
 
             return system_out
 
-    compile_dma_test(module, request, device=device)
+    compile_dma_test(module, target, request, device=device)
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -151,7 +168,296 @@ def test_roundtrip_dma_tiled(
 
             return untilize_out
 
-    compile_dma_test(module, request, device=device)
+    compile_dma_test(module, target, request, device=device)
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize(
+    "shape,remote_kind,start_grid,end_grid,force_compile_time_args",
+    [
+        ((192, 384), "l1_sharded", (1, 3), (2, 2), False),
+        ((192, 384), "dram_sharded", (1, 3), (2, 2), False),
+        ((192, 384), "dram_interleaved", (1, 1), (2, 2), False),
+        ((192, 384), "dram_sharded_force_cta", (1, 3), (2, 2), True),
+    ],
+)
+@pytest.mark.parametrize("use_tensor_accessor_dma", [False, True])
+def test_tensor_accessor_dma_tiled(
+    target: str,
+    shape: Shape,
+    remote_kind: str,
+    start_grid: tuple[int, int],
+    end_grid: tuple[int, int],
+    force_compile_time_args: bool,
+    use_tensor_accessor_dma: bool,
+    request,
+    device,
+):
+    def module(builder: TTIRBuilder):
+        golden = torch.arange(shape[0] * shape[1], dtype=torch.float32).reshape(shape)
+
+        @builder.func([shape], [torch.float32])
+        def tensor_accessor_roundtrip(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            tiled_input = builder.tilize(
+                in0,
+                output_type=builder.get_metal_tensor_layout(
+                    shape,
+                    tiled=True,
+                    memorySpace=ttcore.MemorySpace.DeviceL1,
+                ),
+                unit_attrs=unit_attrs,
+            )
+
+            is_dram = remote_kind.startswith("dram")
+            is_interleaved = remote_kind == "dram_interleaved"
+            remote = builder.to_layout(
+                tiled_input,
+                output_type=builder.get_metal_tensor_layout(
+                    shape,
+                    tiled=True,
+                    memorySpace=(
+                        ttcore.MemorySpace.DeviceDRAM
+                        if is_dram
+                        else ttcore.MemorySpace.DeviceL1
+                    ),
+                    grid=start_grid,
+                    memory_layout=(
+                        ttcore.TensorMemoryLayout.Interleaved
+                        if is_interleaved
+                        else ttcore.TensorMemoryLayout.Sharded
+                    ),
+                ),
+                unit_attrs=unit_attrs,
+            )
+
+            local = builder.to_layout(
+                remote,
+                output_type=builder.get_metal_tensor_layout(
+                    shape,
+                    tiled=True,
+                    memorySpace=ttcore.MemorySpace.DeviceL1,
+                    grid=end_grid,
+                ),
+                unit_attrs=unit_attrs,
+            )
+            output = builder.untilize(
+                local, output_type=in0.type, unit_attrs=unit_attrs
+            )
+            builder.set_goldens({in0: golden}, {output: golden})
+            return output
+
+    compile_dma_test(
+        module,
+        target,
+        request,
+        device=device,
+        use_tensor_accessor_dma=use_tensor_accessor_dma,
+        force_compile_time_args=force_compile_time_args,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("use_tensor_accessor_dma", [False, True])
+def test_tensor_accessor_dma_tiled_vgm(
+    target: str,
+    use_tensor_accessor_dma: bool,
+    request,
+    device,
+):
+    shape = (128, 384)
+
+    def module(builder: TTIRBuilder):
+        golden = torch.arange(shape[0] * shape[1], dtype=torch.float32).reshape(shape)
+
+        @builder.func([shape], [torch.float32])
+        def tensor_accessor_vgm(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            tiled_input = builder.tilize(
+                in0,
+                output_type=builder.get_metal_tensor_layout(
+                    shape,
+                    tiled=True,
+                    memorySpace=ttcore.MemorySpace.DeviceL1,
+                ),
+                unit_attrs=unit_attrs,
+            )
+            virtual_grid = builder.to_layout(
+                tiled_input,
+                output_type=builder.get_metal_tensor_layout(
+                    shape,
+                    tiled=True,
+                    memorySpace=ttcore.MemorySpace.DeviceL1,
+                    grid=(1, 12),
+                ),
+                unit_attrs=unit_attrs,
+            )
+            local = builder.to_layout(
+                virtual_grid,
+                output_type=builder.get_metal_tensor_layout(
+                    shape,
+                    tiled=True,
+                    memorySpace=ttcore.MemorySpace.DeviceL1,
+                    grid=(2, 6),
+                ),
+                unit_attrs=unit_attrs,
+            )
+            output = builder.untilize(
+                local, output_type=in0.type, unit_attrs=unit_attrs
+            )
+            builder.set_goldens({in0: golden}, {output: golden})
+            return output
+
+    compile_dma_test(
+        module,
+        target,
+        request,
+        device=device,
+        use_tensor_accessor_dma=use_tensor_accessor_dma,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttmetal" | SkipIf(["n150", "sim"])])
+def test_tensor_accessor_binary_add(
+    target: str,
+    request,
+    device,
+):
+    """Exercise BFP8 page sizing with two TA reads and one TA write."""
+    shape = (256, 256)
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, shape], [torch.float32, torch.float32])
+        def tensor_accessor_add(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            input0 = torch.arange(shape[0] * shape[1], dtype=torch.float32).reshape(
+                shape
+            ) / (shape[0] * shape[1])
+            input1 = torch.flip(input0, dims=[0, 1]) * 0.5
+            builder.set_goldens(inputs={in0: input0, in1: input1})
+            return builder.add(
+                in0, in1, loc="tensor_accessor_add", unit_attrs=unit_attrs
+            )
+
+    pipeline = (
+        "ttir-to-ttmetal-pipeline{default-input-memspace=dram "
+        "default-output-memspace=dram global-data-format-target=bfp_bf8 "
+        "num-stream-buffers=1 test-buffer-size-policy=max "
+        "use-tensor-accessor-dma=1}"
+    )
+    compile_and_execute_ttir(
+        module,
+        target=target,
+        device=device,
+        custom_pipeline=pipeline,
+        **get_request_kwargs(request),
+    )
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_tensor_accessor_outer_permute(
+    target: str,
+    request,
+    device,
+):
+    """Exercise a non-identity page map while preserving whole tiles."""
+    shape = (2, 3, 64, 128)
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [torch.float32])
+        def tensor_accessor_outer_permute(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            input0 = torch.arange(
+                shape[0] * shape[1] * shape[2] * shape[3],
+                dtype=torch.float32,
+            ).reshape(shape)
+            builder.set_goldens(inputs={in0: input0})
+            return builder.permute(
+                in0,
+                permutation=[1, 0, 2, 3],
+                loc="tensor_accessor_outer_permute",
+                unit_attrs=unit_attrs,
+            )
+
+    pipeline = (
+        "ttir-to-ttmetal-pipeline{collapse-tensors-2d=0 "
+        "num-stream-buffers=1 test-buffer-size-policy=max "
+        "use-tensor-accessor-dma=1}"
+    )
+    compile_and_execute_ttir(
+        module,
+        target=target,
+        device=device,
+        custom_pipeline=pipeline,
+        **get_request_kwargs(request),
+    )
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_tensor_accessor_matmul(
+    target: str,
+    request,
+    device,
+):
+    """Exercise TensorAccessor reads through matmul reblocking and multicast."""
+    lhs_shape = (192, 128)
+    rhs_shape = (128, 192)
+    dtype = torch.bfloat16
+
+    def module(builder: TTIRBuilder):
+        @builder.func([lhs_shape, rhs_shape], [dtype, dtype])
+        def tensor_accessor_matmul(
+            lhs: Operand,
+            rhs: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            lhs_input = torch.linspace(
+                0.001, 0.999, lhs_shape[0] * lhs_shape[1]
+            ).reshape(lhs_shape)
+            rhs_input = torch.linspace(
+                0.999, 0.001, rhs_shape[0] * rhs_shape[1]
+            ).reshape(rhs_shape)
+            builder.set_goldens(
+                inputs={
+                    lhs: lhs_input.to(dtype),
+                    rhs: rhs_input.to(dtype),
+                }
+            )
+            return builder.matmul(
+                lhs,
+                rhs,
+                loc="tensor_accessor_matmul",
+                unit_attrs=unit_attrs,
+            )
+
+    pipeline = (
+        "ttir-to-ttmetal-pipeline{default-input-memspace=dram "
+        "default-output-memspace=dram matmul-interchange=2,0,1 "
+        "num-stream-buffers=1 test-buffer-size-policy=max "
+        "use-tensor-accessor-dma=1 use-tile-matmul=false}"
+    )
+    compile_and_execute_ttir(
+        module,
+        target=target,
+        device=device,
+        custom_pipeline=pipeline,
+        **get_request_kwargs(request),
+        pcc=0.97,
+    )
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -227,7 +533,7 @@ def test_roundtrip_dma_rowmajor(
 
             return system_out
 
-    compile_dma_test(module, request, device=device)
+    compile_dma_test(module, target, request, device=device)
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -266,7 +572,7 @@ def test_host_sharded_dram_roundtrip(
                 unit_attrs=unit_attrs,
             )
 
-    compile_dma_test(module, request, device=device)
+    compile_dma_test(module, target, request, device=device)
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -302,7 +608,7 @@ def test_host_dram_roundtrip_exceeds_l1(
                 unit_attrs=unit_attrs,
             )
 
-    compile_dma_test(module, request, device=device)
+    compile_dma_test(module, target, request, device=device)
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -368,4 +674,4 @@ def test_interleaved_dma(
 
             return untilize_out
 
-    compile_dma_test(module, request, device=device)
+    compile_dma_test(module, target, request, device=device)

--- a/test/python/golden/d2m/test_layout.py
+++ b/test/python/golden/d2m/test_layout.py
@@ -34,6 +34,13 @@ _D2M_POST_GRID_WITH_VIEW_PIPELINE = (
 )
 
 
+def _with_tensor_accessor_dma(pipeline: str, enabled: bool) -> str:
+    return pipeline.replace(
+        "d2m-be-pipeline,",
+        f"d2m-be-pipeline{{use-tensor-accessor-dma={int(enabled)}}},",
+    )
+
+
 @pytest.mark.parametrize("input_grid_y", [1, 2, 3])
 @pytest.mark.parametrize("input_grid_x", [1, 2, 3])
 @pytest.mark.parametrize("output_grid_y", [2, 3, 4])
@@ -407,17 +414,20 @@ def test_multiple_grid_reblocks(
 
 @pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.parametrize(
-    "input_grid,output_grid",
+    "shape,input_grid,output_grid",
     [
-        ((1, 1), (2, 2)),  # 1x1 -> 2x2 tiled reblock
-        ((2, 2), (4, 4)),  # 2x2 -> 4x4 tiled reblock
-        ((4, 4), (2, 2)),  # 4x4 -> 2x2 tiled downscale
+        ((192, 384), (1, 3), (2, 2)),  # Non-square cross-grid reblock
+        ((256, 256), (2, 2), (4, 4)),  # 2x2 -> 4x4 tiled reblock
+        ((256, 256), (4, 4), (2, 2)),  # 4x4 -> 2x2 tiled downscale
     ],
 )
+@pytest.mark.parametrize("use_tensor_accessor_dma", [False, True])
 def test_tiled_grid_reblocking(
     target: str,
+    shape: tuple,
     input_grid: tuple,
     output_grid: tuple,
+    use_tensor_accessor_dma: bool,
     request,
     device,
 ):
@@ -426,11 +436,9 @@ def test_tiled_grid_reblocking(
     Verifies that buildLayoutTransformMap correctly handles tile units vs scalar units
     when computing affine maps for grid reblocking with tiled tensors.
     """
-    # Shape must be divisible by tile size (32) and grid dimensions
-    shape = (256, 256)
 
     def module(builder: D2MBuilder):
-        golden = torch.randn(shape)
+        golden = torch.arange(shape[0] * shape[1], dtype=torch.float32).reshape(shape)
 
         @builder.func([shape], [torch.float32])
         def tiled_reblock(
@@ -493,7 +501,9 @@ def test_tiled_grid_reblocking(
     compile_and_execute_d2m(
         module,
         target=target,
-        custom_pipeline=_D2M_POST_GRID_PIPELINE,
+        custom_pipeline=_with_tensor_accessor_dma(
+            _D2M_POST_GRID_PIPELINE, use_tensor_accessor_dma
+        ),
         device=device,
         **get_request_kwargs(request),
     )

--- a/test/ttmlir/Conversion/D2MToTTKernel/dma_ops.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/dma_ops.mlir
@@ -1,7 +1,9 @@
 // RUN: ttmlir-opt --ttcore-register-device --convert-d2m-to-ttkernel %s | FileCheck %s
+// RUN: ttmlir-opt --ttcore-register-device --convert-d2m-to-ttkernel="force-compile-time-args=true" %s | FileCheck %s --check-prefix=FORCE-CTA
 
 #l1 = #ttcore.memory_space<l1>
 #dram = #ttcore.memory_space<dram>
+#page_map = affine_map<(d0, d1, d2, d3) -> (d0 * 8 + d1 * 2 + d2 * 4 + d3)>
 
 module {
   func.func private @fabric_dma_write_to_dram_uses_bank_noc_addr() attributes {d2m.thread = #d2m.thread<datamovement>} {
@@ -79,6 +81,57 @@ module {
     // CHECK: %[[VIRT_X:[0-9]+]] = ttkernel.experimental.convert_logical_x_to_translated(%[[MY_X]]) : (index) -> index
     // CHECK: ttkernel.noc_async_write %[[SRC_ADDR]], core[%[[VIRT_X]], %[[VIRT_Y]]], %[[DST_ADDR]],
     %tx = d2m.dma_write %src[%c0], %dst[%c0], <1> : (memref<1x!ttcore.tile<32x32, f32>, #l1>, memref<1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<write>
+    d2m.dma_wait %tx : !d2m.mem_tx<write>
+    return
+  }
+
+  // CHECK-LABEL: func.func private @tensor_accessor_dma_reads
+  // CHECK-SAME: ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = buffer_address, operand_index = 0>, <arg_type = buffer_address, operand_index = 1>] ct_args = [<arg_type = tensor_accessor_args, operand_index = 0>, <arg_type = tensor_accessor_args, operand_index = 1>]>
+  // CHECK: %[[ARGS0:.*]] = ttkernel.TensorAccessorArgs(%{{.*}}, %{{.*}})
+  // CHECK-NEXT: %[[ARGS1:.*]] = ttkernel.TensorAccessorArgs(prev = %[[ARGS0]])
+  // CHECK: %[[SRC0:.*]] = ttkernel.get_common_arg_val
+  // CHECK: %[[SRC1:.*]] = ttkernel.get_common_arg_val
+  // CHECK: %[[LOCAL:.*]] = ttkernel.get_write_ptr
+  // CHECK: %[[TA0:.*]] = ttkernel.TensorAccessor(%[[ARGS0]], %[[SRC0]])
+  // CHECK: scf.for
+  // CHECK: scf.for
+  // CHECK: ttkernel.noc_async_read_tile({{.*}}, %[[TA0]], {{.*}})
+  // CHECK: %[[TA1:.*]] = ttkernel.TensorAccessor(%[[ARGS1]], %[[SRC1]])
+  // CHECK: ttkernel.noc_async_read_tile({{.*}}, %[[TA1]], {{.*}})
+  // FORCE-CTA-LABEL: func.func private @tensor_accessor_dma_reads
+  // FORCE-CTA-SAME: ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = buffer_address, operand_index = 0>, <arg_type = buffer_address, operand_index = 1>, <arg_type = tensor_accessor_args, operand_index = 0>, <arg_type = tensor_accessor_args, operand_index = 1>]
+  // FORCE-CTA: %[[C3:.*]] = arith.constant 3 : i32
+  // FORCE-CTA: %[[FARGS0:.*]] = ttkernel.TensorAccessorArgs(%[[C3]], %{{.*}})
+  // FORCE-CTA-NEXT: %[[FARGS1:.*]] = ttkernel.TensorAccessorArgs(prev = %[[FARGS0]])
+  func.func private @tensor_accessor_dma_reads() attributes {d2m.thread = #d2m.thread<datamovement>} {
+    %src0 = d2m.get_arg(0) resolution_stage = runtime : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>
+    %src1 = d2m.get_arg(1) resolution_stage = runtime : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>
+    %cb = d2m.get_cb(2) : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %local0 = d2m.reserve %cb : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+    %tx0 = d2m.dma_read %src0[%c0, %c1], %local0, <0> {tensorAccessorPageMap = #page_map} : (memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+    d2m.dma_wait %tx0 : !d2m.mem_tx<read>
+    %local1 = d2m.reserve %cb : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+    %tx1 = d2m.dma_read %src1[%c0, %c1], %local1, <0> {tensorAccessorPageMap = #page_map} : (memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+    d2m.dma_wait %tx1 : !d2m.mem_tx<read>
+    return
+  }
+
+  // CHECK-LABEL: func.func private @tensor_accessor_dma_write
+  // CHECK: %[[ARGS:.*]] = ttkernel.TensorAccessorArgs
+  // CHECK: %[[DST:.*]] = ttkernel.get_common_arg_val
+  // CHECK: %[[LOCAL:.*]] = ttkernel.get_read_ptr
+  // CHECK: %[[TA:.*]] = ttkernel.TensorAccessor(%[[ARGS]], %[[DST]])
+  // CHECK: ttkernel.noc_async_write_tile({{.*}}, %[[TA]], {{.*}})
+  // CHECK: ttkernel.noc_async_write_barrier
+  func.func private @tensor_accessor_dma_write() attributes {d2m.thread = #d2m.thread<datamovement>} {
+    %dst = d2m.get_arg(0) resolution_stage = runtime : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>
+    %cb = d2m.get_cb(1) : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %local = d2m.wait %cb : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+    %tx = d2m.dma_write %local, %dst[%c0, %c1], <0> {tensorAccessorPageMap = #page_map} : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>) -> !d2m.mem_tx<write>
     d2m.dma_wait %tx : !d2m.mem_tx<write>
     return
   }

--- a/test/ttmlir/Conversion/D2MToTTMetal/generic_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/generic_lowering.mlir
@@ -12,7 +12,7 @@ module {
     %cb_2 = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<1x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_>
     // TODO: add alias example
     // CHECK: "ttmetal.enqueue_program"
-    // CHECK-SAME: {{.*}}cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args<common_rt_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]  >, dm_core = 1, noc0>, #ttmetal.noc_config<@datamovement_kernel1, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args<common_rt_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]  >, dm_core = 0, noc1>, #ttmetal.compute_config<@compute_kernel2, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args<common_rt_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]  >, hifi4, true, false, false, [default]>]
+    // CHECK-SAME: {{.*}}cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args<common_rt_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]  ct_args = [<tensor_accessor_args[0]>]>, dm_core = 1, noc0>, #ttmetal.noc_config<@datamovement_kernel1, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args<common_rt_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]  >, dm_core = 0, noc1>, #ttmetal.compute_config<@compute_kernel2, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args<common_rt_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]  >, hifi4, true, false, false, [default]>]
     %0 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
     %1 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
     %2 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
@@ -25,7 +25,10 @@ module {
     return %alloc  : memref<8x8x1x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>
   }
 
-  func.func private @datamovement_kernel0() attributes {d2m.thread = #d2m.thread<datamovement, dm_core = 1>} {
+  func.func private @datamovement_kernel0() attributes {
+    ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = tensor_accessor_args, operand_index = 0>]>,
+    ttkernel.thread = #ttkernel.thread<noc>
+  } {
     %cb0 = d2m.get_cb(7) : !d2m.cb<memref<1x3x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<12288x4096, 1>, #l1_>>
     %cb1 = d2m.get_cb(8) : !d2m.cb<memref<3x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<49152x4096, 1>, #l1_>>
     %cb2 = d2m.get_cb(9) : !d2m.cb<memref<1x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 1>, #l1_>>

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -181,8 +181,8 @@ module {
   ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
   // CHECK-LABEL: func.func @spatial_two_regions_buffer_address_remap
   // CHECK-COUNT-1: "ttmetal.enqueue_program"
-  // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_b0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args<common_rt_args = [<buffer_address[0]>]  ct_args = [<cb_port[0]>, <cb_port[1]>]>, dm_core = 1, noc0>
-  // CHECK-SAME: #ttmetal.noc_config<@dm_b1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args<common_rt_args = [<buffer_address[2]>]  ct_args = [<cb_port[2]>, <cb_port[3]>]>, dm_core = 1, noc0>]
+  // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_b0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args<common_rt_args = [<buffer_address[0]>]  ct_args = [<cb_port[0]>, <cb_port[1]>, <tensor_accessor_args[0]>]>, dm_core = 1, noc0>
+  // CHECK-SAME: #ttmetal.noc_config<@dm_b1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args<common_rt_args = [<buffer_address[2]>]  ct_args = [<cb_port[2]>, <cb_port[3]>, <tensor_accessor_args[2]>]>, dm_core = 1, noc0>]
   // CHECK-NOT: d2m.spatial
   func.func @spatial_two_regions_buffer_address_remap(
       %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
@@ -213,10 +213,10 @@ module {
     return %out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
   }
 
-  func.func private @dm_b0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+  func.func private @dm_b0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>, <arg_type = tensor_accessor_args, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     return
   }
-  func.func private @dm_b1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+  func.func private @dm_b1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>, <arg_type = tensor_accessor_args, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     return
   }
 }

--- a/test/ttmlir/Conversion/D2MToTTMetal/tensor_accessor_vgm.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/tensor_accessor_vgm.mlir
@@ -1,0 +1,56 @@
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="mock-system-desc-arch=wormhole_b0 disable-tolayout-folding=1 use-tensor-accessor-dma=0 force-compile-time-args=0" -o %t.wh_no_ta.mlir %s
+// RUN: FileCheck %s --check-prefix=CHECK-WH-NO-TA --input-file=%t.wh_no_ta.mlir
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="mock-system-desc-arch=wormhole_b0 disable-tolayout-folding=1 use-tensor-accessor-dma=1 force-compile-time-args=0" -o %t.wh_ta.mlir %s
+// RUN: FileCheck %s --check-prefix=CHECK-WH-TA --input-file=%t.wh_ta.mlir
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="mock-system-desc-arch=blackhole disable-tolayout-folding=1 use-tensor-accessor-dma=0 force-compile-time-args=0" -o %t.bh_no_ta.mlir %s
+// RUN: FileCheck %s --check-prefix=CHECK-BH-NO-TA --input-file=%t.bh_no_ta.mlir
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="mock-system-desc-arch=blackhole disable-tolayout-folding=1 use-tensor-accessor-dma=1 force-compile-time-args=0" -o %t.bh_ta.mlir %s
+// RUN: FileCheck %s --check-prefix=CHECK-BH-TA --input-file=%t.bh_ta.mlir
+
+#layout = #ttcore.metal_layout<logical_shape = 128x384, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+
+module {
+  // CHECK-WH-NO-TA-LABEL: func.func @tensor_accessor_vgm
+  // CHECK-WH-NO-TA-NOT: TensorAccessor
+  // CHECK-WH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-WH-NO-TA-NOT: TensorAccessor
+  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 3x4>
+  // CHECK-WH-NO-TA-NOT: TensorAccessor
+  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 2x6>
+  // CHECK-WH-NO-TA-NOT: TensorAccessor
+
+  // CHECK-WH-TA-LABEL: func.func @tensor_accessor_vgm
+  // CHECK-WH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 3x4>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x6>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-WH-TA: emitc.verbatim "constexpr auto {{.*}} TensorAccessorArgs
+  // CHECK-WH-TA: const uint32_t page_id_{{[0-9]+}}
+
+  // CHECK-BH-NO-TA-LABEL: func.func @tensor_accessor_vgm
+  // CHECK-BH-NO-TA-NOT: TensorAccessor
+  // CHECK-BH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-BH-NO-TA-NOT: TensorAccessor
+  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 1x12>
+  // CHECK-BH-NO-TA-NOT: TensorAccessor
+  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 2x6>
+  // CHECK-BH-NO-TA-NOT: TensorAccessor
+
+  // CHECK-BH-TA-LABEL: func.func @tensor_accessor_vgm
+  // CHECK-BH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 1x12>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x6>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-BH-TA: emitc.verbatim "constexpr auto {{.*}} TensorAccessorArgs
+  // CHECK-BH-TA: const uint32_t page_id_{{[0-9]+}}
+
+  func.func @tensor_accessor_vgm(%arg0: tensor<128x384xf32>) -> tensor<128x384xf32> {
+    %0 = ttir.empty() : tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout>
+    %1 = ttir.to_layout %arg0, %0 : tensor<128x384xf32> into tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout>
+    %2 = ttir.empty() : tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout>
+    %3 = ttir.to_layout %1, %2 : tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout> into tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout>
+    %4 = ttir.empty() : tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout>
+    %5 = ttir.to_layout %3, %4 : tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout> into tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout> -> tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout>
+    %6 = ttir.empty() : tensor<128x384xf32>
+    %7 = ttir.to_layout %5, %6 : tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout> into tensor<128x384xf32> -> tensor<128x384xf32>
+    return %7 : tensor<128x384xf32>
+  }
+}

--- a/test/ttmlir/Conversion/D2MToTTNN/sanity.mlir
+++ b/test/ttmlir/Conversion/D2MToTTNN/sanity.mlir
@@ -51,7 +51,7 @@ module {
     // CHECK: "ttnn.generic"(%[[T1]], %[[T2]])
     // CHECK-SAME: #ttnn.data_movement_kernel<symbol_ref = @read_kernel
     // CHECK-SAME: processor = riscv1, noc_index = noc0, noc_mode = dedicated_noc
-    // CHECK-SAME: ct_args = [#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_semaphore_at<0>, #ttnn.kernel_arg_semaphore_at<1>]
+    // CHECK-SAME: ct_args = [#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_semaphore_at<0>, #ttnn.kernel_arg_semaphore_at<1>, #ttnn.kernel_arg_tensor_accessor_args<0>]
     // CHECK-SAME: common_rt_args = [#ttnn.kernel_arg_address_of_tensor<0>]
     // CHECK-SAME: #ttnn.data_movement_kernel<symbol_ref = @write_kernel
     // CHECK-SAME: processor = riscv0, noc_index = noc1, noc_mode = dedicated_noc
@@ -110,7 +110,8 @@ module {
       ct_args = [
         <arg_type = cb_port, operand_index = 6>,
         <arg_type = local_semaphore, operand_index = 0>,
-        <arg_type = local_semaphore, operand_index = 1>
+        <arg_type = local_semaphore, operand_index = 1>,
+        <arg_type = tensor_accessor_args, operand_index = 0>
       ]
     >,
     ttkernel.thread = #ttkernel.thread<noc>

--- a/test/ttmlir/Conversion/D2MToTTNN/spatial.mlir
+++ b/test/ttmlir/Conversion/D2MToTTNN/spatial.mlir
@@ -101,8 +101,8 @@ module {
   //   dm_ns1   | (0,0)       | 0,1     | address<1>     | [*]
   //   cp_ns0   | (0,0)       | 0,1     | []             | [*]
   //
-  // CHECK-SAME: {{.*}}#ttnn.data_movement_kernel<symbol_ref = @dm_ns0{{.*}}core_ranges = <[#ttnn.core_range<(0,0), (0,0)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>{{.*}}#ttnn.kernel_arg_address_of_tensor<0>], rt_args = [{{[^]]*}}]>,
-  // CHECK-SAME:{{.*}}#ttnn.data_movement_kernel<symbol_ref = @dm_ns1{{.*}}core_ranges = <[#ttnn.core_range<(0,0), (0,0)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>{{.*}}#ttnn.kernel_arg_address_of_tensor<1>], rt_args = [{{[^]]*}}]>,
+  // CHECK-SAME: {{.*}}#ttnn.data_movement_kernel<symbol_ref = @dm_ns0{{.*}}core_ranges = <[#ttnn.core_range<(0,0), (0,0)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>, #ttnn.kernel_arg_tensor_accessor_args<0>{{.*}}#ttnn.kernel_arg_address_of_tensor<0>], rt_args = [{{[^]]*}}]>,
+  // CHECK-SAME:{{.*}}#ttnn.data_movement_kernel<symbol_ref = @dm_ns1{{.*}}core_ranges = <[#ttnn.core_range<(0,0), (0,0)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>, #ttnn.kernel_arg_tensor_accessor_args<1>{{.*}}#ttnn.kernel_arg_address_of_tensor<1>], rt_args = [{{[^]]*}}]>,
   // CHECK-SAME:{{.*}}#ttnn.compute_kernel<symbol_ref = @cp_ns0{{.*}}core_ranges = <[#ttnn.core_range<(0,0), (0,0)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>{{.*}}common_rt_args = [], rt_args = [{{[^]]*}}]>,
   //
   //     Region1 (core (1,1)): local cb 0,1 (same ids as region0; different core); address 2,3
@@ -112,8 +112,8 @@ module {
   //   dm_ns3   | (1,1)       | 0,1     | address<3>     | [*]
   //   cp_ns1   | (1,1)       | 0,1     | []             | [*]
   //
-  // CHECK-SAME:{{.*}}#ttnn.data_movement_kernel<symbol_ref = @dm_ns2{{.*}}core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>{{.*}}#ttnn.kernel_arg_address_of_tensor<2>], rt_args = [{{[^]]*}}]>,
-  // CHECK-SAME:{{.*}}#ttnn.data_movement_kernel<symbol_ref = @dm_ns3{{.*}}core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>{{.*}}#ttnn.kernel_arg_address_of_tensor<3>], rt_args = [{{[^]]*}}]>,
+  // CHECK-SAME:{{.*}}#ttnn.data_movement_kernel<symbol_ref = @dm_ns2{{.*}}core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>, #ttnn.kernel_arg_tensor_accessor_args<2>{{.*}}#ttnn.kernel_arg_address_of_tensor<2>], rt_args = [{{[^]]*}}]>,
+  // CHECK-SAME:{{.*}}#ttnn.data_movement_kernel<symbol_ref = @dm_ns3{{.*}}core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>, #ttnn.kernel_arg_tensor_accessor_args<3>{{.*}}#ttnn.kernel_arg_address_of_tensor<3>], rt_args = [{{[^]]*}}]>,
   // CHECK-SAME:{{.*}}#ttnn.compute_kernel<symbol_ref = @cp_ns1{{.*}}core_ranges = <[#ttnn.core_range<(1,1), (1,1)>]>{{.*}}#ttnn.kernel_arg_cb_buffer_index<0>, #ttnn.kernel_arg_cb_buffer_index<1>{{.*}}common_rt_args = [], rt_args = [{{[^]]*}}]>], cbs =
   //
   //     cbs: kernel_cb 2, 3; semaphores
@@ -150,19 +150,19 @@ module {
     %cast_4 = ttir.ttnn_metal_layout_cast %cast_2 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_1> -> tensor<64x64xf32, #ttnn_layout3>
     return %cast_3, %cast_4 : tensor<64x64xf32, #ttnn_layout2>, tensor<64x64xf32, #ttnn_layout3>
   }
-  func.func private @dm_ns0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+  func.func private @dm_ns0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>, <arg_type = tensor_accessor_args, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     return
   }
-  func.func private @dm_ns1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 1>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+  func.func private @dm_ns1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 1>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>, <arg_type = tensor_accessor_args, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     return
   }
   func.func private @cp_ns0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<compute>} {
     return
   }
-  func.func private @dm_ns2() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+  func.func private @dm_ns2() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>, <arg_type = tensor_accessor_args, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     return
   }
-  func.func private @dm_ns3() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 1>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+  func.func private @dm_ns3() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 1>] ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>, <arg_type = tensor_accessor_args, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     return
   }
   func.func private @cp_ns1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 3>]>, ttkernel.thread = #ttkernel.thread<compute>} {

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2545,14 +2545,32 @@ module {
       %tile_size = arith.constant 8 : i32
       %tile = arith.constant 1 : i32
       %noc = arith.constant 0 : i8
-      // CHECK: emitc.verbatim "auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();"
+      // CHECK: emitc.verbatim "constexpr auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();"
       %tensor_accessor_args = ttkernel.TensorAccessorArgs(%cta_offset, %crta_offset)
       // CHECK: %[[ACCESSOR:.*]] = emitc.call_opaque "TensorAccessor"
       %s = "ttkernel.TensorAccessor"(%tensor_accessor_args, %temp_addr, %tile_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
-      // CHECK: emitc.verbatim "noc0.async_write(CoreLocalMem<uint32_t>({}), {}, {}.get_aligned_page_size()
+      // CHECK: emitc.verbatim "const uint32_t [[WRITE_PAGE_ID:page_id_[0-9]+]] = static_cast<uint32_t>({});"
+      // CHECK-NEXT: emitc.verbatim "noc0.async_write(CoreLocalMem<uint32_t>({}), {}, {}.get_aligned_page_size()
+      // CHECK-SAME: .page_id = [[WRITE_PAGE_ID]]
       "ttkernel.noc_async_write_tile"(%tile, %s, %temp_addr, %noc) : (i32, !ttkernel.TensorAccessor, i32, i8) -> ()
-      // CHECK: emitc.verbatim "noc0.async_read({}, CoreLocalMem<uint32_t>({}), {}.get_aligned_page_size()
+      // CHECK: emitc.verbatim "const uint32_t [[READ_PAGE_ID:page_id_[0-9]+]] = static_cast<uint32_t>({});"
+      // CHECK-NEXT: emitc.verbatim "noc0.async_read({}, CoreLocalMem<uint32_t>({}), {}.get_aligned_page_size()
+      // CHECK-SAME: .page_id = [[READ_PAGE_ID]]
       "ttkernel.noc_async_read_tile"(%tile, %s, %temp_addr, %noc) : (i32, !ttkernel.TensorAccessor, i32, i8) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @tensor_accessor_default_page_size
+    func.func @tensor_accessor_default_page_size() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      %cta_offset = arith.constant 0 : i32
+      %crta_offset = arith.constant 0 : i32
+      %bank_address = arith.constant 303104 : i32
+      // CHECK: %[[DEFAULT_BANK:.*]] = "emitc.constant"() <{value = 303104 : i32}>
+      // CHECK: emitc.verbatim "constexpr auto [[DEFAULT_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<0, 0>();"
+      // CHECK-NEXT: %[[DEFAULT_ARGS_LIT:.*]] = emitc.literal "[[DEFAULT_ARGS]]" : !emitc.opaque<"TensorAccessorArgs">
+      %args = ttkernel.TensorAccessorArgs(%cta_offset, %crta_offset)
+      // CHECK: emitc.call_opaque "TensorAccessor"(%[[DEFAULT_ARGS_LIT]], %[[DEFAULT_BANK]]) : (!emitc.opaque<"TensorAccessorArgs">, i32) -> !emitc.opaque<"TensorAccessor">
+      %tensor_accessor = "ttkernel.TensorAccessor"(%args, %bank_address) : (!ttkernel.TensorAccessorArgs, i32) -> !ttkernel.TensorAccessor
       return
     }
 
@@ -2566,7 +2584,7 @@ module {
       // CHECK: %[[SIZE:.*]] = "emitc.constant"
       %bank_address = arith.constant 303104 : i32
       %page_size = arith.constant 32 : i32
-      // CHECK: emitc.verbatim "auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();"
+      // CHECK: emitc.verbatim "constexpr auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();"
       // CHECK: %[[ARGS_LIT:.*]] = emitc.literal "[[ARGS]]" : !emitc.opaque<"TensorAccessorArgs">
       %tensor_accessor_args = ttkernel.TensorAccessorArgs(%cta_offset, %crta_offset)
       // CHECK: %[[TENSOR_ACCESSOR:.*]] = emitc.call_opaque "TensorAccessor"(%[[ARGS_LIT]], %[[ADDR]], %[[SIZE]]) : (!emitc.opaque<"TensorAccessorArgs">, i32, i32) -> !emitc.opaque<"TensorAccessor">
@@ -2609,17 +2627,17 @@ module {
       %crta_offset_2 = arith.constant 4 : i32
 
       // Case 1: First accessor with literal integer offset (existing functionality)
-      // CHECK: emitc.verbatim "auto [[ARGS1:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
+      // CHECK: emitc.verbatim "constexpr auto [[ARGS1:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
       // CHECK-NEXT: %[[ARGS1_LIT:.*]] = emitc.literal "[[ARGS1]]" : !emitc.opaque<"TensorAccessorArgs">
       %args1 = ttkernel.TensorAccessorArgs(%cta_offset, %crta_offset)
 
       // Case 2: Second accessor chained from first (NEW: chaining via prev_args)
-      // CHECK: emitc.verbatim "auto [[ARGS2:[a-z_0-9]+]] = TensorAccessorArgs<[[ARGS1]].next_compile_time_args_offset(), [[ARGS1]].next_common_runtime_args_offset()>();"
+      // CHECK: emitc.verbatim "constexpr auto [[ARGS2:[a-z_0-9]+]] = TensorAccessorArgs<[[ARGS1]].next_compile_time_args_offset(), [[ARGS1]].next_common_runtime_args_offset()>();"
       // CHECK-NEXT: %[[ARGS2_LIT:.*]] = emitc.literal "[[ARGS2]]" : !emitc.opaque<"TensorAccessorArgs">
       %args2 = ttkernel.TensorAccessorArgs(prev = %args1)
 
       // Case 3: Third accessor chained from second (chaining continues)
-      // CHECK: emitc.verbatim "auto [[ARGS3:[a-z_0-9]+]] = TensorAccessorArgs<[[ARGS2]].next_compile_time_args_offset(), [[ARGS2]].next_common_runtime_args_offset()>();"
+      // CHECK: emitc.verbatim "constexpr auto [[ARGS3:[a-z_0-9]+]] = TensorAccessorArgs<[[ARGS2]].next_compile_time_args_offset(), [[ARGS2]].next_common_runtime_args_offset()>();"
       // CHECK-NEXT: %[[ARGS3_LIT:.*]] = emitc.literal "[[ARGS3]]" : !emitc.opaque<"TensorAccessorArgs">
       %args3 = ttkernel.TensorAccessorArgs(prev = %args2)
 
@@ -2646,13 +2664,13 @@ module {
       %page_size = arith.constant 32 : i32
 
       // Case 1: First accessor args_src with literal offsets
-      // CHECK: emitc.verbatim "auto [[SRC:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
+      // CHECK: emitc.verbatim "constexpr auto [[SRC:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
       // CHECK-NEXT: %[[SRC_LIT:.*]] = emitc.literal "[[SRC]]" : !emitc.opaque<"TensorAccessorArgs">
       %args_src = ttkernel.TensorAccessorArgs(%cta_0, %crta_0)
 
       // Case 2: Second accessor args_dst chains BOTH CTA and CRTA from args_src
       // This is the COMMON PATTERN: TensorAccessorArgs<args_src.next_compile_time_args_offset(), args_src.next_common_runtime_args_offset()>
-      // CHECK: emitc.verbatim "auto [[DST:[a-z_0-9]+]] = TensorAccessorArgs<[[SRC]].next_compile_time_args_offset(), [[SRC]].next_common_runtime_args_offset()>();"
+      // CHECK: emitc.verbatim "constexpr auto [[DST:[a-z_0-9]+]] = TensorAccessorArgs<[[SRC]].next_compile_time_args_offset(), [[SRC]].next_common_runtime_args_offset()>();"
       // CHECK-NEXT: %[[DST_LIT:.*]] = emitc.literal "[[DST]]" : !emitc.opaque<"TensorAccessorArgs">
       %args_dst = ttkernel.TensorAccessorArgs(prev = %args_src)
 
@@ -2678,12 +2696,12 @@ module {
       %page_size = arith.constant 32 : i32
 
       // First accessor
-      // CHECK: emitc.verbatim "auto [[BASE:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
+      // CHECK: emitc.verbatim "constexpr auto [[BASE:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
       // CHECK-NEXT: %[[BASE_LIT:.*]] = emitc.literal "[[BASE]]" : !emitc.opaque<"TensorAccessorArgs">
       %args_base = ttkernel.TensorAccessorArgs(%cta_0, %crta_0)
 
       // Chain CTA only, use literal 0 for CRTA
-      // CHECK: emitc.verbatim "auto [[CTA_ONLY:[a-z_0-9]+]] = TensorAccessorArgs<[[BASE]].next_compile_time_args_offset(), 0>();"
+      // CHECK: emitc.verbatim "constexpr auto [[CTA_ONLY:[a-z_0-9]+]] = TensorAccessorArgs<[[BASE]].next_compile_time_args_offset(), 0>();"
       // CHECK-NEXT: %[[CTA_ONLY_LIT:.*]] = emitc.literal "[[CTA_ONLY]]" : !emitc.opaque<"TensorAccessorArgs">
       %args_cta_only = ttkernel.TensorAccessorArgs(prev = %args_base) crta_expr = "0"
 
@@ -2708,12 +2726,12 @@ module {
       %page_size = arith.constant 32 : i32
 
       // Case: First accessor with constexpr string expression (NEW: cta_expr attribute)
-      // CHECK: emitc.verbatim "auto [[CEXPR:[a-z_0-9]+]] = TensorAccessorArgs<get_base_offset(), 0>();"
+      // CHECK: emitc.verbatim "constexpr auto [[CEXPR:[a-z_0-9]+]] = TensorAccessorArgs<get_base_offset(), 0>();"
       // CHECK-NEXT: %[[CEXPR_LIT:.*]] = emitc.literal "[[CEXPR]]" : !emitc.opaque<"TensorAccessorArgs">
       %args = ttkernel.TensorAccessorArgs(%cta_offset, %crta_offset) cta_expr = "get_base_offset()"
 
       // Chain from a constexpr-based accessor
-      // CHECK: emitc.verbatim "auto [[CEXPR2:[a-z_0-9]+]] = TensorAccessorArgs<[[CEXPR]].next_compile_time_args_offset(), [[CEXPR]].next_common_runtime_args_offset()>();"
+      // CHECK: emitc.verbatim "constexpr auto [[CEXPR2:[a-z_0-9]+]] = TensorAccessorArgs<[[CEXPR]].next_compile_time_args_offset(), [[CEXPR]].next_common_runtime_args_offset()>();"
       // CHECK-NEXT: %[[CEXPR2_LIT:.*]] = emitc.literal "[[CEXPR2]]" : !emitc.opaque<"TensorAccessorArgs">
       %args2 = ttkernel.TensorAccessorArgs(prev = %args)
 
@@ -2740,15 +2758,15 @@ module {
       // CHECK: %[[PAGE_SIZE:.*]] = "emitc.constant"() <{value = 32 : i32}>
       %page_size = arith.constant 32 : i32
 
-      // CHECK: emitc.verbatim "auto [[M1:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
+      // CHECK: emitc.verbatim "constexpr auto [[M1:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
       // CHECK-NEXT: %[[M1_LIT:.*]] = emitc.literal "[[M1]]" : !emitc.opaque<"TensorAccessorArgs">
       %args1 = ttkernel.TensorAccessorArgs(%cta_0, %crta_0)
 
-      // CHECK: emitc.verbatim "auto [[M2:[a-z_0-9]+]] = TensorAccessorArgs<[[M1]].next_compile_time_args_offset(), [[M1]].next_common_runtime_args_offset()>();"
+      // CHECK: emitc.verbatim "constexpr auto [[M2:[a-z_0-9]+]] = TensorAccessorArgs<[[M1]].next_compile_time_args_offset(), [[M1]].next_common_runtime_args_offset()>();"
       // CHECK-NEXT: %[[M2_LIT:.*]] = emitc.literal "[[M2]]" : !emitc.opaque<"TensorAccessorArgs">
       %args2 = ttkernel.TensorAccessorArgs(prev = %args1)
 
-      // CHECK: emitc.verbatim "auto [[M3:[a-z_0-9]+]] = TensorAccessorArgs<[[M2]].next_compile_time_args_offset(), [[M2]].next_common_runtime_args_offset()>();"
+      // CHECK: emitc.verbatim "constexpr auto [[M3:[a-z_0-9]+]] = TensorAccessorArgs<[[M2]].next_compile_time_args_offset(), [[M2]].next_common_runtime_args_offset()>();"
       // CHECK-NEXT: %[[M3_LIT:.*]] = emitc.literal "[[M3]]" : !emitc.opaque<"TensorAccessorArgs">
       %args3 = ttkernel.TensorAccessorArgs(prev = %args2)
 
@@ -2789,13 +2807,13 @@ module {
       %page_size = arith.constant 32 : i32
 
       // First accessor
-      // CHECK: emitc.verbatim "auto [[BASE:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
+      // CHECK: emitc.verbatim "constexpr auto [[BASE:[a-z_0-9]+]] = TensorAccessorArgs<0, 0>();"
       // CHECK-NEXT: %[[BASE_LIT:.*]] = emitc.literal "[[BASE]]" : !emitc.opaque<"TensorAccessorArgs">
       %args_base = ttkernel.TensorAccessorArgs(%cta_0, %crta_0)
 
       // Override chaining with explicit cta_expr (prev_args provided but cta_expr takes precedence)
       // CTA uses explicit "42", CRTA chains from [[BASE]]
-      // CHECK: emitc.verbatim "auto [[OVERRIDE:[a-z_0-9]+]] = TensorAccessorArgs<42, [[BASE]].next_common_runtime_args_offset()>();"
+      // CHECK: emitc.verbatim "constexpr auto [[OVERRIDE:[a-z_0-9]+]] = TensorAccessorArgs<42, [[BASE]].next_common_runtime_args_offset()>();"
       // CHECK-NEXT: %[[OVERRIDE_LIT:.*]] = emitc.literal "[[OVERRIDE]]" : !emitc.opaque<"TensorAccessorArgs">
       %args_override = ttkernel.TensorAccessorArgs(prev = %args_base) cta_expr = "42"
 

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form.mlir
@@ -1,12 +1,16 @@
 // RUN: ttmlir-opt --ttcore-register-device --d2m-lower-dma-to-fully-indexed-form %s | FileCheck %s
+// RUN: ttmlir-opt --ttcore-register-device --d2m-lower-dma-to-fully-indexed-form="use-tensor-accessor-dma=true" %s | FileCheck %s --check-prefix=CHECK-TA
+// CHECK-TA-DAG: #[[REORDER_PAGE_MAP:.*]] = affine_map<(d0, d1, d2, d3) -> (d0 * 8 + d1 + d2 * 4 + d3 * 2)>
 
 #dram = #ttcore.memory_space<dram>
 #l1 = #ttcore.memory_space<l1>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#reorder = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2, d1)>
 #parallel = #ttcore.iterator_type<parallel>
 module attributes {} {
   // CHECK-LABEL: func.func @test_shard_level_read
+  // CHECK-TA-LABEL: func.func @test_shard_level_read
   func.func @test_shard_level_read(%arg0: memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>) {
     %alloc = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
     %stream = d2m.view_layout %arg0 remapping = #map4 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram> -> memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
@@ -27,6 +31,7 @@ module attributes {} {
           %local = d2m.reserve %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           // CHECK-NOT: d2m.dma_read {{.*}}, <0>
           // CHECK: d2m.dma_read %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}], %{{.*}}[%{{.*}}], <8>
+          // CHECK-TA: d2m.dma_read %{{.*}}[%{{.*}}, %{{.*}}], %{{.*}}, <0> {tensorAccessorPageMap = #{{.*}}}
           %tx = d2m.dma_read %stream[%0, %1], %local, <0> : (memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
           d2m.dma_wait %tx : !d2m.mem_tx<read>
           d2m.push %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
@@ -41,6 +46,7 @@ module attributes {} {
   }
 
   // CHECK-LABEL: func.func @test_shard_level_write
+  // CHECK-TA-LABEL: func.func @test_shard_level_write
   func.func @test_shard_level_write(%arg0: memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, %arg1: memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>) {
     %stream = d2m.view_layout %arg1 remapping = #map4 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram> -> memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
     d2m.generic {block_factors = [], grid = #ttcore.grid<2x4>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
@@ -60,6 +66,7 @@ module attributes {} {
           %local = d2m.wait %cb1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           // CHECK-NOT: d2m.dma_write {{.*}}, <0>
           // CHECK: d2m.dma_write %{{.*}}[%{{.*}}], %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}], <8>
+          // CHECK-TA: d2m.dma_write %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}], <0> {tensorAccessorPageMap = #{{.*}}}
           %tx = d2m.dma_write %local, %stream[%0, %1], <0> : (memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>) -> !d2m.mem_tx<write>
           d2m.dma_wait %tx : !d2m.mem_tx<write>
           d2m.pop %cb1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
@@ -74,6 +81,7 @@ module attributes {} {
   }
 
   // CHECK-LABEL: func.func @test_already_fully_indexed
+  // CHECK-TA-LABEL: func.func @test_already_fully_indexed
   func.func @test_already_fully_indexed(%arg0: memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>) {
     %alloc = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
     %stream = d2m.view_layout %arg0 remapping = #map4 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram> -> memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
@@ -91,6 +99,7 @@ module attributes {} {
         scf.for %arg2 = %c0 to %c1 step %c1 {
           %local = d2m.reserve %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           // CHECK: d2m.dma_read %view[%core0, %core1, %c0], %{{.*}}[%c0], <8>
+          // CHECK-TA: d2m.dma_read %view[%core0, %core1, %c0], %{{.*}}[%c0], <8>
           %tx = d2m.dma_read %stream[%core0, %core1, %c0], %local[%c0], <8> : (memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
           d2m.dma_wait %tx : !d2m.mem_tx<read>
           d2m.push %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
@@ -106,6 +115,7 @@ module attributes {} {
 
   // Test: Identity local_copy with contiguous layout - fully coalesced single dma_read.
   // CHECK-LABEL: func.func @test_local_copy_identity
+  // CHECK-TA-LABEL: func.func @test_local_copy_identity
   func.func @test_local_copy_identity() {
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
 
@@ -120,6 +130,8 @@ module attributes {} {
     // CHECK: d2m.push
     // CHECK: d2m.pop
     // CHECK: }, {
+    // CHECK-TA-NOT: d2m.local_copy
+    // CHECK-TA: d2m.dma_read %{{.*}}[%{{.*}}], %{{.*}}[%{{.*}}], <32>
     ^datamovement0:
       %cb_src = d2m.get_cb(0) : !d2m.cb<memref<4x8xbf16, #l1>>
       %cb_dst = d2m.get_cb(3) : !d2m.cb<memref<4x8xbf16, #l1>>
@@ -192,6 +204,83 @@ module attributes {} {
           d2m.pop %cb_dst : <memref<4x8xbf16, #l1>>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
+    }
+    return
+  }
+
+  // CHECK-TA-LABEL: func.func @test_row_major_fallback
+  // CHECK-TA-NOT: tensorAccessorPageMap
+  // CHECK-TA-NOT: d2m.dma_write {{.*}}, <0>
+  // CHECK-TA: d2m.dma_write
+  func.func @test_row_major_fallback(
+      %remote: memref<1x1x4x4xf32, #ttcore.shard<16x4, 1>, #dram>,
+      %local: memref<4x4xf32, #l1>) {
+    %c0 = arith.constant 0 : index
+    %tx = d2m.dma_write %local, %remote[%c0, %c0], <0> : (memref<4x4xf32, #l1>, memref<1x1x4x4xf32, #ttcore.shard<16x4, 1>, #dram>) -> !d2m.mem_tx<write>
+    return
+  }
+
+  // CHECK-TA-LABEL: func.func @test_mcast_fallback
+  // CHECK-TA-NOT: tensorAccessorPageMap
+  // CHECK-TA: d2m.dma_write %{{.*}}[%{{.*}}], %{{.*}}[%{{.*}}] core
+  func.func @test_mcast_fallback(%local: memref<4x4xf32, #l1>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %tx = d2m.dma_write %local, %local core[%c0, %c0] mcast[%c1, %c2], <0> : (memref<4x4xf32, #l1>, memref<4x4xf32, #l1>) -> !d2m.mem_tx<mcast_write>
+    return
+  }
+
+  // CHECK-TA-LABEL: func.func @test_fabric_fallback
+  // CHECK-TA-NOT: tensorAccessorPageMap
+  // CHECK-TA-NOT: d2m.dma_write {{.*}}, <0>
+  // CHECK-TA: d2m.dma_write
+  func.func @test_fabric_fallback(
+      %remote: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>,
+      %local: memref<2x2x!ttcore.tile<32x32, f32>, #l1>) {
+    %c0 = arith.constant 0 : index
+    %tx = d2m.dma_write %local, %remote[%c0, %c0] startDevice[%c0, %c0], <0> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>) -> !d2m.mem_tx<write>
+    return
+  }
+
+  // CHECK-TA-LABEL: func.func @test_non_identity_view_page_map
+  // CHECK-TA: d2m.dma_read %{{.*}}[%{{.*}}, %{{.*}}], %{{.*}}, <0> {tensorAccessorPageMap = #[[REORDER_PAGE_MAP]]}
+  func.func @test_non_identity_view_page_map(%remote: memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>) {
+    %alloc = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %view = d2m.view_layout %remote remapping = #reorder : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram> -> memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x2>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%view : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>)
+        outs(%alloc : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+    ^datamovement0:
+      %cb = d2m.get_cb(0) : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>>
+      %local = d2m.reserve %cb : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %tx = d2m.dma_read %view[%c0, %c1], %local, <0> : (memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+    }, {
+    ^compute0:
+    }
+    return
+  }
+
+  // CHECK-TA-LABEL: func.func @test_in_thread_view_fallback
+  // CHECK-TA-NOT: tensorAccessorPageMap
+  // CHECK-TA-NOT: d2m.dma_read {{.*}}, <0>
+  // CHECK-TA: d2m.dma_read
+  func.func @test_in_thread_view_fallback(%remote: memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>) {
+    %alloc = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x2>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%remote : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>)
+        outs(%alloc : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+    ^datamovement0:
+      %view = d2m.view_layout %remote remapping = #reorder : memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram> -> memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+      %cb = d2m.get_cb(0) : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>>
+      %local = d2m.reserve %cb : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %tx = d2m.dma_read %view[%c0, %c1], %local, <0> : (memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+    }, {
+    ^compute0:
     }
     return
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form_invalid.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_dma_to_fully_indexed_form_invalid.mlir
@@ -1,0 +1,17 @@
+// RUN: not ttmlir-opt --ttcore-register-device --d2m-lower-dma-to-fully-indexed-form="use-tensor-accessor-dma=true" %s 2>&1 | FileCheck %s
+
+#dram = #ttcore.memory_space<dram>
+#l1 = #ttcore.memory_space<l1>
+#page_map = affine_map<(d0, d1, d2, d3) -> (d0 * 4 + d1 * 2 + d2 * 2 + d3)>
+
+module {
+  func.func @preannotated_dma(
+      %remote: memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>,
+      %local: memref<2x2x!ttcore.tile<32x32, f32>, #l1>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    // CHECK: error: 'd2m.dma_read' op unexpected pre-existing TensorAccessor page map
+    %tx = d2m.dma_read %remote[%c0, %c1], %local, <0> {tensorAccessorPageMap = #page_map} : (memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #dram>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx<read>
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
+++ b/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
@@ -261,7 +261,7 @@ func.func @chained_view(%arg0: tensor<2x4x32x32xf32, #layout_base_view>) -> tens
 func.func @test_virtual_dram_bounce_aligned(%arg0: tensor<4x32x32xf32>) -> tensor<4x1x1x1x32x32xf32, #layout_virtual_dram_aligned> {
   // CHECK-LABEL: @test_virtual_dram_bounce_aligned
   // CHECK-NOT: tensor<1x1x128x32xf32
-  // CHECK: %[[DST:.*]] = d2m.empty() : tensor<4x1x1x1x32x32xf32, #layout[[VIRTUAL_LAYOUT_ALIGNED:[0-9]*]]
+  // CHECK: %[[DST:.*]] = d2m.empty() {virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}} : tensor<4x1x1x1x32x32xf32, #layout[[VIRTUAL_LAYOUT_ALIGNED:[0-9]*]]
   // CHECK: d2m.to_device %arg0, %[[DST]] layout = #layout[[VIRTUAL_LAYOUT_ALIGNED]]
   %0 = d2m.empty() : tensor<4x1x1x1x32x32xf32, #layout_virtual_dram_aligned>
   %1 = d2m.to_layout %arg0, %0 : tensor<4x32x32xf32> into tensor<4x1x1x1x32x32xf32, #layout_virtual_dram_aligned> -> tensor<4x1x1x1x32x32xf32, #layout_virtual_dram_aligned>
@@ -273,7 +273,7 @@ func.func @test_virtual_dram_bounce_aligned(%arg0: tensor<4x32x32xf32>) -> tenso
 func.func @test_virtual_dram_bounce_unaligned(%arg0: tensor<4x128x32xf32>) -> tensor<4x4x1x1x32x32xf32, #layout_virtual_dram_unaligned> {
   // CHECK-LABEL: @test_virtual_dram_bounce_unaligned
   // CHECK-NOT: tensor<1x1x512x32xf32
-  // CHECK: %[[DST:.*]] = d2m.empty() : tensor<4x4x1x1x32x32xf32, #layout[[VIRTUAL_LAYOUT_UNALIGNED:[0-9]*]]
+  // CHECK: %[[DST:.*]] = d2m.empty() {virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}} : tensor<4x4x1x1x32x32xf32, #layout[[VIRTUAL_LAYOUT_UNALIGNED:[0-9]*]]
   // CHECK: d2m.to_device %arg0, %[[DST]] layout = #layout[[VIRTUAL_LAYOUT_UNALIGNED]]
   %0 = d2m.empty() : tensor<4x4x1x1x32x32xf32, #layout_virtual_dram_unaligned>
   %1 = d2m.to_layout %arg0, %0 : tensor<4x128x32xf32> into tensor<4x4x1x1x32x32xf32, #layout_virtual_dram_unaligned> -> tensor<4x4x1x1x32x32xf32, #layout_virtual_dram_unaligned>

--- a/test/ttmlir/Silicon/TTMetal/n150/tensor_accessor.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/tensor_accessor.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% default-input-memspace=dram use-tensor-accessor-dma=true" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir
+
+func.func @abs(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  // CHECK: ct_args = [<tensor_accessor_args[0]>]
+  // CHECK: emitc.verbatim "constexpr auto tensor_accessor_args_
+  // CHECK: emitc.verbatim "const uint32_t page_id_
+  // CHECK: .page_id = page_id_
+  // CHECK: emitc.call_opaque "abs_tile"
+  %0 = "ttir.abs"(%arg0) : (tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %0 : tensor<64x128xf32>
+}

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -154,9 +154,11 @@ func.func @ttkernel_noc_oo_tile_render() -> () attributes {ttkernel.thread = #tt
     %args = ttkernel.TensorAccessorArgs(%cta, %crta)
     // CHECK: TensorAccessor [[ACC:v[0-9]+]] = TensorAccessor(
     %s = "ttkernel.TensorAccessor"(%args, %addr, %tile_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
-    // CHECK: [[NOC]].async_read([[ACC]], CoreLocalMem<uint32_t>({{.*}}), [[ACC]].get_aligned_page_size(), {.page_id = static_cast<uint32_t>({{.*}})}, {});
+    // CHECK: const uint32_t [[READ_PAGE_ID:page_id_[0-9]+]] = static_cast<uint32_t>({{.+}});
+    // CHECK: [[NOC]].async_read([[ACC]], CoreLocalMem<uint32_t>({{.*}}), [[ACC]].get_aligned_page_size(), {.page_id = [[READ_PAGE_ID]]}, {});
     "ttkernel.noc_async_read_tile"(%tile, %s, %addr, %noc0) : (i32, !ttkernel.TensorAccessor, i32, i8) -> ()
-    // CHECK: [[NOC]].async_write(CoreLocalMem<uint32_t>({{.*}}), [[ACC]], [[ACC]].get_aligned_page_size(), {} , {.page_id = static_cast<uint32_t>({{.*}})});
+    // CHECK: const uint32_t [[WRITE_PAGE_ID:page_id_[0-9]+]] = static_cast<uint32_t>({{.+}});
+    // CHECK: [[NOC]].async_write(CoreLocalMem<uint32_t>({{.*}}), [[ACC]], [[ACC]].get_aligned_page_size(), {} , {.page_id = [[WRITE_PAGE_ID]]});
     "ttkernel.noc_async_write_tile"(%tile, %s, %addr, %noc0) : (i32, !ttkernel.TensorAccessor, i32, i8) -> ()
     // CHECK: return
     func.return


### PR DESCRIPTION
This PR adds an opt-in path that lowers eligible D2M shard-level DMA operations to page-by-page NoC transfers driven by tt-metal's `TensorAccessor`.
- Enabled by `use-tensor-accessor-dma=true`, defaults to `false`.

## Motivation

Currently the D2M DMA path fully resolves a remote tensor access into physical coordinates & byte offsets in the compiler, the generated kernels does complex address arithmetic for:
- Logical & physical worker grids, plus VGM remapping.
- Sharding and shard-local offsets.
- Page and element strides.
- L1/DRAM addressing and/or bank selection.

These calculations are very flexible but complicates the kernels and can't take advantage of hardware-assisted address generation in Quasar.

We would like to utilize Metalium's `TensorAccessor` address generation mechanism, which abstracts page-to-bank and bank-to-NoC-address translation.
- `TensorAccessor`'s metadata only describes the backing buffer's physical distribution.
  - It answers: on which storage bank or core is that logical page located, and what is its bank-local offset?

The compiler still owns transfer semantics as a view, reblock, or any other TM op determines which pages the operation needs.
- It creates a complementary `TensorAccessorPageMap` that answers: which logical page does this D2M transfer iteration require?

For remote reads/writes of entire tiles, we can then divide the responsibility as:
- The compiler determines which logical pages/tiles a DMA operation must move based on the task at hand, and generate kernels that only does logical page ID calculation.
- The kernel then pass the page ID and the corresponding `TensorAccessor` to the NoC API.
  - For sharded L1/DRAM buffers, `TensorAccessor`'s internal `DistributionSpec` determine where those pages are physically stored across L1 cores or DRAM banks.
  - For interleaved DRAM buffers, `TensorAccessor` uses `InterleavedAddrGen` instead of a `DSpec`.
- The CB protocol determines where each page is staged in local L1 (not affected by this change).

The existing fully indexed DMA path acts as the fallback for any other types of DMAs that are ineligible for using `TensorAccessor`.

For an eligible shard-level `d2m.dma_read`, an overview of the workflow:
1. `D2MLowerDMAToFullyIndexedForm` composes any captured view and attaches a single-result page ID map `tensorAccessorPageMap` to the DMA read.
2. `D2MNormalizeThreadArgs` replaces the captured tensor operand with `d2m.get_arg`.
3. Kernel argument collection emits a base-address binding and a `TensorAccessor` metadata marker.
4. `D2MToTTKernel` creates a `TensorAccessor` and page loops.
5. TTMetal or TTNN conversion remaps both bindings to the same final operand.
6. FlatBuffer serialization records only the marker operand index.
7. Runtime resolves the live buffer and expands its exact `TensorAccessorArgs` CTAs.
8. Kernel C++ reconstructs `TensorAccessorArgs` using the compiler-generated CTA offset.
9. For each local shard page, the kernel computes the logical page ID.
10. `TensorAccessor` converts that page ID into a physical address using `DSpec` or `InterleavedAddrGen`.
11. The NoC API reads one aligned page into the local CB.
12. One barrier completes all reads before the CB is pushed.

A write follows the same sequence, using a local CB read pointer and page writes to the remote `TensorAccessor`.

## Implementation

The D2M dialect:
- Both `d2m.dma_read` & `d2m.dma_write` gets a new optional `tensorAccessorPageMap` affine-map attribute.
- This page map is only legal on shard-level DMA (`numElems == 0`), with verifications.
- `D2MLowerDMAToFullyIndexedForm` owns creation of this attribute, pre-existing ones are rejected.

The `use-tensor-accessor-dma` option:
- It only affects the `D2MLowerDMAToFullyIndexedForm` pass.
- To use it in the full D2M pipeline, do `ttir-to-ttmetal-pipeline{use-tensor-accessor-dma=true}`.
- For a manually composed post-grid pipeline, do `d2m-be-pipeline{use-tensor-accessor-dma=true}`.
- The `ConvertD2MToTTKernel` pass dispatches conversions according to the IR form and the presence of `tensorAccessorPageMap`.

The `LowerDMAToFullyIndexedForm` pass:
- Perform a single walk over all DMA reads & writes and attaches the page map to eligible operations.
  - A DMA read/write is considered eligible iff all of the following conditions are met:
    - It's a shard-level DMA whose read source or write destination is remote.
    - The remote operand is directly captured by the enclosing `d2m.generic`.
    - Both local & remote memref shapes are static.
    - The local & remote element types match and are both of `ttcore::TileType`.
    - The tile page size satisfies both remote-memory and local-L1 NoC alignments.
    - The operation moves the complete remote shard.
    - The backing layout is sharded L1/DRAM, or interleaved DRAM.
    - Grid and shard ranks match, are nonzero, and do not exceed the `TensorAccessor` rank limit of 8.
    - Any captured `d2m.view_layout` chain is non-composite and can be represented by a symbol-free affine map.
    - A write is unicast and remains on the current mesh device.
  - This means the following cases are left to the fallback path:
    - Row-major tensors.
    - Partial-shard/page transfers.
    - Local-to-local reads & writes, and `d2m.local_copy`.
    - Multicast, fabric or device-range writes.
    - Composite views.
    - Views created inside a thread instead of captured as a generic operand.
    - Dynamic shapes.
    - Unsupported layouts, ranks, index counts, alignments, or volume relations.
    - DMA operations that are already fully indexed.
  - The pass's conventional fully indexed DMA and local-copy patterns then pick up all the remaining unmarked operations.
- `TensorAccessorPageMap` construction:
  - Suppose every shape is in the page space (i.e. shard elements are entire tiles) and the grid/shard rank is `R`.
  - The row-major tensor strides is `stride[i] = product_j(G[j] * S[j]) for j > i`, where `G[R]` is the grid shape and `S[R]` is the shard shape.
  - For a specific remote grid coordinate `g[R]` and shard-local page coordinate `s[R]`, the absolute global page coordinate is `absolute[i] = g[i] * S[i] + s[i]`.
  - The flattened logical page ID is therefore `pageID = sum_i(stride[i] * absolute[i])`.
  - If the captured operand is a view, `applyViews` recursively composes the view maps to the front of the page ID map.

The TTKernel dialect:
- Add a new `TensorAccessorArgs` entry to the `ArgType` enum.
  - Its flatbuffer entry is a single `u32` that records its corresponding operand's index.
  - The D2M runtime will expand it to the actual multi-slot kernel CTAs.

The `D2MToTTKernel` pass:
- Step 1: `D2MKernelFunctionArgsRewriter` creates `TensorAccessorArgs` for marked DMA ops.
  - For all DMA reads & writes that have an attached page map, put their remote memref's operand indices behind all other types of CTAs (with deduplication).
    - `TensorAccessorArgs` is not fixed-width, putting it at the end so we don't break other static CTA indices.
  - Then, form a chain of `TensorAccessorArgs` so that in the generated kernel, each args knows which args precedes it in the chain.
    - So we can use `prev_args.next_compile_time_args_offset()` to construct the current args.
  - The `FuncOp - operand_idx - ta_arg` mapping is stored in the pass-scope `TensorAccessorArgsChains` map.
- Step 2: `D2MDMAViaTensorAccessorRewriter` lowers marked shard-level DMA ops to loops containing NoC transfers using `TensorAccessor`s.
  - Require the op's remote operand to be a `d2m.get_arg`, since we look up the corresponding `TensorAccessorArgs` value from `TensorAccessorArgsChains`.
  - Construct `ttkernel.TensorAccessor(args, remoteBaseAddress)` for the remote shard, and `ttkernel.get_{read,write}_ptr` for the local shard.
  - Build nested loop over the remote transfer shard:
    - Evaluate `tensorAccessorPageMap(gridIndices ++ shardIndices)` to get the logical page ID.
    - Compute `localAddress = localBasePtr + localPage * tileSizeBytes`.
    - Emit `ttkernel.noc_async_{read,write}_tile`.
  - The corresponding `d2m.dma_wait` becomes a single NoC barrier after all page transactions.
- The conventional `D2MDMA{Read,Write}Rewriter` require `isFullyIndexed()`, and thus do not touch the marked shard-level DMA ops.

The `TTKernelToEmitC` pass:
- The `TensorAccessorArgs` chain is emitted as:
  - `constexpr auto tensor_accessor_args_0 = TensorAccessorArgs<n_fixed_width_ctas, 0>();`
  - `constexpr auto tensor_accessor_args_1 = TensorAccessorArgs<tensor_accessor_args_0.next_compile_time_args_offset(), tensor_accessor_args_0.next_common_runtime_args_offset()>();`
- Changed `TensorAccessor`'s `page_size_in` argument to optional.
  - This PR omits this argument and simply emit `TensorAccessor(tensor_accessor_args_N, bank_base_address)`.
  - The `TensorAccessor` constructor therefore uses the aligned page size supplied by `TensorAccessorArgs`.
- The tile-level NoC transfer then takes: `(accessor, local_l1_addr, accessor.get_aligned_page_size(), logical_page_id)`.
- The Python wrapper accepts the three-positional-argument form and also allows the page size to be omitted.

The `D2MToTTMetal` pass:
- During spatial-program merging, `TensorAccessorArgs`, `BufferAddress`, and scalar arguments all use the unified I/O remapping table.
- This guarantees that metadata and base address continue to reference the same buffer after multiple programs are merged.

The `TTMetalToFlatbuffer` pass:
- The new `KernelArgTensorAccessorArgs` flatbuffer entry contains no actual `TensorAccessorArgs` u32 words, it only identifies the program operand whose live buffer must be inspected in the D2M runtime.
  - It carries the same logical operand index as the corresponding `BufferAddress`, mapped from the generic's operand index to the corresponding `ttmetal.enqueue_program` argument during `D2MToTTMetal`.
- Breakdown of the actual kernel `TensorAccessorArgs` encoding:
  - All-CTA tt-metal `ArgsConfig` for interleaved buffers:
    - CTAs: `[argsConfig, alignedPageSize]`
    - Length: `2`
  - All-CTA tt-metal `ArgsConfig` for sharded buffers:
    - CTAs: `argsConfig alignedPageSize rank packedNumBanks tensorShapeInPages[rank] shardShapeInPages[rank] packedCoreCoordinates[ceil(numBanks / 2)]`
      - Two `(x, y)` coordinates are packed into a single u32 CTA using eight bits per component.
      - Bit 31 of `packedNumBanks` records `ShardDistributionStrategy::CONTIGUOUS_1D`, while the lower bits hold the bank count.
        - The `BufferDistributionSpec` flatBuffer does not serialize a distribution-strategy field, and runtime reconstruction uses the round-robin default, so this bit is clear for D2M-generated buffers in this PR.
    - Length: `4 + 2 * rank + ceil(numBanks / 2)`
- Since we use the default `ArgConfig::None` for `ArgsConfig`, no CRTA is used to pass the metadata.
  - Chaining still tracks both CTA and CRTA offsets so the IR remains compatible with future argument configurations.
- Update the logic of the serializer for determining the element shape before creating `MeshBuffer` configuration metadata.
  - `TensorAccessor` correctness depends on the `MeshBuffer` using the same page domain as the generated kernels.
    - Both `BufferDistributionSpec` and `ShardSpec` are switched to tile-pages for tiled buffers.
    - Without a `BufferDistributionSpec`, tt-metal classifies a buffer as interleaved when constructing `TensorAccessorArgs`.
  - For tiled buffers, both `elementShape` and `pageShape` use the tile shape, and `pageSize` is the actual tile size in bytes (e.g. BFP8 -> 1088-byte pages).
    - The page sizes must also satisfy the L1 & DRAM NoC alignments.
  - For row-major buffers, `elementShape = 1 x 1`, and `pageShape = 1 x collapsed shard width`.
- Also update the logic for determining the core or bank coordinates in the `BufferDistributionSpec`.
  - For DRAM sharded buffers:
    - The total number of DRAM banks/cores encoded: `numDRAMBanksUsed = min(numDramBanks, gridVolume)`.
      - The DRAM banks are enumerated on the X-axis: `(x = bankId, y = 0)` (not virtualized).
    - Logical shards will use the default round-robin distribution across the used banks.
  - For L1 sharded buffers:
    - Without VGM, logical shard-grid coordinates are mapped through the device worker-grid mapping.
    - With VGM, coordinates are mapped through the stored virtual-grid forward map:
      - Enumerates cores in logical row-major shard order.
  - The mapping between logical grid positions and cores must be a bijection.
  - At runtime, `TensorAccessorArgs` converts these logical core coordinates through `virtual_core_from_logical_core` before packing the NoC coordinates, accounting for harvesting.

D2M runtime changes:
- During execution, `runtime/lib/ttmetal/arguments.h` resolves `KernelArgTensorAccessorArgs` by:
  - Find the `MeshBuffer` using the `operand_idx` from the flatbuffer.
  - Create `tt_metal::TensorAccessorArgs(*meshBuffer)`.
  - Append the CTAs returned from `tt_metal::TensorAccessorArgs::get_compile_time_args()` to the list of CTAs.
    - Fixed-width CTAs precede all `TensorAccessorArgs` so we maintain the continuity of the chain.
    - The `BufferAddress` entry remains separate and contributes the validated base address CTA.
- `MeshBuffer` construction in `runtime/lib/ttmetal/executor_utils.h`:
  - The high level `MeshDevice` sharding is switched to use page units to express sharded `MeshBuffer` geometry.
    - Shapes in `distributed::ShardedBufferConfig` are unit-agnostic and so the datum size is inferred by dividing the global buffer size by the global buffer shape.
    - If we use scalar-shaped geometry, BFP buffers (tile sizes are not powers-of-two) will get truncated in the integer datum-size calculation.
    - Page-shaped geometry will always lead to the correct page size.
  - The low level device-local worker core sharding is supplied through `BufferShardingArgs` & BDS, unchanged.
  - The interleaved DRAM path is restricted to a single mesh device. It uses no BDS, reconstructs interleaved `BufferShardingArgs`, and uses `globalSize = L` with `(1, 1)` global and shard shapes instead of the sharded page-unit mesh geometry above.
  - Note that for sharded buffers, both the legacy 2D `ShardSpecBuffer` and the N-D `BufferDistributionSpec` are constructed.
    - Both should be replaced by `NdShardSpec` & `TensorSpec` when D2M migrate to `MeshTensor`.

The `D2MToTTNN` pass:
- The TTNN generic runtime provides a `TensorAccessor` argument marker, so we map `ArgType::TensorAccessorArgs` to `KernelArgTensorAccessorArgsAttr`.
- Spatial merging remaps this attribute through the same unified tensor-I/O table as `KernelArgAddressOfTensor`.
- At runtime, the marker indexes the live TTNN tensor, obtains its backing `Buffer`, calls `tt_metal::TensorAccessorArgs(buffer)`, and appends the CTAs.
- The kernel-side TTKernel & EmitC logic is shared with the D2M path.

Bugfix in the `LowerToLayout` pass:
- In the builder VGM + `TensorAccessor` tests, a manually constructed `1x12 -> 2x6` reblock will end up requesting a `1x12` launch grid on WH.
- Sequence of events:
  - The explicit layout info will use the basic `d2m.empty` builder in `TTIRToD2M` which doesn't attach VGM metadata.
  - The `GridSelection` pass can't fix it because the explicit `d2m.to_layout` chain has not yet been materialized into GenericOps.
  - Commit b1883766 introduced the reuse of an existing `d2m.empty` in `LowerToLayout`.
  - It will treat an EmptyOp with an oversized grid but no VGM attributes as reusable, and thus bypassing the target-aware empty builder that would have generated the required VGM maps.
  - The generated GenericOp inherits the bare `1x12` grid, and the oversized grid eventually reaches the D2M runtime.
- Fix: do not reuse an output buffer if its grid requires VGM but it lacks VGM metadata, create a new one with proper VGM maps.

## Builder Tests

Added D2M builder tests in `test_dma.py` and `test_layout.py` that test `TensorAccessor` for:
- Manually constructed IR for tensor reblocking.
- DMA round trip for: sharded L1/DRAM, interleaved DRAM.
- Compatibility with forcing all kernel args to be CTA.
- Compatibility with VGM.
- Actual add/permute/matmul from DRAM tensors, as well as f32/bf16/bfp8 data formats.

## Notes & Issues

Correctness invariants:
- `BufferAddress` and `TensorAccessorArgs` must undergo identical I/O remapping, maybe they should be somehow bundled together to avoid footguns.
- The kernel page ID uses the same logical page numbering as the `MeshBuffer`'s sharded / interleaved page configuration.

The PR intentionally does not expose the `TensorAccessor`'s `DSpec` in the `TTKernel` dialect due to the following considerations:
- `DSpec` describes the backing buffer, its fixed strides & shapes are not helpful for expressing arbitrary D2M transfer views.
- A transfer shard might be smaller than the backing buffer's storage shard, thus rendering `DSpec`'s metadata ineffective.
- `DSpec` may squeeze adjacent page dimensions while preserving page mapping as an optimization, so its metadata doesn't even have the same rank as what the compiler expects.
  - For example, a backing tensor shape `8x24` with shard shape `1x3` can be stored internally as tensor shape `192` and shard shape `3`.
- The interleaved `TensorAccessor` specialization does not expose a `DSpec` at all.
- compiler-generated `TensorAccessorPageMap` is more flexible while not incurring too much arithmetic overhead on the device.
  - A row-major linear page ID is invariant under `DSpec`'s rank squeezing, so the compiler computed the page ID in its own view coordinate system will work.

The runtime reconstructs both `BufferDistributionSpec` and legacy `ShardSpecBuffer` metadata.
- tt-metal's `Buffer::num_dev_pages()` prioritizes the legacy shard spec if both are present.
- Overall this part needs some serious cleanup before/during `MeshTensor & TensorSpec` migration.

Missed coalescing opportunities:
- The `TensorAccessor` path move tiles/pages one-by-one without taking advantage of the existing coalescing calculation, its performance impact remains to be measured.
- In the future, we might play with the page size (e.g. `TensorAccessor`'s `page_size_in` argument) to have multiple tiles "coalesced" as one page.

Misc:
- `TensorAccessorArgs` as CRTAs is unsupported for now, this feature frees up the limited CTA slots and might improve kernel cache reuse.
- Composite views can't use `TensorAccessor`s yet, even if it's whole-tile NoC transfers.
- The `TensorAccessor` addition test fails on WH sim.