### PR TITLE
[Optimizer] Add opmodel for chunked sdpa op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3922,7 +3922,7 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
   let hasVerifier = 1;
 }
 
-def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_product_attention", [OpModelExempt]> {
+def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_product_attention"> {
   let summary = "Chunked prefill scaled dot product attention over a paged KV cache.";
   let description = [{
     Chunked-prefill attention. A prefill chunk of `query` attends

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -821,6 +821,32 @@ struct OpModel<PagedFlashMultiLatentAttentionDecodeOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// ChunkedScaledDotProductAttentionOp
+//===----------------------------------------------------------------------===//
+template <>
+struct OpModel<ChunkedScaledDotProductAttentionOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      llvm::ArrayRef<int64_t> chunkStartIdxShape,
+      TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
+      std::optional<SDPAProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      llvm::ArrayRef<int64_t> chunkStartIdxShape,
+      TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
+      std::optional<SDPAProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // ScaledDotProductAttentionOp
 //===----------------------------------------------------------------------===//
 template <>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2328,6 +2328,49 @@ llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// ChunkedScaledDotProductAttentionOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+ChunkedScaledDotProductAttentionOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  assert(inputs.size() == 5 &&
+         "ttnn::chunked_scaled_dot_product_attention has 5 input tensors "
+         "(q, k, v, page_table, chunk_start_idx)");
+
+  const auto queryShape = getQuery().getType().getShape();
+  const auto keyShape = getKey().getType().getShape();
+  const auto valueShape = getValue().getType().getShape();
+  const auto pageTableShape = getPageTable().getType().getShape();
+  const auto chunkStartIdxShape = getChunkStartIdx().getType().getShape();
+
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints,
+      *this, queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
+      pageTableShape, inputs[3], chunkStartIdxShape, inputs[4], getScale(),
+      getProgramConfig(), opConfig.outputLayout);
+}
+
+llvm::Expected<size_t> ChunkedScaledDotProductAttentionOp::getOpRuntime(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  assert(inputs.size() == 5 &&
+         "ttnn::chunked_scaled_dot_product_attention has 5 input tensors "
+         "(q, k, v, page_table, chunk_start_idx)");
+
+  const auto queryShape = getQuery().getType().getShape();
+  const auto keyShape = getKey().getType().getShape();
+  const auto valueShape = getValue().getType().getShape();
+  const auto pageTableShape = getPageTable().getType().getShape();
+  const auto chunkStartIdxShape = getChunkStartIdx().getType().getShape();
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<ChunkedScaledDotProductAttentionOp>::getOpRuntime,
+      *this, queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
+      pageTableShape, inputs[3], chunkStartIdxShape, inputs[4], getScale(),
+      getProgramConfig(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // ScaledDotProductAttentionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -3063,6 +3063,109 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// ChunkedScaledDotProductAttentionOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints>
+OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    llvm::ArrayRef<int64_t> chunkStartIdxShape,
+    TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec pageTableSpec,
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec chunkStartIdxSpec,
+                   detail::convertToTensorSpec(device, chunkStartIdxShape,
+                                               chunkStartIdxLayout));
+
+  std::optional<float> scaleFloat =
+      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
+
+  auto chunkedScaledDotProductAttentionOpQuery = [=]() {
+    return QUERY_OP_CONSTRAINTS(
+        ::ttnn::transformer::chunked_scaled_dot_product_attention, device,
+        querySpec, keySpec, valueSpec, pageTableSpec, chunkStartIdxSpec,
+        scaleFloat, detail::getNullableMemoryConfig(outputLayout),
+        sdpaProgramConfig,
+        /*compute_kernel_config=*/std::nullopt);
+  };
+
+  return operation::getOpConstraints(queryLayout.getContext(),
+                                     chunkedScaledDotProductAttentionOpQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+OpModel<ChunkedScaledDotProductAttentionOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    llvm::ArrayRef<int64_t> chunkStartIdxShape,
+    TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec pageTableSpec,
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec chunkStartIdxSpec,
+                   detail::convertToTensorSpec(device, chunkStartIdxShape,
+                                               chunkStartIdxLayout));
+
+  std::optional<float> scaleFloat =
+      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
+
+  auto chunkedScaledDotProductAttentionOpQuery = [=]() {
+    return QUERY_OP_RUNTIME(
+        ::ttnn::transformer::chunked_scaled_dot_product_attention, device,
+        querySpec, keySpec, valueSpec, pageTableSpec, chunkStartIdxSpec,
+        scaleFloat, detail::getNullableMemoryConfig(outputLayout),
+        sdpaProgramConfig,
+        /*compute_kernel_config=*/std::nullopt);
+  };
+
+  return operation::getOpRuntime(chunkedScaledDotProductAttentionOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // ScaledDotProductAttentionOp
 //===----------------------------------------------------------------------===//
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/chunked_sdpa_rm_layout_propagation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/chunked_sdpa_rm_layout_propagation.mlir
@@ -1,31 +1,13 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
 // REQUIRES: opmodel
 // RUN: ttmlir-opt --ttnn-rm-layout-propagation %s | FileCheck %s
 
-// Regression test: ChunkedScaledDotProductAttentionOp must keep its page_table
+// Check ChunkedScaledDotProductAttentionOp keep its page_table
 // and chunk_start_idx operands ROW_MAJOR through RowMajorLayoutPropagation.
-//
-// The tt-metal kernel hard-rejects a tiled page table
-// ("TT_FATAL: Page table must be row major", sdpa_device_operation.cpp). The
-// page_table / chunk_start_idx arguments arrive ROW_MAJOR. Because chunked SDPA
-// now implements the op-model interface (it is no longer OpModelExempt),
-// RowMajorLayoutPropagation queries the op model, learns the row-major operands
-// are legal, and preserves them. Previously the op was OpModelExempt, so the
-// pass could not query it and inserted a tilizing to_layout fixup on the
-// page table (`opStopsRowMajorPropagation` -> `insertTiledFixup`), which then
-// crashed at runtime.
-//
-// Query/key/value/output stay TILE (bf16 attention); only the integer
-// page_table and chunk_start_idx are row-major.
 
 #dram = #ttnn.buffer_type<dram>
 #system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 104224, erisc_l1_unreserved_base = 98304, dram_unreserved_base = 1048640, dram_unreserved_end = 1073116480, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], dst_physical_size_tiles = 16, num_cbs = 64, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(7, 3), (0, 0), (4, 0), (5, 0), (0, 4), (3, 7), (1, 4), (7, 4), (6, 4), (2, 4), (4, 4), (5, 4)], dram_bank_to_logical_worker_noc1 = [(7, 3), (0, 0), (4, 0), (5, 0), (0, 4), (3, 7), (1, 4), (7, 4), (6, 4), (2, 4), (4, 4), (5, 4)]}], [0], [1 : i32], [ 0x0x0x0]>
 #ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 768 + d1 * 64 + d2, d3), <1x1>, memref<24x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 384 + d1 * 32 + d2, d3), <1x1>, memref<1536x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-// page_table (%arg3) and chunk_start_idx (%arg4) arrive ROW_MAJOR.
 // CHECK-DAG: #[[L2:.+]] = #ttnn.ttnn_layout<{{.*}}memref<1x4xsi32, #dram>
 // CHECK-DAG: #[[L3:.+]] = #ttnn.ttnn_layout<{{.*}}memref<1x1xsi32, #dram>
 #ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4xsi32, #dram>, <interleaved>>
@@ -36,10 +18,8 @@ module attributes {ttcore.system_desc = #system_desc} {
   func.func @chunked_sdpa(%arg0: tensor<1x12x64x64xbf16, #ttnn_layout>, %arg1: tensor<128x12x32x64xbf16, #ttnn_layout1>, %arg2: tensor<128x12x32x64xbf16, #ttnn_layout1>, %arg3: tensor<1x4xi32, #ttnn_layout2>, %arg4: tensor<1xi32, #ttnn_layout3>) -> tensor<1x12x64x64xbf16, #ttnn_layout> {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.empty"(%0) <{shape = #ttnn.shape<1x12x64x64>}> : (!ttnn.device) -> tensor<1x12x64x64xbf16, #ttnn_layout>
-    // The page table / chunk_start_idx must NOT be tilized before the op.
     // CHECK-NOT: "ttnn.to_layout"(%arg3)
     // CHECK-NOT: "ttnn.to_layout"(%arg4)
-    // The op consumes the row-major args directly.
     // CHECK: "ttnn.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4)
     // CHECK-SAME: tensor<1x4xi32, #[[L2]]>, tensor<1xi32, #[[L3]]>)
     %2 = "ttnn.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16, #ttnn_layout>, tensor<128x12x32x64xbf16, #ttnn_layout1>, tensor<128x12x32x64xbf16, #ttnn_layout1>, tensor<1x4xi32, #ttnn_layout2>, tensor<1xi32, #ttnn_layout3>) -> tensor<1x12x64x64xbf16, #ttnn_layout>

--- a/test/ttmlir/Dialect/TTNN/optimizer/chunked_sdpa_rm_layout_propagation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/chunked_sdpa_rm_layout_propagation.mlir
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttnn-rm-layout-propagation %s | FileCheck %s
+
+// Regression test: ChunkedScaledDotProductAttentionOp must keep its page_table
+// and chunk_start_idx operands ROW_MAJOR through RowMajorLayoutPropagation.
+//
+// The tt-metal kernel hard-rejects a tiled page table
+// ("TT_FATAL: Page table must be row major", sdpa_device_operation.cpp). The
+// page_table / chunk_start_idx arguments arrive ROW_MAJOR. Because chunked SDPA
+// now implements the op-model interface (it is no longer OpModelExempt),
+// RowMajorLayoutPropagation queries the op model, learns the row-major operands
+// are legal, and preserves them. Previously the op was OpModelExempt, so the
+// pass could not query it and inserted a tilizing to_layout fixup on the
+// page table (`opStopsRowMajorPropagation` -> `insertTiledFixup`), which then
+// crashed at runtime.
+//
+// Query/key/value/output stay TILE (bf16 attention); only the integer
+// page_table and chunk_start_idx are row-major.
+
+#dram = #ttnn.buffer_type<dram>
+#system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 104224, erisc_l1_unreserved_base = 98304, dram_unreserved_base = 1048640, dram_unreserved_end = 1073116480, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], dst_physical_size_tiles = 16, num_cbs = 64, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(7, 3), (0, 0), (4, 0), (5, 0), (0, 4), (3, 7), (1, 4), (7, 4), (6, 4), (2, 4), (4, 4), (5, 4)], dram_bank_to_logical_worker_noc1 = [(7, 3), (0, 0), (4, 0), (5, 0), (0, 4), (3, 7), (1, 4), (7, 4), (6, 4), (2, 4), (4, 4), (5, 4)]}], [0], [1 : i32], [ 0x0x0x0]>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 768 + d1 * 64 + d2, d3), <1x1>, memref<24x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 384 + d1 * 32 + d2, d3), <1x1>, memref<1536x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// page_table (%arg3) and chunk_start_idx (%arg4) arrive ROW_MAJOR.
+// CHECK-DAG: #[[L2:.+]] = #ttnn.ttnn_layout<{{.*}}memref<1x4xsi32, #dram>
+// CHECK-DAG: #[[L3:.+]] = #ttnn.ttnn_layout<{{.*}}memref<1x1xsi32, #dram>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4xsi32, #dram>, <interleaved>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x1xsi32, #dram>, <interleaved>>
+module attributes {ttcore.system_desc = #system_desc} {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK-LABEL: func.func @chunked_sdpa
+  func.func @chunked_sdpa(%arg0: tensor<1x12x64x64xbf16, #ttnn_layout>, %arg1: tensor<128x12x32x64xbf16, #ttnn_layout1>, %arg2: tensor<128x12x32x64xbf16, #ttnn_layout1>, %arg3: tensor<1x4xi32, #ttnn_layout2>, %arg4: tensor<1xi32, #ttnn_layout3>) -> tensor<1x12x64x64xbf16, #ttnn_layout> {
+    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.empty"(%0) <{shape = #ttnn.shape<1x12x64x64>}> : (!ttnn.device) -> tensor<1x12x64x64xbf16, #ttnn_layout>
+    // The page table / chunk_start_idx must NOT be tilized before the op.
+    // CHECK-NOT: "ttnn.to_layout"(%arg3)
+    // CHECK-NOT: "ttnn.to_layout"(%arg4)
+    // The op consumes the row-major args directly.
+    // CHECK: "ttnn.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4)
+    // CHECK-SAME: tensor<1x4xi32, #[[L2]]>, tensor<1xi32, #[[L3]]>)
+    %2 = "ttnn.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xbf16, #ttnn_layout>, tensor<128x12x32x64xbf16, #ttnn_layout1>, tensor<128x12x32x64xbf16, #ttnn_layout1>, tensor<1x4xi32, #ttnn_layout2>, tensor<1xi32, #ttnn_layout3>) -> tensor<1x12x64x64xbf16, #ttnn_layout>
+    return %2 : tensor<1x12x64x64xbf16, #ttnn_layout>
+  }
+}

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -6755,6 +6755,114 @@ INSTANTIATE_TEST_SUITE_P(ScaledDotProductAttentionTests,
                          OpModelScaledDotProductAttentionParam,
                          scaledDotProductAttentionOpTestValues);
 
+// === ChunkedScaledDotProductAttentionOp Tests ===
+struct ChunkedScaledDotProductAttentionOpParam {
+  detail::TestTensor query;
+  detail::TestTensor key;
+  detail::TestTensor value;
+  detail::TestTensor pageTable;
+  detail::TestTensor chunkStartIdx;
+  float scale;
+  detail::TestTensor output;
+  detail::ExpectedResult expectedResult;
+};
+
+class OpModelChunkedScaledDotProductAttentionParam
+    : public OpModelTest,
+      public testing::WithParamInterface<
+          ChunkedScaledDotProductAttentionOpParam> {
+protected:
+  void RunTest() {
+    // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
+    const auto [queryShape, queryTensorLayout, queryBufferType,
+                queryVirtualGrid] = GetParam().query;
+    const auto [keyShape, keyTensorLayout, keyBufferType, keyVirtualGrid] =
+        GetParam().key;
+    const auto [valueShape, valueTensorLayout, valueBufferType,
+                valueVirtualGrid] = GetParam().value;
+    const auto [pageTableShape, pageTableTensorLayout, pageTableBufferType,
+                pageTableVirtualGrid] = GetParam().pageTable;
+    const auto [chunkStartIdxShape, chunkStartIdxTensorLayout,
+                chunkStartIdxBufferType, chunkStartIdxVirtualGrid] =
+        GetParam().chunkStartIdx;
+
+    const auto [outputShape, outputTensorLayout, outputBufferType,
+                outputVirtualGrid] = GetParam().output;
+
+    const auto expectedLegal = GetParam().expectedResult.expectedLegal;
+
+    const TTNNLayoutAttr queryLayout = CreateTiledLayout(
+        queryShape, queryBufferType, queryTensorLayout, queryVirtualGrid);
+    const TTNNLayoutAttr keyLayout = CreateTiledLayout(
+        keyShape, keyBufferType, keyTensorLayout, keyVirtualGrid);
+    const TTNNLayoutAttr valueLayout = CreateTiledLayout(
+        valueShape, valueBufferType, valueTensorLayout, valueVirtualGrid);
+    // page_table and chunk_start_idx are consumed on device as row-major int32
+    // tensors (the tt-metal kernel requires the page table to be row major).
+    const TTNNLayoutAttr pageTableLayout =
+        CreateRowMajorLayoutInt32(pageTableShape, pageTableBufferType,
+                                  pageTableTensorLayout, pageTableVirtualGrid);
+    const TTNNLayoutAttr chunkStartIdxLayout = CreateRowMajorLayoutInt32(
+        chunkStartIdxShape, chunkStartIdxBufferType, chunkStartIdxTensorLayout,
+        chunkStartIdxVirtualGrid);
+
+    const TTNNLayoutAttr outputLayout = CreateTiledLayout(
+        outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+    const llvm::APFloat scaleAPFloat(GetParam().scale);
+    std::optional<llvm::APFloat> scale = scaleAPFloat;
+
+    std::optional<SDPAProgramConfigAttr> programConfig = std::nullopt;
+
+    auto constraintsExp =
+        OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints(
+            queryShape, queryLayout, keyShape, keyLayout, valueShape,
+            valueLayout, pageTableShape, pageTableLayout, chunkStartIdxShape,
+            chunkStartIdxLayout, scale, programConfig, outputLayout);
+
+    EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+    if (expectedLegal) {
+      const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
+                  outputLayoutReadBacks] = constraintsExp.get();
+      EXPECT_GE(cbSize, 0);
+      EXPECT_GE(l1PeakSize, 0);
+      EXPECT_GE(totalPeakSize, 0);
+      EXPECT_GE(outputSizeResult, 0);
+    } else {
+      llvm::consumeError(constraintsExp.takeError());
+    }
+    // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+  }
+};
+
+TEST_P(OpModelChunkedScaledDotProductAttentionParam,
+       ChunkedScaledDotProductAttentionOp) {
+  RunTest();
+}
+
+const auto chunkedScaledDotProductAttentionOpTestValues =
+    testing::Values(ChunkedScaledDotProductAttentionOpParam{
+        detail::TestTensor{
+            {1, 12, 64, 64}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{{128, 12, 32, 64},
+                           TensorMemoryLayout::Interleaved,
+                           BufferType::DRAM},
+        detail::TestTensor{{128, 12, 32, 64},
+                           TensorMemoryLayout::Interleaved,
+                           BufferType::DRAM},
+        detail::TestTensor{
+            {1, 8}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{
+            {1}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        0.125f,
+        detail::TestTensor{
+            {1, 12, 64, 64}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::ExpectedResult{true}});
+
+INSTANTIATE_TEST_SUITE_P(ChunkedScaledDotProductAttentionTests,
+                         OpModelChunkedScaledDotProductAttentionParam,
+                         chunkedScaledDotProductAttentionOpTestValues);
+
 TEST_F(OpModelTest, AssignOp) {
   const llvm::SmallVector<int64_t> tensorShape = {64, 64};
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -6837,7 +6837,9 @@ protected:
 
 TEST_P(OpModelChunkedScaledDotProductAttentionParam,
        ChunkedScaledDotProductAttentionOp) {
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
   RunTest();
+  // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
 const auto chunkedScaledDotProductAttentionOpTestValues =

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -2402,6 +2402,97 @@ TEST_F(OpModelBase, ScaledDotProductAttentionOpInterfaceWithAttentionSink) {
   }
 }
 
+TEST_F(OpModelBase, ChunkedScaledDotProductAttentionOpInterface) {
+  int64_t numBlocks = 128;
+  int64_t numHeads = 12;
+  int64_t blockSize = 32;
+  int64_t headSize = 64;
+  int64_t seqLen = 64;
+  int64_t numBlocksPerUser = 8;
+
+  llvm::SmallVector<int64_t> queryShape{1, numHeads, seqLen, headSize};
+  llvm::SmallVector<int64_t> keyValueShape{numBlocks, numHeads, blockSize,
+                                           headSize};
+  llvm::SmallVector<int64_t> pageTableShape{1, numBlocksPerUser};
+  llvm::SmallVector<int64_t> chunkStartIdxShape{1};
+
+  auto tiledElemType = ttcore::TileType::get(builder.getBF16Type());
+  // page_table and chunk_start_idx are consumed on device as row-major int32
+  // tensors (the tt-metal kernel requires the page table to be row major).
+  auto pageTableType = builder.getI32Type();
+  auto chunkStartIdxType = builder.getI32Type();
+
+  llvm::SmallVector<int64_t> gridAttr{1, 1};
+  auto tensorMemoryLayoutAttr =
+      TensorMemoryLayoutAttr::get(&context, TensorMemoryLayout::Interleaved);
+
+  auto makeDramLayout = [&](llvm::ArrayRef<int64_t> shape, mlir::Type elem) {
+    return TTNNLayoutAttr::Builder(&context, shape, elem)
+        .setBufferType(BufferType::DRAM)
+        .setMemoryLayout(tensorMemoryLayoutAttr)
+        .setGridShape(gridAttr)
+        .buildWithCanonicalCorePlacement(CreateDeviceAttr());
+  };
+
+  auto queryLayout = makeDramLayout(queryShape, tiledElemType);
+  auto keyValueLayout = makeDramLayout(keyValueShape, tiledElemType);
+  auto pageTableLayout = makeDramLayout(pageTableShape, pageTableType);
+  auto chunkStartIdxLayout =
+      makeDramLayout(chunkStartIdxShape, chunkStartIdxType);
+
+  auto query = createEmptyTensor(queryShape, tiledElemType, queryLayout);
+  auto key = createEmptyTensor(keyValueShape, tiledElemType, keyValueLayout);
+  auto value = createEmptyTensor(keyValueShape, tiledElemType, keyValueLayout);
+  auto pageTable =
+      createEmptyTensor(pageTableShape, pageTableType, pageTableLayout);
+  auto chunkStartIdx = createEmptyTensor(chunkStartIdxShape, chunkStartIdxType,
+                                         chunkStartIdxLayout);
+
+  auto outputType =
+      createRankedTensorType(queryShape, tiledElemType, queryLayout);
+
+  auto chunkedSdpAttention = builder.create<ChunkedScaledDotProductAttentionOp>(
+      builder.getUnknownLoc(), outputType, query, key, value, pageTable,
+      chunkStartIdx,
+      /*scale=*/builder.getF32FloatAttr(0.125f),
+      /*program_config=*/nullptr);
+
+  OpModel backend = dyn_cast<OpModel>(chunkedSdpAttention.getOperation());
+  auto constraintsExp = backend.getOpConstraints(
+      getInputLayouts(chunkedSdpAttention), OpConfig(queryLayout));
+  if (constraintsExp) {
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
+        constraintsExp.get();
+
+    EXPECT_GT(cbSize, 0);
+    EXPECT_GT(totalPeakSize, 0);
+    EXPECT_EQ(outputSize, 0);
+
+    ASSERT_FALSE(outputLayouts.empty());
+    EXPECT_EQ(outputLayouts[0].getLayout(), Layout::Tile);
+    EXPECT_TRUE(outputLayouts[0].hasInterleavedDRAMTensorMemoryLayout());
+  } else {
+    FAIL() << "Missing L1 constraints for ChunkedScaledDotProductAttentionOp; "
+              "Error="
+           << llvm::toString(constraintsExp.takeError());
+  }
+
+  // TODO(https://github.com/tenstorrent/tt-mlir/issues/5738) the runtime query
+  // sporadically hangs for ops that use a page table to index the cache
+  // tensor(s), disable by default for now.
+  constexpr bool skipRuntimeTest = true;
+  if (!skipRuntimeTest) {
+    auto runtimeExp = getOpRuntime(chunkedSdpAttention.getOperation());
+    if (runtimeExp) {
+      EXPECT_TRUE(runtimeExp.get() > 0);
+    } else {
+      FAIL() << "Runtime test failed for "
+                "ChunkedScaledDotProductAttentionOp; Error="
+             << llvm::toString(runtimeExp.takeError());
+    }
+  }
+}
+
 TEST_F(OpModelBase, NLPConcatHeadsOpInterface) {
   int64_t batchSize = 1;
   int64_t numHeads = 8;


### PR DESCRIPTION
### Ticket
#9003 

### Problem description
During RM Layout Propagation, Chunked Scaled Dot Product Op was hitting `insertTiledFixup` because it's opmodel was missing. Due to this, the op was receiving tile layout inputs, erroring out as such:

```
{TT_FATAL @ /localdev/ddilbaz/tt-xla/third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp:212: page_table.layout() == Layout::ROW_MAJOR
info:
Page table must be row major
```

### What's changed
Added op model for Chunked Scaled Dot Product Op. 
Alternative fix: There already is a layout workaround for this op but it isn't whitelisted. We can whitelist this workaround so that the row major layout constraint can be applied through workaround even when opt level >= 1. https://github.com/tenstorrent/tt-mlir/compare/main...ddilbaz/chunked-sdpa-page-table-rowmajor-optimizer 

### Checklist

