### PR TITLE
[ttsim] Update sim D2M coverage and bump up version

### DIFF
--- a/.claude/skills/uplift-ttsim-ci/SKILL.md
+++ b/.claude/skills/uplift-ttsim-ci/SKILL.md
@@ -5,22 +5,75 @@ description: Uplift the TTSim version used by tt-mlir CI and refresh WH/BH simul
 
 # Uplift TTSim CI
 
-## Scope
+Follow the stages below in order. Do not move the regression sweep ahead of
+unskip triage, and do not stop after unskip triage.
 
-Focus on `.github/workflows/call-test-ttsim.yml` and the WH/BH golden D2M tests listed there. Do not spend uplift time on Quasar/QSR unless the user asks.
+## Definition of Done
 
-## Release Update
+An uplift is complete only when all of these are true:
 
-1. Find the latest public TTSim release from `tenstorrent/ttsim` tags or releases.
-2. Confirm the release has both `libttsim_wh.so` and `libttsim_bh.so`.
-3. Update the workflow input default:
+1. The release tag and both WH/BH assets are verified.
+2. Every applicable simulator-skip node is inventoried before testing.
+3. Every executable candidate is run in its own pytest process on each
+   applicable architecture, and the skip edits are resolved.
+4. The temporary `noop` edit is restored.
+5. Every workflow-listed file is run, one file per pytest process, on both WH
+   and BH after the skip edits.
+6. Changed skip files are rerun on both architectures, the workflow is
+   syntax-checked, and the final diff contains no triage-only edits.
 
-```yaml
-ttsim-version:
-  default: "vX.Y.Z"
+If any stage is incomplete, report the coverage gap; do not call the uplift
+done.
+
+## Ground Rules
+
+- `.github/workflows/call-test-ttsim.yml` is the source of truth for the test
+  list, matrix, descriptors, and assets. Re-read it at the start; never reuse a
+  stale test list copied into this skill.
+- Cover `wormhole_b0` and `blackhole`. Ignore Quasar/QSR unless requested.
+- A TTSim error may terminate pytest with no summary, sometimes with exit code
+  `1` rather than a signal-derived code. During unskip triage, one exact node
+  per pytest process is mandatory. A whole-file run with skips disabled is not
+  valid unskip evidence.
+- Serialise candidate nodes within one architecture. WH and BH may run in
+  parallel because they have separate simulator homes, libraries, descriptors,
+  artifact paths, and logs.
+- Use `/opt/ttmlir-toolchain/venv/bin/python -m pytest`; the local `pytest`
+  wrapper may hide useful output.
+- Before local commands, activate without `set -u`; activation expects some
+  variables to be unset:
+
+```bash
+unset BUILD_DIR
+source env/activate
+export BUILD_DIR="$PWD/build"
 ```
 
-4. Keep the workflow matrix focused on:
+## Stage 1: Freeze the Release and CI Scope
+
+1. Find the latest public release of `tenstorrent/ttsim`.
+2. Verify that it contains both `libttsim_wh.so` and `libttsim_bh.so`.
+3. Record the release tag, publication time, asset names, current tt-mlir SHA,
+   and current tt-metal SHA.
+4. Record the initial `git status --short`; preserve unrelated user changes.
+5. Extract the exact `.py` arguments from the `Run golden pytest on TTSim`
+   step into a shell `TEST_FILES` array and print it for review:
+
+```bash
+mapfile -t TEST_FILES < <(
+  awk '/^[[:space:]]+pytest /,/--sys-desc/ {
+    if ($1 ~ /\.py$/) print $1
+  }' .github/workflows/call-test-ttsim.yml
+)
+((${#TEST_FILES[@]} > 0)) || {
+  echo "No TTSim workflow tests found"
+  exit 1
+}
+printf '%s\n' "${TEST_FILES[@]}"
+```
+
+6. Update only the workflow's `ttsim-version` default unless the current
+   release requires a justified matrix/setup change. Keep this matrix:
 
 ```yaml
 - arch: wormhole_b0
@@ -31,81 +84,229 @@ ttsim-version:
   ttsim_asset: libttsim_bh.so
 ```
 
-5. Make these simulator env vars available to locally validate & refresh pytest ttsim skips:
+## Stage 2: Create Independent WH/BH Environments
+
+Use a versioned root and separate result directories:
 
 ```bash
-TT_METAL_HOME="$PWD/third_party/tt-metal/src/tt-metal"
-TT_METAL_SLOW_DISPATCH_MODE=1
-TT_METAL_DISABLE_SFPLOADMACRO=1
-TT_METAL_SIMULATOR=/path/to/libttsim_wh.so-or-libttsim_bh.so
-```
+export TTSIM_VERSION=vX.Y.Z
+export TTSIM_ROOT="${TMPDIR:-/tmp}/ttmlir-ttsim/$TTSIM_VERSION"
+mkdir -p \
+  "$TTSIM_ROOT/wormhole_b0" \
+  "$TTSIM_ROOT/blackhole" \
+  "$TTSIM_ROOT/results/wormhole_b0" \
+  "$TTSIM_ROOT/results/blackhole"
 
-## Local Setup
+curl -L --fail --retry 3 \
+  -o "$TTSIM_ROOT/wormhole_b0/libttsim_wh.so" \
+  "https://github.com/tenstorrent/ttsim/releases/download/$TTSIM_VERSION/libttsim_wh.so"
+curl -L --fail --retry 3 \
+  -o "$TTSIM_ROOT/blackhole/libttsim_bh.so" \
+  "https://github.com/tenstorrent/ttsim/releases/download/$TTSIM_VERSION/libttsim_bh.so"
 
-Use one folder per arch so WH/BH results can run independently:
-
-```bash
-mkdir -p ttsim/vX.Y.Z/wormhole_b0 ttsim/vX.Y.Z/blackhole
-curl -L --fail -o ttsim/vX.Y.Z/wormhole_b0/libttsim_wh.so \
-  https://github.com/tenstorrent/ttsim/releases/download/vX.Y.Z/libttsim_wh.so
-curl -L --fail -o ttsim/vX.Y.Z/blackhole/libttsim_bh.so \
-  https://github.com/tenstorrent/ttsim/releases/download/vX.Y.Z/libttsim_bh.so
 cp third_party/tt-metal/src/tt-metal/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml \
-  ttsim/vX.Y.Z/wormhole_b0/soc_descriptor.yaml
+  "$TTSIM_ROOT/wormhole_b0/soc_descriptor.yaml"
 cp third_party/tt-metal/src/tt-metal/tt_metal/soc_descriptors/blackhole_140_arch.yaml \
-  ttsim/vX.Y.Z/blackhole/soc_descriptor.yaml
+  "$TTSIM_ROOT/blackhole/soc_descriptor.yaml"
 ```
 
-Before every local command, avoid re-activation path corruption. Do not source `env/activate` under `set -u`; the activation script expects unset variables during initialization.
+Override `TTSIM_ROOT` with a durable path when logs must survive a reboot, but
+keep generated binaries, artifacts, and reports outside the git working tree.
+
+Set common variables once:
 
 ```bash
-unset BUILD_DIR
-source env/activate
-export BUILD_DIR="$PWD/build"
-```
-
-Generate one system descriptor per arch:
-
-```bash
+export TT_MLIR_HOME="$PWD"
 export TT_METAL_HOME="$PWD/third_party/tt-metal/src/tt-metal"
 export TT_METAL_SLOW_DISPATCH_MODE=1
 export TT_METAL_DISABLE_SFPLOADMACRO=1
-export LD_LIBRARY_PATH="$PWD/build/lib:${TTMLIR_TOOLCHAIN_DIR}/lib:${LD_LIBRARY_PATH}"
-
-export TT_METAL_SIMULATOR_HOME="$PWD/ttsim/vX.Y.Z/wormhole_b0"
-export TT_METAL_SIMULATOR="$TT_METAL_SIMULATOR_HOME/libttsim_wh.so"
-ttrt query --save-artifacts --artifact-dir "$TT_METAL_SIMULATOR_HOME/ttrt-artifacts" --quiet
-
-export TT_METAL_SIMULATOR_HOME="$PWD/ttsim/vX.Y.Z/blackhole"
-export TT_METAL_SIMULATOR="$TT_METAL_SIMULATOR_HOME/libttsim_bh.so"
-ttrt query --save-artifacts --artifact-dir "$TT_METAL_SIMULATOR_HOME/ttrt-artifacts" --quiet
+export TT_METAL_INSPECTOR=0
+export TT_METAL_INSPECTOR_RPC=0
+export LD_LIBRARY_PATH="$PWD/build/lib:${TTMLIR_TOOLCHAIN_DIR}/lib:${LD_LIBRARY_PATH:-}"
 ```
 
-## Refresh Skips
-
-1. Inspect simulator skips in the exact files passed by the workflow.
-2. Triage with existing `sim` skips disabled, but do not leave triage-only edits in the final diff. A temporary edit to `test/python/golden/conftest.py` can make `_get_current_environment()` return `"silicon"` while `TT_METAL_SIMULATOR` remains set; restore it before final verification.
-3. Prefer precise marks: skip a dtype, shape, op, or arch-specific case instead of an entire file/test.
-4. A single config list is AND'd (subset match), while separate args/groups are OR'd: `skip_config(["n150", "sim"])` skips only WH-sim (single-chip WH `board_id` is `n150`, not `wh`), whereas `SkipIf("n150", "sim")` would skip on WH *or* sim — keep the inner brackets.
-5. Keep non-simulator skips intact. For example, `SkipIf("ttnn", "emitc", "emitpy", "sim")` should usually become `SkipIf("ttnn", "emitc", "emitpy")` if the op now passes on WH/BH TTSim.
-6. If a run aborts inside TTSim, isolate with a single pytest node or a narrow `-k` expression and keep/add the smallest simulator skip that avoids the abort.
-7. When validating a skip refresh, collect the simulator-only node IDs and run them in isolated pytest subprocesses. This keeps one TTSim `UndefinedBehavior` abort from hiding the rest of the skip list. Exclude unconditional `pytest.mark.skip` cases from the executable checklist, but record them separately so they are not mistaken for validated simulator passes.
-
-Run raw pytest through the venv Python for readable output; the local `pytest` console script may summarize through tools like `rtk` and hide details:
+Build the current checkout before testing; results from stale tt-mlir or
+tt-metal binaries are invalid:
 
 ```bash
-/opt/ttmlir-toolchain/venv/bin/python -m pytest -q \
-  test/python/golden/d2m/test_unary.py \
-  --sys-desc "$TT_METAL_SIMULATOR_HOME/ttrt-artifacts/system_desc.ttsys" \
-  --path "$TT_METAL_SIMULATOR_HOME/pytest_artifacts" \
-  --tb=short
+cmake --build "$BUILD_DIR"
 ```
 
-Use the latest list of tests in the workflow file for full validation.
+Generate and retain one system descriptor per architecture. These commands may
+run in parallel:
 
-## Final Checks
+```bash
+export TT_METAL_SIMULATOR_HOME="$TTSIM_ROOT/wormhole_b0"
+export TT_METAL_SIMULATOR="$TT_METAL_SIMULATOR_HOME/libttsim_wh.so"
+ttrt query --save-artifacts \
+  --artifact-dir "$TT_METAL_SIMULATOR_HOME/ttrt-artifacts" --quiet
 
-- Restore all temporary triage edits, especially `conftest.py`.
-- Run focused WH and BH pytest for every changed skip file.
-- Run or at least syntax-check the workflow YAML if local CI tooling is available.
-- Summarize the release tag, assets tested, descriptors used, skip changes, and any full-suite coverage gaps.
+export TT_METAL_SIMULATOR_HOME="$TTSIM_ROOT/blackhole"
+export TT_METAL_SIMULATOR="$TT_METAL_SIMULATOR_HOME/libttsim_bh.so"
+ttrt query --save-artifacts \
+  --artifact-dir "$TT_METAL_SIMULATOR_HOME/ttrt-artifacts" --quiet
+```
+
+Do not share `TT_METAL_SIMULATOR_HOME`, `--sys-desc`, `--path`, or result logs
+between architectures.
+
+## Stage 3: Plan the Unskip Matrix
+
+Complete the candidate plan before executing candidates.
+
+1. Search only the workflow-listed files for `sim` skip sites. Record file,
+   line, mark, parameter scope, and intended architecture in
+   `sim-mark-sites.txt`.
+
+```bash
+rg -n '\bsim\b' "${TEST_FILES[@]}" > sim-mark-sites.txt
+```
+
+2. With the normal environment detection (`"sim"`), collect exact skipped node
+   IDs on WH and BH without executing tests:
+
+```bash
+COLUMNS=10000 /opt/ttmlir-toolchain/venv/bin/python -m pytest \
+  --setup-plan -vv --color=no "${TEST_FILES[@]}" \
+  --sys-desc "$TT_METAL_SIMULATOR_HOME/ttrt-artifacts/system_desc.ttsys" \
+  2>&1 |
+  awk '/ SKIPPED/ {sub(/[[:space:]]+SKIPPED.*/, ""); print}' |
+  LC_ALL=C sort -u
+```
+
+Save this once per architecture as `all-skipped-before-noop.txt`.
+
+3. Temporarily change `_get_current_environment()` in
+   `test/python/golden/conftest.py` to return `"noop"` when
+   `TT_METAL_SIMULATOR` is set. Do not add `noop` to `ALL_ENVIRONMENTS`.
+   Simulator marks no longer match, while unconditional skips, non-simulator
+   skips, and `only_config` behavior remain active.
+4. Repeat the setup-plan collection into `still-skipped-with-noop.txt`.
+5. Both files must be sorted. Produce the executable candidate list with:
+
+```bash
+comm -23 \
+  all-skipped-before-noop.txt \
+  still-skipped-with-noop.txt \
+  > candidates.txt
+```
+
+Review every source mark against the resulting WH/BH lists. Record sim-marked
+nodes that remain skipped under `noop` in `not-executable.txt`; do not count
+them as tested or remove their simulator mark without other evidence. Freeze
+the two candidate lists before execution and record their counts.
+
+## Stage 4: Run Every Candidate in Isolation
+
+Keep the `noop` edit active. For each architecture, run the corresponding
+`candidates.txt` serially. Quote each complete node ID:
+
+```bash
+timeout --signal=TERM --kill-after=10s 180s \
+  env PYTHONUNBUFFERED=1 \
+  /opt/ttmlir-toolchain/venv/bin/python -m pytest -svvv "$node_id" \
+  --sys-desc "$TT_METAL_SIMULATOR_HOME/ttrt-artifacts/system_desc.ttsys" \
+  --path "$TT_METAL_SIMULATOR_HOME/pytest_artifacts_candidates" \
+  --tb=short -rs
+```
+
+Write one log per node plus a TSV/JSON manifest containing architecture,
+node ID, elapsed time, exit code, and result. Continue after nonzero exits and
+print progress after every node. WH and BH loops may run concurrently, but
+never group multiple node IDs into one pytest invocation. Keep `-s` enabled so
+pytest capture cannot swallow the last TTSim error when the process exits.
+
+Classify results from both exit status and the pytest terminal summary:
+
+- `passed`: pytest reports the node passed. This is the only automatic unskip
+  evidence.
+- `failed`: pytest prints a normal failure/error summary.
+- `aborted`: the process ends without a pytest terminal summary, even if its
+  exit code is only `1`.
+- `timed_out`: the 180-second timeout expires.
+- `skipped`, `xfailed`, or `xpassed`: record separately; none proves a clean
+  simulator pass.
+
+For an empty or unclear abort log, rerun that exact node with
+`PYTHONUNBUFFERED=1 -svvv`. Do not rerun a group.
+
+After the matrix is complete:
+
+- Remove a simulator mark only when every architecture to which it applies
+  passed.
+- Narrow mixed results to the smallest dtype, shape, op, or architecture
+  scope. Single-chip WH is `n150`; single-chip BH is `p150`.
+- If a mark on one parametrization axis mixes passing and failing combinations
+  from another axis, restructure the parametrization so the mark names the
+  exact combinations; do not retain the broad axis-level skip.
+- A config list is AND'd; separate groups are OR'd.
+  `skip_config(["n150", "sim"])` means WH simulator only, while
+  `SkipIf("n150", "sim")` means `n150` **or** any simulator.
+- Preserve unrelated skips. For example, if only `sim` is obsolete in
+  `SkipIf("ttnn", "emitc", "emitpy", "sim")`, keep
+  `SkipIf("ttnn", "emitc", "emitpy")`.
+
+If behavior differs from the previous TTSim version, run the smallest failing
+node against both versions with the same tt-mlir checkout and corresponding
+system descriptors.
+
+## Stage 5: Restore Triage State
+
+Restore `_get_current_environment()` to return `"sim"` before any final
+validation. Inspect the diff rather than using a destructive checkout, and
+verify that `conftest.py` has no triage-only change. Keep the candidate
+manifests as validation artifacts, not source changes.
+
+## Stage 6: Run the Full Regression Sweep
+
+This stage is mandatory and happens after skip updates and `noop` restoration.
+
+Run every file in `TEST_FILES`, one file per pytest process, on WH and BH. Do
+not use one aggregate pytest command: an abort would hide the remaining files.
+Continue after failures. The two architecture loops may run in parallel.
+
+```bash
+timeout --signal=TERM --kill-after=15s 3600s \
+  env PYTHONUNBUFFERED=1 \
+  /opt/ttmlir-toolchain/venv/bin/python -m pytest -vv "$test_file" \
+  --sys-desc "$TT_METAL_SIMULATOR_HOME/ttrt-artifacts/system_desc.ttsys" \
+  --path "$TT_METAL_SIMULATOR_HOME/pytest_artifacts_regression" \
+  --tb=short -rs
+```
+
+Some files may take more than 30 minutes, but an individual node should not
+take more than about three minutes. Monitor each live `-vv` log at least every
+three minutes. If progress stops, terminate the file run, isolate the last
+reported node with the 180-second candidate command, update the smallest
+necessary skip, and rerun that file. A generous file timeout is not a
+substitute for progress monitoring.
+
+Record exactly one final status per file per architecture:
+
+- `passed`: pytest exits 0 with a terminal summary; expected skips/xfails are
+  allowed.
+- `failed`: pytest reports normal failures.
+- `aborted`: no pytest terminal summary, regardless of exit code.
+- `timed_out`: the file timeout expires.
+
+Any skip change made during regression requires a fresh run of that file on
+both architectures. Do not finish with an untriaged failed, aborted, or timed
+out file.
+
+## Stage 7: Final Verification and Handoff
+
+1. Run focused WH and BH pytest for every file whose skips changed.
+2. Verify all workflow-listed files have a final WH and BH status.
+3. Syntax-check `.github/workflows/call-test-ttsim.yml` with available local
+   tooling.
+4. Run `git diff --check` and inspect `git status` and the complete diff.
+5. Confirm `conftest.py` is restored and generated simulator assets/results
+   are not in the source diff.
+6. Summarize:
+   - release tag and verified asset names;
+   - descriptor YAML and generated `.ttsys` used per architecture;
+   - candidate counts and result totals per architecture;
+   - simulator skip removals, additions, and narrowings;
+   - per-file regression status for WH and BH;
+   - focused reruns and workflow validation;
+   - any explicit remaining coverage gap.

--- a/.github/workflows/call-test-ttsim.yml
+++ b/.github/workflows/call-test-ttsim.yml
@@ -16,7 +16,7 @@ on:
         description: "TTSim release tag"
         required: false
         type: string
-        default: "v1.9.1"
+        default: "v1.9.6"
       timeout:
         description: "Timeout in minutes for the TTSim test job"
         required: false
@@ -150,7 +150,7 @@ jobs:
           export TT_METAL_INSPECTOR_RPC="0"
           mkdir -p test_reports
 
-          pytest -ssv \
+          pytest -v \
             test/python/golden/d2m/test_binary.py \
             test/python/golden/d2m/test_ternary.py \
             test/python/golden/d2m/test_unary.py \

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -760,7 +760,8 @@ public:
     rewriter.setInsertionPointToStart(rewriter.getInsertionBlock());
     setInsertionPointAfterOperands(rewriter, {inCB, outCB},
                                    /*allowHoisting*/ true);
-    rewriter.create<ttkernel::InitSFPUOp>(store.getLoc(), inCB, outCB);
+    rewriter.create<ttkernel::ComputeKernelHWStartupOp>(store.getLoc(), inCB,
+                                                        nullptr, outCB);
     rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
 
     rewriter.create<ttkernel::CopyTileInitOp>(store.getLoc(), cb);

--- a/test/python/golden/d2m/test_bfp8_typecast.py
+++ b/test/python/golden/d2m/test_bfp8_typecast.py
@@ -139,8 +139,9 @@ def test_cos_bf16(shape: Shape, target: str, request, device):
     )
 
 
-@pytest.mark.skip(
-    reason="Flaky: times out on device causing entire CI workflow to be cancelled. See https://github.com/tenstorrent/tt-mlir/issues/7656"
+@pytest.mark.skip_exec(
+    ("p150",),
+    reason="Flaky: times out on device causing entire CI workflow to be cancelled. See https://github.com/tenstorrent/tt-mlir/issues/7656",
 )
 @pytest.mark.parametrize(
     "shape",

--- a/test/python/golden/d2m/test_composite_ops.py
+++ b/test/python/golden/d2m/test_composite_ops.py
@@ -12,6 +12,7 @@ from builder.base.builder_apis import compile_and_execute_ttir
 
 pytestmark = pytest.mark.frontend("ttir")
 
+
 # =============================================================================
 # SDPA decomposition tests — exercise is_causal, scale, attention_mask
 # =============================================================================
@@ -149,7 +150,7 @@ def test_sdpa_decomposition(
     "shapes,mask_shape,is_causal,scale",
     [
         # Explicit mask, non-causal (broadcast batch+heads)
-        (
+        pytest.param(
             [(1, 8, 64, 64), (1, 8, 64, 64), (1, 8, 64, 64)],
             (1, 1, 64, 64),
             False,

--- a/test/python/golden/d2m/test_dma.py
+++ b/test/python/golden/d2m/test_dma.py
@@ -14,7 +14,6 @@ from builder.base.builder_utils import Operand, Shape
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir
 from conftest import get_request_kwargs
-from test_utils import SkipIf
 
 pytestmark = pytest.mark.frontend("ttir")
 
@@ -323,7 +322,10 @@ def test_tensor_accessor_dma_tiled_vgm(
     )
 
 
-@pytest.mark.parametrize("target", ["ttmetal" | SkipIf(["n150", "sim"])])
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.skip_exec(
+    ("n150", "sim"), reason="TEN-3868 LLK f32 tilize undefined behavior"
+)
 def test_tensor_accessor_binary_add(
     target: str,
     request,
@@ -456,7 +458,6 @@ def test_tensor_accessor_matmul(
         device=device,
         custom_pipeline=pipeline,
         **get_request_kwargs(request),
-        pcc=0.97,
     )
 
 

--- a/test/python/golden/d2m/test_dram_ops.py
+++ b/test/python/golden/d2m/test_dram_ops.py
@@ -21,6 +21,7 @@ from test_utils import shape_str
 
 pytestmark = pytest.mark.frontend("ttir")
 
+
 DRAM_PIPELINE_OPTIONS = [
     "default-input-memspace=dram",
     "default-output-memspace=dram",
@@ -527,7 +528,6 @@ DRAM_EMBEDDING_CASES = [
         (1024, 32),
         torch.uint32,
         torch.int32,
-        marks=pytest.mark.skip_config(["n150", "sim"]),
         id="ui32_indices_i32_table_1x32_1024x32",
     ),
     pytest.param(

--- a/test/python/golden/d2m/test_tms.py
+++ b/test/python/golden/d2m/test_tms.py
@@ -52,7 +52,9 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
         pytest.param(
             (32, 128 * 500),
             [1, 0],
-            marks=pytest.mark.skip_config(["n150", "sim"]),
+            marks=pytest.mark.xfail_config(
+                ["n150", "sim"], reason="ttsim WH grid is 9×8", strict=True
+            ),
         ),
         pytest.param(
             (32, 128 * 501),
@@ -372,8 +374,8 @@ def shapes_to_id(shapes) -> str:
     [
         torch.float32,
         torch.bfloat16,
-        torch.int32 | SkipIf("sim"),
-        torch.int64 | SkipIf("sim"),
+        torch.int32 | SkipIf(["n150", "sim"]),
+        torch.int64 | SkipIf(["n150", "sim"]),
         torch.bool,
     ],
     ids=["f32", "bf16", "i32", "i64", "i1"],
@@ -722,13 +724,18 @@ def test_uncollapsed_tensors(
 
     pipeline_options = f"{{collapse-tensors-2d={str(collapse_tensors).lower()}}}"
     pipeline = f"ttir-to-ttmetal-pipeline{pipeline_options}"
+    request_kwargs = get_request_kwargs(request)
+    request_kwargs["test_base"] = (
+        f"{request.node.name}_{test_name}_"
+        f"{'collapsed' if collapse_tensors else 'non_collapsed'}"
+    )
 
     compile_and_execute_ttir(
         test_func,
         target=target,
         custom_pipeline=pipeline,
-        test_base=f"{request.node.name}_{test_name}_{'collapsed' if collapse_tensors else 'non_collapsed'}",
         device=device,
+        **request_kwargs,
     )
 
 
@@ -812,6 +819,7 @@ def test_rearrange(
 # Data-movement op mirrors (concat/slice/transpose/typecast/pad,
 # previously test_data_movement.py).
 # ============================================================
+
 
 # Concat tests
 @pytest.mark.parametrize(
@@ -943,7 +951,7 @@ def test_concat(shapes: List[Shape], dim: int, target: str, request, device):
     )
 
 
-# Skipping WH sim due to issue https://github.com/tenstorrent/ttsim-private/issues/291
+# Skipping i32 WH sim due to issue https://github.com/tenstorrent/ttsim-private/issues/291
 @pytest.mark.parametrize(
     "shape,repeat_dims",
     [
@@ -957,9 +965,15 @@ def test_concat(shapes: List[Shape], dim: int, target: str, request, device):
     ],
 )
 @pytest.mark.parametrize(
-    "dtype", [torch.float32, torch.int32, torch.bfloat16], ids=["f32", "i32", "bf16"]
+    "dtype",
+    [
+        torch.float32,
+        torch.int32 | SkipIf(["n150", "sim"]),
+        torch.bfloat16,
+    ],
+    ids=["f32", "i32", "bf16"],
 )
-@pytest.mark.parametrize("target", ["ttmetal" | SkipIf(["n150", "sim"])])
+@pytest.mark.parametrize("target", ["ttmetal"])
 def test_repeat(shape: Shape, repeat_dims: List[int], dtype, target, request, device):
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])


### PR DESCRIPTION
### What's changed
- Uplift ttsim to 1.9.6.
- Un-skip or narrow down several tests fixed by the uplift.
- Update skill file.
- Fix a bug uncovered by ttsim 1.9.4+:
  - According to ttsim author: we should flush denormals on all matmuls, as the `!flush_denormals` behavior in RTL is extremely odd and nonintuitive and has extremely undesirable numerical properties. For example, it does not allow you to represent zero!
  - `compute_kernel_hw_startup()` resets the zero flag to `DEFAULT` (via `llk_math_hw_configure` -> `_configure_default_zero_flag_state_`), but it's only emitted once at the top of the kernel.
  - In `lowerCopyTile`, `init_sfpu()` is emitted for every `copy_tile()` operation. This hoists to the block start, after `compute_kernel_hw_startup()`, overriding the `DEFAULT` zero flag state.
    - `init_sfpu()` calls `_configure_unary_preserve_zero_flag_state_()` which sets `ALU_ACC_CTRL_Zero_Flag_disabled_src = 1 `(`UNARY_PRESERVE`, disables denormal flush, preserving bf16 -0.0). This is correct for SFPU unary operations.
  - `matmul_init() / matmul_block_init() / reduce_init()` do NOT reset the zero flag back to `DEFAULT`, they only configure the MOP program and address modes.
  - ttsim sees `MVMUL` with zero flag = 1 and rejects this combination with `UnsupportedFunctionality: tensix_matmul_op: ALU_ACC_CTRL_Zero_Flag_disabled_src=1 (keep SrcB denormals) not modeled.`
  - Fix: emit `compute_kernel_hw_startup()` for `copy_tile()`, it should have never been `init_sfpu()`.
- Fix another bug in `test_uncollapsed_tensors`:
  - The test forgot to pass `**get_request_kwargs(request)` to `compile_and_execute_ttir()`.
  - Compilation therefore uses the implicit `ttrt-artifacts/system_desc.ttsys`, while execution uses the descriptor supplied to pytest, causing failures on ttsim.