### PR TITLE
[StableHLO] Fix rank-3 topk sharding regression

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/FlattenOrConvertComposites.cpp
+++ b/lib/Dialect/StableHLO/Transforms/FlattenOrConvertComposites.cpp
@@ -224,6 +224,32 @@ static bool hasCustomShardingRule(llvm::StringRef name) {
   return llvm::is_contained(utils::kCompositesWithCustomSharding, name);
 }
 
+// Returns true if the composite is one of the tenstorrent.topk* variants.
+static bool isTopKComposite(llvm::StringRef name) {
+  return name == utils::kTTTopKCustomCallTargetName ||
+         name == utils::kTTTopKValuesCustomCallTargetName ||
+         name == utils::kTTTopKIndicesCustomCallTargetName;
+}
+
+// Keep a composite as a custom_call (so Shardy can propagate its custom
+// sharding rule) vs. flatten it. topk is gated to rank-2, the only form
+// getTopKShardingRule() supports; other ranks get an empty rule (see #8601).
+static bool shouldConvertToCustomCall(mlir::stablehlo::CompositeOp composite) {
+  llvm::StringRef name = composite.getName();
+  if (!hasCustomShardingRule(name)) {
+    return false;
+  }
+  // Shape-gate the topk variants to the rank their sharding rule supports.
+  if (isTopKComposite(name)) {
+    auto inputType = composite.getNumOperands() >= 1
+                         ? llvm::dyn_cast<mlir::RankedTensorType>(
+                               composite.getOperand(0).getType())
+                         : nullptr;
+    return inputType && inputType.getRank() == 2;
+  }
+  return true;
+}
+
 // Converts a composite op with a custom sharding rule to a
 // stablehlo.custom_call op. The composite name becomes the call_target_name,
 // composite attributes are carried as a discardable attribute,
@@ -278,9 +304,10 @@ public:
       for (auto compositeOp : llvm::make_early_inc_range(
                funcOp.getOps<mlir::stablehlo::CompositeOp>())) {
 
-        // If this composite has a custom sharding rule, convert it to a
-        // stablehlo.custom_call so that Shardy can propagate through it.
-        if (hasCustomShardingRule(compositeOp.getName())) {
+        // If this composite has a custom sharding rule (and, for topk, matches
+        // the shape that rule supports), convert it to a stablehlo.custom_call
+        // so that Shardy can propagate through it.
+        if (shouldConvertToCustomCall(compositeOp)) {
           convertCompositeToCustomCall(compositeOp, builder);
           continue;
         }

--- a/test/ttmlir/Dialect/StableHLO/flatten_or_convert_composite/flatten_rank3_topk.mlir
+++ b/test/ttmlir/Dialect/StableHLO/flatten_or_convert_composite/flatten_rank3_topk.mlir
@@ -2,16 +2,8 @@
 // RUN: ttmlir-opt -split-input-file --flatten-or-convert-composites -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// Regression for the #8601 sharding regression (tt-xla DeepSeek-V3 TP galaxy
-// `new_volume == old_volume` reshape crash).
-//
-// getTopKShardingRule() only builds a valid rule for the rank-2 [batch, N]
-// form. DeepSeek-V3's MoE gate emits a rank-3 [tokens, groups, experts] topk
-// that is sharded on the batch (tokens) dim, not the reduction (experts) dim.
-// Converting it to a custom_call leaves Shardy with an empty rule, so the batch
-// sharding is not carried across the op and the global batch dim corrupts the
-// local shard. FlattenOrConvertCompositesPass must instead FLATTEN a rank-3
-// topk (no stablehlo.custom_call, no stablehlo.composite remaining).
+// A rank-3 topk has no valid sharding rule, so it must be flattened, not
+// converted to a custom_call (#8601 regression).
 module @jit_topk_rank3 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
   sdy.mesh @mesh = <["batch"=4, "vocab"=1]>
   // CHECK-LABEL: func.func @main
@@ -37,10 +29,8 @@ module @jit_topk_rank3 attributes {mhlo.cross_program_prefetches = [], mhlo.inpu
 
 // -----
 
-// A rank-2 [batch, N] topk is the form getTopKShardingRule() supports, so it
-// must still be converted to a stablehlo.custom_call so Shardy can propagate
-// its custom sharding rule (the intended #8601 path). This is the vLLM
-// vocab-sharded sampling case, where the reduction dim N is the sharded one.
+// A rank-2 topk is the supported form, so it is still converted to a
+// custom_call for Shardy to propagate its sharding rule.
 module @jit_topk_rank2 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
   sdy.mesh @mesh = <["batch"=1, "vocab"=4]>
   // CHECK-LABEL: func.func @main

--- a/test/ttmlir/Dialect/StableHLO/flatten_or_convert_composite/flatten_rank3_topk.mlir
+++ b/test/ttmlir/Dialect/StableHLO/flatten_or_convert_composite/flatten_rank3_topk.mlir
@@ -1,0 +1,66 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt -split-input-file --flatten-or-convert-composites -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Regression for the #8601 sharding regression (tt-xla DeepSeek-V3 TP galaxy
+// `new_volume == old_volume` reshape crash).
+//
+// getTopKShardingRule() only builds a valid rule for the rank-2 [batch, N]
+// form. DeepSeek-V3's MoE gate emits a rank-3 [tokens, groups, experts] topk
+// that is sharded on the batch (tokens) dim, not the reduction (experts) dim.
+// Converting it to a custom_call leaves Shardy with an empty rule, so the batch
+// sharding is not carried across the op and the global batch dim corrupts the
+// local shard. FlattenOrConvertCompositesPass must instead FLATTEN a rank-3
+// topk (no stablehlo.custom_call, no stablehlo.composite remaining).
+module @jit_topk_rank3 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["batch"=4, "vocab"=1]>
+  // CHECK-LABEL: func.func @main
+  // CHECK-NOT: stablehlo.custom_call @tenstorrent.topk
+  // CHECK-NOT: stablehlo.composite "tenstorrent.topk"
+  // CHECK: stablehlo.slice
+  func.func @main(
+    %arg0: tensor<256x8x32xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}]>, ttcore.shard_status = #ttcore.shard_status<presharded>}
+  ) -> (tensor<256x8x2xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>},
+        tensor<256x8x2xi64> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %0:2 = stablehlo.composite "tenstorrent.topk" %arg0 {
+      composite_attributes = {dim = -1 : i64, k = 2 : i64, largest = true, sorted = true},
+      decomposition = @tenstorrent.topk.impl_rank3
+    } : (tensor<256x8x32xf32>) -> (tensor<256x8x2xf32>, tensor<256x8x2xi64>)
+    return %0#0, %0#1 : tensor<256x8x2xf32>, tensor<256x8x2xi64>
+  }
+  func.func private @tenstorrent.topk.impl_rank3(%arg0: tensor<256x8x32xf32>) -> (tensor<256x8x2xf32>, tensor<256x8x2xi64>) {
+    %values = stablehlo.slice %arg0 [0:256, 0:8, 0:2] : (tensor<256x8x32xf32>) -> tensor<256x8x2xf32>
+    %indices = stablehlo.constant dense<0> : tensor<256x8x2xi64>
+    return %values, %indices : tensor<256x8x2xf32>, tensor<256x8x2xi64>
+  }
+}
+
+// -----
+
+// A rank-2 [batch, N] topk is the form getTopKShardingRule() supports, so it
+// must still be converted to a stablehlo.custom_call so Shardy can propagate
+// its custom sharding rule (the intended #8601 path). This is the vLLM
+// vocab-sharded sampling case, where the reduction dim N is the sharded one.
+module @jit_topk_rank2 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["batch"=1, "vocab"=4]>
+  // CHECK-LABEL: func.func @main
+  // CHECK: stablehlo.custom_call @tenstorrent.topk
+  // CHECK-SAME: tt.has_custom_sharding
+  // CHECK-SAME: (tensor<8x256xf32>) -> (tensor<8x2xf32>, tensor<8x2xi64>)
+  // CHECK-NOT: stablehlo.composite "tenstorrent.topk"
+  func.func @main(
+    %arg0: tensor<8x256xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"vocab"}]>, ttcore.shard_status = #ttcore.shard_status<presharded>}
+  ) -> (tensor<8x2xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>},
+        tensor<8x2xi64> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %0:2 = stablehlo.composite "tenstorrent.topk" %arg0 {
+      composite_attributes = {dim = -1 : i64, k = 2 : i64, largest = true, sorted = true},
+      decomposition = @tenstorrent.topk.impl_rank2
+    } : (tensor<8x256xf32>) -> (tensor<8x2xf32>, tensor<8x2xi64>)
+    return %0#0, %0#1 : tensor<8x2xf32>, tensor<8x2xi64>
+  }
+  func.func private @tenstorrent.topk.impl_rank2(%arg0: tensor<8x256xf32>) -> (tensor<8x2xf32>, tensor<8x2xi64>) {
+    %values = stablehlo.slice %arg0 [0:8, 0:2] : (tensor<8x256xf32>) -> tensor<8x2xf32>
+    %indices = stablehlo.constant dense<0> : tensor<8x2xi64>
+    return %values, %indices : tensor<8x2xf32>, tensor<8x2xi64>
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/5603

### Problem description
PR #8601 routes `topk` composites to a `custom_call` so shardy can propagate a custom sharding rule through them, but the sharding rule only supports the rank-2 `[batch, N]` shape. DeepSeek-V3's rank-3 MoE-gate `topk` got routed there anyway, hit an empty rule, and its batch dim was corrupted from the local shard size to the global size - crashing at runtime in `ttnn.reshape` (`new_volume == old_volume`).

### What's changed
Made the routing decision shape-aware: only keeps a `topk` as a `custom_call` when it's rank-2 form (supported). Any other rank is flattened instead. 

- `FlattenOrConvertComposites.cpp`: added a shape-aware `shouldConvertToCustomCall` check gating the `topk` variants to rank-2.
- Added lit test: rank-3 batch-sharded `topk` is flattened; rank-2 `topk` still becomes a `custom_call`.

### Checklist
- [x] New/Existing tests provide coverage for changes
