### PR TITLE
[optimizer] fix wrong layout decisions for cache ops

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -92,6 +92,14 @@ struct PagedFillCacheRuleBook : OpRuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 };
 
+/// PagedUpdateCache: cache (operand 0) DRAM-interleaved (see FillCache);
+/// update_index (operand 2) and page_table (operand 3) must be DRAM-interleaved
+/// row-major (kernel asserts non-sharded update_idxs is ROW_MAJOR +
+/// INTERLEAVED + DRAM).
+struct PagedUpdateCacheRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+};
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_TRANSFORMERRULES_H

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -731,11 +731,24 @@ void MemoryLayoutPropagation::applyInputLayoutFilter(
     if (candidates.empty()) {
       auto tensorType =
           mlir::cast<RankedTensorType>(op->getOperand(operandIdx).getType());
+      auto buildInterleaved = [&](Layout tensorLayout) {
+        return TTNNLayoutAttr::Builder(currentLayout, tensorType.getShape())
+            .setBufferType(BufferType::DRAM)
+            .setMemoryLayout(TensorMemoryLayout::Interleaved)
+            .setLayout(tensorLayout)
+            .build();
+      };
+      // Prefer the current layout; if the op's filter rejects it, flip to the
+      // opposite layout.
       InputCandidate ic;
-      ic.layout = TTNNLayoutAttr::Builder(currentLayout, tensorType.getShape())
-                      .setBufferType(BufferType::DRAM)
-                      .setMemoryLayout(TensorMemoryLayout::Interleaved)
-                      .build();
+      auto layoutAttr = buildInterleaved(currentLayout.getLayout());
+      if (!inputFilter(layoutAttr)) {
+        Layout oppositeLayout = currentLayout.getLayout() == Layout::Tile
+                                    ? Layout::RowMajor
+                                    : Layout::Tile;
+        layoutAttr = buildInterleaved(oppositeLayout);
+      }
+      ic.layout = layoutAttr;
       ic.producerCandidateIndex = 0;
       ic.isReshard = true;
       candidates.push_back(ic);

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -84,6 +84,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static MoeRuleBook moe;
   static FillCacheRuleBook fillCache;
   static PagedFillCacheRuleBook pagedFillCache;
+  static PagedUpdateCacheRuleBook pagedUpdateCache;
 
   static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
   static std::once_flag initFlag;
@@ -124,6 +125,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(PrepareMoEComputeW2WeightsOp::getOperationName(), &moe);
     reg(FillCacheOp::getOperationName(), &fillCache);
     reg(PagedFillCacheOp::getOperationName(), &pagedFillCache);
+    reg(PagedUpdateCacheOp::getOperationName(), &pagedUpdateCache);
   });
   auto it = registry.find(op->getName());
   return it != registry.end() ? *it->second : defaultRules;

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -110,6 +110,16 @@ static LayoutFilterFn cacheBufferDramOnlyFilter() {
   };
 }
 
+// Index operands (update_index, page_table, batch_idx): kernels assert the
+// non-sharded index is ROW_MAJOR + INTERLEAVED + DRAM. Require DRAM-interleaved
+// row-major (reject sharded, L1, and tiled).
+static LayoutFilterFn indexRowMajorFilter() {
+  return [](TTNNLayoutAttr layout) -> bool {
+    return !layout.isTiled() &&
+           layout_filter_utils::requireDRAMInterleaved(layout);
+  };
+}
+
 LayoutFilterFn
 FillCacheRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
   if (operandIdx == 0) {
@@ -122,6 +132,24 @@ LayoutFilterFn
 PagedFillCacheRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
   if (operandIdx == 0) {
     return cacheBufferDramOnlyFilter();
+  }
+  if (operandIdx == 3) {
+    return indexRowMajorFilter();
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// PagedUpdateCache
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn
+PagedUpdateCacheRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
+  if (operandIdx == 0) {
+    return cacheBufferDramOnlyFilter();
+  }
+  if (operandIdx == 2 || operandIdx == 3) {
+    return indexRowMajorFilter();
   }
   return nullptr;
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/paged_fill_cache_batch_idx.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/paged_fill_cache_batch_idx.mlir
@@ -1,0 +1,20 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-kv-cache-dtype=bfp_bf8" -o %t %s -mlir-print-local-scope
+// RUN: FileCheck %s --input-file=%t
+
+// Regression: opt-2 with a bfp8 KV cache. The optimizer's layout decision for
+// the paged_fill_cache batch_idx operand (operand 3) must stay compatible with
+// the ttnn op. batch_idx is computed (argmax over a runtime input) so the
+// optimizer may relayout it.
+
+// CHECK: "ttnn.paged_fill_cache"
+func.func @main(
+    %cache: tensor<128x12x32x256xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.kv_cache},
+    %input: tensor<1x12x65x256xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+    %page_table: tensor<8x16xi32> {ttcore.argument_type = #ttcore.argument_type<input>},
+    %bidx_scores: tensor<1x4xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}
+) -> tensor<128x12x32x256xbf16> {
+    %batch_idx = "ttir.argmax"(%bidx_scores) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<1x4xbf16>) -> tensor<1xi32>
+    %0 = "ttir.paged_fill_cache"(%cache, %input, %page_table, %batch_idx) : (tensor<128x12x32x256xbf16>, tensor<1x12x65x256xbf16>, tensor<8x16xi32>, tensor<1xi32>) -> tensor<128x12x32x256xbf16>
+    return %0 : tensor<128x12x32x256xbf16>
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/paged_update_cache_index.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/paged_update_cache_index.mlir
@@ -1,0 +1,20 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-kv-cache-dtype=bfp_bf8" -o %t %s -mlir-print-local-scope
+// RUN: FileCheck %s --input-file=%t
+
+// Regression: at opt-2 with a bfp8 KV cache, the optimizer's layout decisions
+// for the paged_update_cache operands must stay compatible with the ttnn op.
+// The index is computed (argmax over a runtime input), so it is neither a
+// row-major-seeded integer argument nor const-evaluable -- the optimizer is
+// free to relayout it.
+
+// CHECK: "ttnn.paged_update_cache"
+func.func @main(
+    %cache: tensor<1x8x16x128xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.kv_cache},
+    %input: tensor<1x8x1x128xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+    %scores: tensor<1x4xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}
+) -> tensor<1x8x16x128xbf16> {
+    %idx = "ttir.argmax"(%scores) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<1x4xbf16>) -> tensor<1xi32>
+    %0 = "ttir.update_cache"(%cache, %input, %idx) <{batch_offset = 0 : i32}> : (tensor<1x8x16x128xbf16>, tensor<1x8x1x128xbf16>, tensor<1xi32>) -> tensor<1x8x16x128xbf16>
+    return %0 : tensor<1x8x16x128xbf16>
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/paged_update_cache_page_table.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/paged_update_cache_page_table.mlir
@@ -1,0 +1,21 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-kv-cache-dtype=bfp_bf8" -o %t %s -mlir-print-local-scope
+// RUN: FileCheck %s --input-file=%t
+
+// Regression: opt-2 with a bfp8 KV cache. 4-operand paged_update_cache -- the
+// optimizer's layout decision for the page_table operand (operand 3) must stay
+// compatible with the ttnn op. Both indices are computed (argmax over a runtime
+// input) so the optimizer may relayout them.
+
+// CHECK: "ttnn.paged_update_cache"
+func.func @main(
+    %cache: tensor<7x4x32x128xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.kv_cache},
+    %input: tensor<1x1x4x128xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+    %idx_scores: tensor<1x4xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+    %pt_scores: tensor<1x1x4xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}
+) -> tensor<7x4x32x128xbf16> {
+    %update_index = "ttir.argmax"(%idx_scores) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<1x4xbf16>) -> tensor<1xi32>
+    %page_table = "ttir.argmax"(%pt_scores) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<1x1x4xbf16>) -> tensor<1x1xi32>
+    %0 = "ttir.paged_update_cache"(%cache, %input, %update_index, %page_table) <{share_cache = false}> : (tensor<7x4x32x128xbf16>, tensor<1x1x4x128xbf16>, tensor<1xi32>, tensor<1x1xi32>) -> tensor<7x4x32x128xbf16>
+    return %0 : tensor<7x4x32x128xbf16>
+}


### PR DESCRIPTION
The `ttnn.paged_update_cache` and `ttnn.paged_fill_cache` ops require certain layout for operands. The optimizer isn't respecting those when:
- optimizer level 2 is enabled
- bfp8 KV Cache is enabled
- operands are not function arguments but are results of other ops.

For example, this TTIR:

```mlir
    func.func @main(
        %cache: tensor<1x8x16x128xbf16> {ttcore.kv_cache},
        %input: tensor<1x8x1x128xbf16>,
        %scores: tensor<1x4xbf16>) -> tensor<1x8x16x128xbf16> {
      %idx = "ttir.argmax"(%scores) <{dim_arg = [1 : i32], keep_dim = false}>
               : (tensor<1x4xbf16>) -> tensor<1xi32>
      %0 = "ttir.update_cache"(%cache, %input, %idx)
             <{batch_offset = 0 : i32}> : (tensor<1x8x16x128xbf16>,
             tensor<1x8x1x128xbf16>, tensor<1xi32>) -> tensor<1x8x16x128xbf16>
      return %0 : tensor<1x8x16x128xbf16>
    }
```

failed at optimizer level 2 with bfp8 KV cache, because the optimizer put the index in a tiled, height-sharded L1 layout:

```
    ttnn.paged_update_cache failed validation:
    TT_FATAL paged_update_cache_device_operation.cpp:210:
      update_idxs_tensor_val.layout() == Layout::ROW_MAJOR
      Expected update_idxs to have memory layout in ROW MAJOR
```

After the fix the index operand is DRAM-interleaved row-major:

```mlir
    "ttnn.paged_update_cache"(%arg0, %3, %4) <{share_cache = false}> :
        (..., tensor<1xsi32, ..., memref<1x1xsi32,
         #ttnn.buffer_type<dram>>, <interleaved>>) -> ()
```

Adds regression tests to verify that we can compile them.