### PR TITLE
Uplift third_party/tt-metal to 1cb6f8e40e368cb8c23779cc4675c665eb1f86aa 2026-07-15

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "af5ded324ea7bbb1757ec1784528877b809025bf")
+set(TT_METAL_VERSION "1cb6f8e40e368cb8c23779cc4675c665eb1f86aa")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 1cb6f8e40e368cb8c23779cc4675c665eb1f86aa



### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/29401975405
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/29401976640
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any): 
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):