### PR TITLE
Uplift third_party/tt-metal to 21fbd33819b58d264e25bbf32e53a9557b324441 2026-07-15

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "1cb6f8e40e368cb8c23779cc4675c665eb1f86aa")
+set(TT_METAL_VERSION "21fbd33819b58d264e25bbf32e53a9557b324441")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 21fbd33819b58d264e25bbf32e53a9557b324441



### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/29494914363
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/29461051761
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [Tests originally marked as xfail now passing in tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/issues/3377)
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):