### PR TITLE
[TTIR] Add complex-interleaved RoPE fusion pattern

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.h
@@ -74,6 +74,24 @@ public:
   matchAndRewrite(AddOp srcOp, mlir::PatternRewriter &rewriter) const override;
 };
 
+// Fuses the complex-multiply RoPE butterfly (real = a*c - b*d, imag = b*c +
+// a*d, a/b = de-interleaved x, c/d = cos/sin) re-interleaved to (..., D).
+// Rewrites to rotate-half rotary_embedding over the full D dim, avoiding the
+// sub-tile
+// (..., 1) tensors of the unfused path.
+//
+// Anchors on SubtractOp; finds the sibling AddOp via shared operands. Splits x
+// vs freqs by which operand is broadcast over the head dim.
+class RoPEComplexInterleavedFusingPattern
+    : public mlir::OpRewritePattern<SubtractOp> {
+public:
+  using OpRewritePattern<SubtractOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(SubtractOp srcOp,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
 } // namespace mlir::tt::ttir::fusing
 
 #endif // TTMLIR_DIALECT_TTIR_TRANSFORMS_FUSING_ROPEFUSINGPATTERN_H

--- a/lib/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.cpp
@@ -1058,4 +1058,279 @@ mlir::LogicalResult RoPEInterleavedPairFusingPattern::matchAndRewrite(
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// RoPEComplexInterleavedFusingPattern
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// True if the def-chain of `v` (through shape/layout-only ops) hits a
+// BroadcastOp: distinguishes the head-broadcast freqs from the x activation.
+bool defChainHasBroadcast(Value v, int depth = 24) {
+  if (depth < 0) {
+    return false;
+  }
+  Operation *op = v.getDefiningOp();
+  if (!op) {
+    return false;
+  }
+  if (isa<BroadcastOp>(op)) {
+    return true;
+  }
+  if (!isa<TypecastOp, ReshapeOp, PermuteOp, SliceStaticOp, ConcatOp>(op)) {
+    return false;
+  }
+  for (Value operand : op->getOperands()) {
+    if (defChainHasBroadcast(operand, depth - 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Bounded backward reachability: is `target` an ancestor of `v`?
+bool reachesBackward(Value v, Operation *target, int depth = 20) {
+  if (depth < 0) {
+    return false;
+  }
+  Operation *op = v.getDefiningOp();
+  if (!op) {
+    return false;
+  }
+  if (op == target) {
+    return true;
+  }
+  // Only traverse the RoPE reconstruction ops; do not cross unrelated compute.
+  if (!isa<TypecastOp, ReshapeOp, PermuteOp, SliceStaticOp, ConcatOp>(op)) {
+    return false;
+  }
+  for (Value operand : op->getOperands()) {
+    if (reachesBackward(operand, target, depth - 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Find the view_as_real ConcatOp (last-dim, 2 operands, result (..., 2)) whose
+// operands trace back to `subOp` (real) and `addOp` (imag). Bounded fwd BFS.
+ConcatOp findViewAsRealConcat(SubtractOp subOp, AddOp addOp) {
+  SmallVector<Operation *> worklist{subOp.getOperation()};
+  llvm::SmallPtrSet<Operation *, 32> seen;
+  int steps = 0;
+  while (!worklist.empty() && steps++ < 512) {
+    Operation *cur = worklist.pop_back_val();
+    for (Operation *user : cur->getUsers()) {
+      if (!seen.insert(user).second) {
+        continue;
+      }
+      if (auto concat = dyn_cast<ConcatOp>(user)) {
+        auto rt = mlir::cast<RankedTensorType>(concat.getType());
+        int64_t rank = rt.getRank();
+        if (rank >= 2 && rt.getShape()[rank - 1] == 2 &&
+            concat.getNumOperands() == 2 && concat.getDim() == rank - 1) {
+          bool op0Sub = reachesBackward(concat.getOperand(0), subOp);
+          bool op1Add = reachesBackward(concat.getOperand(1), addOp);
+          bool op0Add = reachesBackward(concat.getOperand(0), addOp);
+          bool op1Sub = reachesBackward(concat.getOperand(1), subOp);
+          if ((op0Sub && op1Add) || (op0Add && op1Sub)) {
+            return concat;
+          }
+        }
+      }
+      worklist.push_back(user);
+    }
+  }
+  return nullptr;
+}
+
+// Split a MultiplyOp into (x, freq); freq is the broadcast operand. nullopt if
+// ambiguous (both or neither broadcast).
+std::optional<std::pair<Value, Value>> splitXFreq(MultiplyOp mul) {
+  Value o0 = mul.getOperand(0);
+  Value o1 = mul.getOperand(1);
+  bool f0 = defChainHasBroadcast(o0);
+  bool f1 = defChainHasBroadcast(o1);
+  if (f0 == f1) {
+    return std::nullopt;
+  }
+  return f0 ? std::make_pair(o1, o0) : std::make_pair(o0, o1);
+}
+
+} // namespace
+
+mlir::LogicalResult RoPEComplexInterleavedFusingPattern::matchAndRewrite(
+    SubtractOp srcOp, mlir::PatternRewriter &rewriter) const {
+
+  // Don't fuse inside decomposition function bodies (infinite recursion).
+  if (utils::isInsideCompositeDecomposition(srcOp)) {
+    return failure();
+  }
+
+  // 1. real = a*c - b*d : both operands must be multiplies.
+  auto reMul0 =
+      dyn_cast_or_null<MultiplyOp>(srcOp.getOperand(0).getDefiningOp());
+  auto reMul1 =
+      dyn_cast_or_null<MultiplyOp>(srcOp.getOperand(1).getDefiningOp());
+  if (!reMul0 || !reMul1) {
+    return failure();
+  }
+
+  // 2. Split each real multiply into (x, freq) via the broadcast heuristic.
+  //    reMul0 = a*c  (a = x, c = cos),  reMul1 = b*d  (b = x, d = sin).
+  auto s0 = splitXFreq(reMul0);
+  auto s1 = splitXFreq(reMul1);
+  if (!s0 || !s1) {
+    return failure();
+  }
+  auto [a, c] = *s0;
+  auto [b, d] = *s1;
+
+  // The four base values must be distinct.
+  if (a == b || a == c || a == d || b == c || b == d || c == d) {
+    return failure();
+  }
+
+  // 3. Find the sibling imag AddOp: imag = b*c + a*d. Look for an AddOp whose
+  //    two operands are MultiplyOp(b, c) and MultiplyOp(a, d) (either order).
+  auto isMulOf = [](MultiplyOp m, Value x, Value y) {
+    return (m.getOperand(0) == x && m.getOperand(1) == y) ||
+           (m.getOperand(0) == y && m.getOperand(1) == x);
+  };
+  AddOp imagAdd = nullptr;
+  for (Operation *userBC : a.getUsers()) {
+    // a participates in a*d in the imag branch.
+    auto mAD = dyn_cast<MultiplyOp>(userBC);
+    if (!mAD || !isMulOf(mAD, a, d)) {
+      continue;
+    }
+    for (Operation *addUser : mAD->getUsers()) {
+      auto add = dyn_cast<AddOp>(addUser);
+      if (!add) {
+        continue;
+      }
+      auto other = dyn_cast_or_null<MultiplyOp>(
+          (add.getOperand(0).getDefiningOp() == mAD)
+              ? add.getOperand(1).getDefiningOp()
+              : add.getOperand(0).getDefiningOp());
+      if (other && isMulOf(other, b, c)) {
+        imagAdd = add;
+        break;
+      }
+    }
+    if (imagAdd) {
+      break;
+    }
+  }
+  if (!imagAdd) {
+    return failure();
+  }
+
+  // 4. a, b, c, d must share a common (..., K) type.
+  auto aType = mlir::dyn_cast<RankedTensorType>(a.getType());
+  if (!aType || aType != mlir::dyn_cast<RankedTensorType>(b.getType()) ||
+      aType != mlir::dyn_cast<RankedTensorType>(c.getType()) ||
+      aType != mlir::dyn_cast<RankedTensorType>(d.getType())) {
+    return failure();
+  }
+  int64_t rank = aType.getRank();
+  int64_t lastDim = rank - 1;
+  int64_t K = aType.getShape()[lastDim];
+  Type elemType = aType.getElementType();
+
+  // 5. Locate the view_as_real concat (the output to replace).
+  ConcatOp vaReal = findViewAsRealConcat(srcOp, imagAdd);
+  if (!vaReal) {
+    return failure();
+  }
+
+  // -------- Rewrite --------
+  Location loc = srcOp.getLoc();
+  int64_t D = 2 * K;
+
+  auto lastDimAttr = rewriter.getSI32IntegerAttr(lastDim);
+
+  // x_rh = concat(a, b) : the even/odd de-interleave is already the rotate-half
+  // layout.  (..., D)
+  SmallVector<int64_t> fullShape(aType.getShape());
+  fullShape[lastDim] = D;
+  auto fullType = RankedTensorType::get(fullShape, elemType);
+  auto xPerm =
+      rewriter.create<ConcatOp>(loc, fullType, ValueRange{a, b}, lastDimAttr);
+
+  // cos/sin: strip the head-broadcast so the promoted rotary_embedding op sees
+  // cos/sin with batch/head dims == 1. cosFull = concat(cosHalf, cosHalf),
+  // sinFull = concat(sinHalf, sinHalf)  (self-concat -> full D).
+  Value cosHalf = get4DEmbeddingInput(c);
+  Value sinHalf = get4DEmbeddingInput(d);
+  auto cosHalfType = mlir::cast<RankedTensorType>(cosHalf.getType());
+  auto sinHalfType = mlir::cast<RankedTensorType>(sinHalf.getType());
+  int64_t cosLastDim = cosHalfType.getRank() - 1;
+  int64_t sinLastDim = sinHalfType.getRank() - 1;
+  SmallVector<int64_t> cosFullShape(cosHalfType.getShape());
+  cosFullShape[cosLastDim] *= 2;
+  auto cosFullType =
+      RankedTensorType::get(cosFullShape, cosHalfType.getElementType());
+  SmallVector<int64_t> sinFullShape(sinHalfType.getShape());
+  sinFullShape[sinLastDim] *= 2;
+  auto sinFullType =
+      RankedTensorType::get(sinFullShape, sinHalfType.getElementType());
+  auto cosFull =
+      rewriter.create<ConcatOp>(loc, cosFullType, ValueRange{cosHalf, cosHalf},
+                                rewriter.getSI32IntegerAttr(cosLastDim));
+  auto sinFull =
+      rewriter.create<ConcatOp>(loc, sinFullType, ValueRange{sinHalf, sinHalf},
+                                rewriter.getSI32IntegerAttr(sinLastDim));
+
+  // out_rh = rotary_embedding(x_rh, cosFull, sinFull) : rotate-half form gives
+  // concat(a*c - b*d, b*c + a*d) = concat(real, imag).  (..., D)
+  auto moduleOp = srcOp->getParentOfType<ModuleOp>();
+  OpBuilder moduleBuilder(moduleOp.getContext());
+  moduleBuilder.setInsertionPointToEnd(moduleOp.getBody());
+  auto decompFunc = buildRoPEDecompositionFunc(
+      moduleBuilder, loc, fullType, cosFullType, sinFullType, fullType,
+      /*isSelfConcatCosSin=*/true);
+  moduleBuilder.insert(decompFunc);
+  auto rotEmb = rewriter.create<ttcore::CompositeOp>(
+      loc, TypeRange{fullType},
+      ValueRange{xPerm.getResult(), cosFull.getResult(), sinFull.getResult()},
+      rewriter.getStringAttr("rotary_embedding"),
+      FlatSymbolRefAttr::get(rewriter.getContext(), decompFunc.getName()),
+      /*composite_attributes=*/nullptr);
+
+  // Re-interleave rotate-half [real | imag] -> [real0, imag0, real1, imag1,
+  // ...] reshape (..., D) -> (..., 2, K); permute swap last two -> (..., K, 2).
+  SmallVector<int64_t> splitShape(aType.getShape());
+  splitShape[lastDim] = 2;
+  splitShape.push_back(K);
+  auto splitType = RankedTensorType::get(splitShape, elemType);
+  SmallVector<int32_t> splitShapeAttr(splitShape.size());
+  for (size_t i = 0; i < splitShape.size(); ++i) {
+    splitShapeAttr[i] = static_cast<int32_t>(splitShape[i]);
+  }
+  auto split =
+      rewriter.create<ReshapeOp>(loc, splitType, rotEmb->getResult(0),
+                                 rewriter.getI32ArrayAttr(splitShapeAttr));
+
+  SmallVector<int64_t> perm(splitShape.size());
+  for (size_t i = 0; i < perm.size(); ++i) {
+    perm[i] = static_cast<int64_t>(i);
+  }
+  std::swap(perm[perm.size() - 2], perm[perm.size() - 1]);
+  SmallVector<int64_t> pairShape(aType.getShape());
+  pairShape.push_back(2); // (..., K, 2)
+  auto pairType = RankedTensorType::get(pairShape, elemType);
+  auto interleaved =
+      rewriter.create<PermuteOp>(loc, pairType, split.getResult(), perm);
+
+  // Match the view_as_real concat's result type, then replace it: both
+  // downstream reshapes (flatten to (..., D)) then consume the fused tensor.
+  auto vaRealType = mlir::cast<RankedTensorType>(vaReal.getType());
+  if (vaRealType.getShape() != ArrayRef<int64_t>(pairShape)) {
+    return failure();
+  }
+  rewriter.replaceOp(vaReal, interleaved.getResult());
+  return success();
+}
+
 } // namespace mlir::tt::ttir::fusing

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -3372,6 +3372,7 @@ public:
       patterns.add<fusing::RoPERotateHalfFusingPattern>(&getContext());
       patterns.add<fusing::RoPEComplexRotationFusingPattern>(&getContext());
       patterns.add<fusing::RoPEInterleavedPairFusingPattern>(&getContext());
+      patterns.add<fusing::RoPEComplexInterleavedFusingPattern>(&getContext());
       patterns.add<fusing::TopKFusingPattern>(&getContext());
 
       GreedyRewriteConfig config;

--- a/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
+++ b/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
@@ -615,3 +615,143 @@ def test_rope_interleaved_pair(
     )
 
     assert check_op(output, "rotary_embedding")
+
+
+# ---------------------------------------------------------------------------
+# Pattern 4: complex-interleaved (Krea CausalWanModel)
+#   view_as_real(view_as_complex(x) * freqs).flatten(): a,b = even/odd of x;
+#   real = a*cos - b*sin; imag = b*cos + a*sin; interleaved back to [..., D].
+#   cos/sin are broadcast over the head dim.
+# ---------------------------------------------------------------------------
+
+
+def torch_rope_complex_interleaved(x, cos, sin):
+    """Golden reference for Krea complex-interleaved RoPE."""
+    a = x[..., 0::2]
+    b = x[..., 1::2]
+    real = a * cos - b * sin
+    imag = b * cos + a * sin
+    out = torch.stack([real, imag], dim=-1)
+    return out.reshape(*x.shape).type_as(x)
+
+
+def build_rope_complex_interleaved(
+    input: Operand,
+    cos_input: Operand,
+    sin_input: Operand,
+    builder: TTIRBuilder,
+):
+    """Build Pattern 4 (complex-interleaved) as a sequence of TTIR ops.
+
+    input is [B, H, S, D]; cos/sin are 3D [1, S, D/2], reshaped to 4D and
+    explicitly broadcast over the head dim (so the fuser classifies them as
+    the freqs table vs the x activation).
+    """
+    B, H, S, D = list(input.type.shape)
+    half_dim = D // 2
+
+    # de-interleave x: (B,H,S,D) -> (B,H,S,D/2,2), slice the two pair components
+    x_pairs = builder.reshape(input, shape=[B, H, S, half_dim, 2])
+    a = builder.reshape(
+        builder.slice(
+            x_pairs,
+            begins=[0, 0, 0, 0, 0],
+            ends=[B, H, S, half_dim, 1],
+            step=[1, 1, 1, 1, 1],
+        ),
+        shape=[B, H, S, half_dim],
+    )
+    b = builder.reshape(
+        builder.slice(
+            x_pairs,
+            begins=[0, 0, 0, 0, 1],
+            ends=[B, H, S, half_dim, 2],
+            step=[1, 1, 1, 1, 1],
+        ),
+        shape=[B, H, S, half_dim],
+    )
+
+    # cos/sin: reshape to 4D and broadcast over batch and heads.
+    cos_4d = builder.reshape(cos_input, shape=[1, 1, S, half_dim])
+    sin_4d = builder.reshape(sin_input, shape=[1, 1, S, half_dim])
+    c = builder.broadcast(cos_4d, broadcast_dimensions=[B, H, 1, 1])
+    d = builder.broadcast(sin_4d, broadcast_dimensions=[B, H, 1, 1])
+
+    # butterfly: real = a*c - b*d, imag = b*c + a*d
+    real = builder.subtract(builder.multiply(a, c), builder.multiply(b, d))
+    imag = builder.add(builder.multiply(b, c), builder.multiply(a, d))
+
+    # view_as_real: interleave real/imag and flatten back to (..., D)
+    real_5d = builder.reshape(real, shape=[B, H, S, half_dim, 1])
+    imag_5d = builder.reshape(imag, shape=[B, H, S, half_dim, 1])
+    vas = builder.concat([real_5d, imag_5d], dim=4)
+    return builder.reshape(vas, shape=[B, H, S, D])
+
+
+# Krea per-device model shape: seq = F*H*W = 3*30*52 = 4680, 40 heads tensor-
+# parallel across 4 chips -> 10/device, head_dim 128.
+COMPLEX_INTERLEAVED_SHAPES = [
+    pytest.param(
+        (1, 10, 4680, 128),
+        (1, 4680, 64),
+        id="krea_realtime_video-prefill",
+    ),
+]
+
+
+@pytest.mark.parametrize("input_shape, cos_sin_shape", COMPLEX_INTERLEAVED_SHAPES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_rope_complex_interleaved(
+    input_shape, cos_sin_shape, dtype, target, request, device
+):
+    """
+    Pattern 4: complex-interleaved RoPE.
+    Used by Krea-Realtime CausalWanModel.
+
+    Verifies that the decomposed complex-multiply RoPE (butterfly + view_as_real
+    re-interleave) fuses into ttnn.rotary_embedding through the full pipeline,
+    avoiding the sub-tile (..., 1) DRAM blow-up of the unfused path.
+    """
+    shapes = [input_shape, cos_sin_shape, cos_sin_shape]
+    dtypes = [dtype] * 3
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def rotary_embedding(
+            input: Operand,
+            cos_input: Operand,
+            sin_input: Operand,
+            builder: TTIRBuilder,
+        ):
+            input_data = torch.randn(input_shape, dtype=dtype)
+            cos_data = torch.randn(cos_sin_shape, dtype=dtype)
+            sin_data = torch.randn(cos_sin_shape, dtype=dtype)
+
+            golden = torch_rope_complex_interleaved(
+                input_data, cos_data.unsqueeze(0), sin_data.unsqueeze(0)
+            )
+
+            result = build_rope_complex_interleaved(
+                input, cos_input, sin_input, builder
+            )
+
+            builder.set_goldens(
+                {input: input_data, cos_input: cos_data, sin_input: sin_data},
+                {result: golden},
+            )
+            return result
+
+    output = compile_and_execute_ttir(
+        module,
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+        pipeline_options=[
+            "enable-ttnn-decomposition-pass=false",
+            "composite-resolution=force-promote",
+        ],
+        save_artifacts=True,
+    )
+
+    assert check_op(output, "rotary_embedding")

--- a/test/ttmlir/Dialect/TTIR/fusing/rotary_embedding/rope.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/rotary_embedding/rope.mlir
@@ -238,3 +238,66 @@ module {
     return %result : tensor<1x4x2x8xf32>
   }
 }
+
+// =========================================================================
+// Pattern 4: complex-interleaved RoPE (Krea CausalWanModel)
+// =========================================================================
+
+// Butterfly (real = a*c - b*d, imag = b*c + a*d) with a,b = even/odd halves of
+// x and c,d = cos/sin broadcast over heads, re-interleaved via concat. Anchored
+// on the subtract, folds to a single composite.
+// CHECK-LABEL: @rope_complex_interleaved_basic
+// CHECK: "ttcore.composite"
+// CHECK-SAME: composite_name = "rotary_embedding"
+module {
+  func.func @rope_complex_interleaved_basic(
+      %x: tensor<2x2x8xf32>,
+      %cos: tensor<2x1x4xf32>,
+      %sin: tensor<2x1x4xf32>) -> tensor<2x2x8xf32> {
+    // de-interleave x: (2,2,8) -> (2,2,4,2), slice the two pair components
+    %x_pairs = "ttir.reshape"(%x) <{shape = [2:i32, 2:i32, 4:i32, 2:i32]}> : (tensor<2x2x8xf32>) -> tensor<2x2x4x2xf32>
+    %a_s = "ttir.slice_static"(%x_pairs) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [2:i32, 2:i32, 4:i32, 1:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<2x2x4x2xf32>) -> tensor<2x2x4x1xf32>
+    %a = "ttir.reshape"(%a_s) <{shape = [2:i32, 2:i32, 4:i32]}> : (tensor<2x2x4x1xf32>) -> tensor<2x2x4xf32>
+    %b_s = "ttir.slice_static"(%x_pairs) <{begins = [0:i32, 0:i32, 0:i32, 1:i32], ends = [2:i32, 2:i32, 4:i32, 2:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<2x2x4x2xf32>) -> tensor<2x2x4x1xf32>
+    %b = "ttir.reshape"(%b_s) <{shape = [2:i32, 2:i32, 4:i32]}> : (tensor<2x2x4x1xf32>) -> tensor<2x2x4xf32>
+
+    // cos/sin broadcast over the head dim (head-independent freqs table)
+    %c = "ttir.broadcast"(%cos) <{broadcast_dimensions = array<i64: 1, 2, 1>}> : (tensor<2x1x4xf32>) -> tensor<2x2x4xf32>
+    %d = "ttir.broadcast"(%sin) <{broadcast_dimensions = array<i64: 1, 2, 1>}> : (tensor<2x1x4xf32>) -> tensor<2x2x4xf32>
+
+    // butterfly: real = a*c - b*d, imag = b*c + a*d
+    %ac = "ttir.multiply"(%a, %c) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %bd = "ttir.multiply"(%b, %d) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %real = "ttir.subtract"(%ac, %bd) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %bc = "ttir.multiply"(%b, %c) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %ad = "ttir.multiply"(%a, %d) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %imag = "ttir.add"(%bc, %ad) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+
+    // view_as_real: re-interleave real/imag and flatten back to (..., D)
+    %real_4d = "ttir.reshape"(%real) <{shape = [2:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<2x2x4xf32>) -> tensor<2x2x4x1xf32>
+    %imag_4d = "ttir.reshape"(%imag) <{shape = [2:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<2x2x4xf32>) -> tensor<2x2x4x1xf32>
+    %vas = "ttir.concat"(%real_4d, %imag_4d) <{dim = 3 : si32}> : (tensor<2x2x4x1xf32>, tensor<2x2x4x1xf32>) -> tensor<2x2x4x2xf32>
+    %result = "ttir.reshape"(%vas) <{shape = [2:i32, 2:i32, 8:i32]}> : (tensor<2x2x4x2xf32>) -> tensor<2x2x8xf32>
+    return %result : tensor<2x2x8xf32>
+  }
+}
+
+// Negative: freqs not broadcast over heads -> x/freqs split is ambiguous -> no fuse.
+// CHECK-LABEL: @rope_complex_interleaved_no_broadcast_no_fuse
+// CHECK-NOT: "ttcore.composite"
+module {
+  func.func @rope_complex_interleaved_no_broadcast_no_fuse(
+      %a: tensor<2x2x4xf32>, %b: tensor<2x2x4xf32>,
+      %c: tensor<2x2x4xf32>, %d: tensor<2x2x4xf32>) -> tensor<2x2x4x2xf32> {
+    %ac = "ttir.multiply"(%a, %c) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %bd = "ttir.multiply"(%b, %d) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %real = "ttir.subtract"(%ac, %bd) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %bc = "ttir.multiply"(%b, %c) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %ad = "ttir.multiply"(%a, %d) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %imag = "ttir.add"(%bc, %ad) : (tensor<2x2x4xf32>, tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %real_4d = "ttir.reshape"(%real) <{shape = [2:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<2x2x4xf32>) -> tensor<2x2x4x1xf32>
+    %imag_4d = "ttir.reshape"(%imag) <{shape = [2:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<2x2x4xf32>) -> tensor<2x2x4x1xf32>
+    %vas = "ttir.concat"(%real_4d, %imag_4d) <{dim = 3 : si32}> : (tensor<2x2x4x1xf32>, tensor<2x2x4x1xf32>) -> tensor<2x2x4x2xf32>
+    return %vas : tensor<2x2x4x2xf32>
+  }
+}


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/5624

### Problem description

- Krea-Realtime `CausalWanModel` express RoPE with `torch.view_as_complex(x) * freqs` followed by `torch.view_as_real(...).flatten()` are not fused by any existing RoPE pattern. 
- After StableHLO complex-decomposition the rotation becomes a "butterfly" of real ops: `real = a*c - b*d` (SubtractOp of two MultiplyOps) and `imag = b*c + a*d` (AddOp of two MultiplyOps), where `a,b` are the even/odd de-interleave of `x` and `c,d` are cos/sin. Because the pair components are sliced off a `(..., D/2, 2)` reshape, every multiply/subtract/add runs on a `(..., D/2, 1)` tensor. 
- A trailing dim of `1` is padded to a full 32x32 tile, so each such buffer is ~32x its logical size (e.g. a `4680x10x64x1` f32 tensor becomes a 383 MB DRAM buffer). 
- Six of these coexist, driving peak DRAM to ~2.67 GB and OOM-ing the sharded transformer. The existing patterns miss it: `RoPEComplexRotationFusingPattern` expects rotate-half (first/second half) slices, and `RoPEInterleavedPairFusingPattern` ([#8725](https://github.com/tenstorrent/tt-mlir/pull/8725)) expects the 6D `(..., D/2, 1, 2)` layout with a single `(..., D/2, 2, 2)` freqs tensor, whereas Krea emits a 4D interleaved layout with separate cos/sin, so neither fires.

### What's changed

- Adds `RoPEComplexInterleavedFusingPattern` (TTIR fusing), anchored on `SubtractOp`. 
- It matches the butterfly `real = a*c - b*d`, finds the sibling `imag = b*c + a*d` via shared operands, and splits x vs freqs by which operand is broadcast over the head dim. It then rewrites to rotate-half over the full `D` dim, reusing the existing `rotary_embedding` composite: `x_rh = concat(a, b)` and `rotary_embedding(x_rh, cos, sin)` where `cos`/`sin` are the head-broadcast-stripped freqs self-concatenated to full `D` (so the promoted op sees batch/head dims == 1), then re-interleaves the result back to `(..., D/2, 2)` and replaces the `view_as_real` concat.
- **Impact:** the rotation now runs on tile-aligned `(..., D/2)` tensors instead of `(..., D/2, 1)`, so the ~32x sub-tile padding is gone. On the Krea transformer the per-buffer footprint drops from 383 MB to ~12 MB, peak RoPE DRAM drops ~2.67 GB -> ~0.77 GB (3.5x), and the RoPE OOM is eliminated; the model now progresses past RoPE into self-attention, where it hits a separate downstream OOM from the unfused SDPA score matrix 

### Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [jul14_krea_rope_before_fix.log](https://github.com/user-attachments/files/30007379/jul14_krea_rope.log)
- [jul14_z_krea_rope_after_fix.log](https://github.com/user-attachments/files/30011177/jul14_z_krea_rope_after_fix.log)
- [jul14_krea_transformer_before_fix.log.zip](https://github.com/user-attachments/files/30007382/jul14_krea_transformer.log.zip)
- [jul14_krea_transformer_after_fix.log.zip](https://github.com/user-attachments/files/30011143/jul14_z_krea_transformer_after_fix.log.zip)


