### PR TITLE
[StableHLO] Support rank-reducing and multi-point scalar single-dim scatter

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -6985,14 +6985,29 @@ public:
 
     // Single-dimensional scatter.
     if (scatterDimsToOperandDims.size() == 1) {
-      // Process indices to match update tensor shape.
       int32_t dim = scatterDimsToOperandDims[0];
-      Value finalIndexTensor =
-          extractElementWiseScatterIndices(srcOp, rewriter);
+      int64_t inputRank = inputType.getRank();
+      int64_t updateRank = updateType.getRank();
+
+      Value finalIndexTensor;
+      Value finalSourceTensor;
+
+      if (updateRank < inputRank) {
+        // Rank-reducing single-dim scatter (single hyper-slice set), e.g.
+        // `x.at[i, :].set(v)`. StableHLO dropped the scattered axis from the
+        // update; promote source and index back to operand rank instead of
+        // flattening. See checkBasicLegality for the exact supported form.
+        std::tie(finalSourceTensor, finalIndexTensor) =
+            buildRankReducingScatterOperands(srcOp, dim, rewriter);
+      } else {
+        // Source is used as-is; build indices shape-aligned with the update.
+        finalSourceTensor = updateTensor;
+        finalIndexTensor = extractElementWiseScatterIndices(srcOp, rewriter);
+      }
 
       // Create ScatterOp.
       rewriter.replaceOpWithNewOp<ttir::ScatterOp>(
-          srcOp, outputType, inputTensor, finalIndexTensor, updateTensor,
+          srcOp, outputType, inputTensor, finalIndexTensor, finalSourceTensor,
           rewriter.getI32IntegerAttr(dim),
           ttcore::ReduceTypeAttr::get(rewriter.getContext(),
                                       *scatterReduceType));
@@ -7097,17 +7112,47 @@ private:
     }
 
     // Checks that apply to single dimensional scatter.
+    if (!multiDimensionalScatter) {
+      RankedTensorType inputType =
+          mlir::cast<RankedTensorType>(op.getInputs()[0].getType());
+      int64_t inputRank = inputType.getRank();
+      int64_t updateRank = static_cast<int64_t>(updateShape.size());
 
-    if (!multiDimensionalScatter && indexShape.size() > updateShape.size()) {
-      return rewriter.notifyMatchFailure(
-          op, "TTIR scatter requires indices.rank <= updates.rank. Please add "
-              "support for rank promotion if needed.");
-    }
-
-    if (!multiDimensionalScatter && indexVectorDim != 1u) {
-      return rewriter.notifyMatchFailure(
-          op,
-          "TTIR single dimensional scatter requires index_vector_dim to be 1");
+      if (updateRank < inputRank) {
+        // Rank-reducing single-dim scatter (e.g. `x.at[i, :].set(v)`): a single
+        // hyper-slice along the scattered axis is overwritten. StableHLO
+        // collapses that axis in the update, so its rank is exactly one less
+        // than the operand's. We support this by promoting index/source back to
+        // operand rank (see matchAndRewrite) rather than flattening, so the
+        // index_vector_dim == 1 requirement does not apply. Only the exact
+        // "scattered axis collapsed, all other axes are window" form is
+        // supported; reject anything else.
+        int64_t scatterDim = scatterDimsToOperandDims[0];
+        if (insertedWindowDims.size() != 1 ||
+            insertedWindowDims[0] != scatterDim || inputRank - 1 != updateRank) {
+          return rewriter.notifyMatchFailure(
+              op, "TTIR single dimensional scatter: unsupported rank-reducing "
+                  "form (only setting a single hyper-slice along the scattered "
+                  "axis is supported)");
+        }
+        // The single scatter coordinate must be a single value.
+        if (ttmlir::utils::volume(indexShape) != 1) {
+          return rewriter.notifyMatchFailure(
+              op, "TTIR single dimensional scatter: rank-reducing form expects "
+                  "exactly one scatter coordinate");
+        }
+      } else {
+        if (indexShape.size() > updateShape.size()) {
+          return rewriter.notifyMatchFailure(
+              op, "TTIR scatter requires indices.rank <= updates.rank. Please "
+                  "add support for rank promotion if needed.");
+        }
+        if (indexVectorDim != 1u) {
+          return rewriter.notifyMatchFailure(
+              op, "TTIR single dimensional scatter requires index_vector_dim "
+                  "to be 1");
+        }
+      }
     }
 
     return success();
@@ -7405,6 +7450,79 @@ private:
     // Flatten the computed indices to 1D.
     return ttir::utils::flattenTensor(rewriter, loc, flatIndices,
                                       "_flatten_expanded_indices");
+  }
+
+  /// Builds the {source, index} operands for a rank-reducing single-dimensional
+  /// scatter that sets a single hyper-slice along the scattered axis, e.g.
+  /// `x.at[i, :].set(v)`.
+  ///
+  /// StableHLO collapses the scattered axis in the update, so `update` has rank
+  /// `operandRank - 1`. Rather than flattening the whole scatter to 1D, we
+  /// promote both operands back to operand rank with size 1 at the scattered
+  /// axis, which lets `ttir.scatter` (dim = scattered axis) express the write
+  /// directly. The exact supported form is validated in checkBasicLegality
+  /// (single inserted window dim equal to the scattered axis, exactly one
+  /// scatter coordinate, all other axes are window).
+  ///
+  /// Example (operand 3x3, `x.at[0, :].set(v)`, dim = 0):
+  ///   update  tensor<3xf32>  -> source tensor<1x3xf32>  (reshape)
+  ///   indices (coord 0)      -> index  tensor<1x3xi32>  (reshape to 1x1 then
+  ///                                                       broadcast), all 0
+  ///   ttir.scatter then writes output[0][j] = source[0][j].
+  ///
+  /// Example (operand 2x3x4x5, `x.at[:, 1, :, :].set(v)`, dim = 1):
+  ///   update  tensor<2x4x5xf32> -> source tensor<2x1x4x5xf32> (reshape;
+  ///                                  a size-1 axis inserted at dim 1)
+  ///   indices (coord 1)         -> index  tensor<2x1x4x5xi32> (reshape to
+  ///                                  1x1x1x1 then broadcast), all 1
+  ///   ttir.scatter then writes output[a][1][c][d] = source[a][0][c][d];
+  ///   the other slices along dim 1 are untouched.
+  ///
+  /// Returns {promotedSource, promotedIndex}, both shaped like the operand with
+  /// size 1 at `dim`.
+  std::pair<Value, Value>
+  buildRankReducingScatterOperands(mlir::stablehlo::ScatterOp op, int32_t dim,
+                                   PatternRewriter &rewriter) const {
+    Location loc = op.getLoc();
+    RankedTensorType inputType =
+        mlir::cast<RankedTensorType>(op.getInputs()[0].getType());
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+    int64_t inputRank = inputType.getRank();
+
+    // Operand-rank shape with size 1 at the scattered axis. Both source and
+    // index take this shape (ttir.scatter requires index.shape == source.shape
+    // and both to match the input rank).
+    llvm::SmallVector<int64_t> promotedShape(inputShape.begin(),
+                                             inputShape.end());
+    promotedShape[dim] = 1;
+
+    // Source: reshape the (row-major) update to the promoted shape. Inserting a
+    // size-1 axis at the scattered position preserves element order.
+    Value promotedSource = ttir::utils::createReshapeOp(
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_source_promote"),
+        op.getUpdates()[0], promotedShape);
+
+    // Index: the ttir.scatter index must hold the scattered-axis coordinate at
+    // every element. There is exactly one coordinate, so reshape it to all-ones
+    // operand rank and broadcast it across the promoted shape.
+    Value indices = op.getScatterIndices();
+    RankedTensorType indicesType =
+        mlir::cast<RankedTensorType>(indices.getType());
+    llvm::SmallVector<int64_t> onesShape(inputRank, 1);
+    Value reshapedIndex = ttir::utils::createReshapeOp(
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_index_reshape"),
+        indices, onesShape);
+
+    RankedTensorType broadcastType = RankedTensorType::get(
+        promotedShape, indicesType.getElementType(), indicesType.getEncoding());
+    llvm::SmallVector<int64_t> broadcastDims =
+        ttmlir::utils::getBroadcastDimensions<int64_t>(onesShape, promotedShape);
+    Value promotedIndex = rewriter.create<ttir::BroadcastOp>(
+        ttmlir::utils::appendLocationSuffix(loc, "_index_broadcast"),
+        broadcastType, reshapedIndex,
+        rewriter.getDenseI64ArrayAttr(broadcastDims));
+
+    return {promotedSource, promotedIndex};
   }
 
   Value extractElementWiseScatterIndices(mlir::stablehlo::ScatterOp op,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -7142,7 +7142,24 @@ private:
                   "exactly one scatter coordinate");
         }
       } else {
-        if (indexShape.size() > updateShape.size()) {
+        // Multi-point scalar scatter into a 1-D operand, e.g. a runtime index
+        // list `zeros(4).at[idx].add(u)` with idx = [0, 2, 1]. The updates are
+        // scalar (no window) and the index carries a trailing length-1
+        // coordinate axis, so its rank is exactly one more than the update's
+        // (index [N, 1], update [N]). The element-wise path squeezes that
+        // coordinate axis away (index [N, 1] -> [N]), producing a valid
+        // equal-rank ttir.scatter, so this shape is allowed past the general
+        // indices.rank <= updates.rank guard below.
+        ArrayRef<int64_t> updateWindowDims =
+            adaptor.getScatterDimensionNumbers().getUpdateWindowDims();
+        bool multiPointScalarScatter =
+            updateWindowDims.empty() &&
+            indexVectorDim < static_cast<uint32_t>(indexShape.size()) &&
+            indexShape.size() == updateShape.size() + 1 &&
+            indexShape[indexVectorDim] == 1;
+
+        if (!multiPointScalarScatter &&
+            indexShape.size() > updateShape.size()) {
           return rewriter.notifyMatchFailure(
               op, "TTIR scatter requires indices.rank <= updates.rank. Please "
                   "add support for rank promotion if needed.");

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -7129,7 +7129,8 @@ private:
         // supported; reject anything else.
         int64_t scatterDim = scatterDimsToOperandDims[0];
         if (insertedWindowDims.size() != 1 ||
-            insertedWindowDims[0] != scatterDim || inputRank - 1 != updateRank) {
+            insertedWindowDims[0] != scatterDim ||
+            inputRank - 1 != updateRank) {
           return rewriter.notifyMatchFailure(
               op, "TTIR single dimensional scatter: unsupported rank-reducing "
                   "form (only setting a single hyper-slice along the scattered "
@@ -7533,7 +7534,8 @@ private:
     RankedTensorType broadcastType = RankedTensorType::get(
         promotedShape, indicesType.getElementType(), indicesType.getEncoding());
     llvm::SmallVector<int64_t> broadcastDims =
-        ttmlir::utils::getBroadcastDimensions<int64_t>(onesShape, promotedShape);
+        ttmlir::utils::getBroadcastDimensions<int64_t>(onesShape,
+                                                       promotedShape);
     Value promotedIndex = rewriter.create<ttir::BroadcastOp>(
         ttmlir::utils::appendLocationSuffix(loc, "_index_broadcast"),
         broadcastType, reshapedIndex,

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_negative.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_negative.mlir
@@ -1,0 +1,46 @@
+// REQUIRES: stablehlo
+// RUN: not ttmlir-opt --split-input-file --stablehlo-to-ttir-pipeline %s 2>&1 | FileCheck %s
+// Negative tests for the rank-reducing single-dim scatter path. These are
+// valid stablehlo but fall outside the tightly-gated form accepted by
+// checkBasicLegality, so conversion must reject them (fail to legalize) rather
+// than silently miscompile.
+
+// The update dropped more than one axis (operand rank 3, update rank 1), i.e.
+// two inserted window dims. Only a single collapsed axis is supported.
+// -----
+module attributes {} {
+  func.func @scatter_rank_reducing_drops_two_dims(%operand: tensor<4x5x6xf32>, %indices: tensor<1xi64>, %update: tensor<6xf32>) -> tensor<4x5x6xf32> {
+    // CHECK: error: failed to legalize operation 'stablehlo.scatter'
+    %0 = "stablehlo.scatter"(%operand, %indices, %update) <{
+      scatter_dimension_numbers = #stablehlo.scatter<
+        update_window_dims = [0],
+        inserted_window_dims = [0, 1],
+        scatter_dims_to_operand_dims = [0],
+        index_vector_dim = 0>
+    }> ({
+    ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+      stablehlo.return %b : tensor<f32>
+    }) : (tensor<4x5x6xf32>, tensor<1xi64>, tensor<6xf32>) -> tensor<4x5x6xf32>
+    return %0 : tensor<4x5x6xf32>
+  }
+}
+
+// The collapsed (inserted) window dim is dim 1, but the scattered axis is dim 0
+// they must be the same axis for the rank-reducing form.
+// -----
+module attributes {} {
+  func.func @scatter_rank_reducing_axis_mismatch(%operand: tensor<3x4xf32>, %indices: tensor<1xi64>, %update: tensor<3xf32>) -> tensor<3x4xf32> {
+    // CHECK: error: failed to legalize operation 'stablehlo.scatter'
+    %0 = "stablehlo.scatter"(%operand, %indices, %update) <{
+      scatter_dimension_numbers = #stablehlo.scatter<
+        update_window_dims = [0],
+        inserted_window_dims = [1],
+        scatter_dims_to_operand_dims = [0],
+        index_vector_dim = 0>
+    }> ({
+    ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+      stablehlo.return %b : tensor<f32>
+    }) : (tensor<3x4xf32>, tensor<1xi64>, tensor<3xf32>) -> tensor<3x4xf32>
+    return %0 : tensor<3x4xf32>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
@@ -165,6 +165,91 @@ module @jit_scatter attributes {} {
         return %0 : tensor<3x394xi64>
     }
 
+    // Rank-reducing single-dim scatter `x.at[i, :].set(v)`: StableHLO drops the
+    // scattered axis from the update (update rank == operand rank - 1). Instead
+    // of flattening, source and index are promoted back to operand rank with a
+    // size-1 scattered axis: the update is reshaped and the single scatter
+    // coordinate is reshaped to all-ones then broadcast across the slice.
+    func.func public @test_rank_reducing_scatter_row(%operand: tensor<3x3xf32>, %indices: tensor<1xi64>, %update: tensor<3xf32>) -> tensor<3x3xf32> {
+        // CHECK-LABEL: func.func public @test_rank_reducing_scatter_row
+        // CHECK: [[SRC:%[0-9]+]] = "ttir.reshape"(%arg2)
+        // CHECK-SAME: -> tensor<1x3xf32>
+        // CHECK: [[IDX:%[0-9]+]] = "ttir.reshape"(%arg1)
+        // CHECK-SAME: -> tensor<1x1xi64>
+        // CHECK: [[BIDX:%[0-9]+]] = "ttir.broadcast"([[IDX]])
+        // CHECK-SAME: -> tensor<1x3xi64>
+        // CHECK: "ttir.scatter"(%arg0, [[BIDX]], [[SRC]])
+        // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}>
+        // CHECK-SAME: (tensor<3x3xf32>, tensor<1x3xi64>, tensor<1x3xf32>) -> tensor<3x3xf32>
+        %result = "stablehlo.scatter"(%operand, %indices, %update) <{
+            scatter_dimension_numbers = #stablehlo.scatter<
+                update_window_dims = [0], 
+                inserted_window_dims = [0], 
+                scatter_dims_to_operand_dims = [0], 
+                index_vector_dim = 0>
+        }> ({
+        ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+            stablehlo.return %b : tensor<f32>
+        }) : (tensor<3x3xf32>, tensor<1xi64>, tensor<3xf32>) -> tensor<3x3xf32>
+        return %result : tensor<3x3xf32>
+    }
+
+    // Rank-reducing single-dim scatter into a non-leading axis `x.at[:, i, :, :].set(v)`
+    // (scattered axis is dim 1). The promoted source/index insert the size-1 axis
+    // at dim 1 and the ttir.scatter runs along dim 1.
+    func.func public @test_rank_reducing_scatter_middle_dim(%operand: tensor<2x3x4x5xf32>, %indices: tensor<1xi64>, %update: tensor<2x4x5xf32>) -> tensor<2x3x4x5xf32> {
+        // CHECK-LABEL: func.func public @test_rank_reducing_scatter_middle_dim
+        // CHECK: [[SRC:%[0-9]+]] = "ttir.reshape"(%arg2)
+        // CHECK-SAME: -> tensor<2x1x4x5xf32>
+        // CHECK: [[IDX:%[0-9]+]] = "ttir.reshape"(%arg1)
+        // CHECK-SAME: -> tensor<1x1x1x1xi64>
+        // CHECK: [[BIDX:%[0-9]+]] = "ttir.broadcast"([[IDX]])
+        // CHECK-SAME: -> tensor<2x1x4x5xi64>
+        // CHECK: "ttir.scatter"(%arg0, [[BIDX]], [[SRC]])
+        // CHECK-SAME: <{dim = 1 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}>
+        // CHECK-SAME: (tensor<2x3x4x5xf32>, tensor<2x1x4x5xi64>, tensor<2x1x4x5xf32>) -> tensor<2x3x4x5xf32>
+        %result = "stablehlo.scatter"(%operand, %indices, %update) <{
+            scatter_dimension_numbers = #stablehlo.scatter<
+                update_window_dims = [0, 1, 2], 
+                inserted_window_dims = [1], 
+                scatter_dims_to_operand_dims = [1], 
+                index_vector_dim = 0>
+        }> ({
+        ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+            stablehlo.return %b : tensor<f32>
+        }) : (tensor<2x3x4x5xf32>, tensor<1xi64>, tensor<2x4x5xf32>) -> tensor<2x3x4x5xf32>
+        return %result : tensor<2x3x4x5xf32>
+    }
+
+    // Rank-reducing single-dim scatter with an accumulating (sum) combine
+    // region. The reduce type is taken from the scatter body and flows into
+    // ttir.scatter. Scatter dim 1 is used because a leading-axis sum scatter is
+    // matched by the embedding_backward pattern instead of this one.
+    func.func public @test_rank_reducing_scatter_sum(%operand: tensor<2x3x4xf32>, %indices: tensor<1xi64>, %update: tensor<2x4xf32>) -> tensor<2x3x4xf32> {
+        // CHECK-LABEL: func.func public @test_rank_reducing_scatter_sum
+        // CHECK: [[SRC:%[0-9]+]] = "ttir.reshape"(%arg2)
+        // CHECK-SAME: -> tensor<2x1x4xf32>
+        // CHECK: [[IDX:%[0-9]+]] = "ttir.reshape"(%arg1)
+        // CHECK-SAME: -> tensor<1x1x1xi64>
+        // CHECK: [[BIDX:%[0-9]+]] = "ttir.broadcast"([[IDX]])
+        // CHECK-SAME: -> tensor<2x1x4xi64>
+        // CHECK: "ttir.scatter"(%arg0, [[BIDX]], [[SRC]])
+        // CHECK-SAME: <{dim = 1 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>
+        // CHECK-SAME: (tensor<2x3x4xf32>, tensor<2x1x4xi64>, tensor<2x1x4xf32>) -> tensor<2x3x4xf32>
+        %result = "stablehlo.scatter"(%operand, %indices, %update) <{
+            scatter_dimension_numbers = #stablehlo.scatter<
+                update_window_dims = [0, 1],
+                inserted_window_dims = [1],
+                scatter_dims_to_operand_dims = [1],
+                index_vector_dim = 0>
+        }> ({
+        ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+            %sum = stablehlo.add %a, %b : tensor<f32>
+            stablehlo.return %sum : tensor<f32>
+        }) : (tensor<2x3x4xf32>, tensor<1xi64>, tensor<2x4xf32>) -> tensor<2x3x4xf32>
+        return %result : tensor<2x3x4xf32>
+    }
+
     func.func @test_multidim_scatter_with_window_extracted_from_model(%arg186: tensor<1x2xbf16>, %arg187: tensor<1xi64>, %arg188: tensor<1xi64>) -> (tensor<1x7x2xbf16>) {
         // CHECK: "ttir.scatter"
         // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
@@ -278,6 +278,32 @@ module @jit_scatter attributes {} {
         return %result : tensor<4xf32>
     }
 
+    // Multi-point scalar scatter into a 1-D operand `x.at[idx].add(u)` with a
+    // runtime index list (e.g. idx = [0, 2, 1]). Updates are scalar (no window)
+    // and the index carries a trailing length-1 coordinate axis, so index rank
+    // (2) is one more than update rank (1). The element-wise path squeezes that
+    // coordinate axis away (index [3,1] -> [3]) and scatters along dim 0 with
+    // the sum reduce type taken from the combine region.
+    func.func public @test_multipoint_scalar_scatter_1d(%operand: tensor<4xf32>, %indices: tensor<3x1xi64>, %update: tensor<3xf32>) -> tensor<4xf32> {
+        // CHECK-LABEL: func.func public @test_multipoint_scalar_scatter_1d
+        // CHECK: [[IDX:%[0-9]+]] = "ttir.reshape"(%arg1)
+        // CHECK-SAME: -> tensor<3xi64>
+        // CHECK: "ttir.scatter"(%arg0, [[IDX]], %arg2)
+        // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>
+        // CHECK-SAME: (tensor<4xf32>, tensor<3xi64>, tensor<3xf32>) -> tensor<4xf32>
+        %result = "stablehlo.scatter"(%operand, %indices, %update) <{
+            scatter_dimension_numbers = #stablehlo.scatter<
+                inserted_window_dims = [0],
+                scatter_dims_to_operand_dims = [0],
+                index_vector_dim = 1>
+        }> ({
+        ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+            %sum = stablehlo.add %a, %b : tensor<f32>
+            stablehlo.return %sum : tensor<f32>
+        }) : (tensor<4xf32>, tensor<3x1xi64>, tensor<3xf32>) -> tensor<4xf32>
+        return %result : tensor<4xf32>
+    }
+
     func.func @test_multidim_scatter_with_window_extracted_from_model(%arg186: tensor<1x2xbf16>, %arg187: tensor<1xi64>, %arg188: tensor<1xi64>) -> (tensor<1x7x2xbf16>) {
         // CHECK: "ttir.scatter"
         // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
@@ -250,6 +250,34 @@ module @jit_scatter attributes {} {
         return %result : tensor<2x3x4xf32>
     }
 
+    // Rank-reducing single-dim scatter into a 1-D operand `x.at[i].set(v)`: the
+    // update collapses all the way to a scalar (rank 0). Source and index are
+    // promoted back to operand rank (a size-1 axis), so ttir.scatter runs along
+    // dim 0 with a single coordinate.
+    func.func public @test_rank_reducing_scatter_1d(%operand: tensor<4xf32>, %indices: tensor<1xi64>, %update: tensor<f32>) -> tensor<4xf32> {
+        // CHECK-LABEL: func.func public @test_rank_reducing_scatter_1d
+        // CHECK: [[SRC:%[0-9]+]] = "ttir.reshape"(%arg2)
+        // CHECK-SAME: -> tensor<1xf32>
+        // CHECK: [[IDX:%[0-9]+]] = "ttir.reshape"(%arg1)
+        // CHECK-SAME: -> tensor<1xi64>
+        // CHECK: [[BIDX:%[0-9]+]] = "ttir.broadcast"([[IDX]])
+        // CHECK-SAME: -> tensor<1xi64>
+        // CHECK: "ttir.scatter"(%arg0, [[BIDX]], [[SRC]])
+        // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<invalid>}>
+        // CHECK-SAME: (tensor<4xf32>, tensor<1xi64>, tensor<1xf32>) -> tensor<4xf32>
+        %result = "stablehlo.scatter"(%operand, %indices, %update) <{
+            scatter_dimension_numbers = #stablehlo.scatter<
+                update_window_dims = [],
+                inserted_window_dims = [0],
+                scatter_dims_to_operand_dims = [0],
+                index_vector_dim = 0>
+        }> ({
+        ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+            stablehlo.return %b : tensor<f32>
+        }) : (tensor<4xf32>, tensor<1xi64>, tensor<f32>) -> tensor<4xf32>
+        return %result : tensor<4xf32>
+    }
+
     func.func @test_multidim_scatter_with_window_extracted_from_model(%arg186: tensor<1x2xbf16>, %arg187: tensor<1xi64>, %arg188: tensor<1xi64>) -> (tensor<1x7x2xbf16>) {
         // CHECK: "ttir.scatter"
         // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
@@ -183,9 +183,9 @@ module @jit_scatter attributes {} {
         // CHECK-SAME: (tensor<3x3xf32>, tensor<1x3xi64>, tensor<1x3xf32>) -> tensor<3x3xf32>
         %result = "stablehlo.scatter"(%operand, %indices, %update) <{
             scatter_dimension_numbers = #stablehlo.scatter<
-                update_window_dims = [0], 
-                inserted_window_dims = [0], 
-                scatter_dims_to_operand_dims = [0], 
+                update_window_dims = [0],
+                inserted_window_dims = [0],
+                scatter_dims_to_operand_dims = [0],
                 index_vector_dim = 0>
         }> ({
         ^bb0(%a: tensor<f32>, %b: tensor<f32>):
@@ -210,9 +210,9 @@ module @jit_scatter attributes {} {
         // CHECK-SAME: (tensor<2x3x4x5xf32>, tensor<2x1x4x5xi64>, tensor<2x1x4x5xf32>) -> tensor<2x3x4x5xf32>
         %result = "stablehlo.scatter"(%operand, %indices, %update) <{
             scatter_dimension_numbers = #stablehlo.scatter<
-                update_window_dims = [0, 1, 2], 
-                inserted_window_dims = [1], 
-                scatter_dims_to_operand_dims = [1], 
+                update_window_dims = [0, 1, 2],
+                inserted_window_dims = [1],
+                scatter_dims_to_operand_dims = [1],
                 index_vector_dim = 0>
         }> ({
         ^bb0(%a: tensor<f32>, %b: tensor<f32>):

--- a/test/ttmlir/Silicon/StableHLO/n150/data_movement/scatter_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/data_movement/scatter_op.mlir
@@ -31,9 +31,9 @@ func.func @rank_reducing_scatter_middle_dim(%operand: tensor<2x32x32xbf16>, %ind
   // CHECK: "ttnn.scatter"
   %result = "stablehlo.scatter"(%operand, %indices, %update) <{
     scatter_dimension_numbers = #stablehlo.scatter<
-      update_window_dims = [0, 1], 
-      inserted_window_dims = [1], 
-      scatter_dims_to_operand_dims = [1], 
+      update_window_dims = [0, 1],
+      inserted_window_dims = [1],
+      scatter_dims_to_operand_dims = [1],
       index_vector_dim = 0>
   }> ({
   ^bb0(%a: tensor<bf16>, %b: tensor<bf16>):

--- a/test/ttmlir/Silicon/StableHLO/n150/data_movement/scatter_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/data_movement/scatter_op.mlir
@@ -60,3 +60,22 @@ func.func @rank_reducing_scatter_1d(%operand: tensor<32xbf16>, %indices: tensor<
   }) : (tensor<32xbf16>, tensor<1xi64>, tensor<bf16>) -> tensor<32xbf16>
   return %result : tensor<32xbf16>
 }
+
+// Multi-point scalar scatter-add into a 1-D operand `x.at[idx].add(u)` with a
+// runtime index list. Scalar updates + a trailing length-1 coordinate axis, so
+// the element-wise path squeezes the index to rank 1 and scatters along dim 0.
+func.func @multipoint_scalar_scatter_1d(%operand: tensor<32xbf16>, %indices: tensor<8x1xi64>, %update: tensor<8xbf16>) -> tensor<32xbf16> {
+  // CHECK-LABEL: func.func @multipoint_scalar_scatter_1d
+  // CHECK: "ttnn.scatter"
+  %result = "stablehlo.scatter"(%operand, %indices, %update) <{
+    scatter_dimension_numbers = #stablehlo.scatter<
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1>
+  }> ({
+  ^bb0(%a: tensor<bf16>, %b: tensor<bf16>):
+    %s = stablehlo.add %a, %b : tensor<bf16>
+    stablehlo.return %s : tensor<bf16>
+  }) : (tensor<32xbf16>, tensor<8x1xi64>, tensor<8xbf16>) -> tensor<32xbf16>
+  return %result : tensor<32xbf16>
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/data_movement/scatter_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/data_movement/scatter_op.mlir
@@ -1,0 +1,43 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s -o %t.mlir --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%"
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+// Rank-reducing single-dim scatter `x.at[i, :].set(v)`: the StableHLO update
+// drops the scattered axis, so the conversion promotes source/index back to
+// operand rank with a size-1 scattered axis and lowers to a single ttnn.scatter.
+
+func.func @rank_reducing_scatter_row(%operand: tensor<32x32xbf16>, %indices: tensor<1xi64>, %update: tensor<32xbf16>) -> tensor<32x32xbf16> {
+  // CHECK-LABEL: func.func @rank_reducing_scatter_row
+  // CHECK: "ttnn.scatter"
+  %result = "stablehlo.scatter"(%operand, %indices, %update) <{
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [0],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 0>
+  }> ({
+  ^bb0(%a: tensor<bf16>, %b: tensor<bf16>):
+    stablehlo.return %b : tensor<bf16>
+  }) : (tensor<32x32xbf16>, tensor<1xi64>, tensor<32xbf16>) -> tensor<32x32xbf16>
+  return %result : tensor<32x32xbf16>
+}
+
+// Scatter into a non-leading axis `x.at[:, i, :].set(v)` (scattered axis is dim 1).
+func.func @rank_reducing_scatter_middle_dim(%operand: tensor<2x32x32xbf16>, %indices: tensor<1xi64>, %update: tensor<2x32xbf16>) -> tensor<2x32x32xbf16> {
+  // CHECK-LABEL: func.func @rank_reducing_scatter_middle_dim
+  // CHECK: "ttnn.scatter"
+  %result = "stablehlo.scatter"(%operand, %indices, %update) <{
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [0, 1], 
+      inserted_window_dims = [1], 
+      scatter_dims_to_operand_dims = [1], 
+      index_vector_dim = 0>
+  }> ({
+  ^bb0(%a: tensor<bf16>, %b: tensor<bf16>):
+    stablehlo.return %b : tensor<bf16>
+  }) : (tensor<2x32x32xbf16>, tensor<1xi64>, tensor<2x32xbf16>) -> tensor<2x32x32xbf16>
+  return %result : tensor<2x32x32xbf16>
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/data_movement/scatter_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/data_movement/scatter_op.mlir
@@ -41,3 +41,22 @@ func.func @rank_reducing_scatter_middle_dim(%operand: tensor<2x32x32xbf16>, %ind
   }) : (tensor<2x32x32xbf16>, tensor<1xi64>, tensor<2x32xbf16>) -> tensor<2x32x32xbf16>
   return %result : tensor<2x32x32xbf16>
 }
+
+// Scatter into a 1-D operand `x.at[i].set(v)`: the update collapses all the way
+// to a scalar, so source/index are promoted to a size-1 axis and it lowers to a
+// single ttnn.scatter along dim 0.
+func.func @rank_reducing_scatter_1d(%operand: tensor<32xbf16>, %indices: tensor<1xi64>, %update: tensor<bf16>) -> tensor<32xbf16> {
+  // CHECK-LABEL: func.func @rank_reducing_scatter_1d
+  // CHECK: "ttnn.scatter"
+  %result = "stablehlo.scatter"(%operand, %indices, %update) <{
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 0>
+  }> ({
+  ^bb0(%a: tensor<bf16>, %b: tensor<bf16>):
+    stablehlo.return %b : tensor<bf16>
+  }) : (tensor<32xbf16>, tensor<1xi64>, tensor<bf16>) -> tensor<32xbf16>
+  return %result : tensor<32xbf16>
+}


### PR DESCRIPTION
### Ticket
Related: https://github.com/tenstorrent/tt-xla/issues/5183

### Problem description
Several common JAX scatter patterns failed to legalize with
`failed to legalize operation 'stablehlo.scatter'` (PJRT `Error code: 13`)
in the StableHLO→TTIR conversion. Two shapes were unsupported by the
single-dimensional scatter path:

1. Rank-reducing single-dim scatter, e.g. `x.at[i, :].set(v)`. StableHLO
   collapses the scattered axis in the update, so the update rank is one less
   than the operand rank. The old path required `index_vector_dim == 1` and an
   equal-rank `ttir.scatter`, so it rejected this form.
2. Multi-point scalar scatter into a 1-D operand, e.g. `zeros(4).at[idx].add(u)`
   with a runtime index list `idx = [0, 2, 1]`. Updates are scalar (no window)
   and the index carries a trailing length-1 coordinate axis, giving
   `index [N, 1]` vs `update [N]`; this tripped the `indices.rank <= updates.rank`
   guard.

### What's changed
- Rank-reducing single-dim scatter: instead of flattening the whole scatter to
  1-D, promote `source` and `index` back to operand rank with a size-1 axis at
  the scattered dimension (reshape + broadcast), then emit a single
  `ttir.scatter` on the scattered axis. Supported form is tightly gated in
  `checkBasicLegality` (single inserted window dim equal to the scattered axis,
  exactly one scatter coordinate).
- Multi-point scalar scatter into a 1-D operand: detect the shape
  (`updateWindowDims` empty, `index.rank == update.rank + 1`, length-1
  coordinate axis) and allow it past the rank guard. The existing element-wise
  path squeezes the length-1 coordinate axis (`index [N,1] -> [N]`), yielding a
  valid rank-1 `ttir.scatter` carrying the reduce type from the combine region.
- Tests: conversion checks in `StableHLOToTTIR/scatter_op.mlir` (row, middle-dim,
  sum, 1-D single-index, and multi-point 1-D), negative cases in
  `scatter_negative.mlir`, and silicon lowering coverage in
  `Silicon/StableHLO/n150/data_movement/scatter_op.mlir`.

Verified end-to-end on Wormhole: `jnp.zeros(4).at[i].add(u)` now compiles,
executes on device, and matches the CPU golden.

### Checklist
- [x] New/Existing tests provide coverage for changes