### PR TITLE
[TTIR] Preserve logical embedding index shape

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -4197,6 +4197,16 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
 
 // EmbeddingOp canonicalization
 //
+// Restore the logical index shape when a frontend flattens indices around a
+// typecast. The embedding operates on the recovered 2D indices and its result
+// is reshaped back for existing consumers. Keeping the logical shape on the
+// embedding exposes both parallel dimensions to downstream layout selection.
+//
+//   Embedding(Typecast(Reshape([A,B] -> [A*B])))
+//     -> Reshape(Embedding(Typecast([A,B])), [A*B,C])
+//   Embedding(Reshape(Typecast([A,B]), [A*B]))
+//     -> Reshape(Embedding(Typecast([A,B])), [A*B,C])
+//
 // Squeeze unit dimensions out of the index tensor before the embedding lookup,
 // then reshape the result back to the original output shape.
 //
@@ -4216,6 +4226,76 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
 //
 void mlir::tt::ttir::EmbeddingOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  patterns.add(+[](mlir::tt::ttir::EmbeddingOp op,
+                   mlir::PatternRewriter &rewriter) -> LogicalResult {
+    RankedTensorType flattenedIndicesType = op.getInput().getType();
+    RankedTensorType flattenedResultType = op.getType();
+    if (!flattenedIndicesType.hasStaticShape() ||
+        flattenedIndicesType.getRank() != 1 ||
+        !flattenedResultType.hasStaticShape()) {
+      return failure();
+    }
+
+    auto findExpandedSource = [&](Value value, bool requireTypecast) -> Value {
+      while (auto reshape = value.getDefiningOp<ttir::ReshapeOp>()) {
+        value = reshape.getInput();
+        auto type = mlir::dyn_cast<RankedTensorType>(value.getType());
+        if (type && type.hasStaticShape() && type.getRank() == 2 &&
+            type.getNumElements() == flattenedIndicesType.getNumElements() &&
+            (!requireTypecast ||
+             value.getDefiningOp<ttir::TypecastOp>() != nullptr)) {
+          return value;
+        }
+      }
+      return {};
+    };
+
+    Value expandedIndices;
+    if (auto typecast = op.getInput().getDefiningOp<ttir::TypecastOp>()) {
+      Value expandedInput =
+          findExpandedSource(typecast.getInput(), /*requireTypecast=*/false);
+      if (!expandedInput) {
+        return failure();
+      }
+
+      auto expandedInputType =
+          mlir::cast<RankedTensorType>(expandedInput.getType());
+      auto expandedCastType = RankedTensorType::get(
+          expandedInputType.getShape(), flattenedIndicesType.getElementType(),
+          expandedInputType.getEncoding());
+      expandedIndices = rewriter.create<ttir::TypecastOp>(
+          typecast.getLoc(), expandedCastType, expandedInput,
+          typecast.getConservativeFolding());
+    } else {
+      expandedIndices =
+          findExpandedSource(op.getInput(), /*requireTypecast=*/true);
+      if (!expandedIndices ||
+          mlir::cast<RankedTensorType>(expandedIndices.getType())
+                  .getElementType() != flattenedIndicesType.getElementType()) {
+        return failure();
+      }
+    }
+
+    RankedTensorType expandedIndicesType =
+        mlir::cast<RankedTensorType>(expandedIndices.getType());
+    RankedTensorType weightType = op.getWeight().getType();
+    SmallVector<int64_t> expandedResultShape(expandedIndicesType.getShape());
+    expandedResultShape.push_back(weightType.getShape().back());
+    auto expandedResultType = RankedTensorType::get(
+        expandedResultShape, flattenedResultType.getElementType(),
+        flattenedResultType.getEncoding());
+    Value expandedEmbedding = rewriter.create<ttir::EmbeddingOp>(
+        op.getLoc(), expandedResultType, expandedIndices, op.getWeight());
+
+    SmallVector<int32_t> flattenedResultShape(
+        flattenedResultType.getShape().begin(),
+        flattenedResultType.getShape().end());
+    rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
+        op, flattenedResultType, expandedEmbedding,
+        rewriter.getI32ArrayAttr(flattenedResultShape));
+    return success();
+  });
+
   patterns.add(+[](mlir::tt::ttir::EmbeddingOp op,
                    mlir::PatternRewriter &rewriter) -> LogicalResult {
     // Do not apply when the indices are not produced by a ReshapeOp or when the

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection_embedding.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection_embedding.mlir
@@ -1,6 +1,6 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --canonicalize %s | FileCheck %s --check-prefix=BEFORE
-// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-grid-selection --canonicalize %s | FileCheck %s --check-prefix=AFTER
-// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-grid-selection --canonicalize --ttcore-one-shot-bufferize %s | FileCheck %s --check-prefix=BUFFER
+// RUN: ttmlir-opt --ttcore-register-device --canonicalize --ttir-to-d2m --canonicalize %s | FileCheck %s --check-prefix=BEFORE
+// RUN: ttmlir-opt --ttcore-register-device --canonicalize --ttir-to-d2m --d2m-grid-selection --canonicalize %s | FileCheck %s --check-prefix=AFTER
+// RUN: ttmlir-opt --ttcore-register-device --canonicalize --ttir-to-d2m --d2m-grid-selection --canonicalize --ttcore-one-shot-bufferize %s | FileCheck %s --check-prefix=BUFFER
 
 module {
   func.func @embedding_grid(%indices: tensor<8x4xi32>, %weight: tensor<16x32xf32>) -> tensor<8x4x32xf32> {
@@ -53,5 +53,21 @@ module {
     // BUFFER-SAME: : memref
     %0 = "ttir.embedding"(%indices, %weight) : (tensor<1x4xi32>, tensor<16x16xf32>) -> tensor<1x4x16xf32>
     return %0 : tensor<1x4x16xf32>
+  }
+
+  func.func @embedding_flattened_indices(
+      %indices: tensor<32x18xsi32>,
+      %weight: tensor<128256x4096xbf16>) -> tensor<576x4096xbf16> {
+    // AFTER-LABEL: func.func @embedding_flattened_indices
+    // AFTER: d2m.to_layout %arg1
+    // AFTER: d2m.generic
+    // AFTER-SAME: grid = #ttcore.grid<8x8
+    // AFTER: d2m.embedding
+    // AFTER-SAME: <576, 4096>
+    // AFTER-SAME: {indicesShape = array<i64: 32, 18>}
+    %0 = "ttir.typecast"(%indices) <{conservative_folding = false}> : (tensor<32x18xsi32>) -> tensor<32x18xui32>
+    %1 = "ttir.reshape"(%0) <{shape = [576 : i32]}> : (tensor<32x18xui32>) -> tensor<576xui32>
+    %2 = "ttir.embedding"(%1, %weight) : (tensor<576xui32>, tensor<128256x4096xbf16>) -> tensor<576x4096xbf16>
+    return %2 : tensor<576x4096xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
@@ -53,6 +53,36 @@ module {
     return %2 : tensor<2x2x8xf32>
   }
 
+  // Flattening around the index typecast is removed so the embedding retains
+  // the logical index dimensions.
+  func.func @embedding_flatten_typecast_restore(%input: tensor<32x18xi64>, %weight: tensor<128256x4096xbf16>) -> tensor<32x18x4096xbf16> {
+    // CHECK-LABEL: func.func @embedding_flatten_typecast_restore
+    // CHECK-NOT:   "ttir.reshape"
+    // CHECK:       %[[CAST:.*]] = "ttir.typecast"(%arg0) <{conservative_folding = false}> : (tensor<32x18xi64>) -> tensor<32x18xui32>
+    // CHECK:       %[[EMBEDDING:.*]] = "ttir.embedding"(%[[CAST]], %arg1) : (tensor<32x18xui32>, tensor<128256x4096xbf16>) -> tensor<32x18x4096xbf16>
+    // CHECK:       return %[[EMBEDDING]] : tensor<32x18x4096xbf16>
+    %0 = "ttir.reshape"(%input) <{shape = [1 : i32, 32 : i32, 18 : i32]}> : (tensor<32x18xi64>) -> tensor<1x32x18xi64>
+    %1 = "ttir.reshape"(%0) <{shape = [576 : i32]}> : (tensor<1x32x18xi64>) -> tensor<576xi64>
+    %2 = "ttir.typecast"(%1) <{conservative_folding = false}> : (tensor<576xi64>) -> tensor<576xui32>
+    %3 = "ttir.embedding"(%2, %weight) : (tensor<576xui32>, tensor<128256x4096xbf16>) -> tensor<576x4096xbf16>
+    %4 = "ttir.reshape"(%3) <{shape = [32 : i32, 18 : i32, 4096 : i32]}> : (tensor<576x4096xbf16>) -> tensor<32x18x4096xbf16>
+    return %4 : tensor<32x18x4096xbf16>
+  }
+
+  // The same canonicalization applies after preprocessing commutes the typecast
+  // ahead of the flatten.
+  func.func @embedding_typecast_then_flatten(%input: tensor<32x18xsi32>, %weight: tensor<128256x4096xbf16>) -> tensor<576x4096xbf16> {
+    // CHECK-LABEL: func.func @embedding_typecast_then_flatten
+    // CHECK:       %[[CAST:.*]] = "ttir.typecast"(%arg0) <{conservative_folding = false}> : (tensor<32x18xsi32>) -> tensor<32x18xui32>
+    // CHECK-NEXT:  %[[EMBEDDING:.*]] = "ttir.embedding"(%[[CAST]], %arg1) : (tensor<32x18xui32>, tensor<128256x4096xbf16>) -> tensor<32x18x4096xbf16>
+    // CHECK-NEXT:  %[[FLATTENED:.*]] = "ttir.reshape"(%[[EMBEDDING]]) <{shape = [576 : i32, 4096 : i32]}> : (tensor<32x18x4096xbf16>) -> tensor<576x4096xbf16>
+    // CHECK-NEXT:  return %[[FLATTENED]] : tensor<576x4096xbf16>
+    %0 = "ttir.typecast"(%input) <{conservative_folding = false}> : (tensor<32x18xsi32>) -> tensor<32x18xui32>
+    %1 = "ttir.reshape"(%0) <{shape = [576 : i32]}> : (tensor<32x18xui32>) -> tensor<576xui32>
+    %2 = "ttir.embedding"(%1, %weight) : (tensor<576xui32>, tensor<128256x4096xbf16>) -> tensor<576x4096xbf16>
+    return %2 : tensor<576x4096xbf16>
+  }
+
   // Indices do not come from reshape, output does not go to reshape, pattern must NOT fire.
   func.func @embedding_1d_no_canonicalize_reshapes(%input: tensor<4x1xi32>, %weight: tensor<10x8xf32>) -> tensor<4x1x8xf32> {
     // CHECK-LABEL: func.func @embedding_1d_no_canonicalize_reshapes


### PR DESCRIPTION
## Summary

- recover a 2D embedding index shape when frontend reshapes flatten indices around a typecast
- run the embedding with the recovered logical shape, then reshape its result for existing flattened consumers
- cover both typecast-before-flatten and flatten-before-typecast forms
- verify the Llama 3 8B prefill shapes (32x18 indices, 128256x4096 table) lower with `indicesShape = [32, 18]` on an `8x8` grid

## Testing

- `llvm-lit -a test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir test/ttmlir/Dialect/D2M/Transforms/grid_selection_embedding.mlir`
- `pre-commit run --all-files`
- exact clean-branch `ttmlir-opt` build
- Llama 3 8B prefill IR inspection after D2M frontend canonicalization

Local `check-ttmlir` result: 1539 passed, 645 unsupported, 2 configuration-only failures because the fresh local build had StableHLO disabled and those tests invoked unavailable StableHLO flags.