### PR TITLE
[Optimizer] Add RepeatRuleBook pinning repeat output sharding grid to input

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
@@ -46,6 +46,21 @@ struct ConcatRuleBook : OpRuleBook {
                  const std::vector<OpConfig> &legalConfigs) const override;
 };
 
+/// RepeatOp: pin the output sharding grid to the input's grid.
+/// With a NULL/gridless output memory config, tt-metal's repeat re-derives the
+/// output shard spec onto the full compute grid, so the grid it reports no
+/// longer matches the physically-allocated (trimmed) grid and downstream
+/// consumers read the wrong cores (tt-xla#5605). Force an explicit sharded
+/// output on the input's memory layout and grid.
+struct RepeatRuleBook : OpRuleBook {
+  bool isValidOutputHintForInputs(
+      const OpConfig &hint,
+      llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) const override;
+  OutputHints
+  getOutputHints(Operation *op,
+                 const std::vector<OpConfig> &legalConfigs) const override;
+};
+
 /// SliceStaticOp, SliceDynamicOp: reject all sharded inputs, non-sharded
 /// output, no reshards.
 struct SliceRuleBook : OpRuleBook {

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -129,6 +129,63 @@ OutputHints ConcatRuleBook::getOutputHints(
 }
 
 //===----------------------------------------------------------------------===//
+// RepeatRuleBook
+//===----------------------------------------------------------------------===//
+
+bool RepeatRuleBook::isValidOutputHintForInputs(
+    const OpConfig &hint, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) const {
+  // ttnn.repeat has a single tensor operand.
+  if (inputLayouts.empty()) {
+    return true;
+  }
+
+  auto inputMem = inputLayouts[0].getMemLayout();
+  bool inputSharded = inputMem && isShardedMemoryLayout(inputMem.getValue());
+
+  // Interleaved input: no grid constraint (output stays interleaved).
+  if (!inputSharded) {
+    return true;
+  }
+
+  // Sharded input: a NULL/gridless output config lets tt-metal re-derive the
+  // output shard spec onto the full compute grid, so the reported grid no
+  // longer matches the physically-allocated (trimmed) grid and consumers read
+  // the wrong cores (tt-xla#5605). Require an explicit sharded output on the
+  // same memory layout type and the same grid as the input.
+  if (!hint.outputLayout) {
+    return false;
+  }
+  auto hintMem = hint.outputLayout.getMemLayout();
+  bool hintSharded = hintMem && isShardedMemoryLayout(hintMem.getValue());
+  if (!hintSharded || hintMem != inputMem) {
+    return false;
+  }
+  return hint.outputLayout.getGridShape() == inputLayouts[0].getGridShape();
+}
+
+OutputHints RepeatRuleBook::getOutputHints(
+    Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
+  // Promote sharded configs to primary hints so a grid-matching sharded
+  // candidate exists for a sharded input. Relying on the NULL hint alone lets
+  // tt-metal re-grid the output onto the full compute grid (the tt-xla#5605
+  // regression); isValidOutputHintForInputs then keeps only the config whose
+  // grid equals the input's. The NULL hint remains for the interleaved-input
+  // case (backend picks an interleaved output).
+  OutputHints result;
+  result.hints.push_back(OpConfig(TTNNLayoutAttr()));
+  for (const auto &cfg : legalConfigs) {
+    if (!cfg.outputLayout) {
+      continue;
+    }
+    auto memLayout = cfg.outputLayout.getMemLayout();
+    if (memLayout && isShardedMemoryLayout(memLayout.getValue())) {
+      result.hints.push_back(cfg);
+    }
+  }
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
 // SliceRuleBook
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -73,6 +73,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static SliceRuleBook slice;
   static ReshapeRuleBook reshape;
   static PadRuleBook pad;
+  static RepeatRuleBook repeat;
   static ConcatenateHeadsRuleBook concatHeads;
   static SDPARuleBook sdpa;
   static SDPADecodeRuleBook sdpaDecode;
@@ -109,6 +110,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     // https://github.com/tenstorrent/tt-mlir/issues/7988
     reg(PermuteOp::getOperationName(), &reshape);
     reg(PadOp::getOperationName(), &pad);
+    reg(RepeatOp::getOperationName(), &repeat);
     reg(ConcatenateHeadsOp::getOperationName(), &concatHeads);
     reg(NLPConcatHeadsDecodeOp::getOperationName(), &sdpa);
     reg(ScaledDotProductAttentionOp::getOperationName(), &sdpa);


### PR DESCRIPTION
### Ticket

Fixes https://github.com/tenstorrent/tt-xla/issues/5605

### Problem

At opt-level 2 the greedy layout optimizer lets ttnn.repeat re-grid its output from the input's sharded grid (e.g. <1x4>) onto the full compute grid (<8x8>). The reported grid then mismatches the physically-allocated grid, so downstream consumers (SDPA-decode) read the wrong cores → decode PCC collapses on single-chip LLMs (Falcon3-1b, Llama3.1-8b, Qwen3-8b).

### What's changed

Adds a RepeatRuleBook that forces ttnn.repeat's output to keep the same sharding grid as its input — i.e. the pre-uplift behavior that had good PCC. It promotes sharded configs to primary hints and rejects any output hint whose grid differs from the input's (mirrors ConcatRuleBook).

### Note

This is a quick/interim fix at the compiler level to restore the known-good behavior. A proper root-cause fix in tt-metal (making repeat's reported output sharding match the physically-trimmed grid) is on the way; this can be revisited once that lands.
https://github.com/tenstorrent/tt-metal/pull/50174

### Checklist
- [x] Verified on llama_3_1_8b: repeat output returns to <1x4> (was <8x8>), deterministically, passing PCC
 https://github.com/tenstorrent/tt-xla/actions/runs/29533155530/job/87738126685
