### PR TITLE
[TTNN] Replace general ToLayout with ToTensorSpec

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -58,10 +58,15 @@ def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config"> {
 def TTNN_ToLayoutOp : TTNN_Op<"to_layout", [TTNN_LayoutOpInterface]> {
     let summary = "ToLayout op.";
     let description = [{
-      This op wraps all layout information gathered from ttir.toLayout. It is used/updated by the optimizer
-      to perform optimizations, and later broken down into specific memory/layout operations (toDevice, toMemoryConfig etc.).
-      Currently in the TTNN backend, we use this op solely for tilize/untilize, therefore marking all other attrs as optional.
-      Once ttnn::to_layout supports other attrs, we can remove the optional tag.
+      This is the narrow layout op: it may only change the page layout
+      (tile <-> row-major) of the input tensor and, optionally, its data type.
+      It doesn't change the memory config (buffer type / tensor memory layout /
+      grid) or device placement - those aggregate changes belong to
+      ttnn.to_tensor_spec.
+
+      ttnn.to_layout is produced by the TTNNDecomposeLayouts pass (alongside
+      to_device / to_memory_config / typecast) when it breaks down an aggregate
+      ttnn.to_tensor_spec.
 
       The output data type is derived from the result tensor's TTNNLayoutAttr
       encoding via the TTNN_DtypeOpInterface. The target page layout (tile vs
@@ -73,13 +78,43 @@ def TTNN_ToLayoutOp : TTNN_Op<"to_layout", [TTNN_LayoutOpInterface]> {
     let results = (outs AnyRankedTensor:$result);
 
     let hasFolder = 1;
-    let hasCanonicalizer = 1;
     let hasVerifier = 1;
 
     let extraClassDeclaration = [{
       // Returns true iff the input and result element data types differ,
       // i.e. this to_layout actually performs a dtype conversion as part of
       // the layout change.
+      bool hasDtypeChange();
+    }];
+}
+
+def TTNN_ToTensorSpecOp : TTNN_Op<"to_tensor_spec", [TTNN_TensorSpecInterface, TTNN_LayoutOpInterface]> {
+    let summary = "ToTensorSpec op.";
+    let description = [{
+      This op wraps all layout information gathered from ttir.toLayout (data type,
+      page layout, memory config and device placement). It is the aggregate op
+      that ttir.to_layout lowers to; it is used/updated by the optimizer to perform
+      optimizations, and later broken down into specific memory/layout operations
+      (to_layout, to_device, to_memory_config, typecast) by the TTNNDecomposeLayouts
+      pass. It never reaches flatbuffer serialization.
+
+      The output data type, target page layout (tile vs row-major) and memory config
+      are all derived from the result tensor's TTNNLayoutAttr encoding via the
+      TTNN_TensorSpecInterface. Whether this op actually changes dtype can be queried
+      via `hasDtypeChange()`.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input);
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasFolder = 1;
+    let hasCanonicalizer = 1;
+    let hasVerifier = 1;
+
+    let extraClassDeclaration = [{
+      // Returns true iff the input and result element data types differ,
+      // i.e. this to_tensor_spec actually performs a dtype conversion as part
+      // of the layout change.
       bool hasDtypeChange();
     }];
 }

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dRewritePattern.h
@@ -35,7 +35,7 @@ mlir::Value moveToHostRowMajorIfNeeded(ConvOp op,
     desiredDataType = ttcore::DataType::BFloat16;
   }
 
-  return utils::createToLayoutOp(
+  return utils::createToTensorSpecOp(
       op, value, rewriter, Layout::RowMajor, BufferType::SystemMemory,
       /*targetTensorMemoryLayout=*/nullptr, desiredDataType, locSuffix);
 }

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv3dRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv3dRewritePattern.h
@@ -27,7 +27,7 @@ mlir::Value convertToLayoutIfNeeded(Conv3dOp op,
     return nullptr;
   }
 
-  return utils::createToLayoutOp(
+  return utils::createToTensorSpecOp(
       op, tensor, rewriter, targetLayout, layoutAttr.getBufferType(),
       layoutAttr.getMemLayout(), layoutAttr.getDataType(), suffix);
 }

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.h
@@ -12,7 +12,7 @@
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
-// Creates a height-sharded L1 ToLayoutOp for the input of
+// Creates a height-sharded L1 ToTensorSpecOp for the input of
 // NLPConcatHeadsDecodeOp with virtual grid [batchSize, 1]. Returns
 // std::nullopt if input is already height-sharded in L1. Caller is
 // responsible for erasing the returned op if it is temporary.
@@ -20,8 +20,8 @@ std::optional<ToTensorSpecOp> getWorkaroundedInput(NLPConcatHeadsDecodeOp op,
                                                    PatternRewriter &rewriter);
 
 // NLPConcatHeadsDecodeOp requires height-sharded L1 input. This workaround
-// inserts a ToLayoutOp to convert the input to height-sharded L1 Tile layout
-// with virtual grid [batchSize, 1] if it isn't already sharded.
+// inserts a ToTensorSpecOp to convert the input to height-sharded L1 Tile
+// layout with virtual grid [batchSize, 1] if it isn't already sharded.
 class NLPConcatHeadsDecodeInputRewritePattern
     : public OpRewritePattern<ttnn::NLPConcatHeadsDecodeOp> {
 public:

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.h
@@ -16,8 +16,8 @@ namespace mlir::tt::ttnn::workarounds::decomposition {
 // NLPConcatHeadsDecodeOp with virtual grid [batchSize, 1]. Returns
 // std::nullopt if input is already height-sharded in L1. Caller is
 // responsible for erasing the returned op if it is temporary.
-std::optional<ToLayoutOp> getWorkaroundedInput(NLPConcatHeadsDecodeOp op,
-                                               PatternRewriter &rewriter);
+std::optional<ToTensorSpecOp> getWorkaroundedInput(NLPConcatHeadsDecodeOp op,
+                                                   PatternRewriter &rewriter);
 
 // NLPConcatHeadsDecodeOp requires height-sharded L1 input. This workaround
 // inserts a ToLayoutOp to convert the input to height-sharded L1 Tile layout

--- a/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
@@ -18,11 +18,13 @@ GetDeviceOp getOrInsertDevice(mlir::RewriterBase &rewriter,
 
 GetDeviceOp getOrInsertDevice(mlir::RewriterBase &rewriter, mlir::Block *block);
 
-// Helper method to insert a ToLayoutOp to convert the input operand to the
-// desired tensor layout, buffer type and memory layout. When targetGrid is
-// provided, the output encoding uses the given grid instead of deriving it
-// from the input layout.
-ToLayoutOp createToLayoutOp(
+// Helper method to insert a ToTensorSpecOp to convert the input operand to the
+// desired tensor layout, buffer type and memory layout. This is the aggregate
+// op that gets broken down by the TTNNDecomposeLayouts pass; use it whenever
+// the conversion changes memory config (buffer type / tensor memory layout /
+// grid) or device placement. When targetGrid is provided, the output encoding
+// uses the given grid instead of deriving it from the input layout.
+ToTensorSpecOp createToTensorSpecOp(
     mlir::Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
     RewriterBase &rewriter, Layout targetTensorLayout,
     BufferType targetTensorBufferType,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -173,7 +173,7 @@ public:
 
     RankedTensorType result = mlir::cast<RankedTensorType>(op.getType(0));
 
-    rewriter.replaceOpWithNewOp<ttnn::ToLayoutOp>(
+    rewriter.replaceOpWithNewOp<ttnn::ToTensorSpecOp>(
         op, this->getTypeConverter()->convertType(result), adaptor.getInput());
 
     return success();

--- a/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
+++ b/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
@@ -229,6 +229,31 @@ public:
   }
 };
 
+class TTNNToTensorSpecToTTIRToLayoutConversionPattern
+    : public mlir::OpConversionPattern<mlir::tt::ttnn::ToTensorSpecOp> {
+public:
+  using mlir::OpConversionPattern<
+      mlir::tt::ttnn::ToTensorSpecOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::ToTensorSpecOp srcOp,
+                  mlir::tt::ttnn::ToTensorSpecOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto outputType = mlir::cast<mlir::RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+
+    auto emptyOp = rewriter.create<mlir::tt::ttir::EmptyOp>(
+        srcOp.getLoc(), outputType.getShape(), outputType.getElementType(),
+        outputType.getEncoding());
+
+    rewriter.replaceOpWithNewOp<mlir::tt::ttir::ToLayoutOp>(
+        srcOp, mlir::TypeRange{outputType}, adaptor.getInput(), emptyOp,
+        /*layout=*/mlir::tt::ttcore::MetalLayoutAttr{});
+
+    return mlir::success();
+  }
+};
+
 class TTNNFullOpToTTIRFullOpConversionPattern
     : public mlir::OpConversionPattern<mlir::tt::ttnn::FullOp> {
 public:
@@ -407,6 +432,8 @@ void populateTTNNToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<TTNNMatmulToTTIRMatmulConversionPattern>(typeConverter, ctx);
   patterns.add<TTNNFullOpToTTIRFullOpConversionPattern>(typeConverter, ctx);
   patterns.add<TTNNToLayoutToTTIRToLayoutConversionPattern>(typeConverter, ctx);
+  patterns.add<TTNNToTensorSpecToTTIRToLayoutConversionPattern>(typeConverter,
+                                                                ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -456,7 +456,7 @@ void L1SpillManagement<MemoryTracker>::revalidateConsumers(
       if (!mlir::dyn_cast<OpModel>(consumer)) {
         continue;
       }
-      if (isa<ToLayoutOp>(consumer)) {
+      if (isa<ToTensorSpecOp>(consumer)) {
         continue;
       }
 
@@ -862,7 +862,7 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
       if (!mlir::dyn_cast<OpModel>(consumer)) {
         continue;
       }
-      if (isa<ToLayoutOp>(consumer)) {
+      if (isa<ToTensorSpecOp>(consumer)) {
         continue;
       }
 
@@ -1339,10 +1339,10 @@ void L1SpillManagement<MemoryTracker>::run() {
       continue;
     }
 
-    // ToLayoutOp requires special handling due to the fact it is a complex op
-    // which decomposes into few real TTNN ops. MemoryLayoutPropagation skips
+    // ToTensorSpecOp requires special handling due to the fact it is a complex
+    // op which decomposes into few real TTNN ops. MemoryLayoutPropagation skips
     // these, and pre-decomposition OpModel is impossible.
-    if (isa<ToLayoutOp>(op)) {
+    if (isa<ToTensorSpecOp>(op)) {
       auto resultType =
           mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
       auto lo =

--- a/lib/Dialect/TTNN/Analysis/LegalOpLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalOpLayoutAnalysis.cpp
@@ -38,7 +38,7 @@ static bool cantChangeOutputLayout(Operation *op) {
     return true;
   }
 
-  if (llvm::isa<ToLayoutOp>(op)) {
+  if (llvm::isa<ToTensorSpecOp>(op)) {
     return true;
   }
 

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -349,9 +349,9 @@ void MemoryLayoutPropagation::run() {
     if (!mlir::dyn_cast<OpModel>(op)) {
       return;
     }
-    // Skip ToLayoutOp -- these are inserted by earlier passes and their
+    // Skip ToTensorSpecOp -- these are inserted by earlier passes and their
     // layouts should be preserved, not re-decided by layout propagation.
-    if (isa<ToLayoutOp>(op)) {
+    if (isa<ToTensorSpecOp>(op)) {
       return;
     }
     if (!legalConfigs.count(op)) {
@@ -1516,7 +1516,7 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
       outputLayout.getLayout();
   Operation *reshardOp =
       pageLayoutChanges
-          ? builder.create<ToLayoutOp>(loc, newTensorType, operand)
+          ? builder.create<ToTensorSpecOp>(loc, newTensorType, operand)
                 .getOperation()
           : builder.create<ToMemoryConfigOp>(loc, newTensorType, operand)
                 .getOperation();

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2154,13 +2154,50 @@ static bool isValidDeviceLayout(TensorMemoryLayoutAttr memLayoutAttr) {
 //===----------------------------------------------------------------------===//
 
 ::mlir::LogicalResult ToLayoutOp::verify() {
-  return verifyTTNNLayoutInterface<ToLayoutOp>(*this);
+  if (mlir::failed(verifyTTNNLayoutInterface<ToLayoutOp>(*this))) {
+    return mlir::failure();
+  }
+
+  // ttnn.to_layout is the narrow layout op: it may only change the page layout
+  // (tile <-> row-major) and, optionally, the data type. It must not change
+  // memory config or device placement - those aggregate changes belong to
+  // ttnn.to_tensor_spec, which the TTNNDecomposeLayouts pass breaks down into
+  // to_device / to_memory_config / typecast / to_layout.
+  auto inputLayout = mlir::dyn_cast_if_present<TTNNLayoutAttr>(
+      getInput().getType().getEncoding());
+  auto outputLayout = mlir::dyn_cast_if_present<TTNNLayoutAttr>(
+      getResult().getType().getEncoding());
+  if (!inputLayout) {
+    return emitOpError("Input tensor type missing layout attribute");
+  }
+  if (!outputLayout) {
+    return emitOpError("Output tensor type missing layout attribute");
+  }
+
+  if (inputLayout.getBufferType() != outputLayout.getBufferType()) {
+    return emitOpError("ttnn.to_layout cannot change buffer type from '")
+           << stringifyBufferType(inputLayout.getBufferType()) << "' to '"
+           << stringifyBufferType(outputLayout.getBufferType())
+           << "'; use ttnn.to_tensor_spec for memory-config or device "
+              "placement changes";
+  }
+  if (inputLayout.getMemLayoutOpt() != outputLayout.getMemLayoutOpt()) {
+    return emitOpError("ttnn.to_layout cannot change tensor memory layout; use "
+                       "ttnn.to_tensor_spec for memory-config changes");
+  }
+  if (inputLayout.getGridShape() != outputLayout.getGridShape()) {
+    return emitOpError("ttnn.to_layout cannot change grid shape; use"
+                       "ttnn.to_tensor_spec for memory-config changes");
+  }
+
+  return mlir::success();
 }
 
 namespace {
-// ToLayoutOp can be folded if its input has the same layout as the output of
-// ToLayoutOp.
-mlir::OpFoldResult foldIdentityToLayoutOp(ttnn::ToLayoutOp op) {
+// A ToLayout-style op (ttnn.to_layout / ttnn.to_tensor_spec) can be folded if
+// its input has the same layout as the output of the op.
+template <typename OpTy>
+mlir::OpFoldResult foldIdentityToLayoutOp(OpTy op) {
   mlir::RankedTensorType inputType = op.getInput().getType();
   ttnn::TTNNLayoutAttr inputLayout =
       mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
@@ -2197,9 +2234,11 @@ mlir::OpFoldResult foldIdentityToLayoutOp(ttnn::ToLayoutOp op) {
 //      -----------------------
 //                |
 //
-mlir::OpFoldResult foldConsecutiveToLayoutOp(ttnn::ToLayoutOp op) {
-  // Get the input operand and verify that the previous op is ToLayoutOp.
-  ttnn::ToLayoutOp producerOp = op.getInput().getDefiningOp<ttnn::ToLayoutOp>();
+template <typename OpTy>
+mlir::OpFoldResult foldConsecutiveToLayoutOp(OpTy op) {
+  // Get the input operand and verify that the previous op is the same op type.
+  mlir::Value inputValue = op.getInput();
+  OpTy producerOp = inputValue.template getDefiningOp<OpTy>();
 
   if (!producerOp) {
     return nullptr;
@@ -2261,11 +2300,65 @@ mlir::OpFoldResult foldConsecutiveToLayoutOp(ttnn::ToLayoutOp op) {
 
   return op.getResult();
 }
+} // namespace
 
-// A ToLayoutOp whose input is produced by a TypecastOp can read the
+// Returns true iff input/result data types differ, i.e. this to_layout
+// actually performs a dtype conversion alongside the layout change.
+bool ttnn::ToLayoutOp::hasDtypeChange() {
+  auto inputDtype = ttnn::getDtypeFromValue(getInput());
+  auto resultDtype = ttnn::getDtypeFromValue(getResult());
+
+  // If we can't determine one of the dtypes, conservatively assume there is
+  // no dtype change so we don't drive a dtype-aware code path with stale
+  // information.
+  if (!inputDtype || !resultDtype) {
+    return false;
+  }
+
+  return inputDtype.getValue() != resultDtype.getValue();
+}
+
+// ToLayoutOp folder
+mlir::OpFoldResult ttnn::ToLayoutOp::fold(FoldAdaptor adaptor) {
+  if (auto foldResult = foldIdentityToLayoutOp(*this)) {
+    return foldResult;
+  }
+
+  if (auto foldResult = foldConsecutiveToLayoutOp(*this)) {
+    return foldResult;
+  }
+
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// ToTensorSpecOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult ToTensorSpecOp::verify() {
+  return verifyTTNNLayoutInterface<ToTensorSpecOp>(*this);
+}
+
+// Returns true iff input/result data types differ, i.e. this to_tensor_spec
+// actually performs a dtype conversion alongside the layout change.
+bool ttnn::ToTensorSpecOp::hasDtypeChange() {
+  auto inputDtype = ttnn::getDtypeFromValue(getInput());
+  auto resultDtype = ttnn::getDtypeFromValue(getResult());
+
+  // If we can't determine one of the dtypes, conservatively assume there is
+  // no dtype change so we don't drive a dtype-aware code path with stale
+  // information.
+  if (!inputDtype || !resultDtype) {
+    return false;
+  }
+
+  return inputDtype.getValue() != resultDtype.getValue();
+}
+
+// A ToTensorSpecOp whose input is produced by a TypecastOp can read the
 // pre-typecast value directly when the net dtype is a lossless round-trip:
 //
-//   x --typecast--> mid --to_layout(+layout L)--> out,   with out == dtype(x)
+//  x --typecast--> mid --to_tensor_spec(+layout L)--> out, with out == dtype(x)
 //
 // Collapsing cast(cast(x, mid), out) into cast(x, out) is value-preserving only
 // when the typecast widened losslessly (mid exactly represents x), so narrowing
@@ -2275,7 +2368,8 @@ mlir::OpFoldResult foldConsecutiveToLayoutOp(ttnn::ToLayoutOp op) {
 // FP->Int->FP. TTNN carries no conservative_folding attribute (it does not
 // survive TTIR->TTNN lowering), so we require a provably lossless producer
 // rather than relying on caller intent.
-mlir::OpFoldResult foldTypecastIntoToLayoutOp(ttnn::ToLayoutOp op) {
+static mlir::OpFoldResult
+foldTypecastIntoToTensorSpecOp(ttnn::ToTensorSpecOp op) {
   ttnn::TypecastOp typecastOp = op.getInput().getDefiningOp<ttnn::TypecastOp>();
   if (!typecastOp) {
     return nullptr;
@@ -2305,26 +2399,9 @@ mlir::OpFoldResult foldTypecastIntoToLayoutOp(ttnn::ToLayoutOp op) {
 
   return op.getResult();
 }
-} // namespace
 
-// Returns true iff input/result data types differ, i.e. this to_layout
-// actually performs a dtype conversion alongside the layout change.
-bool ttnn::ToLayoutOp::hasDtypeChange() {
-  auto inputDtype = ttnn::getDtypeFromValue(getInput());
-  auto resultDtype = ttnn::getDtypeFromValue(getResult());
-
-  // If we can't determine one of the dtypes, conservatively assume there is
-  // no dtype change so we don't drive a dtype-aware code path with stale
-  // information.
-  if (!inputDtype || !resultDtype) {
-    return false;
-  }
-
-  return inputDtype.getValue() != resultDtype.getValue();
-}
-
-// ToLayoutOp folder
-mlir::OpFoldResult ttnn::ToLayoutOp::fold(FoldAdaptor adaptor) {
+// ToTensorSpecOp folder
+mlir::OpFoldResult ttnn::ToTensorSpecOp::fold(FoldAdaptor adaptor) {
   if (auto foldResult = foldIdentityToLayoutOp(*this)) {
     return foldResult;
   }
@@ -2333,20 +2410,21 @@ mlir::OpFoldResult ttnn::ToLayoutOp::fold(FoldAdaptor adaptor) {
     return foldResult;
   }
 
-  if (auto foldResult = foldTypecastIntoToLayoutOp(*this)) {
+  if (auto foldResult = foldTypecastIntoToTensorSpecOp(*this)) {
     return foldResult;
   }
 
   return nullptr;
 }
 
-// ToLayoutOp canonicalization.
-void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
+// ToTensorSpecOp canonicalization.
+void mlir::tt::ttnn::ToTensorSpecOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
-  // Merge to layout op into TTNN creation ops.
-  patterns.add(+[](mlir::tt::ttnn::ToLayoutOp toLayoutOp,
+  // Merge to tensor spec op into TTNN creation ops.
+  patterns.add(+[](ToTensorSpecOp toTensorSpecOp,
                    mlir::PatternRewriter &rewriter) {
-    Operation *creationOp = toLayoutOp.getInput().getDefiningOp();
+    mlir::Value inputValue = toTensorSpecOp.getInput();
+    Operation *creationOp = inputValue.getDefiningOp();
     if (!creationOp ||
         !creationOp
              ->hasTrait<mlir::tt::ttcore::Trait::TTCoreCreationOpTrait>()) {
@@ -2364,18 +2442,18 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
     }
 
     auto ttnnLayoutAttr =
-        mlir::dyn_cast<TTNNLayoutAttr>(toLayoutOp.getType().getEncoding());
+        mlir::dyn_cast<TTNNLayoutAttr>(toTensorSpecOp.getType().getEncoding());
     if (!ttnnLayoutAttr) {
       return failure();
     }
 
     MemoryConfigAttr targetMemoryConfigAttr =
         mlir::cast<mlir::tt::ttnn::TTNNMemoryConfigOpInterface>(
-            toLayoutOp.getOperation())
+            toTensorSpecOp.getOperation())
             .getMemoryConfigAttr();
 
-    // If the to layout op tends to move the tensor to host, we can't merge it
-    // into creation op if creation op doesn't support execution on host. For
+    // If the to tensor spec op tends to move the tensor to host, we can't merge
+    // it into creation op if creation op doesn't support execution on host. For
     // example Rand and Empty op can only work on device.
     if (!creationOp->hasTrait<CanExecuteOnHostTrait>() &&
         (!targetMemoryConfigAttr ||
@@ -2399,7 +2477,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
     if (!deviceOperandInterface.getDevice() && newBufferType &&
         isDeviceBufferType(newBufferType.getValue())) {
       deviceOperandInterface.setDevice(
-          utils::getOrInsertDevice(rewriter, toLayoutOp));
+          utils::getOrInsertDevice(rewriter, toTensorSpecOp));
     } else if (deviceOperandInterface.getDevice() && newBufferType &&
                isSystemBufferType(newBufferType.getValue())) {
       // If the new buffer type is a system buffer type, we need to remove
@@ -2416,17 +2494,18 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
             .setElementType(ttnnLayoutAttr.getScalarElementType()));
 
     rewriter.finalizeOpModification(tensorSpecOp);
-    rewriter.replaceAllOpUsesWith(toLayoutOp, tensorSpecOp);
-    rewriter.eraseOp(toLayoutOp);
+    rewriter.replaceAllOpUsesWith(toTensorSpecOp, tensorSpecOp);
+    rewriter.eraseOp(toTensorSpecOp);
     return success();
   });
 
-  // Merging to layout op into TTNN empty op on host should produce ttnn.zeros
-  // op on host.
-  patterns.add(+[](mlir::tt::ttnn::ToLayoutOp toLayoutOp,
+  // Merging to tensor spec op into TTNN empty op on host should produce
+  // ttnn.zeros op on host.
+  patterns.add(+[](ToTensorSpecOp toTensorSpecOp,
                    mlir::PatternRewriter &rewriter) {
-    // Check if the toLayoutOp is being applied on a TTNN empty op
-    EmptyOp emptyOp = toLayoutOp.getInput().getDefiningOp<ttnn::EmptyOp>();
+    // Check if the toTensorSpecOp is being applied on a TTNN empty op
+    mlir::Value inputValue = toTensorSpecOp.getInput();
+    EmptyOp emptyOp = inputValue.getDefiningOp<ttnn::EmptyOp>();
     if (!emptyOp) {
       return mlir::failure();
     }
@@ -2439,10 +2518,10 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
     // Verify that the target buffer type is a system memory.
     BufferTypeAttr bufferTypeAttr = nullptr;
     if (mlir::cast<mlir::tt::ttnn::TTNNMemoryConfigOpInterface>(
-            toLayoutOp.getOperation())
+            toTensorSpecOp.getOperation())
             .getMemoryConfigAttr()) {
       bufferTypeAttr = mlir::cast<mlir::tt::ttnn::TTNNMemoryConfigOpInterface>(
-                           toLayoutOp.getOperation())
+                           toTensorSpecOp.getOperation())
                            .getMemoryConfigAttr()
                            .getBufferType();
     }
@@ -2455,10 +2534,11 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
     // encoding via the TTNN_DtypeOpInterface and no longer needs to be passed
     // through the builder.
     auto zerosOp = rewriter.replaceOpWithNewOp<mlir::tt::ttnn::ZerosOp>(
-        emptyOp, toLayoutOp.getType(), /*device=*/nullptr, emptyOp.getShape());
+        emptyOp, toTensorSpecOp.getType(), /*device=*/nullptr,
+        emptyOp.getShape());
 
-    rewriter.replaceAllOpUsesWith(toLayoutOp, zerosOp);
-    rewriter.eraseOp(toLayoutOp);
+    rewriter.replaceAllOpUsesWith(toTensorSpecOp, zerosOp);
+    rewriter.eraseOp(toTensorSpecOp);
     return mlir::success();
   });
 }

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1760,6 +1760,62 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// ToTensorSpecOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+//
+// to_tensor_spec is the aggregate op that ttir.to_layout lowers to and that
+// TTNNDecomposeLayouts breaks down into a ::ttnn::to_layout (plus to_device /
+// to_memory_config / typecast). Its cost is therefore modeled as the same
+// ::ttnn::to_layout query, so it reuses the ToLayoutOp op-model backend.
+
+llvm::Expected<op_model::OpConstraints>
+ToTensorSpecOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                 const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+  assert(opConfig.outputLayout && "ToTensorSpecOp requires output layout");
+  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
+
+  const auto inputShape = getInput().getType().getShape();
+
+  // Only signal a dtype conversion to the op model when this op is genuinely
+  // changing dtype. Use the resolved (candidate or intrinsic) output dtype,
+  // and compare it against the input dtype.
+  std::optional<ttcore::DataType> outputDtype = std::nullopt;
+  if (ttcore::DataTypeAttr dtype =
+          detail::resolveOutputDtype(getOperation(), opConfig.outputLayout)) {
+    if (dtype.getValue() != inputs[0].getDataType()) {
+      outputDtype = dtype.getValue();
+    }
+  }
+
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<ToLayoutOp>::getOpConstraints, *this, inputShape,
+      inputs[0], outputDtype, opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+ToTensorSpecOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+  assert(opConfig.outputLayout && "ToTensorSpecOp requires output layout");
+  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::optional<ttcore::DataType> outputDtype = std::nullopt;
+  if (ttcore::DataTypeAttr dtype =
+          detail::resolveOutputDtype(getOperation(), opConfig.outputLayout)) {
+    if (dtype.getValue() != inputs[0].getDataType()) {
+      outputDtype = dtype.getValue();
+    }
+  }
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<ToLayoutOp>::getOpRuntime, *this, inputShape, inputs[0],
+      outputDtype, opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // ToMemoryConfigOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1762,57 +1762,24 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // ToTensorSpecOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
-//
+
 // to_tensor_spec is the aggregate op that ttir.to_layout lowers to and that
-// TTNNDecomposeLayouts breaks down into a ::ttnn::to_layout (plus to_device /
-// to_memory_config / typecast). Its cost is therefore modeled as the same
-// ::ttnn::to_layout query, so it reuses the ToLayoutOp op-model backend.
+// TTNNDecomposeLayouts breaks down into to_layout, to_device, to_memory_config
+// and typecast ops. It is always decomposed before reaching a backend, so there
+// is no need to model it via the constraint API.
 
 llvm::Expected<op_model::OpConstraints>
 ToTensorSpecOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-  assert(opConfig.outputLayout && "ToTensorSpecOp requires output layout");
-  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
-
-  const auto inputShape = getInput().getType().getShape();
-
-  // Only signal a dtype conversion to the op model when this op is genuinely
-  // changing dtype. Use the resolved (candidate or intrinsic) output dtype,
-  // and compare it against the input dtype.
-  std::optional<ttcore::DataType> outputDtype = std::nullopt;
-  if (ttcore::DataTypeAttr dtype =
-          detail::resolveOutputDtype(getOperation(), opConfig.outputLayout)) {
-    if (dtype.getValue() != inputs[0].getDataType()) {
-      outputDtype = dtype.getValue();
-    }
-  }
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ToLayoutOp>::getOpConstraints, *this, inputShape,
-      inputs[0], outputDtype, opConfig.outputLayout);
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
 }
 
 llvm::Expected<size_t>
 ToTensorSpecOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-  assert(opConfig.outputLayout && "ToTensorSpecOp requires output layout");
-  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
-
-  const auto inputShape = getInput().getType().getShape();
-
-  std::optional<ttcore::DataType> outputDtype = std::nullopt;
-  if (ttcore::DataTypeAttr dtype =
-          detail::resolveOutputDtype(getOperation(), opConfig.outputLayout)) {
-    if (dtype.getValue() != inputs[0].getDataType()) {
-      outputDtype = dtype.getValue();
-    }
-  }
-
-  return opRuntimeCache().getOrCompute(
-      op_model::OpModel<ToLayoutOp>::getOpRuntime, *this, inputShape, inputs[0],
-      outputDtype, opConfig.outputLayout);
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
@@ -142,8 +142,8 @@ public:
         if (!mlir::dyn_cast<OpModel>(op)) {
           return;
         }
-        // Skip ToLayoutOp -- their layouts are set by other passes.
-        if (isa<ToLayoutOp>(op)) {
+        // Skip ToTensorSpecOp -- their layouts are set by other passes.
+        if (isa<ToTensorSpecOp>(op)) {
           return;
         }
 

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -111,9 +111,10 @@ void applyOutputLayoutRevert(Operation *operation, size_t resultIndex,
                              TTNNLayoutAttr actualOutputLayout,
                              TTNNLayoutAttr expectedOutputLayout);
 
-ToLayoutOp createToLayoutOp(OpBuilder &builder, Location loc,
-                            RankedTensorType resultType, Value inputValue,
-                            TTNNLayoutAttr targetLayout);
+ToTensorSpecOp createToTensorSpecOp(OpBuilder &builder, Location loc,
+                                    RankedTensorType resultType,
+                                    Value inputValue,
+                                    TTNNLayoutAttr targetLayout);
 
 // Try fallback configurations for a failed operation
 bool tryFallbacks(Operation *operation,
@@ -165,9 +166,9 @@ public:
 
     moduleOp->walk([&](func::FuncOp func) {
       func.walk([&](Operation *operation) -> WalkResult {
-        if (auto toLayoutOp = mlir::dyn_cast<ttnn::ToLayoutOp>(operation)) {
-          // Skip ToLayout operations - they will be decomposed later, so there
-          // is no point in validating them here.
+        if (mlir::isa<ttnn::ToTensorSpecOp>(operation)) {
+          // Skip ToTensorSpec operations - they will be decomposed later, so
+          // there is no point in validating them here.
           return WalkResult::skip();
         }
 
@@ -824,12 +825,12 @@ void applyInputOperandChange(Operation *operation, size_t operandIndex,
 
   // Insert ToLayout operation to perform the transformation
   OpBuilder builder(operation);
-  auto toLayoutOp =
-      createToLayoutOp(builder, operation->getLoc(), currentTensorType, operand,
-                       targetLayoutAttr);
+  auto toTensorSpecOp =
+      createToTensorSpecOp(builder, operation->getLoc(), currentTensorType,
+                           operand, targetLayoutAttr);
 
-  // Replace the operand with the result of ToLayout
-  operation->setOperand(operandIndex, toLayoutOp.getResult());
+  // Replace the operand with the result of ToTensorSpec
+  operation->setOperand(operandIndex, toTensorSpecOp.getResult());
 
   TTMLIR_DEBUG(
       ttmlir::LogComponent::ValidationFallback,
@@ -871,32 +872,33 @@ void applyOutputLayoutRevert(Operation *operation, size_t resultIndex,
   OpBuilder builder(operation->getContext());
   builder.setInsertionPointAfter(operation);
 
-  auto revertToLayoutOp =
-      createToLayoutOp(builder,
-                       ttmlir::utils::appendLocationSuffix(operation->getLoc(),
-                                                           "_revert_layout"),
-                       currentResultType, result, expectedOutputLayout);
+  auto revertToTensorSpecOp =
+      createToTensorSpecOp(builder,
+                           ttmlir::utils::appendLocationSuffix(
+                               operation->getLoc(), "_revert_layout"),
+                           currentResultType, result, expectedOutputLayout);
 
   TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
-               "Inserted revert ToLayout op after operation {} to restore "
+               "Inserted revert ToTensorSpec op after operation {} to restore "
                "expected layout",
                operation->getName());
 
   // Update all saved uses to point to the revert operation instead
   for (auto &use : uses) {
     Operation *useOp = use.first;
-    useOp->setOperand(use.second, revertToLayoutOp.getResult());
+    useOp->setOperand(use.second, revertToTensorSpecOp.getResult());
     TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                  "Updated consumer {}@{} to use reverted layout",
                  useOp->getName(), useOp->getLoc());
   }
 }
 
-ToLayoutOp createToLayoutOp(OpBuilder &builder, Location loc,
-                            RankedTensorType currentResultType,
-                            Value inputValue, TTNNLayoutAttr targetLayout) {
+ToTensorSpecOp createToTensorSpecOp(OpBuilder &builder, Location loc,
+                                    RankedTensorType currentResultType,
+                                    Value inputValue,
+                                    TTNNLayoutAttr targetLayout) {
 
-  // Create result type for ToLayoutOp, which has the same shape as
+  // Create result type for ToTensorSpecOp, which has the same shape as
   // currentResultType but use scalar element type and encoding from
   // targetLayout
   Type scalarElementType = mlir::tt::ttcore::dataTypeToElementType(
@@ -904,7 +906,7 @@ ToLayoutOp createToLayoutOp(OpBuilder &builder, Location loc,
   RankedTensorType resultType = RankedTensorType::get(
       currentResultType.getShape(), scalarElementType, targetLayout);
 
-  return builder.create<ToLayoutOp>(loc, resultType, inputValue);
+  return builder.create<ToTensorSpecOp>(loc, resultType, inputValue);
 }
 
 // Try config fallbacks for Conv2d-like operations

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -823,7 +823,7 @@ void applyInputOperandChange(Operation *operation, size_t operandIndex,
   Value operand = operation->getOperand(operandIndex);
   auto currentTensorType = mlir::cast<RankedTensorType>(operand.getType());
 
-  // Insert ToLayout operation to perform the transformation
+  // Insert ToTensorSpec operation to perform the transformation
   OpBuilder builder(operation);
   auto toTensorSpecOp =
       createToTensorSpecOp(builder, operation->getLoc(), currentTensorType,
@@ -867,7 +867,7 @@ void applyOutputLayoutRevert(Operation *operation, size_t resultIndex,
     uses.emplace_back(use.getOwner(), use.getOperandNumber());
   }
 
-  // Insert ToLayoutOp after the operation to revert back to the original
+  // Insert ToTensorSpecOp after the operation to revert back to the original
   // expected layout
   OpBuilder builder(operation->getContext());
   builder.setInsertionPointAfter(operation);

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/RowMajorLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/RowMajorLayoutPropagation.cpp
@@ -72,11 +72,11 @@ public:
       llvm::SmallVector<Value> funcInputArguments =
           identifyInputArguments(func);
 
-      llvm::SmallVector<ttnn::ToLayoutOp> toRemoveToLayoutOps =
-          findRedundantToLayoutOps(funcInputArguments);
+      llvm::SmallVector<ttnn::ToTensorSpecOp> toRemoveToTensorSpecOps =
+          findRedundantToTensorSpecOps(funcInputArguments);
 
       llvm::SmallVector<Value> rowMajorArgs =
-          bypassRedundantToLayoutOps(toRemoveToLayoutOps);
+          bypassRedundantToTensorSpecOps(toRemoveToTensorSpecOps);
 
       llvm::DenseMap<Operation *, Layout> opLayoutConstraints;
       propagateRowMajorLayout(func, rowMajorArgs, opLayoutConstraints);
@@ -123,9 +123,9 @@ private:
   // Finds ToLayoutOps that convert RowMajor layout to Tiled layout on function
   // inputs. Such ToLayoutOps are redundant and can be removed. Returns the
   // list of ToLayoutOps to be removed.
-  llvm::SmallVector<ttnn::ToLayoutOp>
-  findRedundantToLayoutOps(const llvm::SmallVector<Value> &inputArgs) {
-    llvm::SmallVector<ttnn::ToLayoutOp> opsToRemove;
+  llvm::SmallVector<ttnn::ToTensorSpecOp>
+  findRedundantToTensorSpecOps(const llvm::SmallVector<Value> &inputArgs) {
+    llvm::SmallVector<ttnn::ToTensorSpecOp> opsToRemove;
     for (Value arg : inputArgs) {
       auto tensorType = mlir::dyn_cast<RankedTensorType>(arg.getType());
       TTNNLayoutAttr argTTNNLayout =
@@ -139,17 +139,18 @@ private:
       }
 
       for (const auto &user : arg.getUsers()) {
-        if (!mlir::isa<ttnn::ToLayoutOp>(user)) {
+        if (!mlir::isa<ttnn::ToTensorSpecOp>(user)) {
           continue;
         }
-        ttnn::ToLayoutOp toLayoutOp = mlir::dyn_cast<ttnn::ToLayoutOp>(user);
+        ttnn::ToTensorSpecOp toLayoutOp =
+            mlir::dyn_cast<ttnn::ToTensorSpecOp>(user);
 
         TTNNLayoutAttr targetLayout = mlir::cast<ttnn::TTNNLayoutAttr>(
             mlir::cast<RankedTensorType>(toLayoutOp->getResult(0).getType())
                 .getEncoding());
         assert(targetLayout && "Expected TTNNLayoutAttr on ToLayoutOp result");
         if (!targetLayout.isTiled()) {
-          // This toLayout keeps RM layout, so we can skip it.
+          // This ToTensorSpecOp keeps RM layout, so we can skip it.
           continue;
         }
 
@@ -161,7 +162,7 @@ private:
           opsToRemove.push_back(toLayoutOp);
           TTMLIR_DEBUG(ttmlir::LogComponent::RMPropagation,
                        "Arg layout {} differs from target layout {} only in "
-                       "page layout, we can remove ToLayoutOp {}",
+                       "page layout, we can remove ToTensorSpecOp {}",
                        argTTNNLayout, targetLayout, toLayoutOp);
         }
       }
@@ -169,16 +170,17 @@ private:
     return opsToRemove;
   }
 
-  // Bypasses given ToLayoutOps by rewiring their inputs to their users. Returns
-  // the list of argument Values that were inputs to the removed ToLayoutOps.
-  llvm::SmallVector<Value> bypassRedundantToLayoutOps(
-      llvm::SmallVector<ttnn::ToLayoutOp> &toRemoveToLayoutOps) {
+  // Bypasses given ToTensorSpecOps by rewiring their inputs to their users.
+  // Returns the list of argument Values that were inputs to the removed
+  // ToTensorSpecOps.
+  llvm::SmallVector<Value> bypassRedundantToTensorSpecOps(
+      llvm::SmallVector<ttnn::ToTensorSpecOp> &toRemoveToTensorSpecOps) {
     SmallVector<Value> rmArgs;
-    for (ttnn::ToLayoutOp &toLayoutOp : toRemoveToLayoutOps) {
-      Value arg = toLayoutOp.getInput();
+    for (ttnn::ToTensorSpecOp &toTensorSpecOp : toRemoveToTensorSpecOps) {
+      Value arg = toTensorSpecOp.getInput();
 
       llvm::SmallVector<std::pair<Operation *, unsigned>> uses;
-      for (auto &use : toLayoutOp->getResult(0).getUses()) {
+      for (auto &use : toTensorSpecOp->getResult(0).getUses()) {
         uses.emplace_back(use.getOwner(), use.getOperandNumber());
       }
 
@@ -189,8 +191,8 @@ private:
       rmArgs.push_back(arg);
 
       TTMLIR_DEBUG(ttmlir::LogComponent::RMPropagation,
-                   "Bypassing and erasing ToLayoutOp {}", toLayoutOp);
-      toLayoutOp.erase();
+                   "Bypassing and erasing ToTensorSpecOp {}", toTensorSpecOp);
+      toTensorSpecOp.erase();
     }
     return rmArgs;
   }
@@ -227,7 +229,7 @@ private:
         TTNNLayoutAttr::Builder(rmOutputLayout, userResultType.getShape())
             .setElementType(tensorElementType);
 
-    auto toLayoutOp = utils::createToLayoutOp(
+    auto toTensorSpecOp = utils::createToTensorSpecOp(
         user,
         mlir::cast<mlir::TypedValue<RankedTensorType>>(user->getResult(0)),
         rewriter, rmLayoutWithTargetDtype.getLayout(),
@@ -235,9 +237,10 @@ private:
         rmLayoutWithTargetDtype.getMemLayout(),
         rmLayoutWithTargetDtype.getDataType(), "_dtype_conversion");
 
-    user->getResult(0).replaceAllUsesExcept(toLayoutOp.getResult(), toLayoutOp);
+    user->getResult(0).replaceAllUsesExcept(toTensorSpecOp.getResult(),
+                                            toTensorSpecOp);
 
-    return toLayoutOp.getResult();
+    return toTensorSpecOp.getResult();
   }
 
   // Propagates RowMajor layout through the function starting from the given
@@ -318,11 +321,12 @@ private:
   // error. Returns the RowMajor output layout if operation is valid.
   llvm::Expected<TTNNLayoutAttr>
   opStopsRowMajorPropagation(Operation *op, unsigned operandIdx) {
-    if (auto toLayoutOp = mlir::dyn_cast<ttnn::ToLayoutOp>(op)) {
+    if (auto toTensorSpecOp = mlir::dyn_cast<ttnn::ToTensorSpecOp>(op)) {
       TTMLIR_DEBUG(ttmlir::LogComponent::RMPropagation,
-                   "Stopping RM propagation at ToLayoutOp {}", toLayoutOp);
+                   "Stopping RM propagation at ToTensorSpecOp {}",
+                   toTensorSpecOp);
       return llvm::make_error<llvm::StringError>(
-          "Stopping RM propagation at ToLayoutOp",
+          "Stopping RM propagation at ToTensorSpecOp",
           llvm::inconvertibleErrorCode());
     }
 
@@ -401,14 +405,14 @@ private:
             .setLayout(Layout::Tile);
 
     rewriter.setInsertionPoint(consumer);
-    auto toLayoutOp = utils::createToLayoutOp(
+    auto toTensorSpecOp = utils::createToTensorSpecOp(
         consumer,
         mlir::cast<mlir::TypedValue<RankedTensorType>>(propagatedValue),
         rewriter, tiledLayout.getLayout(), tiledLayout.getBufferType(),
         tiledLayout.getMemLayout(), tiledLayout.getDataType(),
         "_stop_propagation_conversion");
 
-    consumerOperand.set(toLayoutOp.getResult());
+    consumerOperand.set(toTensorSpecOp.getResult());
   }
 
   // Handles ReturnOp during propagation. Checks if actual layout matches
@@ -447,13 +451,13 @@ private:
 
     rewriter.setInsertionPoint(returnOp);
 
-    auto toLayoutOp = utils::createToLayoutOp(
+    auto toTensorSpecOp = utils::createToTensorSpecOp(
         returnOp, mlir::cast<mlir::TypedValue<RankedTensorType>>(previousOp),
         rewriter, expectedLayout.getLayout(), expectedLayout.getBufferType(),
         expectedLayout.getMemLayout(), expectedLayout.getDataType(),
         "_return_conversion");
 
-    returnOp.setOperand(operandIdx, toLayoutOp.getResult());
+    returnOp.setOperand(operandIdx, toTensorSpecOp.getResult());
   }
 
   // Extract OpConfig from operation's IR

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv3dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv3dWeights.cpp
@@ -52,7 +52,7 @@ private:
           mlir::cast<TTNNLayoutAttr>(weight.getType().getEncoding());
       if (weightLayout.getLayout() != Layout::Tile) {
         rewriter.setInsertionPoint(convOp);
-        ToLayoutOp toTileOp = utils::createToLayoutOp(
+        ToTensorSpecOp toTileOp = utils::createToTensorSpecOp(
             convOp, weight, rewriter, Layout::Tile,
             weightLayout.getBufferType(), weightLayout.getMemLayout(),
             weightLayout.getDataType(), "_prepare_conv3d_weight_to_tile");
@@ -95,13 +95,13 @@ private:
         mlir::cast<TTNNLayoutAttr>(rawWeight.getType().getEncoding());
     if (rawWeightLayout.getLayout() != Layout::RowMajor ||
         rawWeightLayout.getBufferType() != BufferType::SystemMemory) {
-      rawWeight =
-          utils::createToLayoutOp(convOp, rawWeight, rewriter, Layout::RowMajor,
-                                  BufferType::SystemMemory,
-                                  /*targetTensorMemoryLayout=*/nullptr,
-                                  rawWeightLayout.getDataType(),
-                                  "_prepare_conv3d_weight_to_row_major")
-              .getResult();
+      rawWeight = utils::createToTensorSpecOp(
+                      convOp, rawWeight, rewriter, Layout::RowMajor,
+                      BufferType::SystemMemory,
+                      /*targetTensorMemoryLayout=*/nullptr,
+                      rawWeightLayout.getDataType(),
+                      "_prepare_conv3d_weight_to_row_major")
+                      .getResult();
     }
 
     auto prepareOp = rewriter.create<PrepareConv3dWeightsOp>(
@@ -119,7 +119,7 @@ private:
     // constraint on the weight (its input was the raw 5D weight).
     auto preparedLayout =
         mlir::cast<TTNNLayoutAttr>(preparedWeightType.getEncoding());
-    ToLayoutOp toTileOp = utils::createToLayoutOp(
+    ToTensorSpecOp toTileOp = utils::createToTensorSpecOp(
         convOp, prepareOp.getResult(), rewriter, Layout::Tile,
         preparedLayout.getBufferType(), preparedLayout.getMemLayout(),
         preparedLayout.getDataType(), "_prepare_conv3d_weight_to_tile");

--- a/lib/Dialect/TTNN/Transforms/TTNNConstEvalInputsToSystemMemory.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNConstEvalInputsToSystemMemory.cpp
@@ -63,15 +63,15 @@ static bool shouldTransferArgumentToDevice(BlockArgument blockArgument) {
     return true;
   }
 
-  auto toLayoutOp =
-      mlir::dyn_cast<ttnn::ToLayoutOp>(*blockArgument.getUsers().begin());
+  auto toTensorSpecOp =
+      mlir::dyn_cast<ttnn::ToTensorSpecOp>(*blockArgument.getUsers().begin());
 
-  if (!toLayoutOp) {
+  if (!toTensorSpecOp) {
     return true;
   }
 
   return mlir::cast<mlir::tt::ttnn::TTNNMemoryConfigOpInterface>(
-             toLayoutOp.getOperation())
+             toTensorSpecOp.getOperation())
              .getMemoryConfigAttr()
              .getBufferType()
              .getValue() != BufferType::SystemMemory;
@@ -173,13 +173,14 @@ static void convertArgumentOfConstEvalFunc(func::FuncOp constEvalFuncOp,
     auto deviceTensorType =
         mlir::cast<RankedTensorType>(blockArgument.getType());
 
-    // Create to_layout op to convert the argument to the original layout.
-    auto toLayoutOp = builder.create<ttnn::ToLayoutOp>(
+    // Create to_tensor_spec op to convert the argument to the original layout.
+    auto toTensorSpecOp = builder.create<ttnn::ToTensorSpecOp>(
         blockArgument.getLoc(), deviceTensorType, blockArgument);
 
-    // Replace the argument usages with the to_layout op result.
+    // Replace the argument usages with the to_tensor_spec op result.
     //
-    blockArgument.replaceAllUsesExcept(toLayoutOp.getResult(), toLayoutOp);
+    blockArgument.replaceAllUsesExcept(toTensorSpecOp.getResult(),
+                                       toTensorSpecOp);
   }
 
   // Finally, update the block argument type and the function type.

--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -59,14 +59,17 @@ public:
       assert(func.getBody().hasOneBlock() &&
              "Found func that didn't have one block!");
       func->walk([&](Operation *op) {
-        if (!isa<ttnn::ToLayoutOp>(op)) {
+        if (!isa<ttnn::ToTensorSpecOp>(op)) {
+          assert(!isa<ttnn::ToLayoutOp>(op) &&
+                 "ttnn.to_layout op should not be present before "
+                 "TTNNDecomposeLayouts pass. Use ttnn.to_tensor_spec instead.");
           return;
         }
         opsToReplace.push_back(op);
       });
     });
     for (Operation *op : opsToReplace) {
-      if (failed(createLayoutConversionOps(mlir::cast<ttnn::ToLayoutOp>(op),
+      if (failed(createLayoutConversionOps(mlir::cast<ttnn::ToTensorSpecOp>(op),
                                            rewriter))) {
         signalPassFailure();
         return;
@@ -92,7 +95,7 @@ private:
 
   // True if the result of `op` feeds a CPU-hoisted function call. We move to
   // host first and perform the layout/typecast there.
-  bool isInputToCPUHoistedFunction(ttnn::ToLayoutOp op) const {
+  bool isInputToCPUHoistedFunction(ttnn::ToTensorSpecOp op) const {
     if (!op.getResult().hasOneUse()) {
       return false;
     }
@@ -201,7 +204,7 @@ private:
   //===--------------------------------------------------------------------===//
 
   std::pair<TTNNLayoutAttr, TTNNLayoutAttr>
-  getInputOutputLayouts(ttnn::ToLayoutOp op) const {
+  getInputOutputLayouts(ttnn::ToTensorSpecOp op) const {
     auto inputLayoutAttr =
         mlir::cast<TTNNLayoutAttr>(op.getInput().getType().getEncoding());
     auto outputLayoutAttr =
@@ -524,7 +527,7 @@ private:
   // Orchestration.
   //===--------------------------------------------------------------------===//
 
-  mlir::LogicalResult createLayoutConversionOps(ttnn::ToLayoutOp op,
+  mlir::LogicalResult createLayoutConversionOps(ttnn::ToTensorSpecOp op,
                                                 IRRewriter &rewriter) const {
     auto [input, output] = getInputOutputLayouts(op);
 
@@ -546,8 +549,8 @@ private:
   }
 
   // Emits the layout/dtype/memory conversion ops and returns the final value.
-  mlir::Value buildLayoutConversion(ttnn::ToLayoutOp op, IRRewriter &rewriter,
-                                    TTNNLayoutAttr input,
+  mlir::Value buildLayoutConversion(ttnn::ToTensorSpecOp op,
+                                    IRRewriter &rewriter, TTNNLayoutAttr input,
                                     TTNNLayoutAttr output) const {
     mlir::Value current = op.getInput();
 

--- a/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
@@ -989,7 +989,7 @@ public:
           mlir::dyn_cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
 
       if (inputLayout && inputLayout.isTiled()) {
-        auto rowMajorInput = utils::createToLayoutOp(
+        auto rowMajorInput = utils::createToTensorSpecOp(
             op, mlir::cast<mlir::TypedValue<RankedTensorType>>(permuteInput),
             rewriter, Layout::RowMajor, inputLayout.getBufferType(),
             inputLayout.getMemLayout(), inputLayout.getDataType(),
@@ -1014,7 +1014,7 @@ public:
         reshapeUser.getLoc(), rowMajorReshapeResultType, reshapeInput,
         reshapeUser.getShapeAttr());
 
-    auto restoredLayout = utils::createToLayoutOp(
+    auto restoredLayout = utils::createToTensorSpecOp(
         reshapeUser,
         mlir::cast<mlir::TypedValue<RankedTensorType>>(
             newReshapeOp.getResult()),
@@ -1109,7 +1109,7 @@ public:
           mlir::dyn_cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
 
       if (inputLayout && inputLayout.isTiled()) {
-        auto rowMajorInput = utils::createToLayoutOp(
+        auto rowMajorInput = utils::createToTensorSpecOp(
             op, mlir::cast<mlir::TypedValue<RankedTensorType>>(reshapeInput),
             rewriter, Layout::RowMajor, inputLayout.getBufferType(),
             inputLayout.getMemLayout(), inputLayout.getDataType(),
@@ -1127,7 +1127,7 @@ public:
         newReshapeOp.getResult(), permuteUser.getPermutation(),
         permuteUser.getPadValue());
 
-    auto restoredLayout = utils::createToLayoutOp(
+    auto restoredLayout = utils::createToTensorSpecOp(
         permuteUser,
         mlir::cast<mlir::TypedValue<RankedTensorType>>(
             newPermuteOp.getResult()),

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -646,38 +646,40 @@ private:
       RankedTensorType currentTensorType =
           mlir::cast<RankedTensorType>(arg.getType());
 
-      ttnn::ToLayoutOp layoutOp = nullptr;
+      ttnn::ToTensorSpecOp tensorSpecOp = nullptr;
 
-      // Check if argument has only one use and it's a ToLayoutOp.
+      // Check if argument has only one use and it's a ToTensorSpecOp.
       if (arg.hasOneUse()) {
         auto *user = *arg.getUsers().begin();
-        if (auto directLayoutOp = mlir::dyn_cast<ttnn::ToLayoutOp>(user)) {
-          layoutOp = directLayoutOp;
+        if (auto directTensorSpecOp =
+                mlir::dyn_cast<ttnn::ToTensorSpecOp>(user)) {
+          tensorSpecOp = directTensorSpecOp;
         }
       }
 
-      // If there's no ToLayoutOp pattern, keep the original type.
-      if (!layoutOp) {
+      // If there's no ToTensorSpecOp pattern, keep the original type.
+      if (!tensorSpecOp) {
         newInputTypes.push_back(currentTensorType);
         continue;
       }
 
-      // Get the target type from the ToLayoutOp and update the function
+      // Get the target type from the ToTensorSpecOp and update the function
       // argument type directly.
-      RankedTensorType targetTensorType = layoutOp.getResult().getType();
+      RankedTensorType targetTensorType = tensorSpecOp.getResult().getType();
       TTNNLayoutAttr targetLayoutAttr =
           utils::getLayoutAttrFromTensor(targetTensorType);
       TTNNLayoutAttr currentLayoutAttr =
           utils::getLayoutAttrFromTensor(currentTensorType);
       if (targetLayoutAttr.getDataType() != currentLayoutAttr.getDataType()) {
-        return funcOp.emitError("ToLayoutOp changed data type for argument ")
+        return funcOp.emitError(
+                   "ToTensorSpecOp changed data type for argument ")
                << argIdx << ", expected only buffer type change";
       }
       newInputTypes.push_back(targetTensorType);
 
-      // Replace all uses of ToLayoutOp with the function argument.
-      layoutOp.getResult().replaceAllUsesWith(arg);
-      opsToErase.push_back(layoutOp);
+      // Replace all uses of ToTensorSpecOp with the function argument.
+      tensorSpecOp.getResult().replaceAllUsesWith(arg);
+      opsToErase.push_back(tensorSpecOp);
 
       hasChanges = true;
     }
@@ -790,14 +792,14 @@ private:
       }
       // For inputs, convert them to system memory/row major if needed
       else if (layout.getBufferType() != ttnn::BufferType::SystemMemory) {
-        // Convert to system memory using ToLayoutOp
+        // Convert to system memory using ToTensorSpecOp
         RankedTensorType systemMemoryTileType =
             utils::RankedTensorTypeFactory::create(
                 tensorType, ttnn::BufferType::SystemMemory);
 
-        auto toLayoutOp = builder.create<ttnn::ToLayoutOp>(
+        auto toTensorSpecOp = builder.create<ttnn::ToTensorSpecOp>(
             funcOp.getLoc(), systemMemoryTileType, input);
-        tensorInputs.push_back(toLayoutOp.getResult());
+        tensorInputs.push_back(toTensorSpecOp.getResult());
       } else {
         // Already on system memory
         tensorInputs.push_back(input);

--- a/lib/Dialect/TTNN/Transforms/TTNNUniqueLocs.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNUniqueLocs.cpp
@@ -40,7 +40,7 @@ public:
         return;
       }
 
-      if (mlir::isa<ToLayoutOp>(op)) {
+      if (mlir::isa<ToTensorSpecOp>(op)) {
         return;
       }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
@@ -101,10 +101,10 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
     return failure();
   }
 
-  // Apply ToLayoutOp to convert the input tensor to width-sharded L1.
+  // Apply ToTensorSpecOp to convert the input tensor to width-sharded L1.
   RankedTensorType memoryConfigedInputType =
       inputType.cloneWithEncoding(desiredInputLayout);
-  auto inputToLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
+  auto inputToTensorSpecOp = rewriter.create<ttnn::ToTensorSpecOp>(
       op.getLoc(), memoryConfigedInputType, op.getInput());
 
   // The fused kernel requires the weight in ROW_MAJOR layout. The 1D->2D
@@ -129,9 +129,9 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
               .setLayout(ttnn::Layout::RowMajor);
       RankedTensorType rowMajorWeightType =
           weightType.cloneWithEncoding(rowMajorLayout);
-      auto weightToLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
+      auto weightToTensorSpecOp = rewriter.create<ttnn::ToTensorSpecOp>(
           op.getLoc(), rowMajorWeightType, weight);
-      weight = weightToLayoutOp.getResult();
+      weight = weightToTensorSpecOp.getResult();
     }
   }
 
@@ -146,9 +146,9 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
     if (residualLayout != desiredInputLayout) {
       RankedTensorType shardedResidualType =
           residualType.cloneWithEncoding(desiredInputLayout);
-      auto residualToLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
+      auto residualToTensorSpecOp = rewriter.create<ttnn::ToTensorSpecOp>(
           op.getLoc(), shardedResidualType, residual);
-      residual = residualToLayoutOp.getResult();
+      residual = residualToTensorSpecOp.getResult();
     }
   }
 
@@ -210,7 +210,7 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
   // the TTNNAllocateDistributedOpBuffers / TTNNAllocateDistributedOpSemaphores
   // passes (see DistributedOpInterface implementation in TTNNOps.cpp).
   auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
-      op.getLoc(), shardedOutputType, inputToLayoutOp.getResult(), weight,
+      op.getLoc(), shardedOutputType, inputToTensorSpecOp.getResult(), weight,
       residual, /*stats=*/nullptr, /*semaphore=*/nullptr, op.getDevice(),
       static_cast<uint32_t>(op.getClusterAxis()), op.getEpsilon(),
       op.getSubDeviceIdAttr(), op.getNumLinksAttr(), op.getTopologyAttr(),

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeGptLayoutRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeGptLayoutRewritePattern.cpp
@@ -90,10 +90,11 @@ Value buildPreparedWeight(PatternRewriter &rewriter, Operation *anchor,
       weightType, BufferType::SystemMemory);
   Value hostWeight = rewriter.create<FromDeviceOp>(loc, hostType, weight);
 
-  // Step 2: to_layout TILE on host (no dtype).
+  // Step 2: to layout TILE on host (no dtype).
   auto hostTiledType =
       utils::RankedTensorTypeFactory::create(hostType, Layout::Tile);
-  Value hostTiled = rewriter.create<ToLayoutOp>(loc, hostTiledType, hostWeight);
+  Value hostTiled =
+      rewriter.create<ToTensorSpecOp>(loc, hostTiledType, hostWeight);
 
   // Step 3: typecast to bfp4 on host.
   auto hostBfp4Type = utils::RankedTensorTypeFactory::create(

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.cpp
@@ -12,8 +12,8 @@
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
-std::optional<ToLayoutOp> getWorkaroundedInput(NLPConcatHeadsDecodeOp op,
-                                               PatternRewriter &rewriter) {
+std::optional<ToTensorSpecOp> getWorkaroundedInput(NLPConcatHeadsDecodeOp op,
+                                                   PatternRewriter &rewriter) {
   auto inputType = mlir::cast<RankedTensorType>(op.getInput().getType());
   TTNNLayoutAttr inputLayout = utils::getLayoutAttrFromTensor(inputType);
 
@@ -39,7 +39,7 @@ std::optional<ToLayoutOp> getWorkaroundedInput(NLPConcatHeadsDecodeOp op,
   auto dataType = ttcore::elementTypeToDataType(inputElementType);
 
   rewriter.setInsertionPoint(op);
-  return utils::createToLayoutOp(
+  return utils::createToTensorSpecOp(
       op, mlir::cast<mlir::TypedValue<RankedTensorType>>(op.getInput()),
       rewriter, Layout::Tile, BufferType::L1, memLayoutAttr, dataType,
       /*locSuffix=*/"", llvm::ArrayRef<int64_t>(virtualGridSize));

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
@@ -53,17 +53,17 @@ LogicalResult PagedUpdateCacheOpRewritePattern::matchAndRewrite(
     return failure();
   }
 
-  // Apply ToLayoutOp to convert the input tensor to the desired layout.
+  // Apply ToTensorSpecOp to convert the input tensor to the desired layout.
   RankedTensorType memoryConfigedInputType =
       inputType.cloneWithEncoding(desiredInputLayout);
-  auto toLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
+  auto toTensorSpecOp = rewriter.create<ttnn::ToTensorSpecOp>(
       op.getLoc(), memoryConfigedInputType, op.getInput());
 
   // Replace the original PagedUpdateCacheOp with one which takes our properly
   // configured input tensor.
   auto pagedUpdateCacheOp = rewriter.create<ttnn::PagedUpdateCacheOp>(
-      op.getLoc(), op.getCache(), toLayoutOp.getResult(), op.getUpdateIndex(),
-      op.getShareCache(), op.getPageTable());
+      op.getLoc(), op.getCache(), toTensorSpecOp.getResult(),
+      op.getUpdateIndex(), op.getShareCache(), op.getPageTable());
 
   rewriter.replaceOp(op, pagedUpdateCacheOp);
   return success();

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -81,8 +81,9 @@ static void revertOutputLayout(wa::TTNNWorkaroundInterface &op,
   // Insert the toLayoutOp after the op output.
   rewriter.setInsertionPointAfter(op);
 
-  // Cast the data type back to the previous data type by inserting ToLayoutOp.
-  mlir::Value castLayoutOp = utils::createToLayoutOp(
+  // Cast the data type back to the previous data type by inserting
+  // ToTensorSpecOp.
+  mlir::Value castLayoutOp = utils::createToTensorSpecOp(
       op.getOperation(), newOpResult, rewriter,
       workaroundResults.tensorLayoutResult.previousValue,
       workaroundResults.tensorBufferTypeResult.previousValue,
@@ -118,9 +119,9 @@ static bool workaroundInputOperand(
     return false;
   }
 
-  // Apply the workarounds on the input operand by inserting the ToLayoutOp with
-  // the desired tensor layout, buffer type and memory layout.
-  mlir::Value insertedToLayoutOpValue = utils::createToLayoutOp(
+  // Apply the workarounds on the input operand by inserting the ToTensorSpecOp
+  // with the desired tensor layout, buffer type and memory layout.
+  mlir::Value insertedToTensorSpecOp = utils::createToTensorSpecOp(
       op.getOperation(), inputValue, rewriter,
       inputWorkaroundResults.tensorLayoutResult.targetValue,
       inputWorkaroundResults.tensorBufferTypeResult.targetValue,
@@ -131,7 +132,7 @@ static bool workaroundInputOperand(
   // intended, tag the inserted op so ConstEvalHoist permits hoisting it
   // despite the L1-resident result.
   if (inputWorkaround.allowL1ConstEval) {
-    insertedToLayoutOpValue.getDefiningOp()->setAttr(
+    insertedToTensorSpecOp.getDefiningOp()->setAttr(
         utils::g_ConstEvalAllowedAttrName, rewriter.getUnitAttr());
   }
 
@@ -139,7 +140,7 @@ static bool workaroundInputOperand(
   // to convert the input operand to the desired tensor layout, buffer type.
   rewriter.modifyOpInPlace(op, [&]() {
     // Update the input operand with the new toLayout op operand.
-    op->setOperand(inputOperand.getOperandNumber(), insertedToLayoutOpValue);
+    op->setOperand(inputOperand.getOperandNumber(), insertedToTensorSpecOp);
   });
 
   return true;
@@ -274,9 +275,10 @@ public:
       return failure();
     }
 
-    // To layout op is a special case, we don't want to rewrite it. We use it
-    // to apply workarounds to the operands and results of TTNN operations.
-    if (mlir::isa<ttnn::ToLayoutOp>(op.getOperation())) {
+    // The aggregate to_tensor_spec op is a special case, we don't want to
+    // rewrite it. We use it to apply workarounds to the operands and results of
+    // TTNN operations.
+    if (mlir::isa<ttnn::ToTensorSpecOp>(op.getOperation())) {
       return failure();
     }
 
@@ -380,7 +382,7 @@ public:
         op.getIndex(), zero.getResult());
 
     // %safe_u32 = ttnn.to_layout(%safe) -> ui32
-    ttnn::ToLayoutOp safeIdxU32 = ttnn::utils::createToLayoutOp(
+    ttnn::ToTensorSpecOp safeIdxU32 = ttnn::utils::createToTensorSpecOp(
         op.getOperation(),
         mlir::cast<mlir::TypedValue<RankedTensorType>>(safeIdx.getResult()),
         rewriter, indexLayout.getLayout(), indexLayout.getBufferType(),

--- a/lib/Dialect/TTNN/Utils/D2MOptimizerUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/D2MOptimizerUtils.cpp
@@ -46,9 +46,8 @@ void applyChosenLayoutToD2MSubgraphOp(D2MSubgraphOp dispatchOp,
         ++argIdx;
       }
     }
-    // Insert a trailing to_layout to convert the last op's output to the
+    // Insert a trailing to_tensor_spec to convert the last op's output to the
     // chosen layout. The TTNN→TTIR conversion pattern will lower this to
-    // ttir.to_layout, which TTMetal's D2MToLayoutOpRewriter then handles.
     Block &block = mainFunc.getBody().front();
     Operation *terminator = block.getTerminator();
     if (func::ReturnOp returnOp = dyn_cast<func::ReturnOp>(terminator)) {
@@ -58,9 +57,9 @@ void applyChosenLayoutToD2MSubgraphOp(D2MSubgraphOp dispatchOp,
           OpBuilder builder(dispatchOp.getContext());
           builder.setInsertionPoint(returnOp);
           Location loc = mainFunc.getLoc();
-          ToLayoutOp toLayoutOp = builder.create<ToLayoutOp>(
+          ToTensorSpecOp toTensorSpecOp = builder.create<ToTensorSpecOp>(
               loc, newTensorType, currentResultValue);
-          returnOp.setOperand(0, toLayoutOp.getResult());
+          returnOp.setOperand(0, toTensorSpecOp.getResult());
         }
       }
     }

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -67,16 +67,15 @@ GetDeviceOp getOrInsertDevice(RewriterBase &rewriter, Block *block) {
   return deviceOp;
 }
 
-// Helper method to insert a ToLayoutOp to convert the input operand to the
+// Helper method to insert a ToTensorSpecOp to convert the input operand to the
 // desired tensor layout, buffer type and memory layout.
-ToLayoutOp
-createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
-                 RewriterBase &rewriter, Layout targetTensorLayout,
-                 BufferType targetTensorBufferType,
-                 TensorMemoryLayoutAttr targetTensorMemoryLayout,
-                 ttcore::DataType targetTensorDataType,
-                 llvm::StringRef locSuffix,
-                 std::optional<llvm::ArrayRef<int64_t>> targetGridShape) {
+ToTensorSpecOp createToTensorSpecOp(
+    Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
+    RewriterBase &rewriter, Layout targetTensorLayout,
+    BufferType targetTensorBufferType,
+    TensorMemoryLayoutAttr targetTensorMemoryLayout,
+    ttcore::DataType targetTensorDataType, llvm::StringRef locSuffix,
+    std::optional<llvm::ArrayRef<int64_t>> targetGridShape) {
   TTNNLayoutAttr inputLayoutAttr =
       getLayoutAttrFromTensor(inputValue.getType());
 
@@ -98,21 +97,21 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
   if (targetGridShape) {
     builder.setGridShape(*targetGridShape);
   }
-  TTNNLayoutAttr toLayoutOpResultEncoding =
+  TTNNLayoutAttr toTensorSpecOpResultEncoding =
       builder.buildWithCanonicalCorePlacement(deviceAttr);
 
   // Create the output result type with the new data type and encoding.
-  RankedTensorType toLayoutOpResultType = RankedTensorTypeFactory::create(
+  RankedTensorType toTensorSpecOpResultType = RankedTensorTypeFactory::create(
       RankedTensorTypeFactory::create(
           inputToLayoutOpType,
           mlir::tt::ttcore::dataTypeToElementType(rewriter.getContext(),
                                                   targetTensorDataType)),
-      toLayoutOpResultEncoding);
+      toTensorSpecOpResultEncoding);
   Location loc = ttmlir::utils::appendLocationSuffix(op->getLoc(), locSuffix);
-  // Create a ToLayoutOp to convert the input operand to the desired
+  // Create a ToTensorSpecOp to convert the input operand to the desired
   // tensor layout, buffer type and memory layout.
-  return rewriter.create<ttnn::ToLayoutOp>(loc, toLayoutOpResultType,
-                                           inputValue);
+  return rewriter.create<ttnn::ToTensorSpecOp>(loc, toTensorSpecOpResultType,
+                                               inputValue);
 }
 
 } // namespace mlir::tt::ttnn::utils

--- a/test/python/golden/mlir_snippets/ttnn/ttnn_constant.mlir
+++ b/test/python/golden/mlir_snippets/ttnn/ttnn_constant.mlir
@@ -6,7 +6,7 @@
 module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
   func.func @constant_row_major() -> tensor<2x2xf32, #ttnn_layout2> {
     %0 = "ttnn.constant"() <{value = dense<"0x0000803F000000400000404000008040"> : tensor<2x2xf32>}> : () -> tensor<2x2xf32, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0)  : (tensor<2x2xf32, #ttnn_layout1>) -> tensor<2x2xf32, #ttnn_layout2>
+    %1 = "ttnn.to_tensor_spec"(%0)  : (tensor<2x2xf32, #ttnn_layout1>) -> tensor<2x2xf32, #ttnn_layout2>
     return %1 : tensor<2x2xf32, #ttnn_layout2>
   }
   func.func @constant_tile() -> tensor<2x2xf32, #ttnn_layout2> {

--- a/test/python/golden/mlir_snippets/ttnn/ttnn_full.mlir
+++ b/test/python/golden/mlir_snippets/ttnn/ttnn_full.mlir
@@ -7,7 +7,7 @@ module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
   func.func @full_row_major() -> tensor<32x32xbf16, #ttnn_layout> {
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.full"(%0) <{fill_value = 1.000000e+00 : f32, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
-    %2 = "ttnn.to_layout"(%1)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout>
+    %2 = "ttnn.to_tensor_spec"(%1)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout>
     return %2 : tensor<32x32xbf16, #ttnn_layout>
   }
   func.func @full_tile() -> tensor<32x32xf32, #ttnn_layout2> {

--- a/test/python/golden/test_ttnn_ops.py
+++ b/test/python/golden/test_ttnn_ops.py
@@ -638,7 +638,7 @@ def test_full(
                 unit_attrs=unit_attrs,
             )
             if full_layout == ttnn.Layout.RowMajor:
-                return builder.to_layout(
+                return builder.to_tensor_spec(
                     full, layout=ttnn.Layout.Tile, output_type=dtype
                 )
             return full
@@ -688,7 +688,7 @@ def test_constant(
                 buffer_type=buffer_type,
             )
             if constant_layout == ttnn.Layout.RowMajor:
-                return builder.to_layout(
+                return builder.to_tensor_spec(
                     constant,
                     layout=ttnn.Layout.Tile,
                     buffer_type=ttnn.BufferType.DRAM,

--- a/test/python/golden/ttnn_ops/eltwise/test_ttnn_binary.py
+++ b/test/python/golden/ttnn_ops/eltwise/test_ttnn_binary.py
@@ -19,7 +19,6 @@ from test_utils import (
 )
 from ttmlir.dialects import ttnn
 
-
 pytestmark = pytest.mark.frontend("ttnn")
 
 
@@ -213,8 +212,8 @@ def test_add_dram_sharded(
     """Smoke test for DRAM-sharded layouts on a binary eltwise op.
 
     (DRAM-Interleaved args)
-        -> to_layout x2 -> (DRAM-sharded)
-        -> add          -> (DRAM-Interleaved, builder default)
+        -> to_tensor_spec x2 -> (DRAM-sharded)
+        -> add               -> (DRAM-Interleaved, builder default)
     """
 
     def module(builder: TTNNBuilder):
@@ -231,8 +230,8 @@ def test_add_dram_sharded(
                 tensor_memory_layout=memory_layout,
                 grid_shape=grid_shape,
             )
-            sharded_a = builder.to_layout(in0, **shard_kwargs)
-            sharded_b = builder.to_layout(in1, **shard_kwargs)
+            sharded_a = builder.to_tensor_spec(in0, **shard_kwargs)
+            sharded_b = builder.to_tensor_spec(in1, **shard_kwargs)
             return builder.add(sharded_a, sharded_b, unit_attrs=unit_attrs)
 
     compile_and_execute_ttnn(

--- a/test/python/golden/ttnn_ops/eltwise/test_ttnn_unary.py
+++ b/test/python/golden/ttnn_ops/eltwise/test_ttnn_unary.py
@@ -411,11 +411,11 @@ def test_relu_dram_sharded(
     """Smoke test for DRAM-sharded layouts, using an arbitrary op (relu).
 
         (DRAM-Interleaved arg)
-            -> to_layout -> (DRAM-sharded)
-            -> relu      -> (DRAM-Interleaved, builder default for op outputs)
+            -> to_tensor_spec -> (DRAM-sharded)
+            -> relu           -> (DRAM-Interleaved, builder default for op outputs)
 
-    Exercises block-arg construction, the explicit DRAM-sharded `to_layout`
-    reshard, and a unary op consuming a sharded operand.
+    Exercises block-arg construction, the explicit DRAM-sharded
+    `to_tensor_spec` reshard, and a unary op consuming a sharded operand.
     """
 
     def module(builder: TTNNBuilder):
@@ -425,7 +425,7 @@ def test_relu_dram_sharded(
             builder: TTNNBuilder,
             unit_attrs: Optional[List[str]] = None,
         ):
-            sharded_in = builder.to_layout(
+            sharded_in = builder.to_tensor_spec(
                 in0,
                 layout=ttnn.Layout.Tile,
                 buffer_type=ttnn.BufferType.DRAM,
@@ -443,6 +443,7 @@ def test_relu_dram_sharded(
 
 
 # Hoisted unary ops
+
 
 # Create hoisted versions of operations by currying the unit_attrs parameter
 def create_hoisted_unary_op(op_func, name):

--- a/test/ttmlir/Conversion/TTIRToTTNN/to_tensor_spec.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTNN/to_tensor_spec.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --ttcore-register-device --convert-ttir-to-ttnn -o %t %s
+// RUN: FileCheck %s --input-file=%t
+//
+// Verify that ttir.to_layout lowers to the aggregate ttnn.to_tensor_spec op
+// (and NOT ttnn.to_layout, which is the narrow tilize/untilize op that
+// ttnn-decompose-layouts emits later and which survives to the backend).
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#host = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
+#device = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  func.func @to_layout_lowers_to_to_tensor_spec(%arg0: tensor<64x128xf32, #host>) -> tensor<64x128xbf16, #device> {
+    // CHECK-LABEL: func.func @to_layout_lowers_to_to_tensor_spec
+    // CHECK: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-NOT: "ttnn.to_layout"
+    %0 = ttir.empty() : tensor<64x128xbf16, #device>
+    %1 = ttir.to_layout %arg0, %0 : tensor<64x128xf32, #host> into tensor<64x128xbf16, #device> -> tensor<64x128xbf16, #device>
+    return %1 : tensor<64x128xbf16, #device>
+  }
+}

--- a/test/ttmlir/Conversion/TTNNToTTIR/to_layout_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/to_layout_op.mlir
@@ -5,10 +5,25 @@
 #l1 = #ttnn.buffer_type<l1>
 
 #dram_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#dram_rm_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xbf16, #dram>, <interleaved>>
 #l1_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <block_sharded>, core_ranges = <[#ttnn.core_range<(0, 0), (0, 0)>]>>
 
 module {
-  func.func @test(%arg0: tensor<32x32xbf16, #dram_layout>) -> tensor<32x32xbf16, #l1_layout> {
+  func.func @test_to_layout(%arg0: tensor<32x32xbf16, #dram_layout>) -> tensor<32x32xbf16, #dram_rm_layout> {
+    // CHECK: %[[EMPTY:.*]] = ttir.empty() : tensor<32x32xbf16,
+    // CHECK-SAME: memref<32x32xbf16, #ttnn.buffer_type<dram>>, <interleaved>>>
+    // CHECK: %[[RESULT:.*]] = ttir.to_layout %arg0, %[[EMPTY]] :
+    // CHECK-SAME: memref<1x1x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
+    // CHECK-SAME: into
+    // CHECK-SAME: memref<32x32xbf16, #ttnn.buffer_type<dram>>, <interleaved>>>
+    // CHECK-SAME: ->
+    // CHECK-SAME: memref<32x32xbf16, #ttnn.buffer_type<dram>>, <interleaved>>>
+    // CHECK-NOT: "ttnn.to_layout"
+    %0 = "ttnn.to_layout"(%arg0)  {ttnn.hoist_generic_via_d2m} : (tensor<32x32xbf16, #dram_layout>) -> tensor<32x32xbf16, #dram_rm_layout>
+    return %0 : tensor<32x32xbf16, #dram_rm_layout>
+  }
+
+  func.func @test_to_tensor_spec(%arg0: tensor<32x32xbf16, #dram_layout>) -> tensor<32x32xbf16, #l1_layout> {
     // CHECK: %[[EMPTY:.*]] = ttir.empty() : tensor<32x32xbf16,
     // CHECK-SAME: #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (0,0)>]>>>
     // CHECK: %[[RESULT:.*]] = ttir.to_layout %arg0, %[[EMPTY]] :
@@ -17,8 +32,8 @@ module {
     // CHECK-SAME: #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (0,0)>]>>>
     // CHECK-SAME: ->
     // CHECK-SAME: #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = <[#ttnn.core_range<(0,0), (0,0)>]>>>
-    // CHECK-NOT: "ttnn.to_layout"
-    %0 = "ttnn.to_layout"(%arg0)  {ttnn.hoist_generic_via_d2m} : (tensor<32x32xbf16, #dram_layout>) -> tensor<32x32xbf16, #l1_layout>
+    // CHECK-NOT: "ttnn.to_tensor_spec"
+    %0 = "ttnn.to_tensor_spec"(%arg0)  {ttnn.hoist_generic_via_d2m} : (tensor<32x32xbf16, #dram_layout>) -> tensor<32x32xbf16, #l1_layout>
     return %0 : tensor<32x32xbf16, #l1_layout>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/layout_to_creation_ops_canonicalizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/layout_to_creation_ops_canonicalizer.mlir
@@ -23,7 +23,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.empty"(%0) <{ shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
@@ -35,7 +35,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.empty"(%0) <{ shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
   }
 
@@ -47,7 +47,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.rand"(%0) <{size = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
@@ -56,13 +56,12 @@ module attributes {} {
     // CHECK: "ttnn.rand"
     // CHECK-SAME: -> tensor<32x32xf32,
     // CHECK-SAME: memref<32x32x
-    // CHECK-NOT: "ttnn.to_layout"
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<32x32xbf16,
     // CHECK-SAME: !ttcore.tile<32x32,
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.rand"(%0) <{size = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_dram_f32_rm>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xf32, #ttnn_layout_dram_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_host_bf16_tile>
   }
 
@@ -74,7 +73,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.arange"() <{ start = 0 : si64, step = 1 : si64, end = 32 : si64}> : () -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32xf32, #ttnn_layout_1_host_f32_rm>) -> tensor<32xbf16, #ttnn_layout_1_device_bf16_tile>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32xf32, #ttnn_layout_1_host_f32_rm>) -> tensor<32xbf16, #ttnn_layout_1_device_bf16_tile>
     return %2 : tensor<32xbf16, #ttnn_layout_1_device_bf16_tile>
   }
 
@@ -86,7 +85,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.arange"() <{ start = 0 : si64, step = 1 : si64, end = 32 : si64}> : () -> tensor<32xf32, #ttnn_layout_1_device_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32xf32, #ttnn_layout_1_device_bf16_tile>) -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32xf32, #ttnn_layout_1_device_bf16_tile>) -> tensor<32xf32, #ttnn_layout_1_host_f32_rm>
     return %2 : tensor<32xf32, #ttnn_layout_1_host_f32_rm>
   }
 
@@ -98,7 +97,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.zeros"() <{ shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
@@ -110,7 +109,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.zeros"() <{ shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
     return %2 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>
   }
 
@@ -122,7 +121,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.ones"() <{ shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
@@ -134,7 +133,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.ones"() <{ shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
     return %2 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>
   }
 
@@ -146,7 +145,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.full"() <{ shape = #ttnn.shape<32x32>, fill_value = 7.0 : f32}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
@@ -158,7 +157,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.full"() <{ shape = #ttnn.shape<32x32>, fill_value = 7.0 : f32}> : () -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
     return %2 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>
   }
 
@@ -170,7 +169,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.constant"() <{value = dense_resource<dense_attr_f32> : tensor<32x32xf32>}> : () -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xf32, #ttnn_layout_host_f32_rm>) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
     return %2 : tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
   }
 
@@ -182,7 +181,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.constant"(%0) <{value = dense_resource<dense_attr_bf16> : tensor<32x32xbf16>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
     return %2 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>
   }
 
@@ -191,11 +190,11 @@ module attributes {} {
     // CHECK: "ttnn.constant"
     // CHECK-SAME: -> tensor<32x32xbf16,
     // CHECK-SAME: !ttcore.tile<32x32,
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK: "ttnn.to_layout"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.constant"(%0) <{value = dense_resource<dense_attr_bf16> : tensor<32x32xbf16>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>
-    %2 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_host_f32_rm>
     %3 = "ttnn.to_layout"(%1) : (tensor<32x32xbf16, #ttnn_layout_dram_bf16_tile>) -> tensor<32x32xf32, #ttnn_layout_dram_bf16_rm>
     return %2, %3 : tensor<32x32xf32, #ttnn_layout_host_f32_rm>, tensor<32x32xf32, #ttnn_layout_dram_bf16_rm>
   }

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/merge_typecast_into_to_layout.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/merge_typecast_into_to_layout.mlir
@@ -15,10 +15,10 @@ module attributes {} {
   // CHECK-LABEL: func.func @merge_lossless_roundtrip
   func.func @merge_lossless_roundtrip(%arg0: tensor<32x32xbf16, #bf16_l1>) -> tensor<32x32xbf16, #bf16_dram> {
     // CHECK-NOT: "ttnn.typecast"
-    // CHECK: "ttnn.to_layout"(%arg0)
+    // CHECK: "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: -> tensor<32x32xbf16,
     %0 = "ttnn.typecast"(%arg0) : (tensor<32x32xbf16, #bf16_l1>) -> tensor<32x32xf32, #f32_l1>
-    %1 = "ttnn.to_layout"(%0) : (tensor<32x32xf32, #f32_l1>) -> tensor<32x32xbf16, #bf16_dram>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<32x32xf32, #f32_l1>) -> tensor<32x32xbf16, #bf16_dram>
     return %1 : tensor<32x32xbf16, #bf16_dram>
   }
 
@@ -27,10 +27,10 @@ module attributes {} {
   // CHECK-LABEL: func.func @merge_lossless_roundtrip_multi_use
   func.func @merge_lossless_roundtrip_multi_use(%arg0: tensor<32x32xbf16, #bf16_l1>) -> (tensor<32x32xbf16, #bf16_dram>, tensor<32x32xf32, #f32_l1>) {
     // CHECK: "ttnn.typecast"(%arg0)
-    // CHECK: "ttnn.to_layout"(%arg0)
+    // CHECK: "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: -> tensor<32x32xbf16,
     %0 = "ttnn.typecast"(%arg0) : (tensor<32x32xbf16, #bf16_l1>) -> tensor<32x32xf32, #f32_l1>
-    %1 = "ttnn.to_layout"(%0) : (tensor<32x32xf32, #f32_l1>) -> tensor<32x32xbf16, #bf16_dram>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<32x32xf32, #f32_l1>) -> tensor<32x32xbf16, #bf16_dram>
     return %1, %0 : tensor<32x32xbf16, #bf16_dram>, tensor<32x32xf32, #f32_l1>
   }
 
@@ -39,9 +39,9 @@ module attributes {} {
   // CHECK-LABEL: func.func @no_merge_lossy_bf16_roundtrip
   func.func @no_merge_lossy_bf16_roundtrip(%arg0: tensor<32x32xf32, #f32_l1>) -> tensor<32x32xf32, #f32_dram> {
     // CHECK: %[[TC:.*]] = "ttnn.typecast"(%arg0)
-    // CHECK: "ttnn.to_layout"(%[[TC]])
+    // CHECK: "ttnn.to_tensor_spec"(%[[TC]])
     %0 = "ttnn.typecast"(%arg0) : (tensor<32x32xf32, #f32_l1>) -> tensor<32x32xbf16, #bf16_l1>
-    %1 = "ttnn.to_layout"(%0) : (tensor<32x32xbf16, #bf16_l1>) -> tensor<32x32xf32, #f32_dram>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<32x32xbf16, #bf16_l1>) -> tensor<32x32xf32, #f32_dram>
     return %1 : tensor<32x32xf32, #f32_dram>
   }
 
@@ -50,9 +50,9 @@ module attributes {} {
   // CHECK-LABEL: func.func @no_merge_lossy_f16_roundtrip
   func.func @no_merge_lossy_f16_roundtrip(%arg0: tensor<32x32xbf16, #bf16_l1>) -> tensor<32x32xbf16, #bf16_dram> {
     // CHECK: %[[TC:.*]] = "ttnn.typecast"(%arg0)
-    // CHECK: "ttnn.to_layout"(%[[TC]])
+    // CHECK: "ttnn.to_tensor_spec"(%[[TC]])
     %0 = "ttnn.typecast"(%arg0) : (tensor<32x32xbf16, #bf16_l1>) -> tensor<32x32xf16, #f16_l1>
-    %1 = "ttnn.to_layout"(%0) : (tensor<32x32xf16, #f16_l1>) -> tensor<32x32xbf16, #bf16_dram>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<32x32xf16, #f16_l1>) -> tensor<32x32xbf16, #bf16_dram>
     return %1 : tensor<32x32xbf16, #bf16_dram>
   }
 
@@ -61,9 +61,9 @@ module attributes {} {
   // CHECK-LABEL: func.func @no_merge_fp_int_fp
   func.func @no_merge_fp_int_fp(%arg0: tensor<32x32xf32, #f32_l1>) -> tensor<32x32xf32, #f32_dram> {
     // CHECK: %[[TC:.*]] = "ttnn.typecast"(%arg0)
-    // CHECK: "ttnn.to_layout"(%[[TC]])
+    // CHECK: "ttnn.to_tensor_spec"(%[[TC]])
     %0 = "ttnn.typecast"(%arg0) : (tensor<32x32xf32, #f32_l1>) -> tensor<32x32xsi32, #si32_l1>
-    %1 = "ttnn.to_layout"(%0) : (tensor<32x32xsi32, #si32_l1>) -> tensor<32x32xf32, #f32_dram>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<32x32xsi32, #si32_l1>) -> tensor<32x32xf32, #f32_dram>
     return %1 : tensor<32x32xf32, #f32_dram>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/simple_to_layout_op_canonicalizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/simple_to_layout_op_canonicalizer.mlir
@@ -6,59 +6,15 @@
 #ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xbf16, #dram>, <interleaved>>
 #ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#ttnn_layout4 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #system_memory>>
-#ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xf32, #system_memory>>
 module attributes {} {
-  func.func @merge_to_layout_op_layout(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout2> {
+  func.func @merge_to_layout_op_data_type(%arg0: tensor<32x32xbf16, #ttnn_layout2>) -> tensor<32x32xf32, #ttnn_layout3> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
     // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout1>
+    // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout1>
     // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout2>
-    return %1 : tensor<32x32xbf16, #ttnn_layout2>
-  }
-
-  func.func @merge_to_layout_op_data_type(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout3> {
-    // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
-    // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout2>
-    // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout2>) -> tensor<32x32xbf16, #ttnn_layout1>
     %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout3>
     return %1 : tensor<32x32xf32, #ttnn_layout3>
-  }
-
-  func.func @merge_to_layout_op_memory_config(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout4> {
-    // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
-    // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout3>
-    // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout4>
-    return %1 : tensor<32x32xbf16, #ttnn_layout4>
-  }
-
-  func.func @merge_to_layout_op_all(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
-    // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
-    // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout4>
-    // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
-    return %1 : tensor<32x32xf32, #ttnn_layout5>
-  }
-
-  func.func @merge_to_layout_op_4x(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
-    // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
-    // CHECK: "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout4>
-    // CHECK-NEXT: return
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
-    %1 = "ttnn.to_layout"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
-    %2 = "ttnn.to_layout"(%1)  : (tensor<32x32xf32, #ttnn_layout5>) -> tensor<32x32xf32, #ttnn_layout3>
-    %3 = "ttnn.to_layout"(%2)  : (tensor<32x32xf32, #ttnn_layout3>) -> tensor<32x32xf32, #ttnn_layout5>
-    return %3 : tensor<32x32xf32, #ttnn_layout5>
   }
 
   func.func @fold_to_layout_op(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/to_tensor_spec_op_canonicalizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/to_tensor_spec_op_canonicalizer.mlir
@@ -1,0 +1,77 @@
+// RUN: ttmlir-opt --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xbf16, #system_memory>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xbf16, #dram>, <interleaved>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout4 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #system_memory>>
+#ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xf32, #system_memory>>
+module attributes {} {
+  func.func @merge_to_tensor_spec_op_layout(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout2> {
+    // Verify that the to_tensor_spec op is canonicalized to a single to_tensor_spec op and the attributes are merged.
+    // CHECK-LABEL: func.func @merge_to_tensor_spec_op_layout
+    // CHECK: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout1>
+    // CHECK-NEXT: return
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_tensor_spec"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout2>
+    return %1 : tensor<32x32xbf16, #ttnn_layout2>
+  }
+
+  func.func @merge_to_tensor_spec_op_data_type(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout3> {
+    // Verify that the to_tensor_spec op is canonicalized to a single to_tensor_spec op and the attributes are merged.
+    // CHECK-LABEL: func.func @merge_to_tensor_spec_op_data_type
+    // CHECK: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout2>
+    // CHECK-NEXT: return
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_tensor_spec"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout3>
+    return %1 : tensor<32x32xf32, #ttnn_layout3>
+  }
+
+  func.func @merge_to_tensor_spec_op_memory_config(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout4> {
+    // Verify that the to_tensor_spec op is canonicalized to a single to_tensor_spec op and the attributes are merged.
+    // CHECK-LABEL: func.func @merge_to_tensor_spec_op_memory_config
+    // CHECK: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout3>
+    // CHECK-NEXT: return
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_tensor_spec"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout4>
+    return %1 : tensor<32x32xbf16, #ttnn_layout4>
+  }
+
+  func.func @merge_to_tensor_spec_op_all(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
+    // Verify that the to_tensor_spec op is canonicalized to a single to_tensor_spec op and the attributes are merged.
+    // CHECK-LABEL: func.func @merge_to_tensor_spec_op_all
+    // CHECK: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout4>
+    // CHECK-NEXT: return
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_tensor_spec"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
+    return %1 : tensor<32x32xf32, #ttnn_layout5>
+  }
+
+  func.func @merge_to_tensor_spec_op_4x(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
+    // Verify that the to_tensor_spec op is canonicalized to a single to_tensor_spec op and the attributes are merged.
+    // CHECK-LABEL: func.func @merge_to_tensor_spec_op_4x
+    // CHECK: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout4>
+    // CHECK-NEXT: return
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_tensor_spec"(%0)  : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
+    %2 = "ttnn.to_tensor_spec"(%1)  : (tensor<32x32xf32, #ttnn_layout5>) -> tensor<32x32xf32, #ttnn_layout3>
+    %3 = "ttnn.to_tensor_spec"(%2)  : (tensor<32x32xf32, #ttnn_layout3>) -> tensor<32x32xf32, #ttnn_layout5>
+    return %3 : tensor<32x32xf32, #ttnn_layout5>
+  }
+
+  func.func @fold_to_tensor_spec_op(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {
+    // Verify folding of to_tensor_spec_op.
+    // CHECK-LABEL: func.func @fold_to_tensor_spec_op
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+    // CHECK-NOT: "ttnn.to_tensor_spec"
+    return %0 : tensor<32x32xbf16, #ttnn_layout>
+    // CHECK: return %arg0 : tensor<32x32xbf16
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decompose_layouts_affine_map_test.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decompose_layouts_affine_map_test.mlir
@@ -21,7 +21,7 @@
 #ttnn_layout_dram_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x64x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>
 module {
   func.func @forward(%arg0: tensor<1x1x8x2048xbf16, #ttnn_layout_dram_rm>) -> tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile> {
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<1x1x8x2048xbf16, #ttnn_layout_dram_rm>) -> tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile>
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<1x1x8x2048xbf16, #ttnn_layout_dram_rm>) -> tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile>
     // CHECK: "ttnn.to_layout"
     return %0 : tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile>
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_cpu_hoisted.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_cpu_hoisted.mlir
@@ -31,7 +31,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.to_layout"
     // CHECK: return %[[TO_DEVICE]]
     %0 = func.call @cpu_hoisted_rm() {ttir.cpu_hoist_call = unit} : () -> tensor<64x128xf32, #ttnn_layout_host_rm>
-    %1 = "ttnn.to_layout"(%0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+    %1 = "ttnn.to_tensor_spec"(%0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
     return %1 : tensor<64x128xf32, #ttnn_layout_device_tile>
   }
 
@@ -46,7 +46,7 @@ module attributes {} {
     // CHECK-NOT: "ttnn.typecast"
     // CHECK: return %[[TO_DEVICE]]
     %0 = func.call @cpu_hoisted_rm() {ttir.cpu_hoist_call = unit} : () -> tensor<64x128xf32, #ttnn_layout_host_rm>
-    %1 = "ttnn.to_layout"(%0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+    %1 = "ttnn.to_tensor_spec"(%0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     return %1 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
   }
 
@@ -62,7 +62,7 @@ module attributes {} {
     // CHECK-NEXT: %[[TO_DEVICE:.*]] = "ttnn.to_device"(%[[TO_LAYOUT]], %[[GET_DEVICE]])
     // CHECK: return %[[TO_DEVICE]]
     %0 = func.call @cpu_hoisted_rm() {ttir.cpu_hoist_call = unit} : () -> tensor<64x128xf32, #ttnn_layout_host_rm>
-    %1 = "ttnn.to_layout"(%0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+    %1 = "ttnn.to_tensor_spec"(%0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     return %1 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
   }
 
@@ -75,7 +75,7 @@ module attributes {} {
     // CHECK-NEXT: %[[CALL:.*]] = call @cpu_hoisted_input_rm(%[[TO_LAYOUT]])
     // CHECK-NOT: "ttnn.to_layout"
     // CHECK: return %[[CALL]]
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_device_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_device_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
     %1 = func.call @cpu_hoisted_input_rm(%0) {ttir.cpu_hoist_call = unit} : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
     return %1 : tensor<64x128xf32, #ttnn_layout_host_rm>
   }
@@ -90,7 +90,7 @@ module attributes {} {
     // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
     // CHECK-NEXT: %[[CALL:.*]] = call @cpu_hoisted_input_rm(%[[TO_LAYOUT]])
     // CHECK: return %[[CALL]]
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
     %1 = func.call @cpu_hoisted_input_rm(%0) {ttir.cpu_hoist_call = unit} : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
     return %1 : tensor<64x128xf32, #ttnn_layout_host_rm>
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
@@ -25,7 +25,7 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -38,7 +38,7 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
     }
 
@@ -48,7 +48,7 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
     }
 
@@ -60,7 +60,7 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
@@ -72,7 +72,7 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -84,7 +84,7 @@ module attributes {} {
         // This test verifies that the `to_layout` operation is correctly inserted to change the layout from tile to row-major on the host.
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
@@ -93,7 +93,7 @@ module attributes {} {
         // This test verifies that the `to_layout` operation is correctly inserted to change the layout from row-major to tile on the host.
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
@@ -105,7 +105,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
@@ -118,7 +118,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -131,7 +131,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -144,7 +144,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
         return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 
@@ -159,7 +159,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
@@ -171,7 +171,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
@@ -186,7 +186,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -200,7 +200,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<{{.*}}!ttcore.tile<32x32, f32>
         // CHECK-NOT: "ttnn.typecast"
         // CHECK: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_tile>
     }
 
@@ -214,7 +214,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<{{.*}}!ttcore.tile<32x32, bf16>
         // CHECK-NOT: "ttnn.typecast"
         // CHECK: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -229,7 +229,7 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}ui32
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
         return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
@@ -27,7 +27,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TO_LAYOUT]])
         // CHECK-NOT: "ttnn.typecast"
         // CHECK: return %[[TO_MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
         return %0 : tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
     }
 
@@ -44,7 +44,7 @@ module attributes {} {
         // CHECK-NEXT: %[[SLICE:.*]] = "ttnn.slice_static"(%[[TILIZE]])
         // CHECK-NEXT: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[SLICE]])
         // CHECK-NEXT: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x4xbf16, #ttnn_layout_l1_hs_rm_bf16_nontile>) -> tensor<32x4xbf16, #ttnn_layout_l1_hs_tile_bf16_nontile>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x4xbf16, #ttnn_layout_l1_hs_rm_bf16_nontile>) -> tensor<32x4xbf16, #ttnn_layout_l1_hs_tile_bf16_nontile>
         return %0 : tensor<32x4xbf16, #ttnn_layout_l1_hs_tile_bf16_nontile>
     }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv2d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv2d_workaround.mlir
@@ -6,13 +6,13 @@ module attributes {} {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x1x1024x64xbf16>
-    // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
-    // CHECK: %[[CONV2D_BIAS:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_BIAS:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
-    // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0)
           <{
@@ -36,13 +36,13 @@ module attributes {} {
   func.func @conv_transpose2d_with_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
-    // CHECK: %[[CONV2D_BIAS:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_BIAS:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
-    // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %arg2, %0)
           <{
@@ -69,10 +69,10 @@ module attributes {} {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x1x1024x64xbf16>
-    // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
-    // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     %2 = "ttnn.conv2d"(%1, %arg1, %0)
           <{
@@ -97,10 +97,10 @@ module attributes {} {
   func.func @conv_transpose2d_without_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>) -> tensor<1x30x30x64xbf16> {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_WEIGHTS:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK-SAME: system_memory
-    // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONV2D_INPUT:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %0)
           <{

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv3d_typecast_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv3d_typecast_workaround.mlir
@@ -5,8 +5,8 @@
 module {
   func.func public @test_conv3d_f32_to_bf16(%arg0: tensor<1x8x28x28x4xf32>, %arg1: tensor<16x4x3x3x3xf32>) -> tensor<1x6x26x26x16xf32> {
     // CHECK-LABEL: func.func public @test_conv3d_f32_to_bf16
-    // CHECK: "ttnn.to_layout"{{.*}}-> tensor<{{.*}}xbf16,
-    // CHECK: "ttnn.to_layout"{{.*}}-> tensor<{{.*}}xbf16,
+    // CHECK: "ttnn.to_tensor_spec"{{.*}}-> tensor<{{.*}}xbf16,
+    // CHECK: "ttnn.to_tensor_spec"{{.*}}-> tensor<{{.*}}xbf16,
     // CHECK: "ttnn.conv3d"
     %0 = "ttir.conv3d"(%arg0, %arg1)
             <{
@@ -20,9 +20,9 @@ module {
 
   func.func public @test_conv3d_f32_to_bf16_with_bias(%arg0: tensor<1x8x28x28x4xf32>, %arg1: tensor<16x4x3x3x3xf32>, %arg2: tensor<1x1x1x1x16xf32>) -> tensor<1x6x26x26x16xf32> {
     // CHECK-LABEL: func.func public @test_conv3d_f32_to_bf16_with_bias
-    // CHECK: "ttnn.to_layout"{{.*}}-> tensor<{{.*}}xbf16,
-    // CHECK: "ttnn.to_layout"{{.*}}-> tensor<{{.*}}xbf16,
-    // CHECK: "ttnn.to_layout"{{.*}}-> tensor<{{.*}}xbf16,
+    // CHECK: "ttnn.to_tensor_spec"{{.*}}-> tensor<{{.*}}xbf16,
+    // CHECK: "ttnn.to_tensor_spec"{{.*}}-> tensor<{{.*}}xbf16,
+    // CHECK: "ttnn.to_tensor_spec"{{.*}}-> tensor<{{.*}}xbf16,
     // CHECK: "ttnn.conv3d"
     %0 = "ttir.conv3d"(%arg0, %arg1, %arg2)
             <{

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
@@ -10,10 +10,10 @@ module @test_distributed_rms_norm_workaround attributes {} {
       %arg0: tensor<1x1x32x128xbf16, #ttnn_layout_supported>,
       %arg1: tensor<4x32xbf16, #ttnn_layout_weight_2d>) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported> {
     // CHECK-LABEL: func.func public @test_workaround_layout_only
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: #ttnn.buffer_type<l1>
     // CHECK-SAME: <width_sharded>
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<4x32xbf16,
     // CHECK-SAME: memref<4x32xbf16, #ttnn.buffer_type
     // CHECK: "ttnn.distributed_rms_norm"

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
@@ -10,32 +10,32 @@
 #ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {} {
   func.func @backward(%arg0: tensor<1x1x1x32xf32, #ttnn_layout>, %arg1: tensor<512x128xf32, #ttnn_layout1>, %arg2: tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<512x128xf32, #ttnn_layout1> {
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<1x1x1x32xf32, #ttnn_layout>) -> tensor<1x1x1x32xf32, #ttnn_layout3>
-    %1 = "ttnn.to_layout"(%arg1)  : (tensor<512x128xf32, #ttnn_layout1>) -> tensor<512x128xf32, #ttnn_layout4>
-    %2 = "ttnn.to_layout"(%arg2)  : (tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<1x32x128xf32, #ttnn_layout5>
-    // CHECK: "ttnn.to_layout"(%arg2)
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<1x1x1x32xf32, #ttnn_layout>) -> tensor<1x1x1x32xf32, #ttnn_layout3>
+    %1 = "ttnn.to_tensor_spec"(%arg1)  : (tensor<512x128xf32, #ttnn_layout1>) -> tensor<512x128xf32, #ttnn_layout4>
+    %2 = "ttnn.to_tensor_spec"(%arg2)  : (tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<1x32x128xf32, #ttnn_layout5>
+    // CHECK: "ttnn.to_tensor_spec"(%arg2)
     // CHECK: "ttnn.reshape"
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]}> : (tensor<1x32x128xf32, #ttnn_layout5>) -> tensor<1x1x32x128xf32, #ttnn_layout5>
     // Check that the input operand is transformed into the row major layout.
-    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: -> tensor<1x1x1x32xui32
     // CHECK-SAME: memref<1x32xui32, #ttnn.buffer_type
     // Check that the data type of the weight operand is transformed in bf16.
-    // CHECK: %[[TO_LAYOUT_WEIGHTS:.*]] = "ttnn.to_layout"(%arg1)
+    // CHECK: %[[TO_LAYOUT_WEIGHTS:.*]] = "ttnn.to_tensor_spec"(%arg1)
     // CHECK-SAME: -> tensor<512x128xbf16
     // CHECK-SAME: !ttcore.tile<32x32,
     // Check that the data type of the in gradient operand is transformed in bf16.
-    // CHECK: %[[TO_LAYOUT_IN_GRADIENT:.*]] = "ttnn.to_layout"
+    // CHECK: %[[TO_LAYOUT_IN_GRADIENT:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<1x1x32x128xbf16
     // CHECK-SAME: !ttcore.tile<32x32,
     // Check that the data type of the output operand is transformed in bf16.
     %4 = "ttnn.embedding_bw"(%0, %1, %3) : (tensor<1x1x1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<512x128xf32, #ttnn_layout4>
     // CHECK: %[[EMBEDDING_BW_OP:.*]] = "ttnn.embedding_bw"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]], %[[TO_LAYOUT_IN_GRADIENT]])
     // Check that the output operand is transformed back into the f32 data type.
-    // CHECK: "ttnn.to_layout"(%[[EMBEDDING_BW_OP]])
+    // CHECK: "ttnn.to_tensor_spec"(%[[EMBEDDING_BW_OP]])
     // CHECK-SAME: -> tensor<512x128xf32
     // CHECK-SAME: memref<512x128xf32, #ttnn.buffer_type
-    %5 = "ttnn.to_layout"(%4)  : (tensor<512x128xf32, #ttnn_layout4>) -> tensor<512x128xf32, #ttnn_layout1>
+    %5 = "ttnn.to_tensor_spec"(%4)  : (tensor<512x128xf32, #ttnn_layout4>) -> tensor<512x128xf32, #ttnn_layout1>
     return %5 : tensor<512x128xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_workaround.mlir
@@ -8,17 +8,17 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<32x32xf32, #ttnn_layout>, %arg1: tensor<512x128xf32, #ttnn_layout1>) -> tensor<32x32x128xf32, #ttnn_layout2> {
     // Check that the input operand is transformed into the row major layout.
-    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
+    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<32x32xui32
     // CHECK-SAME: memref<32x32xui32, #ttnn.buffer_type
     // Check that the data type of the weight operand is transformed in bf16.
-    // CHECK-NEXT: %[[TO_LAYOUT_WEIGHTS:.*]] = "ttnn.to_layout"
+    // CHECK-NEXT: %[[TO_LAYOUT_WEIGHTS:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<512x128xbf16
     // CHECK-SAME: memref<512x128xbf16, #ttnn.buffer_type
     %0 = "ttnn.embedding"(%arg0, %arg1) : (tensor<32x32xf32, #ttnn_layout>, tensor<512x128xf32, #ttnn_layout1>) -> tensor<32x32x128xf32, #ttnn_layout2>
     // CHECK-NEXT: %[[EMBEDDING_OP:.*]] = "ttnn.embedding"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]])
     // Check that the output operand is transformed back into the f32 data type.
-    // CHECK-NEXT: "ttnn.to_layout"(%[[EMBEDDING_OP]])
+    // CHECK-NEXT: "ttnn.to_tensor_spec"(%[[EMBEDDING_OP]])
     // CHECK-SAME: -> tensor<32x32x128xf32
     // CHECK-SAME: !ttcore.tile<32x32,
     return %0 : tensor<32x32x128xf32, #ttnn_layout2>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/erf_int_typecast_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/erf_int_typecast_workaround.mlir
@@ -9,12 +9,12 @@
 module {
   func.func public @test_erf_i32_to_bf16(%arg0: tensor<128x128xsi32>) -> tensor<128x128xsi32> {
     // CHECK-LABEL: func.func public @test_erf_i32_to_bf16
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK: "ttnn.erf"
     // CHECK-SAME: tensor<128x128xbf16
     // CHECK-SAME: -> tensor<128x128xbf16
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     %0 = "ttir.erf"(%arg0) : (tensor<128x128xsi32>) -> tensor<128x128xsi32>
     return %0 : tensor<128x128xsi32>
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/flash_mla_prefill_f32_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/flash_mla_prefill_f32_workaround.mlir
@@ -15,13 +15,13 @@ module {
   // f32 query + key only (no value, no mask, causal).
   func.func public @flash_mla_prefill_f32_qk(%query: tensor<1x16x32x128xf32>, %key: tensor<1x1x32x128xf32>) -> tensor<1x16x32x64xf32> {
     // CHECK-LABEL: func.func public @flash_mla_prefill_f32_qk
-    // CHECK-DAG: %[[Q_BF16:.*]] = "ttnn.to_layout"(%arg0)
-    // CHECK-DAG: %[[K_BF16:.*]] = "ttnn.to_layout"(%arg1)
+    // CHECK-DAG: %[[Q_BF16:.*]] = "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-DAG: %[[K_BF16:.*]] = "ttnn.to_tensor_spec"(%arg1)
     // CHECK: %[[OUT_BF16:.*]] = "ttnn.flash_mla_prefill"(%{{[0-9]+}}, %{{[0-9]+}})
     // CHECK-SAME: tensor<1x16x32x128xbf16
     // CHECK-SAME: tensor<1x1x32x128xbf16
     // CHECK-SAME: -> tensor<1x16x32x64xbf16
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[OUT_BF16]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[OUT_BF16]])
     // CHECK-SAME: tensor<1x16x32x64xbf16
     // CHECK-SAME: -> tensor<1x16x32x64xf32
     %0 = "ttnn.flash_mla_prefill"(%query, %key) <{operandSegmentSizes = array<i32: 1, 1, 0, 0>, head_dim_v = 64 : ui32, is_causal = true}> : (tensor<1x16x32x128xf32>, tensor<1x1x32x128xf32>) -> tensor<1x16x32x64xf32>
@@ -31,15 +31,15 @@ module {
   // f32 query + key + value (causal).
   func.func public @flash_mla_prefill_f32_qkv(%query: tensor<1x16x32x128xf32>, %key: tensor<1x1x32x128xf32>, %value: tensor<1x1x32x64xf32>) -> tensor<1x16x32x64xf32> {
     // CHECK-LABEL: func.func public @flash_mla_prefill_f32_qkv
-    // CHECK-DAG: "ttnn.to_layout"(%arg0)
-    // CHECK-DAG: "ttnn.to_layout"(%arg1)
-    // CHECK-DAG: "ttnn.to_layout"(%arg2)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg1)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg2)
     // CHECK: %[[OUT_BF16:.*]] = "ttnn.flash_mla_prefill"(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}})
     // CHECK-SAME: tensor<1x16x32x128xbf16
     // CHECK-SAME: tensor<1x1x32x128xbf16
     // CHECK-SAME: tensor<1x1x32x64xbf16
     // CHECK-SAME: -> tensor<1x16x32x64xbf16
-    // CHECK: "ttnn.to_layout"(%[[OUT_BF16]])
+    // CHECK: "ttnn.to_tensor_spec"(%[[OUT_BF16]])
     // CHECK-SAME: -> tensor<1x16x32x64xf32
     %0 = "ttnn.flash_mla_prefill"(%query, %key, %value) <{operandSegmentSizes = array<i32: 1, 1, 1, 0>, head_dim_v = 64 : ui32, is_causal = true}> : (tensor<1x16x32x128xf32>, tensor<1x1x32x128xf32>, tensor<1x1x32x64xf32>) -> tensor<1x16x32x64xf32>
     return %0 : tensor<1x16x32x64xf32>
@@ -48,15 +48,15 @@ module {
   // f32 query + key + mask (non-causal).
   func.func public @flash_mla_prefill_f32_qk_mask(%query: tensor<1x16x32x128xf32>, %key: tensor<1x1x32x128xf32>, %mask: tensor<1x1x32x32xf32>) -> tensor<1x16x32x64xf32> {
     // CHECK-LABEL: func.func public @flash_mla_prefill_f32_qk_mask
-    // CHECK-DAG: "ttnn.to_layout"(%arg0)
-    // CHECK-DAG: "ttnn.to_layout"(%arg1)
-    // CHECK-DAG: "ttnn.to_layout"(%arg2)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg1)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg2)
     // CHECK: %[[OUT_BF16:.*]] = "ttnn.flash_mla_prefill"(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}})
     // CHECK-SAME: tensor<1x16x32x128xbf16
     // CHECK-SAME: tensor<1x1x32x128xbf16
     // CHECK-SAME: tensor<1x1x32x32xbf16
     // CHECK-SAME: -> tensor<1x16x32x64xbf16
-    // CHECK: "ttnn.to_layout"(%[[OUT_BF16]])
+    // CHECK: "ttnn.to_tensor_spec"(%[[OUT_BF16]])
     // CHECK-SAME: -> tensor<1x16x32x64xf32
     %0 = "ttnn.flash_mla_prefill"(%query, %key, %mask) <{operandSegmentSizes = array<i32: 1, 1, 0, 1>, head_dim_v = 64 : ui32, is_causal = false}> : (tensor<1x16x32x128xf32>, tensor<1x1x32x128xf32>, tensor<1x1x32x32xf32>) -> tensor<1x16x32x64xf32>
     return %0 : tensor<1x16x32x64xf32>
@@ -65,13 +65,13 @@ module {
   // f32 query + key + value + mask (non-causal, all optional operands present).
   func.func public @flash_mla_prefill_f32_all(%query: tensor<2x8x64x128xf32>, %key: tensor<2x1x64x128xf32>, %value: tensor<2x1x64x96xf32>, %mask: tensor<2x1x64x64xf32>) -> tensor<2x8x64x96xf32> {
     // CHECK-LABEL: func.func public @flash_mla_prefill_f32_all
-    // CHECK-DAG: "ttnn.to_layout"(%arg0)
-    // CHECK-DAG: "ttnn.to_layout"(%arg1)
-    // CHECK-DAG: "ttnn.to_layout"(%arg2)
-    // CHECK-DAG: "ttnn.to_layout"(%arg3)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg1)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg2)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg3)
     // CHECK: %[[OUT_BF16:.*]] = "ttnn.flash_mla_prefill"(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}})
     // CHECK-SAME: -> tensor<2x8x64x96xbf16
-    // CHECK: "ttnn.to_layout"(%[[OUT_BF16]])
+    // CHECK: "ttnn.to_tensor_spec"(%[[OUT_BF16]])
     // CHECK-SAME: -> tensor<2x8x64x96xf32
     %0 = "ttnn.flash_mla_prefill"(%query, %key, %value, %mask) <{operandSegmentSizes = array<i32: 1, 1, 1, 1>, head_dim_v = 96 : ui32, is_causal = false, scale = 1.250000e-01 : f32}> : (tensor<2x8x64x128xf32>, tensor<2x1x64x128xf32>, tensor<2x1x64x96xf32>, tensor<2x1x64x64xf32>) -> tensor<2x8x64x96xf32>
     return %0 : tensor<2x8x64x96xf32>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/gather_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/gather_workaround.mlir
@@ -21,11 +21,11 @@ module attributes {} {
       -> tensor<2x3xf32, #ttnn_layout_output> {
     // CHECK-LABEL: func.func @gather_row_major_inputs
     // Check that the input operand is converted to tiled layout.
-    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: -> tensor<5x3xf32,
     // CHECK-SAME: !ttcore.tile<32x32,
     // Check that the index operand is converted to tiled layout.
-    // CHECK-NEXT: %[[TO_LAYOUT_INDEX:.*]] = "ttnn.to_layout"(%arg1)
+    // CHECK-NEXT: %[[TO_LAYOUT_INDEX:.*]] = "ttnn.to_tensor_spec"(%arg1)
     // CHECK-SAME: -> tensor<2x3xui32,
     // CHECK-SAME: !ttcore.tile<32x32,
     %0 = "ttnn.gather"(%arg0, %arg1)
@@ -44,7 +44,7 @@ module attributes {} {
       %arg1: tensor<2x3xui32, #ttnn_layout_index_tile>)
       -> tensor<2x3xf32, #ttnn_layout_output> {
     // CHECK-LABEL: func.func @gather_tiled_inputs
-    // CHECK-NOT: "ttnn.to_layout"
+    // CHECK-NOT: "ttnn.to_tensor_spec"
     // CHECK: "ttnn.gather"
     %0 = "ttnn.gather"(%arg0, %arg1)
         <{dim = 0 : si32}>
@@ -71,7 +71,7 @@ module attributes {} {
     // %safe = ttnn.maximum(idx, zero)  -> si32 (negatives clamped to 0)
     // CHECK: %[[CLAMPED:.*]] = "ttnn.maximum"(%arg1, %[[ZERO]])
     // %safe_u32 = ttnn.to_layout(safe) -> ui32
-    // CHECK: %[[SAFE_U32:.*]] = "ttnn.to_layout"(%[[CLAMPED]])
+    // CHECK: %[[SAFE_U32:.*]] = "ttnn.to_tensor_spec"(%[[CLAMPED]])
     // CHECK-SAME: -> tensor<2x3xui32,
     // %raw = ttnn.gather(input, safe_u32, dim)
     // CHECK: %[[RAW:.*]] = "ttnn.gather"(%arg0, %[[SAFE_U32]])

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
@@ -8,22 +8,22 @@
 #ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4096 + d1 * 64 + d2, d3), <1x1>, memref<128x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {} {
   func.func @forward(%arg0: tensor<1x128x128x32xf32, #ttnn_layout>) -> tensor<1x64x64x32xf32, #ttnn_layout1> {
-    %0 = "ttnn.to_layout"(%arg0)  : (tensor<1x128x128x32xf32, #ttnn_layout>) -> tensor<1x128x128x32xf32, #ttnn_layout2>
-    // CHECK: "ttnn.to_layout"
+    %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<1x128x128x32xf32, #ttnn_layout>) -> tensor<1x128x128x32xf32, #ttnn_layout2>
+    // CHECK: "ttnn.to_tensor_spec"
     %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 1 : i32, 16384 : i32, 32 : i32]}> : (tensor<1x128x128x32xf32, #ttnn_layout2>) -> tensor<1x1x16384x32xf32, #ttnn_layout2>
     // Check that the input operand is transformed into the row major layout.
-    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
+    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<1x1x16384x32xbf16,
     // CHECK-SAME: memref<16384x32xbf16, #ttnn.buffer_type
     %2 = "ttnn.max_pool2d"(%1) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_size = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0>, in_place_halo = false}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
     // CHECK-NEXT: %[[MAX_POOL_2D_OP:.*]] = "ttnn.max_pool2d"(%[[TO_LAYOUT_INPUT]])
     // Check that the output operand is transformed back into the tile and f32 data type.
-    // CHECK-NEXT: %[[TO_LAYOUT_OUTPUT:.*]] = "ttnn.to_layout"(%[[MAX_POOL_2D_OP]])
+    // CHECK-NEXT: %[[TO_LAYOUT_OUTPUT:.*]] = "ttnn.to_tensor_spec"(%[[MAX_POOL_2D_OP]])
     // CHECK-SAME: -> tensor<1x1x4096x32xf32
     // CHECK-SAME: !ttcore.tile<32x32,
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 64 : i32, 64 : i32, 32 : i32]}> : (tensor<1x1x4096x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout3>
     // CHECK-NEXT: ttnn.reshape
-    %4 = "ttnn.to_layout"(%3)  : (tensor<1x64x64x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout1>
+    %4 = "ttnn.to_tensor_spec"(%3)  : (tensor<1x64x64x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout1>
     return %4 : tensor<1x64x64x32xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/moe_ccl_workaround_with_optimizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/moe_ccl_workaround_with_optimizer.mlir
@@ -23,13 +23,13 @@ module {
   func.func @all_to_all_dispatch(%input: tensor<1x1x128x2880xbf16, #disp_in>, %indices: tensor<1x1x128x4xsi32, #disp_idx>, %mapping: tensor<1x1x32x8xsi32, #disp_map>) -> (tensor<1x2x128x2880xbf16, #disp_out>, tensor<1x2x128x4xsi32, #disp_meta>) {
     // CHECK-LABEL: func.func @all_to_all_dispatch
     // input_tensor -> RowMajor BFLOAT16.
-    // CHECK: %[[IN:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: -> tensor<1x1x128x2880xbf16, {{.*}} memref<128x2880xbf16,
     // expert_indices -> RowMajor UINT16.
-    // CHECK: %[[IDX:.*]] = "ttnn.to_layout"(%arg1)
+    // CHECK: %[[IDX:.*]] = "ttnn.to_tensor_spec"(%arg1)
     // CHECK-SAME: -> tensor<1x1x128x4xui16, {{.*}} memref<128x4xui16,
     // expert_mapping -> RowMajor UINT16.
-    // CHECK: %[[MAP:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK: %[[MAP:.*]] = "ttnn.to_tensor_spec"(%arg2)
     // CHECK-SAME: -> tensor<1x1x32x8xui16, {{.*}} memref<32x8xui16,
     // CHECK: "ttnn.all_to_all_dispatch"(%[[IN]], %[[IDX]], %[[MAP]])
     %dispatched, %metadata = "ttnn.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16, #disp_in>, tensor<1x1x128x4xsi32, #disp_idx>, tensor<1x1x32x8xsi32, #disp_map>) -> (tensor<1x2x128x2880xbf16, #disp_out>, tensor<1x2x128x4xsi32, #disp_meta>)
@@ -50,13 +50,13 @@ module {
   func.func @all_to_all_combine(%input: tensor<4x2x128x2880xbf16, #comb_in>, %metadata: tensor<1x2x128x4xsi32, #comb_meta>, %mapping: tensor<1x1x32x8xsi32, #comb_map>) -> tensor<4x1x128x2880xbf16, #comb_out> {
     // CHECK-LABEL: func.func @all_to_all_combine
     // input_tensor -> RowMajor BFLOAT16.
-    // CHECK: %[[IN:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: -> tensor<4x2x128x2880xbf16, {{.*}} memref<1024x2880xbf16,
     // expert_metadata -> RowMajor UINT16.
-    // CHECK: %[[META:.*]] = "ttnn.to_layout"(%arg1)
+    // CHECK: %[[META:.*]] = "ttnn.to_tensor_spec"(%arg1)
     // CHECK-SAME: -> tensor<1x2x128x4xui16, {{.*}} memref<256x4xui16,
     // expert_mapping -> RowMajor UINT16.
-    // CHECK: %[[MAP:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK: %[[MAP:.*]] = "ttnn.to_tensor_spec"(%arg2)
     // CHECK-SAME: -> tensor<1x1x32x8xui16, {{.*}} memref<32x8xui16,
     // CHECK: "ttnn.all_to_all_combine"(%[[IN]], %[[META]], %[[MAP]])
     %result = "ttnn.all_to_all_combine"(%input, %metadata, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64, output_shard_dim = 1 : i64}> : (tensor<4x2x128x2880xbf16, #comb_in>, tensor<1x2x128x4xsi32, #comb_meta>, tensor<1x1x32x8xsi32, #comb_map>) -> tensor<4x1x128x2880xbf16, #comb_out>
@@ -77,13 +77,13 @@ module {
   func.func @moe_expert_token_remap(%topk: tensor<1x2x128x32xbf16, #rmp_topk>, %mapping: tensor<1x1x32x8xsi32, #rmp_map>, %metadata: tensor<1x2x128x4xsi32, #rmp_meta>) -> (tensor<1x2x128x4xbf16, #rmp_topk>, tensor<1x1x8x4xbf16, #rmp_red>) {
     // CHECK-LABEL: func.func @moe_expert_token_remap
     // topk_tensor -> RowMajor BFLOAT16.
-    // CHECK: %[[TOPK:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[TOPK:.*]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: -> tensor<1x2x128x32xbf16, {{.*}} memref<256x32xbf16,
     // expert_mapping -> RowMajor UINT16.
-    // CHECK: %[[MAP:.*]] = "ttnn.to_layout"(%arg1)
+    // CHECK: %[[MAP:.*]] = "ttnn.to_tensor_spec"(%arg1)
     // CHECK-SAME: -> tensor<1x1x32x8xui16, {{.*}} memref<32x8xui16,
     // expert_metadata -> RowMajor UINT16.
-    // CHECK: %[[META:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK: %[[META:.*]] = "ttnn.to_tensor_spec"(%arg2)
     // CHECK-SAME: -> tensor<1x2x128x4xui16, {{.*}} memref<256x4xui16,
     // CHECK: "ttnn.moe_expert_token_remap"(%[[TOPK]], %[[MAP]], %[[META]])
     %mapping_out, %reduced = "ttnn.moe_expert_token_remap"(%topk, %mapping, %metadata) <{reduction_size = 32 : i64}> : (tensor<1x2x128x32xbf16, #rmp_topk>, tensor<1x1x32x8xsi32, #rmp_map>, tensor<1x2x128x4xsi32, #rmp_meta>) -> (tensor<1x2x128x4xbf16, #rmp_topk>, tensor<1x1x8x4xbf16, #rmp_red>)
@@ -108,13 +108,13 @@ module {
   func.func @all_to_all_dispatch_metadata(%input: tensor<1x1x32x128xbf16, #dm_in>, %indices: tensor<1x1x32x4xui16, #dm_idx>, %scores: tensor<1x1x32x4xbf16, #dm_score>, %mapping: tensor<8x4xui16, #dm_map>) -> (tensor<1x32x128xbf16, #dm_disp>, tensor<1x32x4xui16, #dm_iout>, tensor<1x32x4xbf16, #dm_sout>) {
     // CHECK-LABEL: func.func @all_to_all_dispatch_metadata
     // input_tensor -> L1-interleaved RowMajor BFLOAT16.
-    // CHECK: %[[IN:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: -> tensor<1x1x32x128xbf16, {{.*}} memref<1x4096xbf16, #ttnn.buffer_type<l1>>
     // expert_indices -> L1-interleaved RowMajor UINT16.
-    // CHECK: %[[IDX:.*]] = "ttnn.to_layout"(%arg1)
+    // CHECK: %[[IDX:.*]] = "ttnn.to_tensor_spec"(%arg1)
     // CHECK-SAME: -> tensor<1x1x32x4xui16, {{.*}} memref<1x128xui16, #ttnn.buffer_type<l1>>
     // expert_scores -> L1-interleaved RowMajor BFLOAT16.
-    // CHECK: %[[SC:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK: %[[SC:.*]] = "ttnn.to_tensor_spec"(%arg2)
     // CHECK-SAME: -> tensor<1x1x32x4xbf16, {{.*}} memref<1x128xbf16, #ttnn.buffer_type<l1>>
     // CHECK: "ttnn.all_to_all_dispatch_metadata"(%[[IN]], %[[IDX]], %[[SC]], %arg3)
     %disp, %idx, %sc = "ttnn.all_to_all_dispatch_metadata"(%input, %indices, %scores, %mapping) <{cluster_axis = 0 : i64, num_devices = 1 : i64, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0, 0, 0>}> : (tensor<1x1x32x128xbf16, #dm_in>, tensor<1x1x32x4xui16, #dm_idx>, tensor<1x1x32x4xbf16, #dm_score>, tensor<8x4xui16, #dm_map>) -> (tensor<1x32x128xbf16, #dm_disp>, tensor<1x32x4xui16, #dm_iout>, tensor<1x32x4xbf16, #dm_sout>)
@@ -137,7 +137,7 @@ module {
 module {
   func.func public @sparse_matmul_sparsity_f32_to_bf16(%a: tensor<1x4x32x256xbf16, #sm_a>, %b: tensor<1x4x256x64xbf16, #sm_b>, %s: tensor<1x4x1x4xf32, #sm_sf>) -> tensor<1x4x1x4x32x64xbf16, #sm_o> {
     // CHECK-LABEL: func.func public @sparse_matmul_sparsity_f32_to_bf16
-    // CHECK: %[[SPARSITY:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK: %[[SPARSITY:.*]] = "ttnn.to_tensor_spec"(%arg2)
     // CHECK-SAME: tensor<1x4x1x4xf32,
     // CHECK-SAME: -> tensor<1x4x1x4xbf16, {{.*}} memref<4x4xbf16,
     // CHECK: "ttnn.sparse_matmul"(%arg0, %arg1, %[[SPARSITY]])
@@ -156,7 +156,7 @@ module {
 module {
   func.func public @sparse_matmul_sparsity_ui16_to_bf16(%a: tensor<1x4x32x256xbf16, #sm_a>, %b: tensor<1x4x256x64xbf16, #sm_b>, %s: tensor<1x4x1x4xui16, #sm_su>) -> tensor<1x4x1x4x32x64xbf16, #sm_o> {
     // CHECK-LABEL: func.func public @sparse_matmul_sparsity_ui16_to_bf16
-    // CHECK: %[[SPARSITY:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK: %[[SPARSITY:.*]] = "ttnn.to_tensor_spec"(%arg2)
     // CHECK-SAME: tensor<1x4x1x4xui16,
     // CHECK-SAME: -> tensor<1x4x1x4xbf16, {{.*}} memref<4x4xbf16,
     // CHECK: "ttnn.sparse_matmul"(%arg0, %arg1, %[[SPARSITY]])

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
@@ -7,14 +7,14 @@
 module attributes {} {
   func.func @test_pad_workaround(%arg0: tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1> {
     // CHECK-LABEL: @test_pad_workaround
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: tensor<1x30x30xsi32,
     // CHECK-SAME: -> tensor<1x30x30xsi32,
     // CHECK: %[[PAD:[0-9]+]] = "ttnn.pad"(%[[ARG0]])
     // CHECK-SAME: tensor<1x30x30xsi32
     // CHECK-SAME: -> tensor<1x32x32xsi32,
     %0 = "ttnn.pad"(%arg0) <{padding = array<i32: 0, 0, 1, 1, 1, 1>, use_multicore = false, value = 0.000000e+00 : f32}> : (tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1>
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[PAD]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[PAD]])
     // CHECK-SAME: tensor<1x32x32xsi32,
     // CHECK-SAME: -> tensor<1x32x32xsi32,
     return %0 : tensor<1x32x32xsi32, #ttnn_layout1>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/permute_dtype_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/permute_dtype_workaround.mlir
@@ -5,11 +5,11 @@
 #ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 128 + d1, d2), <1x1>, memref<256x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
 module attributes {} {
   func.func @permute_general(%arg0: tensor<32x64x128xsi32, #ttnn_layout>) -> tensor<64x128x32xsi32, #ttnn_layout1> {
-    // CHECK: %[[LAYOUT_TYPE_CAST0:[0-9]+]] = "ttnn.to_layout"(%arg0
+    // CHECK: %[[LAYOUT_TYPE_CAST0:[0-9]+]] = "ttnn.to_tensor_spec"(%arg0
     // CHECK-SAME: -> tensor<32x64x128xf32
     // CHECK: %[[PERMUTE:[0-9]+]] = "ttnn.permute"(%[[LAYOUT_TYPE_CAST0]])
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 2, 0>}> : (tensor<32x64x128xsi32, #ttnn_layout>) -> tensor<64x128x32xsi32, #ttnn_layout1>
-    // CHECK: %[[LAYOUT_TYPE_CAST1:[0-9]+]] = "ttnn.to_layout"(%[[PERMUTE]]
+    // CHECK: %[[LAYOUT_TYPE_CAST1:[0-9]+]] = "ttnn.to_tensor_spec"(%[[PERMUTE]]
     // CHECK-SAME: -> tensor<64x128x32xsi32
     return %0 : tensor<64x128x32xsi32, #ttnn_layout1>
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
@@ -6,7 +6,7 @@
 #ttnn_layout1 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x4x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
 func.func public @test_reduce_max(%arg0: tensor<128x32xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
   // CHECK-LABEL: @test_reduce_max
-  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
+  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_tensor_spec"(%arg0)
   // CHECK-SAME: tensor<128x32xsi32,
   // CHECK-SAME: -> tensor<128x32xf32,
   // CHECK: %[[MAX:[0-9]+]] = "ttnn.max"(%[[ARG0]])
@@ -14,7 +14,7 @@ func.func public @test_reduce_max(%arg0: tensor<128x32xsi32, #ttnn_layout>) -> t
   // CHECK-SAME: tensor<128x32xf32,
   // CHECK-SAME: -> tensor<128xf32,
   %0 = "ttnn.max"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x32xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
-  // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[MAX]])
+  // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[MAX]])
   // CHECK-SAME: tensor<128xf32,
   // CHECK-SAME: -> tensor<128xsi32,
   return %0 : tensor<128xsi32, #ttnn_layout1>
@@ -22,7 +22,7 @@ func.func public @test_reduce_max(%arg0: tensor<128x32xsi32, #ttnn_layout>) -> t
 
 func.func public @test_reduce_sum(%arg0: tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
   // CHECK-LABEL: @test_reduce_sum
-  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
+  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_tensor_spec"(%arg0)
   // CHECK-SAME: tensor<128x10xsi32,
   // CHECK-SAME: -> tensor<128x10xf32,
   // CHECK: %[[SUM:[0-9]+]] = "ttnn.sum"(%[[ARG0]])
@@ -30,7 +30,7 @@ func.func public @test_reduce_sum(%arg0: tensor<128x10xsi32, #ttnn_layout>) -> t
   // CHECK-SAME: tensor<128x10xf32,
   // CHECK-SAME: -> tensor<128xf32,
   %0 = "ttnn.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
-  // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[SUM]])
+  // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[SUM]])
   // CHECK-SAME: tensor<128xf32,
   // CHECK-SAME: -> tensor<128xsi32,
   return %0 : tensor<128xsi32, #ttnn_layout1>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sampling_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sampling_workaround.mlir
@@ -33,17 +33,17 @@ module attributes {} {
     // CHECK-LABEL: func.func @sampling_rank2_input_decomposes_to_rank4
     // CHECK-DAG: "ttnn.reshape"
     // CHECK-DAG-SAME: shape = [1 : i32, 1 : i32, 1 : i32, 32 : i32]
-    // CHECK-DAG: "ttnn.to_layout"{{.*}}memref<{{[0-9x]+}}si32,
-    // CHECK-DAG: "ttnn.to_layout"{{.*}}memref<{{[0-9x]+}}ui32,
-    // CHECK-DAG: "ttnn.to_layout"{{.*}}memref<{{[0-9x]+}}bf16,
-    // CHECK-DAG: "ttnn.to_layout"{{.*}}memref<{{[0-9x]+}}bf16,
+    // CHECK-DAG: "ttnn.to_tensor_spec"{{.*}}memref<{{[0-9x]+}}si32,
+    // CHECK-DAG: "ttnn.to_tensor_spec"{{.*}}memref<{{[0-9x]+}}ui32,
+    // CHECK-DAG: "ttnn.to_tensor_spec"{{.*}}memref<{{[0-9x]+}}bf16,
+    // CHECK-DAG: "ttnn.to_tensor_spec"{{.*}}memref<{{[0-9x]+}}bf16,
     // ttnn.sampling now operates on the kernel-true rank-4 shape and yields ui32.
     // CHECK: "ttnn.sampling"
     // CHECK-SAME: (tensor<1x1x1x32xbf16{{.*}}>, tensor<1x1x1x32xsi32{{.*}}>, tensor<1xui32{{.*}}>, tensor<1xbf16{{.*}}>, tensor<1xbf16{{.*}}>)
     // CHECK-SAME: -> tensor<1x1x1x1xui32
     // Result is converted from ui32 -> si32 (dtype workaround) and reshaped
     // from [1,1,1,batch] -> [batch] (rank-2 decomposition's trailing reshape).
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<1x1x1x1xsi32
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
@@ -71,7 +71,7 @@ module attributes {} {
       %arg4: tensor<1xbf16, #ttnn_layout_p_tile>)
       -> tensor<1xsi32, #ttnn_layout_out> {
     // CHECK-LABEL: func.func @sampling_k_si32_gets_retyped_to_ui32
-    // CHECK: "ttnn.to_layout"(%arg2)
+    // CHECK: "ttnn.to_tensor_spec"(%arg2)
     // CHECK-SAME: (tensor<1xsi32{{.*}}>) -> tensor<1xui32
     // CHECK: "ttnn.sampling"
     %0 = "ttnn.sampling"(%arg0, %arg1, %arg2, %arg3, %arg4)

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_f32_input_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_f32_input_workaround.mlir
@@ -5,7 +5,7 @@
 module {
   func.func public @test_sort_f32_input_workaround(%arg0: tensor<1x10xf32>) -> (tensor<1x10xf32>, tensor<1x10xsi32>) {
     // CHECK-LABEL: func.func public @test_sort_f32_input_workaround
-    // CHECK: %[[INPUT_BF16:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[INPUT_BF16:.*]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: tensor<1x10xf32
     // CHECK-SAME: -> tensor<1x10xbf16
     // CHECK: %[[VALUES:.*]], %{{.*}} = "ttnn.sort"(%[[INPUT_BF16]])
@@ -13,7 +13,7 @@ module {
     // CHECK-SAME: tensor<1x10xbf16
     // CHECK-SAME: -> (tensor<1x10xbf16
     // CHECK-SAME: tensor<1x10xui16
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[VALUES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[VALUES]])
     // CHECK-SAME: tensor<1x10xbf16
     // CHECK-SAME: -> tensor<1x10xf32
     %values, %indices = "ttir.sort"(%arg0) <{descending = true, dim = 1 : si32, stable = false}> : (tensor<1x10xf32>) -> (tensor<1x10xf32>, tensor<1x10xsi32>)

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_integer_input_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_integer_input_workaround.mlir
@@ -6,7 +6,7 @@ module {
   func.func public @test_sort_integer_input_workaround(%arg0: tensor<1x10xsi32>) -> (tensor<1x10xsi32>, tensor<1x10xsi32>) {
     // CHECK-LABEL: func.func public @test_sort_integer_input_workaround
     // Verify si32→ui16 typecast is inserted
-    // CHECK: ttnn.to_layout
+    // CHECK: ttnn.to_tensor_spec
     // CHECK: tensor<1x10xsi32
     // CHECK: tensor<1x10xui16
     // Verify sort operates on ui16
@@ -16,7 +16,7 @@ module {
     // CHECK: tensor<1x10xui16
     // CHECK: tensor<1x10xui16
     // Verify values converted back to si32
-    // CHECK: ttnn.to_layout
+    // CHECK: ttnn.to_tensor_spec
     // CHECK: tensor<1x10xui16
     // CHECK: tensor<1x10xsi32
     %values, %indices = "ttir.sort"(%arg0) <{descending = true, dim = 1 : si32, stable = false}> : (tensor<1x10xsi32>) -> (tensor<1x10xsi32>, tensor<1x10xsi32>)

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_vocab_size_uint32.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_vocab_size_uint32.mlir
@@ -10,7 +10,7 @@ module {
     // CHECK-SAME: -> (tensor<1x50272xbf16,
     // CHECK-SAME: tensor<1x50272xui32,
     %0, %1 = "ttir.sort"(%arg0) : (tensor<1x50272xbf16>) -> (tensor<1x50272xbf16>, tensor<1x50272xsi32>)
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[INDICES]])
     // CHECK-SAME: tensor<1x50272xui32,
     // CHECK-SAME: -> tensor<1x50272xsi32,
     return %0, %1 : tensor<1x50272xbf16>, tensor<1x50272xsi32>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_workaround.mlir
@@ -10,7 +10,7 @@ module {
     // CHECK-SAME: -> (tensor<64x128xbf16,
     // CHECK-SAME: tensor<64x128xui16,
     %0, %1 = "ttir.sort"(%arg0) : (tensor<64x128xbf16>) -> (tensor<64x128xbf16>, tensor<64x128xsi32>)
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[INDICES]])
     // CHECK-SAME: tensor<64x128xui16,
     // CHECK-SAME: -> tensor<64x128xsi32,
     return %0, %1 : tensor<64x128xbf16>, tensor<64x128xsi32>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sparse_matmul_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sparse_matmul_workaround.mlir
@@ -22,7 +22,7 @@ module {
       %b: tensor<1x4x256x64xbf16>,
       %s: tensor<1x4x1x4xf32>) -> tensor<1x4x1x4x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sparse_matmul_sparsity_f32_to_bf16
-    // CHECK: %[[SPARSITY_BF16:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK: %[[SPARSITY_BF16:.*]] = "ttnn.to_tensor_spec"(%arg2)
     // CHECK-SAME: tensor<1x4x1x4xf32,
     // CHECK-SAME: -> tensor<1x4x1x4xbf16,
     // CHECK: "ttnn.sparse_matmul"(%{{.*}}, %{{.*}}, %[[SPARSITY_BF16]])
@@ -46,7 +46,7 @@ module {
       %b: tensor<1x4x256x64xbf16>,
       %s: tensor<1x4x1x4xui16>) -> tensor<1x4x1x4x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sparse_matmul_sparsity_ui16_to_bf16
-    // CHECK: %[[SPARSITY_BF16:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK: %[[SPARSITY_BF16:.*]] = "ttnn.to_tensor_spec"(%arg2)
     // CHECK-SAME: tensor<1x4x1x4xui16,
     // CHECK-SAME: -> tensor<1x4x1x4xbf16,
     // CHECK: "ttnn.sparse_matmul"(%{{.*}}, %{{.*}}, %[[SPARSITY_BF16]])

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/to_layout_canonical_l1_interleaved.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/to_layout_canonical_l1_interleaved.mlir
@@ -33,15 +33,15 @@ module attributes {} {
   // CHECK-LABEL: func.func @dispatch_metadata_l1_canonical_form
 
   // input_tensor: 32 x 128 = 4096 -> memref<1x4096xbf16, l1>
-  // CHECK: "ttnn.to_layout"
+  // CHECK: "ttnn.to_tensor_spec"
   // CHECK-SAME: -> tensor<{{.*}}xbf16, #ttnn.ttnn_layout<{{.*}} memref<1x4096xbf16, #ttnn.buffer_type<l1>>, <interleaved>>>
 
   // expert_indices: 32 x 4 = 128 -> memref<1x128xui16, l1>
-  // CHECK: "ttnn.to_layout"
+  // CHECK: "ttnn.to_tensor_spec"
   // CHECK-SAME: -> tensor<{{.*}}xui16, #ttnn.ttnn_layout<{{.*}} memref<1x128xui16, #ttnn.buffer_type<l1>>, <interleaved>>>
 
   // expert_scores: 32 x 4 = 128 -> memref<1x128xbf16, l1>
-  // CHECK: "ttnn.to_layout"
+  // CHECK: "ttnn.to_tensor_spec"
   // CHECK-SAME: -> tensor<{{.*}}xbf16, #ttnn.ttnn_layout<{{.*}} memref<1x128xbf16, #ttnn.buffer_type<l1>>, <interleaved>>>
   func.func @dispatch_metadata_l1_canonical_form(
       %input:   tensor<1x1x32x128xbf16, #dram_input>,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_f32_input_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_f32_input_workaround.mlir
@@ -5,7 +5,7 @@
 module {
   func.func public @test_topk_f32_input_workaround(%arg0: tensor<2x3x32x128xf32>) -> (tensor<2x3x32x5xf32>, tensor<2x3x32x5xsi32>) {
     // CHECK-LABEL: func.func public @test_topk_f32_input_workaround
-    // CHECK: %[[INPUT_BF16:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[INPUT_BF16:.*]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: tensor<2x3x32x128xf32
     // CHECK-SAME: -> tensor<2x3x32x128xbf16
     // CHECK: %[[VALUES:.*]], %[[INDICES:.*]] = "ttnn.topk"(%[[INPUT_BF16]])
@@ -13,10 +13,10 @@ module {
     // CHECK-SAME: tensor<2x3x32x128xbf16
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16
     // CHECK-SAME: tensor<2x3x32x5xui16
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[INDICES]])
     // CHECK-SAME: tensor<2x3x32x5xui16
     // CHECK-SAME: -> tensor<2x3x32x5xsi32
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[VALUES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[VALUES]])
     // CHECK-SAME: tensor<2x3x32x5xbf16
     // CHECK-SAME: -> tensor<2x3x32x5xf32
     %values, %indices = "ttir.topk"(%arg0) { k = 5 : i32 } : (tensor<2x3x32x128xf32>) -> (tensor<2x3x32x5xf32>, tensor<2x3x32x5xsi32>)

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround.mlir
@@ -10,7 +10,7 @@ module {
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
     // CHECK-SAME: tensor<2x3x32x5xui16,
     %values, %indices = "ttir.topk"(%arg0) { k = 5 : i32 } : (tensor<2x3x32x128xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>)
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[INDICES]])
     // CHECK-SAME: tensor<2x3x32x5xui16,
     // CHECK-SAME: -> tensor<2x3x32x5xsi32,
     return %values, %indices : tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>
@@ -27,7 +27,7 @@ module {
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
     // CHECK-SAME: tensor<2x3x32x5xui32,
     %values, %indices = "ttir.topk"(%arg0) { k = 5 : i32 } : (tensor<2x3x32x128000xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>)
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[INDICES]])
     // CHECK-SAME: tensor<2x3x32x5xui32,
     // CHECK-SAME: -> tensor<2x3x32x5xsi32,
     return %values, %indices : tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround_with_optimizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround_with_optimizer.mlir
@@ -33,7 +33,7 @@ module {
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
     // CHECK-SAME: tensor<2x3x32x5xui16,
     %values, %indices = "ttir.topk"(%arg0) { k = 5 : i32 } : (tensor<2x3x32x128xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>)
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[INDICES]])
     // CHECK-SAME: tensor<2x3x32x5xui16,
     // CHECK-SAME: -> tensor<2x3x32x5xsi32,
     return %values, %indices : tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>
@@ -50,7 +50,7 @@ module {
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
     // CHECK-SAME: tensor<2x3x32x5xui32,
     %values, %indices = "ttir.topk"(%arg0) { k = 5 : i32 } : (tensor<2x3x32x128000xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>)
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[INDICES]])
     // CHECK-SAME: tensor<2x3x32x5xui32,
     // CHECK-SAME: -> tensor<2x3x32x5xsi32,
     return %values, %indices : tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>
@@ -64,7 +64,7 @@ module {
 module {
   func.func public @test_topk_workaround_with_optimizer_f32_input(%arg0: tensor<2x3x32x128xf32>) -> (tensor<2x3x32x5xf32>, tensor<2x3x32x5xsi32>) {
     // CHECK-LABEL: func.func public @test_topk_workaround_with_optimizer_f32_input
-    // CHECK: %[[INPUT_BF16:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK: %[[INPUT_BF16:.*]] = "ttnn.to_tensor_spec"(%arg0)
     // CHECK-SAME: tensor<2x3x32x128xf32
     // CHECK-SAME: -> tensor<2x3x32x128xbf16
     // CHECK: %[[VALUES:.*]], %[[INDICES:.*]] = "ttnn.topk"(%[[INPUT_BF16]])
@@ -72,10 +72,10 @@ module {
     // CHECK-SAME: tensor<2x3x32x128xbf16
     // CHECK-SAME: -> (tensor<2x3x32x5xbf16
     // CHECK-SAME: tensor<2x3x32x5xui16
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[INDICES]])
     // CHECK-SAME: tensor<2x3x32x5xui16
     // CHECK-SAME: -> tensor<2x3x32x5xsi32
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[VALUES]])
+    // CHECK: %{{[0-9]+}} = "ttnn.to_tensor_spec"(%[[VALUES]])
     // CHECK-SAME: tensor<2x3x32x5xbf16
     // CHECK-SAME: -> tensor<2x3x32x5xf32
     %values, %indices = "ttir.topk"(%arg0) { k = 5 : i32 } : (tensor<2x3x32x128xf32>) -> (tensor<2x3x32x5xf32>, tensor<2x3x32x5xsi32>)

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_bilinear_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_bilinear_workaround.mlir
@@ -11,11 +11,11 @@ module {
   func.func @test_layout_padding_sharding(%arg0: tensor<1x8x8x30xf32, #layout_tile_interleaved>) -> tensor<1x16x16x30xf32, #layout_tile_interleaved_out> {
     // CHECK: %[[PADDED:.*]] = "ttnn.pad"(%arg0)
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 0, 0, 2>
-    // CHECK: %[[TO_ROWMAJOR:.*]] = "ttnn.to_layout"(%[[PADDED]])
+    // CHECK: %[[TO_ROWMAJOR:.*]] = "ttnn.to_tensor_spec"(%[[PADDED]])
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK: %[[UPSAMPLE:.*]] = "ttnn.upsample"(%[[TO_ROWMAJOR]])
     // CHECK-SAME: mode = "bilinear"
-    // CHECK: %[[TO_TILE:.*]] = "ttnn.to_layout"(%[[UPSAMPLE]])
+    // CHECK: %[[TO_TILE:.*]] = "ttnn.to_tensor_spec"(%[[UPSAMPLE]])
     // CHECK-SAME: -> tensor<{{.*}}xf32,
     // CHECK: "ttnn.slice_static"(%[[TO_TILE]])
     // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32]
@@ -28,7 +28,7 @@ module {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: %[[UPSAMPLE:.*]] = "ttnn.upsample"(%arg0)
     // CHECK-SAME: mode = "bilinear"
-    // CHECK-NOT: "ttnn.to_layout"
+    // CHECK-NOT: "ttnn.to_tensor_spec"
     // CHECK-NOT: "ttnn.pad"
     %1 = "ttnn.upsample"(%arg0) <{mode = "bilinear", scale_factor = 2 : si32}> : (tensor<1x16x16x32xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 512 + d1 * 16 + d2, d3), <16x1>, memref<16x32xbf16, #l1>, <height_sharded>, core_ranges = <[#ttnn.core_range<(0, 0), (7, 1)>]>>>) -> tensor<1x32x32x32xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <16x1>, memref<64x32xbf16, #l1>, <height_sharded>, core_ranges = <[#ttnn.core_range<(0, 0), (7, 1)>]>>>
     return %1 : tensor<1x32x32x32xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <16x1>, memref<64x32xbf16, #l1>, <height_sharded>, core_ranges = <[#ttnn.core_range<(0, 0), (7, 1)>]>>>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_workaround.mlir
@@ -11,18 +11,18 @@
 module attributes {} {
   func.func @upsample2d_scale_unifrom(%arg0: tensor<4x32x64x3xf32, #ttnn_layout>) -> tensor<4x64x128x3xf32, #ttnn_layout1> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0)  : (tensor<4x32x64x3xf32, #ttnn_layout>) -> tensor<4x32x64x3xf32, #ttnn_layout2>
+    %1 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<4x32x64x3xf32, #ttnn_layout>) -> tensor<4x32x64x3xf32, #ttnn_layout2>
     %2 = "ttnn.to_device"(%1, %0) : (tensor<4x32x64x3xf32, #ttnn_layout2>, !ttnn.device) -> tensor<4x32x64x3xf32, #ttnn_layout3>
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<4x32x64x3xf32, #ttnn_layout2>) -> ()
-    // CHECK: "ttnn.to_layout"
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<{{.*}}xbf16,
     // CHECK: "ttnn.upsample"
     %3 = "ttnn.upsample"(%2) <{mode = "nearest", scale_factor = 2 : si32}> : (tensor<4x32x64x3xf32, #ttnn_layout3>) -> tensor<4x64x128x3xf32, #ttnn_layout4>
     "ttnn.deallocate"(%2) <{force = false}> : (tensor<4x32x64x3xf32, #ttnn_layout3>) -> ()
     %4 = "ttnn.from_device"(%3) : (tensor<4x64x128x3xf32, #ttnn_layout4>) -> tensor<4x64x128x3xf32, #ttnn_layout5>
     "ttnn.deallocate"(%3) <{force = false}> : (tensor<4x64x128x3xf32, #ttnn_layout4>) -> ()
-    %5 = "ttnn.to_layout"(%4)  : (tensor<4x64x128x3xf32, #ttnn_layout5>) -> tensor<4x64x128x3xf32, #ttnn_layout1>
+    %5 = "ttnn.to_tensor_spec"(%4)  : (tensor<4x64x128x3xf32, #ttnn_layout5>) -> tensor<4x64x128x3xf32, #ttnn_layout1>
     "ttnn.deallocate"(%4) <{force = false}> : (tensor<4x64x128x3xf32, #ttnn_layout5>) -> ()
     return %5 : tensor<4x64x128x3xf32, #ttnn_layout1>
   }

--- a/test/ttmlir/Dialect/TTNN/optimizer/all_gather_ttnn_rm_layout_propagation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/all_gather_ttnn_rm_layout_propagation.mlir
@@ -11,9 +11,9 @@ module attributes {ttcore.system_desc = #system_desc} {
   func.func @main(%arg0: tensor<1x1xsi32, #ttnn_layout> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<1x2xui32, #ttnn_layout1> attributes {tt.function_type = "forward_device"} {
     // CHECK-LABEL: func.func @main
     // CHECK: %[[TC:.*]] = "ttnn.typecast"(%arg0)
-    // CHECK: %[[FIX:.*]] = "ttnn.to_layout"(%[[TC]])
+    // CHECK: %[[FIX:.*]] = "ttnn.to_tensor_spec"(%[[TC]])
     // CHECK: "ttnn.all_gather"(%[[FIX]])
-    %0 = "ttnn.to_layout"(%arg0) : (tensor<1x1xsi32, #ttnn_layout>) -> tensor<1x1xsi32, #ttnn_layout2>
+    %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<1x1xsi32, #ttnn_layout>) -> tensor<1x1xsi32, #ttnn_layout2>
     %1 = "ttnn.typecast"(%0) : (tensor<1x1xsi32, #ttnn_layout2>) -> tensor<1x1xui32, #ttnn_layout1>
     %2 = "ttnn.all_gather"(%1) <{all_gather_dim = 1 : si32, cluster_axis = 1 : ui32}> : (tensor<1x1xui32, #ttnn_layout1>) -> tensor<1x2xui32, #ttnn_layout1>
     return %2 : tensor<1x2xui32, #ttnn_layout1>

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/binary_ops_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/binary_ops_validation.mlir
@@ -16,7 +16,7 @@ module attributes {} {
     // doesn't match the expected one, so it inserts a revert to tile layout.
 
     // CHECK: %[[SUB_RES:.*]] = "ttnn.subtract"
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: (%[[SUB_RES]]
 
     %1 = "ttnn.subtract"(%arg0, %arg1) : (tensor<1x1x32x32xsi32, #ttnn_layout_row_major_si32>, tensor<1x1x32x32xsi32, #ttnn_layout_row_major_si32>) -> tensor<1x1x32x32xbf16, #ttnn_layout_tile_bf16>
@@ -32,7 +32,7 @@ module attributes {} {
     // inserts a revert to tile layout.
 
     // CHECK: %[[ADD_RES:.*]] = "ttnn.add"
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: (%[[ADD_RES]]
 
     %1 = "ttnn.add"(%arg0, %arg1) : (tensor<1x1x32x32xbf16, #ttnn_layout_row_major_bf16>, tensor<1x1x32x32xbf16, #ttnn_layout_row_major_bf16>) -> tensor<1x1x32x32xbf16, #ttnn_layout_tile_bf16>

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/concat_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/concat_validation.mlir
@@ -14,7 +14,7 @@ module attributes {} {
     // but the output layout doesn't match the expected one, so it inserts a revert to tile layout with bf16.
 
     // CHECK: %[[CONCAT_RES:.*]] = "ttnn.concat"
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: (%[[CONCAT_RES]]
     // CHECK-SAME: -> tensor<{{.*}}bf16
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/embedding_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/embedding_validation.mlir
@@ -16,7 +16,7 @@ module attributes {} {
     // The post-optimizer validation should detect that embedding requires:
     // BFloat16 data type for weight tensor (f32 -> bf16)
 
-    // CHECK: %[[CONVERTED:.*]] = "ttnn.to_layout"
+    // CHECK: %[[CONVERTED:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<100x32xbf16
     // CHECK: "ttnn.embedding"
     // CHECK-SAME: %[[CONVERTED]])
@@ -32,9 +32,9 @@ module attributes {} {
     // The post-optimizer validation should detect that embedding requires:
     // BFloat16 data type for weight tensor (f32 -> bf16)
 
-    // CHECK: %[[ARG0_BF16:.*]] = "ttnn.to_layout"
+    // CHECK: %[[ARG0_BF16:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<32x32xbf16
-    // CHECK: %[[ARG1_BF16:.*]] = "ttnn.to_layout"
+    // CHECK: %[[ARG1_BF16:.*]] = "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<1000x32xbf16
     // CHECK: "ttnn.embedding"
     // CHECK-SAME: (%[[ARG0_BF16]], %[[ARG1_BF16]])

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/pool2d_layout_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/pool2d_layout_validation.mlir
@@ -18,11 +18,11 @@ module attributes {} {
     // 2. Returns row-major layout
     // Therefore, the pass will insert the necessary type conversion and revert output layout ops.
 
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<1x1x16384x32xbf16,
     // CHECK-NEXT: "ttnn.max_pool2d"
     // CHECK-SAME: -> tensor<1x1x4096x32xbf16,
-    // CHECK-NEXT: "ttnn.to_layout"
+    // CHECK-NEXT: "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<1x1x4096x32xbf16,
     // CHECK-SAME: !ttcore.tile<32x32,
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/reshape_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/reshape_validation.mlir
@@ -11,7 +11,7 @@ module attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
     // CHECK: %[[RESHAPE_RES:.*]] = "ttnn.reshape"
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: (%[[RESHAPE_RES]]
 
     %1 = "ttnn.reshape"(%arg0) <{

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/sort_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/sort_validation.mlir
@@ -16,7 +16,7 @@ module attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
     // CHECK: %[[VALUES:.*]], %[[INDICES:.*]] = "ttnn.sort"
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: (%[[INDICES]]
     // CHECK-SAME: -> tensor<128x32xsi32
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/sum_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/sum_validation.mlir
@@ -14,7 +14,7 @@ module attributes {} {
     // but the output layout doesn't match the expected one, so it inserts a revert to row-major layout with bf16.
 
     // CHECK: %[[SUM_RES:.*]] = "ttnn.sum"
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: (%[[SUM_RES]]
     // CHECK-SAME: -> tensor<1x1x1x1xbf16,
     // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/tanh_dtype_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/tanh_dtype_validation.mlir
@@ -14,7 +14,7 @@ module attributes {} {
     // but the output layout doesn't match the expected one, so it inserts a revert to tile layout with bf16.
 
     // CHECK: %[[TANH_RES:.*]] = "ttnn.tanh"
-    // CHECK: "ttnn.to_layout"(%[[TANH_RES]])
+    // CHECK: "ttnn.to_tensor_spec"(%[[TANH_RES]])
     // CHECK-SAME: -> tensor<1x1x32x32xbf16,
     // CHECK-SAME: !ttcore.tile<32x32,
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/upsample_post_optimizer_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/upsample_post_optimizer_validation.mlir
@@ -15,9 +15,9 @@ module attributes {} {
     // and automatically insert layout conversion for tile input.
     // Also, the output layout of upsample op will be the same as input layout, so revert it back to the expected layout.
 
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-NEXT: "ttnn.upsample"
-    // CHECK-NEXT: "ttnn.to_layout"
+    // CHECK-NEXT: "ttnn.to_tensor_spec"
     // CHECK-SAME: -> tensor<4x64x128x3xbf16,
     // CHECK-SAME: !ttcore.tile<32x32,
 

--- a/test/ttmlir/Dialect/TTNN/test_remove_dead_values_pass.mlir
+++ b/test/ttmlir/Dialect/TTNN/test_remove_dead_values_pass.mlir
@@ -8,50 +8,50 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32, #ttnn_layout>, %arg1: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %1 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %2 = "ttnn.to_device"(%1, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %3 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %3 = "ttnn.to_tensor_spec"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %4 = "ttnn.to_device"(%3, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%3) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK: "ttnn.multiply"
     %5 = "ttnn.multiply"(%2, %4) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%4) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%2) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %6 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %6 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %7 = "ttnn.to_device"(%6, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%6) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %8 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %8 = "ttnn.to_tensor_spec"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %9 = "ttnn.to_device"(%8, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%8) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.add"
     %10 = "ttnn.add"(%7, %9) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%9) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%7) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %11 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %11 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %12 = "ttnn.to_device"(%11, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%11) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %13 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %13 = "ttnn.to_tensor_spec"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %14 = "ttnn.to_device"(%13, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%13) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.subtract"
     %15 = "ttnn.subtract"(%12, %14) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%14) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%12) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %16 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %16 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %17 = "ttnn.to_device"(%16, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%16) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %18 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %18 = "ttnn.to_tensor_spec"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %19 = "ttnn.to_device"(%18, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%18) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.divide"
     %20 = "ttnn.divide"(%17, %19) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%19) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%17) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %21 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %21 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %22 = "ttnn.to_device"(%21, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%21) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
-    %23 = "ttnn.to_layout"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
+    %23 = "ttnn.to_tensor_spec"(%arg1)  : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
     %24 = "ttnn.to_device"(%23, %0) : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%23) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.eq"

--- a/test/ttmlir/Dialect/TTNN/trace/midgraph_creation_op.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/midgraph_creation_op.mlir
@@ -36,7 +36,7 @@ module {
         // in as a trace input alongside the two real inputs.
         // CHECK: "ttnn.get_device"
         // CHECK: %[[FULL:.+]] = "ttnn.full"
-        // CHECK: %[[FULL_HOST:.+]] = "ttnn.to_layout"(%[[FULL]])
+        // CHECK: %[[FULL_HOST:.+]] = "ttnn.to_tensor_spec"(%[[FULL]])
         // CHECK: "ttnn.capture_or_execute_trace"({{.*}}%[[FULL_HOST]])
         %dev = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
         %add = "ttnn.add"(%arg0, %arg1) : (tensor<1x12x32x64xbf16, #ttnn_layout>, tensor<1x12x32x64xbf16, #ttnn_layout>) -> tensor<1x12x32x64xbf16, #ttnn_layout>

--- a/test/ttmlir/EmitPy/transformer/chunked_scaled_dot_product_attention.mlir
+++ b/test/ttmlir/EmitPy/transformer/chunked_scaled_dot_product_attention.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround --convert-ttnn-to-emitpy -o %t.mlir %s
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround --ttnn-decompose-layouts --convert-ttnn-to-emitpy -o %t.mlir %s
 // RUN: ttmlir-translate --mlir-to-python %t.mlir | FileCheck %s
 
 func.func @chunked_sdpa(%arg0: tensor<1x12x64x64xbf16>, %arg1: tensor<128x12x32x64xbf16>, %arg2: tensor<128x12x32x64xbf16>, %arg3: tensor<1x8xi32>, %arg4: tensor<1xi32>) -> tensor<1x12x64x64xbf16> {

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_dram_sharded.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_dram_sharded.mlir
@@ -63,7 +63,7 @@ module attributes {} {
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[TO_DEV]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: return %[[UNTILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #host_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xbf16, #host_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
@@ -76,7 +76,7 @@ module attributes {} {
         // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[UNTILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_RM_BF16]]>
         // CHECK: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_il_rm_bf16>
     }
 
@@ -88,7 +88,7 @@ module attributes {} {
         // CHECK-NOT: ttnn.to_memory_config
         // CHECK-NOT: ttnn.from_device
         // CHECK: return %[[UNTILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
@@ -99,7 +99,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%[[UNTILIZE]])
         // CHECK: return %[[FROM_DEV]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #host_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #host_rm_bf16>
         return %0 : tensor<32x384xbf16, #host_rm_bf16>
     }
 
@@ -112,7 +112,7 @@ module attributes {} {
         // CHECK-NOT: ttnn.to_memory_config
         // CHECK-NOT: ttnn.from_device
         // CHECK: return %[[UNTILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<256x32xbf16, #dram_hs_tile_bf16>) -> tensor<256x32xbf16, #dram_hs_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<256x32xbf16, #dram_hs_tile_bf16>) -> tensor<256x32xbf16, #dram_hs_rm_bf16>
         return %0 : tensor<256x32xbf16, #dram_hs_rm_bf16>
     }
 
@@ -132,7 +132,7 @@ module attributes {} {
         // CHECK: %[[UNTILIZE:.*]] = "ttnn.to_layout"(%[[CAST]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: return %[[UNTILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #host_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xf32, #host_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
@@ -148,7 +148,7 @@ module attributes {} {
         // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[UNTILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_RM_BF16]]>
         // CHECK: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #dram_il_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xf32, #dram_il_tile_f32>) -> tensor<32x384xbf16, #dram_ws_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_rm_bf16>
     }
 
@@ -164,7 +164,7 @@ module attributes {} {
         // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[UNTILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_IL_RM_BF16]]>
         // CHECK: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #dram_ws_tile_f32>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xf32, #dram_ws_tile_f32>) -> tensor<32x384xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x384xbf16, #dram_il_rm_bf16>
     }
 
@@ -181,7 +181,7 @@ module attributes {} {
         // CHECK: %[[TILIZE:.*]] = "ttnn.to_layout"(%[[TO_DEV]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: return %[[TILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #host_rm_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xbf16, #host_rm_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16>
     }
 
@@ -200,7 +200,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK-NOT: "ttnn.typecast"
         // CHECK: return %[[TILIZE]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #host_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xf32, #host_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16>
     }
 
@@ -215,7 +215,7 @@ module attributes {} {
         // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[TILIZE]])
         // CHECK-SAME: -> tensor<32x384xbf16, #[[DRAM_WS_TILE_BF16]]>
         // CHECK: return %[[RESHARD]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xf32, #dram_il_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xf32, #dram_il_rm_f32>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16>
     }
 
@@ -233,7 +233,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST]])
         // CHECK-SAME: -> tensor<32x384xf32, #[[DRAM_IL_TILE_F32]]>
         // CHECK-NEXT: return %[[TO_MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xf32, #dram_il_tile_f32>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xf32, #dram_il_tile_f32>
         return %0 : tensor<32x384xf32, #dram_il_tile_f32>
     }
 
@@ -246,7 +246,7 @@ module attributes {} {
         // CHECK-NOT: ttnn.to_layout
         // CHECK-NOT: ttnn.typecast
         // CHECK: return %[[TO_MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16_grid6>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xbf16, #dram_ws_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16_grid6>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16_grid6>
     }
 
@@ -259,7 +259,7 @@ module attributes {} {
         // CHECK-NOT: ttnn.to_layout
         // CHECK-NOT: ttnn.typecast
         // CHECK: return %[[TO_MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x384xbf16, #l1_bs_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x384xbf16, #l1_bs_tile_bf16>) -> tensor<32x384xbf16, #dram_ws_tile_bf16>
         return %0 : tensor<32x384xbf16, #dram_ws_tile_bf16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
@@ -26,7 +26,7 @@ module attributes {} {
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -39,7 +39,7 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
     }
 
@@ -49,7 +49,7 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
     }
 
@@ -61,7 +61,7 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}xbf16,
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
@@ -73,7 +73,7 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -85,7 +85,7 @@ module attributes {} {
         // This test verifies that the `to_layout` operation is correctly inserted to change the layout from tile to row-major on the host.
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
@@ -94,7 +94,7 @@ module attributes {} {
         // This test verifies that the `to_layout` operation is correctly inserted to change the layout from row-major to tile on the host.
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
@@ -106,7 +106,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
@@ -119,7 +119,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -132,7 +132,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -145,7 +145,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
         return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 
@@ -160,7 +160,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
@@ -172,7 +172,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: !ttcore.tile<32x32,
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
@@ -187,7 +187,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: memref<{{.*}}x{{.*}}, #ttnn.buffer_type
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
@@ -201,7 +201,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<{{.*}}f32
         // CHECK-NOT: "ttnn.typecast"
         // CHECK: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
         return %0 : tensor<64x128xf32, #ttnn_layout_device_tile>
     }
 
@@ -215,7 +215,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK-NOT: "ttnn.typecast"
         // CHECK: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
         return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
@@ -230,7 +230,7 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: -> tensor<{{.*}}ui32
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
         return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 
@@ -243,7 +243,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<{{.*}}bf16
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TYPECAST]])
         // CHECK: return %[[MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<1x1x784x512xf32, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <7x8>, memref<4x2x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,6)>]>>>) -> tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<1x1x784x512xf32, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <7x8>, memref<4x2x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<l1>>, <block_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (7,6)>]>>>) -> tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
         return %0 : tensor<1x1x784x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 800 + d1 * 800 + d2, d3), <1x1>, memref<25x16x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>
     }
 

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_on_device.mlir
@@ -22,7 +22,7 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TO_LAYOUT]])
         // CHECK-NOT: "ttnn.typecast"
         // CHECK: return %[[TO_MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<64x128xui16, #ttnn_layout_l1_rm_ui16>) -> tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
         return %0 : tensor<64x128xui16, #ttnn_layout_dram_tile_ui16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_typecast_on_device_rm.mlir
@@ -26,7 +26,7 @@ module attributes {} {
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: return %[[CAST]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #dram_il_rm_f32>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #dram_il_rm_f32>
         return %0 : tensor<32x128xf32, #dram_il_rm_f32>
     }
 
@@ -37,7 +37,7 @@ module attributes {} {
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<32x128xbf16, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: return %[[CAST]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xf32, #dram_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x128xf32, #dram_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x128xbf16, #dram_il_rm_bf16>
     }
 
@@ -48,7 +48,7 @@ module attributes {} {
         // CHECK: %[[CAST:.*]] = "ttnn.typecast"(%arg0)
         // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<l1>
         // CHECK-NEXT: return %[[CAST]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xbf16, #l1_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x128xbf16, #l1_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
         return %0 : tensor<32x128xf32, #l1_il_rm_f32>
     }
 
@@ -62,7 +62,7 @@ module attributes {} {
         // CHECK-NEXT: %[[MEM:.*]] = "ttnn.to_memory_config"(%[[CAST]])
         // CHECK-SAME: -> tensor<32x128xf32, {{.*}}#ttnn.buffer_type<l1>
         // CHECK-NEXT: return %[[MEM]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x128xbf16, #dram_il_rm_bf16>) -> tensor<32x128xf32, #l1_il_rm_f32>
         return %0 : tensor<32x128xf32, #l1_il_rm_f32>
     }
 
@@ -77,7 +77,7 @@ module attributes {} {
         // CHECK-NEXT: %[[MEM:.*]] = "ttnn.to_memory_config"(%[[CAST]])
         // CHECK-SAME: -> tensor<32x128xbf16, {{.*}}#ttnn.buffer_type<dram>
         // CHECK-NEXT: return %[[MEM]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x128xf32, #l1_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x128xf32, #l1_il_rm_f32>) -> tensor<32x128xbf16, #dram_il_rm_bf16>
         return %0 : tensor<32x128xbf16, #dram_il_rm_bf16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_untilize_on_device.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_untilize_on_device.mlir
@@ -29,7 +29,7 @@ module attributes {} {
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[MEM_CONFIG]])
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xbf16, #ttnn_layout_device_l1_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x2048xbf16, #ttnn_layout_device_l1_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
         return %0 : tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
     }
 
@@ -40,7 +40,7 @@ module attributes {} {
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[MEM_CONFIG]])
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xf32, #ttnn_layout_device_l1_tile_f32>) -> tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x2048xf32, #ttnn_layout_device_l1_tile_f32>) -> tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32>
         return %0 : tensor<32x2048xf32, #ttnn_layout_device_dram_rm_f32>
     }
 
@@ -52,7 +52,7 @@ module attributes {} {
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%[[TO_LAYOUT]])
         // CHECK: return %[[MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16>
         return %0 : tensor<32x2048xbf16, #ttnn_layout_device_l1_rm_bf16>
     }
 
@@ -61,7 +61,7 @@ module attributes {} {
         // CHECK-LABEL: func.func @from_dram_tile_to_dram_rm_bf16
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0)  : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
+        %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<32x2048xbf16, #ttnn_layout_device_dram_tile_bf16>) -> tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
         return %0 : tensor<32x2048xbf16, #ttnn_layout_device_dram_rm_bf16>
     }
 
@@ -75,7 +75,7 @@ module attributes {} {
         // CHECK: %[[MEM_CONFIG:.*]] = "ttnn.to_memory_config"(%arg0)
         // CHECK: %[[TO_LAYOUT:.*]] = "ttnn.to_layout"(%[[MEM_CONFIG]])
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x256xbf16, #ttnn_layout_device_l1_block_sharded_tile_bf16>) -> tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x256xbf16, #ttnn_layout_device_l1_block_sharded_tile_bf16>) -> tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small>
         return %0 : tensor<32x256xbf16, #ttnn_layout_device_dram_rm_bf16_small>
     }
 
@@ -89,7 +89,7 @@ module attributes {} {
         // CHECK-SAME: -> tensor<32x2048xui16, #[[DRAM_RM_UI16]]>
         // CHECK-NOT: "ttnn.from_device"
         // CHECK: return %[[TO_LAYOUT]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_dram_rm_ui16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_dram_rm_ui16>
         return %0 : tensor<32x2048xui16, #ttnn_layout_device_dram_rm_ui16>
     }
 
@@ -106,7 +106,7 @@ module attributes {} {
         // CHECK-NOT: "ttnn.typecast"
         // CHECK-NOT: "ttnn.from_device"
         // CHECK: return %[[MEM_CONFIG]]
-        %0 = "ttnn.to_layout"(%arg0) : (tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_l1_rm_ui16>
+        %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<32x2048xui16, #ttnn_layout_device_dram_tile_ui16>) -> tensor<32x2048xui16, #ttnn_layout_device_l1_rm_ui16>
         return %0 : tensor<32x2048xui16, #ttnn_layout_device_l1_rm_ui16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/op_validation_fallback_multi_output.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/op_validation_fallback_multi_output.mlir
@@ -11,11 +11,11 @@ module @NlpCreateQkvHeadsDecode attributes {} {
     // Input is row major which triggers TT_FATAL in backend validation.
     // Fallback should fix the input to tile and insert revert to_layout ops
     // for all 3 outputs.
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK: "ttnn.nlp_create_qkv_heads_decode"
-    // CHECK: "ttnn.to_layout"
-    // CHECK: "ttnn.to_layout"
-    // CHECK: "ttnn.to_layout"
+    // CHECK: "ttnn.to_tensor_spec"
+    // CHECK: "ttnn.to_tensor_spec"
+    // CHECK: "ttnn.to_tensor_spec"
     %query, %key, %value = "ttnn.nlp_create_qkv_heads_decode"(%arg0) <{num_heads = 32 : ui32, num_kv_heads = 8 : ui32}>
       : (tensor<1x1x32x3072xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<32x3072xbf16, #ttnn.buffer_type<dram>>, <interleaved>>>)
       -> (tensor<1x32x32x64xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>>,

--- a/test/ttmlir/Transforms/memory_management.mlir
+++ b/test/ttmlir/Transforms/memory_management.mlir
@@ -116,13 +116,13 @@ module {
   }
   // permute-reshape row-major adjust:
   // CHECK-LABEL: func.func @permute_reshape_row_major_adjusting
-  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0)
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
   // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RM_IN]])
   // CHECK-SAME: permutation = array<i64: 1, 0>
   // CHECK-SAME: -> tensor<67108864x1xf32
   // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[PERM]]) <{shape = [8192 : i32, 8192 : i32]}>
   // CHECK-SAME: -> tensor<8192x8192xf32
-  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[RESHAPE]])
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_tensor_spec"(%[[RESHAPE]])
   // CHECK: return %[[RESTORED]]
   func.func @permute_reshape_row_major_adjusting(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<8192x8192xf32, #layout_8192x8192_tile> {
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
@@ -132,7 +132,7 @@ module {
 
   // permute-repeat-reshape row-major adjust:
   // CHECK-LABEL: func.func @permute_repeat_reshape_row_major_adjusting
-  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0)
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
   // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RM_IN]])
   // CHECK-SAME: permutation = array<i64: 1, 0>
   // CHECK-SAME: -> tensor<67108864x1xf32
@@ -140,7 +140,7 @@ module {
   // CHECK-SAME: -> tensor<67108864x2xf32
   // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[REPEAT]]) <{shape = [8192 : i32, 16384 : i32]}>
   // CHECK-SAME: -> tensor<8192x16384xf32
-  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[RESHAPE]])
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_tensor_spec"(%[[RESHAPE]])
   // CHECK: return %[[RESTORED]]
   func.func @permute_repeat_reshape_row_major_adjusting(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<8192x16384xf32, #layout_8192x16384_tile> {
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
@@ -151,13 +151,13 @@ module {
 
   // reshape-permute row-major adjust:
   // CHECK-LABEL: func.func @reshape_permute_row_major_adjusting
-  // CHECK: %[[RM_IN:.*]] = "ttnn.to_layout"(%arg0)
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
   // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[RM_IN]]) <{shape = [8192 : i32, 8192 : i32, 1 : i32, 1 : i32]}>
   // CHECK-SAME: -> tensor<8192x8192x1x1xf32
   // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RESHAPE]])
   // CHECK-SAME: permutation = array<i64: 2, 3, 0, 1>
   // CHECK-SAME: -> tensor<1x1x8192x8192xf32
-  // CHECK: %[[RESTORED:.*]] = "ttnn.to_layout"(%[[PERM]])
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_tensor_spec"(%[[PERM]])
   // CHECK: return %[[RESTORED]]
   func.func @reshape_permute_row_major_adjusting(%arg0: tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>) -> tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile> {
     %0 = "ttnn.reshape"(%arg0) <{shape = [8192 : i32, 8192 : i32, 1 : i32, 1 : i32]}> : (tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>) -> tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -8554,13 +8554,17 @@ class TTNNBuilder(Builder):
         self,
         input: Operand,
         layout: Optional[ttnn.ir.LayoutAttr] = None,
-        buffer_type: ttnn.ir.BufferType = ttnn.BufferType.DRAM,
-        tensor_memory_layout: ttnn.ir.TensorMemoryLayout = ttnn.TensorMemoryLayout.Interleaved,
-        grid_shape: Optional[List[int]] = None,
-        core_range_set: Optional[ttnn.ir.CoreRangeSetAttr] = None,
         output_type: Optional[torch.dtype] = None,
         loc: Optional[str] = None,
     ) -> OpResult:
+        """Change only the page layout (Tile<->RowMajor) and optionally the
+        data type.
+
+        The memory config (buffer type, tensor memory layout, sharding, grid)
+        is preserved from the input -- ``ttnn.to_layout`` structurally cannot
+        change it (enforced by the op verifier).  For any memory-config or
+        device-placement change use :meth:`to_tensor_spec` instead.
+        """
         ttnn_op = self.get_opview_from_method(TTNNBuilder.to_layout)
 
         if output_type is None:
@@ -8571,8 +8575,18 @@ class TTNNBuilder(Builder):
         input_golden = self._get_golden_tensor(input)
         shape = input.type.shape
 
-        if grid_shape is None:
-            grid_shape = [1, 1]
+        # Preserve the input's memory config; to_layout only changes page
+        # layout / dtype.
+        input_enc = ttnn.ir.TTNNLayoutAttr.maybe_downcast(
+            self._get_type(input).encoding
+        )
+        buffer_type = ttnn.ir.BufferTypeAttr.maybe_downcast(
+            input_enc.memory_space
+        ).value
+        tensor_memory_layout = ttnn.TensorMemoryLayout(
+            input_enc.tensor_memory_layout_as_int
+        )
+        grid_shape = list(input_enc.grid_shape)
 
         layout_attr = ttnn.ir.LayoutAttr.get(self._ctx, layout)
         result = self.create_ttnn_tensor(
@@ -8582,7 +8596,6 @@ class TTNNBuilder(Builder):
             buffer_type=buffer_type,
             tensor_memory_layout=tensor_memory_layout,
             grid_shape=grid_shape,
-            core_range_set=core_range_set,
         )
 
         op_golden_function = get_golden_function(ttnn_op)
@@ -8686,6 +8699,158 @@ class TTNNBuilder(Builder):
                 ]
 
         return to_layout_module, to_layout_builder
+
+    ############### ttnn.ToTensorSpecOp ###############
+
+    @tag(ttnn.ToTensorSpecOp)
+    def to_tensor_spec(
+        self,
+        input: Operand,
+        layout: Optional[ttnn.ir.LayoutAttr] = None,
+        buffer_type: ttnn.ir.BufferType = ttnn.BufferType.DRAM,
+        tensor_memory_layout: ttnn.ir.TensorMemoryLayout = ttnn.TensorMemoryLayout.Interleaved,
+        grid_shape: Optional[List[int]] = None,
+        core_range_set: Optional[ttnn.ir.CoreRangeSetAttr] = None,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+    ) -> OpResult:
+        """Aggregate layout / memory-config change.
+
+        Wraps all layout information (data type, page layout, memory config and
+        device placement) into a single ``ttnn.to_tensor_spec`` op that the
+        ``TTNNDecomposeLayouts`` pass later breaks down into the concrete
+        ``to_layout`` / ``to_device`` / ``to_memory_config`` / ``typecast`` ops.
+        Use this for any memory-config change (buffer type, sharding, grid) or
+        device placement; use :meth:`to_layout` only for a pure page-layout
+        (+/- dtype) change.
+        """
+        ttnn_op = self.get_opview_from_method(TTNNBuilder.to_tensor_spec)
+
+        if output_type is None:
+            mlir_output_type = self.get_type(input)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        input_golden = self._get_golden_tensor(input)
+        shape = input.type.shape
+
+        if grid_shape is None:
+            grid_shape = [1, 1]
+
+        layout_attr = ttnn.ir.LayoutAttr.get(self._ctx, layout)
+        result = self.create_ttnn_tensor(
+            shape,
+            mlir_output_type,
+            layout=layout,
+            buffer_type=buffer_type,
+            tensor_memory_layout=tensor_memory_layout,
+            grid_shape=grid_shape,
+            core_range_set=core_range_set,
+        )
+
+        op_golden_function = get_golden_function(ttnn_op)
+        golden_output = op_golden_function(input_golden, layout_attr, mlir_output_type)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = ttnn_op(
+            result,
+            input,
+            loc=loc,
+        )
+        op_result = op.result
+
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(ttnn.ToTensorSpecOp)
+    def to_tensor_spec_parser(
+        self,
+        old_op: ttnn.ToTensorSpecOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttnn_op = self.get_opview_from_parser(TTNNBuilder.to_tensor_spec_parser)
+        in0 = global_dict[old_op.input]
+        result = old_op.result.type
+
+        new_op = ttnn_op(
+            result,
+            in0,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(ttnn_op)
+        result_layout = ttnn.ir.TTNNLayoutAttr.maybe_downcast(result.encoding)
+        layout = (
+            ttnn.Layout.Tile
+            if result_layout is not None
+            and "ttcore.tile" in str(result_layout.memref.element_type)
+            else ttnn.Layout.RowMajor
+        )
+        layout_attr = ttnn.ir.LayoutAttr.get(self._ctx, layout)
+        golden_output = op_golden_function(input0, layout_attr, result.element_type)
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        return new_op, {old_op.result: new_op_result}
+
+    @split(ttnn.ToTensorSpecOp)
+    def to_tensor_spec_split(
+        self,
+        old_op: ttnn.ToTensorSpecOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.to_tensor_spec_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            to_tensor_spec_module = Module.create()
+            to_tensor_spec_builder = TTNNBuilder(
+                old_ctx, old_loc, self._mesh_shape, self._mesh_dict
+            )
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(to_tensor_spec_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="to_tensor_spec_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttnn_op(
+                        result,
+                        in0,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    to_tensor_spec_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+                    input0 = self._get_golden_tensor(old_op.input)
+                    to_tensor_spec_builder._set_golden_tensor(in0, input0)
+                    to_tensor_spec_builder._annotate_presharded_arg(in0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                to_tensor_spec_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return to_tensor_spec_module, to_tensor_spec_builder
 
     ############### ttnn.ToDeviceOp ###############
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -9177,6 +9177,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.ConstantOp: ttnn_constant_golden,
     # Layout/Device operations
     ttnn.ToLayoutOp: ttnn_to_layout_golden,
+    ttnn.ToTensorSpecOp: ttnn_to_layout_golden,
     ttnn.ToDeviceOp: ttnn_to_device_golden,
     ttnn.FromDeviceOp: ttnn_from_device_golden,
     # CCL (Collective Communication Library) operations


### PR DESCRIPTION
Adds `ToTensorSpecOp` to TTNN dialect to replace pre-decompose version of `ToLayoutOp` (that changes tensor layout, memory config, device), while `ToLayoutOp` is repurposed to only change tensor layout

### Ticket
Closes #8263,  closes #8265 

### Problem description
`ttnn.to_layout` op had two different roles. Before `TTNNDecomposeLayouts` pass, it is an aggregate op that changes a lot of stuff in tensor specification. After that pass it is a narrow op that only changes tensor layout (and optionally dtype).

This PR splits these into two different ops.


### What's changed

In `TTNNOps.td` and `TTNNOps.cpp` - added a new op, changed the `ToLayoutOp` description to match its new role, moved canonicalizers that didn't make sense on the narrow `ToLayoutOp` to the new `ToTensorSpecOp` op (while those that make sense on both are duplicated), updated the verifier of the `ToLayoutOp` to check that it only changes the layout.

Changed `TTIRToTTNN.cpp` to lower `ttir.to_layout` to `ttnn.to_tensor_spec`. Added the opposite conversion to `TTNNToTTIRPatterns.cpp`.

`TTNNDecomposeLayouts.cpp` now decomposes `ttnn.to_tensor_spec` op (and asserts that `ttnn.to_layout` is not present in the IR before that).

`TTNNOpModelInterface.cpp` adds `getOpConstraint` and `getOpRuntime` function members to the new op, that match the `ToLayoutOp` implementations.

Add builder for the new op in `ttnn_builder.py`.

The rest of the files mainly replace creation and checking for `ToLayoutOp` with `ToTensorSpecOp` in passes that happen before `TTNNDecomposeLayouts`.

#### Changes in tests

Added `test/ttmlir/Conversion/TTIRToTTNN/to_tensor_spec.mlir` and a test in `test/ttmlir/Conversion/TTNNToTTIR/to_layout_op.mlir` to test the new conversions.

In `test/ttmlir/EmitPy/transformer/chunked_scaled_dot_product_attention.mlir` added `--ttnn-decompose-layouts` to force it to decompose `ttnn.to_tensor_spec` ops.

Updated TTNN canonicalizer tests.

Updated python tests to build the new op instead of `to_layout`.

In rest of the tests just replaced `ttnn.to_layout` with `ttnn.to_tensor_spec`.


### Checklist
- [x] New/Existing tests provide coverage for changes
