### PR TITLE
[D2M] prefer xfail over skip in builder tests

### DIFF
--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -791,9 +791,12 @@ def _mark_item_for_skip(
     skip_handler_fn,
     negate_check=False,
 ):
-    matches = []
+    matching_markers = []
+    has_marker_configs = False
     for marker in item.iter_markers(name=marker_name):
+        marker_matches = False
         for platform_config in marker.args:
+            has_marker_configs = True
 
             # All of the operations we need to do on these are set membership based
             platform_config = set(platform_config)
@@ -808,19 +811,22 @@ def _mark_item_for_skip(
             match = platform_config <= set(
                 [current_target, board_id, current_environment, current_image]
             )
-            matches.append(match)
+            marker_matches = marker_matches or match
 
-    if len(matches) == 0:
+        if marker_matches:
+            matching_markers.append(marker)
+
+    if not has_marker_configs:
         return
 
-    should_skip = any(matches)
+    should_skip = bool(matching_markers)
 
     # For only_config we want to skip if config is NOT in the allowed list
     if negate_check:
         should_skip = not should_skip
 
     if should_skip:
-        skip_handler_fn(item)
+        skip_handler_fn(item, matching_markers)
 
 
 def pytest_collection_modifyitems(config, items):
@@ -862,31 +868,37 @@ def pytest_collection_modifyitems(config, items):
         current_image = _get_current_image()
         board_id = get_board_id(system_desc)
 
-        def skip_config_handler(item):
-            reason = next(
-                (
-                    m.kwargs["reason"]
-                    for m in item.iter_markers("skip_config")
-                    if "reason" in m.kwargs
-                ),
+        def skip_config_handler(item, matching_markers):
+            marker_kwargs = matching_markers[0].kwargs
+            reason = marker_kwargs.get(
+                "reason",
                 "Test marked as skip for this platform/target combination",
             )
             item.add_marker(pytest.mark.skip(reason=reason))
 
-        def only_config_handler(item):
+        def only_config_handler(item, _matching_markers):
             item.add_marker(
                 pytest.mark.skip(
                     reason="Test marked as skip for this platform/target combination"
                 )
             )
 
-        def skip_exec_handler(item):
+        def xfail_config_handler(item, matching_markers):
+            marker_kwargs = matching_markers[0].kwargs
+            reason = marker_kwargs.get(
+                "reason",
+                "Test marked as xfail for this platform/target combination",
+            )
+            strict = marker_kwargs.get("strict", True)
+            item.add_marker(pytest.mark.xfail(reason=reason, strict=strict))
+
+        def skip_exec_handler(item, _matching_markers):
             # Set skip_exec attribute on the item instead of marking as skipped
             item.skip_exec = True
             xfail_reason = f"Execution marked as skip"
             item.skip_exec_reason = xfail_reason
             # Mark test as xfail so it's expected to fail
-            item.add_marker(pytest.mark.xfail(reason=xfail_reason, strict=False))
+            item.add_marker(pytest.mark.xfail(reason=xfail_reason, strict=True))
 
         _mark_item_for_skip(
             item,
@@ -906,6 +918,15 @@ def pytest_collection_modifyitems(config, items):
             "only_config",
             only_config_handler,
             negate_check=True,
+        )
+        _mark_item_for_skip(
+            item,
+            current_target,
+            board_id,
+            current_environment,
+            current_image,
+            "xfail_config",
+            xfail_config_handler,
         )
         _mark_item_for_skip(
             item,

--- a/test/python/golden/d2m/test_binary.py
+++ b/test/python/golden/d2m/test_binary.py
@@ -168,13 +168,14 @@ binary_ops = [
     add,
     atan2,
     div,
-    gelu_backward | Marks(pytest.mark.skip_config(["ttmetal"])),
-    gelu_backward_tanh | Marks(pytest.mark.skip_config(["ttmetal"])),
+    gelu_backward | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+    gelu_backward_tanh
+    | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
     maximum,
     minimum,
     multiply,
     pow,
-    remainder | Marks(pytest.mark.skip_config(["ttmetal"])),
+    remainder | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
     subtract,
 ]
 
@@ -216,7 +217,7 @@ def test_binary_ops(
             "TODO(dloke): int32 div is not supported on ttmetal yet, need to support floor or truncate division"
         )
     if test_fn.__name__ == "atan2" and (dtype == torch.int32 or dtype == torch.int64):
-        pytest.skip("atan2 with integer inputs is not supported on ttmetal")
+        pytest.xfail("atan2 with integer inputs is not supported on ttmetal")
 
     def module(builder: TTIRBuilder):
         @builder.func([shape, shape], [dtype, dtype])
@@ -466,7 +467,7 @@ def test_scalar_binary_ops(
     is_fractional = scalar_value != int(scalar_value)
 
     if is_int and test_fn.__name__ in float_only_ops:
-        pytest.skip(f"{test_fn.__name__} not supported for {dtype}")
+        pytest.xfail(f"{test_fn.__name__} not supported for {dtype}")
     if is_int and is_fractional:
         pytest.skip(f"fractional scalar {scalar_value} not valid for {dtype}")
 

--- a/test/python/golden/d2m/test_binary_tree.py
+++ b/test/python/golden/d2m/test_binary_tree.py
@@ -50,7 +50,7 @@ def test_binary_tree(
             return builder.add(left, right)
 
     if shape == (2048, 2048) and dtype == torch.float32:
-        pytest.skip(
+        pytest.xfail(
             "Hitting L1 limits in Allocator, need to enable DRAM spilling for intermediate allocs."
         )
 

--- a/test/python/golden/d2m/test_composite_ops.py
+++ b/test/python/golden/d2m/test_composite_ops.py
@@ -349,7 +349,7 @@ def test_softmax_decomposition(
 ):
     """Test softmax decomposition for the TTMetal pipeline."""
     if dimension == 0:
-        pytest.skip("Out of place reduction not supported with blocking. See #8290")
+        pytest.xfail("Out of place reduction not supported with blocking. See #8290")
 
     def module(builder: TTIRBuilder):
         @builder.func([shape], [torch.float32])

--- a/test/python/golden/d2m/test_reductions.py
+++ b/test/python/golden/d2m/test_reductions.py
@@ -260,7 +260,7 @@ def test_reduce_3d_inner(
     device,
 ):
     if len(dim_arg) >= 2 and not keep_dim:
-        pytest.skip(
+        pytest.xfail(
             "keep_dim=False not supported for multi-dim reductions on inner 2 dims because the reshape after the reduction is unsupported due to noc issue: https://github.com/tenstorrent/tt-mlir/issues/6377"
         )
 
@@ -291,7 +291,8 @@ _3D_OUTER_COMBOS = [
 )
 @pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.xfail(
-    reason="Out of place reduction not supported with blocking. See #8290"
+    reason="Out of place reduction not supported with blocking. See #8290",
+    strict=True,
 )
 def test_reduce_outer_3d(
     b: int,
@@ -353,7 +354,7 @@ def test_reduce_4d_inner(
     device,
 ):
     if len(dim_arg) >= 2 and not keep_dim:
-        pytest.skip(
+        pytest.xfail(
             "keep_dim=False not supported for multi-dim reductions on inner 2 dims because the reshape after the reduction is unsupported due to noc issue: https://github.com/tenstorrent/tt-mlir/issues/6377"
         )
 
@@ -384,7 +385,8 @@ _4D_OUTER_COMBOS = [
     _cycled_reduction_params(_4D_OUTER_COMBOS, keep_dims=[True]),
 )
 @pytest.mark.xfail(
-    reason="Out of place reduction not supported with blocking. See #8290"
+    reason="Out of place reduction not supported with blocking. See #8290",
+    strict=True,
 )
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_reduce_outer_4d(
@@ -415,7 +417,7 @@ def test_reduce_outer_4d(
     # non-square 10x13 grid. Re-enable once grid selection handles non-square
     # grids without inflating per-core L1.
     if reduce_dim == 1 and a == 3 and b == 8 and get_board_id(system_desc) == "p150":
-        pytest.skip("L1 OOM on non-square grid (see #8079)")
+        pytest.xfail("L1 OOM on non-square grid (see #8079)")
 
     tile_size = 32
     shape = (a, b, m * tile_size, n * tile_size)
@@ -553,7 +555,8 @@ def test_reduce_i32_3d_inner(
 @pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.parametrize("dtype", [torch.int32 | SkipIf(["n150", "sim"])], ids=["i32"])
 @pytest.mark.xfail(
-    reason="Out of place reduction not supported with blocking. See #8290"
+    reason="Out of place reduction not supported with blocking. See #8290",
+    strict=True,
 )
 def test_reduce_i32_outer_3d(
     b: int,

--- a/test/python/golden/d2m/test_spatial.py
+++ b/test/python/golden/d2m/test_spatial.py
@@ -643,8 +643,9 @@ def test_spatial_two_regions_two_matmuls(
         pytest.param(
             "ttnn-mode",
             id="ttnn-mode",
-            marks=pytest.mark.skip(
-                reason="Temporarily skip ttnn-mode target for all-gather spatial path."
+            marks=pytest.mark.xfail(
+                reason="Temporarily skip ttnn-mode target for all-gather spatial path.",
+                strict=True,
             ),
         ),
     ],

--- a/test/python/golden/d2m/test_stablehlo_ops.py
+++ b/test/python/golden/d2m/test_stablehlo_ops.py
@@ -210,8 +210,9 @@ def module_compare_lt(builder: StableHLOBuilder):
         module_mul,
         module_pow,
         module_subtract,
-        module_remainder | Marks(pytest.mark.skip_config(["ttmetal"])),
-        module_atan2 | Marks(pytest.mark.skip_config(["ttmetal"])),
+        module_remainder
+        | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+        module_atan2,
     ],
 )
 def test_binary_ops(test_fn: Callable, target: str, request, device):
@@ -227,12 +228,18 @@ def test_binary_ops(test_fn: Callable, target: str, request, device):
 @pytest.mark.parametrize(
     "test_fn",
     [
-        module_compare_eq | Marks(pytest.mark.skip_config(["ttmetal"])),
-        module_compare_ne | Marks(pytest.mark.skip_config(["ttmetal"])),
-        module_compare_ge | Marks(pytest.mark.skip_config(["ttmetal"])),
-        module_compare_gt | Marks(pytest.mark.skip_config(["ttmetal"])),
-        module_compare_le | Marks(pytest.mark.skip_config(["ttmetal"])),
-        module_compare_lt | Marks(pytest.mark.skip_config(["ttmetal"])),
+        module_compare_eq
+        | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+        module_compare_ne
+        | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+        module_compare_ge
+        | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+        module_compare_gt
+        | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+        module_compare_le
+        | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+        module_compare_lt
+        | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
     ],
 )
 def test_compare_ops(test_fn: Callable, target: str, request, device):
@@ -292,9 +299,9 @@ def test_transpose(
     if len(shape) != len(permutation):
         pytest.skip(f"Permutation {permutation} doesn't match shape rank {len(shape)}")
 
-    # Skip ttmetal for dimensions > 2
+    # Xfail ttmetal for dimensions > 2.
     if target == "ttmetal" and len(shape) > 2:
-        pytest.skip(
+        pytest.xfail(
             f"ttmetal does not support transpose for dimensions > 2, got shape with {len(shape)} dimensions"
         )
 
@@ -323,8 +330,9 @@ def test_transpose(
     [
         pytest.param(
             "ttmetal",
-            marks=pytest.mark.skip(
-                reason="ttir.pad lowering not supported on ttmetal, failed to legalize"
+            marks=pytest.mark.xfail(
+                reason="ttir.pad lowering not supported on ttmetal, failed to legalize",
+                strict=True,
             ),
         )
     ],
@@ -392,38 +400,35 @@ def test_slice(
     )
 
 
-# ---------------------------------------------------------------------------
-# test_reshape ttmetal mirror — original used a dynamically-built
-# `_RESHAPE_PARAMS` list where every ttmetal entry was marked
-# `pytest.mark.skip(reason="reshape lowering not yet supported in TTMetal
-# backend")`. Preserve that here.
-# ---------------------------------------------------------------------------
-_RESHAPE_CASES_TTMETAL = [
-    ([(2, 3), (3, 2)], "swap"),
-    ([(2, 3), (6,)], "flatten"),
-    ([(1, 784), (1, 28, 28)], "unflatten"),
-    ([(4, 8, 16), (4, 128)], "3d_to_2d"),
-    ([(64, 512), (64, 1, 512)], "expand_dims"),
-    ([(128, 128), (64, 256)], "rearrange_2d"),
-    ([(10,), (10,)], "identity"),
-    ([(0, 6), (0, 2, 3)], "zero_dim"),
-]
-
-_RESHAPE_PARAMS_TTMETAL = [
-    pytest.param(
-        shapes,
-        "ttmetal",
-        id=f"{case_id}-ttmetal",
-        marks=pytest.mark.skip(
-            reason="reshape lowering not yet supported in TTMetal backend"
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [(2, 3), (3, 2)] | Marks(pytest.mark.xfail(reason="Bad PCC", strict=True)),
+        [(2, 3), (6,)] | Marks(pytest.mark.xfail(reason="Bad PCC", strict=True)),
+        pytest.param(
+            [(1, 784), (1, 28, 28)],
+            marks=[pytest.mark.xfail_config(["n150"], reason="Bad PCC", strict=True)],
         ),
-    )
-    for shapes, case_id in _RESHAPE_CASES_TTMETAL
-]
-
-
-@pytest.mark.parametrize("shapes, target", _RESHAPE_PARAMS_TTMETAL)
+        [(4, 8, 16), (4, 128)],
+        [(64, 512), (64, 1, 512)],
+        [(128, 128), (64, 256)],
+        [(10,), (10,)],
+        [(0, 6), (0, 2, 3)]
+        | Marks(pytest.mark.xfail(reason="Compilation failure", strict=True)),
+    ],
+    ids=[
+        "swap",
+        "flatten",
+        "unflatten",
+        "3d_to_2d",
+        "expand_dims",
+        "rearrange_2d",
+        "identity",
+        "zero_dim",
+    ],
+)
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize("target", ["ttmetal"])
 def test_reshape(shapes: tuple, target: str, dtype: torch.dtype, request, device):
     input_shape, output_shape = shapes
 

--- a/test/python/golden/d2m/test_tms.py
+++ b/test/python/golden/d2m/test_tms.py
@@ -52,50 +52,34 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
         pytest.param(
             (32, 128 * 500),
             [1, 0],
-            marks=pytest.mark.skip_config(
-                ["n150", "sim"],
-                reason="L1 memory usage exceeds capacity on non-square grid (see #8079)",
-            ),
+            marks=pytest.mark.skip_config(["n150", "sim"]),
         ),
         pytest.param(
             (32, 128 * 501),
             [1, 0],
             marks=[
-                pytest.mark.skip_config(
+                pytest.mark.xfail_config(
                     ["n150"],
-                    ["n300"],
                     reason="L1 memory usage exceeds capacity #7559",
+                    strict=True,
                 ),
-                pytest.mark.skip_config(
-                    ["p150"],
-                    reason="L1 memory usage exceeds capacity on non-square grid (see #8079)",
-                ),
+                pytest.mark.skip_config(["n150", "sim"], ["p150", "sim"]),
             ],
         ),
         pytest.param(
             (32, 128 * 800),
             [1, 0],
             marks=[
-                pytest.mark.skip_config(
-                    ["n150"],
-                    ["n300"],
-                    reason="L1 memory usage exceeds capacity #7559",
-                ),
-                pytest.mark.skip_config(
-                    ["p150"],
-                    reason="L1 memory usage exceeds capacity on non-square grid (see #8079)",
-                ),
+                pytest.mark.skip_config(["p150", "sim"]),
             ],
         ),
         pytest.param(
             (32, 128 * 801),
             [1, 0],
-            marks=pytest.mark.skip_config(
-                ["n150"],
-                ["n300"],
-                ["p150"],
-                ["p300"],
+            marks=pytest.mark.xfail_config(
+                ["ttmetal"],
                 reason="L1 memory usage exceeds capacity #7559",
+                strict=True,
             ),
         ),
         # 3d inner permutes
@@ -151,17 +135,7 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
         [(1, 8, 128, 64), [0, 1, 3, 2]],
         [(1, 8, 64, 128), [0, 1, 3, 2]],
         # 4d inner permutes (llama3-70b, qwen3-32b)
-        pytest.param(
-            (32, 8, 128, 128),
-            [0, 1, 3, 2],
-            marks=[
-                pytest.mark.skip_config(
-                    ["p150"],
-                    ["p300"],
-                    reason="L1 memory usage exceeds capacity on p150/p300",
-                ),
-            ],
-        ),
+        [(32, 8, 128, 128), [0, 1, 3, 2]],
         # 4d complex permutes (llama3-70b, qwen3-32b)
         [(32, 1, 1, 128), [2, 1, 0, 3]],
         # 4d outer permutes (deepseek-671b)
@@ -728,14 +702,7 @@ def module_transpose_inner_dims(builder: TTIRBuilder):
         (module_unary_exp_4d_exp, "4d_exp"),
         # Batched matmul (fixed in #6648)
         (module_batch_matmul, "matmul"),
-        # Operations with known issues (marked as skip)
-        pytest.param(
-            module_transpose_inner_dims,
-            "transpose",
-            marks=pytest.mark.skip(
-                reason="Hardcoded rank==2 assertions in permute rewriter cause core dump"
-            ),
-        ),
+        (module_transpose_inner_dims, "transpose"),
     ],
     ids=["3d_add", "3d_multiply", "3d_exp", "4d_add", "4d_exp", "matmul", "transpose"],
 )
@@ -1027,22 +994,34 @@ def test_repeat(shape: Shape, repeat_dims: List[int], dtype, target, request, de
             [3],
             [62],
             [7],
-            marks=pytest.mark.skip_config(
-                ["sim"],
-                ["ttmetal"],
-                reason="NOC alignment violation, see https://github.com/tenstorrent/tt-mlir/issues/8077",
-            ),
+            marks=[
+                pytest.mark.skip_config(
+                    ["sim"],
+                    reason="NOC alignment violation in simulator, see https://github.com/tenstorrent/tt-mlir/issues/8077",
+                ),
+                pytest.mark.xfail_config(
+                    ["ttmetal"],
+                    reason="NOC alignment violation, see https://github.com/tenstorrent/tt-mlir/issues/8077",
+                    strict=True,
+                ),
+            ],
         ),
         pytest.param(
             (2048,),
             [0],
             [2048],
             [3],
-            marks=pytest.mark.skip_config(
-                ["sim"],
-                ["ttmetal"],
-                reason="NOC alignment violation, see https://github.com/tenstorrent/tt-mlir/issues/8077",
-            ),
+            marks=[
+                pytest.mark.skip_config(
+                    ["sim"],
+                    reason="NOC alignment violation in simulator, see https://github.com/tenstorrent/tt-mlir/issues/8077",
+                ),
+                pytest.mark.xfail_config(
+                    ["ttmetal"],
+                    reason="NOC alignment violation, see https://github.com/tenstorrent/tt-mlir/issues/8077",
+                    strict=True,
+                ),
+            ],
         ),
         # Simple 2D
         ((64, 64), [0, 0], [32, 32], None),
@@ -1057,10 +1036,11 @@ def test_repeat(shape: Shape, repeat_dims: List[int], dtype, target, request, de
             [0, 3],
             [32, 128 * 991],
             [2, 991],
-            marks=pytest.mark.skip_config(
+            marks=pytest.mark.xfail_config(
                 ["ttmetal", "p150"],
                 ["ttmetal", "p300"],
                 reason="L1 memory usage exceeds capacity #7559",
+                strict=True,
             ),
         ),
         ((131072, 32), [5, 1], [128 * 997, 32], [997, 2]),

--- a/test/python/golden/d2m/test_unaligned.py
+++ b/test/python/golden/d2m/test_unaligned.py
@@ -37,6 +37,7 @@ UNALIGNED_SHAPES = [
     (9, 43, 7),
     (5, 61, 49),
     (51, 19, 23),
+    (677, 1, 1),
     (2, 3, 5, 7),
     (3, 37, 5, 53),
     (37, 3, 5, 53),
@@ -48,7 +49,7 @@ UNALIGNED_SHAPES = [
 ]
 
 
-@pytest.mark.parametrize("shape", UNALIGNED_SHAPES + [(677, 1, 1)], ids=shape_str)
+@pytest.mark.parametrize("shape", UNALIGNED_SHAPES, ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_unaligned_shapes_neg(
@@ -72,16 +73,7 @@ def test_unaligned_shapes_neg(
     )
 
 
-@pytest.mark.parametrize(
-    "shape",
-    UNALIGNED_SHAPES
-    + [
-        pytest.param(
-            (677, 1, 1), marks=pytest.mark.skip_config(["n150"])
-        ),  # TODO (anuragsingh): Fix nondeterministic issue with Allocator for this test.
-    ],
-    ids=shape_str,
-)
+@pytest.mark.parametrize("shape", UNALIGNED_SHAPES, ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_unaligned_shapes_add(

--- a/test/python/golden/d2m/test_unary.py
+++ b/test/python/golden/d2m/test_unary.py
@@ -259,11 +259,11 @@ def tanh(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = N
 
 unary_ops = [
     abs,
-    acos | Marks(pytest.mark.skip_config(["ttmetal"])),
-    asin | Marks(pytest.mark.skip_config(["ttmetal"])),
-    asinh | Marks(pytest.mark.skip_config(["ttmetal"])),
-    atan | Marks(pytest.mark.skip_config(["ttmetal"])),
-    cbrt | Marks(pytest.mark.skip_config(["ttmetal"])),
+    acos | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+    asin | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+    asinh | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+    atan | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
+    cbrt | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
     ceil,
     cos,
     erf,
@@ -273,15 +273,15 @@ unary_ops = [
     exp2 | SkipIf("ttnn", "emitc", "emitpy"),
     floor,
     gelu,
-    is_finite | Marks(pytest.mark.skip_config(["ttmetal"])),
+    is_finite | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
     log,
     log1p,
     logical_not,
-    mish | Marks(pytest.mark.skip_config(["ttmetal"])),
+    mish | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
     neg,
     reciprocal,
     relu,
-    relu6 | Marks(pytest.mark.skip_config(["ttmetal"])),
+    relu6 | Marks(pytest.mark.xfail(reason="Not implemented", strict=True)),
     rsqrt,
     sigmoid,
     sign,
@@ -329,7 +329,7 @@ def test_unary_ops(
         "relu",
         "sign",
     }:
-        pytest.skip("int32 unary op is not in the allowlist for this test")
+        pytest.xfail("int32 unary op is not in the allowlist for this test")
 
     # tt-metal #41850 replaced the SFPU erf kernel with a LUT-based rational
     # approximation. The new kernel reads the input as a float, so int32 bit
@@ -337,10 +337,10 @@ def test_unary_ops(
     # TTNN pipeline inserts a bf16 typecast workaround around ttnn.erf for
     # integer inputs (see TTNNWorkaroundsPass), but the TTMetal pipeline
     # lowers ttir.erf directly into a D2M tile op without that workaround.
-    # Skip until a TTIR-level decomposition is added for ttmetal.
+    # Xfail until a TTIR-level decomposition is added for ttmetal.
     # Tracking issue: https://github.com/tenstorrent/tt-mlir/issues/8105
     if dtype == torch.int32 and test_fn is erf and target == "ttmetal":
-        pytest.skip(
+        pytest.xfail(
             "erf with int32 input is not supported on ttmetal yet; "
             "TTNN typecast workaround doesn't apply to the ttmetal pipeline. "
             "See https://github.com/tenstorrent/tt-mlir/issues/8105"

--- a/test/python/golden/d2m/test_virtual_grid_rowmajor.py
+++ b/test/python/golden/d2m/test_virtual_grid_rowmajor.py
@@ -108,7 +108,7 @@ def constructNDVirtualGridAffineMap(
     return map
 
 
-@pytest.mark.skip(reason="Still in development")
+@pytest.mark.xfail(reason="Still in development", strict=True)
 @pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.parametrize(
     "shape, grid_shape",

--- a/test/python/golden/pytest.ini
+++ b/test/python/golden/pytest.ini
@@ -7,5 +7,6 @@ markers =
   llmbox: mark test as running on llmbox
   frontend(fe_name): denotes which builder frontend this uses (ttir vs shlo)
   skip_config(config, ... reason=None): skip test if all of the specified targets/backends per config are present
+  xfail_config(config, ... reason=None, strict=True): xfail test if all of the specified targets/backends per config are present
   only_config(config, ... reason=None): only run test if all of the specified targets/backends per config are present
   skip_exec(config, ... reason=None): compile test but skip execution if all of the specified targets/backends per config are present. The test function must retrieve the skip_exec flag with 'skip_exec = getattr(request.node, "skip_exec", False)' and pass it to compile_and_execute_* functions. The test will be marked as xfail when conditions match.

--- a/test/python/golden/test_utils.py
+++ b/test/python/golden/test_utils.py
@@ -63,10 +63,17 @@ class SkipIf:
     >>> test_case | SkipConfig("ttmetal", ["ttnn", "sim"])
     """
 
-    def __init__(self, *marks_groups, mark_fn=pytest.mark.skip_config, reason=None):
+    def __init__(
+        self,
+        *marks_groups,
+        mark_fn=pytest.mark.skip_config,
+        reason=None,
+        marker_kwargs=None,
+    ):
         self.marks_groups = [g if isinstance(g, list) else [g] for g in marks_groups]
         self.mark_fn = mark_fn
         self.reason = reason
+        self.marker_kwargs = dict(marker_kwargs or {})
 
     def __ror__(self, lhs):
         """
@@ -82,7 +89,9 @@ class SkipIf:
         pytest.param
             Marked test parameter
         """
-        kwargs = {"reason": self.reason} if self.reason is not None else {}
+        kwargs = self.marker_kwargs.copy()
+        if self.reason is not None:
+            kwargs["reason"] = self.reason
         return pytest.param(
             lhs, marks=[self.mark_fn(g, **kwargs) for g in self.marks_groups]
         )
@@ -91,6 +100,16 @@ class SkipIf:
 class OnlyIf(SkipIf):
     def __init__(self, *marks_groups):
         super().__init__(*marks_groups, mark_fn=pytest.mark.only_config)
+
+
+class XFailIf(SkipIf):
+    def __init__(self, *marks_groups, reason=None, strict=True):
+        super().__init__(
+            *marks_groups,
+            mark_fn=pytest.mark.xfail_config,
+            reason=reason,
+            marker_kwargs={"strict": strict},
+        )
 
 
 class SkipExecIf(SkipIf):


### PR DESCRIPTION
### What's changed
- In D2M builder tests, prefer strict `xfail` over `skip` so when a test is "accidentally" fixed, the user can be aware of it and remove the marker (so it doesn't silently regress again).
  - TTSim markers stay `skip` because sim failures typically aborts the entire test process.
- Tighten several tests that are now passing.
- Also updated the builder test framework to make sure `reason` and `strict` are forwarded correctly, then sourced from the same matching marker.