### PR TITLE
fix pykernel-demo dependency

### DIFF
--- a/test/pykernel/demo/CMakeLists.txt
+++ b/test/pykernel/demo/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 add_custom_target(pykernel-demo
     COMMENT "Running PyKernel demo tests"
     COMMAND pytest ${CMAKE_CURRENT_SOURCE_DIR}/test.py
-    DEPENDS pykernel)
+    DEPENDS TTPykernelModules)
 
 # Add info message for demo completion
 add_custom_command(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
pykernel was removed in commit fe730835f, but the pykernel-demo dependency was not updated.

### What's changed
remove dependency of pykernel in pykernel-demo
add dependency of TTPykernelModules in pykernel-demo

### Checklist
- [ ] New/Existing tests provide coverage for changes
