### PR TITLE
Uplift third_party/tt-metal to 771807262cf3051238364bb5afe3f4bcbde01fde 2026-07-16

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=d59e06f1c51211089bd34705099745b0b6b05833
+ARG TT_METAL_DEPENDENCIES_COMMIT=771807262cf3051238364bb5afe3f4bcbde01fde
 
 # Install dependencies
 RUN <<EOT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "1cb6f8e40e368cb8c23779cc4675c665eb1f86aa")
+set(TT_METAL_VERSION "771807262cf3051238364bb5afe3f4bcbde01fde")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 771807262cf3051238364bb5afe3f4bcbde01fde

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/29531177411/job/87769238143
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/29525509236
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  -https://github.com/tenstorrent/tt-forge-onnx/issues/3377
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):