### PR TITLE
[D2M] Reblock padded L1 outputs before DRAM transfer

### DIFF
--- a/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/LowerToLayout.cpp
@@ -189,7 +189,8 @@ public:
         (inputLayout.getLogicalShape() == outputLayout.getLogicalShape() &&
          inputLayout.getDimAlignments() == outputLayout.getDimAlignments() &&
          inputLayout.getCollapsedIntervals() ==
-             outputLayout.getCollapsedIntervals());
+             outputLayout.getCollapsedIntervals() &&
+         inputInfo.type.getNumElements() == outputInfo.type.getNumElements());
 
     bool bothTilized =
         ttcore::isTiled(inputInfo.type) && ttcore::isTiled(outputInfo.type);

--- a/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout/Plan.cpp
@@ -282,15 +282,19 @@ modifyDeviceType(MLIRContext *ctx, RankedTensorType baseType,
 void emitTilizedReshardDecomposition(
     Plan &plan, MLIRContext *ctx, RankedTensorType currentType,
     ttcore::MetalLayoutAttr currentLayout, RankedTensorType targetType,
-    ttcore::MetalLayoutAttr targetLayout, ArrayRef<int64_t> targetGridShape,
-    AffineMap currentRemapping, AffineMap currentVgmForward,
+    ttcore::MetalLayoutAttr targetLayout, AffineMap currentVgmForward,
     AffineMap currentVgmInverse, AffineMap targetVgmForward,
     AffineMap targetVgmInverse) {
   Type scalarType = getScalarType(currentType.getElementType());
-  auto untilizedType = modifyDeviceType(
-      ctx, currentType, currentLayout, targetGridShape, currentRemapping,
-      ttcore::MemorySpace::DeviceL1, /*newTensorGrid=*/{}, scalarType,
-      /*newTileShape=*/{}, /*reblockVirtualGridShapes=*/false);
+  ArrayRef<int64_t> sourceTileShape = ttcore::getTensorTileShape(currentType);
+  SmallVector<int64_t> untilizedShape(currentType.getShape());
+  assert(untilizedShape.size() >= sourceTileShape.size());
+  for (size_t i = 0; i < sourceTileShape.size(); ++i) {
+    untilizedShape[untilizedShape.size() - sourceTileShape.size() + i] *=
+        sourceTileShape[i];
+  }
+  auto untilizedType =
+      RankedTensorType::get(untilizedShape, scalarType, currentLayout);
   plan.push_back(
       UntilizeStep{currentType, makeOutputSpec(untilizedType, currentVgmForward,
                                                currentVgmInverse)});
@@ -312,9 +316,9 @@ void emitTilizedReshardDecomposition(
 
   ArrayRef<int64_t> tileShape = ttcore::getTensorTileShape(targetType);
   auto tiledType = RankedTensorType::get(
-      targetLayout.getDeviceShape(targetLayout.getGridShape(targetType),
-                                  tileShape),
-      targetType.getElementType(), targetLayout);
+      scalarTargetLayout.getDeviceShape(targetLayout.getGridShape(targetType),
+                                        tileShape),
+      targetType.getElementType(), scalarTargetLayout);
   plan.push_back(TilizeStep{
       llvm::to_vector(tileShape), scalarTargetType,
       makeOutputSpec(tiledType, targetVgmForward, targetVgmInverse)});
@@ -401,11 +405,13 @@ Plan canonicalize(const PlanState &src, const PlanState &tgt,
     updateStateFromOutput(current, output, current.remapping);
   }
 
-  // L1 → DRAM: the DMA writes directly into the output DRAM buffer, including
-  // the target virtual-grid metadata. Otherwise a following VGM-only rebuffer
-  // would become an unsupported DRAM→DRAM copy.
+  // L1 -> DRAM can reblock directly when the physical volumes match. A view
+  // maps the output to the source grid, preserving parallel virtual-grid DMA.
+  // Padded volume changes must first reshard in L1 so extra source shards do
+  // not address past the target DRAM allocation.
   if (current.hasLayout() && !current.isDRAM() && tgt.hasLayout() &&
-      tgt.isDRAM()) {
+      tgt.isDRAM() &&
+      current.type.getNumElements() == tgt.type.getNumElements()) {
     auto output = makeOutputSpec(tgt.type, tgt.vgmForward, tgt.vgmInverse);
     plan.push_back(L1ToDRAMStep{output, AffineMap()});
     updateStateFromOutput(current, output);
@@ -430,12 +436,14 @@ Plan canonicalize(const PlanState &src, const PlanState &tgt,
                                    tgt.getLayout()->getDimAlignments());
 
     if (needsMappingChange) {
-      bool isSimpleReblocking = (current.getLayout()->getLogicalShape() ==
-                                     tgt.getLayout()->getLogicalShape() &&
-                                 current.getLayout()->getDimAlignments() ==
-                                     tgt.getLayout()->getDimAlignments() &&
-                                 current.getLayout()->getCollapsedIntervals() ==
-                                     tgt.getLayout()->getCollapsedIntervals());
+      bool isSimpleReblocking =
+          (current.getLayout()->getLogicalShape() ==
+               tgt.getLayout()->getLogicalShape() &&
+           current.getLayout()->getDimAlignments() ==
+               tgt.getLayout()->getDimAlignments() &&
+           current.getLayout()->getCollapsedIntervals() ==
+               tgt.getLayout()->getCollapsedIntervals() &&
+           current.type.getNumElements() == tgt.type.getNumElements());
       bool bothTilized =
           ttcore::isTiled(current.type) && ttcore::isTiled(tgt.type);
 
@@ -443,9 +451,8 @@ Plan canonicalize(const PlanState &src, const PlanState &tgt,
         // Tilized, misaligned shards: mapping must go through scalar space.
         emitTilizedReshardDecomposition(
             plan, ctx, current.type, *current.getLayout(), tgt.type,
-            *tgt.getLayout(), targetGridShape, current.remapping,
-            current.vgmForward, current.vgmInverse, tgt.vgmForward,
-            tgt.vgmInverse);
+            *tgt.getLayout(), current.vgmForward, current.vgmInverse,
+            tgt.vgmForward, tgt.vgmInverse);
         updateStateFromOutput(current,
                               std::get<TilizeStep>(plan.back()).output);
       } else {
@@ -466,6 +473,16 @@ Plan canonicalize(const PlanState &src, const PlanState &tgt,
         updateStateFromOutput(current, output);
       }
     }
+  }
+
+  // L1 -> DRAM after any required padded mapping change. The DMA writes into
+  // the output DRAM buffer with the target virtual-grid metadata, avoiding an
+  // unsupported DRAM-to-DRAM rebuffer.
+  if (current.hasLayout() && !current.isDRAM() && tgt.hasLayout() &&
+      tgt.isDRAM()) {
+    auto output = makeOutputSpec(tgt.type, tgt.vgmForward, tgt.vgmInverse);
+    plan.push_back(L1ToDRAMStep{output, AffineMap()});
+    updateStateFromOutput(current, output);
   }
 
   // Materialize into a fresh buffer when VGM changes or when we need to clear

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_to_layout_l1_to_dram_reblock.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_to_layout_l1_to_dram_reblock.mlir
@@ -1,0 +1,35 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-lower-to-layout %s | FileCheck %s
+
+#l1 = #ttcore.metal_layout<logical_shape = 576x4096, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+#dram = #ttcore.metal_layout<logical_shape = 576x4096, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, dram, sharded>
+
+// Reblock in L1 before transferring to a differently shaped DRAM grid. Copying
+// directly from the 8x8 source grid would launch 64 writers for 48 DRAM shards.
+// CHECK-LABEL: func.func @l1_to_dram_reblock
+// CHECK: %[[DRAM_OUT:.*]] = d2m.empty() : tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #[[DRAM_LAYOUT:.*]]>
+// CHECK: %[[SCALAR_8X8:.*]] = d2m.empty() : tensor<8x8x96x512xbf16, #[[L1_LAYOUT:.*]]>
+// CHECK: %[[UNTILIZED:.*]] = d2m.generic
+// CHECK-SAME: grid = #ttcore.grid<8x8>
+// CHECK: ins(%arg0 : tensor<8x8x3x16x!ttcore.tile<32x32, bf16>, #[[L1_LAYOUT]]>)
+// CHECK: outs(%[[SCALAR_8X8]] : tensor<8x8x96x512xbf16, #[[L1_LAYOUT]]>)
+// CHECK: %[[SCALAR_6X8:.*]] = d2m.empty() : tensor<6x8x96x512xbf16, #[[L1_LAYOUT]]>
+// CHECK: %[[SRC_VIEW:.*]] = d2m.view_layout %[[UNTILIZED]]
+// CHECK: %[[REBLOCKED:.*]] = d2m.generic
+// CHECK-SAME: grid = #ttcore.grid<6x8>
+// CHECK: ins(%[[SRC_VIEW]] : tensor<6x8x96x512xbf16, #[[L1_LAYOUT]]>)
+// CHECK: outs(%[[SCALAR_6X8]] : tensor<6x8x96x512xbf16, #[[L1_LAYOUT]]>)
+// CHECK: %[[TILED_L1:.*]] = d2m.empty() : tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #[[L1_LAYOUT]]>
+// CHECK: %[[TILIZED:.*]] = d2m.generic
+// CHECK-SAME: grid = #ttcore.grid<6x8>
+// CHECK: ins(%[[REBLOCKED]] : tensor<6x8x96x512xbf16, #[[L1_LAYOUT]]>)
+// CHECK: outs(%[[TILED_L1]] : tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #[[L1_LAYOUT]]>)
+// CHECK: %[[COPIED:.*]] = d2m.generic
+// CHECK-SAME: grid = #ttcore.grid<6x8>
+// CHECK: ins(%[[TILIZED]] : tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #[[L1_LAYOUT]]>)
+// CHECK: outs(%[[DRAM_OUT]] : tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #[[DRAM_LAYOUT]]>)
+// CHECK: return %[[COPIED]]
+func.func @l1_to_dram_reblock(%arg0: tensor<8x8x3x16x!ttcore.tile<32x32, bf16>, #l1>) -> tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #dram> {
+  %0 = d2m.empty() : tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #dram>
+  %1 = d2m.to_layout %arg0, %0 : tensor<8x8x3x16x!ttcore.tile<32x32, bf16>, #l1> into tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #dram> -> tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #dram>
+  return %1 : tensor<6x8x3x16x!ttcore.tile<32x32, bf16>, #dram>
+}


### PR DESCRIPTION
## Summary
- defer L1-to-DRAM transfers when source and target padded physical volumes differ
- perform required tilized mapping changes through scalar L1 space before writing the target DRAM allocation
- preserve the source-grid shape for untilize and the target-grid L1 layout for tilize
- add an exact 8x8 L1 to 6x8 DRAM regression covering the 576x4096 prefill output shape

Directly viewing the 6x8 DRAM target through the 8x8 source grid launches 64 writers for 48 allocated DRAM shards. This change keeps the direct DMA path when physical volumes match; otherwise it reblocks in L1 and performs the final DRAM transfer on the target grid.

## Testing
- `llvm-lit -a` on 11 LowerToLayout tests: 11 passed
- `pre-commit run --all-files`: passed
- `cmake --build build --target check-ttmlir`: 1540 passed, 645 unsupported, 2 unrelated configuration failures because this clean build was configured without StableHLO while two StableHLO-only tests remain discovered