### PR TITLE
Add experimental topk_large_indices op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -4293,6 +4293,52 @@ def TTNN_TopKOp : TTNN_Op<"topk"> {
   let hasVerifier = 1;
 }
 
+def TTNN_TopKLargeIndicesOp : TTNN_Op<"topk_large_indices"> {
+  let summary = "Experimental top-k indices over large row-major rows.";
+  let description = [{
+    Returns the sorted-descending top-k indices along the last dimension of a
+    row-major BFLOAT16 tensor. Corresponds to
+    `ttnn.experimental.topk_large_indices`
+    (`ttnn::experimental::topk_large_indices`).
+
+    The output has the same shape as the input except that the last dimension
+    is `k`, and its element type is UINT32. Input values equal to `-inf`
+    produce the sentinel index `0xFFFFFFFF` when they survive into the final
+    top-k result.
+
+    This op is intended for large row-major rows: internally it snaps `k` to the
+    nearest supported LLK window and streams each input row in LLK-sized
+    windows.
+
+    Constraints (tt-metal op restrictions):
+        * input must be a ROW_MAJOR BFLOAT16 tensor of rank >= 1;
+        * the last dimension is the input row length and must be >= `k`;
+        * `k` must be in [16, 2048] and a multiple of 16.
+
+    Args:
+        input (AnyRankedTensor): row-major BFLOAT16 tensor `[..., N]`.
+        k (uint): required number of indices to return.
+
+    Returns:
+        AnyRankedTensor: UINT32 indices tensor `[..., k]`.
+
+    Note: this op is only supported on Blackhole.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       UI32Attr:$k);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+      return wa::TTNNOperandsWorkaroundsFactory::createTopKLargeIndicesOpOperandsWorkarounds(*this);
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
 def TTNN_TopKRouterGptOp : TTNN_Op<"topk_router_gpt"> {
   let summary = "Fused router linear layer for GPT-style mixture-of-experts models.";
   let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -23,6 +23,7 @@ class SliceStaticOp;
 class RotaryEmbeddingOp;
 class Conv3dOp;
 class TopKOp;
+class TopKLargeIndicesOp;
 class TopKRouterGptOp;
 class MoeComputeOp;
 class PrepareMoEComputeW0W1WeightsOp;
@@ -440,6 +441,12 @@ public:
   // Issue page: https://github.com/tenstorrent/tt-metal/issues/40086
   static TTNNOperandsWorkarounds
   createTopKOpOperandsWorkarounds(ttnn::TopKOp op);
+
+  // Create workarounds for topk_large_indices op.
+  // The tt-metal kernel requires a ROW_MAJOR BFloat16 input and produces a
+  // ROW_MAJOR UInt32 indices output.
+  static TTNNOperandsWorkarounds
+  createTopKLargeIndicesOpOperandsWorkarounds(ttnn::TopKLargeIndicesOp op);
 
   // Create workarounds for topk_router_gpt op.
   // The kernel always returns both outputs (expert_indices, expert_weights) in

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -69,6 +69,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include "ttnn/operations/experimental/dropout/dropout.hpp"
 #include "ttnn/operations/experimental/paged_cache/paged_cache.hpp"
+#include "ttnn/operations/experimental/topk_large_indices/topk_large_indices.hpp"
 #include "ttnn/operations/experimental/topk_router_gpt/topk_router_gpt.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -2069,6 +2069,23 @@ struct OpModel<TopKOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// TopKLargeIndicesOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<TopKLargeIndicesOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, uint32_t k,
+                   TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             uint32_t k,
+                                             TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // SamplingOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/Target/TTNN/operations/reduction.fbs
+++ b/include/ttmlir/Target/TTNN/operations/reduction.fbs
@@ -45,6 +45,12 @@ table TopKOp {
   outputs: [tt.target.ttnn.TensorRef];
 }
 
+table TopKLargeIndicesOp {
+  input: tt.target.ttnn.TensorRef;
+  k: uint32;
+  out: tt.target.ttnn.TensorRef;
+}
+
 table SamplingOp {
   input_values: tt.target.ttnn.TensorRef;
   input_indices: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -156,6 +156,7 @@ union OpType {
   RegionStartOp,
   RegionEndOp,
   TopKOp,
+  TopKLargeIndicesOp,
   TopKRouterGptOp,
   CreateGlobalSemaphoreOp,
   ResetGlobalSemaphoreOp,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -9549,6 +9549,132 @@ public:
 } // namespace
 
 namespace {
+// Builds the primitive decomposition body for the ttcore.composite op for the
+// experimental large-row top-k indices op. This is the fallback that gets
+// inlined by the TTNNResolveComposites pass when the composite cannot be
+// promoted to ttnn.topk_large_indices (e.g. on non-Blackhole architectures).
+//
+// It reuses the existing ttir.topk primitive, keeping only the (UINT32)
+// indices result and discarding the values:
+//   indices = topk(input, k, dim=-1, largest=true, sorted=true).indices
+//
+// input [..., N] bf16 -> [..., k] ui32.
+static Value
+buildTopKLargeIndicesDecompositionBody(OpBuilder &builder, Location loc,
+                                       Value input, uint32_t k,
+                                       RankedTensorType outputType) {
+  auto inputType = mlir::cast<RankedTensorType>(input.getType());
+  int64_t rank = inputType.getRank();
+
+  // The values result mirrors the indices shape but keeps the input dtype.
+  SmallVector<int64_t> topkShape(inputType.getShape());
+  topkShape[rank - 1] = static_cast<int64_t>(k);
+  auto valuesType = RankedTensorType::get(topkShape, inputType.getElementType(),
+                                          inputType.getEncoding());
+
+  auto topKOp = builder.create<ttir::TopKOp>(
+      loc, valuesType, /*indices=*/outputType, input,
+      builder.getI32IntegerAttr(static_cast<int32_t>(k)),
+      /*dim=*/builder.getI32IntegerAttr(-1),
+      /*largest=*/builder.getBoolAttr(true),
+      /*sorted=*/builder.getBoolAttr(true));
+  return topKOp.getIndices();
+}
+
+// Converts stablehlo.custom_call @tt.topk_large_indices into a ttcore.composite
+// "topk_large_indices" carrying the synthesized primitive decomposition. The
+// composite is promoted to ttnn.topk_large_indices by TTNNResolveComposites
+// (Blackhole only); the decomposition body is the inlined fallback.
+class StableHLOToTTCoreTopKLargeIndicesOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
+  using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CustomCallOp srcOp,
+                  mlir::stablehlo::CustomCallOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    StringAttr funcName = adaptor.getCallTargetNameAttr();
+    if (funcName != "tt.topk_large_indices") {
+      return failure();
+    }
+
+    auto operands = adaptor.getOperands();
+    if (operands.size() != 1) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "topk_large_indices expects exactly 1 operand (input).");
+    }
+    Value input = operands[0];
+
+    // k is a required string-valued frontend attribute.
+    mlir::DictionaryAttr frontendAttributes =
+        mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+            srcOp->getDiscardableAttr("mhlo.frontend_attributes"));
+    if (!frontendAttributes) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "topk_large_indices op must have mhlo.frontend_attributes "
+                 "attribute.");
+    }
+    auto kStringAttr = frontendAttributes.getAs<mlir::StringAttr>("k");
+    if (!kStringAttr) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "topk_large_indices op requires a k attribute.");
+    }
+    uint32_t k;
+    if (!llvm::to_integer(kStringAttr.getValue(), k) || k == 0) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "k attribute must be a positive integer. Received \"" +
+                     kStringAttr.getValue() + "\".");
+    }
+    IntegerAttr kAttr = rewriter.getUI32IntegerAttr(k);
+
+    RankedTensorType outputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult(0).getType()));
+
+    // Synthesize the private decomposition function (inlined fallback).
+    ModuleOp moduleOp = srcOp->getParentOfType<ModuleOp>();
+    std::string decompFuncName = "topk_large_indices_decomp";
+    {
+      unsigned counter = 0;
+      while (SymbolTable::lookupSymbolIn(moduleOp, decompFuncName)) {
+        decompFuncName =
+            "topk_large_indices_decomp_" + std::to_string(counter++);
+      }
+    }
+
+    SmallVector<Value> compositeInputs = {input};
+    SmallVector<Type> argTypes =
+        llvm::to_vector(ValueRange(compositeInputs).getTypes());
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToEnd(moduleOp.getBody());
+      auto decompFunc = rewriter.create<func::FuncOp>(
+          srcOp.getLoc(), decompFuncName,
+          rewriter.getFunctionType(argTypes, {outputType}));
+      decompFunc.setPrivate();
+      Block *entry = decompFunc.addEntryBlock();
+      rewriter.setInsertionPointToStart(entry);
+
+      Value decompResult = buildTopKLargeIndicesDecompositionBody(
+          rewriter, srcOp.getLoc(), entry->getArgument(0), k, outputType);
+      rewriter.create<mlir::func::ReturnOp>(srcOp.getLoc(), decompResult);
+    }
+
+    SmallVector<NamedAttribute> compositeAttrList;
+    compositeAttrList.push_back(rewriter.getNamedAttr("k", kAttr));
+
+    rewriter.replaceOpWithNewOp<ttcore::CompositeOp>(
+        srcOp, TypeRange{outputType}, ValueRange(compositeInputs),
+        rewriter.getStringAttr("topk_large_indices"),
+        FlatSymbolRefAttr::get(rewriter.getContext(), decompFuncName),
+        rewriter.getDictionaryAttr(compositeAttrList));
+
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 // Pattern to convert mhlo.topk to ttir.topk
 class StableHLOTopKOpMHLOConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
@@ -10107,6 +10233,7 @@ static void addScaledDotProductAttentionDecodeOpConversionPattern(
       StableHLOToTTIRPagedScaledDotProductAttentionDecodeOpConversionPattern,
       StableHLOToTTCoreFlashMlaPrefillOpConversionPattern,
       StableHLOToTTIRPagedFlashMLADecodeOpConversionPattern,
+      StableHLOToTTCoreTopKLargeIndicesOpConversionPattern,
       StableHLOToTTIRChunkedScaledDotProductAttentionOpConversionPattern>(
       typeConverter, ctx);
 }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -9560,8 +9560,8 @@ namespace {
 //
 // input [..., N] bf16 -> [..., k] ui32.
 static Value
-buildTopKLargeIndicesDecompositionBody(OpBuilder &builder, Location loc,
-                                       Value input, uint32_t k,
+buildTopKLargeIndicesDecompositionBody(ConversionPatternRewriter &rewriter,
+                                       Location loc, Value input, uint32_t k,
                                        RankedTensorType outputType) {
   auto inputType = mlir::cast<RankedTensorType>(input.getType());
   int64_t rank = inputType.getRank();
@@ -9572,12 +9572,12 @@ buildTopKLargeIndicesDecompositionBody(OpBuilder &builder, Location loc,
   auto valuesType = RankedTensorType::get(topkShape, inputType.getElementType(),
                                           inputType.getEncoding());
 
-  auto topKOp = builder.create<ttir::TopKOp>(
+  auto topKOp = rewriter.create<ttir::TopKOp>(
       loc, valuesType, /*indices=*/outputType, input,
-      builder.getI32IntegerAttr(static_cast<int32_t>(k)),
-      /*dim=*/builder.getI32IntegerAttr(-1),
-      /*largest=*/builder.getBoolAttr(true),
-      /*sorted=*/builder.getBoolAttr(true));
+      rewriter.getI32IntegerAttr(static_cast<int32_t>(k)),
+      /*dim=*/rewriter.getI32IntegerAttr(-1),
+      /*largest=*/rewriter.getBoolAttr(true),
+      /*sorted=*/rewriter.getBoolAttr(true));
   return topKOp.getIndices();
 }
 

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -5487,6 +5487,39 @@ public:
   }
 };
 
+class TTNNToEmitCTopKLargeIndicesOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::TopKLargeIndicesOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.topk_large_indices";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn::experimental::topk_large_indices";
+  }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::TopKLargeIndicesOp>::TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::TopKLargeIndicesOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::TopKLargeIndicesOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getK()),
+    };
+
+    emitter.replaceOp(*this, args);
+    return success();
+  }
+};
+
 class TTNNToEmitCSamplingOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::SamplingOp> {
 public:
@@ -5654,6 +5687,7 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
            SliceDynamicOpConversionPattern, SortOpConversionPattern,
            PermuteOpConversionPattern, PadOpConversionPattern,
            TTNNToEmitCTopKOpConversionPattern,
+           TTNNToEmitCTopKLargeIndicesOpConversionPattern,
            TTNNToEmitCSamplingOpConversionPattern, GatherOpConversionPattern>(
           typeConverter, ctx);
 

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -4919,6 +4919,37 @@ public:
   }
 };
 
+class TopKLargeIndicesOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<tt::ttnn::TopKLargeIndicesOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.topk_large_indices";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn.experimental.topk_large_indices";
+  }
+
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      tt::ttnn::TopKLargeIndicesOp>::TTNNToEmitPyBaseOpConversionPattern;
+  LogicalResult
+  matchAndRewrite(tt::ttnn::TopKLargeIndicesOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<tt::ttnn::TopKLargeIndicesOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getK(), "k"),
+    };
+
+    emitter.replaceOp(*this, args);
+    return success();
+  }
+};
+
 class SamplingOpConversionPattern
     : public TTNNToEmitPyBaseOpConversionPattern<tt::ttnn::SamplingOp> {
 public:
@@ -5543,6 +5574,7 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
                DistributeTensorOpConversionPattern,
                AggregateTensorOpConversionPattern,
                TopKOpConversionPattern,
+               TopKLargeIndicesOpConversionPattern,
                AllToAllDispatchOpConversionPattern,
                AllToAllDispatchMetadataOpConversionPattern,
                AllToAllCombineOpConversionPattern,

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -49,6 +49,9 @@ static constexpr llvm::StringLiteral moeExpertTokenRemapTargetName =
 static constexpr llvm::StringLiteral flashMlaPrefillTargetName =
     "tt.flash_mla_prefill";
 
+static constexpr llvm::StringLiteral topkLargeIndicesTargetName =
+    "tt.topk_large_indices";
+
 static mlir::sdy::OpShardingRuleAttr
 getScatterShardingRule(mlir::stablehlo::ScatterOp scatterOp) {
   mlir::Operation::operand_range inputs = scatterOp.getInputs();
@@ -1577,6 +1580,78 @@ getTopKShardingRule(mlir::stablehlo::CustomCallOp op) {
   return builder.build();
 }
 
+// Sharding rule for the `tt.topk_large_indices` custom_call (fused, single
+// device large-row top-k indices op).
+//
+//   input  : [..., N]   leading (row) dims, N is the row length (reduce dim)
+//   output : [..., k]   same leading dims, N replaced by k selected indices
+//
+// Factor design:
+//   - Leading (row) dims (kPassThrough): each row's top-k is independent, so
+//     they are data-parallel and pass straight through input dim i -> output
+//     dim i.
+//   - Row length N (kNeedReplication): unlike the decomposed `tenstorrent.topk`
+//     path, this is a single fused tt-metal op that needs the whole row on one
+//     device to compute the global top-k. N must not be sharded; Shardy
+//     all-gathers it (to replicate) if a sharding is present. N has no
+//     corresponding output dim.
+//   - Selected count k (kNeedReplication): a new output-only dim with no input
+//     correspondence; it cannot be sharded.
+static mlir::sdy::OpShardingRuleAttr
+getTopKLargeIndicesShardingRule(mlir::stablehlo::CustomCallOp op) {
+  if (op.getNumOperands() != 1 || op.getNumResults() != 1) {
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto inputType = llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+  auto resultType = llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
+  if (!inputType || !resultType) {
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  int64_t rank = inputType.getRank();
+  if (rank < 1 || resultType.getRank() != rank) {
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  ArrayRef<int64_t> inShape = inputType.getShape();
+  ArrayRef<int64_t> outShape = resultType.getShape();
+
+  auto isStaticPositiveDim = [](int64_t dim) {
+    return !ShapedType::isDynamic(dim) && dim > 0;
+  };
+
+  // Only the last dim changes (N -> k); all leading dims must match statically.
+  for (int64_t i = 0; i + 1 < rank; ++i) {
+    if (!isStaticPositiveDim(inShape[i]) || inShape[i] != outShape[i]) {
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+  }
+  int64_t n = inShape[rank - 1];
+  int64_t k = outShape[rank - 1];
+  if (!isStaticPositiveDim(n) || !isStaticPositiveDim(k)) {
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  mlir::sdy::OpShardingRuleBuilder builder(op);
+
+  // Leading (row) dims: data-parallel pass-through.
+  for (int64_t i = 0; i + 1 < rank; ++i) {
+    builder.addFactor({i}, {i}, inShape[i],
+                      mlir::sdy::FactorType::kPassThrough);
+  }
+
+  // Row length N (input last dim): must be replicated, no output dim.
+  builder.addFactor({rank - 1}, {mlir::sdy::kNullDim}, n,
+                    mlir::sdy::FactorType::kNeedReplication);
+
+  // Selected count k (output last dim): must be replicated, no input dim.
+  builder.addFactor({mlir::sdy::kNullDim}, {rank - 1}, k,
+                    mlir::sdy::FactorType::kNeedReplication);
+
+  return builder.build();
+}
+
 // Sharding rule for tenstorrent.argmax custom_call op (converted from
 // composite by FlattenOrConvertCompositesPass).
 //
@@ -1841,6 +1916,7 @@ private:
           {moeExpertTokenRemapTargetName, getMoeExpertTokenRemapShardingRule},
           {utils::kTTRMSNormCustomCallTargetName, getRMSNormShardingRule},
           {flashMlaPrefillTargetName, getFlashMlaPrefillShardingRule},
+          {topkLargeIndicesTargetName, getTopKLargeIndicesShardingRule},
           {utils::kTTTopKCustomCallTargetName, getTopKShardingRule},
           {utils::kTTTopKValuesCustomCallTargetName, getTopKShardingRule},
           {utils::kTTTopKIndicesCustomCallTargetName, getTopKShardingRule},

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -6919,6 +6919,65 @@ void mlir::tt::ttnn::D2MSubgraphOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// TopKLargeIndicesOp
+//===----------------------------------------------------------------------===//
+
+// TopKLargeIndicesOp verification
+::mlir::LogicalResult mlir::tt::ttnn::TopKLargeIndicesOp::verify() {
+  RankedTensorType inputType = getInput().getType();
+  RankedTensorType resultType = getResult().getType();
+  int64_t inputRank = inputType.getRank();
+  uint32_t k = getK();
+
+  if (inputRank < 1) {
+    return emitOpError("Input must have rank >= 1");
+  }
+
+  // tt-metal topk_large_indices requires a BFLOAT16 input.
+  if (!inputType.getElementType().isBF16()) {
+    return emitOpError("Input element type must be bf16");
+  }
+
+  // The op returns UINT32 indices.
+  if (!resultType.getElementType().isUnsignedInteger(32)) {
+    return emitOpError("Result element type must be ui32");
+  }
+
+  if (resultType.getRank() != inputRank) {
+    return emitOpError("Result rank must match input rank");
+  }
+
+  // Only the last dimension changes (to k); all leading dims must match.
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  ArrayRef<int64_t> resultShape = resultType.getShape();
+  for (int64_t i = 0; i + 1 < inputRank; ++i) {
+    if (inputShape[i] != resultShape[i]) {
+      return emitOpError("Result leading dimensions must match input leading "
+                         "dimensions");
+    }
+  }
+
+  int64_t inputLastDim = inputShape[inputRank - 1];
+  int64_t resultLastDim = resultShape[inputRank - 1];
+  if (resultLastDim != static_cast<int64_t>(k)) {
+    return emitOpError("Result last dimension must equal k, got ")
+           << resultLastDim << " (k = " << k << ")";
+  }
+  if (inputLastDim < static_cast<int64_t>(k)) {
+    return emitOpError("Input last dimension (")
+           << inputLastDim << ") must be >= k (" << k << ")";
+  }
+
+  // tt-metal restricts k to [16, 2048] and a multiple of 16.
+  if (k < 16 || k > 2048 || (k % 16) != 0) {
+    return emitOpError("k must be in [16, 2048] and a multiple of 16, got ")
+           << k;
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TopKRouterGptOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1725,6 +1725,24 @@ TTNNOperandsWorkaroundsFactory::createTopKOpOperandsWorkarounds(
       .addOutputOperandWorkaround(outputIndicesWorkaround);
 }
 
+// The tt-metal topk_large_indices kernel requires a ROW_MAJOR BFloat16 input
+// and produces a ROW_MAJOR UInt32 indices output.
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createTopKLargeIndicesOpOperandsWorkarounds(
+    ttnn::TopKLargeIndicesOp op) {
+  TTNNOperandWorkarounds inputWorkaround;
+  inputWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
+  inputWorkaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
+
+  TTNNOperandWorkarounds outputWorkaround;
+  outputWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
+  outputWorkaround.tensorDataTypeWorkaround = ttcore::DataType::UInt32;
+
+  return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+      .addInputOperandWorkaround(inputWorkaround)
+      .addOutputOperandWorkaround(outputWorkaround);
+}
+
 // The topk_router_gpt kernel always returns outputs in ROW_MAJOR layout in L1.
 // expert_indices must be UInt16, expert_weights must be BFloat16.
 TTNNOperandsWorkarounds

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -5101,4 +5101,28 @@ TopKOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       inputShape, inputs[0], getK(), getDim(), getLargest(), getSorted(),
       opConfig.outputLayout);
 }
+
+//===----------------------------------------------------------------------===//
+// TopKLargeIndicesOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+TopKLargeIndicesOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+  const auto inputShape = getInput().getType().getShape();
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<mlir::tt::ttnn::TopKLargeIndicesOp>::getOpConstraints,
+      *this, inputShape, inputs[0], getK(), opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+TopKLargeIndicesOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                 const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+  const auto inputShape = getInput().getType().getShape();
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<mlir::tt::ttnn::TopKLargeIndicesOp>::getOpRuntime,
+      *this, inputShape, inputs[0], getK(), opConfig.outputLayout);
+}
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
@@ -30,10 +31,18 @@ using CompositeValidatorFn =
     std::function<OpValidationResult(ttcore::CompositeOp, OpBuilder &)>;
 using CompositeBuilderFn =
     std::function<Operation *(ttcore::CompositeOp, OpBuilder &)>;
+// An optional guard checked before promoting a composite to its typed op. When
+// it returns failure, the composite is inlined (its decomposition body is
+// spliced in) instead of promoted, and the pass keeps going. Used for
+// composites whose typed op is only valid under certain conditions, e.g. on a
+// specific architecture.
+using CompositePromotionGuardFn =
+    std::function<LogicalResult(ttcore::CompositeOp)>;
 
 struct CompositeEntry {
   CompositeValidatorFn validate;
   CompositeBuilderFn build;
+  CompositePromotionGuardFn promotionGuard; // may be empty
 };
 
 static llvm::StringMap<CompositeEntry> &getCompositeRegistry() {
@@ -80,6 +89,16 @@ extractFlashMlaPrefillArgs(ttcore::CompositeOp compositeOp) {
   return args;
 }
 
+// Recover the k attribute from a "topk_large_indices" composite. Shared by its
+// validate and build callbacks.
+static uint32_t getTopKLargeIndicesK(ttcore::CompositeOp compositeOp) {
+  DictionaryAttr attrs = compositeOp.getCompositeAttributes().value_or(nullptr);
+  TT_assert(attrs);
+  auto kAttr = attrs.getAs<mlir::IntegerAttr>("k");
+  TT_assert(kAttr);
+  return static_cast<uint32_t>(kAttr.getValue().getZExtValue());
+}
+
 static void registerBuiltinComposites() {
   auto &registry = getCompositeRegistry();
   if (!registry.empty()) {
@@ -122,7 +141,8 @@ static void registerBuiltinComposites() {
             compositeOp.getInputs()[2],
             builder.getI32IntegerAttr(kAttr.getInt()),
             builder.getI32IntegerAttr(numExpertsAttr.getInt()));
-      }};
+      },
+      /*promotionGuard=*/nullptr};
 
   registry["rotary_embedding"] = CompositeEntry{
       // Validate
@@ -147,7 +167,8 @@ static void registerBuiltinComposites() {
             compositeOp.getInputs()[2],
             /*token_index=*/mlir::IntegerAttr(),
             /*compute_config=*/nullptr);
-      }};
+      },
+      /*promotionGuard=*/nullptr};
 
   registry["flash_mla_prefill"] = CompositeEntry{
       // Validate
@@ -175,6 +196,47 @@ static void registerBuiltinComposites() {
             args.key, args.value, args.attentionMask,
             static_cast<uint32_t>(args.headDimV.getValue().getZExtValue()),
             args.isCausal.getValue(), args.scale);
+      },
+      /*promotionGuard=*/nullptr};
+
+  registry["topk_large_indices"] = CompositeEntry{
+      // Validate
+      [](ttcore::CompositeOp compositeOp,
+         OpBuilder &builder) -> OpValidationResult {
+        TT_assert(compositeOp.getInputs().size() == 1u);
+
+        uint32_t k = getTopKLargeIndicesK(compositeOp);
+        SmallVector<Type> resultTypes(compositeOp.getResultTypes());
+        IsolatedIRValidationWrapper validator(compositeOp.getContext());
+        return validator.validateOp<TopKLargeIndicesOp>(
+            compositeOp.getOperation(), compositeOp.getLoc(), resultTypes,
+            compositeOp.getInputs()[0], k);
+      },
+      // Build
+      [](ttcore::CompositeOp compositeOp, OpBuilder &builder) -> Operation * {
+        uint32_t k = getTopKLargeIndicesK(compositeOp);
+        return builder.create<TopKLargeIndicesOp>(
+            compositeOp.getLoc(), compositeOp.getResultTypes(),
+            compositeOp.getInputs()[0], k);
+      },
+      // Promotion guard: ttnn.experimental.topk_large_indices is
+      // Blackhole-only. On any other architecture, veto promotion so the
+      // composite falls back to inlining its decomposition instead of
+      // failing the pass.
+      [](ttcore::CompositeOp compositeOp) -> LogicalResult {
+        ModuleOp moduleOp = compositeOp->getParentOfType<ModuleOp>();
+        auto sysDesc = moduleOp
+                           ? moduleOp->getAttrOfType<ttcore::SystemDescAttr>(
+                                 ttcore::SystemDescAttr::name)
+                           : nullptr;
+        // Without a system descriptor in scope (e.g. running the pass in
+        // isolation) the architecture is unknown; allow promotion and defer the
+        // check to the metal runtime, which fails on non-Blackhole devices.
+        if (!sysDesc) {
+          return success();
+        }
+        ttcore::Arch arch = sysDesc.getChipDesc(0).getArch().getValue();
+        return success(arch == ttcore::Arch::Blackhole);
       }};
 }
 
@@ -221,8 +283,8 @@ static LogicalResult inlineDecomposition(ttcore::CompositeOp compositeOp,
 // Try to create the typed op for a registered composite.
 //
 // Returns nullptr when the composite should be inlined instead — either because
-// the resolution mode is Inline, the composite is not in the registry, or
-// validation failed (in Validate mode).
+// the resolution mode is Inline, the composite is not in the registry, a
+// promotion guard vetoed promotion, or validation failed (in Validate mode).
 static Operation *tryCreateTypedOp(ttcore::CompositeOp compositeOp,
                                    OpBuilder &builder,
                                    CompositeResolution resolution) {
@@ -237,6 +299,12 @@ static Operation *tryCreateTypedOp(ttcore::CompositeOp compositeOp,
   }
 
   auto &entry = it->second;
+
+  // A promotion guard can veto promotion (even under force-promote).
+  // When it fails, fall back to inlining the decomposition.
+  if (entry.promotionGuard && mlir::failed(entry.promotionGuard(compositeOp))) {
+    return nullptr;
+  }
 
   if (resolution == CompositeResolution::Validate) {
     auto validationResult = entry.validate(compositeOp, builder);

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -546,6 +546,11 @@ const std::set<mlir::StringRef>
         // TopK's operands workaround forces input bf16 + indices ui16/ui32;
         // without it, opt_level>=1 dtype propagation picks f32. See #8141.
         ttnn::TopKOp::getOperationName(),
+        // TopKLargeIndices' operands workaround forces ROW_MAJOR bf16 input and
+        // ROW_MAJOR ui32 output (the tt-metal kernel hard-rejects anything
+        // else); without it, opt_level>=1 layout/dtype propagation picks
+        // Tile/f32.
+        ttnn::TopKLargeIndicesOp::getOperationName(),
         // FlashMlaPrefill's operands workaround forces Q/K/V/output to a
         // tt-metal SDPA-supported dtype (bf16). Without it, opt_level>=1 leaves
         // f32 operands

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -8188,6 +8188,57 @@ llvm::Expected<size_t> OpModel<TopKOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// TopKLargeIndicesOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<TopKLargeIndicesOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, uint32_t k,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+
+  // ttnn::experimental::topk_large_indices selects its own (ROW_MAJOR UINT32)
+  // output layout, so outputLayout is not forwarded.
+  auto topKLargeIndicesQuery = [=]() {
+    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::topk_large_indices,
+                                device, inputSpec, k);
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(),
+                                     topKLargeIndicesQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<TopKLargeIndicesOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, uint32_t k,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+
+  auto topKLargeIndicesQuery = [=]() {
+    return QUERY_OP_RUNTIME(::ttnn::experimental::topk_large_indices, device,
+                            inputSpec, k);
+  };
+
+  return operation::getOpRuntime(topKLargeIndicesQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // SamplingOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -4185,6 +4185,18 @@ createOp(FlatbufferObjectCache &cache, TopKOp op) {
                                                 sorted, memoryConfig, &outputs);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::TopKLargeIndicesOp>
+createOp(FlatbufferObjectCache &cache, TopKLargeIndicesOp op) {
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  uint32_t k = op.getK();
+  auto out =
+      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
+                                  /*local_shape*/ std::nullopt);
+
+  return ::tt::target::ttnn::CreateTopKLargeIndicesOp(*cache.fbb, in, k, out);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::SamplingOp>
 createOp(FlatbufferObjectCache &cache, SamplingOp op) {
   auto inputValues = cache.at<::tt::target::ttnn::TensorRef>(
@@ -5060,6 +5072,11 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   if (auto topKOp = dyn_cast<TopKOp>(op); topKOp) {
     return createOperation(cache, createOp(cache, topKOp), debugString,
                            locInfo);
+  }
+  if (auto topKLargeIndicesOp = dyn_cast<TopKLargeIndicesOp>(op);
+      topKLargeIndicesOp) {
+    return createOperation(cache, createOp(cache, topKLargeIndicesOp),
+                           debugString, locInfo);
   }
   if (auto topKRouterGptOp = dyn_cast<TopKRouterGptOp>(op); topKRouterGptOp) {
     return createOperation(cache, createOp(cache, topKRouterGptOp), debugString,

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -42,6 +42,7 @@
 #include "ttnn/operations/experimental/conv3d/conv3d.hpp"
 #include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include "ttnn/operations/experimental/paged_cache/paged_cache.hpp"
+#include "ttnn/operations/experimental/topk_large_indices/topk_large_indices.hpp"
 #include "ttnn/operations/experimental/topk_router_gpt/topk_router_gpt.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"
 #include "ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.hpp"

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -102,6 +102,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/reduction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/sampling.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/topk.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/reduction/topk_large_indices.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/topk_router_gpt.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/tensor_serialization/dump_tensor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/tensor_serialization/load_tensor.cpp

--- a/runtime/lib/ttnn/operations/reduction/topk_large_indices.cpp
+++ b/runtime/lib/ttnn/operations/reduction/topk_large_indices.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/reduction/topk_large_indices.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
+
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::reduction::topk_large_indices {
+void run(const ::tt::target::ttnn::TopKLargeIndicesOp *op,
+         ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
+
+  ::ttnn::Tensor out = ::ttnn::experimental::topk_large_indices(input, op->k());
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+} // namespace tt::runtime::ttnn::operations::reduction::topk_large_indices

--- a/runtime/lib/ttnn/operations/reduction/topk_large_indices.h
+++ b/runtime/lib/ttnn/operations/reduction/topk_large_indices.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_REDUCTION_TOPK_LARGE_INDICES_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_REDUCTION_TOPK_LARGE_INDICES_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::reduction::topk_large_indices {
+void run(const ::tt::target::ttnn::TopKLargeIndicesOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::reduction::topk_large_indices
+
+#endif // RUNTIME_LIB_TTNN_OPERATIONS_REDUCTION_TOPK_LARGE_INDICES_H

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -103,6 +103,7 @@
 #include "operations/reduction/reduction.h"
 #include "operations/reduction/sampling.h"
 #include "operations/reduction/topk.h"
+#include "operations/reduction/topk_large_indices.h"
 #include "operations/reduction/topk_router_gpt.h"
 #include "operations/tensor_serialization/dump_tensor.h"
 #include "operations/tensor_serialization/load_tensor.h"
@@ -705,6 +706,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::TopKOp: {
     return operations::reduction::topk::run(op->type_as_TopKOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::TopKLargeIndicesOp: {
+    return operations::reduction::topk_large_indices::run(
+        op->type_as_TopKLargeIndicesOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::TopKRouterGptOp: {
     return operations::reduction::topk_router_gpt::run(

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1582,6 +1582,10 @@ std::vector<tt::runtime::TensorRef> getOpOutputRefs(OpContext opContextHandle) {
         opContext.type_as_TopKOp()->outputs());
     break;
   }
+  case ::tt::target::ttnn::OpType::TopKLargeIndicesOp: {
+    tensorRefs = {opContext.type_as_TopKLargeIndicesOp()->out()};
+    break;
+  }
   case ::tt::target::ttnn::OpType::TopKRouterGptOp: {
     auto *op = opContext.type_as_TopKRouterGptOp();
     tensorRefs = {op->expert_indices(), op->expert_weights()};
@@ -1785,6 +1789,10 @@ std::vector<tt::runtime::TensorRef> getOpInputRefs(OpContext opContextHandle) {
   }
   case ::tt::target::ttnn::OpType::TopKOp: {
     tensorRefs = {opContext.type_as_TopKOp()->input_tensor()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::TopKLargeIndicesOp: {
+    tensorRefs = {opContext.type_as_TopKLargeIndicesOp()->input()};
     break;
   }
   case ::tt::target::ttnn::OpType::TopKRouterGptOp: {

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -2546,3 +2546,74 @@ def test_flash_mla_prefill_value_mask_scale(
     )
 
     check_op(output, "flash_mla_prefill")
+
+
+# Experimental large-row top-k indices op (stablehlo.custom_call
+# @tt.topk_large_indices -> ttcore.composite -> ttnn.topk_large_indices).
+#
+# Two lowering paths:
+#   * on Blackhole:
+#       shlo.custom_call -> ttcore.composite -> ttnn.topk_large_indices
+#   * otherwise:
+#       shlo.custom_call -> ttcore.composite -> decomposed into a ttnn.topk
+#       whose (UINT32) indices are kept
+@pytest.mark.parametrize(
+    "shape,k",
+    [
+        # input [num_rows, N] -> indices [num_rows, k]. N > k exercises a real
+        # top-k selection (not a full sort). k is a multiple of 16 in [16, 2048]
+        # so the typed Blackhole op accepts it.
+        ((2, 64), 16),
+        ((4, 256), 64),
+    ],
+    ids=["rows2_n64_k16", "rows4_n256_k64"],
+)
+@pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
+def test_topk_large_indices(
+    shape: Shape,
+    k: int,
+    target: str,
+    device,
+    request,
+    system_desc,
+):
+    def module(builder: StableHLOBuilder):
+        @builder.func([shape], [torch.bfloat16])
+        def topk_large_indices(
+            input: Operand,
+            builder: StableHLOBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.topk_large_indices(input, k=k, unit_attrs=unit_attrs)
+
+    output = compile_and_execute_shlo(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        save_artifacts=True,
+        ttir_pipeline_options=["optimization-level=1"],
+        # The op returns top-k *indices*. When several elements tie (common in
+        # bf16, which has only 8 mantissa bits), the order of the tied indices
+        # is unspecified, so the device and the torch golden may return the same
+        # index set in a different order. Positional PCC on index labels is not a
+        # meaningful correctness metric in that case (same convention as the
+        # boolean compare-op tests above), so skip it; the op still compiles
+        # through the full pipeline and executes on device, and the typed-op
+        # promotion is checked explicitly below.
+        check_pcc=False,
+    )
+
+    # The typed ttnn.topk_large_indices op is Blackhole-only; everywhere else
+    # the composite falls back to its ttnn.topk-based decomposition.
+    expect_typed_op = system_desc.get_arch() == "Blackhole"
+
+    # The promoted typed op appears in a target-specific form.
+    typed_op_marker = {
+        "ttnn": "ttnn.topk_large_indices",
+        "emitc": "ttnn::experimental::topk_large_indices",
+        "emitpy": "ttnn.experimental.topk_large_indices",
+    }[target]
+    with open(output, "r") as f:
+        has_typed_op = any(typed_op_marker in line for line in f)
+    assert has_typed_op == expect_typed_op

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -2560,13 +2560,11 @@ def test_flash_mla_prefill_value_mask_scale(
 @pytest.mark.parametrize(
     "shape,k",
     [
-        # input [num_rows, N] -> indices [num_rows, k]. N > k exercises a real
-        # top-k selection (not a full sort). k is a multiple of 16 in [16, 2048]
-        # so the typed Blackhole op accepts it.
         ((2, 64), 16),
         ((4, 256), 64),
+        ((2, 4, 256), 64),
     ],
-    ids=["rows2_n64_k16", "rows4_n256_k64"],
+    ids=["rows2_n64_k16", "rows4_n256_k64", "batch2_hidden4_seq256_k64"],
 )
 @pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
 def test_topk_large_indices(
@@ -2616,4 +2614,65 @@ def test_topk_large_indices(
     }[target]
     with open(output, "r") as f:
         has_typed_op = any(typed_op_marker in line for line in f)
+    assert has_typed_op == expect_typed_op
+
+
+@pytest.mark.parametrize(
+    "input_dim_axes",
+    [
+        [["y"], [], []],  # shard batch on axis x
+        [[], ["y"], []],  # shard hidden_size on axis y
+        [[], [], ["y"]],  # shard seq_len on y
+    ],
+    ids=["batch_y", "hidden_y", "seqlen_y"],
+)
+@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=["1x2"])
+def test_sharded_topk_large_indices(
+    input_dim_axes,
+    target: str,
+    mesh_shape: Tuple[int, int],
+    device,
+    request,
+    system_desc,
+):
+    shape = (64, 1024, 256)  # batch, hidden, seq_len
+    k = 64
+
+    def module(builder: StableHLOBuilder):
+        @builder.func([shape], [torch.bfloat16])
+        def sharded_topk_large_indices(input: Operand, builder: StableHLOBuilder):
+            # Mark the desired sharding on the input tensor and build the op in
+            # its global shape. The pipeline derives the partitioned program.
+            input_sharding = builder.tensor_sharding_attr(
+                mesh_name="mesh",
+                dimension_shardings=[
+                    builder.dimension_sharding_attr(
+                        axes=[builder.axis_ref_attr(name=a) for a in axes],
+                        is_closed=True,
+                    )
+                    for axes in input_dim_axes
+                ],
+            )
+            sharded_input = builder.sharding_constraint(input, input_sharding)
+            return builder.topk_large_indices(sharded_input, k=k)
+
+    output = compile_and_execute_shlo(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        save_artifacts=True,
+        ttir_pipeline_options=["optimization-level=1"],
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        # As in test_topk_large_indices: top-k index labels tie under bf16, so
+        # positional PCC on the returned indices is not a meaningful metric.
+        check_pcc=False,
+    )
+
+    # As in test_topk_large_indices, the typed ttnn.topk_large_indices op is
+    # Blackhole-only; elsewhere the composite falls back to its decomposition.
+    expect_typed_op = system_desc.get_arch() == "Blackhole"
+    with open(output, "r") as f:
+        has_typed_op = any("ttnn.topk_large_indices" in line for line in f)
     assert has_typed_op == expect_typed_op

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduction/topk_large_indices.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduction/topk_large_indices.mlir
@@ -1,0 +1,27 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module @topk_large_indices attributes {} {
+  // stablehlo.custom_call @tt.topk_large_indices lowers to a
+  // ttcore.composite "topk_large_indices" carrying k, plus a synthesized
+  // primitive decomposition function (a ttir.topk keeping only the indices).
+  func.func public @topk_large_indices(%input: tensor<2x64xbf16>) -> tensor<2x16xui32> {
+    // CHECK-LABEL: @topk_large_indices
+    // CHECK: "ttcore.composite"(%arg0)
+    // CHECK-SAME: k = 16 : ui32
+    // CHECK-SAME: composite_name = "topk_large_indices"
+    // CHECK-SAME: decomposition = @topk_large_indices_decomp
+    // CHECK-SAME: (tensor<2x64xbf16>) -> tensor<2x16xui32>
+    %0 = stablehlo.custom_call @tt.topk_large_indices(%input) {api_version = 0 : i32, mhlo.frontend_attributes = {k = "16"}} : (tensor<2x64xbf16>) -> tensor<2x16xui32>
+    return %0 : tensor<2x16xui32>
+  }
+
+  // The synthesized decomposition holds the primitive lowering: a single
+  // ttir.topk over the last dimension whose (UINT32) indices result is
+  // returned and whose values result is discarded.
+  // CHECK: func.func private @topk_large_indices_decomp
+  // CHECK: "ttir.topk"
+  // CHECK-SAME: k = 16 : i32
+  // CHECK-SAME: (tensor<2x64xbf16>) -> (tensor<2x16xbf16>, tensor<2x16xui32>)
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduction/topk_large_indices_negative.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduction/topk_large_indices_negative.mlir
@@ -1,0 +1,14 @@
+// REQUIRES: stablehlo
+// RUN: not ttmlir-opt --split-input-file --stablehlo-to-ttir-pipeline %s 2>&1 | FileCheck %s
+
+// topk_large_indices expects exactly 1 operand (input). With the wrong operand
+// count the custom_call fails to legalize (the k-value and shape constraints
+// are enforced later by the ttnn.topk_large_indices verifier; see
+// test/ttmlir/Dialect/TTNN/reduction/topk_large_indices_negative.mlir).
+module {
+  func.func public @topk_large_indices_bad_operand_count(%input: tensor<2x64xbf16>, %extra: tensor<2x64xbf16>) -> tensor<2x16xui32> {
+    // CHECK: error: failed to legalize operation 'stablehlo.custom_call'
+    %0 = stablehlo.custom_call @tt.topk_large_indices(%input, %extra) {api_version = 0 : i32, mhlo.frontend_attributes = {k = "16"}} : (tensor<2x64xbf16>, tensor<2x64xbf16>) -> tensor<2x16xui32>
+    return %0 : tensor<2x16xui32>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_topk_large_indices.mlir
+++ b/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_topk_large_indices.mlir
@@ -1,0 +1,40 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt -split-input-file --stablehlo-pipeline -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// tt.topk_large_indices layout:
+//   input [rows, N] -> indices [rows, k]   (top-k over the last dim N).
+
+// Data parallelism over rows. The input/output shard on the leading (row) dim;
+// the row-length dim N stays replicated (the fused op needs the whole row), so
+// the op runs entirely on local row-shards with no collective.
+// CHECK-LABEL: module @TopKLargeIndices_Sharding_Rows
+module @TopKLargeIndices_Sharding_Rows attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<4x256xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22_axis_0\22}, {}]>"}, mhlo.sharding = "{devices=[2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "input"}) -> tensor<4x64xui32> {
+    // CHECK-NOT: stablehlo.all_gather
+    // CHECK-NOT: stablehlo.all_reduce
+    // CHECK: stablehlo.custom_call @tt.topk_large_indices
+    // CHECK-SAME: tensor<2x256xbf16>
+    // CHECK-SAME: -> tensor<2x64xui32>
+    %0 = stablehlo.custom_call @tt.topk_large_indices(%arg0) {api_version = 0 : i32, mhlo.frontend_attributes = {k = "64"}} : (tensor<4x256xbf16>) -> tensor<4x64xui32>
+    return %0 : tensor<4x64xui32>
+  }
+}
+
+// -----
+
+// Sharding the row-length dim N. Because N is kNeedReplication (the fused op
+// needs the whole row on one device), the partitioner inserts an all_gather to
+// replicate N before the op; the op then runs on the full row length.
+// CHECK-LABEL: module @TopKLargeIndices_Sharding_RowLen
+module @TopKLargeIndices_Sharding_RowLen attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<4x256xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}]>"}, mhlo.sharding = "{devices=[1,2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "input"}) -> tensor<4x64xui32> {
+    // CHECK: stablehlo.all_gather
+    // CHECK: stablehlo.custom_call @tt.topk_large_indices
+    // CHECK-SAME: tensor<4x256xbf16>
+    // CHECK-SAME: -> tensor<4x64xui32>
+    %0 = stablehlo.custom_call @tt.topk_large_indices(%arg0) {api_version = 0 : i32, mhlo.frontend_attributes = {k = "64"}} : (tensor<4x256xbf16>) -> tensor<4x64xui32>
+    return %0 : tensor<4x64xui32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_large_indices_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_large_indices_workaround.mlir
@@ -1,0 +1,28 @@
+// RUN: ttmlir-opt --ttcore-register-device="mock-system-desc-arch=blackhole" --ttnn-layout --convert-ttir-to-ttnn --ttnn-resolve-composites="composite-resolution=force-promote" --ttnn-workaround --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// The tt-metal topk_large_indices kernel requires a ROW_MAJOR bf16 input and
+// produces a ROW_MAJOR ui32 output. The TTNNWorkaround pass inserts
+// ttnn.to_layout ops so the promoted ttnn.topk_large_indices runs on
+// ROW_MAJOR (untiled) operands.
+
+// ROW_MAJOR layouts are the ones whose memref has plain (non-tile) elements.
+// CHECK-DAG: #[[ROW_BF16:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<1x512xbf16, #dram>{{.*}}>
+// CHECK-DAG: #[[ROW_U32:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<1x512xui32, #dram>{{.*}}>
+
+module {
+  func.func @topk_large_indices(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+    // CHECK-LABEL: @topk_large_indices
+    // CHECK: "ttnn.to_layout"
+    // CHECK: %[[IDX:[0-9]+]] = "ttnn.topk_large_indices"
+    // CHECK-SAME: <{k = 512 : ui32}>
+    // CHECK-SAME: (tensor<1x512xbf16, #[[ROW_BF16]]>) -> tensor<1x512xui32, #[[ROW_U32]]>
+    // CHECK: "ttnn.to_layout"(%[[IDX]])
+    %0 = "ttcore.composite"(%input) <{composite_name = "topk_large_indices", decomposition = @decomp, composite_attributes = {k = 512 : ui32}}> : (tensor<1x512xbf16>) -> tensor<1x512xui32>
+    return %0 : tensor<1x512xui32>
+  }
+  func.func private @decomp(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+    %values, %indices = "ttir.topk"(%input) <{k = 512 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x512xbf16>) -> (tensor<1x512xbf16>, tensor<1x512xui32>)
+    return %indices : tensor<1x512xui32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/reduction/topk_large_indices_arch_fallback.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/topk_large_indices_arch_fallback.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt --ttnn-resolve-composites="composite-resolution=force-promote" %s | FileCheck %s
+
+// ttnn.experimental.topk_large_indices is Blackhole-only. On a non-Blackhole
+// target the promotion guard vetoes promotion, so TTNNResolveComposites inlines
+// the decomposition body instead of promoting -- even under force-promote,
+// which would otherwise promote to the typed op. The wormhole system_desc is
+// what triggers the inline fallback.
+
+#system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], dst_physical_size_tiles = 16, num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(7, 3), (0, 0), (3, 0), (4, 0), (0, 4), (7, 7), (1, 4), (6, 4), (5, 4), (2, 6), (3, 4), (4, 4)], dram_bank_to_logical_worker_noc1 = [(7, 3), (0, 0), (3, 0), (4, 0), (0, 4), (7, 7), (1, 4), (6, 4), (5, 4), (2, 6), (3, 4), (4, 4)]}], [0], [1 : i32], [ 0x0x0x0]>
+
+module attributes {ttcore.system_desc = #system_desc} {
+  func.func @topk_large_indices(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+    // CHECK-LABEL: @topk_large_indices
+    // CHECK-NOT: "ttnn.topk_large_indices"
+    // CHECK-NOT: "ttcore.composite"
+    // The decomposition body (ttir.topk) is spliced in verbatim.
+    // CHECK: "ttir.topk"
+    %0 = "ttcore.composite"(%input) <{composite_name = "topk_large_indices", decomposition = @decomp, composite_attributes = {k = 512 : ui32}}> : (tensor<1x512xbf16>) -> tensor<1x512xui32>
+    return %0 : tensor<1x512xui32>
+  }
+  func.func private @decomp(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+    %values, %indices = "ttir.topk"(%input) <{k = 512 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x512xbf16>) -> (tensor<1x512xbf16>, tensor<1x512xui32>)
+    return %indices : tensor<1x512xui32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/reduction/topk_large_indices_decomposition_wh.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/topk_large_indices_decomposition_wh.mlir
@@ -1,0 +1,16 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="mock-system-desc-arch=wormhole_b0" -o %t2.mlir %t.mlir
+// RUN: FileCheck %s --input-file=%t2.mlir --implicit-check-not="ttnn.topk_large_indices"
+
+// End-to-end decomposition path: on a non-Blackhole target (Wormhole), the
+// ttcore.composite "topk_large_indices" is replaced by its decomposition of
+// ttnn primitives (a plain ttnn.topk whose indices are kept).
+
+module @topk_large_indices {
+  func.func public @topk_large_indices(%input: tensor<2x64xbf16>) -> tensor<2x16xui32> {
+    // CHECK: "ttnn.topk"
+    %0 = stablehlo.custom_call @tt.topk_large_indices(%input) {api_version = 0 : i32, mhlo.frontend_attributes = {k = "16"}} : (tensor<2x64xbf16>) -> tensor<2x16xui32>
+    return %0 : tensor<2x16xui32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/reduction/topk_large_indices_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/topk_large_indices_negative.mlir
@@ -1,0 +1,67 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+// Negative tests for the ttnn.topk_large_indices verifier.
+
+// Input element type must be bf16.
+module {
+  func.func @topk_large_indices_bad_input_dtype(%input: tensor<2x64xf32>) -> tensor<2x16xui32> {
+    // CHECK: error: 'ttnn.topk_large_indices' op Input element type must be bf16
+    %0 = "ttnn.topk_large_indices"(%input) <{k = 16 : ui32}> : (tensor<2x64xf32>) -> tensor<2x16xui32>
+    return %0 : tensor<2x16xui32>
+  }
+}
+
+// -----
+
+// Result element type must be ui32.
+module {
+  func.func @topk_large_indices_bad_result_dtype(%input: tensor<2x64xbf16>) -> tensor<2x16xi32> {
+    // CHECK: error: 'ttnn.topk_large_indices' op Result element type must be ui32
+    %0 = "ttnn.topk_large_indices"(%input) <{k = 16 : ui32}> : (tensor<2x64xbf16>) -> tensor<2x16xi32>
+    return %0 : tensor<2x16xi32>
+  }
+}
+
+// -----
+
+// Result last dimension must equal k.
+module {
+  func.func @topk_large_indices_bad_result_last_dim(%input: tensor<2x64xbf16>) -> tensor<2x32xui32> {
+    // CHECK: error: 'ttnn.topk_large_indices' op Result last dimension must equal k
+    %0 = "ttnn.topk_large_indices"(%input) <{k = 16 : ui32}> : (tensor<2x64xbf16>) -> tensor<2x32xui32>
+    return %0 : tensor<2x32xui32>
+  }
+}
+
+// -----
+
+// Result leading dimensions must match the input leading dimensions.
+module {
+  func.func @topk_large_indices_bad_leading_dim(%input: tensor<2x64xbf16>) -> tensor<4x16xui32> {
+    // CHECK: error: 'ttnn.topk_large_indices' op Result leading dimensions must match
+    %0 = "ttnn.topk_large_indices"(%input) <{k = 16 : ui32}> : (tensor<2x64xbf16>) -> tensor<4x16xui32>
+    return %0 : tensor<4x16xui32>
+  }
+}
+
+// -----
+
+// Input last dimension must be >= k.
+module {
+  func.func @topk_large_indices_input_smaller_than_k(%input: tensor<2x16xbf16>) -> tensor<2x32xui32> {
+    // CHECK: error: 'ttnn.topk_large_indices' op Input last dimension
+    %0 = "ttnn.topk_large_indices"(%input) <{k = 32 : ui32}> : (tensor<2x16xbf16>) -> tensor<2x32xui32>
+    return %0 : tensor<2x32xui32>
+  }
+}
+
+// -----
+
+// k must be in [16, 2048] and a multiple of 16 (here k is not a multiple of 16).
+module {
+  func.func @topk_large_indices_bad_k(%input: tensor<2x64xbf16>) -> tensor<2x20xui32> {
+    // CHECK: error: 'ttnn.topk_large_indices' op k must be in [16, 2048] and a multiple of 16
+    %0 = "ttnn.topk_large_indices"(%input) <{k = 20 : ui32}> : (tensor<2x64xbf16>) -> tensor<2x20xui32>
+    return %0 : tensor<2x20xui32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/reduction/topk_large_indices_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/topk_large_indices_positive.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="mock-system-desc-arch=blackhole composite-resolution=force-promote" %s | FileCheck %s
+
+// Resolves a ttcore.composite "topk_large_indices" through the TTNN backend
+// pipeline (TTNNResolveComposites) on a Blackhole target and verifies it is
+// promoted to the typed ttnn.topk_large_indices op carrying k. The synthesized
+// decomposition function is the fallback body and is deleted once the typed
+// promotion succeeds.
+
+module {
+  func.func @topk_large_indices(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+    // CHECK-LABEL: @topk_large_indices
+    // CHECK: "ttnn.topk_large_indices"
+    // CHECK-SAME: k = 512 : ui32
+    // CHECK-NOT: "ttcore.composite"
+    %0 = "ttcore.composite"(%input) <{composite_name = "topk_large_indices", decomposition = @decomp, composite_attributes = {k = 512 : ui32}}> : (tensor<1x512xbf16>) -> tensor<1x512xui32>
+    return %0 : tensor<1x512xui32>
+  }
+  func.func private @decomp(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+    %values, %indices = "ttir.topk"(%input) <{k = 512 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x512xbf16>) -> (tensor<1x512xbf16>, tensor<1x512xui32>)
+    return %indices : tensor<1x512xui32>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/reduction/topk_large_indices.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/topk_large_indices.mlir
@@ -1,0 +1,25 @@
+// REQUIRES: Blackhole
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path% composite-resolution=force-promote" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-translate --mlir-to-cpp -o %t.cpp %t2.mlir
+// RUN: FileCheck %s --input-file=%t.cpp
+
+// The ttcore.composite "topk_large_indices" is promoted to
+// ttnn.topk_large_indices by TTNNResolveComposites and then emitted to C++ as
+// ttnn::experimental::topk_large_indices.
+
+module {
+  func.func @topk_large_indices(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+    // CHECK: ttnn::experimental::topk_large_indices
+    %0 = "ttcore.composite"(%input) <{composite_name = "topk_large_indices", decomposition = @decomp, composite_attributes = {k = 512 : ui32}}> : (tensor<1x512xbf16>) -> tensor<1x512xui32>
+    return %0 : tensor<1x512xui32>
+  }
+  func.func private @decomp(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+    %values, %indices = "ttir.topk"(%input) <{k = 512 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x512xbf16>) -> (tensor<1x512xbf16>, tensor<1x512xui32>)
+    return %indices : tensor<1x512xui32>
+  }
+}

--- a/test/ttmlir/EmitPy/reduction/topk_large_indices.mlir
+++ b/test/ttmlir/EmitPy/reduction/topk_large_indices.mlir
@@ -1,0 +1,18 @@
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline="mock-system-desc-arch=blackhole composite-resolution=force-promote" -o %t.mlir %s
+// RUN: ttmlir-translate --mlir-to-python -o %t.py %t.mlir
+// RUN: FileCheck %s --input-file=%t.py
+
+// The ttcore.composite "topk_large_indices" is promoted to
+// ttnn.topk_large_indices by TTNNResolveComposites and then emitted to Python
+// as ttnn.experimental.topk_large_indices.
+
+func.func @topk_large_indices(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+  // CHECK-LABEL: def topk_large_indices
+  // CHECK: ttnn.experimental.topk_large_indices({{[a-z_0-9]+}}, k=512)
+  %0 = "ttcore.composite"(%input) <{composite_name = "topk_large_indices", decomposition = @decomp, composite_attributes = {k = 512 : ui32}}> : (tensor<1x512xbf16>) -> tensor<1x512xui32>
+  return %0 : tensor<1x512xui32>
+}
+func.func private @decomp(%input: tensor<1x512xbf16>) -> tensor<1x512xui32> {
+  %values, %indices = "ttir.topk"(%input) <{k = 512 : i32, dim = -1 : i32, largest = true, sorted = true}> : (tensor<1x512xbf16>) -> (tensor<1x512xbf16>, tensor<1x512xui32>)
+  return %indices : tensor<1x512xui32>
+}

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -7034,6 +7034,69 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterfaceWithMask) {
 }
 
 //===----------------------------------------------------------------------===//
+// TopKLargeIndicesOp
+//===----------------------------------------------------------------------===//
+
+// ttnn.experimental.topk_large_indices is Blackhole-only: on any other
+// architecture the metal op raises (TT_FATAL), which the op-model query
+// surfaces as an error. The test therefore skips when the query is unavailable
+// so it still exercises the binding on Blackhole hardware without failing
+// elsewhere.
+TEST_F(OpModelBase, TopKLargeIndicesOpInterface) {
+  // input [num_rows, N] bf16 -> indices [num_rows, k] ui32.
+  llvm::SmallVector<int64_t> inputShape = {2, 512};
+  llvm::SmallVector<int64_t> outputShape = {2, 512};
+  const uint32_t k = 512;
+
+  llvm::SmallVector<int64_t> gridAttr{1, 1};
+  auto tensorMemoryLayoutAttr =
+      TensorMemoryLayoutAttr::get(&context, TensorMemoryLayout::Interleaved);
+
+  // The tt-metal kernel requires a ROW_MAJOR bf16 input and produces a
+  // ROW_MAJOR ui32 output, so use the untiled element types.
+  auto bf16Type = builder.getBF16Type();
+  auto ui32Type = builder.getIntegerType(32, false);
+
+  auto makeDramLayout = [&](llvm::ArrayRef<int64_t> shape, mlir::Type elem) {
+    return TTNNLayoutAttr::Builder(&context, shape, elem)
+        .setBufferType(BufferType::DRAM)
+        .setMemoryLayout(tensorMemoryLayoutAttr)
+        .setGridShape(gridAttr)
+        .buildWithCanonicalCorePlacement(CreateDeviceAttr());
+  };
+
+  auto inputLayout = makeDramLayout(inputShape, bf16Type);
+  auto outputLayout = makeDramLayout(outputShape, ui32Type);
+
+  auto input = createEmptyTensor(inputShape, bf16Type, inputLayout);
+  auto outputType = createRankedTensorType(outputShape, ui32Type, outputLayout);
+
+  auto topKOp = builder.create<TopKLargeIndicesOp>(builder.getUnknownLoc(),
+                                                   outputType, input, k);
+
+  topKOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
+
+  auto constraintsExp = getOpConstraints(topKOp.getOperation());
+  if (!constraintsExp) {
+    GTEST_SKIP() << "topk_large_indices op-model query unavailable "
+                    "(Blackhole-only): "
+                 << llvm::toString(constraintsExp.takeError());
+  }
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
+      constraintsExp.get();
+  EXPECT_GE(cbSize, 0);
+  EXPECT_GE(l1PeakSize, 0);
+  EXPECT_GE(totalPeakSize, 0);
+
+  auto runtimeExp = getOpRuntime(topKOp.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    llvm::consumeError(runtimeExp.takeError());
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // SamplingOp
 //===----------------------------------------------------------------------===//
 

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -9864,6 +9864,70 @@ class StableHLOBuilder(Builder):
 
         return op.result
 
+    ############### stablehlo.CustomCallOp @tt.topk_large_indices ###############
+
+    @tag(stablehlo.CustomCallOp)
+    def topk_large_indices(
+        self,
+        input: Operand,
+        k: int,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        """
+        Emit a `stablehlo.custom_call @tt.topk_large_indices`.
+
+        Experimental large-row top-k indices op. Returns the sorted-descending
+        top-k indices along the last dimension of a row-major BFLOAT16 tensor.
+        The output has the same shape as the input except that the last
+        dimension is `k`, and its element type is UINT32. `k` is carried as a
+        string-valued frontend attribute.
+        """
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.topk_large_indices)
+
+        inputs = [input]
+
+        # Output is the input shape with the last dim replaced by k, dtype ui32.
+        input_shape = list(self.get_shape(input))
+        output_shape = input_shape[:-1] + [k]
+        output_type = self._create_ranked_tensor_type(
+            output_shape, IntegerType.get_unsigned(32, self._ctx)
+        )
+
+        # tt.topk_large_indices carries k as a string-valued frontend attribute.
+        frontend_attrs = {
+            "k": StringAttr.get(str(k)),
+        }
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = stablehlo_op(
+            [output_type],
+            inputs,
+            "tt.topk_large_indices",
+            api_version=IntegerAttr.get(IntegerType.get_signless(32), 0),
+            loc=loc,
+        )
+        op.operation.attributes["mhlo.frontend_attributes"] = DictAttr.get(
+            frontend_attrs, self._ctx
+        )
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        op_golden_function = get_custom_call_golden_function("tt.topk_large_indices")
+        golden_output = op_golden_function(
+            self._get_golden_tensor(input),
+            k,
+        )
+        self._set_golden_tensor(op.result, golden_output)
+
+        return op.result
+
     # ----- Public Shardy Attribute Generators ----
 
     def mesh_axis_attr(

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -8422,6 +8422,22 @@ def flash_mla_prefill_golden(
     return output.to(output_dtype)
 
 
+def topk_large_indices_golden(
+    input: GoldenMapTensor,
+    k: int,
+) -> GoldenMapTensor:
+    """
+    Golden for the tt.topk_large_indices custom_call (experimental large-row
+    top-k indices op).
+
+    Returns the sorted-descending top-k indices along the last dimension:
+        indices = topk(input, k, dim=-1, largest=True, sorted=True).indices
+    as a UINT32 tensor of shape ``[..., k]``.
+    """
+    _, indices = torch.topk(input.float(), k=k, dim=-1, largest=True, sorted=True)
+    return indices.to(torch.uint32)
+
+
 def ttir_paged_sdpa_decode_golden(
     query: GoldenMapTensor,
     key: GoldenMapTensor,
@@ -9082,6 +9098,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
 # StableHLO custom_call goldens
 STABLEHLO_CUSTOM_CALL_GOLDEN_MAPPINGS: Dict[str, Callable] = {
     "tt.flash_mla_prefill": flash_mla_prefill_golden,
+    "tt.topk_large_indices": topk_large_indices_golden,
 }
 
 

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -41,6 +41,7 @@
 #include "operations/experimental/conv3d/conv3d.hpp"
 #include "operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include "operations/experimental/dropout/dropout.hpp"
+#include "operations/experimental/topk_large_indices/topk_large_indices.hpp"
 #include "operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"
 #include "operations/experimental/unary_backward/gelu_backward/gelu_backward.hpp"
 #include "operations/kv_cache/kv_cache.hpp"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3102

### Problem description
We do not currently support lowering to the ttnn.experimental.topk_large_indices op. Adding this support allows us to leverage custom built tt-metal kernels to use in DSA, instead of replicating it as a naive decomposition.

### What's changed
- Lowering support from stablehlo.custom_call -> ttcore.composite -> ttnn.topk_large_indices op -> EmitC/EmitPy/Flatbuffer.
- Added an optional CompositePromotionGuardFn to ttcore.composite ops. If this guard is failed then that op will NOT get promoted to the corresponding ttnn op (even if it would've passed OpModel verification). This is useful for gating ops' promotion based on architecture. 

(Note: this promotion guard is also present in https://github.com/tenstorrent/tt-mlir/pull/8969. If that PR gets merged before this one, I'll remove the functionality from this one)

### Checklist
- [ ] New/Existing tests provide coverage for changes
