### PR TITLE
[opmodel] fix ArangeOp constraint query

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -7429,8 +7429,8 @@ OpModel<mlir::tt::ttnn::ArangeOp>::getOpConstraints(
       deviceRef = *device;
 
   auto arangeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::arange, device, start.getInt(),
-                                end.getInt(), step.getInt(), dataType,
+    return QUERY_OP_CONSTRAINTS(::ttnn::arange, device, start.getSInt(),
+                                end.getSInt(), step.getSInt(), dataType,
                                 deviceRef, memoryConfig, layout);
   };
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -3804,10 +3804,11 @@ TEST_F(OpModelTest, ArangeOp) {
   const mlir::tt::ttnn::TTNNLayoutAttr inputLayout =
       CreateTiledLayout(inputTensorShape, mlir::tt::ttnn::BufferType::DRAM,
                         mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  // Create IntegerAttr parameters
-  ::mlir::IntegerAttr startAttr = builder.getI32IntegerAttr(0);
-  ::mlir::IntegerAttr endAttr = builder.getI32IntegerAttr(10);
-  ::mlir::IntegerAttr stepAttr = builder.getI32IntegerAttr(1);
+  // Create signed IntegerAttr parameters
+  ::mlir::Type si64 = builder.getIntegerType(64, /*isSigned=*/true);
+  ::mlir::IntegerAttr startAttr = builder.getIntegerAttr(si64, 0);
+  ::mlir::IntegerAttr endAttr = builder.getIntegerAttr(si64, 10);
+  ::mlir::IntegerAttr stepAttr = builder.getIntegerAttr(si64, 1);
 
   // Create optional dtype
   std::optional<mlir::tt::ttcore::DataType> dtype =

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -5214,10 +5214,11 @@ TEST_F(OpModelBase, ArangeOpInterface) {
   auto resultType =
       createRankedTensorType(tensorShape, builder.getBF16Type(), layout);
 
-  // Create ArangeOp with IntegerAttr parameters
-  auto startAttr = builder.getI64IntegerAttr(0);
-  auto endAttr = builder.getI64IntegerAttr(10);
-  auto stepAttr = builder.getI64IntegerAttr(2);
+  // Create ArangeOp with signed IntegerAttr parameters
+  auto si64 = builder.getIntegerType(64, /*isSigned=*/true);
+  auto startAttr = builder.getIntegerAttr(si64, 0);
+  auto endAttr = builder.getIntegerAttr(si64, 10);
+  auto stepAttr = builder.getIntegerAttr(si64, 2);
 
   auto arange = builder.create<ArangeOp>(builder.getUnknownLoc(), resultType,
                                          /*device=*/nullptr, startAttr, endAttr,


### PR DESCRIPTION
`ttnn.arange`'s start/end/step are signed (SI64Attr), but the ArangeOp OpModel read them via `IntegerAttr::getInt()`, which asserts the attr is signless. So any OpModel constraint query on an arange (optimization level >= 1) aborts:

```
 IntegerAttr::getInt(): Assertion `... isSignlessInteger() ...' failed.
```

The attrs were flipped signless -> signed in #8800 without updating these calls. Switch them to `getSInt()`.