### PR TITLE
[TTNN] Keep data-movement ops row-major when tile-pad waste >= 1 GiB

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -239,10 +239,13 @@ public:
       Location newLoc =
           appendInputSuffix(op->getLoc(), operand.getOperandNumber());
 
+      // Movement ops with a large tile-pad-waste input stay row-major.
+      bool tiled = !movementStaysRowMajor(op);
+
       // Given the operand constraint, create the desired layout for the operand
       std::optional<Value> desiredLayout = createToLayoutOp(
           rewriter, newLoc, operand.get(), g_defaultMemorySpaceDevice,
-          /*tiled=*/true);
+          /*tiled=*/tiled);
 
       // If layout changed update the operand
       if (desiredLayout) {
@@ -272,6 +275,11 @@ public:
 private:
   bool shouldTilizeResult(Operation *op) const {
 
+    // Movement ops with a large tile-pad-waste input stay row-major.
+    if (movementStaysRowMajor(op)) {
+      return false;
+    }
+
     // TTNN Reshape does not support implicit tilization/untilization
     // Therefore input output layouts should be the same
     if (auto reshapeOp = mlir::dyn_cast<ttir::ReshapeOp>(op)) {
@@ -288,6 +296,43 @@ private:
     }
 
     return true;
+  }
+
+  // Pure data-movement ops (valid in row-major).
+  static bool isTensorMovementOp(Operation *op) {
+    return op->hasTrait<ttir::TensorManipulation::Trait>() ||
+           mlir::isa<ttir::SliceStaticOp>(op);
+  }
+
+  // Bytes wasted by padding the last two dims to 32x32 tiles.
+  static int64_t tilePadWasteBytes(RankedTensorType ty) {
+    int64_t rank = ty.getRank();
+    // Skip <2D and non-int/float (e.g. quantized) elements: no bit width.
+    if (rank < 2 || !ty.getElementType().isIntOrFloat()) {
+      return 0;
+    }
+    constexpr int64_t tileH = ttcore::TileType::getDefaultShape()[0];
+    constexpr int64_t tileW = ttcore::TileType::getDefaultShape()[1];
+    int64_t logical = 1, padded = 1;
+    for (int64_t i = 0; i < rank; ++i) {
+      int64_t d = ty.getDimSize(i);
+      logical *= d;
+      if (i == rank - 2) {
+        d = ((d + tileH - 1) / tileH) * tileH;
+      } else if (i == rank - 1) {
+        d = ((d + tileW - 1) / tileW) * tileW;
+      }
+      padded *= d;
+    }
+    return (padded - logical) * (ty.getElementTypeBitWidth() / 8);
+  }
+
+  // Movement op whose input tile-pad waste is >= 1 GiB.
+  static bool movementStaysRowMajor(Operation *op) {
+    constexpr int64_t kMinWasteBytes = 1LL * 1024 * 1024 * 1024;
+    return isTensorMovementOp(op) &&
+           tilePadWasteBytes(mlir::cast<RankedTensorType>(
+               op->getOperand(0).getType())) >= kMinWasteBytes;
   }
 };
 } // namespace

--- a/test/ttmlir/Dialect/TTNN/Transforms/tile_pad_waste_row_major.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/tile_pad_waste_row_major.mlir
@@ -1,0 +1,32 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --mlir-print-local-scope %s | FileCheck %s
+
+// A movement op stays row-major when tiling its input wastes >= 1 GiB (the
+// HiDream RoPE freqs `...x2x2` blow-up). Shapes mimic the model.
+module {
+  // freqs slice: input 1x4480x1x64x2x2 tiles to ~1.17 GiB of padding -> row-major.
+  // CHECK-LABEL: @rope_freqs_slice_row_major
+  func.func @rope_freqs_slice_row_major(%arg0: tensor<1x4480x1x64x2x2xf32> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<1x4480x1x64x2x1xf32> {
+    // CHECK: ttir.slice_static
+    // CHECK-SAME: -> tensor<1x4480x1x64x2x1xf32, {{.*}}memref<{{[0-9x]+}}xf32,
+    %0 = "ttir.slice_static"(%arg0) <{begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32, 0 : i32, 0 : i32], ends = [1 : i32, 4480 : i32, 1 : i32, 64 : i32, 2 : i32, 1 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1x4480x1x64x2x2xf32>) -> tensor<1x4480x1x64x2x1xf32>
+    return %0 : tensor<1x4480x1x64x2x1xf32>
+  }
+
+  // cos/sin reshape: input 1x4480x1x64x1x1 (~1.17 GiB) collapsed in row-major.
+  // CHECK-LABEL: @rope_cos_reshape_row_major
+  func.func @rope_cos_reshape_row_major(%arg0: tensor<1x4480x1x64x1x1xf32> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<1x4480x1x64xf32> {
+    // CHECK: ttir.reshape
+    // CHECK-SAME: -> tensor<1x4480x1x64xf32, {{.*}}memref<{{[0-9x]+}}xf32,
+    %0 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 4480 : i32, 1 : i32, 64 : i32]}> : (tensor<1x4480x1x64x1x1xf32>) -> tensor<1x4480x1x64xf32>
+    return %0 : tensor<1x4480x1x64xf32>
+  }
+
+  // Tiny trailing dims but tiny tensor: waste << 1 GiB, so it still tilizes.
+  // CHECK-LABEL: @small_waste_tilizes
+  func.func @small_waste_tilizes(%arg0: tensor<1x64x2x2xf32> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<1x64x2x1xf32> {
+    // CHECK: ttir.slice_static
+    // CHECK-SAME: -> tensor<1x64x2x1xf32, {{.*}}!ttcore.tile<32x32
+    %0 = "ttir.slice_static"(%arg0) <{begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32], ends = [1 : i32, 64 : i32, 2 : i32, 1 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1x64x2x2xf32>) -> tensor<1x64x2x1xf32>
+    return %0 : tensor<1x64x2x1xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
