### PR TITLE
[D2M] Add d2m-jit mesh and global semaphore support

### DIFF
--- a/test/d2m-jit/lit/global_semaphore.py
+++ b/test/d2m-jit/lit/global_semaphore.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR coverage for d2m-jit global-semaphore kernel arguments."""
+
+import d2m_jit as d2m
+from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise
+from ttmlir.passmanager import PassManager
+
+
+@d2m.kernel
+def fake_semaphore_kernel(in0, out0, wait_value, end_sem):
+    cy = core_index(0)
+    value = remote_load(in0, [cy, 0])
+    remote_store(out0, [cy, 0], value)
+    end_sem.wait(wait_value)
+
+
+layout = d2m.Layout(
+    shape=(64, 64),
+    dtype=d2m.float32,
+    block_shape=[1, 1],
+    grid_shape=[2, 2],
+)
+input_ = d2m.empty(layout)
+output = d2m.empty(layout)
+end_sem = d2m.global_semaphore(grid_shape=(8, 8), init=7)
+fake_semaphore_kernel(input_, output, 1, end_sem, grid=(2, 2))
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [output])
+PassManager.parse(
+    "builtin.module(ttcore-register-device{mock-system-desc-arch=wormhole_b0})",
+    context=builder.ctx,
+).run(builder.module.operation)
+builder.module.operation.verify()
+print(builder.module)
+_Builder.reset()
+
+
+# CHECK: %[[BACKING:.*]] = d2m.empty() : tensor<8x8x1x1xui32
+# CHECK: %[[SEM:.*]] = d2m.create_global_semaphore(%[[BACKING]]) {value = 7 : ui32}
+# CHECK: d2m.generic
+# CHECK: additionalArgs(%{{.*}}, %[[SEM]] : index, !d2m.global_semaphore)
+# CHECK: d2m.semaphore_wait %[[SEM]]
+# CHECK: d2m.reset_global_semaphore(%[[SEM]]) {value = 7 : ui32}

--- a/test/d2m-jit/lit/mesh_shard.py
+++ b/test/d2m-jit/lit/mesh_shard.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR coverage for d2m-jit mesh shard and gather boundaries."""
+
+import torch
+
+import d2m_jit as d2m
+from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise
+
+d2m.mesh((1, 2), topology=("linear", "ring"))
+layout = d2m.Layout(
+    shape=(64, 64),
+    dtype=d2m.float32,
+    block_shape=[1, 1],
+    grid_shape=[2, 2],
+)
+full = torch.zeros((64, 128), dtype=torch.float32)
+shard = d2m.mesh_shard(
+    full,
+    layout,
+    shard_dims=[0, 1],
+    shard_shape=[1, 2],
+)
+gathered = d2m.mesh_gather(shard)
+
+builder = _Builder.get()
+assert builder._mesh_shape == [1, 2]
+assert builder._mesh_topology == ["linear", "ring"]
+assert shard.mesh.full_shape == [64, 128]
+_emit_returns_and_finalise(builder, [gathered])
+builder.module.operation.verify()
+print(builder.module)
+_Builder.reset()
+
+
+# CHECK: module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x2>]>}
+# CHECK: func.func @main(%{{.*}}: tensor<64x128xf32>) -> tensor<64x128xf32>
+# CHECK: shard_direction = #ttcore.shard_direction<full_to_shard>
+# CHECK-SAME: tensor<64x128xf32> -> tensor<64x64xf32, #ttcore.tensor_mesh<"mesh">>
+# CHECK: tensor<64x64xf32, #ttcore.tensor_mesh<"mesh">>
+# CHECK: shard_direction = #ttcore.shard_direction<shard_to_full>
+# CHECK-SAME: tensor<64x64xf32, #ttcore.tensor_mesh<"mesh">> -> tensor<64x128xf32>

--- a/test/d2m-jit/test_mesh.py
+++ b/test/d2m-jit/test_mesh.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import functools
+import json
+import os
+import re
+
+import pytest
+import torch
+
+import d2m_jit as d2m
+from d2m_jit._src.builder import _Builder
+
+try:
+    from _ttmlir_runtime import binary, runtime
+except (ImportError, ModuleNotFoundError):
+    binary = None
+    runtime = None
+
+
+@functools.lru_cache(maxsize=1)
+def _num_devices():
+    """Read the chip count without opening a runtime device."""
+    system_desc = os.environ.get("SYSTEM_DESC_PATH")
+    if binary is None or not system_desc:
+        return 0
+    try:
+        desc = binary.load_system_desc_from_path(system_desc).as_json()
+        desc = re.sub(r"\bnan\b", "NaN", desc)
+        desc = re.sub(r"\binf\b", "Infinity", desc)
+        return len(json.loads(desc)["system_desc"]["chip_desc_indices"])
+    except Exception:
+        return 0
+
+
+requires_mesh = pytest.mark.skipif(
+    runtime is None or _num_devices() < 2,
+    reason="requires SYSTEM_DESC_PATH for a system with at least two devices",
+)
+
+
+def test_mesh_configuration():
+    d2m.mesh((1, 2), topology=("linear", "ring"))
+    builder = _Builder.get()
+
+    assert '#ttcore.meshes<[<"mesh" = 1x2>]>' in str(builder.module.operation)
+    assert builder._mesh_shape == [1, 2]
+    assert builder._mesh_topology == ["linear", "ring"]
+
+
+def test_mesh_gather_derives_full_shape():
+    d2m.mesh((2, 2), topology=("linear", "linear"))
+    layout = d2m.Layout(
+        shape=(64, 32),
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=[2, 1],
+    )
+
+    gathered = d2m.mesh_gather(
+        d2m.empty(layout),
+        shard_dims=[1, 1],
+        shard_shape=[1, 4],
+    )
+
+    assert gathered.mesh.full_shape == [64, 128]
+
+
+@requires_mesh
+def test_mesh_shard_round_trip_1x2():
+    d2m.mesh((1, 2), topology=("linear", "ring"))
+    layout = d2m.Layout(
+        shape=(512, 512),
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=[2, 2],
+    )
+    full = torch.randn((512, 1024), dtype=torch.float32)
+
+    shard = d2m.mesh_shard(
+        full,
+        layout,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    )
+    result = shard.to_host()
+
+    assert result.shape == full.shape
+    assert torch.allclose(result, full, atol=1e-2)
+
+
+@requires_mesh
+def test_mesh_compute_round_trip_1x2():
+    @d2m.kernel
+    def sigmoid_kernel(input_, output, m_blocks, n_blocks):
+        m_offset = core_index(0) * m_blocks
+        n_offset = core_index(1) * n_blocks
+        for m in range(m_blocks):
+            for n in range(n_blocks):
+                value = remote_load(input_, [m_offset + m, n_offset + n])
+                remote_store(
+                    output,
+                    [m_offset + m, n_offset + n],
+                    sigmoid(value),
+                )
+
+    d2m.mesh((1, 2), topology=("linear", "ring"))
+    layout = d2m.Layout(
+        shape=(64, 64),
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=[2, 2],
+    )
+    full = torch.randn((64, 128), dtype=torch.float32) * 0.5
+    input_ = d2m.mesh_shard(
+        full,
+        layout,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    )
+    output = d2m.empty(layout)
+
+    sigmoid_kernel(input_, output, 1, 1, grid=(2, 2))
+    result = d2m.mesh_gather(
+        output,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    ).to_host()
+
+    assert result.shape == full.shape
+    assert (torch.sigmoid(full) - result).abs().max().item() < 0.05

--- a/tools/d2m-jit/_src/ast.py
+++ b/tools/d2m-jit/_src/ast.py
@@ -22,6 +22,13 @@ from .tensor_layout import Layout
 _D2M_KERNEL_TYPES = {None, "datamovement", "noc", "compute", "unified"}
 
 
+class _SemaphoreArg:
+    """Sentinel used to type a kernel argument as a global semaphore."""
+
+
+SEMAPHORE_ARG = _SemaphoreArg()
+
+
 def _as_value(v):
     """Coerce an OpView or Value to an ir.Value."""
     return v.result if isinstance(v, OpView) else v
@@ -270,6 +277,8 @@ class D2MCompiler(ast.NodeVisitor):
                 func_operand_types.append(
                     rt_arg.build_device_tensor_type(self.ctx, blocked=True)
                 )
+            elif isinstance(rt_arg, _SemaphoreArg):
+                func_operand_types.append(d2m.ir.GlobalSemaphoreType.get(self.ctx))
             elif isinstance(rt_arg, int):
                 func_operand_types.append(IndexType.get(self.ctx))
             else:

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -906,7 +906,7 @@ def _semaphore_backing_type(ctx, grid_shape):
         for i in range(rank)
         for endpoint in (i, i + 1)
     ]
-    collapse = DenseIntElementsAttr.get(interval_type, interval_values)
+    collapse = DenseIntElementsAttr.get(interval_values, type=interval_type)
     metal_layout = ttcore.ir.MetalLayoutAttr.get(
         ctx,
         list(grid_shape),

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -906,7 +906,7 @@ def _semaphore_backing_type(ctx, grid_shape):
         for i in range(rank)
         for endpoint in (i, i + 1)
     ]
-    collapse = DenseIntElementsAttr.get(interval_values, type=interval_type)
+    collapse = DenseIntElementsAttr.get(interval_type, interval_values)
     metal_layout = ttcore.ir.MetalLayoutAttr.get(
         ctx,
         list(grid_shape),

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -39,7 +39,7 @@ from ttmlir.passmanager import PassManager
 from ttmlir.dialects import d2m, func, arith, linalg, ttcore
 from ttmlir.passes import ttmetal_to_flatbuffer_bin
 
-from .ast import D2MCompiler
+from .ast import D2MCompiler, SEMAPHORE_ARG
 from .config import config
 from .errors import D2mJitError
 from .tensor_layout import Layout
@@ -58,6 +58,7 @@ def _ttcore_to_torch_dtype(dt):
             ttcore.DataType.Float32: torch.float32,
             ttcore.DataType.Float16: torch.float16,
             ttcore.DataType.BFloat16: torch.bfloat16,
+            ttcore.DataType.UInt32: torch.uint32,
         }
     if dt not in _TTCORE_TO_TORCH:
         raise ValueError(f"No torch dtype for ttcore.DataType {dt}")
@@ -254,15 +255,69 @@ class _Builder:
         # Parallel arrays: MLIR arg types and the torch tensor that backs each.
         self._input_types: list = []
         self._input_tensors: list = []
+        # The shape is represented by the module's ttcore.meshes attribute.
+        # Topology is a register-device pass option.
+        self._mesh_shape = None
+        self._mesh_topology = None
+        self._mesh_name = None
+
+    def set_mesh(self, shape, topology=None):
+        """Declare the device mesh used by this graph."""
+        shape = tuple(shape)
+        if not shape or any(
+            not isinstance(dim, int) or isinstance(dim, bool) or dim <= 0
+            for dim in shape
+        ):
+            raise ValueError(f"mesh shape must contain positive integers, got {shape}")
+        if len(shape) != 2:
+            raise ValueError(f"TTMetal requires a rank-2 mesh, got shape {shape}")
+        if topology is not None:
+            topology = tuple(topology)
+            if len(topology) != len(shape):
+                raise ValueError(
+                    "mesh topology must have one entry per mesh dimension, "
+                    f"got shape {shape} and topology {topology}"
+                )
+            invalid = [
+                value
+                for value in topology
+                if value not in {"disabled", "linear", "ring"}
+            ]
+            if invalid:
+                raise ValueError(
+                    "mesh topology entries must be 'disabled', 'linear', or "
+                    f"'ring', got {invalid}"
+                )
+        requested_topology = list(topology) if topology is not None else None
+        if self._mesh_shape is not None:
+            if (
+                self._mesh_shape == list(shape)
+                and self._mesh_topology == requested_topology
+            ):
+                return
+            raise RuntimeError(
+                "the current graph already declares mesh "
+                f"{tuple(self._mesh_shape)} with topology "
+                f"{self._mesh_topology}; it cannot be redefined"
+            )
+
+        dims = "x".join(str(dim) for dim in shape)
+        with self.ctx, self.loc:
+            meshes = Attribute.parse(f'#ttcore.meshes<[<"mesh" = {dims}>]>', self.ctx)
+        self.module.operation.attributes["ttcore.meshes"] = meshes
+        self._mesh_shape = list(shape)
+        self._mesh_topology = requested_topology
+        self._mesh_name = "mesh"
 
     def _refresh_function_type(self, results=None):
         with self.ctx, self.loc:
             ft = FunctionType.get(self._input_types, results or [])
             self.func_op.attributes["function_type"] = TypeAttr.get(ft)
 
-    def add_host_input(self, layout: Layout, host_tensor):
+    def add_host_input(self, layout: Layout, host_tensor, host_ty=None):
         """Append a host-typed func arg and return its BlockArgument."""
-        host_ty = layout.build_host_tensor_type(self.ctx)
+        if host_ty is None:
+            host_ty = layout.build_host_tensor_type(self.ctx)
         bb_arg = self.entry_block.add_argument(host_ty, self.loc)
         self._input_types.append(host_ty)
         self._input_tensors.append(host_tensor)
@@ -513,7 +568,7 @@ class LazyTensor:
       - a materialised torch.Tensor (after to_host).
     """
 
-    __slots__ = ("layout", "value", "generation", "materialized", "is_view")
+    __slots__ = ("layout", "value", "generation", "materialized", "is_view", "mesh")
 
     def __init__(
         self,
@@ -522,6 +577,7 @@ class LazyTensor:
         generation,
         materialized=None,
         is_view: bool = False,
+        mesh=None,
     ):
         self.layout = layout
         self.value = value
@@ -532,6 +588,8 @@ class LazyTensor:
         # data is not in the view's logical form -- so we refuse it and
         # ask the user to materialise via to_layout first.
         self.is_view = is_view
+        # Optional metadata describing this tensor's per-device mesh shard.
+        self.mesh = mesh
 
     def to_host(self):
         return to_host(self)[0]
@@ -547,6 +605,13 @@ class LazyTensor:
         if self.generation == b.generation:
             return self
         if self.materialized is not None:
+            if self.mesh is not None:
+                return mesh_shard(
+                    self.materialized,
+                    self.layout,
+                    self.mesh.shard_dims,
+                    self.mesh.shard_shape,
+                )
             return to_layout(self.materialized, layout=self.layout)
         raise RuntimeError(
             "Stale LazyTensor: produced by a prior builder that was reset "
@@ -586,7 +651,7 @@ def to_layout(input_, layout: Layout) -> LazyTensor:
             dst_empty = d2m.empty(dst_unblocked_ty)
             converted = d2m.ToLayoutOp([dst_unblocked_ty], src_val, dst_empty).result
             val = layout.build_blocked_view(b.ctx, converted)
-        return LazyTensor(layout, val, b.generation)
+        return LazyTensor(layout, val, b.generation, mesh=src.mesh)
 
     if torch is not None and isinstance(input_, torch.Tensor):
         assert list(input_.shape) == list(layout.logical_shape), (
@@ -828,6 +893,300 @@ def arange(layout: Layout, start: int = 0, step: int = 1) -> LazyTensor:
     return to_layout(flat.reshape(list(layout.logical_shape)), layout)
 
 
+# --- Global semaphores -------------------------------------------------------
+
+
+def _semaphore_backing_type(ctx, grid_shape):
+    """Build a 1x1-sharded ui32 backing tensor over the worker grid."""
+    rank = len(grid_shape)
+    i64_type = IntegerType.get_signless(64, ctx)
+    interval_type = RankedTensorType.get([rank, 2], i64_type)
+    interval_values = [
+        IntegerAttr.get(i64_type, endpoint)
+        for i in range(rank)
+        for endpoint in (i, i + 1)
+    ]
+    collapse = DenseIntElementsAttr.get(interval_values, type=interval_type)
+    metal_layout = ttcore.ir.MetalLayoutAttr.get(
+        ctx,
+        list(grid_shape),
+        int(ttcore.MemorySpace.DeviceL1),
+        int(ttcore.TensorMemoryLayout.Sharded),
+        collapse,
+        [1] * rank,
+    )
+    device_shape = ttcore.ir.MetalLayoutAttr.maybe_downcast(
+        metal_layout
+    ).getDeviceShape(list(grid_shape), [])
+    return RankedTensorType.get(
+        device_shape, IntegerType.get_unsigned(32, ctx), encoding=metal_layout
+    )
+
+
+class GlobalSemaphore:
+    """Host handle for a `!d2m.global_semaphore` kernel argument."""
+
+    __slots__ = ("value", "generation", "grid_shape", "init", "_consumed")
+
+    def __init__(self, value, generation, grid_shape, init):
+        self.value = value
+        self.generation = generation
+        self.grid_shape = tuple(grid_shape)
+        self.init = init
+        self._consumed = False
+
+    def _resolve_value(self):
+        b = _get_scope()
+        if self.generation != b.generation:
+            raise RuntimeError(
+                "Stale GlobalSemaphore: create it in the same builder "
+                "generation as the kernel call."
+            )
+        if self._consumed:
+            raise RuntimeError(
+                "GlobalSemaphore has already been consumed by a kernel call. "
+                "Create a separate semaphore for each call."
+            )
+        return self.value
+
+
+_g_worker_grid = None
+_g_worker_grid_source = None
+
+
+def _device_worker_grid():
+    """Return the worker grid as `(rows, cols)` from the system descriptor."""
+    import json
+    import re
+
+    global _g_worker_grid, _g_worker_grid_source
+    system_desc_path = _get_system_desc_path()
+    source = system_desc_path or "<runtime>"
+    if _g_worker_grid is not None and _g_worker_grid_source == source:
+        return _g_worker_grid
+
+    if binary is not None and system_desc_path:
+        system_desc = binary.load_system_desc_from_path(system_desc_path)
+    elif runtime is not None:
+        system_desc = runtime.get_current_system_desc()
+    else:
+        raise RuntimeError(
+            "global_semaphore() needs a system descriptor to size the worker "
+            "grid; set SYSTEM_DESC_PATH or pass grid_shape explicitly."
+        )
+
+    desc_json = re.sub(r"\bnan\b", "NaN", system_desc.as_json())
+    desc_json = re.sub(r"\binf\b", "Infinity", desc_json)
+    desc = json.loads(desc_json)
+    root = desc.get("system_desc", desc)
+    grid = root["chip_descs"][0]["grid_size"]
+    _g_worker_grid = (int(grid["y"]), int(grid["x"]))
+    _g_worker_grid_source = source
+    return _g_worker_grid
+
+
+def global_semaphore(grid_shape=None, init=0) -> GlobalSemaphore:
+    """Create a global semaphore backed by the device worker grid."""
+    b = _get_scope()
+    if not isinstance(b, _Builder):
+        raise RuntimeError("global_semaphore() requires the lazy builder scope")
+    if grid_shape is None:
+        grid_shape = _device_worker_grid()
+    grid_shape = tuple(grid_shape)
+    if len(grid_shape) != 2 or any(
+        not isinstance(dim, int) or isinstance(dim, bool) or dim <= 0
+        for dim in grid_shape
+    ):
+        raise ValueError(
+            "global semaphore grid_shape must contain two positive integers, "
+            f"got {grid_shape}"
+        )
+    if not isinstance(init, int) or isinstance(init, bool) or not 0 <= init < 2**32:
+        raise ValueError(f"global semaphore init must be a ui32 value, got {init!r}")
+
+    with b.ctx, b.loc, b.insert_point:
+        backing_ty = _semaphore_backing_type(b.ctx, grid_shape)
+        backing = d2m.empty(backing_ty)
+        sem_ty = d2m.ir.GlobalSemaphoreType.get(b.ctx)
+        sem = d2m.create_global_semaphore(backing, value=init, results=[sem_ty])
+    return GlobalSemaphore(sem, b.generation, grid_shape, init)
+
+
+# --- Device meshes -----------------------------------------------------------
+
+
+def mesh(shape, topology=None):
+    """Declare the device mesh used by the current lazy graph."""
+    b = _get_scope()
+    if not isinstance(b, _Builder):
+        raise RuntimeError("mesh() requires the lazy builder scope")
+    b.set_mesh(shape, topology)
+
+
+class MeshShard:
+    """Metadata needed to gather a per-device shard back to its full tensor."""
+
+    __slots__ = ("full_shape", "shard_dims", "shard_shape")
+
+    def __init__(self, full_shape, shard_dims, shard_shape):
+        self.full_shape = list(full_shape)
+        self.shard_dims = list(shard_dims)
+        self.shard_shape = list(shard_shape)
+
+
+def _validate_mesh_mapping(mesh_shape, tensor_rank, shard_dims, shard_shape):
+    if len(shard_dims) != len(mesh_shape):
+        raise ValueError(
+            "mesh shard_dims must have one entry per mesh dimension, "
+            f"got mesh {mesh_shape} and shard_dims {shard_dims}"
+        )
+    if len(shard_shape) != tensor_rank:
+        raise ValueError(
+            "mesh shard_shape must have one entry per tensor dimension, "
+            f"got tensor rank {tensor_rank} and shard_shape {shard_shape}"
+        )
+
+    for dim in shard_dims:
+        if (
+            not isinstance(dim, int)
+            or isinstance(dim, bool)
+            or dim < -1
+            or dim >= tensor_rank
+        ):
+            raise ValueError(
+                f"mesh shard dimension {dim!r} is invalid for rank {tensor_rank}"
+            )
+    for factor in shard_shape:
+        if not isinstance(factor, int) or isinstance(factor, bool) or factor <= 0:
+            raise ValueError(f"mesh shard factor must be positive, got {factor!r}")
+
+    expected_shape = [1] * tensor_rank
+    for mesh_axis, tensor_dim in enumerate(shard_dims):
+        if tensor_dim >= 0:
+            expected_shape[tensor_dim] *= mesh_shape[mesh_axis]
+    if list(shard_shape) != expected_shape:
+        raise ValueError(
+            f"mesh shard_shape {shard_shape} does not match mesh {mesh_shape} "
+            f"mapped by shard_dims {shard_dims}; expected {expected_shape}"
+        )
+
+
+def _shard_logical_shape(mesh_shape, full_shape, shard_dims, shard_shape):
+    _validate_mesh_mapping(mesh_shape, len(full_shape), shard_dims, shard_shape)
+    shard = list(full_shape)
+    for dim, factor in enumerate(shard_shape):
+        if shard[dim] % factor != 0:
+            raise ValueError(
+                f"mesh shard: full dim {dim} ({shard[dim]}) is not divisible "
+                f"by shard factor {factor}"
+            )
+        shard[dim] //= factor
+    return shard
+
+
+def _emit_mesh_shard(b, value, dst_ty, direction, shard_dims, shard_shape):
+    shard_type = Attribute.parse("#ttcore.shard_type<devices>", b.ctx)
+    shard_direction = Attribute.parse(f"#ttcore.shard_direction<{direction}>", b.ctx)
+    return d2m.mesh_shard(
+        dst_ty,
+        value,
+        shard_type,
+        shard_direction,
+        list(shard_shape),
+        list(shard_dims),
+    )
+
+
+def _tensor_mesh_attr(b):
+    if b._mesh_name is None:
+        raise RuntimeError("mesh_shard() requires a preceding mesh() declaration")
+    with b.ctx, b.loc:
+        return Attribute.parse(f'#ttcore.tensor_mesh<"{b._mesh_name}">', b.ctx)
+
+
+def mesh_shard(input_, layout: Layout, shard_dims, shard_shape) -> LazyTensor:
+    """Distribute a full host tensor into one `layout` shard per device.
+
+    `shard_dims` maps each mesh axis to a tensor dimension (`-1` replicates
+    that mesh axis). `shard_shape` has tensor rank and records the resulting
+    factor for each tensor dimension.
+    """
+    if torch is None or not isinstance(input_, torch.Tensor):
+        raise TypeError("mesh_shard expects a torch.Tensor containing the full tensor")
+    b = _get_scope()
+    if not isinstance(b, _Builder):
+        raise RuntimeError("mesh_shard() requires the lazy builder scope")
+    if b._mesh_name is None:
+        raise RuntimeError("mesh_shard() requires a preceding mesh() declaration")
+
+    shard_dims = list(shard_dims)
+    shard_shape = list(shard_shape)
+    full_shape = list(input_.shape)
+    expected_shape = _shard_logical_shape(
+        b._mesh_shape, full_shape, shard_dims, shard_shape
+    )
+    if list(layout.logical_shape) != expected_shape:
+        raise ValueError(
+            f"mesh_shard layout shape {list(layout.logical_shape)} does not "
+            f"match expected per-device shape {expected_shape}"
+        )
+
+    with b.ctx, b.loc, b.insert_point:
+        elem_type = layout.get_host_elem_type(b.ctx)
+        full_ty = RankedTensorType.get(full_shape, elem_type)
+        shard_ty = RankedTensorType.get(
+            expected_shape, elem_type, encoding=_tensor_mesh_attr(b)
+        )
+        host = b.add_host_input(layout, input_, host_ty=full_ty)
+        shard = _emit_mesh_shard(
+            b, host, shard_ty, "full_to_shard", shard_dims, shard_shape
+        )
+        device = layout.build_to_device(b.ctx, shard)
+    return LazyTensor(
+        layout,
+        device,
+        b.generation,
+        mesh=MeshShard(full_shape, shard_dims, shard_shape),
+    )
+
+
+def mesh_gather(lt: LazyTensor, shard_dims=None, shard_shape=None) -> LazyTensor:
+    """Mark a per-device tensor for a `shard_to_full` gather in `to_host`.
+
+    Tensors returned by `mesh_shard` already carry the mapping. Other tensors,
+    such as kernel outputs, require `shard_dims` and `shard_shape`.
+    """
+    if not isinstance(lt, LazyTensor):
+        raise TypeError(f"mesh_gather expected a LazyTensor, got {type(lt).__name__}")
+    b = _get_scope()
+    if not isinstance(b, _Builder) or b._mesh_name is None:
+        raise RuntimeError("mesh_gather() requires a preceding mesh() declaration")
+
+    if lt.mesh is not None:
+        if shard_dims is not None and list(shard_dims) != lt.mesh.shard_dims:
+            raise ValueError("mesh_gather shard_dims do not match existing metadata")
+        if shard_shape is not None and list(shard_shape) != lt.mesh.shard_shape:
+            raise ValueError("mesh_gather shard_shape does not match existing metadata")
+        return lt._resolve()
+    if shard_dims is None or shard_shape is None:
+        raise ValueError(
+            "mesh_gather needs shard_dims and shard_shape for a tensor not "
+            "produced by mesh_shard"
+        )
+
+    shard_dims = list(shard_dims)
+    shard_shape = list(shard_shape)
+    _validate_mesh_mapping(
+        b._mesh_shape, len(lt.layout.logical_shape), shard_dims, shard_shape
+    )
+    lt = lt._resolve()
+    full_shape = [
+        dim * factor for dim, factor in zip(lt.layout.logical_shape, shard_shape)
+    ]
+    lt.mesh = MeshShard(full_shape, shard_dims, shard_shape)
+    return lt
+
+
 def reshape(lt: LazyTensor, *shape) -> LazyTensor:
     """torch.reshape-style logical-shape change.
 
@@ -855,6 +1214,11 @@ def reshape(lt: LazyTensor, *shape) -> LazyTensor:
     """
     if not isinstance(lt, LazyTensor):
         raise TypeError(f"reshape expected a LazyTensor, got {type(lt).__name__}")
+    if lt.mesh is not None:
+        raise ValueError(
+            "reshape does not yet define how to remap mesh sharding; gather "
+            "and create a new mesh_shard explicitly"
+        )
     if torch is None:
         raise RuntimeError("torch is required for d2m_jit.reshape()")
 
@@ -967,6 +1331,11 @@ def _emit_view_layout(lt: LazyTensor, affine_map, spec) -> LazyTensor:
     """Lower form: take an already-built AffineMap + spec and emit
     `d2m.view_layout`. Used by both view_layout (with a user lambda)
     and view (with a lifted blocked-rank spec built in Python)."""
+    if lt.mesh is not None:
+        raise ValueError(
+            "view operations do not yet remap mesh sharding; materialize a "
+            "gathered tensor and create a new mesh_shard explicitly"
+        )
     b = _get_scope()
     with b.ctx, b.loc, b.insert_point:
         src_type = lt.value.type
@@ -1016,6 +1385,13 @@ def view_layout(lt: LazyTensor, remapping_fn) -> LazyTensor:
     paired (grid, tile) permutation. Arithmetic remappings preserve the source
     physical shape and inherit the source Layout unchanged.
     """
+    if not isinstance(lt, LazyTensor):
+        raise TypeError(f"view_layout expected a LazyTensor, got {type(lt).__name__}")
+    if lt.mesh is not None:
+        raise ValueError(
+            "view_layout does not yet remap mesh sharding; materialize a "
+            "gathered tensor and create a new mesh_shard explicitly"
+        )
     lt = lt._resolve()
     b = _get_scope()
     with b.ctx, b.loc:
@@ -1055,6 +1431,13 @@ def view(lt: LazyTensor, remapping_fn) -> LazyTensor:
     permutations (no constants) are supported here -- use `view_layout`
     for richer remappings.
     """
+    if not isinstance(lt, LazyTensor):
+        raise TypeError(f"view expected a LazyTensor, got {type(lt).__name__}")
+    if lt.mesh is not None:
+        raise ValueError(
+            "view does not yet remap mesh sharding; materialize a gathered "
+            "tensor and create a new mesh_shard explicitly"
+        )
     lt = lt._resolve()
     b = _get_scope()
     with b.ctx, b.loc:
@@ -1081,6 +1464,11 @@ def permute(lt: LazyTensor, *dims) -> LazyTensor:
     """
     if not isinstance(lt, LazyTensor):
         raise TypeError(f"permute expected a LazyTensor, got {type(lt).__name__}")
+    if lt.mesh is not None:
+        raise ValueError(
+            "permute does not yet remap mesh sharding; materialize a gathered "
+            "tensor and create a new mesh_shard explicitly"
+        )
     lt = lt._resolve()
     n_logical = len(lt.layout.logical_shape)
     if len(dims) != n_logical:
@@ -1220,18 +1608,44 @@ def _emit_returns_and_finalise(b: _Builder, lts):
     with b.ctx, b.loc, b.insert_point:
         for lt in lts:
             dev = lt.layout.build_device_view(b.ctx, lt.value)
-            host = lt.layout.build_from_device(b.ctx, dev)
+            if lt.mesh is not None:
+                elem_type = lt.layout.get_host_elem_type(b.ctx)
+                host_shard_ty = RankedTensorType.get(
+                    lt.layout.logical_shape,
+                    elem_type,
+                    encoding=_tensor_mesh_attr(b),
+                )
+                host_shard = d2m.ToLayoutOp(
+                    [host_shard_ty], dev, d2m.empty(host_shard_ty)
+                ).result
+                host_ty = RankedTensorType.get(lt.mesh.full_shape, elem_type)
+                host = _emit_mesh_shard(
+                    b,
+                    host_shard,
+                    host_ty,
+                    "shard_to_full",
+                    lt.mesh.shard_dims,
+                    lt.mesh.shard_shape,
+                )
+            else:
+                host = lt.layout.build_from_device(b.ctx, dev)
+                host_ty = lt.layout.build_host_tensor_type(b.ctx)
             host_values.append(host)
-            host_types.append(lt.layout.build_host_tensor_type(b.ctx))
+            host_types.append(host_ty)
         func.ReturnOp(host_values)
     b._refresh_function_type(results=host_types)
 
 
 def _run_pipeline(b: _Builder):
     system_desc = _get_system_desc_path()
-    register = "ttcore-register-device"
+    register_options = []
     if system_desc:
-        register += f"{{system-desc-path={system_desc}}}"
+        register_options.append(f"system-desc-path={system_desc}")
+    if b._mesh_topology:
+        register_options.append("mesh-topology=" + ",".join(b._mesh_topology))
+    register = "ttcore-register-device"
+    if register_options:
+        register += "{" + " ".join(register_options) + "}"
     pipeline_str = f"builtin.module({register},{','.join(_pipeline_passes())})"
 
     if config.print_pipeline:
@@ -1325,7 +1739,10 @@ def _execute(b: _Builder, lts):
     rt_outputs = []
     for lt in lts:
         torch_dtype = _ttcore_to_torch_dtype(lt.layout.dtype)
-        t_out = torch.empty(list(lt.layout.logical_shape), dtype=torch_dtype)
+        output_shape = (
+            lt.mesh.full_shape if lt.mesh is not None else lt.layout.logical_shape
+        )
+        t_out = torch.empty(list(output_shape), dtype=torch_dtype)
         out_torch.append(t_out)
         rt_outputs.append(
             runtime.create_borrowed_host_tensor(
@@ -1570,30 +1987,51 @@ def _emit_kernel_generic(
             cause=cause,
         )
 
-    # Split args, preserving "all LazyTensors precede all scalars" ordering.
+    # Split args while preserving the GenericOp contract: all tensors precede
+    # all additional args (runtime scalars and global semaphores).
     lazy_args = []
-    scalar_args = []
-    saw_scalar = False
+    extras = []
+    seen_semaphores = set()
+    saw_extra = False
     for i, a in enumerate(args):
         if isinstance(a, LazyTensor):
-            if saw_scalar:
+            if saw_extra:
                 raise _call_error(
                     f"argument {i} to kernel '{kernel.fn.__name__}' is a "
-                    f"LazyTensor but a scalar was already seen; tensor "
-                    f"arguments must precede scalars",
+                    f"LazyTensor but an additional argument was already seen; "
+                    f"tensor arguments must precede scalars and semaphores",
                     cause=TypeError(),
                 )
             lazy_args.append(a._resolve())
+        elif isinstance(a, GlobalSemaphore):
+            if not isinstance(b, _Builder):
+                raise _call_error(
+                    "global semaphore arguments require the top-level lazy "
+                    "builder and are not supported inside a pattern rewrite "
+                    "or d2m.spatial",
+                    cause=TypeError(),
+                )
+            if id(a) in seen_semaphores:
+                raise _call_error(
+                    "the same GlobalSemaphore cannot be passed more than once "
+                    "to a kernel call",
+                    cause=ValueError(),
+                )
+            a._resolve_value()
+            seen_semaphores.add(id(a))
+            saw_extra = True
+            extras.append(("semaphore", a))
         elif isinstance(a, int) and not isinstance(a, bool):
-            saw_scalar = True
-            scalar_args.append(a)
+            saw_extra = True
+            extras.append(("scalar", a))
         else:
             raise _call_error(
                 f"argument {i} to kernel '{kernel.fn.__name__}' has "
                 f"unsupported type {type(a).__name__}: {a!r}",
                 hint=(
-                    "kernel arguments must be d2m_jit.LazyTensor or int. "
-                    "Use d2m.to_layout(t, L) to lift a torch tensor."
+                    "kernel arguments must be d2m_jit.LazyTensor, int, or "
+                    "d2m_jit.GlobalSemaphore. Use d2m.to_layout(t, L) to "
+                    "lift a torch tensor."
                 ),
                 cause=TypeError(),
             )
@@ -1642,22 +2080,26 @@ def _emit_kernel_generic(
     # lazy `_Builder` keeps the runtime-arg form: scalars stay index func args
     # (see add_scalar_input) so the binary remains parameterised.
     bake_scalars = not isinstance(b, (_Builder, _SpatialRegionScope))
-    if bake_scalars and scalar_args:
+    if bake_scalars and extras:
         formal_names = [a.arg for a in kernel._ast.body[0].args.args]
-        scalar_names = formal_names[len(lazy_args) : len(lazy_args) + len(scalar_args)]
+        scalar_names = formal_names[len(lazy_args) : len(lazy_args) + len(extras)]
         effective_captures = dict(kernel._captures)
         effective_captures.update(
-            {n: int(v) for n, v in zip(scalar_names, scalar_args)}
+            {name: int(value) for name, (_, value) in zip(scalar_names, extras)}
         )
-        runtime_scalars = []
+        runtime_extras = []
     else:
         effective_captures = kernel._captures
-        runtime_scalars = list(scalar_args)
+        runtime_extras = list(extras)
 
     # Compile the kernel body in the current builder's context. D2MCompiler
     # picks up b.ctx via get_default_loc_context.
     with b.ctx, b.loc:
-        compiler_args = [lt.layout for lt in lazy_args] + runtime_scalars
+        extra_compiler_args = [
+            value if kind == "scalar" else SEMAPHORE_ARG
+            for kind, value in runtime_extras
+        ]
+        compiler_args = [lt.layout for lt in lazy_args] + extra_compiler_args
         compiler = D2MCompiler(
             kernel.fn.__name__,
             "unified",
@@ -1672,11 +2114,12 @@ def _emit_kernel_generic(
 
     # Emit the GenericOp + splice the kernel body.
     with b.ctx, b.loc, b.insert_point:
-        # Scalars are sourced from func args (not host-scope constants) so the
-        # GenericOp's region stays isolated-from-above. In a rewrite scope the
-        # scalars were baked into the kernel body above, so runtime_scalars is
-        # empty and no additionalArgs are emitted for them.
-        additional = [b.add_scalar_input(s) for s in runtime_scalars]
+        # Scalars come from func args; semaphores reuse their host-scope
+        # create_global_semaphore results.
+        additional = [
+            (b.add_scalar_input(value) if kind == "scalar" else value._resolve_value())
+            for kind, value in runtime_extras
+        ]
         inputs = [lt.value for lt in input_lts]
         outputs = [lt.value for lt in output_lts]
         output_types = [v.type for v in outputs]
@@ -1724,6 +2167,13 @@ def _emit_kernel_generic(
             orig_arg.replace_all_uses_with(op)
         for _ in range(len(block.arguments)):
             block.erase_argument(0)
+
+        # Reset closes the semaphore's lifetime and allows its backing buffer
+        # to be deallocated. A handle is intentionally single-use.
+        for kind, value in runtime_extras:
+            if kind == "semaphore":
+                d2m.reset_global_semaphore(value._resolve_value(), value.init)
+                value._consumed = True
 
     # Rebind output LazyTensors to the GenericOp's results.
     for i, lt in enumerate(output_lts):

--- a/tools/d2m-jit/_src/tensor_layout.py
+++ b/tools/d2m-jit/_src/tensor_layout.py
@@ -5,12 +5,12 @@
 from ttmlir.ir import *
 from ttmlir.dialects import ttcore, d2m
 
-
 # Public dtype constants. Pass to `dtype=` on Layout / tilize / untilize
 # instead of strings ("fp32", "bf16", ...). The strings are still accepted.
 float32 = ttcore.DataType.Float32
 float16 = ttcore.DataType.Float16
 bfloat16 = ttcore.DataType.BFloat16
+uint32 = ttcore.DataType.UInt32
 
 
 def _to_data_type(dtype):
@@ -23,6 +23,8 @@ def _to_data_type(dtype):
         return ttcore.DataType.Float16
     if s in {"torch.bfloat16", "bf16"}:
         return ttcore.DataType.BFloat16
+    if s in {"torch.uint32", "uint32", "u32"}:
+        return ttcore.DataType.UInt32
     raise TypeError(f"Unsupported dtype {dtype}")
 
 
@@ -106,6 +108,8 @@ class Layout:
             return F16Type.get(ctx)
         if self.dtype == ttcore.DataType.BFloat16:
             return BF16Type.get(ctx)
+        if self.dtype == ttcore.DataType.UInt32:
+            return IntegerType.get_unsigned(32, ctx)
         raise TypeError(f"Unsupported data type {self.dtype}")
 
     def get_host_elem_type(self, ctx):

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -14,10 +14,19 @@ from ._src.utils import _asindex
 from ._src.ast import syntax
 from ._src.config import config
 from ._src.errors import D2mJitError
-from ._src.tensor_layout import Layout, float32, float16, bfloat16, _to_data_type
+from ._src.tensor_layout import (
+    Layout,
+    float32,
+    float16,
+    bfloat16,
+    uint32,
+    _to_data_type,
+)
 from ._src.builder import (
     CompiledKernel,
+    GlobalSemaphore,
     LazyTensor,
+    MeshShard,
     kernel,
     to_layout,
     tilize,
@@ -33,6 +42,10 @@ from ._src.builder import (
     reshape,
     spatial,
     to_host,
+    global_semaphore,
+    mesh,
+    mesh_shard,
+    mesh_gather,
 )
 from ._src.rewrite import (
     pattern,
@@ -1161,6 +1174,14 @@ class Semaphore:
             ast_self, _asindex(value), _asindex(core), _asindex(mcast)
         )
 
+    def wait(ast_self, value, reset=None):
+        return d2m.semaphore_wait(
+            ast_self, _asindex(value), reset_value=_asindex(reset)
+        )
+
+
+@syntax("!d2m.global_semaphore")
+class GlobalSemaphoreOps:
     def wait(ast_self, value, reset=None):
         return d2m.semaphore_wait(
             ast_self, _asindex(value), reset_value=_asindex(reset)


### PR DESCRIPTION
## Summary
- add d2m-jit mesh declarations, shard/gather boundaries, topology propagation, and full-shape host materialization
- add global semaphore handles, ui32 layout support, kernel argument typing, and single-use reset lifecycle
- add compiler-only coverage plus gated 1x2 mesh runtime tests

## Test plan
- [x] `cmake --build build --target d2m-jit`
- [x] `llvm-lit -v build/test --filter='d2m-jit'` (12 passed)
- [x] global semaphore lowering tests (3 passed)
- [x] `pytest test/d2m-jit/test_mesh.py -q` (2 passed, 2 multi-device tests skipped)
- [x] pre-commit checks on changed files

The skipped pytest cases require a runtime-enabled build, `SYSTEM_DESC_PATH`, and at least two devices.

Made with [Cursor](https://cursor.com)