### PR TITLE
[StableHLOToTTIR] Guard gather->slice/repeat/concat against rank-changing gathers

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -6162,20 +6162,18 @@ public:
     // them here would build a concat whose element shape mismatches the
     // declared output type. Bail out so such gathers fall through to the
     // embedding lowering, which handles them correctly.
-    {
-      auto gatherOutputType = mlir::cast<RankedTensorType>(
-          getTypeConverter()->convertType(srcOp.getResult().getType()));
-      auto gatherOutputShape = gatherOutputType.getShape();
-      if (gatherOutputShape.size() != inputShape.size()) {
+    auto outputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult().getType()));
+    auto outputShape = outputType.getShape();
+    if (outputShape.size() != inputShape.size()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "gather output rank differs from operand rank");
+    }
+    for (int64_t i = 0; i < static_cast<int64_t>(inputShape.size()); ++i) {
+      if (i != indexedDim && outputShape[i] != inputShape[i]) {
         return rewriter.notifyMatchFailure(
-            srcOp, "gather output rank differs from operand rank");
-      }
-      for (int64_t i = 0; i < static_cast<int64_t>(inputShape.size()); ++i) {
-        if (i != indexedDim && gatherOutputShape[i] != inputShape[i]) {
-          return rewriter.notifyMatchFailure(
-              srcOp, "gather output shape differs from operand shape on a "
-                     "non-indexed dimension");
-        }
+            srcOp, "gather output shape differs from operand shape on a "
+                   "non-indexed dimension");
       }
     }
 
@@ -6237,9 +6235,6 @@ public:
         createSlices(ends, indexedDim, sliceSize,
                      /*sliceStart=*/inputShape[indexedDim] - sliceSize,
                      inputShape, inputType, rewriter, srcOp, input));
-
-    auto outputType = mlir::cast<RankedTensorType>(
-        getTypeConverter()->convertType(srcOp.getResult().getType()));
 
     Value result = rewriter.create<ttir::ConcatOp>(
         srcOp.getLoc(), outputType, slicesToConcat,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -6153,6 +6153,32 @@ public:
     int64_t indexedDim = startIndexMap[0];
     int64_t maxIndex = inputShape[indexedDim] - sliceSizes[indexedDim];
     int64_t sliceSize = sliceSizes[indexedDim];
+
+    // This pattern reconstructs the gather as a concat of operand-shaped
+    // frames along `indexedDim`, so it is only valid when the gather output
+    // has the same rank as the operand and differs only in `indexedDim`.
+    // Batched index vectors (e.g. a RoPE `cos[position_ids]` lookup with
+    // start_indices of shape [1, N]) add leading dims to the output; matching
+    // them here would build a concat whose element shape mismatches the
+    // declared output type. Bail out so such gathers fall through to the
+    // embedding lowering, which handles them correctly.
+    {
+      auto gatherOutputType = mlir::cast<RankedTensorType>(
+          getTypeConverter()->convertType(srcOp.getResult().getType()));
+      auto gatherOutputShape = gatherOutputType.getShape();
+      if (gatherOutputShape.size() != inputShape.size()) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "gather output rank differs from operand rank");
+      }
+      for (int64_t i = 0; i < static_cast<int64_t>(inputShape.size()); ++i) {
+        if (i != indexedDim && gatherOutputShape[i] != inputShape[i]) {
+          return rewriter.notifyMatchFailure(
+              srcOp, "gather output shape differs from operand shape on a "
+                     "non-indexed dimension");
+        }
+      }
+    }
+
     int32_t starts = 0, ends = 0, lastIndex = 0;
     // It is expected that the indices are consecutive and in ascending order.
     // Like [0,0,0,1,2,3,4,5,5,5,5,5].

--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
@@ -146,6 +146,9 @@ module @test_gather_repeat_front_singleton_indexed_dim {
 // is the InternLM2 RoPE `cos[position_ids]` pattern (operand [S, D], indices
 // [1, S], output [1, S, D]); matching it here produced an invalid concat
 // ('ttir.concat' output dim mismatch "1 vs. N").
+//
+// This covers only the output-rank-mismatch leg of the legality guard; see
+// @gather_offset_dim_mismatch_falls_through below for the same-rank leg.
 // CHECK-LABEL: func.func @rope_cos_gather_falls_through
 module @test_gather_rope_cos {
   func.func @rope_cos_gather_falls_through(%arg0: tensor<8x4xbf16>) -> tensor<1x8x4xbf16> {
@@ -155,5 +158,26 @@ module @test_gather_rope_cos {
     %1 = "stablehlo.constant"() <{value = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>}> : () -> tensor<1x8xi64>
     %2 = "stablehlo.gather"(%arg0, %1) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<8x4xbf16>, tensor<1x8xi64>) -> tensor<1x8x4xbf16>
     return %2 : tensor<1x8x4xbf16>
+  }
+}
+
+// Same output rank as the operand (2 == 2), but placing the offset dim first
+// (offset_dims = [0]) puts the batch dim in output position 1 instead of
+// position 0. Indices [0, 1, ..., 7] are consecutive ascending, so this would
+// otherwise match the replicate-padding heuristic, but the guard's positional
+// non-indexed-dim comparison catches that output dim 1 (size 8, from the
+// batch) does not match operand dim 1 (size 4, D) and rejects the match. A
+// literal slice/repeat/concat of operand-shaped [8, 4] frames cannot produce
+// a [4, 8] result, so this must fall through to the embedding lowering
+// (which permutes/reshapes to handle arbitrary offset_dims ordering).
+// CHECK-LABEL: func.func @gather_offset_dim_mismatch_falls_through
+module @test_gather_offset_dim_mismatch {
+  func.func @gather_offset_dim_mismatch_falls_through(%arg0: tensor<8x4xbf16>) -> tensor<4x8xbf16> {
+    // CHECK-NOT: "ttir.concat"
+    // CHECK: "ttir.embedding"
+    // CHECK-NOT: stablehlo.gather
+    %1 = "stablehlo.constant"() <{value = dense<[0, 1, 2, 3, 4, 5, 6, 7]> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %2 = "stablehlo.gather"(%arg0, %1) <{dimension_numbers = #stablehlo.gather<offset_dims = [0], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<8x4xbf16>, tensor<8xi64>) -> tensor<4x8xbf16>
+    return %2 : tensor<4x8xbf16>
   }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
@@ -137,3 +137,23 @@ module @test_gather_repeat_front_singleton_indexed_dim {
     return %2 : tensor<1x16x3x40x64xbf16>
   }
 }
+
+// Consecutive ascending indices [0, 1, ..., N-1] would otherwise match the
+// replicate-padding heuristic, but a batched index vector (start_indices shape
+// [1, N]) makes the gather output rank (3) exceed the operand rank (2). The
+// slice/repeat/concat rewrite reconstructs operand-shaped frames, so it cannot
+// represent that output and must fall through to the embedding lowering. This
+// is the InternLM2 RoPE `cos[position_ids]` pattern (operand [S, D], indices
+// [1, S], output [1, S, D]); matching it here produced an invalid concat
+// ('ttir.concat' output dim mismatch "1 vs. N").
+// CHECK-LABEL: func.func @rope_cos_gather_falls_through
+module @test_gather_rope_cos {
+  func.func @rope_cos_gather_falls_through(%arg0: tensor<8x4xbf16>) -> tensor<1x8x4xbf16> {
+    // CHECK-NOT: "ttir.concat"
+    // CHECK: "ttir.embedding"
+    // CHECK-NOT: stablehlo.gather
+    %1 = "stablehlo.constant"() <{value = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>}> : () -> tensor<1x8xi64>
+    %2 = "stablehlo.gather"(%arg0, %1) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<8x4xbf16>, tensor<1x8xi64>) -> tensor<1x8x4xbf16>
+    return %2 : tensor<1x8x4xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`StableHLOGatherToSliceRepeatConcatPattern` lowers a `stablehlo.gather` into a `slice` / `repeat` / `concat` of **operand-shaped frames** along the indexed dimension. It is a heuristic for "replicate-padding" gathers (index sequences like `[0,0,0,1,2,3,3,3]`).

Its legality check only inspected:
- `start_index_map.size() == 1`,
- that the start indices are a constant, and
- that the indices are consecutive / ascending.

It never verified that the gather's **output layout** can actually be reconstructed from operand-shaped slices. As a result it also matched gathers whose output rank/shape it cannot represent.

The InternLM2 RoPE lookup `cos[position_ids]` hits this:
- operand `cos`: `tensor<S x D>` (rank 2)
- indices `position_ids`: `tensor<1 x S>` with consecutive values `[0, 1, …, S-1]`
- output: `tensor<1 x S x D>` (rank 3)

The consecutive indices look like replicate-padding, so the pattern matched — but the batched index vector adds a leading batch dim, making the gather output rank 3 while the operand is rank 2. The pattern then built a `ttir.concat` of rank-2 slices carrying a rank-3 output type, which fails the concat verifier and aborts SHLO→TTIR conversion:

```
'ttir.concat' op Output tensor dimension 0 does not match the sum of input tensor dimensions: 1 vs. 512
```

This blocks compilation of any model whose RoPE emits `cos[position_ids]` as a `stablehlo.gather` (e.g. OpenGVLab InternVL2-26B / InternLM2).


### What's changed

Added a legality guard to `StableHLOGatherToSliceRepeatConcatPattern` so it fires only when the gather output is genuinely an operand-shaped slice/concat:
- the gather output has the **same rank** as the operand, and
- every **non-indexed dimension** has an identical size in operand and output.

When either condition fails, the pattern calls `notifyMatchFailure` and the gather falls through to the existing embedding lowering (`StableHLOGatherToEmbeddingPattern`), which handles the RoPE-style shape correctly.



### Checklist
- [ ] New/Existing tests provide coverage for changes
