### PR TITLE
[d2m-jit] Add support for d2m.spatial

### DIFF
--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -2024,14 +2024,21 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
           "GenericOp virtual grid affine map must have 2 inputs, or be empty.");
     }
 
-    // Verify that the grid volume fits within the device's worker grid.
-    auto device = ttcore::lookupDevice(*this);
-    int64_t gridVolume = getGrid().getGridVolume();
-    int64_t deviceVolume = device.getWorkerGrid().getGridVolume();
-    if (gridVolume > deviceVolume) {
-      return emitOpError("grid volume (")
-             << gridVolume << ") exceeds device worker grid capacity ("
-             << deviceVolume << ")";
+    // This op may be verified before an enclosing device has been registered
+    // (e.g. d2m-jit early verify before ttcore-register-device). Device-
+    // dependent checks are deferred until a device op is available, matching
+    // CreateGlobalSemaphoreOp::verify, rather than asserting in lookupDevice.
+    auto deviceOp = ttcore::lookupDeviceOp(getOperation());
+    if (deviceOp) {
+      // Verify that the grid volume fits within the device's worker grid.
+      ttcore::DeviceAttr device = deviceOp.getDeviceAttr();
+      int64_t gridVolume = getGrid().getGridVolume();
+      int64_t deviceVolume = device.getWorkerGrid().getGridVolume();
+      if (gridVolume > deviceVolume) {
+        return emitOpError("grid volume (")
+               << gridVolume << ") exceeds device worker grid capacity ("
+               << deviceVolume << ")";
+      }
     }
 
     auto isDRAM = [](Value output) {
@@ -2052,7 +2059,8 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
     // 1. The output operand's inverse VGM matches the GenericOp GridAttr's
     //    inverse map.
     // 2. The inverse map applied to the physical grid shape produces a virtual
-    //    grid shape matching the output's grid shape.
+    //    grid shape matching the output's grid shape. (requires device;
+    //    getPhysicalGridShape looks up the worker grid)
     // DRAM outputs may carry VGM attrs used for address calculation, but they
     // are not constrained by the GenericOp's L1 execution grid.
     AffineMap gridInvMap = getGrid().getPhysicalToVirtMap();
@@ -2066,6 +2074,10 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
         if (!outputInvMap && !gridInvMap.isEmpty()) {
           return emitOpError("grid has an inverse map but output operand "
                              "does not have a VGM");
+        }
+
+        if (!deviceOp) {
+          continue;
         }
 
         SmallVector<int64_t> physicalGridShape =

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -2059,8 +2059,7 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
     // 1. The output operand's inverse VGM matches the GenericOp GridAttr's
     //    inverse map.
     // 2. The inverse map applied to the physical grid shape produces a virtual
-    //    grid shape matching the output's grid shape. (requires device;
-    //    getPhysicalGridShape looks up the worker grid)
+    //    grid shape matching the output's grid shape.
     // DRAM outputs may carry VGM attrs used for address calculation, but they
     // are not constrained by the GenericOp's L1 execution grid.
     AffineMap gridInvMap = getGrid().getPhysicalToVirtMap();

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -274,6 +274,17 @@ void populateTTModule(nb::module_ &m) {
       .def_prop_ro("y", &tt::ttcore::CoreCoordAttr::getY)
       .def_prop_ro("x", &tt::ttcore::CoreCoordAttr::getX);
 
+  tt_attribute_class<tt::ttcore::CoreRangeAttr>(m, "CoreRangeAttr")
+      .def_static("get",
+                  [](MlirContext ctx, MlirAttribute start, MlirAttribute end) {
+                    return wrap(tt::ttcore::CoreRangeAttr::get(
+                        unwrap(ctx),
+                        mlir::cast<tt::ttcore::CoreCoordAttr>(unwrap(start)),
+                        mlir::cast<tt::ttcore::CoreCoordAttr>(unwrap(end))));
+                  })
+      .def_prop_ro("start_coord", &tt::ttcore::CoreRangeAttr::getStartCoord)
+      .def_prop_ro("end_coord", &tt::ttcore::CoreRangeAttr::getEndCoord);
+
   tt_attribute_class<tt::ttcore::ChipCoordAttr>(m, "ChipCoordAttr")
       .def_static("get",
                   [](MlirContext ctx, unsigned rack, unsigned shelf, unsigned y,

--- a/test/d2m-jit/lit/spatial.py
+++ b/test/d2m-jit/lit/spatial.py
@@ -5,7 +5,15 @@
 # RUN: %python %s 2>&1 | FileCheck %s
 # REQUIRES: d2m-jit
 
-"""IR-shape coverage for d2m-jit d2m.spatial emission."""
+"""IR-shape coverage for d2m-jit d2m.spatial emission.
+
+Mirrors the expression axes in test/d2m-jit/test_spatial.py:
+  1. multi-region nesting with different kernels / shared input
+  2. non-shared inputs across regions
+  3. heterogeneous kernels (eltwise + matmul) in one spatial
+  4. multicore matmul + multicore eltwise in one spatial
+  5. three regions in one spatial
+"""
 
 import d2m_jit as d2m
 
@@ -24,6 +32,50 @@ def k_mul(in_t, out_t):
     remote_store(out_t, [0, 0], x * x)
 
 
+@d2m.kernel
+def k_exp(in_t, out_t):
+    x = remote_load(in_t, [0, 0])
+    remote_store(out_t, [0, 0], exp(x))
+
+
+@d2m.kernel
+def k_exp_multicore(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], exp(x))
+
+
+@d2m.kernel
+def k_matmul(lhs, rhs, out):
+    a = remote_load(lhs, [0, 0])
+    b = remote_load(rhs, [0, 0])
+    remote_store(out, [0, 0], a @ b)
+
+
+@d2m.kernel
+def k_matmul_multicore(lhs, rhs, out, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            a = remote_load(lhs, [m_off + m, n_off + n])
+            b = remote_load(rhs, [m_off + m, n_off + n])
+            remote_store(out, [m_off + m, n_off + n], a @ b)
+
+
+def _finalize(label, outs):
+    builder = _Builder.get()
+    _emit_returns_and_finalise(builder, list(outs))
+    print(label)
+    print(builder.module.operation.get_asm(assume_verified=True))
+    _Builder.reset()
+
+
+# --- 1. Multi-region shared input -------------------------------------------
+
 L = d2m.Layout(shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1])
 inp = d2m.empty(L)
 out_add = d2m.empty(L)
@@ -38,14 +90,9 @@ d2m.spatial(
         lambda: k_mul(inp, out_mul, grid=(1, 1)),
     ],
 )
+_finalize("MULTI_REGION_SHARED_INPUT_IR", [out_add, out_mul])
 
-builder = _Builder.get()
-_emit_returns_and_finalise(builder, [out_add, out_mul])
-print(builder.module.operation.get_asm(assume_verified=True))
-_Builder.reset()
-
-
-# CHECK-LABEL: func.func @main
+# CHECK-LABEL: MULTI_REGION_SHARED_INPUT_IR
 # CHECK:       d2m.spatial
 # CHECK-SAME:  grid_ranges = [#ttcore.core_range<(0,0), (0,0)>, #ttcore.core_range<(1,0), (1,0)>]
 # CHECK:       d2m.generic
@@ -55,4 +102,133 @@ _Builder.reset()
 # CHECK-SAME:  grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1)>
 # CHECK:       "d2m.tile_mul"
 # CHECK:       d2m.spatial_yield
-# CHECK:       return
+
+
+# --- 2. Non-shared inputs ---------------------------------------------------
+
+inp0 = d2m.empty(L)
+inp1 = d2m.empty(L)
+out_add = d2m.empty(L)
+out_mul = d2m.empty(L)
+
+d2m.spatial(
+    inputs=[inp0, inp1],
+    outputs=[out_add, out_mul],
+    grid_ranges=[((0, 0), (0, 0)), ((1, 1), (1, 1))],
+    region_builders=[
+        lambda: k_add(inp0, out_add, grid=(1, 1)),
+        lambda: k_mul(inp1, out_mul, grid=(1, 1)),
+    ],
+)
+_finalize("INPUTS_NOT_SHARED_IR", [out_add, out_mul])
+
+# CHECK-LABEL: INPUTS_NOT_SHARED_IR
+# CHECK:       d2m.spatial
+# CHECK-SAME:  grid_ranges = [#ttcore.core_range<(0,0), (0,0)>, #ttcore.core_range<(1,1), (1,1)>]
+# CHECK:       d2m.generic
+# CHECK:       "d2m.tile_add"
+# CHECK:       d2m.spatial_yield
+# CHECK:       d2m.generic
+# CHECK-SAME:  grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>
+# CHECK:       "d2m.tile_mul"
+# CHECK:       d2m.spatial_yield
+
+
+# --- 3. Heterogeneous kernels (eltwise + matmul) ----------------------------
+
+inp = d2m.empty(L)
+weight = d2m.empty(L)
+out_exp = d2m.empty(L)
+out_mm = d2m.empty(L)
+
+d2m.spatial(
+    inputs=[inp, weight],
+    outputs=[out_exp, out_mm],
+    grid_ranges=[((0, 0), (0, 0)), ((1, 0), (1, 0))],
+    region_builders=[
+        lambda: k_exp(inp, out_exp, grid=(1, 1)),
+        lambda: k_matmul(inp, weight, out_mm, grid=(1, 1)),
+    ],
+)
+_finalize("HETEROGENEOUS_KERNELS_IR", [out_exp, out_mm])
+
+# CHECK-LABEL: HETEROGENEOUS_KERNELS_IR
+# CHECK:       d2m.spatial
+# CHECK-SAME:  grid_ranges = [#ttcore.core_range<(0,0), (0,0)>, #ttcore.core_range<(1,0), (1,0)>]
+# CHECK:       d2m.generic
+# CHECK:       "d2m.tile_exp"
+# CHECK:       d2m.spatial_yield
+# CHECK:       d2m.generic
+# CHECK-SAME:  grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1)>
+# CHECK:       "d2m.tile_matmul"
+# CHECK:       d2m.spatial_yield
+
+
+# --- 4. Multicore matmul + multicore eltwise --------------------------------
+
+L2 = d2m.Layout(
+    shape=(64, 64), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[2, 2]
+)
+lhs = d2m.empty(L2)
+rhs = d2m.empty(L2)
+inp = d2m.empty(L2)
+out_mm = d2m.empty(L2)
+out_exp = d2m.empty(L2)
+
+d2m.spatial(
+    inputs=[lhs, rhs, inp],
+    outputs=[out_mm, out_exp],
+    grid_ranges=[((0, 0), (1, 1)), ((2, 0), (3, 1))],
+    region_builders=[
+        lambda: k_matmul_multicore(lhs, rhs, out_mm, 1, 1, grid=(2, 2)),
+        lambda: k_exp_multicore(inp, out_exp, 1, 1, grid=(2, 2)),
+    ],
+)
+_finalize("MULTICORE_MATMUL_AND_ELTWISE_IR", [out_mm, out_exp])
+
+# CHECK-LABEL: MULTICORE_MATMUL_AND_ELTWISE_IR
+# CHECK:       d2m.spatial
+# CHECK-SAME:  grid_ranges = [#ttcore.core_range<(0,0), (1,1)>, #ttcore.core_range<(2,0), (3,1)>]
+# CHECK:       d2m.generic
+# CHECK-SAME:  grid = #ttcore.grid<2x2>
+# CHECK:       "d2m.tile_matmul"
+# CHECK:       d2m.spatial_yield
+# CHECK:       d2m.generic
+# CHECK-SAME:  grid = #ttcore.grid<2x2, virt_to_physical_map = (d0, d1) -> (0, d0 + 2, d1), physical_to_virt_map = (d0, d1) -> (0, d0 - 2, d1)>
+# CHECK:       "d2m.tile_exp"
+# CHECK:       d2m.spatial_yield
+
+
+# --- 5. Three regions -------------------------------------------------------
+
+inp = d2m.empty(L)
+out_add = d2m.empty(L)
+out_mul = d2m.empty(L)
+out_exp = d2m.empty(L)
+
+d2m.spatial(
+    inputs=[inp],
+    outputs=[out_add, out_mul, out_exp],
+    grid_ranges=[((0, 0), (0, 0)), ((0, 1), (0, 1)), ((1, 0), (1, 0))],
+    region_builders=[
+        lambda: k_add(inp, out_add, grid=(1, 1)),
+        lambda: k_mul(inp, out_mul, grid=(1, 1)),
+        lambda: k_exp(inp, out_exp, grid=(1, 1)),
+    ],
+)
+_finalize("THREE_REGIONS_IR", [out_add, out_mul, out_exp])
+
+# CHECK-LABEL: THREE_REGIONS_IR
+# CHECK:       d2m.spatial
+# CHECK-SAME:  grid_ranges = [#ttcore.core_range<(0,0), (0,0)>, #ttcore.core_range<(0,1), (0,1)>, #ttcore.core_range<(1,0), (1,0)>]
+# CHECK:       d2m.generic
+# CHECK:       "d2m.tile_add"
+# CHECK:       d2m.spatial_yield
+# CHECK:       d2m.generic
+# CHECK-SAME:  grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0, d1 - 1)>
+# CHECK:       "d2m.tile_mul"
+# CHECK:       d2m.spatial_yield
+# CHECK:       d2m.generic
+# CHECK-SAME:  grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1)>
+# CHECK:       "d2m.tile_exp"
+# CHECK:       d2m.spatial_yield

--- a/test/d2m-jit/lit/spatial.py
+++ b/test/d2m-jit/lit/spatial.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR-shape coverage for d2m-jit d2m.spatial emission."""
+
+import d2m_jit as d2m
+
+from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise
+
+
+@d2m.kernel
+def k_add(in_t, out_t):
+    x = remote_load(in_t, [0, 0])
+    remote_store(out_t, [0, 0], x + x)
+
+
+@d2m.kernel
+def k_mul(in_t, out_t):
+    x = remote_load(in_t, [0, 0])
+    remote_store(out_t, [0, 0], x * x)
+
+
+L = d2m.Layout(shape=(32, 32), dtype=d2m.float32, block_shape=[1, 1])
+inp = d2m.empty(L)
+out_add = d2m.empty(L)
+out_mul = d2m.empty(L)
+
+d2m.spatial(
+    inputs=[inp],
+    outputs=[out_add, out_mul],
+    grid_ranges=[((0, 0), (0, 0)), ((1, 0), (1, 0))],
+    region_builders=[
+        lambda: k_add(inp, out_add, grid=(1, 1)),
+        lambda: k_mul(inp, out_mul, grid=(1, 1)),
+    ],
+)
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [out_add, out_mul])
+print(builder.module.operation.get_asm(assume_verified=True))
+_Builder.reset()
+
+
+# CHECK-LABEL: func.func @main
+# CHECK:       d2m.spatial
+# CHECK-SAME:  grid_ranges = [#ttcore.core_range<(0,0), (0,0)>, #ttcore.core_range<(1,0), (1,0)>]
+# CHECK:       d2m.generic
+# CHECK:       "d2m.tile_add"
+# CHECK:       d2m.spatial_yield
+# CHECK:       d2m.generic
+# CHECK-SAME:  grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1)>
+# CHECK:       "d2m.tile_mul"
+# CHECK:       d2m.spatial_yield
+# CHECK:       return

--- a/test/d2m-jit/test_spatial.py
+++ b/test/d2m-jit/test_spatial.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import d2m_jit as d2m
+
+
+@d2m.kernel
+def k_spatial_add(in_t, out_t):
+    x = remote_load(in_t, [0, 0])
+    remote_store(out_t, [0, 0], x + x)
+
+
+@d2m.kernel
+def k_spatial_mul(in_t, out_t):
+    x = remote_load(in_t, [0, 0])
+    remote_store(out_t, [0, 0], x * x)
+
+
+def test_spatial_two_regions_two_outputs():
+    t = torch.randn(32, 32, dtype=torch.float32)
+    in_layout = d2m.Layout(
+        shape=t.shape, dtype=d2m.float32, block_shape=[1, 1], mem_space="dram"
+    )
+    out_layout = d2m.Layout(shape=t.shape, dtype=d2m.float32, block_shape=[1, 1])
+
+    inp = d2m.to_layout(t, in_layout)
+    out_add = d2m.empty(out_layout)
+    out_mul = d2m.empty(out_layout)
+
+    d2m.spatial(
+        inputs=[inp],
+        outputs=[out_add, out_mul],
+        grid_ranges=[((0, 0), (0, 0)), ((1, 0), (1, 0))],
+        region_builders=[
+            lambda: k_spatial_add(inp, out_add, grid=(1, 1)),
+            lambda: k_spatial_mul(inp, out_mul, grid=(1, 1)),
+        ],
+    )
+
+    add_result, mul_result = d2m.to_host(out_add, out_mul)
+    add_diff = (t + t - add_result).abs().max().item()
+    mul_diff = (t * t - mul_result).abs().max().item()
+    assert add_diff < 0.01, f"spatial add max diff {add_diff}"
+    assert mul_diff < 0.05, f"spatial mul max diff {mul_diff}"

--- a/test/d2m-jit/test_spatial.py
+++ b/test/d2m-jit/test_spatial.py
@@ -2,6 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Probe d2m-jit authoring limits for `d2m.spatial`.
+
+Each test covers one expression axis (not spatial-op functional coverage):
+  1. multi-region nesting with different kernels / shared input
+  2. non-shared inputs across regions
+  3. heterogeneous kernels (eltwise + matmul) in one spatial
+  4. multicore matmul + multicore eltwise in one spatial
+  5. three regions in one spatial
+"""
+
 import torch
 import d2m_jit as d2m
 
@@ -18,7 +28,54 @@ def k_spatial_mul(in_t, out_t):
     remote_store(out_t, [0, 0], x * x)
 
 
+@d2m.kernel
+def k_spatial_exp(in_t, out_t):
+    x = remote_load(in_t, [0, 0])
+    remote_store(out_t, [0, 0], exp(x))
+
+
+@d2m.kernel
+def k_spatial_exp_multicore(in_t, out_t, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            x = remote_load(in_t, [m_off + m, n_off + n])
+            remote_store(out_t, [m_off + m, n_off + n], exp(x))
+
+
+@d2m.kernel
+def k_spatial_matmul(lhs, rhs, out):
+    a = remote_load(lhs, [0, 0])
+    b = remote_load(rhs, [0, 0])
+    remote_store(out, [0, 0], a @ b)
+
+
+@d2m.kernel
+def k_spatial_matmul_multicore(lhs, rhs, out, m_blocks, n_blocks):
+    m_off = core_index(0) * m_blocks
+    n_off = core_index(1) * n_blocks
+    for m in range(m_blocks):
+        for n in range(n_blocks):
+            a = remote_load(lhs, [m_off + m, n_off + n])
+            b = remote_load(rhs, [m_off + m, n_off + n])
+            remote_store(out, [m_off + m, n_off + n], a @ b)
+
+
+def _per_shard_matmul(lhs, rhs, grid_y=2, grid_x=2, tile=32):
+    expected = torch.zeros_like(lhs)
+    for gy in range(grid_y):
+        for gx in range(grid_x):
+            ly, lx = gy * tile, gx * tile
+            expected[ly : ly + tile, lx : lx + tile] = (
+                lhs[ly : ly + tile, lx : lx + tile]
+                @ rhs[ly : ly + tile, lx : lx + tile]
+            )
+    return expected
+
+
 def test_spatial_two_regions_two_outputs():
+    """Multi-region nesting: different kernels, shared input, offset region."""
     t = torch.randn(32, 32, dtype=torch.float32)
     in_layout = d2m.Layout(
         shape=t.shape, dtype=d2m.float32, block_shape=[1, 1], mem_space="dram"
@@ -44,3 +101,137 @@ def test_spatial_two_regions_two_outputs():
     mul_diff = (t * t - mul_result).abs().max().item()
     assert add_diff < 0.01, f"spatial add max diff {add_diff}"
     assert mul_diff < 0.05, f"spatial mul max diff {mul_diff}"
+
+
+def test_spatial_inputs_not_shared():
+    """Non-shared inputs: each region references a distinct input tensor."""
+    t0 = torch.randn(32, 32, dtype=torch.float32)
+    t1 = torch.randn(32, 32, dtype=torch.float32)
+    in_layout = d2m.Layout(
+        shape=t0.shape, dtype=d2m.float32, block_shape=[1, 1], mem_space="dram"
+    )
+    out_layout = d2m.Layout(shape=t0.shape, dtype=d2m.float32, block_shape=[1, 1])
+
+    inp0 = d2m.to_layout(t0, in_layout)
+    inp1 = d2m.to_layout(t1, in_layout)
+    out_add = d2m.empty(out_layout)
+    out_mul = d2m.empty(out_layout)
+
+    d2m.spatial(
+        inputs=[inp0, inp1],
+        outputs=[out_add, out_mul],
+        grid_ranges=[((0, 0), (0, 0)), ((1, 1), (1, 1))],
+        region_builders=[
+            lambda: k_spatial_add(inp0, out_add, grid=(1, 1)),
+            lambda: k_spatial_mul(inp1, out_mul, grid=(1, 1)),
+        ],
+    )
+
+    add_result, mul_result = d2m.to_host(out_add, out_mul)
+    add_diff = (t0 + t0 - add_result).abs().max().item()
+    mul_diff = (t1 * t1 - mul_result).abs().max().item()
+    assert add_diff < 0.01, f"spatial non-shared add max diff {add_diff}"
+    assert mul_diff < 0.05, f"spatial non-shared mul max diff {mul_diff}"
+
+
+def test_spatial_heterogeneous_kernels():
+    """Heterogeneous kernels: eltwise and matmul regions in one spatial."""
+    t = torch.randn(32, 32, dtype=torch.float32) * 0.25
+    w = torch.randn(32, 32, dtype=torch.float32) * 0.25
+    in_layout = d2m.Layout(
+        shape=t.shape, dtype=d2m.float32, block_shape=[1, 1], mem_space="dram"
+    )
+    out_layout = d2m.Layout(shape=t.shape, dtype=d2m.float32, block_shape=[1, 1])
+
+    inp = d2m.to_layout(t, in_layout)
+    weight = d2m.to_layout(w, in_layout)
+    out_exp = d2m.empty(out_layout)
+    out_mm = d2m.empty(out_layout)
+
+    d2m.spatial(
+        inputs=[inp, weight],
+        outputs=[out_exp, out_mm],
+        grid_ranges=[((0, 0), (0, 0)), ((1, 0), (1, 0))],
+        region_builders=[
+            lambda: k_spatial_exp(inp, out_exp, grid=(1, 1)),
+            lambda: k_spatial_matmul(inp, weight, out_mm, grid=(1, 1)),
+        ],
+    )
+
+    exp_result, mm_result = d2m.to_host(out_exp, out_mm)
+    exp_diff = (torch.exp(t) - exp_result).abs().max().item()
+    mm_diff = (t @ w - mm_result).abs().max().item()
+    assert exp_diff < 0.05, f"spatial heterogeneous exp max diff {exp_diff}"
+    assert mm_diff < 0.1, f"spatial heterogeneous matmul max diff {mm_diff}"
+
+
+def test_spatial_multicore_matmul_and_eltwise():
+    """Multicore matmul + multicore eltwise regions in one spatial."""
+    lhs = torch.randn(64, 64, dtype=torch.float32) * 0.25
+    rhs = torch.randn(64, 64, dtype=torch.float32) * 0.25
+    t = torch.randn(64, 64, dtype=torch.float32) * 0.5
+    layout = d2m.Layout(
+        shape=(64, 64),
+        dtype=d2m.float32,
+        block_shape=[1, 1],
+        grid_shape=[2, 2],
+        mem_space="dram",
+    )
+    out_layout = d2m.Layout(
+        shape=(64, 64), dtype=d2m.float32, block_shape=[1, 1], grid_shape=[2, 2]
+    )
+
+    lhs_d = d2m.to_layout(lhs, layout)
+    rhs_d = d2m.to_layout(rhs, layout)
+    inp = d2m.to_layout(t, layout)
+    out_mm = d2m.empty(out_layout)
+    out_exp = d2m.empty(out_layout)
+
+    d2m.spatial(
+        inputs=[lhs_d, rhs_d, inp],
+        outputs=[out_mm, out_exp],
+        grid_ranges=[((0, 0), (1, 1)), ((2, 0), (3, 1))],
+        region_builders=[
+            lambda: k_spatial_matmul_multicore(lhs_d, rhs_d, out_mm, 1, 1, grid=(2, 2)),
+            lambda: k_spatial_exp_multicore(inp, out_exp, 1, 1, grid=(2, 2)),
+        ],
+    )
+
+    mm_result, exp_result = d2m.to_host(out_mm, out_exp)
+    mm_diff = (_per_shard_matmul(lhs, rhs) - mm_result).abs().max().item()
+    exp_diff = (torch.exp(t) - exp_result).abs().max().item()
+    assert mm_diff < 0.1, f"spatial multicore matmul max diff {mm_diff}"
+    assert exp_diff < 0.05, f"spatial multicore eltwise max diff {exp_diff}"
+
+
+def test_spatial_three_regions():
+    """Three regions in one spatial: add, mul, and exp on distinct cores."""
+    t = torch.randn(32, 32, dtype=torch.float32) * 0.5
+    in_layout = d2m.Layout(
+        shape=t.shape, dtype=d2m.float32, block_shape=[1, 1], mem_space="dram"
+    )
+    out_layout = d2m.Layout(shape=t.shape, dtype=d2m.float32, block_shape=[1, 1])
+
+    inp = d2m.to_layout(t, in_layout)
+    out_add = d2m.empty(out_layout)
+    out_mul = d2m.empty(out_layout)
+    out_exp = d2m.empty(out_layout)
+
+    d2m.spatial(
+        inputs=[inp],
+        outputs=[out_add, out_mul, out_exp],
+        grid_ranges=[((0, 0), (0, 0)), ((0, 1), (0, 1)), ((1, 0), (1, 0))],
+        region_builders=[
+            lambda: k_spatial_add(inp, out_add, grid=(1, 1)),
+            lambda: k_spatial_mul(inp, out_mul, grid=(1, 1)),
+            lambda: k_spatial_exp(inp, out_exp, grid=(1, 1)),
+        ],
+    )
+
+    add_result, mul_result, exp_result = d2m.to_host(out_add, out_mul, out_exp)
+    add_diff = (t + t - add_result).abs().max().item()
+    mul_diff = (t * t - mul_result).abs().max().item()
+    exp_diff = (torch.exp(t) - exp_result).abs().max().item()
+    assert add_diff < 0.01, f"spatial three-region add max diff {add_diff}"
+    assert mul_diff < 0.05, f"spatial three-region mul max diff {mul_diff}"
+    assert exp_diff < 0.05, f"spatial three-region exp max diff {exp_diff}"

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -176,6 +176,7 @@ kernel body.
 | `d2m.view_layout(lt, lambda d0, d1, d2, d3: ...)` | Low-level: lambda parameter count matches the source's MLIR rank (typically `2 * logical_rank` for tiled tensors). Each result expression may be a parameter, literal `0`, or affine arithmetic with integer constants (`+`, `-`, `*`, `//`, `%`). Arithmetic remappings preserve the source physical shape. |
 | `d2m.permute(lt, *dims)` | `torch.permute`-style positional permutation. |
 | `d2m.reshape(lt, *new_shape)` | `torch.reshape`-style logical-shape change. A single `-1` dim is inferred from the others. Currently a host roundtrip (`to_host` -> `torch.reshape` -> `to_layout`); pays a DRAM transfer. Use for shape changes not expressible as a `view`. |
+| `d2m.spatial(inputs, outputs, grid_ranges, region_builders)` | Emit a `d2m.spatial` wrapper around one `@d2m.kernel` call per disjoint core range. |
 | `d2m.to_host(*lts)` | Compile and execute; return a tuple of `torch.Tensor`s. Resets the builder. |
 | `LazyTensor.to_host()` | Sugar for `to_host(self)[0]`. |
 
@@ -408,6 +409,8 @@ RNG is deterministic per test. `test/d2m-jit/utils.py` provides
 
 ```
 ttcore-register-device,
+canonicalize,
+d2m-materialize-view-returns,
 canonicalize,
 d2m-lower-to-layout,
 canonicalize,

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -410,8 +410,6 @@ RNG is deterministic per test. `test/d2m-jit/utils.py` provides
 ```
 ttcore-register-device,
 canonicalize,
-d2m-materialize-view-returns,
-canonicalize,
 d2m-lower-to-layout,
 canonicalize,
 ttir-bufferization-pipeline,

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -139,6 +139,8 @@ def _pipeline_passes():
     """
     passes = [
         "canonicalize",
+        "d2m-materialize-view-returns",
+        "canonicalize",
         "d2m-lower-to-layout",
         "canonicalize",
         "ttir-bufferization-pipeline",
@@ -324,6 +326,155 @@ class RewriteScope:
         with self.ctx, self.loc, self.insert_point:
             idx_ty = IndexType.get(self.ctx)
             return arith.ConstantOp(idx_ty, IntegerAttr.get(idx_ty, int(value))).result
+
+
+def _has_nonzero_offset(offset):
+    return any(coord != 0 for coord in offset)
+
+
+def _add_affine_const(expr, value, ctx):
+    if value == 0:
+        return expr
+    return AffineExpr.get_add(expr, AffineExpr.get_constant(value, ctx))
+
+
+def _spatial_grid_maps(ctx, offset):
+    if len(offset) != 2:
+        raise ValueError(f"d2m.spatial grid offset must be 2D, got {offset}")
+
+    d0 = AffineDimExpr.get(0)
+    d1 = AffineDimExpr.get(1)
+    zero = AffineExpr.get_constant(0, ctx)
+    forward_map = AffineMap.get(
+        2,
+        0,
+        [
+            zero,
+            _add_affine_const(d0, offset[0], ctx),
+            _add_affine_const(d1, offset[1], ctx),
+        ],
+    )
+    inverse_map = AffineMap.get(
+        2,
+        0,
+        [
+            zero,
+            _add_affine_const(d0, -offset[0], ctx),
+            _add_affine_const(d1, -offset[1], ctx),
+        ],
+    )
+    return forward_map, inverse_map
+
+
+def _spatial_empty_vgm_maps(ctx, grid_rank, offset):
+    if grid_rank != 2:
+        raise ValueError(f"d2m.spatial only supports 2D nested grids, got {grid_rank}D")
+    if len(offset) != 2:
+        raise ValueError(f"d2m.spatial grid offset must be 2D, got {offset}")
+
+    dims = [AffineDimExpr.get(i) for i in range(2 * grid_rank)]
+    inverse_map = _spatial_grid_maps(ctx, offset)[1]
+    forward_map = AffineMap.get(
+        2 * grid_rank,
+        0,
+        [
+            _add_affine_const(dims[0], offset[0], ctx),
+            _add_affine_const(dims[1], offset[1], ctx),
+            dims[2],
+            dims[3],
+        ],
+    )
+    return inverse_map, forward_map
+
+
+class _SpatialRegionScope:
+    """Build-scope view for one region of a `d2m.spatial` op.
+
+    Kernel calls inside the region still share the parent lazy builder's
+    function arguments and generation, but they insert into the spatial region
+    and defer LazyTensor rebinding until the enclosing spatial op is complete.
+    """
+
+    def __init__(
+        self, parent, insert_point, spatial_op, output_lts, grid_shape, offset
+    ):
+        self.parent = parent
+        self.ctx = parent.ctx
+        self.loc = parent.loc
+        self.insert_point = insert_point
+        self.generation = parent.generation
+        self.spatial_op = spatial_op
+        self.output_lts = list(output_lts)
+        self._output_index_by_id = {id(lt): i for i, lt in enumerate(output_lts)}
+        self._remapped_outputs = {}
+        self.grid_shape = list(grid_shape)
+        self.offset = list(offset)
+        self.defer_kernel_output_rebind = True
+        self.disallow_kernel_io_in_dram = True
+        self.emitted_generics = []
+
+    def add_host_input(self, layout, host_tensor):
+        return self.parent.add_host_input(layout, host_tensor)
+
+    def add_scalar_input(self, value: int):
+        return self.parent.add_scalar_input(value)
+
+    def capture_kernel_generic(self, emitted):
+        self.emitted_generics.append(emitted)
+
+    def validate_grid(self, grid):
+        grid = list(grid)
+        if len(grid) != 2:
+            raise ValueError(
+                f"d2m.spatial only supports 2D nested generic grids, got {grid}"
+            )
+        if grid[0] > self.grid_shape[0] or grid[1] > self.grid_shape[1]:
+            raise ValueError(
+                f"nested generic grid {grid} exceeds spatial region shape "
+                f"{self.grid_shape}"
+            )
+
+    def grid_attr(self, grid):
+        grid = list(grid)
+        if not _has_nonzero_offset(self.offset):
+            return ttcore.ir.GridAttr.get(self.ctx, grid)
+        forward_map, inverse_map = _spatial_grid_maps(self.ctx, self.offset)
+        return ttcore.ir.GridAttr.get(self.ctx, grid, forward_map, inverse_map)
+
+    def remap_output(self, lt: "LazyTensor", grid):
+        if not _has_nonzero_offset(self.offset):
+            return lt
+
+        output_idx = self._output_index_by_id.get(id(lt))
+        if output_idx is None:
+            raise ValueError(
+                "d2m.spatial region kernel writes an output that was not listed "
+                "in d2m.spatial(outputs=...)"
+            )
+
+        if output_idx not in self._remapped_outputs:
+            inverse_map, forward_map = _spatial_empty_vgm_maps(
+                self.ctx, len(grid), self.offset
+            )
+            with self.ctx, self.loc, InsertionPoint(self.spatial_op.operation):
+                remapped_value = d2m.empty(
+                    lt.value.type,
+                    virtual_grid_inverse_mapping=inverse_map,
+                    virtual_grid_forward_mapping=forward_map,
+                )
+            spatial_output_operand_idx = len(self.spatial_op.inputs) + output_idx
+            self.spatial_op.operation.operands[
+                spatial_output_operand_idx
+            ] = remapped_value
+            self._remapped_outputs[output_idx] = remapped_value
+
+        return LazyTensor(
+            lt.layout,
+            self._remapped_outputs[output_idx],
+            lt.generation,
+            materialized=lt.materialized,
+            is_view=lt.is_view,
+        )
 
 
 # --- LazyTensor --------------------------------------------------------------
@@ -915,6 +1066,157 @@ def permute(lt: LazyTensor, *dims) -> LazyTensor:
     return _emit_perm_view(lt, list(dims))
 
 
+def _require_int(value, what):
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{what} must be an int, got {type(value).__name__}")
+    return value
+
+
+def _core_range_array_attr(ctx, grid_ranges):
+    range_attrs = []
+    normalized = []
+    for i, grid_range in enumerate(grid_ranges):
+        try:
+            start_yx, end_yx = grid_range
+            sy, sx = start_yx
+            ey, ex = end_yx
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "grid_ranges entries must be ((start_y, start_x), "
+                f"(end_y, end_x)) pairs, got {grid_range!r} at index {i}"
+            ) from exc
+        sy = _require_int(sy, f"grid_ranges[{i}].start_y")
+        sx = _require_int(sx, f"grid_ranges[{i}].start_x")
+        ey = _require_int(ey, f"grid_ranges[{i}].end_y")
+        ex = _require_int(ex, f"grid_ranges[{i}].end_x")
+        if ey < sy or ex < sx:
+            raise ValueError(
+                f"grid_ranges[{i}] end ({ey}, {ex}) must be greater than "
+                f"or equal to start ({sy}, {sx})"
+            )
+        range_attrs.append(
+            Attribute.parse(f"#ttcore.core_range<({sy}, {sx}), ({ey}, {ex})>", ctx)
+        )
+        normalized.append(((sy, sx), (ey, ex)))
+    return ArrayAttr.get(range_attrs), normalized
+
+
+def _resolve_lazy_tensor_sequence(values, name):
+    if isinstance(values, LazyTensor):
+        raise TypeError(f"{name} must be a sequence of LazyTensor objects")
+    try:
+        seq = list(values)
+    except TypeError as exc:
+        raise TypeError(f"{name} must be a sequence of LazyTensor objects") from exc
+    for i, value in enumerate(seq):
+        if not isinstance(value, LazyTensor):
+            raise TypeError(
+                f"{name}[{i}] must be a LazyTensor, got {type(value).__name__}"
+            )
+    return [value._resolve() for value in seq]
+
+
+def spatial(inputs, outputs, grid_ranges, region_builders):
+    """Emit a `d2m.spatial` op around one kernel call per region.
+
+    Args:
+      inputs: LazyTensor inputs referenced by the nested kernels.
+      outputs: LazyTensor outputs produced by the nested kernels. The flattened
+        order must match the order the region kernels write their outputs.
+      grid_ranges: One inclusive `((start_y, start_x), (end_y, end_x))` core
+        range per region.
+      region_builders: One zero-argument callable per region. Each callable
+        must emit exactly one `@d2m.kernel` call.
+
+    Returns the output LazyTensors after rebinding them to the spatial results.
+    """
+    b = _get_scope()
+    if not hasattr(b, "module") and not isinstance(b, RewriteScope):
+        raise RuntimeError("d2m.spatial() requires a lazy builder-like scope")
+
+    try:
+        builders = list(region_builders)
+    except TypeError as exc:
+        raise TypeError("region_builders must be a sequence of callables") from exc
+    if not builders:
+        raise ValueError("region_builders must contain at least one callable")
+    for i, builder_fn in enumerate(builders):
+        if not callable(builder_fn):
+            raise TypeError(
+                f"region_builders[{i}] must be callable, got "
+                f"{type(builder_fn).__name__}"
+            )
+
+    try:
+        ranges = list(grid_ranges)
+    except TypeError as exc:
+        raise TypeError("grid_ranges must be a sequence") from exc
+    if len(ranges) != len(builders):
+        raise ValueError(
+            f"grid_ranges has {len(ranges)} entries but region_builders has "
+            f"{len(builders)}"
+        )
+
+    input_lts = _resolve_lazy_tensor_sequence(inputs, "inputs")
+    output_lts = _resolve_lazy_tensor_sequence(outputs, "outputs")
+    if not output_lts:
+        raise ValueError("outputs must contain at least one LazyTensor")
+
+    emitted_generics = []
+    with b.ctx, b.loc, b.insert_point:
+        grid_ranges_attr, normalized_ranges = _core_range_array_attr(b.ctx, ranges)
+        result_types = [lt.value.type for lt in output_lts]
+        spatial_op = d2m.SpatialOp(
+            result_types,
+            [lt.value for lt in input_lts],
+            [lt.value for lt in output_lts],
+            grid_ranges_attr,
+            len(builders),
+        )
+
+        for region_idx, build_region in enumerate(builders):
+            block = Block.create_at_start(spatial_op.regions[region_idx], [], [])
+            (sy, sx), (ey, ex) = normalized_ranges[region_idx]
+            region_scope = _SpatialRegionScope(
+                b,
+                InsertionPoint(block),
+                spatial_op,
+                output_lts,
+                grid_shape=[ey - sy + 1, ex - sx + 1],
+                offset=[sy, sx],
+            )
+            with _push_scope(region_scope):
+                build_region()
+            if len(region_scope.emitted_generics) != 1:
+                raise ValueError(
+                    "each d2m.spatial region must emit exactly one "
+                    f"@d2m.kernel call, got {len(region_scope.emitted_generics)} "
+                    f"in region {region_idx}"
+                )
+            emitted = region_scope.emitted_generics[0]
+            emitted_generics.append(emitted)
+            with region_scope.insert_point:
+                d2m.spatial_yield(list(emitted.generic.results))
+
+    emitted_outputs = []
+    for emitted in emitted_generics:
+        emitted_outputs.extend(emitted.user_output_lts)
+    if len(emitted_outputs) != len(output_lts) or any(
+        actual is not expected for actual, expected in zip(emitted_outputs, output_lts)
+    ):
+        raise ValueError(
+            "d2m.spatial outputs must match the region kernel outputs in "
+            "flattened region order"
+        )
+
+    for i, lt in enumerate(output_lts):
+        lt.value = spatial_op.results[i]
+        lt.generation = b.generation
+        lt.materialized = None
+        lt.is_view = False
+    return tuple(output_lts)
+
+
 # --- Materialisation ---------------------------------------------------------
 
 
@@ -944,7 +1246,7 @@ def _run_pipeline(b: _Builder):
         print(f"[d2m-jit] pipeline: {pipeline_str}")
     if config.print_ir_before_pipeline:
         print("[d2m-jit] IR before pipeline:")
-        print(b.module)
+        print(b.module.operation.get_asm(assume_verified=True))
 
     pm = PassManager.parse(pipeline_str, context=b.ctx)
     pm.enable_verifier(config.verify_passes)
@@ -1089,7 +1391,6 @@ def to_host(*lts: LazyTensor):
     assert all(lt.generation == b.generation for lt in resolved)
 
     _emit_returns_and_finalise(b, resolved)
-    b.module.operation.verify()
     _run_pipeline(b)
     outs = _execute(b, resolved)
 
@@ -1213,6 +1514,31 @@ def _to_dram_kernel_arg(lt: LazyTensor) -> LazyTensor:
     return to_layout(lt, lt.layout.replace(mem_space=ttcore.MemorySpace.DeviceDRAM))
 
 
+class _EmittedKernelGeneric:
+    __slots__ = ("generic", "input_lts", "output_lts", "user_output_lts")
+
+    def __init__(self, generic, input_lts, output_lts, user_output_lts):
+        self.generic = generic
+        self.input_lts = input_lts
+        self.output_lts = output_lts
+        self.user_output_lts = user_output_lts
+
+
+def _get_spatial_kernel_yield_values(block, outputs):
+    latest_store_results = [None] * len(outputs)
+    for op in block.operations:
+        if op.name != "d2m.remote_store" or not op.results:
+            continue
+        stored_output = op.operands[0]
+        for i, output in enumerate(outputs):
+            if stored_output == output:
+                latest_store_results[i] = op.results[0]
+    return [
+        store_result if store_result is not None else output
+        for store_result, output in zip(latest_store_results, outputs)
+    ]
+
+
 def _emit_kernel_generic(
     kernel: "CompiledKernel",
     args,
@@ -1292,6 +1618,15 @@ def _emit_kernel_generic(
             f"kernel_io_in_dram must be a bool, got {type(kernel_io_in_dram).__name__}",
             cause=TypeError(),
         )
+    if kernel_io_in_dram and getattr(b, "disallow_kernel_io_in_dram", False):
+        raise _call_error(
+            "kernel_io_in_dram is not supported inside d2m.spatial",
+            hint=(
+                "Pass kernel_io_in_dram=False for kernels called from "
+                "d2m.spatial, or temporarily disable d2m.config.kernel_io_in_dram."
+            ),
+            cause=ValueError(),
+        )
 
     if kernel_io_in_dram:
         dram_arg_cache = {}
@@ -1328,6 +1663,14 @@ def _emit_kernel_generic(
     else:
         effective_captures = kernel._captures
         runtime_scalars = list(scalar_args)
+    grid = list(grid)
+    validate_grid = getattr(b, "validate_grid", None)
+    if validate_grid is not None:
+        validate_grid(grid)
+    remap_output = getattr(b, "remap_output", None)
+    if remap_output is not None:
+        output_lts = [remap_output(lt, grid) for lt in output_lts]
+        lazy_args = input_lts + output_lts
 
     # Compile the kernel body in the current builder's context. D2MCompiler
     # picks up b.ctx via get_default_loc_context.
@@ -1359,19 +1702,40 @@ def _emit_kernel_generic(
         threads = ArrayAttr.get(
             [compiler.func_entry.attributes[d2m.ir.ThreadAttr.name]]
         )
-        grid_attr = ttcore.ir.GridAttr.get(b.ctx, list(grid))
+        build_grid_attr = getattr(b, "grid_attr", None)
+        grid_attr = (
+            build_grid_attr(grid)
+            if build_grid_attr is not None
+            else ttcore.ir.GridAttr.get(b.ctx, grid)
+        )
 
         bf = list(block_factors or [])
         if bf and isinstance(bf[0], tuple):
             bf = [v for tup in bf for v in tup]
 
-        indexing_attrs = [_affine_map_from_lambda(f)[0] for f in (indexing_maps or [])]
+        use_default_spatial_parallelization = (
+            getattr(b, "defer_kernel_output_rebind", False)
+            and block_factors is None
+            and indexing_maps is None
+            and iterator_types is None
+        )
+        if use_default_spatial_parallelization:
+            rank = len(grid)
+            bf = [1] * rank
+            identity = AffineMap.get_identity(rank)
+            indexing_attrs = [identity] * (len(inputs) + len(outputs))
+            iterator_values = ["parallel"] * rank
+        else:
+            indexing_attrs = [
+                _affine_map_from_lambda(f)[0] for f in (indexing_maps or [])
+            ]
+            iterator_values = list(iterator_types or [])
         iter_attr = ArrayAttr.get(
             [
                 ttcore.ir.IteratorTypeAttr.get(
                     b.ctx, ttcore.IteratorType[i.title()].value
                 )
-                for i in (iterator_types or [])
+                for i in iterator_values
             ]
         )
 
@@ -1399,6 +1763,17 @@ def _emit_kernel_generic(
             orig_arg.replace_all_uses_with(op)
         for _ in range(len(block.arguments)):
             block.erase_argument(0)
+        if use_default_spatial_parallelization:
+            yield_values = _get_spatial_kernel_yield_values(block, outputs)
+            with InsertionPoint(block):
+                d2m.yield_(yield_values)
+
+    emitted = _EmittedKernelGeneric(generic, input_lts, output_lts, user_output_lts)
+    capture = getattr(b, "capture_kernel_generic", None)
+    if capture is not None:
+        capture(emitted)
+    if getattr(b, "defer_kernel_output_rebind", False):
+        return emitted
 
     # Rebind output LazyTensors to the GenericOp's results.
     for i, lt in enumerate(output_lts):
@@ -1411,6 +1786,7 @@ def _emit_kernel_generic(
             user_lt.generation = b.generation
             user_lt.materialized = None
             user_lt.is_view = kernel_lt.is_view
+    return emitted
 
 
 class CompiledKernel:

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -20,6 +20,7 @@ import functools
 import inspect
 import os
 import threading
+from collections import Counter
 from typing import Optional
 
 try:
@@ -139,8 +140,6 @@ def _pipeline_passes():
     """
     passes = [
         "canonicalize",
-        "d2m-materialize-view-returns",
-        "canonicalize",
         "d2m-lower-to-layout",
         "canonicalize",
         "ttir-bufferization-pipeline",
@@ -175,9 +174,16 @@ def _pipeline_passes():
 # A `RewriteScope` (defined alongside the pattern-rewrite framework) plugs
 # in a `PatternRewriter`'s context + insertion point so that calling a
 # `@d2m.kernel` from inside a rewrite emits the GenericOp at the matched
-# op's site rather than into a fresh module. From the perspective of the
-# emission helpers, all scopes quack the same: they expose `ctx`, `loc`,
-# `insert_point`, `generation`, `add_host_input`, `add_scalar_input`.
+# op's site rather than into a fresh module.
+#
+# `_SpatialRegionScope` is pushed for each `d2m.spatial` region so nested
+# kernel calls emit into that region's block (and apply spatial-only policy
+# such as grid offset / VGM remap). `d2m.spatial()` itself requires the
+# lazy `_Builder` scope; nested spatial is not supported.
+#
+# From the perspective of the emission helpers, all scopes quack the same:
+# they expose `ctx`, `loc`, `insert_point`, `generation`, `add_host_input`,
+# `add_scalar_input`.
 #
 # `_get_scope()` returns the top of a thread-local stack, falling back to
 # the lazy `_Builder` singleton when nothing is pushed. Push/pop is done
@@ -328,101 +334,50 @@ class RewriteScope:
             return arith.ConstantOp(idx_ty, IntegerAttr.get(idx_ty, int(value))).result
 
 
-def _has_nonzero_offset(offset):
-    return any(coord != 0 for coord in offset)
-
-
-def _add_affine_const(expr, value, ctx):
-    if value == 0:
-        return expr
-    return AffineExpr.get_add(expr, AffineExpr.get_constant(value, ctx))
-
-
-def _spatial_grid_maps(ctx, offset):
-    if len(offset) != 2:
-        raise ValueError(f"d2m.spatial grid offset must be 2D, got {offset}")
-
-    d0 = AffineDimExpr.get(0)
-    d1 = AffineDimExpr.get(1)
-    zero = AffineExpr.get_constant(0, ctx)
-    forward_map = AffineMap.get(
-        2,
-        0,
-        [
-            zero,
-            _add_affine_const(d0, offset[0], ctx),
-            _add_affine_const(d1, offset[1], ctx),
-        ],
-    )
-    inverse_map = AffineMap.get(
-        2,
-        0,
-        [
-            zero,
-            _add_affine_const(d0, -offset[0], ctx),
-            _add_affine_const(d1, -offset[1], ctx),
-        ],
-    )
-    return forward_map, inverse_map
-
-
-def _spatial_empty_vgm_maps(ctx, grid_rank, offset):
-    if grid_rank != 2:
-        raise ValueError(f"d2m.spatial only supports 2D nested grids, got {grid_rank}D")
-    if len(offset) != 2:
-        raise ValueError(f"d2m.spatial grid offset must be 2D, got {offset}")
-
-    dims = [AffineDimExpr.get(i) for i in range(2 * grid_rank)]
-    inverse_map = _spatial_grid_maps(ctx, offset)[1]
-    forward_map = AffineMap.get(
-        2 * grid_rank,
-        0,
-        [
-            _add_affine_const(dims[0], offset[0], ctx),
-            _add_affine_const(dims[1], offset[1], ctx),
-            dims[2],
-            dims[3],
-        ],
-    )
-    return inverse_map, forward_map
-
-
 class _SpatialRegionScope:
-    """Build-scope view for one region of a `d2m.spatial` op.
+    """Build scope for one `d2m.spatial` region (exactly one nested generic)."""
 
-    Kernel calls inside the region still share the parent lazy builder's
-    function arguments and generation, but they insert into the spatial region
-    and defer LazyTensor rebinding until the enclosing spatial op is complete.
-    """
-
-    def __init__(
-        self, parent, insert_point, spatial_op, output_lts, grid_shape, offset
-    ):
+    def __init__(self, parent, insert_point, spatial_op, grid_shape, offset):
         self.parent = parent
         self.ctx = parent.ctx
         self.loc = parent.loc
         self.insert_point = insert_point
         self.generation = parent.generation
         self.spatial_op = spatial_op
-        self.output_lts = list(output_lts)
-        self._output_index_by_id = {id(lt): i for i, lt in enumerate(output_lts)}
-        self._remapped_outputs = {}
         self.grid_shape = list(grid_shape)
         self.offset = list(offset)
-        self.defer_kernel_output_rebind = True
-        self.disallow_kernel_io_in_dram = True
-        self.emitted_generics = []
+        if len(self.offset) != 2:
+            raise ValueError(f"d2m.spatial grid offset must be 2D, got {self.offset}")
+        self._emitted_generic = None
+        self._finished = False
 
     def add_host_input(self, layout, host_tensor):
-        return self.parent.add_host_input(layout, host_tensor)
+        raise RuntimeError(
+            "Cannot lift a host tensor from inside d2m.spatial. Spatial "
+            "regions operate on device tensors only; prepare inputs/outputs "
+            "outside the spatial op and pass them via inputs=/outputs=."
+        )
 
     def add_scalar_input(self, value: int):
         return self.parent.add_scalar_input(value)
 
-    def capture_kernel_generic(self, emitted):
-        self.emitted_generics.append(emitted)
+    def finish(self):
+        """Emit `d2m.spatial_yield` of the nested generic results; return its
+        output operands for matching against SpatialOp outs=."""
+        if self._finished:
+            raise RuntimeError("d2m.spatial region already finished")
+        if self._emitted_generic is None:
+            raise ValueError(
+                "each d2m.spatial region must emit exactly one @d2m.kernel call"
+            )
+        # TODO (hkwon): Allow yielding values other than the nested generic results.
+        with self.ctx, self.loc, self.insert_point:
+            d2m.spatial_yield(list(self._emitted_generic.results))
+        self._finished = True
+        return list(self._emitted_generic.outputs)
 
-    def validate_grid(self, grid):
+    def _validate_grid(self, grid):
+        """Validate nested generic grid; return normalized 2D list."""
         grid = list(grid)
         if len(grid) != 2:
             raise ValueError(
@@ -433,47 +388,117 @@ class _SpatialRegionScope:
                 f"nested generic grid {grid} exceeds spatial region shape "
                 f"{self.grid_shape}"
             )
+        return grid
 
-    def grid_attr(self, grid):
-        grid = list(grid)
-        if not _has_nonzero_offset(self.offset):
-            return ttcore.ir.GridAttr.get(self.ctx, grid)
-        forward_map, inverse_map = _spatial_grid_maps(self.ctx, self.offset)
-        return ttcore.ir.GridAttr.get(self.ctx, grid, forward_map, inverse_map)
+    def _make_offset_vgm_maps(self):
+        oy, ox = self.offset
+        d0 = AffineDimExpr.get(0)
+        d1 = AffineDimExpr.get(1)
+        zero = AffineExpr.get_constant(0, self.ctx)
 
-    def remap_output(self, lt: "LazyTensor", grid):
-        if not _has_nonzero_offset(self.offset):
-            return lt
+        def add_const(expr, value):
+            if value == 0:
+                return expr
+            return AffineExpr.get_add(expr, AffineExpr.get_constant(value, self.ctx))
 
-        output_idx = self._output_index_by_id.get(id(lt))
+        inverse = AffineMap.get(2, 0, [zero, add_const(d0, -oy), add_const(d1, -ox)])
+        dims = [AffineDimExpr.get(i) for i in range(4)]
+        forward = AffineMap.get(
+            4,
+            0,
+            [
+                add_const(dims[0], oy),
+                add_const(dims[1], ox),
+                dims[2],
+                dims[3],
+            ],
+        )
+        return inverse, forward
+
+    def _remap_spatial_output(self, lt: "LazyTensor"):
+        # Replace the matching SpatialOp out with a VGM empty so L1 lands on
+        # this region's physical cores.
+        output_idx = next(
+            (i for i, v in enumerate(self.spatial_op.outputs) if v == lt.value), None
+        )
         if output_idx is None:
+            raise ValueError("kernel output not listed in d2m.spatial(outputs=...)")
+
+        inverse, forward = self._make_offset_vgm_maps()
+        with self.ctx, self.loc, InsertionPoint(self.spatial_op.operation):
+            remapped_value = d2m.empty(
+                lt.value.type,
+                virtual_grid_inverse_mapping=inverse,
+                virtual_grid_forward_mapping=forward,
+            )
+        self.spatial_op.operation.operands[
+            len(self.spatial_op.inputs) + output_idx
+        ] = remapped_value
+        lt.value = remapped_value
+        return lt
+
+    def _remap_output_args(self, args, num_outs):
+        """Remap trailing num_outs LazyTensors; return prepared args."""
+        args = list(args)
+        num_tensors = next(
+            (i for i, a in enumerate(args) if not isinstance(a, LazyTensor)),
+            len(args),
+        )
+        if num_outs < 1 or num_tensors < num_outs:
             raise ValueError(
-                "d2m.spatial region kernel writes an output that was not listed "
-                "in d2m.spatial(outputs=...)"
+                f"need at least {num_outs} tensor args for outputs, got {num_tensors}"
+            )
+        tensors, rest = args[:num_tensors], args[num_tensors:]
+        inputs = tensors[:-num_outs]
+        outputs = [lt._resolve() for lt in tensors[-num_outs:]]
+        remapped = [self._remap_spatial_output(lt) for lt in outputs]
+        return tuple(inputs + remapped + rest)
+
+    def _emit_kernel_for_spatial(
+        self,
+        kernel: "CompiledKernel",
+        args,
+        grid,
+        num_outs: int,
+        block_factors,
+        indexing_maps,
+        iterator_types,
+        kernel_io_in_dram=None,
+    ):
+        """Emit one nested generic for this spatial region."""
+        if self._emitted_generic is not None:
+            raise ValueError(
+                "each d2m.spatial region must emit exactly one @d2m.kernel call"
             )
 
-        if output_idx not in self._remapped_outputs:
-            inverse_map, forward_map = _spatial_empty_vgm_maps(
-                self.ctx, len(grid), self.offset
-            )
-            with self.ctx, self.loc, InsertionPoint(self.spatial_op.operation):
-                remapped_value = d2m.empty(
-                    lt.value.type,
-                    virtual_grid_inverse_mapping=inverse_map,
-                    virtual_grid_forward_mapping=forward_map,
-                )
-            spatial_output_operand_idx = len(self.spatial_op.inputs) + output_idx
-            self.spatial_op.operation.operands[
-                spatial_output_operand_idx
-            ] = remapped_value
-            self._remapped_outputs[output_idx] = remapped_value
+        grid = self._validate_grid(grid)
 
-        return LazyTensor(
-            lt.layout,
-            self._remapped_outputs[output_idx],
-            lt.generation,
-            materialized=lt.materialized,
-            is_view=lt.is_view,
+        # TODO (hkwon): Support kernel_io_in_dram inside d2m.spatial by
+        # updating SpatialOp outs/result types to the DRAM destination,
+        # similar to _remap_spatial_output's VGM operand rewrite.
+        resolved_dram = (
+            config.kernel_io_in_dram if kernel_io_in_dram is None else kernel_io_in_dram
+        )
+        if resolved_dram is True:
+            raise ValueError(
+                "kernel_io_in_dram is not currently supported inside "
+                "d2m.spatial; pass kernel_io_in_dram=False or disable "
+                "d2m.config.kernel_io_in_dram"
+            )
+
+        if self.offset[0] != 0 or self.offset[1] != 0:
+            args = self._remap_output_args(args, num_outs)
+
+        self._emitted_generic = _emit_kernel_generic(
+            kernel,
+            args,
+            grid=grid,
+            num_outs=num_outs,
+            block_factors=block_factors,
+            indexing_maps=indexing_maps,
+            iterator_types=iterator_types,
+            kernel_io_in_dram=kernel_io_in_dram,
+            grid_offset=self.offset,
         )
 
 
@@ -1066,15 +1091,9 @@ def permute(lt: LazyTensor, *dims) -> LazyTensor:
     return _emit_perm_view(lt, list(dims))
 
 
-def _require_int(value, what):
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise TypeError(f"{what} must be an int, got {type(value).__name__}")
-    return value
-
-
-def _core_range_array_attr(ctx, grid_ranges):
-    range_attrs = []
-    normalized = []
+def _parse_grid_ranges(grid_ranges):
+    """Parse grid_ranges into inclusive ((start_y, start_x), (end_y, end_x))."""
+    parsed = []
     for i, grid_range in enumerate(grid_ranges):
         try:
             start_yx, end_yx = grid_range
@@ -1085,61 +1104,45 @@ def _core_range_array_attr(ctx, grid_ranges):
                 "grid_ranges entries must be ((start_y, start_x), "
                 f"(end_y, end_x)) pairs, got {grid_range!r} at index {i}"
             ) from exc
-        sy = _require_int(sy, f"grid_ranges[{i}].start_y")
-        sx = _require_int(sx, f"grid_ranges[{i}].start_x")
-        ey = _require_int(ey, f"grid_ranges[{i}].end_y")
-        ex = _require_int(ex, f"grid_ranges[{i}].end_x")
         if ey < sy or ex < sx:
             raise ValueError(
                 f"grid_ranges[{i}] end ({ey}, {ex}) must be greater than "
                 f"or equal to start ({sy}, {sx})"
             )
-        range_attrs.append(
-            Attribute.parse(f"#ttcore.core_range<({sy}, {sx}), ({ey}, {ex})>", ctx)
-        )
-        normalized.append(((sy, sx), (ey, ex)))
-    return ArrayAttr.get(range_attrs), normalized
-
-
-def _resolve_lazy_tensor_sequence(values, name):
-    if isinstance(values, LazyTensor):
-        raise TypeError(f"{name} must be a sequence of LazyTensor objects")
-    try:
-        seq = list(values)
-    except TypeError as exc:
-        raise TypeError(f"{name} must be a sequence of LazyTensor objects") from exc
-    for i, value in enumerate(seq):
-        if not isinstance(value, LazyTensor):
-            raise TypeError(
-                f"{name}[{i}] must be a LazyTensor, got {type(value).__name__}"
-            )
-    return [value._resolve() for value in seq]
+        parsed.append(((sy, sx), (ey, ex)))
+    return parsed
 
 
 def spatial(inputs, outputs, grid_ranges, region_builders):
     """Emit a `d2m.spatial` op around one kernel call per region.
 
+    Only supported under the lazy `_Builder` scope (not RewriteScope).
+
     Args:
-      inputs: LazyTensor inputs referenced by the nested kernels.
-      outputs: LazyTensor outputs produced by the nested kernels. The flattened
-        order must match the order the region kernels write their outputs.
+      inputs: Device tensors referenced by the nested kernels.
+      outputs: Device tensors written by the nested kernels, in spatial
+        result order.
       grid_ranges: One inclusive `((start_y, start_x), (end_y, end_x))` core
         range per region.
-      region_builders: One zero-argument callable per region. Each callable
-        must emit exactly one `@d2m.kernel` call.
+      region_builders: One zero-argument callable per region. Each must emit
+        exactly one `@d2m.kernel` call on device LazyTensors from
+        inputs=/outputs= (no host tensor lifts).
 
-    Returns the output LazyTensors after rebinding them to the spatial results.
+    Returns a tuple of the output LazyTensors.
     """
     b = _get_scope()
-    if not hasattr(b, "module") and not isinstance(b, RewriteScope):
-        raise RuntimeError("d2m.spatial() requires a lazy builder-like scope")
+    if isinstance(b, _SpatialRegionScope):
+        raise RuntimeError("nested d2m.spatial is not supported")
+    if not isinstance(b, _Builder):
+        raise RuntimeError("d2m.spatial() requires the lazy builder scope")
 
-    try:
-        builders = list(region_builders)
-    except TypeError as exc:
-        raise TypeError("region_builders must be a sequence of callables") from exc
-    if not builders:
-        raise ValueError("region_builders must contain at least one callable")
+    builders = list(region_builders)
+    ranges = list(grid_ranges)
+    if len(ranges) != len(builders):
+        raise ValueError(
+            f"grid_ranges has {len(ranges)} entries but region_builders has "
+            f"{len(builders)}"
+        )
     for i, builder_fn in enumerate(builders):
         if not callable(builder_fn):
             raise TypeError(
@@ -1147,24 +1150,24 @@ def spatial(inputs, outputs, grid_ranges, region_builders):
                 f"{type(builder_fn).__name__}"
             )
 
-    try:
-        ranges = list(grid_ranges)
-    except TypeError as exc:
-        raise TypeError("grid_ranges must be a sequence") from exc
-    if len(ranges) != len(builders):
-        raise ValueError(
-            f"grid_ranges has {len(ranges)} entries but region_builders has "
-            f"{len(builders)}"
-        )
-
-    input_lts = _resolve_lazy_tensor_sequence(inputs, "inputs")
-    output_lts = _resolve_lazy_tensor_sequence(outputs, "outputs")
+    input_lts = [v._resolve() for v in inputs]
+    output_lts = [v._resolve() for v in outputs]
     if not output_lts:
-        raise ValueError("outputs must contain at least one LazyTensor")
+        raise ValueError("d2m.spatial outputs= must be non-empty")
 
-    emitted_generics = []
+    emitted_output_values = []
     with b.ctx, b.loc, b.insert_point:
-        grid_ranges_attr, normalized_ranges = _core_range_array_attr(b.ctx, ranges)
+        parsed_ranges = _parse_grid_ranges(ranges)
+        grid_ranges_attr = ArrayAttr.get(
+            [
+                ttcore.ir.CoreRangeAttr.get(
+                    b.ctx,
+                    ttcore.ir.CoreCoordAttr.get(b.ctx, sy, sx),
+                    ttcore.ir.CoreCoordAttr.get(b.ctx, ey, ex),
+                )
+                for (sy, sx), (ey, ex) in parsed_ranges
+            ]
+        )
         result_types = [lt.value.type for lt in output_lts]
         spatial_op = d2m.SpatialOp(
             result_types,
@@ -1176,37 +1179,24 @@ def spatial(inputs, outputs, grid_ranges, region_builders):
 
         for region_idx, build_region in enumerate(builders):
             block = Block.create_at_start(spatial_op.regions[region_idx], [], [])
-            (sy, sx), (ey, ex) = normalized_ranges[region_idx]
+            (sy, sx), (ey, ex) = parsed_ranges[region_idx]
             region_scope = _SpatialRegionScope(
                 b,
                 InsertionPoint(block),
                 spatial_op,
-                output_lts,
                 grid_shape=[ey - sy + 1, ex - sx + 1],
                 offset=[sy, sx],
             )
             with _push_scope(region_scope):
                 build_region()
-            if len(region_scope.emitted_generics) != 1:
-                raise ValueError(
-                    "each d2m.spatial region must emit exactly one "
-                    f"@d2m.kernel call, got {len(region_scope.emitted_generics)} "
-                    f"in region {region_idx}"
-                )
-            emitted = region_scope.emitted_generics[0]
-            emitted_generics.append(emitted)
-            with region_scope.insert_point:
-                d2m.spatial_yield(list(emitted.generic.results))
+            emitted_output_values.extend(region_scope.finish())
 
-    emitted_outputs = []
-    for emitted in emitted_generics:
-        emitted_outputs.extend(emitted.user_output_lts)
-    if len(emitted_outputs) != len(output_lts) or any(
-        actual is not expected for actual, expected in zip(emitted_outputs, output_lts)
-    ):
+    # Counter compares as a multiset: same Values/counts, order ignored.
+    # Check that region-kernel dst operands match SpatialOp outs=.
+    if Counter(emitted_output_values) != Counter(spatial_op.outputs):
         raise ValueError(
-            "d2m.spatial outputs must match the region kernel outputs in "
-            "flattened region order"
+            "d2m.spatial outputs= must list the same tensors written by the "
+            "region kernels"
         )
 
     for i, lt in enumerate(output_lts):
@@ -1246,7 +1236,7 @@ def _run_pipeline(b: _Builder):
         print(f"[d2m-jit] pipeline: {pipeline_str}")
     if config.print_ir_before_pipeline:
         print("[d2m-jit] IR before pipeline:")
-        print(b.module.operation.get_asm(assume_verified=True))
+        print(b.module)
 
     pm = PassManager.parse(pipeline_str, context=b.ctx)
     pm.enable_verifier(config.verify_passes)
@@ -1391,6 +1381,7 @@ def to_host(*lts: LazyTensor):
     assert all(lt.generation == b.generation for lt in resolved)
 
     _emit_returns_and_finalise(b, resolved)
+    b.module.operation.verify()
     _run_pipeline(b)
     outs = _execute(b, resolved)
 
@@ -1514,29 +1505,34 @@ def _to_dram_kernel_arg(lt: LazyTensor) -> LazyTensor:
     return to_layout(lt, lt.layout.replace(mem_space=ttcore.MemorySpace.DeviceDRAM))
 
 
-class _EmittedKernelGeneric:
-    __slots__ = ("generic", "input_lts", "output_lts", "user_output_lts")
+def _make_grid_attr(ctx, grid, grid_offset=(0, 0)):
+    """Build a GridAttr from grid shape and an optional virtual-grid offset.
 
-    def __init__(self, generic, input_lts, output_lts, user_output_lts):
-        self.generic = generic
-        self.input_lts = input_lts
-        self.output_lts = output_lts
-        self.user_output_lts = user_output_lts
+    Zero offset yields a plain shape-only GridAttr. Nonzero offset attaches
+    virt_to_physical / physical_to_virt maps (2D, leading zero pad) so the
+    nested generic's virtual cores land on the region's physical cores.
+    """
+    grid = list(grid)
+    offset = list(grid_offset)
+    if len(offset) != 2:
+        raise ValueError(f"grid_offset must be 2D, got {offset}")
+    if offset[0] == 0 and offset[1] == 0:
+        return ttcore.ir.GridAttr.get(ctx, grid)
 
+    oy, ox = offset
 
-def _get_spatial_kernel_yield_values(block, outputs):
-    latest_store_results = [None] * len(outputs)
-    for op in block.operations:
-        if op.name != "d2m.remote_store" or not op.results:
-            continue
-        stored_output = op.operands[0]
-        for i, output in enumerate(outputs):
-            if stored_output == output:
-                latest_store_results[i] = op.results[0]
-    return [
-        store_result if store_result is not None else output
-        for store_result, output in zip(latest_store_results, outputs)
-    ]
+    def add_const(expr, value):
+        if value == 0:
+            return expr
+        return AffineExpr.get_add(expr, AffineExpr.get_constant(value, ctx))
+
+    d0 = AffineDimExpr.get(0)
+    d1 = AffineDimExpr.get(1)
+    zero = AffineExpr.get_constant(0, ctx)
+    # 2D GridAttr maps: leading zero pad, then y/x with +/- offset.
+    grid_forward = AffineMap.get(2, 0, [zero, add_const(d0, oy), add_const(d1, ox)])
+    offset_inverse = AffineMap.get(2, 0, [zero, add_const(d0, -oy), add_const(d1, -ox)])
+    return ttcore.ir.GridAttr.get(ctx, grid, grid_forward, offset_inverse)
 
 
 def _emit_kernel_generic(
@@ -1548,6 +1544,7 @@ def _emit_kernel_generic(
     indexing_maps,
     iterator_types,
     kernel_io_in_dram=None,
+    grid_offset=(0, 0),
 ):
     """Append a d2m.GenericOp to the open host func that invokes `kernel`."""
     b = _get_scope()
@@ -1618,15 +1615,6 @@ def _emit_kernel_generic(
             f"kernel_io_in_dram must be a bool, got {type(kernel_io_in_dram).__name__}",
             cause=TypeError(),
         )
-    if kernel_io_in_dram and getattr(b, "disallow_kernel_io_in_dram", False):
-        raise _call_error(
-            "kernel_io_in_dram is not supported inside d2m.spatial",
-            hint=(
-                "Pass kernel_io_in_dram=False for kernels called from "
-                "d2m.spatial, or temporarily disable d2m.config.kernel_io_in_dram."
-            ),
-            cause=ValueError(),
-        )
 
     if kernel_io_in_dram:
         dram_arg_cache = {}
@@ -1651,7 +1639,7 @@ def _emit_kernel_generic(
     # captures (in-region constants) and emit no additionalArgs for them. The
     # lazy `_Builder` keeps the runtime-arg form: scalars stay index func args
     # (see add_scalar_input) so the binary remains parameterised.
-    bake_scalars = not isinstance(b, _Builder)
+    bake_scalars = not isinstance(b, (_Builder, _SpatialRegionScope))
     if bake_scalars and scalar_args:
         formal_names = [a.arg for a in kernel._ast.body[0].args.args]
         scalar_names = formal_names[len(lazy_args) : len(lazy_args) + len(scalar_args)]
@@ -1663,14 +1651,6 @@ def _emit_kernel_generic(
     else:
         effective_captures = kernel._captures
         runtime_scalars = list(scalar_args)
-    grid = list(grid)
-    validate_grid = getattr(b, "validate_grid", None)
-    if validate_grid is not None:
-        validate_grid(grid)
-    remap_output = getattr(b, "remap_output", None)
-    if remap_output is not None:
-        output_lts = [remap_output(lt, grid) for lt in output_lts]
-        lazy_args = input_lts + output_lts
 
     # Compile the kernel body in the current builder's context. D2MCompiler
     # picks up b.ctx via get_default_loc_context.
@@ -1702,40 +1682,19 @@ def _emit_kernel_generic(
         threads = ArrayAttr.get(
             [compiler.func_entry.attributes[d2m.ir.ThreadAttr.name]]
         )
-        build_grid_attr = getattr(b, "grid_attr", None)
-        grid_attr = (
-            build_grid_attr(grid)
-            if build_grid_attr is not None
-            else ttcore.ir.GridAttr.get(b.ctx, grid)
-        )
+        grid_attr = _make_grid_attr(b.ctx, grid, grid_offset)
 
         bf = list(block_factors or [])
         if bf and isinstance(bf[0], tuple):
             bf = [v for tup in bf for v in tup]
 
-        use_default_spatial_parallelization = (
-            getattr(b, "defer_kernel_output_rebind", False)
-            and block_factors is None
-            and indexing_maps is None
-            and iterator_types is None
-        )
-        if use_default_spatial_parallelization:
-            rank = len(grid)
-            bf = [1] * rank
-            identity = AffineMap.get_identity(rank)
-            indexing_attrs = [identity] * (len(inputs) + len(outputs))
-            iterator_values = ["parallel"] * rank
-        else:
-            indexing_attrs = [
-                _affine_map_from_lambda(f)[0] for f in (indexing_maps or [])
-            ]
-            iterator_values = list(iterator_types or [])
+        indexing_attrs = [_affine_map_from_lambda(f)[0] for f in (indexing_maps or [])]
         iter_attr = ArrayAttr.get(
             [
                 ttcore.ir.IteratorTypeAttr.get(
                     b.ctx, ttcore.IteratorType[i.title()].value
                 )
-                for i in iterator_values
+                for i in (iterator_types or [])
             ]
         )
 
@@ -1763,17 +1722,6 @@ def _emit_kernel_generic(
             orig_arg.replace_all_uses_with(op)
         for _ in range(len(block.arguments)):
             block.erase_argument(0)
-        if use_default_spatial_parallelization:
-            yield_values = _get_spatial_kernel_yield_values(block, outputs)
-            with InsertionPoint(block):
-                d2m.yield_(yield_values)
-
-    emitted = _EmittedKernelGeneric(generic, input_lts, output_lts, user_output_lts)
-    capture = getattr(b, "capture_kernel_generic", None)
-    if capture is not None:
-        capture(emitted)
-    if getattr(b, "defer_kernel_output_rebind", False):
-        return emitted
 
     # Rebind output LazyTensors to the GenericOp's results.
     for i, lt in enumerate(output_lts):
@@ -1786,7 +1734,7 @@ def _emit_kernel_generic(
             user_lt.generation = b.generation
             user_lt.materialized = None
             user_lt.is_view = kernel_lt.is_view
-    return emitted
+    return generic
 
 
 class CompiledKernel:
@@ -1815,16 +1763,29 @@ class CompiledKernel:
         iterator_types=None,
         kernel_io_in_dram=None,
     ):
-        _emit_kernel_generic(
-            self,
-            args,
-            grid=grid,
-            num_outs=num_outs,
-            block_factors=block_factors,
-            indexing_maps=indexing_maps,
-            iterator_types=iterator_types,
-            kernel_io_in_dram=kernel_io_in_dram,
-        )
+        b = _get_scope()
+        if not isinstance(b, _SpatialRegionScope):
+            _emit_kernel_generic(
+                self,
+                args,
+                grid=grid,
+                num_outs=num_outs,
+                block_factors=block_factors,
+                indexing_maps=indexing_maps,
+                iterator_types=iterator_types,
+                kernel_io_in_dram=kernel_io_in_dram,
+            )
+        else:
+            b._emit_kernel_for_spatial(
+                self,
+                args,
+                grid=grid,
+                num_outs=num_outs,
+                block_factors=block_factors,
+                indexing_maps=indexing_maps,
+                iterator_types=iterator_types,
+                kernel_io_in_dram=kernel_io_in_dram,
+            )
 
 
 def kernel(fn):

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -1143,6 +1143,8 @@ def spatial(inputs, outputs, grid_ranges, region_builders):
             f"grid_ranges has {len(ranges)} entries but region_builders has "
             f"{len(builders)}"
         )
+    if not builders:
+        raise ValueError("d2m.spatial requires at least one region")
     for i, builder_fn in enumerate(builders):
         if not callable(builder_fn):
             raise TypeError(

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -31,6 +31,7 @@ from ._src.builder import (
     view,
     permute,
     reshape,
+    spatial,
     to_host,
 )
 from ._src.rewrite import (


### PR DESCRIPTION
### Ticket
close #9060

### Problem description
- d2m-jit cannot author `d2m.spatial`, so concurrent kernels on disjoint grid ranges are unavailable
- Without it, independent work cannot overlap across cores in a single program

### What's changed
 - Add d2m.spatial(...) to d2m-jit (builder + public api)
 - Emit one @d2m.kernel per region, with grid offset / VGM handling for non-origin ranges
 - Add device + lit tests covering multi-region, shared/non-shared inputs, and heterogeneous kernels
 - Document the new API in the d2m-jit README

### Checklist
- [ ] New/Existing tests provide coverage for changes
