### PR TITLE
[TTNN] Add fused minimal_matmul_strided_reduce_scatter_async op as TTIR composite op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_TRANSFORMS_FUSING_MATMULREDUCESCATTERFUSINGPATTERN_H
+#define TTMLIR_DIALECT_TTIR_TRANSFORMS_FUSING_MATMULREDUCESCATTERFUSINGPATTERN_H
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttir::fusing {
+
+// Fuses reduce_scatter(matmul/linear(input, weight)) into a
+// ttcore.composite "minimal_matmul_strided_reduce_scatter_async" (resolved
+// later by TTNNResolveComposites). Templated on MatmulOp/LinearOp; the linear
+// variant's bias rides along into the composite (matmul has no bias). Anchored
+// on ReduceScatterOp. Bails on transposed operands and multi-use projections;
+// defers to MatmulReduceScatterAddcmulFusing when a gated-residual epilogue
+// follows.
+template <typename MatmulLikeOp>
+class MatmulReduceScatterFusing
+    : public mlir::OpRewritePattern<ReduceScatterOp> {
+public:
+  using mlir::OpRewritePattern<ReduceScatterOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ReduceScatterOp reduceScatterOp,
+                  mlir::PatternRewriter &rewriter) const final;
+};
+
+// Fuses `residual + gate * reduce_scatter(matmul/linear(input, weight))` into
+// the same composite, mapping residual/gate to the addcmul operands (residual
+// -> addcmul_input1, gate -> addcmul_input2) with scalar = 1.0. Anchored on
+// AddOp; templated on the projection op (MatmulOp/LinearOp).
+template <typename MatmulLikeOp>
+class MatmulReduceScatterAddcmulFusing : public mlir::OpRewritePattern<AddOp> {
+public:
+  using mlir::OpRewritePattern<AddOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(AddOp addOp, mlir::PatternRewriter &rewriter) const final;
+};
+
+} // namespace mlir::tt::ttir::fusing
+
+#endif // TTMLIR_DIALECT_TTIR_TRANSFORMS_FUSING_MATMULREDUCESCATTERFUSINGPATTERN_H

--- a/include/ttmlir/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.h
@@ -33,9 +33,10 @@ public:
 // Fuses `residual + gate * reduce_scatter(matmul/linear(input, weight))` into
 // the same composite, mapping residual/gate to the addcmul operands (residual
 // -> addcmul_input1, gate -> addcmul_input2) with scalar = 1.0. Looks through
-// a leading-unit reshape and a broadcast on the gate so DiT's
-// `[M, N] -> [1, M, N]` unsqueeze and AdaLN broadcast do not block. Anchored on
-// AddOp; templated on the projection op (MatmulOp/LinearOp).
+// a leading-unit reshape, a broadcast on the gate, and a post-scatter
+// row-broadcast bias add (Wan FF2 `D/tp` bias). That bias is not fused
+// `has_bias`; it is reapplied after the composite as `gate * bias`. Anchored
+// on AddOp; templated on the projection op (MatmulOp/LinearOp).
 template <typename MatmulLikeOp>
 class MatmulReduceScatterAddcmulFusing : public mlir::OpRewritePattern<AddOp> {
 public:

--- a/include/ttmlir/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.h
@@ -16,9 +16,9 @@ namespace mlir::tt::ttir::fusing {
 // ttcore.composite "minimal_matmul_strided_reduce_scatter_async" (resolved
 // later by TTNNResolveComposites). Templated on MatmulOp/LinearOp; the linear
 // variant's bias rides along into the composite (matmul has no bias). Anchored
-// on ReduceScatterOp. Bails on transposed operands and multi-use projections;
-// defers to MatmulReduceScatterAddcmulFusing when a gated-residual epilogue
-// follows.
+// on ReduceScatterOp. `transpose_b` is materialized as a permute of the weight
+// to `[K, N]`; `transpose_a` is rejected. Defers to
+// MatmulReduceScatterAddcmulFusing when a gated-residual epilogue follows.
 template <typename MatmulLikeOp>
 class MatmulReduceScatterFusing
     : public mlir::OpRewritePattern<ReduceScatterOp> {
@@ -32,7 +32,9 @@ public:
 
 // Fuses `residual + gate * reduce_scatter(matmul/linear(input, weight))` into
 // the same composite, mapping residual/gate to the addcmul operands (residual
-// -> addcmul_input1, gate -> addcmul_input2) with scalar = 1.0. Anchored on
+// -> addcmul_input1, gate -> addcmul_input2) with scalar = 1.0. Looks through
+// a leading-unit reshape and a broadcast on the gate so DiT's
+// `[M, N] -> [1, M, N]` unsqueeze and AdaLN broadcast do not block. Anchored on
 // AddOp; templated on the projection op (MatmulOp/LinearOp).
 template <typename MatmulLikeOp>
 class MatmulReduceScatterAddcmulFusing : public mlir::OpRewritePattern<AddOp> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3287,6 +3287,60 @@ def TTNN_AllReduceOp: TTNN_Op<"all_reduce", [OpModelExempt]> {
     let hasFolder = 1;
 }
 
+def TTNN_MinimalMatmulStridedReduceScatterAsyncOp: TTNN_Op<"minimal_matmul_strided_reduce_scatter_async",
+    [AttrSizedOperandSegments, TTNN_DistributedOpInterface, OpModelExempt]> {
+    let summary = "Fused async minimal matmul + strided reduce-scatter op.";
+    let description = [{
+      Fused matmul + collective op (maps to
+      `ttnn::experimental::minimal_matmul_strided_reduce_scatter_async`).
+      Computes `input @ weight` with a minimal-matmul kernel and, in the same
+      program, reduce-scatters the partial products across `cluster_axis`
+      (row-parallel FFN down-projection), summing across ranks and scattering
+      the result along `dim` in a strided layout, overlapping compute with
+      communication. Optional epilogues: row-broadcast `bias` (present only for
+      the linear variant; matmul has no bias), and gated residual
+      `addcmul_input1 + scalar * reduce_scatter(input @ weight + bias) * addcmul_input2`
+      (DiT blocks).
+
+      The async collective is synchronized by the `multi_device_semaphore`
+      global semaphores and `barrier_semaphore`; left unbound, these are
+      materialized by `TTNNAllocateDistributedOpSemaphores` via the
+      `DistributedOpInterface`. `fused_activation`, `MinimalMatmulConfig`,
+      persistent buffers, and the reduce-scatter core-grid offset use tt-metal
+      defaults.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$weight,
+                         Optional<AnyRankedTensor>:$bias,
+                         Optional<AnyRankedTensor>:$addcmul_input1,
+                         Optional<AnyRankedTensor>:$addcmul_input2,
+                         Variadic<TTNN_GlobalSemaphore>:$multi_device_semaphore,
+                         Optional<TTNN_GlobalSemaphore>:$barrier_semaphore,
+                         TTNN_Device:$device,
+                         OptionalAttr<UI32Attr>:$cluster_axis,
+                         OptionalAttr<F32Attr>:$scalar,
+                         OptionalAttr<TTCore_TopologyAttr>:$topology,
+                         OptionalAttr<UI32Attr>:$num_links,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                         OptionalAttr<TTCore_DataTypeAttr>:$dtype,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config,
+                         DefaultValuedAttr<UI32Attr, "1">:$num_workers_per_link,
+                         DefaultValuedAttr<UI32Attr, "1">:$num_buffers_per_channel,
+                         DefaultValuedAttr<SI32Attr, "0">:$dim);
+
+    let results = (outs Variadic<AnyRankedTensor>:$results);
+
+    let extraClassDeclaration = [{
+      bool hasUnboundBuffers();
+      void allocateBuffers(::mlir::RewriterBase &rewriter);
+      bool hasUnboundSemaphores();
+      void allocateSemaphores(::mlir::RewriterBase &rewriter);
+    }];
+
+    let hasVerifier = 1;
+}
+
 def TTNN_AllReduceAsyncOp: TTNN_Op<"all_reduce_async", [OpModelExempt]> {
     let summary = "Asynchronous all reduce op.";
     let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3332,9 +3332,11 @@ def TTNN_MinimalMatmulStridedReduceScatterAsyncOp: TTNN_Op<"minimal_matmul_strid
     let results = (outs Variadic<AnyRankedTensor>:$results);
 
     let extraClassDeclaration = [{
-      bool hasUnboundBuffers();
-      void allocateBuffers(::mlir::RewriterBase &rewriter);
-      bool hasUnboundSemaphores();
+      bool hasUnboundBuffers() { return false; }
+      void allocateBuffers(::mlir::RewriterBase &rewriter) {}
+      bool hasUnboundSemaphores() {
+        return getMultiDeviceSemaphore().empty() || !getBarrierSemaphore();
+      }
       void allocateSemaphores(::mlir::RewriterBase &rewriter);
     }];
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3305,9 +3305,13 @@ def TTNN_MinimalMatmulStridedReduceScatterAsyncOp: TTNN_Op<"minimal_matmul_strid
       The async collective is synchronized by the `multi_device_semaphore`
       global semaphores and `barrier_semaphore`; left unbound, these are
       materialized by `TTNNAllocateDistributedOpSemaphores` via the
-      `DistributedOpInterface`. `fused_activation`, `MinimalMatmulConfig`,
-      persistent buffers, and the reduce-scatter core-grid offset use tt-metal
-      defaults.
+      `DistributedOpInterface`. Rank-4 / scatter dim 3 is applied at
+      runtime as a view (`unsqueeze`), matching metal Wan. `num_links`,
+      `num_workers_per_link`, and `num_buffers_per_channel` are optional;
+      when unset the runtime fills them like `get_fused_mmrs_config`
+      (`num_buffers_per_channel` stays unset / metal `None`).
+      `fused_activation`, `MinimalMatmulConfig`, persistent buffers, and the
+      reduce-scatter core-grid offset use tt-metal defaults.
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
@@ -3325,9 +3329,9 @@ def TTNN_MinimalMatmulStridedReduceScatterAsyncOp: TTNN_Op<"minimal_matmul_strid
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
                          OptionalAttr<TTCore_DataTypeAttr>:$dtype,
                          OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config,
-                         DefaultValuedAttr<UI32Attr, "1">:$num_workers_per_link,
-                         DefaultValuedAttr<UI32Attr, "1">:$num_buffers_per_channel,
-                         DefaultValuedAttr<SI32Attr, "0">:$dim);
+                         OptionalAttr<UI32Attr>:$num_workers_per_link,
+                         OptionalAttr<UI32Attr>:$num_buffers_per_channel,
+                         DefaultValuedAttr<SI32Attr, "-1">:$dim);
 
     let results = (outs Variadic<AnyRankedTensor>:$results);
 

--- a/include/ttmlir/Target/TTNN/operations/ccl.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ccl.fbs
@@ -37,6 +37,27 @@ table AllReduceAsyncOp {
   topology: tt.target.Topology = null;
 }
 
+table MinimalMatmulStridedReduceScatterAsyncOp {
+  input: tt.target.ttnn.TensorRef;
+  weight: tt.target.ttnn.TensorRef;
+  bias: tt.target.ttnn.TensorRef;
+  addcmul_input1: tt.target.ttnn.TensorRef;
+  addcmul_input2: tt.target.ttnn.TensorRef;
+  multi_device_semaphore: [tt.target.ttnn.GlobalSemaphoreRef];
+  barrier_semaphore: tt.target.ttnn.GlobalSemaphoreRef;
+  cluster_axis: uint32 = null;
+  scalar: float = null;
+  topology: tt.target.Topology = null;
+  num_links: uint32 = null;
+  memory_config: tt.target.ttnn.MemoryConfig;
+  dtype: tt.target.DataType = null;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
+  num_workers_per_link: uint32;
+  num_buffers_per_channel: uint32;
+  dim: int32;
+  outputs: [tt.target.ttnn.TensorRef];
+}
+
 table ReduceScatterOp {
   in: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/operations/ccl.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ccl.fbs
@@ -52,8 +52,8 @@ table MinimalMatmulStridedReduceScatterAsyncOp {
   memory_config: tt.target.ttnn.MemoryConfig;
   dtype: tt.target.DataType = null;
   compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
-  num_workers_per_link: uint32;
-  num_buffers_per_channel: uint32;
+  num_workers_per_link: uint32 = null;
+  num_buffers_per_channel: uint32 = null;
   dim: int32;
   outputs: [tt.target.ttnn.TensorRef];
 }

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -97,6 +97,7 @@ union OpType {
   SparseMatmulOp,
   MaxPool2dWithIndicesOp,
   MeshPartitionOp,
+  MinimalMatmulStridedReduceScatterAsyncOp,
   MoeExpertTokenRemapOp,
   MoeGptOp,
   PrepareMoEComputeW0W1WeightsOp,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3147,6 +3147,69 @@ public:
 };
 } // namespace
 
+// MinimalMatmulStridedReduceScatterAsyncOp conversion pattern
+//
+namespace {
+class MinimalMatmulStridedReduceScatterAsyncOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::MinimalMatmulStridedReduceScatterAsyncOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.minimal_matmul_strided_reduce_scatter_async";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn::experimental::minimal_matmul_strided_reduce_scatter_async";
+  }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::MinimalMatmulStridedReduceScatterAsyncOp>::
+      TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::tt::ttnn::MinimalMatmulStridedReduceScatterAsyncOp srcOp,
+      OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const override {
+    ttnn_to_emitc::EmitCTTNNEmitter<
+        mlir::tt::ttnn::MinimalMatmulStridedReduceScatterAsyncOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getWeight()),
+        emitter.emit(srcOp.getDim()),
+        rewriter.getAttr<emitc::OpaqueAttr>(
+            "std::vector<::ttnn::GlobalSemaphore>{}"),
+        rewriter.getAttr<emitc::OpaqueAttr>("::ttnn::CoreCoord{0, 0}"),
+        emitter.emit(srcOp.getComputeConfig()),
+        emitter.emit(srcOp.getNumLinks()),
+        emitter.emit(srcOp.getMemoryConfig()),
+        emitter.emit(std::nullopt),
+        emitter.emit(std::nullopt),
+        emitter.emit(srcOp.getTopology()),
+        emitter.emit(srcOp.getClusterAxis()),
+        emitter.emit(srcOp.getBias()),
+        emitter.emit(std::nullopt),
+        emitter.emit(std::nullopt),
+        emitter.emit(std::nullopt),
+        rewriter.getAttr<emitc::OpaqueAttr>("false"),
+        emitter.emit(std::nullopt),
+        emitter.emit(srcOp.getNumWorkersPerLink()),
+        emitter.emit(srcOp.getNumBuffersPerChannel()),
+        emitter.emit(std::nullopt),
+        emitter.emit(std::nullopt),
+        emitter.emit(srcOp.getScalar()),
+        emitter.emit(srcOp.getAddcmulInput1()),
+        emitter.emit(srcOp.getAddcmulInput2()),
+        emitter.emit(srcOp.getDtype()),
+    };
+
+    emitter.replaceOp(*this, args);
+    return success();
+  }
+};
+} // namespace
+
 namespace {
 class ScatterOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::ScatterOp> {
@@ -5730,6 +5793,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   patterns.add<AllReduceOpConversionPattern>(typeConverter, ctx);
   patterns.add<AllReduceAsyncOpConversionPattern>(typeConverter, ctx);
   patterns.add<ReduceScatterOpConversionPattern>(typeConverter, ctx);
+  patterns.add<MinimalMatmulStridedReduceScatterAsyncOpConversionPattern>(
+      typeConverter, ctx);
   patterns.add<ScatterOpConversionPattern>(typeConverter, ctx);
   patterns.add<MeshPartitionOpConversionPattern>(typeConverter, ctx);
   patterns.add<DistributeTensorOpConversionPattern>(typeConverter, ctx);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -3733,6 +3733,55 @@ public:
 };
 } // namespace
 
+// MinimalMatmulStridedReduceScatterAsyncOp
+//
+namespace {
+class MinimalMatmulStridedReduceScatterAsyncOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::MinimalMatmulStridedReduceScatterAsyncOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.minimal_matmul_strided_reduce_scatter_async";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn.experimental.minimal_matmul_strided_reduce_scatter_async";
+  }
+
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::MinimalMatmulStridedReduceScatterAsyncOp>::
+      TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::tt::ttnn::MinimalMatmulStridedReduceScatterAsyncOp srcOp,
+      OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const override {
+    ttnn_to_emitpy::EmitPyTTNNEmitter<
+        mlir::tt::ttnn::MinimalMatmulStridedReduceScatterAsyncOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput(), "input_tensor"),
+        emitter.emit(srcOp.getWeight(), "weight_tensor"),
+        emitter.emit(srcOp.getDim(), "dim"),
+        emitter.emit(srcOp.getNumLinks(), "num_links"),
+        emitter.emit(srcOp.getMemoryConfig(), "memory_config_mm"),
+        emitter.emit(srcOp.getTopology(), "topology"),
+        emitter.emit(srcOp.getClusterAxis(), "cluster_axis"),
+        emitter.emit(srcOp.getBias(), "bias"),
+        emitter.emit(srcOp.getScalar(), "fused_ternary_scalar"),
+        emitter.emit(srcOp.getAddcmulInput1(), "addcmul_input_tensor1"),
+        emitter.emit(srcOp.getAddcmulInput2(), "addcmul_input_tensor2"),
+        emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
+        emitter.emit(srcOp.getDtype(), "dtype"),
+    };
+
+    emitter.replaceOp(*this, args);
+    return success();
+  }
+};
+} // namespace
+
 // AllReduceOp
 //
 namespace {
@@ -5545,6 +5594,7 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   // clang-format off
   patterns.add<AllGatherOpConversionPattern,
                ReduceScatterOpConversionPattern,
+               MinimalMatmulStridedReduceScatterAsyncOpConversionPattern,
                AllReduceOpConversionPattern,
                AllReduceAsyncOpConversionPattern,
                PointToPointOpConversionPattern,

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -21,6 +21,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         ReductionForceKeepDim.cpp
         Transforms.cpp
         TTIRFusing.cpp
+        Fusing/MatmulReduceScatterFusingPattern.cpp
         Fusing/RoPEFusingPattern.cpp
         Fusing/TopKFusingPattern.cpp
         MultiDeviceTensorAnnotation.cpp

--- a/lib/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.cpp
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Utils/Utils.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+#include <atomic>
+#include <type_traits>
+
+namespace mlir::tt::ttir::fusing {
+
+namespace {
+
+// Name of the composite this fusion emits. Must match the key registered in
+// TTNNResolveComposites' composite registry.
+constexpr llvm::StringLiteral kCompositeName =
+    "minimal_matmul_strided_reduce_scatter_async";
+
+std::string getUniqueDecompName() {
+  static std::atomic<uint64_t> counter{0};
+  return "minimal_matmul_strided_reduce_scatter_async_decomp_" +
+         std::to_string(counter.fetch_add(1));
+}
+
+// Coefficient for the addcmul epilogue's scalar slot, which computes
+//   result = addcmul_input1 + scalar * proj * addcmul_input2
+// The gated residual we fuse carries no coefficient, so this is the identity
+// 1.0 (see the addcmul pattern for the full derivation).
+constexpr double kAddcmulScalar = 1.0;
+
+// True if this reduce_scatter result flows into a gated-residual epilogue
+// (a multiply then an add), which the addcmul pattern folds in whole.
+bool feedsGatedResidualEpilogue(ReduceScatterOp reduceScatterOp) {
+  if (!reduceScatterOp.getResult().hasOneUse()) {
+    return false;
+  }
+  auto mulOp = mlir::dyn_cast<MultiplyOp>(
+      *reduceScatterOp.getResult().getUsers().begin());
+  if (!mulOp || !mulOp.getResult().hasOneUse()) {
+    return false;
+  }
+  return mlir::isa<AddOp>(*mulOp.getResult().getUsers().begin());
+}
+
+func::FuncOp buildDecompositionFunc(OpBuilder &builder, Location loc,
+                                    ArrayRef<Value> captures,
+                                    ArrayRef<Operation *> ops,
+                                    Type resultType) {
+  auto argTypes =
+      llvm::map_to_vector(captures, [](Value v) { return v.getType(); });
+  auto funcOp =
+      func::FuncOp::create(loc, getUniqueDecompName(),
+                           builder.getFunctionType(argTypes, {resultType}));
+  funcOp.setVisibility(SymbolTable::Visibility::Private);
+  funcOp->setAttr(utils::kCompositeDecompositionAttr,
+                  UnitAttr::get(builder.getContext()));
+
+  Block *block = funcOp.addEntryBlock();
+  OpBuilder fb(block, block->end());
+
+  // Map each captured value to its matching block argument so cloned ops
+  // reference the function's arguments; clone() rewires chained results.
+  IRMapping mapping;
+  for (auto [capture, arg] : llvm::zip(captures, block->getArguments())) {
+    mapping.map(capture, arg);
+  }
+
+  Operation *last = nullptr;
+  for (Operation *op : ops) {
+    last = fb.clone(*op, mapping);
+  }
+
+  fb.create<func::ReturnOp>(loc, last->getResults());
+  return funcOp;
+}
+
+} // namespace
+
+// Match, with no gated-residual epilogue, and fold into the composite:
+//
+//   proj = matmul(input, weight) + bias
+//   out  = reduce_scatter(proj)
+//
+// where `+ bias` applies only to the linear variant (matmul has no bias).
+// If a `residual + gate * out` epilogue follows, defer to
+// MatmulReduceScatterAddcmulFusing so the whole thing folds at once.
+template <typename MatmulLikeOp>
+mlir::LogicalResult MatmulReduceScatterFusing<MatmulLikeOp>::matchAndRewrite(
+    ReduceScatterOp reduceScatterOp, mlir::PatternRewriter &rewriter) const {
+  // Don't re-fuse the primitive ops we cloned into a decomposition body.
+  if (utils::isInsideCompositeDecomposition(reduceScatterOp)) {
+    return mlir::failure();
+  }
+
+  MatmulLikeOp matmulOp =
+      reduceScatterOp.getInput().template getDefiningOp<MatmulLikeOp>();
+  if (!matmulOp || !matmulOp.getResult().hasOneUse()) {
+    return mlir::failure();
+  }
+
+  if (matmulOp.getTransposeA() || matmulOp.getTransposeB()) {
+    return mlir::failure();
+  }
+
+  // Let the addcmul pattern fold the whole gated-residual epilogue instead.
+  if (feedsGatedResidualEpilogue(reduceScatterOp)) {
+    return mlir::failure();
+  }
+
+  Value bias;
+  if constexpr (std::is_same_v<MatmulLikeOp, LinearOp>) {
+    bias = matmulOp.getBias();
+  }
+
+  auto resultType =
+      mlir::cast<RankedTensorType>(reduceScatterOp.getResult().getType());
+
+  // Captures feed the composite/decomposition in order: input, weight, [bias].
+  SmallVector<Value> captures{matmulOp.getA(), matmulOp.getB()};
+  if (bias) {
+    captures.push_back(bias);
+  }
+  SmallVector<Operation *> ops{matmulOp, reduceScatterOp};
+
+  Operation *anchor = reduceScatterOp.getOperation();
+  ModuleOp moduleOp = anchor->getParentOfType<ModuleOp>();
+  OpBuilder moduleBuilder(moduleOp.getContext());
+  moduleBuilder.setInsertionPointToEnd(moduleOp.getBody());
+  func::FuncOp decompFunc = buildDecompositionFunc(
+      moduleBuilder, reduceScatterOp.getLoc(), captures, ops, resultType);
+  moduleBuilder.insert(decompFunc);
+
+  // Collective parameters and operand-presence flags travel on the composite so
+  // TTNNResolveComposites can rebuild the typed op without re-inspecting the
+  // IR.
+  mlir::MLIRContext *ctx = rewriter.getContext();
+  SmallVector<NamedAttribute> attrs;
+  attrs.emplace_back(
+      StringAttr::get(ctx, "scatter_dim"),
+      rewriter.getSI32IntegerAttr(reduceScatterOp.getScatterDim()));
+  attrs.emplace_back(
+      StringAttr::get(ctx, "cluster_axis"),
+      rewriter.getUI32IntegerAttr(reduceScatterOp.getClusterAxis()));
+  attrs.emplace_back(StringAttr::get(ctx, "has_bias"),
+                     rewriter.getBoolAttr(bias != nullptr));
+  attrs.emplace_back(StringAttr::get(ctx, "has_addcmul"),
+                     rewriter.getBoolAttr(false));
+
+  rewriter.replaceOpWithNewOp<ttcore::CompositeOp>(
+      anchor, TypeRange{resultType}, captures,
+      rewriter.getStringAttr(kCompositeName),
+      FlatSymbolRefAttr::get(ctx, decompFunc.getName()),
+      DictionaryAttr::get(ctx, attrs));
+  return mlir::success();
+}
+
+template <typename MatmulLikeOp>
+mlir::LogicalResult
+MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
+    AddOp addOp, mlir::PatternRewriter &rewriter) const {
+  // Don't re-fuse the primitive ops we cloned into a decomposition body.
+  if (utils::isInsideCompositeDecomposition(addOp)) {
+    return mlir::failure();
+  }
+
+  // Match the DiT gated residual:
+  //
+  //   result = residual + gate * proj,
+  //   where proj = reduce_scatter(matmul(input, weight) + bias)
+  //   (`+ bias` applies only to the linear variant; matmul has no bias)
+  //
+  // walking backwards from the anchor `add`:  add -> multiply -> reduce_scatter
+  // -> matmul. Both the add and the multiply are commutative, so we try each
+  // operand order.
+  //
+  // This maps to tt-metal's `addcmul` epilogue, whose fixed formula is
+  //
+  //   result = addcmul_input1 + scalar * proj * addcmul_input2
+  //
+  // The gated residual carries no coefficient in front of the product, so
+  // `scalar` is the multiplicative identity (kAddcmulScalar == 1.0):
+  //
+  //   residual + 1.0 * proj * gate  ==  residual + gate * proj
+  //
+  // matching tt-metal, where every DiT call site passes 1.0; the slot stays
+  // configurable only because the underlying addcmul kernel is general.
+
+  // add: one operand is the `gate * proj` multiply, the other is the residual.
+  MultiplyOp gateMulOp = addOp.getLhs().getDefiningOp<MultiplyOp>();
+  mlir::Value residual = addOp.getRhs();
+  if (!gateMulOp) {
+    gateMulOp = addOp.getRhs().getDefiningOp<MultiplyOp>();
+    residual = addOp.getLhs();
+  }
+  if (!gateMulOp || !gateMulOp.getResult().hasOneUse()) {
+    return mlir::failure();
+  }
+
+  // multiply: one operand is the reduce_scatter projection, the other the gate.
+  ReduceScatterOp reduceScatterOp =
+      gateMulOp.getLhs().getDefiningOp<ReduceScatterOp>();
+  mlir::Value gate = gateMulOp.getRhs();
+  if (!reduceScatterOp) {
+    reduceScatterOp = gateMulOp.getRhs().getDefiningOp<ReduceScatterOp>();
+    gate = gateMulOp.getLhs();
+  }
+  if (!reduceScatterOp || !reduceScatterOp.getResult().hasOneUse()) {
+    return mlir::failure();
+  }
+
+  MatmulLikeOp projOp =
+      reduceScatterOp.getInput().template getDefiningOp<MatmulLikeOp>();
+  if (!projOp || !projOp.getResult().hasOneUse()) {
+    return mlir::failure();
+  }
+
+  if (projOp.getTransposeA() || projOp.getTransposeB()) {
+    return mlir::failure();
+  }
+
+  Value bias;
+  if constexpr (std::is_same_v<MatmulLikeOp, LinearOp>) {
+    bias = projOp.getBias();
+  }
+
+  auto resultType = mlir::cast<RankedTensorType>(addOp.getResult().getType());
+
+  // Captures feed the composite/decomposition in order:
+  //   input, weight, [bias], residual, gate.
+  SmallVector<Value> captures{projOp.getA(), projOp.getB()};
+  if (bias) {
+    captures.push_back(bias);
+  }
+  captures.push_back(residual);
+  captures.push_back(gate);
+  SmallVector<Operation *> ops{projOp, reduceScatterOp, gateMulOp, addOp};
+
+  ModuleOp moduleOp = addOp->getParentOfType<ModuleOp>();
+  OpBuilder moduleBuilder(moduleOp.getContext());
+  moduleBuilder.setInsertionPointToEnd(moduleOp.getBody());
+  func::FuncOp decompFunc = buildDecompositionFunc(
+      moduleBuilder, addOp.getLoc(), captures, ops, resultType);
+  moduleBuilder.insert(decompFunc);
+
+  // Collective parameters and operand-presence flags travel on the composite so
+  // TTNNResolveComposites can rebuild the typed op without re-inspecting the
+  // IR.
+  mlir::MLIRContext *ctx = rewriter.getContext();
+  SmallVector<NamedAttribute> attrs;
+  attrs.emplace_back(
+      StringAttr::get(ctx, "scatter_dim"),
+      rewriter.getSI32IntegerAttr(reduceScatterOp.getScatterDim()));
+  attrs.emplace_back(
+      StringAttr::get(ctx, "cluster_axis"),
+      rewriter.getUI32IntegerAttr(reduceScatterOp.getClusterAxis()));
+  attrs.emplace_back(StringAttr::get(ctx, "has_bias"),
+                     rewriter.getBoolAttr(bias != nullptr));
+  attrs.emplace_back(StringAttr::get(ctx, "has_addcmul"),
+                     rewriter.getBoolAttr(true));
+  // out = residual + kAddcmulScalar * proj * gate  (scalar == 1.0; see
+  // kAddcmulScalar for why).
+  attrs.emplace_back(StringAttr::get(ctx, "scalar"),
+                     rewriter.getF32FloatAttr(kAddcmulScalar));
+
+  rewriter.replaceOpWithNewOp<ttcore::CompositeOp>(
+      addOp, TypeRange{resultType}, captures,
+      rewriter.getStringAttr(kCompositeName),
+      FlatSymbolRefAttr::get(ctx, decompFunc.getName()),
+      DictionaryAttr::get(ctx, attrs));
+  return mlir::success();
+}
+
+// Explicit template instantiations.
+template class MatmulReduceScatterFusing<MatmulOp>;
+template class MatmulReduceScatterFusing<LinearOp>;
+template class MatmulReduceScatterAddcmulFusing<MatmulOp>;
+template class MatmulReduceScatterAddcmulFusing<LinearOp>;
+
+} // namespace mlir::tt::ttir::fusing

--- a/lib/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.cpp
@@ -39,6 +39,35 @@ std::string getUniqueDecompName() {
 // 1.0 (see the addcmul pattern for the full derivation).
 constexpr double kAddcmulScalar = 1.0;
 
+// True if the reduce_scatter scatters the last axis of its input. tt-metal's
+// fused minimal-matmul kernel only supports scattering the matmul output's
+// last (N) dim (its validate asserts dim == 3 on the 4D tensor), so scatters
+// on any other axis must not fuse.
+bool scattersLastAxis(ReduceScatterOp reduceScatterOp) {
+  auto inputType =
+      mlir::cast<RankedTensorType>(reduceScatterOp.getInput().getType());
+  int64_t rank = inputType.getRank();
+  int64_t scatterDim = reduceScatterOp.getScatterDim();
+  if (scatterDim < 0) {
+    scatterDim += rank;
+  }
+  return scatterDim == rank - 1;
+}
+
+// True if `v` is a per-channel (row-broadcast) tensor: every dim except the
+// last is 1, e.g. `[1, N]`. The fused addcmul epilogue applies the gate
+// per-channel, broadcasting it across the row (M) dim; a full `[M, N]` gate
+// would be silently collapsed to its first row (see the addcmul pattern), so
+// only a row-broadcast gate may fuse.
+bool isRowBroadcast(mlir::Value v) {
+  auto type = mlir::dyn_cast<RankedTensorType>(v.getType());
+  if (!type) {
+    return false;
+  }
+  return llvm::all_of(type.getShape().drop_back(),
+                      [](int64_t dim) { return dim == 1; });
+}
+
 // True if this reduce_scatter result flows into a gated-residual epilogue
 // (a multiply then an add), which the addcmul pattern folds in whole.
 bool feedsGatedResidualEpilogue(ReduceScatterOp reduceScatterOp) {
@@ -100,6 +129,11 @@ mlir::LogicalResult MatmulReduceScatterFusing<MatmulLikeOp>::matchAndRewrite(
     ReduceScatterOp reduceScatterOp, mlir::PatternRewriter &rewriter) const {
   // Don't re-fuse the primitive ops we cloned into a decomposition body.
   if (utils::isInsideCompositeDecomposition(reduceScatterOp)) {
+    return mlir::failure();
+  }
+
+  // The fused kernel only scatters the matmul output's last (N) dim.
+  if (!scattersLastAxis(reduceScatterOp)) {
     return mlir::failure();
   }
 
@@ -216,6 +250,17 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
     gate = gateMulOp.getLhs();
   }
   if (!reduceScatterOp || !reduceScatterOp.getResult().hasOneUse()) {
+    return mlir::failure();
+  }
+
+  // The fused kernel only scatters the matmul output's last (N) dim.
+  if (!scattersLastAxis(reduceScatterOp)) {
+    return mlir::failure();
+  }
+
+  // The fused epilogue only supports a row-broadcast gate; a full `[M, N]`
+  // gate would be silently collapsed, so leave that case unfused.
+  if (!isRowBroadcast(gate)) {
     return mlir::failure();
   }
 

--- a/lib/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.cpp
@@ -112,11 +112,47 @@ Value skipViewOps(Value v) {
   return v;
 }
 
+// If `addOp` is `scatter_path + row-broadcast_bias` (Wan FF2 post-scatter
+// D/tp bias), return the scatter-side value; otherwise null. Does not look
+// through the add — callers pass the add's operands already view-stripped.
+Value scatterOperandOfPostScatterBiasAdd(AddOp addOp) {
+  if (!addOp.getResult().hasOneUse()) {
+    return Value();
+  }
+  Value lhs = skipViewOps(addOp.getLhs());
+  Value rhs = skipViewOps(addOp.getRhs());
+  if (lhs.getDefiningOp<ReduceScatterOp>() && isRowBroadcast(rhs)) {
+    return lhs;
+  }
+  if (rhs.getDefiningOp<ReduceScatterOp>() && isRowBroadcast(lhs)) {
+    return rhs;
+  }
+  return Value();
+}
+
+Value skipToScatter(Value v, Value *postScatterBias) {
+  v = skipViewOps(v);
+  if (auto addOp = v.getDefiningOp<AddOp>()) {
+    Value scatter = scatterOperandOfPostScatterBiasAdd(addOp);
+    if (scatter) {
+      if (postScatterBias) {
+        Value lhs = skipViewOps(addOp.getLhs());
+        // Keep the add's bias operand (broadcast and all) so `g * b` can
+        // be reapplied at the residual add's type without a new broadcast.
+        *postScatterBias = lhs.getDefiningOp<ReduceScatterOp>()
+                              ? addOp.getRhs()
+                              : addOp.getLhs();
+      }
+      return scatter;
+    }
+  }
+  return v;
+}
+
 // True if this reduce_scatter result flows into a gated-residual epilogue
-// (optionally through a leading-unit reshape, then a multiply then an add).
-// A post-scatter bias add between the reshape and the multiply is *not*
-// treated as that epilogue: that bias is sharded D/tp and must stay outside
-// the fused kernel (whose bias slot is the pre-scatter N).
+// (optionally through a leading-unit reshape, a post-scatter row-broadcast
+// bias add, then a multiply then an add). The bias add is not fused
+// `has_bias`; the addcmul pattern still owns that epilogue.
 bool feedsGatedResidualEpilogue(ReduceScatterOp reduceScatterOp) {
   if (!reduceScatterOp.getResult().hasOneUse()) {
     return false;
@@ -128,6 +164,12 @@ bool feedsGatedResidualEpilogue(ReduceScatterOp reduceScatterOp) {
       return false;
     }
     user = *reshapeOp.getResult().getUsers().begin();
+  }
+  if (auto biasAdd = mlir::dyn_cast<AddOp>(user)) {
+    if (!scatterOperandOfPostScatterBiasAdd(biasAdd)) {
+      return false;
+    }
+    user = *biasAdd.getResult().getUsers().begin();
   }
   auto mulOp = mlir::dyn_cast<MultiplyOp>(user);
   if (!mulOp || !mulOp.getResult().hasOneUse()) {
@@ -162,6 +204,45 @@ Value reshapeToType(OpBuilder &builder, Location loc, Value input,
                                   resultType.getShape().end());
   return builder.create<ReshapeOp>(loc, resultType, input,
                                     builder.getI32ArrayAttr(shapeI32));
+}
+
+// `r + g*(s+b) = (r+g*s) + g*b`. Multiply at the row-broadcast `[1, N]` /
+// `[1, 1, N]` layout (cheap), then broadcast onto the residual. Never reshape
+// a `[1, N]` tensor to `[1, M, N]` — those volumes differ.
+Value gatedPostScatterBias(PatternRewriter &rewriter, Location loc, Value gate,
+                            Value postScatterBias, RankedTensorType addType) {
+  SmallVector<int64_t> smallShape(addType.getRank(), 1);
+  smallShape.back() = addType.getDimSize(addType.getRank() - 1);
+  auto smallType = RankedTensorType::get(
+      smallShape, addType.getElementType(), addType.getEncoding());
+
+  auto canCollapseToSmall = [&](Value v) {
+    auto type = mlir::dyn_cast<RankedTensorType>(v.getType());
+    return type && type.getNumElements() == smallType.getNumElements();
+  };
+
+  Value g, b, gbFull;
+  Value gateSmall = skipViewOps(gate);
+  Value biasSmall = skipViewOps(postScatterBias);
+  if (canCollapseToSmall(gateSmall) && canCollapseToSmall(biasSmall) &&
+      succeeded(utils::broadcastValue(rewriter, gateSmall, smallType, g, loc,
+                                      /*frontUnsqueeze=*/true)) &&
+      succeeded(utils::broadcastValue(rewriter, biasSmall, smallType, b, loc,
+                                      /*frontUnsqueeze=*/true))) {
+    Value gb = rewriter.create<MultiplyOp>(loc, smallType, g, b);
+    if (succeeded(utils::broadcastValue(rewriter, gb, addType, gbFull, loc,
+                                       /*frontUnsqueeze=*/true))) {
+      return gbFull;
+    }
+  }
+
+  if (failed(utils::broadcastValue(rewriter, gate, addType, g, loc,
+                                     /*frontUnsqueeze=*/true)) ||
+      failed(utils::broadcastValue(rewriter, postScatterBias, addType, b, loc,
+                                    /*frontUnsqueeze=*/true))) {
+    return Value();
+  }
+  return rewriter.create<MultiplyOp>(loc, addType, g, b);
 }
 
 // Squeeze leading unit dims until `v` has `targetRank`. Used to capture a
@@ -374,8 +455,9 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
   //   (`+ bias` applies only to the linear variant; matmul has no bias)
   //
   // walking backwards from the anchor `add`:  add -> multiply ->
-  // [leading-unit reshape / broadcast] -> reduce_scatter -> matmul. Both the
-  // add and the multiply are commutative, so we try each operand order.
+  // [leading-unit reshape / broadcast / post-scatter row-broadcast bias] ->
+  // reduce_scatter -> matmul. Both the add and the multiply are commutative,
+  // so we try each operand order.
   //
   // This maps to tt-metal's `addcmul` epilogue, whose fixed formula is
   //
@@ -384,8 +466,9 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
   // The gated residual carries no coefficient in front of the product, so
   // `scalar` is the multiplicative identity (kAddcmulScalar == 1.0).
   //
-  // A post-scatter bias add is intentionally not skipped: that bias is
-  // sharded along D/tp and is not the fused kernel's pre-scatter N bias.
+  // A post-scatter D/tp bias is skipped for matching (it is not fused
+  // `has_bias`). Original math is `r + g * (s + b)`; the kernel computes
+  // `r + g * s`, so `g * b` is added after the composite.
 
   // add: one operand is the `gate * proj` multiply, the other is the residual.
   MultiplyOp gateMulOp = addOp.getLhs().getDefiningOp<MultiplyOp>();
@@ -398,10 +481,12 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
     return mlir::failure();
   }
 
-  // multiply: one operand is the (possibly reshaped) scatter, the other
-  // the gate (which may itself be a broadcast of a row-broadcast tensor).
-  auto matchScatter = [](Value v) -> ReduceScatterOp {
-    return skipViewOps(v).getDefiningOp<ReduceScatterOp>();
+  // multiply: one operand is the (possibly reshaped / post-scatter-biased)
+  // scatter, the other the gate (which may itself be a broadcast of a
+  // row-broadcast tensor).
+  Value postScatterBias;
+  auto matchScatter = [&](Value v) -> ReduceScatterOp {
+    return skipToScatter(v, &postScatterBias).getDefiningOp<ReduceScatterOp>();
   };
   ReduceScatterOp reduceScatterOp = matchScatter(gateMulOp.getLhs());
   mlir::Value gate = gateMulOp.getRhs();
@@ -463,6 +548,17 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
     return mlir::failure();
   }
 
+  auto addType = mlir::cast<RankedTensorType>(addOp.getResult().getType());
+  Value gatedBias;
+  if (postScatterBias) {
+    gatedBias = gatedPostScatterBias(rewriter, addOp.getLoc(), gate,
+                                     postScatterBias, addType);
+    if (!gatedBias) {
+      return rewriter.notifyMatchFailure(
+          addOp, "cannot broadcast gate * post-scatter bias onto residual");
+    }
+  }
+
   SmallVector<Value> captures{projOp.getA(), weight};
   if (bias) {
     captures.push_back(bias);
@@ -490,9 +586,12 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
 
   // The fused kernel writes the scattered 2D layout. If the original add
   // was 3D (`[1, M, N]`), restore that for downstream users.
-  auto addType = mlir::cast<RankedTensorType>(addOp.getResult().getType());
   Value result = reshapeToType(rewriter, addOp.getLoc(),
                                  compositeOp.getResult(0), addType);
+  if (gatedBias) {
+    result =
+        rewriter.create<AddOp>(addOp.getLoc(), addType, result, gatedBias);
+  }
   rewriter.replaceOp(addOp, result);
   return mlir::success();
 }

--- a/lib/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/STLExtras.h"
 
 #include <atomic>
+#include <numeric>
 #include <type_traits>
 
 namespace mlir::tt::ttir::fusing {
@@ -55,10 +56,10 @@ bool scattersLastAxis(ReduceScatterOp reduceScatterOp) {
 }
 
 // True if `v` is a per-channel (row-broadcast) tensor: every dim except the
-// last is 1, e.g. `[1, N]`. The fused addcmul epilogue applies the gate
-// per-channel, broadcasting it across the row (M) dim; a full `[M, N]` gate
-// would be silently collapsed to its first row (see the addcmul pattern), so
-// only a row-broadcast gate may fuse.
+// last is 1, e.g. `[1, N]` or `[1, 1, N]`. The fused addcmul epilogue applies
+// the gate per-channel, broadcasting it across the row (M) dim; a full
+// `[M, N]` gate would be silently collapsed to its first row, so only a
+// row-broadcast gate may fuse.
 bool isRowBroadcast(mlir::Value v) {
   auto type = mlir::dyn_cast<RankedTensorType>(v.getType());
   if (!type) {
@@ -68,24 +69,139 @@ bool isRowBroadcast(mlir::Value v) {
                       [](int64_t dim) { return dim == 1; });
 }
 
+// True if `reshape` only inserts or removes a leading unit dimension, e.g.
+// `[M, N] <-> [1, M, N]`. DiT lowers the projection in 2D then unsqueezes
+// a batch dim before the gated residual; that reshape must not block addcmul.
+bool isLeadingUnitDimReshape(ReshapeOp reshapeOp) {
+  auto inType = mlir::dyn_cast<RankedTensorType>(reshapeOp.getInput().getType());
+  auto outType =
+      mlir::dyn_cast<RankedTensorType>(reshapeOp.getResult().getType());
+  if (!inType || !outType) {
+    return false;
+  }
+  ArrayRef<int64_t> inShape = inType.getShape();
+  ArrayRef<int64_t> outShape = outType.getShape();
+  if (outType.getRank() == inType.getRank() + 1 && outShape.front() == 1 &&
+      outShape.drop_front() == inShape) {
+    return true;
+  }
+  if (inType.getRank() == outType.getRank() + 1 && inShape.front() == 1 &&
+      inShape.drop_front() == outShape) {
+    return true;
+  }
+  return false;
+}
+
+// Skip leading-unit reshapes and broadcasts so matchers see the 2D
+// projection or the `[1, N]` AdaLN gate underneath.
+Value skipViewOps(Value v) {
+  while (true) {
+    auto reshapeOp = v.getDefiningOp<ReshapeOp>();
+    if (reshapeOp && reshapeOp.getResult().hasOneUse() &&
+        isLeadingUnitDimReshape(reshapeOp)) {
+      v = reshapeOp.getInput();
+      continue;
+    }
+    auto broadcastOp = v.getDefiningOp<BroadcastOp>();
+    if (broadcastOp && broadcastOp.getResult().hasOneUse()) {
+      v = broadcastOp.getInput();
+      continue;
+    }
+    break;
+  }
+  return v;
+}
+
 // True if this reduce_scatter result flows into a gated-residual epilogue
-// (a multiply then an add), which the addcmul pattern folds in whole.
+// (optionally through a leading-unit reshape, then a multiply then an add).
+// A post-scatter bias add between the reshape and the multiply is *not*
+// treated as that epilogue: that bias is sharded D/tp and must stay outside
+// the fused kernel (whose bias slot is the pre-scatter N).
 bool feedsGatedResidualEpilogue(ReduceScatterOp reduceScatterOp) {
   if (!reduceScatterOp.getResult().hasOneUse()) {
     return false;
   }
-  auto mulOp = mlir::dyn_cast<MultiplyOp>(
-      *reduceScatterOp.getResult().getUsers().begin());
+  Operation *user = *reduceScatterOp.getResult().getUsers().begin();
+  if (auto reshapeOp = mlir::dyn_cast<ReshapeOp>(user)) {
+    if (!isLeadingUnitDimReshape(reshapeOp) ||
+        !reshapeOp.getResult().hasOneUse()) {
+      return false;
+    }
+    user = *reshapeOp.getResult().getUsers().begin();
+  }
+  auto mulOp = mlir::dyn_cast<MultiplyOp>(user);
   if (!mulOp || !mulOp.getResult().hasOneUse()) {
     return false;
   }
   return mlir::isa<AddOp>(*mulOp.getResult().getUsers().begin());
 }
 
+// Swap the last two dims of `input` so a `transpose_b` weight `[N, K]` becomes
+// the `[K, N]` layout the fused kernel expects. Lives outside the composite
+// (and is typically const-eval'd for parameter weights).
+Value createTransposePermute(OpBuilder &builder, Location loc, Value input) {
+  auto inputType = mlir::cast<RankedTensorType>(input.getType());
+  int64_t rank = inputType.getRank();
+  SmallVector<int64_t> permutation(rank);
+  std::iota(permutation.begin(), permutation.end(), 0);
+  std::swap(permutation[rank - 2], permutation[rank - 1]);
+
+  SmallVector<int64_t> permutedShape(inputType.getShape());
+  std::swap(permutedShape[rank - 2], permutedShape[rank - 1]);
+  auto permutedType = RankedTensorType::get(
+      permutedShape, inputType.getElementType(), inputType.getEncoding());
+  return builder.create<PermuteOp>(loc, permutedType, input, permutation);
+}
+
+Value reshapeToType(OpBuilder &builder, Location loc, Value input,
+                     RankedTensorType resultType) {
+  if (input.getType() == resultType) {
+    return input;
+  }
+  SmallVector<int32_t> shapeI32(resultType.getShape().begin(),
+                                  resultType.getShape().end());
+  return builder.create<ReshapeOp>(loc, resultType, input,
+                                    builder.getI32ArrayAttr(shapeI32));
+}
+
+// Squeeze leading unit dims until `v` has `targetRank`. Used to capture a
+// 3D residual/gate against a 2D scattered projection without changing addcmul
+// math.
+Value squeezeLeadingUnitToRank(OpBuilder &builder, Location loc, Value v,
+                                int64_t targetRank) {
+  auto type = mlir::cast<RankedTensorType>(v.getType());
+  if (type.getRank() == targetRank) {
+    return v;
+  }
+  if (type.getRank() < targetRank) {
+    return Value();
+  }
+  ArrayRef<int64_t> shape = type.getShape();
+  int64_t leading = type.getRank() - targetRank;
+  if (!llvm::all_of(shape.take_front(leading),
+                     [](int64_t dim) { return dim == 1; })) {
+    return Value();
+  }
+  auto squeezedType = RankedTensorType::get(
+      shape.drop_front(leading), type.getElementType(), type.getEncoding());
+  return reshapeToType(builder, loc, v, squeezedType);
+}
+
+void clearTransposeAttrs(Operation *op) {
+  if (auto matmulOp = mlir::dyn_cast<MatmulOp>(op)) {
+    matmulOp.setTransposeA(false);
+    matmulOp.setTransposeB(false);
+  } else if (auto linearOp = mlir::dyn_cast<LinearOp>(op)) {
+    linearOp.setTransposeA(false);
+    linearOp.setTransposeB(false);
+  }
+}
+
 func::FuncOp buildDecompositionFunc(OpBuilder &builder, Location loc,
                                     ArrayRef<Value> captures,
-                                    ArrayRef<Operation *> ops,
-                                    Type resultType) {
+                                    ReduceScatterOp reduceScatterOp,
+                                    Operation *projOp, bool clearProjTranspose,
+                                    bool hasAddcmul, Type resultType) {
   auto argTypes =
       llvm::map_to_vector(captures, [](Value v) { return v.getType(); });
   auto funcOp =
@@ -98,20 +214,63 @@ func::FuncOp buildDecompositionFunc(OpBuilder &builder, Location loc,
   Block *block = funcOp.addEntryBlock();
   OpBuilder fb(block, block->end());
 
-  // Map each captured value to its matching block argument so cloned ops
-  // reference the function's arguments; clone() rewires chained results.
+  // Captures: input, weight, [bias], [residual, gate]. Map the original
+  // projection's A/B (and bias) onto those args so clone() rewires them even
+  // when the weight capture is a permute of the original B.
   IRMapping mapping;
-  for (auto [capture, arg] : llvm::zip(captures, block->getArguments())) {
-    mapping.map(capture, arg);
+  if (auto matmulOp = mlir::dyn_cast<MatmulOp>(projOp)) {
+    mapping.map(matmulOp.getA(), block->getArgument(0));
+    mapping.map(matmulOp.getB(), block->getArgument(1));
+  } else if (auto linearOp = mlir::dyn_cast<LinearOp>(projOp)) {
+    mapping.map(linearOp.getA(), block->getArgument(0));
+    mapping.map(linearOp.getB(), block->getArgument(1));
+    if (linearOp.getBias()) {
+      mapping.map(linearOp.getBias(), block->getArgument(2));
+    }
   }
 
-  Operation *last = nullptr;
-  for (Operation *op : ops) {
-    last = fb.clone(*op, mapping);
+  Operation *clonedProj = fb.clone(*projOp, mapping);
+  if (clearProjTranspose) {
+    clearTransposeAttrs(clonedProj);
+  }
+  mapping.map(projOp->getResult(0), clonedProj->getResult(0));
+  Operation *clonedScatter = fb.clone(*reduceScatterOp, mapping);
+
+  Value result = clonedScatter->getResult(0);
+  if (hasAddcmul) {
+    unsigned residualIdx = captures.size() - 2;
+    Value residual = block->getArgument(residualIdx);
+    Value gate = block->getArgument(residualIdx + 1);
+    auto mulType = mlir::cast<RankedTensorType>(result.getType());
+    auto mulOp = fb.create<MultiplyOp>(loc, mulType, result, gate);
+    auto addOp = fb.create<AddOp>(loc, mulType, residual, mulOp.getResult());
+    result = addOp.getResult();
   }
 
-  fb.create<func::ReturnOp>(loc, last->getResults());
+  fb.create<func::ReturnOp>(loc, result);
   return funcOp;
+}
+
+SmallVector<NamedAttribute> buildCompositeAttrs(OpBuilder &rewriter,
+                                               ReduceScatterOp reduceScatterOp,
+                                               bool hasBias, bool hasAddcmul) {
+  mlir::MLIRContext *ctx = rewriter.getContext();
+  SmallVector<NamedAttribute> attrs;
+  attrs.emplace_back(
+      StringAttr::get(ctx, "scatter_dim"),
+      rewriter.getSI32IntegerAttr(reduceScatterOp.getScatterDim()));
+  attrs.emplace_back(
+      StringAttr::get(ctx, "cluster_axis"),
+      rewriter.getUI32IntegerAttr(reduceScatterOp.getClusterAxis()));
+  attrs.emplace_back(StringAttr::get(ctx, "has_bias"),
+                     rewriter.getBoolAttr(hasBias));
+  attrs.emplace_back(StringAttr::get(ctx, "has_addcmul"),
+                     rewriter.getBoolAttr(hasAddcmul));
+  if (hasAddcmul) {
+    attrs.emplace_back(StringAttr::get(ctx, "scalar"),
+                       rewriter.getF32FloatAttr(kAddcmulScalar));
+  }
+  return attrs;
 }
 
 } // namespace
@@ -124,6 +283,8 @@ func::FuncOp buildDecompositionFunc(OpBuilder &builder, Location loc,
 // where `+ bias` applies only to the linear variant (matmul has no bias).
 // If a `residual + gate * out` epilogue follows, defer to
 // MatmulReduceScatterAddcmulFusing so the whole thing folds at once.
+// `transpose_b` is materialized as a permute of the weight to `[K, N]`;
+// `transpose_a` is rejected because the kernel scatters the last dim of A@B.
 template <typename MatmulLikeOp>
 mlir::LogicalResult MatmulReduceScatterFusing<MatmulLikeOp>::matchAndRewrite(
     ReduceScatterOp reduceScatterOp, mlir::PatternRewriter &rewriter) const {
@@ -143,7 +304,7 @@ mlir::LogicalResult MatmulReduceScatterFusing<MatmulLikeOp>::matchAndRewrite(
     return mlir::failure();
   }
 
-  if (matmulOp.getTransposeA() || matmulOp.getTransposeB()) {
+  if (matmulOp.getTransposeA()) {
     return mlir::failure();
   }
 
@@ -157,45 +318,43 @@ mlir::LogicalResult MatmulReduceScatterFusing<MatmulLikeOp>::matchAndRewrite(
     bias = matmulOp.getBias();
   }
 
+  bool transposeB = matmulOp.getTransposeB();
+  Value weight = matmulOp.getB();
+  if (transposeB) {
+    auto weightType = mlir::cast<RankedTensorType>(weight.getType());
+    if (weightType.getRank() < 2) {
+      return mlir::failure();
+    }
+    rewriter.setInsertionPoint(matmulOp);
+    weight = createTransposePermute(rewriter, matmulOp.getLoc(), weight);
+  }
+
   auto resultType =
       mlir::cast<RankedTensorType>(reduceScatterOp.getResult().getType());
 
-  // Captures feed the composite/decomposition in order: input, weight, [bias].
-  SmallVector<Value> captures{matmulOp.getA(), matmulOp.getB()};
+  SmallVector<Value> captures{matmulOp.getA(), weight};
   if (bias) {
     captures.push_back(bias);
   }
-  SmallVector<Operation *> ops{matmulOp, reduceScatterOp};
 
   Operation *anchor = reduceScatterOp.getOperation();
   ModuleOp moduleOp = anchor->getParentOfType<ModuleOp>();
   OpBuilder moduleBuilder(moduleOp.getContext());
   moduleBuilder.setInsertionPointToEnd(moduleOp.getBody());
   func::FuncOp decompFunc = buildDecompositionFunc(
-      moduleBuilder, reduceScatterOp.getLoc(), captures, ops, resultType);
+      moduleBuilder, reduceScatterOp.getLoc(), captures, reduceScatterOp,
+      matmulOp.getOperation(), /*clearProjTranspose=*/transposeB,
+      /*hasAddcmul=*/false, resultType);
   moduleBuilder.insert(decompFunc);
-
-  // Collective parameters and operand-presence flags travel on the composite so
-  // TTNNResolveComposites can rebuild the typed op without re-inspecting the
-  // IR.
-  mlir::MLIRContext *ctx = rewriter.getContext();
-  SmallVector<NamedAttribute> attrs;
-  attrs.emplace_back(
-      StringAttr::get(ctx, "scatter_dim"),
-      rewriter.getSI32IntegerAttr(reduceScatterOp.getScatterDim()));
-  attrs.emplace_back(
-      StringAttr::get(ctx, "cluster_axis"),
-      rewriter.getUI32IntegerAttr(reduceScatterOp.getClusterAxis()));
-  attrs.emplace_back(StringAttr::get(ctx, "has_bias"),
-                     rewriter.getBoolAttr(bias != nullptr));
-  attrs.emplace_back(StringAttr::get(ctx, "has_addcmul"),
-                     rewriter.getBoolAttr(false));
 
   rewriter.replaceOpWithNewOp<ttcore::CompositeOp>(
       anchor, TypeRange{resultType}, captures,
       rewriter.getStringAttr(kCompositeName),
-      FlatSymbolRefAttr::get(ctx, decompFunc.getName()),
-      DictionaryAttr::get(ctx, attrs));
+      FlatSymbolRefAttr::get(rewriter.getContext(), decompFunc.getName()),
+      DictionaryAttr::get(rewriter.getContext(),
+                           buildCompositeAttrs(rewriter, reduceScatterOp,
+                                               bias != nullptr,
+                                               /*hasAddcmul=*/false)));
   return mlir::success();
 }
 
@@ -214,21 +373,19 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
   //   where proj = reduce_scatter(matmul(input, weight) + bias)
   //   (`+ bias` applies only to the linear variant; matmul has no bias)
   //
-  // walking backwards from the anchor `add`:  add -> multiply -> reduce_scatter
-  // -> matmul. Both the add and the multiply are commutative, so we try each
-  // operand order.
+  // walking backwards from the anchor `add`:  add -> multiply ->
+  // [leading-unit reshape / broadcast] -> reduce_scatter -> matmul. Both the
+  // add and the multiply are commutative, so we try each operand order.
   //
   // This maps to tt-metal's `addcmul` epilogue, whose fixed formula is
   //
   //   result = addcmul_input1 + scalar * proj * addcmul_input2
   //
   // The gated residual carries no coefficient in front of the product, so
-  // `scalar` is the multiplicative identity (kAddcmulScalar == 1.0):
+  // `scalar` is the multiplicative identity (kAddcmulScalar == 1.0).
   //
-  //   residual + 1.0 * proj * gate  ==  residual + gate * proj
-  //
-  // matching tt-metal, where every DiT call site passes 1.0; the slot stays
-  // configurable only because the underlying addcmul kernel is general.
+  // A post-scatter bias add is intentionally not skipped: that bias is
+  // sharded along D/tp and is not the fused kernel's pre-scatter N bias.
 
   // add: one operand is the `gate * proj` multiply, the other is the residual.
   MultiplyOp gateMulOp = addOp.getLhs().getDefiningOp<MultiplyOp>();
@@ -241,12 +398,15 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
     return mlir::failure();
   }
 
-  // multiply: one operand is the reduce_scatter projection, the other the gate.
-  ReduceScatterOp reduceScatterOp =
-      gateMulOp.getLhs().getDefiningOp<ReduceScatterOp>();
+  // multiply: one operand is the (possibly reshaped) scatter, the other
+  // the gate (which may itself be a broadcast of a row-broadcast tensor).
+  auto matchScatter = [](Value v) -> ReduceScatterOp {
+    return skipViewOps(v).getDefiningOp<ReduceScatterOp>();
+  };
+  ReduceScatterOp reduceScatterOp = matchScatter(gateMulOp.getLhs());
   mlir::Value gate = gateMulOp.getRhs();
   if (!reduceScatterOp) {
-    reduceScatterOp = gateMulOp.getRhs().getDefiningOp<ReduceScatterOp>();
+    reduceScatterOp = matchScatter(gateMulOp.getRhs());
     gate = gateMulOp.getLhs();
   }
   if (!reduceScatterOp || !reduceScatterOp.getResult().hasOneUse()) {
@@ -258,9 +418,9 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
     return mlir::failure();
   }
 
-  // The fused epilogue only supports a row-broadcast gate; a full `[M, N]`
-  // gate would be silently collapsed, so leave that case unfused.
-  if (!isRowBroadcast(gate)) {
+  // The fused epilogue only supports a row-broadcast gate; look through
+  // broadcast/unsqueeze so AdaLN's `[1, 1, N] -> [1, M, N]` still matches.
+  if (!isRowBroadcast(skipViewOps(gate))) {
     return mlir::failure();
   }
 
@@ -270,7 +430,7 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
     return mlir::failure();
   }
 
-  if (projOp.getTransposeA() || projOp.getTransposeB()) {
+  if (projOp.getTransposeA()) {
     return mlir::failure();
   }
 
@@ -279,50 +439,61 @@ MatmulReduceScatterAddcmulFusing<MatmulLikeOp>::matchAndRewrite(
     bias = projOp.getBias();
   }
 
-  auto resultType = mlir::cast<RankedTensorType>(addOp.getResult().getType());
+  bool transposeB = projOp.getTransposeB();
+  rewriter.setInsertionPoint(addOp);
+  Value weight = projOp.getB();
+  if (transposeB) {
+    auto weightType = mlir::cast<RankedTensorType>(weight.getType());
+    if (weightType.getRank() < 2) {
+      return mlir::failure();
+    }
+    weight = createTransposePermute(rewriter, addOp.getLoc(), weight);
+  }
 
-  // Captures feed the composite/decomposition in order:
-  //   input, weight, [bias], residual, gate.
-  SmallVector<Value> captures{projOp.getA(), projOp.getB()};
+  auto scatterType =
+      mlir::cast<RankedTensorType>(reduceScatterOp.getResult().getType());
+  Value squeezedResidual = squeezeLeadingUnitToRank(
+      rewriter, addOp.getLoc(), skipViewOps(residual), scatterType.getRank());
+  Value squeezedGate = squeezeLeadingUnitToRank(
+      rewriter, addOp.getLoc(), skipViewOps(gate), scatterType.getRank());
+  if (!squeezedResidual || !squeezedGate) {
+    return mlir::failure();
+  }
+  if (!isRowBroadcast(squeezedGate)) {
+    return mlir::failure();
+  }
+
+  SmallVector<Value> captures{projOp.getA(), weight};
   if (bias) {
     captures.push_back(bias);
   }
-  captures.push_back(residual);
-  captures.push_back(gate);
-  SmallVector<Operation *> ops{projOp, reduceScatterOp, gateMulOp, addOp};
+  captures.push_back(squeezedResidual);
+  captures.push_back(squeezedGate);
 
   ModuleOp moduleOp = addOp->getParentOfType<ModuleOp>();
   OpBuilder moduleBuilder(moduleOp.getContext());
   moduleBuilder.setInsertionPointToEnd(moduleOp.getBody());
   func::FuncOp decompFunc = buildDecompositionFunc(
-      moduleBuilder, addOp.getLoc(), captures, ops, resultType);
+      moduleBuilder, addOp.getLoc(), captures, reduceScatterOp,
+      projOp.getOperation(), /*clearProjTranspose=*/transposeB,
+      /*hasAddcmul=*/true, scatterType);
   moduleBuilder.insert(decompFunc);
 
-  // Collective parameters and operand-presence flags travel on the composite so
-  // TTNNResolveComposites can rebuild the typed op without re-inspecting the
-  // IR.
-  mlir::MLIRContext *ctx = rewriter.getContext();
-  SmallVector<NamedAttribute> attrs;
-  attrs.emplace_back(
-      StringAttr::get(ctx, "scatter_dim"),
-      rewriter.getSI32IntegerAttr(reduceScatterOp.getScatterDim()));
-  attrs.emplace_back(
-      StringAttr::get(ctx, "cluster_axis"),
-      rewriter.getUI32IntegerAttr(reduceScatterOp.getClusterAxis()));
-  attrs.emplace_back(StringAttr::get(ctx, "has_bias"),
-                     rewriter.getBoolAttr(bias != nullptr));
-  attrs.emplace_back(StringAttr::get(ctx, "has_addcmul"),
-                     rewriter.getBoolAttr(true));
-  // out = residual + kAddcmulScalar * proj * gate  (scalar == 1.0; see
-  // kAddcmulScalar for why).
-  attrs.emplace_back(StringAttr::get(ctx, "scalar"),
-                     rewriter.getF32FloatAttr(kAddcmulScalar));
-
-  rewriter.replaceOpWithNewOp<ttcore::CompositeOp>(
-      addOp, TypeRange{resultType}, captures,
+  auto compositeOp = rewriter.create<ttcore::CompositeOp>(
+      addOp.getLoc(), TypeRange{scatterType}, captures,
       rewriter.getStringAttr(kCompositeName),
-      FlatSymbolRefAttr::get(ctx, decompFunc.getName()),
-      DictionaryAttr::get(ctx, attrs));
+      FlatSymbolRefAttr::get(rewriter.getContext(), decompFunc.getName()),
+      DictionaryAttr::get(rewriter.getContext(),
+                           buildCompositeAttrs(rewriter, reduceScatterOp,
+                                               bias != nullptr,
+                                               /*hasAddcmul=*/true)));
+
+  // The fused kernel writes the scattered 2D layout. If the original add
+  // was 3D (`[1, M, N]`), restore that for downstream users.
+  auto addType = mlir::cast<RankedTensorType>(addOp.getResult().getType());
+  Value result = reshapeToType(rewriter, addOp.getLoc(),
+                                 compositeOp.getResult(0), addType);
+  rewriter.replaceOp(addOp, result);
   return mlir::success();
 }
 

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Fusing/MatmulReduceScatterFusingPattern.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Fusing/TopKFusingPattern.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
@@ -3679,6 +3680,12 @@ public:
       patterns.add<fusing::RoPEComplexRotationFusingPattern>(&getContext());
       patterns.add<fusing::RoPEInterleavedPairFusingPattern>(&getContext());
       patterns.add<fusing::TopKFusingPattern>(&getContext());
+
+      patterns.add<fusing::MatmulReduceScatterFusing<MatmulOp>,
+                   fusing::MatmulReduceScatterFusing<LinearOp>,
+                   fusing::MatmulReduceScatterAddcmulFusing<MatmulOp>,
+                   fusing::MatmulReduceScatterAddcmulFusing<LinearOp>>(
+          &getContext());
 
       GreedyRewriteConfig config;
       config.setUseTopDownTraversal(true);

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3207,6 +3207,131 @@ bool MoeComputeOp::hasUnboundSemaphores() { return false; }
 void MoeComputeOp::allocateSemaphores(::mlir::RewriterBase &rewriter) {}
 
 //===----------------------------------------------------------------------===//
+// MinimalMatmulStridedReduceScatterAsyncOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult MinimalMatmulStridedReduceScatterAsyncOp::verify() {
+  RankedTensorType inputType = getInput().getType();
+  RankedTensorType weightType = getWeight().getType();
+
+  if (inputType.getRank() < 2) {
+    return emitOpError("input tensor must have rank >= 2");
+  }
+  if (weightType.getRank() < 2) {
+    return emitOpError("weight tensor must have rank >= 2");
+  }
+
+  // The reduce-scatter is synchronized by exactly two global semaphores. When
+  // the operand is left unbound it is materialized later by
+  // TTNNAllocateDistributedOpSemaphores; if provided it must be a pair.
+  if (!getMultiDeviceSemaphore().empty() &&
+      getMultiDeviceSemaphore().size() != 2) {
+    return emitOpError(
+               "expects exactly two multi-device global semaphores, got ")
+           << getMultiDeviceSemaphore().size();
+  }
+
+  if (getResults().empty()) {
+    return emitOpError("expects at least one result tensor");
+  }
+
+  // bias is row-broadcast: its last dim must match the matmul output width N.
+  if (getBias()) {
+    RankedTensorType biasType = getBias().getType();
+    if (biasType.getRank() < 1) {
+      return emitOpError("bias tensor must have rank >= 1");
+    }
+    int64_t n = weightType.getShape().back();
+    if (biasType.getShape().back() != n) {
+      return emitOpError("bias last dimension (")
+             << biasType.getShape().back()
+             << ") must match weight's last dimension N (" << n << ")";
+    }
+  }
+
+  // The gated-residual (addcmul) fusion needs both tensor operands together.
+  // The slots are not interchangeable: the epilogue computes
+  //   addcmul_input1 + scalar * reduce_scatter(input @ weight) * addcmul_input2
+  // so addcmul_input1 is the additive residual and addcmul_input2 is the
+  // multiplicative gate. The fusing pattern (MatmulReduceScatterAddcmulFusing)
+  // fixes this mapping via its capture order (residual then gate); nothing
+  // here can recover it once fused, so callers must preserve that order.
+  if (static_cast<bool>(getAddcmulInput1()) !=
+      static_cast<bool>(getAddcmulInput2())) {
+    return emitOpError("addcmul_input1 and addcmul_input2 must both be present "
+                       "or both absent");
+  }
+
+  return success();
+}
+
+bool MinimalMatmulStridedReduceScatterAsyncOp::hasUnboundBuffers() {
+  return false;
+}
+
+void MinimalMatmulStridedReduceScatterAsyncOp::allocateBuffers(
+    ::mlir::RewriterBase &rewriter) {}
+
+bool MinimalMatmulStridedReduceScatterAsyncOp::hasUnboundSemaphores() {
+  return getMultiDeviceSemaphore().empty() || !getBarrierSemaphore();
+}
+
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+void MinimalMatmulStridedReduceScatterAsyncOp::allocateSemaphores(
+    ::mlir::RewriterBase &rewriter) {
+  if (!hasUnboundSemaphores()) {
+    return;
+  }
+
+  // The reduce-scatter semaphores must live on cores that exist on the device.
+  // Derive the core range from the input tensor's layout (its worker grid).
+  MLIRContext *ctx = rewriter.getContext();
+  auto inputLayout = mlir::dyn_cast_if_present<TTNNLayoutAttr>(
+      getInput().getType().getEncoding());
+  CoreRangeSetAttr coreRangeSet =
+      inputLayout ? inputLayout.getCoreRangeSet() : CoreRangeSetAttr();
+
+  if (!coreRangeSet) {
+    ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(*this);
+    llvm::ArrayRef<int64_t> gridShape = deviceAttr.getWorkerGrid().getShape();
+    coreRangeSet = CoreRangeSetAttr::get(
+        ctx, {CoreRangeAttr::get(
+                 ctx, CoreCoordAttr::get(ctx, 0, 0),
+                 CoreCoordAttr::get(ctx, gridShape[1] - 1, gridShape[0] - 1))});
+  }
+
+  Value device = getDevice();
+
+  // All prelude ops are inserted right after the device def so they sit in the
+  // block prelude (see DistributedRMSNormOp for the trace-hoisting rationale).
+  auto createSemaphore = [&]() -> Value {
+    OpBuilder::InsertionGuard guard(rewriter);
+    if (Operation *deviceDef = device.getDefiningOp()) {
+      rewriter.setInsertionPointAfter(deviceDef);
+    } else {
+      rewriter.setInsertionPointToStart(getOperation()->getBlock());
+    }
+    auto semaphoreOp = rewriter.create<ttnn::CreateGlobalSemaphoreOp>(
+        getLoc(), GlobalSemaphoreType::get(ctx), device,
+        /*initial_value=*/rewriter.getUI32IntegerAttr(0), coreRangeSet);
+    return semaphoreOp.getResult();
+  };
+
+  if (getMultiDeviceSemaphore().empty()) {
+    SmallVector<Value> semaphores = {createSemaphore(), createSemaphore()};
+    rewriter.modifyOpInPlace(
+        *this, [&]() { getMultiDeviceSemaphoreMutable().assign(semaphores); });
+  }
+
+  if (!getBarrierSemaphore()) {
+    Value barrier = createSemaphore();
+    rewriter.modifyOpInPlace(
+        *this, [&]() { getBarrierSemaphoreMutable().assign(barrier); });
+  }
+}
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)
+
+//===----------------------------------------------------------------------===//
 // AllocOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3214,11 +3214,22 @@ void MoeComputeOp::allocateSemaphores(::mlir::RewriterBase &rewriter) {}
   RankedTensorType inputType = getInput().getType();
   RankedTensorType weightType = getWeight().getType();
 
-  if (inputType.getRank() < 2) {
-    return emitOpError("input tensor must have rank >= 2");
+  if (inputType.getRank() != 4) {
+    return emitOpError(
+        "input tensor must have rank 4 (tt-metal indexes scatter dim 3)");
   }
   if (weightType.getRank() < 2) {
     return emitOpError("weight tensor must have rank >= 2");
+  }
+
+  int32_t dim = getDim();
+  if (dim < 0) {
+    dim += inputType.getRank();
+  }
+  if (dim != 3) {
+    return emitOpError("scatter dim must be 3 (last axis of the rank-4 "
+                       "activation), got ")
+           << getDim();
   }
 
   // The reduce-scatter is synchronized by exactly three global semaphores

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3266,17 +3266,6 @@ void MoeComputeOp::allocateSemaphores(::mlir::RewriterBase &rewriter) {}
   return success();
 }
 
-bool MinimalMatmulStridedReduceScatterAsyncOp::hasUnboundBuffers() {
-  return false;
-}
-
-void MinimalMatmulStridedReduceScatterAsyncOp::allocateBuffers(
-    ::mlir::RewriterBase &rewriter) {}
-
-bool MinimalMatmulStridedReduceScatterAsyncOp::hasUnboundSemaphores() {
-  return getMultiDeviceSemaphore().empty() || !getBarrierSemaphore();
-}
-
 // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
 void MinimalMatmulStridedReduceScatterAsyncOp::allocateSemaphores(
     ::mlir::RewriterBase &rewriter) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3221,13 +3221,14 @@ void MoeComputeOp::allocateSemaphores(::mlir::RewriterBase &rewriter) {}
     return emitOpError("weight tensor must have rank >= 2");
   }
 
-  // The reduce-scatter is synchronized by exactly two global semaphores. When
-  // the operand is left unbound it is materialized later by
-  // TTNNAllocateDistributedOpSemaphores; if provided it must be a pair.
+  // The reduce-scatter is synchronized by exactly three global semaphores
+  // (tt-metal's validate asserts semaphore.size() == 3). When the operand is
+  // left unbound it is materialized later by
+  // TTNNAllocateDistributedOpSemaphores; if provided it must be a triple.
   if (!getMultiDeviceSemaphore().empty() &&
-      getMultiDeviceSemaphore().size() != 2) {
+      getMultiDeviceSemaphore().size() != 3) {
     return emitOpError(
-               "expects exactly two multi-device global semaphores, got ")
+               "expects exactly three multi-device global semaphores, got ")
            << getMultiDeviceSemaphore().size();
   }
 
@@ -3283,22 +3284,20 @@ void MinimalMatmulStridedReduceScatterAsyncOp::allocateSemaphores(
     return;
   }
 
-  // The reduce-scatter semaphores must live on cores that exist on the device.
-  // Derive the core range from the input tensor's layout (its worker grid).
+  // The global semaphores must live on every core that participates in the
+  // fused op -- the matmul cores span the top of the grid and the
+  // reduce-scatter cores the bottom -- so they are created over the FULL
+  // compute grid, matching tt-metal's own test (which builds them on
+  // `all_cores`). Scoping them to just the input tensor's (possibly small,
+  // sharded) core range would leave the matmul/RS cores waiting on a semaphore
+  // that does not exist for them, which deadlocks.
   MLIRContext *ctx = rewriter.getContext();
-  auto inputLayout = mlir::dyn_cast_if_present<TTNNLayoutAttr>(
-      getInput().getType().getEncoding());
-  CoreRangeSetAttr coreRangeSet =
-      inputLayout ? inputLayout.getCoreRangeSet() : CoreRangeSetAttr();
-
-  if (!coreRangeSet) {
-    ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(*this);
-    llvm::ArrayRef<int64_t> gridShape = deviceAttr.getWorkerGrid().getShape();
-    coreRangeSet = CoreRangeSetAttr::get(
-        ctx, {CoreRangeAttr::get(
-                 ctx, CoreCoordAttr::get(ctx, 0, 0),
-                 CoreCoordAttr::get(ctx, gridShape[1] - 1, gridShape[0] - 1))});
-  }
+  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(*this);
+  llvm::ArrayRef<int64_t> gridShape = deviceAttr.getWorkerGrid().getShape();
+  CoreRangeSetAttr coreRangeSet = CoreRangeSetAttr::get(
+      ctx, {CoreRangeAttr::get(
+               ctx, CoreCoordAttr::get(ctx, 0, 0),
+               CoreCoordAttr::get(ctx, gridShape[1] - 1, gridShape[0] - 1))});
 
   Value device = getDevice();
 
@@ -3318,7 +3317,8 @@ void MinimalMatmulStridedReduceScatterAsyncOp::allocateSemaphores(
   };
 
   if (getMultiDeviceSemaphore().empty()) {
-    SmallVector<Value> semaphores = {createSemaphore(), createSemaphore()};
+    SmallVector<Value> semaphores = {createSemaphore(), createSemaphore(),
+                                     createSemaphore()};
     rewriter.modifyOpInPlace(
         *this, [&]() { getMultiDeviceSemaphoreMutable().assign(semaphores); });
   }

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3214,21 +3214,23 @@ void MoeComputeOp::allocateSemaphores(::mlir::RewriterBase &rewriter) {}
   RankedTensorType inputType = getInput().getType();
   RankedTensorType weightType = getWeight().getType();
 
-  if (inputType.getRank() != 4) {
+  if (inputType.getRank() < 2 || inputType.getRank() > 4) {
     return emitOpError(
-        "input tensor must have rank 4 (tt-metal indexes scatter dim 3)");
+        "input tensor must have rank 2, 3, or 4 (the runtime unsqueezes "
+        "leading unit dims to rank 4 so tt-metal can index scatter dim 3)");
   }
   if (weightType.getRank() < 2) {
     return emitOpError("weight tensor must have rank >= 2");
   }
 
   int32_t dim = getDim();
+  int64_t rank = inputType.getRank();
   if (dim < 0) {
-    dim += inputType.getRank();
+    dim += rank;
   }
-  if (dim != 3) {
-    return emitOpError("scatter dim must be 3 (last axis of the rank-4 "
-                       "activation), got ")
+  if (dim != rank - 1) {
+    return emitOpError("scatter dim must be the last axis of the activation "
+                       "(tt-metal indexes dim 3 after unsqueeze-to-4D), got ")
            << getDim();
   }
 

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -6,11 +6,13 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 
 #include "ttmlir/Asserts.h"
@@ -175,6 +177,64 @@ static void registerBuiltinComposites() {
             args.key, args.value, args.attentionMask,
             static_cast<uint32_t>(args.headDimV.getValue().getZExtValue()),
             args.isCausal.getValue(), args.scale);
+      }};
+
+  registry["minimal_matmul_strided_reduce_scatter_async"] = CompositeEntry{
+      // Validate — the fused collective op is OpModelExempt, so there are no
+      // op-model constraints to check; it is always promotable.
+      [](ttcore::CompositeOp, OpBuilder &) -> OpValidationResult {
+        return OpValidationResult::success();
+      },
+      // Build
+      [](ttcore::CompositeOp compositeOp, OpBuilder &builder) -> Operation * {
+        DictionaryAttr attrs =
+            compositeOp.getCompositeAttributes().value_or(nullptr);
+        TT_assert(attrs);
+
+        auto readBool = [&](StringRef name) -> bool {
+          auto a = attrs.getAs<BoolAttr>(name);
+          return a && a.getValue();
+        };
+        bool hasBias = readBool("has_bias");
+        bool hasAddcmul = readBool("has_addcmul");
+
+        // Recover operands using the presence flags. Input order mirrors the
+        // composite: input, weight, [bias], [addcmul_input1, addcmul_input2].
+        auto inputs = compositeOp.getInputs();
+        Value input = inputs[0];
+        Value weight = inputs[1];
+        unsigned idx = 2;
+        Value bias = hasBias ? inputs[idx++] : Value();
+        Value addcmulInput1 = hasAddcmul ? inputs[idx++] : Value();
+        Value addcmulInput2 = hasAddcmul ? inputs[idx++] : Value();
+
+        auto clusterAxis = attrs.getAs<IntegerAttr>("cluster_axis");
+        auto scatterDim = attrs.getAs<IntegerAttr>("scatter_dim");
+        TT_assert(scatterDim);
+        FloatAttr scalar =
+            hasAddcmul ? attrs.getAs<FloatAttr>("scalar") : FloatAttr();
+
+        // The typed op needs a device handle and (later) semaphores; those are
+        // TTNN-level concerns that belong here, not in the TTIR fusing pattern.
+        // Semaphores are left unbound and materialized by
+        // TTNNAllocateDistributedOpSemaphores via the DistributedOpInterface.
+        IRRewriter rewriter(builder.getContext());
+        rewriter.setInsertionPoint(compositeOp);
+        Value device =
+            ttnn::utils::getOrInsertDevice(rewriter, compositeOp).getResult();
+
+        return rewriter.create<MinimalMatmulStridedReduceScatterAsyncOp>(
+            compositeOp.getLoc(), compositeOp.getResultTypes(), input, weight,
+            bias, addcmulInput1, addcmulInput2,
+            /*multi_device_semaphore=*/ValueRange{},
+            /*barrier_semaphore=*/Value(), device, clusterAxis, scalar,
+            /*topology=*/ttcore::TopologyAttr(),
+            /*num_links=*/IntegerAttr(), /*memory_config=*/MemoryConfigAttr(),
+            /*dtype=*/ttcore::DataTypeAttr(),
+            /*compute_config=*/DeviceComputeKernelConfigAttr(),
+            /*num_workers_per_link=*/1u, /*num_buffers_per_channel=*/1u,
+            /*dim=*/
+            static_cast<int32_t>(scatterDim.getValue().getSExtValue()));
       }};
 }
 

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -252,7 +252,8 @@ static void registerBuiltinComposites() {
             /*compute_config=*/DeviceComputeKernelConfigAttr(),
             /*num_workers_per_link=*/1u, /*num_buffers_per_channel=*/1u,
             /*dim=*/dim);
-      }};
+      },
+      /*promotionGuard=*/nullptr};
 }
 
 // Inline the decomposition function body at the composite ops location,

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -214,10 +214,23 @@ static void registerBuiltinComposites() {
         FloatAttr scalar =
             hasAddcmul ? attrs.getAs<FloatAttr>("scalar") : FloatAttr();
 
-        // The typed op needs a device handle and (later) semaphores; those are
-        // TTNN-level concerns that belong here, not in the TTIR fusing pattern.
-        // Semaphores are left unbound and materialized by
-        // TTNNAllocateDistributedOpSemaphores via the DistributedOpInterface.
+        // The tt-metal kernel asserts the scatter targets dim 3, so
+        // canonicalize the last-axis index (all the fusing pattern matches) to
+        // 3.
+        constexpr int32_t kMetalScatterDim = 3;
+        int64_t rank =
+            mlir::cast<RankedTensorType>(compositeOp.getResult(0).getType())
+                .getRank();
+        int64_t scatterDimValue = scatterDim.getValue().getSExtValue();
+        if (scatterDimValue < 0) {
+          scatterDimValue += rank;
+        }
+        int32_t dim = scatterDimValue == rank - 1
+                          ? kMetalScatterDim
+                          : static_cast<int32_t>(scatterDimValue);
+
+        // The typed op needs a device handle; semaphores are left unbound and
+        // materialized later by TTNNAllocateDistributedOpSemaphores.
         IRRewriter rewriter(builder.getContext());
         rewriter.setInsertionPoint(compositeOp);
         Value device =
@@ -228,13 +241,17 @@ static void registerBuiltinComposites() {
             bias, addcmulInput1, addcmulInput2,
             /*multi_device_semaphore=*/ValueRange{},
             /*barrier_semaphore=*/Value(), device, clusterAxis, scalar,
-            /*topology=*/ttcore::TopologyAttr(),
+            // The kernel only supports Ring topology, so pin it here. The mesh
+            // must therefore be opened with a ring fabric (FABRIC_1D_RING) or
+            // it deadlocks.
+            /*topology=*/
+            ttcore::TopologyAttr::get(builder.getContext(),
+                                      ttcore::Topology::Ring),
             /*num_links=*/IntegerAttr(), /*memory_config=*/MemoryConfigAttr(),
             /*dtype=*/ttcore::DataTypeAttr(),
             /*compute_config=*/DeviceComputeKernelConfigAttr(),
             /*num_workers_per_link=*/1u, /*num_buffers_per_channel=*/1u,
-            /*dim=*/
-            static_cast<int32_t>(scatterDim.getValue().getSExtValue()));
+            /*dim=*/dim);
       }};
 }
 

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -214,31 +215,64 @@ static void registerBuiltinComposites() {
         FloatAttr scalar =
             hasAddcmul ? attrs.getAs<FloatAttr>("scalar") : FloatAttr();
 
-        // The tt-metal kernel asserts the scatter targets dim 3, so
-        // canonicalize the last-axis index (all the fusing pattern matches) to
-        // 3.
-        constexpr int32_t kMetalScatterDim = 3;
-        int64_t rank =
-            mlir::cast<RankedTensorType>(compositeOp.getResult(0).getType())
-                .getRank();
-        int64_t scatterDimValue = scatterDim.getValue().getSExtValue();
-        if (scatterDimValue < 0) {
-          scatterDimValue += rank;
-        }
-        int32_t dim = scatterDimValue == rank - 1
-                          ? kMetalScatterDim
-                          : static_cast<int32_t>(scatterDimValue);
-
         // The typed op needs a device handle; semaphores are left unbound and
         // materialized later by TTNNAllocateDistributedOpSemaphores.
         IRRewriter rewriter(builder.getContext());
         rewriter.setInsertionPoint(compositeOp);
+        Location loc = compositeOp.getLoc();
         Value device =
             ttnn::utils::getOrInsertDevice(rewriter, compositeOp).getResult();
 
-        return rewriter.create<MinimalMatmulStridedReduceScatterAsyncOp>(
-            compositeOp.getLoc(), compositeOp.getResultTypes(), input, weight,
-            bias, addcmulInput1, addcmulInput2,
+        // tt-metal's kernel indexes scatter dim 3 of a rank-4 activation
+        // (`shape[3]`). DiT/Wan fuse a 2D `[M, K]` matmul. Unsqueeze leading
+        // unit dims so the typed op is always rank 4 with dim = 3, then
+        // reshape the result back to the composite type.
+        constexpr int64_t kMetalRank = 4;
+        constexpr int32_t kMetalScatterDim = 3;
+        auto typeWithShape = [](RankedTensorType type,
+                                   ArrayRef<int64_t> newShape) {
+          if (type.getEncoding()) {
+            return utils::RankedTensorTypeFactory::create(type, newShape);
+          }
+          return RankedTensorType::get(newShape, type.getElementType());
+        };
+        auto unsqueezeToRank = [&](Value v) -> Value {
+          if (!v) {
+            return v;
+          }
+          auto type = mlir::cast<RankedTensorType>(v.getType());
+          if (type.getRank() >= kMetalRank) {
+            return v;
+          }
+          SmallVector<int64_t> newShape(kMetalRank - type.getRank(), 1);
+          newShape.append(type.getShape().begin(), type.getShape().end());
+          RankedTensorType newType = typeWithShape(type, newShape);
+          SmallVector<int32_t> shapeAttr(newShape.begin(), newShape.end());
+          return rewriter
+              .create<ReshapeOp>(loc, newType, v,
+                                 rewriter.getI32ArrayAttr(shapeAttr))
+              .getResult();
+        };
+
+        input = unsqueezeToRank(input);
+        addcmulInput1 = unsqueezeToRank(addcmulInput1);
+        addcmulInput2 = unsqueezeToRank(addcmulInput2);
+
+        auto origResultType =
+            mlir::cast<RankedTensorType>(compositeOp.getResult(0).getType());
+        Type fusedResultType = origResultType;
+        bool squeezeResult = origResultType.getRank() < kMetalRank;
+        if (squeezeResult) {
+          SmallVector<int64_t> newShape(kMetalRank - origResultType.getRank(),
+                                         1);
+          newShape.append(origResultType.getShape().begin(),
+                          origResultType.getShape().end());
+          fusedResultType = typeWithShape(origResultType, newShape);
+        }
+
+        auto fused = rewriter.create<MinimalMatmulStridedReduceScatterAsyncOp>(
+            loc, TypeRange{fusedResultType}, input, weight, bias, addcmulInput1,
+            addcmulInput2,
             /*multi_device_semaphore=*/ValueRange{},
             /*barrier_semaphore=*/Value(), device, clusterAxis, scalar,
             // The kernel only supports Ring topology, so pin it here. The mesh
@@ -251,7 +285,17 @@ static void registerBuiltinComposites() {
             /*dtype=*/ttcore::DataTypeAttr(),
             /*compute_config=*/DeviceComputeKernelConfigAttr(),
             /*num_workers_per_link=*/1u, /*num_buffers_per_channel=*/1u,
-            /*dim=*/dim);
+            /*dim=*/kMetalScatterDim);
+
+        if (!squeezeResult) {
+          return fused;
+        }
+        SmallVector<int32_t> origShapeAttr(origResultType.getShape().begin(),
+                                           origResultType.getShape().end());
+        return rewriter
+            .create<ReshapeOp>(loc, origResultType, fused.getResult(0),
+                               rewriter.getI32ArrayAttr(origShapeAttr))
+            .getOperation();
       },
       /*promotionGuard=*/nullptr};
 }

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -7,7 +7,6 @@
 #include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
-#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -223,56 +222,21 @@ static void registerBuiltinComposites() {
         Value device =
             ttnn::utils::getOrInsertDevice(rewriter, compositeOp).getResult();
 
-        // tt-metal's kernel indexes scatter dim 3 of a rank-4 activation
-        // (`shape[3]`). DiT/Wan fuse a 2D `[M, K]` matmul. Unsqueeze leading
-        // unit dims so the typed op is always rank 4 with dim = 3, then
-        // reshape the result back to the composite type.
-        constexpr int64_t kMetalRank = 4;
-        constexpr int32_t kMetalScatterDim = 3;
-        auto typeWithShape = [](RankedTensorType type,
-                                   ArrayRef<int64_t> newShape) {
-          if (type.getEncoding()) {
-            return utils::RankedTensorTypeFactory::create(type, newShape);
-          }
-          return RankedTensorType::get(newShape, type.getElementType());
-        };
-        auto unsqueezeToRank = [&](Value v) -> Value {
-          if (!v) {
-            return v;
-          }
-          auto type = mlir::cast<RankedTensorType>(v.getType());
-          if (type.getRank() >= kMetalRank) {
-            return v;
-          }
-          SmallVector<int64_t> newShape(kMetalRank - type.getRank(), 1);
-          newShape.append(type.getShape().begin(), type.getShape().end());
-          RankedTensorType newType = typeWithShape(type, newShape);
-          SmallVector<int32_t> shapeAttr(newShape.begin(), newShape.end());
-          return rewriter
-              .create<ReshapeOp>(loc, newType, v,
-                                 rewriter.getI32ArrayAttr(shapeAttr))
-              .getResult();
-        };
-
-        input = unsqueezeToRank(input);
-        addcmulInput1 = unsqueezeToRank(addcmulInput1);
-        addcmulInput2 = unsqueezeToRank(addcmulInput2);
-
-        auto origResultType =
-            mlir::cast<RankedTensorType>(compositeOp.getResult(0).getType());
-        Type fusedResultType = origResultType;
-        bool squeezeResult = origResultType.getRank() < kMetalRank;
-        if (squeezeResult) {
-          SmallVector<int64_t> newShape(kMetalRank - origResultType.getRank(),
-                                         1);
-          newShape.append(origResultType.getShape().begin(),
-                          origResultType.getShape().end());
-          fusedResultType = typeWithShape(origResultType, newShape);
-        }
-
-        auto fused = rewriter.create<MinimalMatmulStridedReduceScatterAsyncOp>(
-            loc, TypeRange{fusedResultType}, input, weight, bias, addcmulInput1,
-            addcmulInput2,
+        // Rank-4 is a metal kernel requirement (`shape[3]`), not a compiler
+        // layout. Wan uses `ttnn.unsqueeze` (a view) then `squeeze`. Inserting
+        // `ttnn.reshape` here materializes a DRAM sandwich around an
+        // OpModelExempt op. Leave the 2D `[M, K]` activation as-is; the
+        // runtime unsqueezes leading 1s before the kernel. Scatter along the
+        // last axis (`-1` / composite `scatter_dim`).
+        //
+        // Leave `num_links` / workers / buffers unset. Metal Wan fills them
+        // from `get_fused_mmrs_config` + `ccl_manager.num_links`; the runtime
+        // does the same. Hardcoding `1` under-provisions RS workers (deadlock
+        // risk) and kills overlap (`num_buffers_per_channel=None` in the
+        // MMRS table, not AGMM's 24/48).
+        return rewriter.create<MinimalMatmulStridedReduceScatterAsyncOp>(
+            loc, compositeOp.getResultTypes(), input, weight, bias,
+            addcmulInput1, addcmulInput2,
             /*multi_device_semaphore=*/ValueRange{},
             /*barrier_semaphore=*/Value(), device, clusterAxis, scalar,
             // The kernel only supports Ring topology, so pin it here. The mesh
@@ -284,18 +248,10 @@ static void registerBuiltinComposites() {
             /*num_links=*/IntegerAttr(), /*memory_config=*/MemoryConfigAttr(),
             /*dtype=*/ttcore::DataTypeAttr(),
             /*compute_config=*/DeviceComputeKernelConfigAttr(),
-            /*num_workers_per_link=*/1u, /*num_buffers_per_channel=*/1u,
-            /*dim=*/kMetalScatterDim);
-
-        if (!squeezeResult) {
-          return fused;
-        }
-        SmallVector<int32_t> origShapeAttr(origResultType.getShape().begin(),
-                                           origResultType.getShape().end());
-        return rewriter
-            .create<ReshapeOp>(loc, origResultType, fused.getResult(0),
-                               rewriter.getI32ArrayAttr(origShapeAttr))
-            .getOperation();
+            /*num_workers_per_link=*/IntegerAttr(),
+            /*num_buffers_per_channel=*/IntegerAttr(),
+            /*dim=*/static_cast<int32_t>(
+                scatterDim.getValue().getSExtValue()));
       },
       /*promotionGuard=*/nullptr};
 }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1168,6 +1168,87 @@ createOp(FlatbufferObjectCache &cache, AllReduceAsyncOp op) {
       op.getClusterAxis(), subDeviceId, memoryConfig, numLinks, topology);
 }
 
+::flatbuffers::Offset<
+    ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp>
+createOp(FlatbufferObjectCache &cache,
+         MinimalMatmulStridedReduceScatterAsyncOp op) {
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto weight = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getWeight()));
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> bias = 0;
+  if (op.getBias()) {
+    bias = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getBias()));
+  }
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> addcmulInput1 = 0;
+  if (op.getAddcmulInput1()) {
+    addcmulInput1 = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getAddcmulInput1()));
+  }
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> addcmulInput2 = 0;
+  if (op.getAddcmulInput2()) {
+    addcmulInput2 = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getAddcmulInput2()));
+  }
+
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>>
+      multiDeviceSemaphore;
+  for (auto semaphore : op.getMultiDeviceSemaphore()) {
+    multiDeviceSemaphore.push_back(
+        cache.at<::tt::target::ttnn::GlobalSemaphoreRef>(semaphore));
+  }
+
+  ::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>
+      barrierSemaphore = 0;
+  if (op.getBarrierSemaphore()) {
+    barrierSemaphore = cache.at<::tt::target::ttnn::GlobalSemaphoreRef>(
+        op.getBarrierSemaphore());
+  }
+
+  // `cluster_axis`, `num_links`, `topology`, `scalar`, and `dtype` are all
+  // schema-optional (= null); use the toFlatbuffer overloads that return
+  // flatbuffers::Optional so unset attrs serialize as the absent marker.
+  auto clusterAxis = toFlatbuffer(cache, op.getClusterAxis());
+  ::flatbuffers::Optional<float> scalar = toFlatbuffer(
+      cache, op.getScalar()
+                 ? std::make_optional(op.getScalar().value().convertToFloat())
+                 : std::nullopt);
+  auto topology = toFlatbuffer(cache, op.getTopology());
+  auto numLinks = toFlatbuffer(cache, op.getNumLinks());
+  // `memory_config` is schema-optional; skip serialization when unset so we do
+  // not dereference a null MemoryConfigAttr in toFlatbuffer.
+  ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig = 0;
+  if (op.getMemoryConfigAttr()) {
+    memoryConfig = toFlatbuffer(cache, op.getMemoryConfigAttr());
+  }
+  ::flatbuffers::Optional<::tt::target::DataType> dtype =
+      toFlatbuffer(cache, op.getDtype());
+
+  ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>
+      computeConfig = 0;
+  if (op.getComputeConfig().has_value()) {
+    computeConfig = toFlatbuffer(cache, op.getComputeConfig().value());
+  }
+
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> outputs;
+  for (auto result : op.getResults()) {
+    outputs.push_back(cache.getOrCreateNoSharding(
+        result, tensorValueToFlatbuffer, /*local_shape*/ std::nullopt));
+  }
+
+  return ::tt::target::ttnn::
+      CreateMinimalMatmulStridedReduceScatterAsyncOpDirect(
+          *cache.fbb, input, weight, bias, addcmulInput1, addcmulInput2,
+          &multiDeviceSemaphore, barrierSemaphore, clusterAxis, scalar,
+          topology, numLinks, memoryConfig, dtype, computeConfig,
+          op.getNumWorkersPerLink(), op.getNumBuffersPerChannel(), op.getDim(),
+          &outputs);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::ReduceScatterOp>
 createOp(FlatbufferObjectCache &cache, ReduceScatterOp op) {
   auto input = cache.at<::tt::target::ttnn::TensorRef>(
@@ -4686,6 +4767,13 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   if (auto reduceScatterOp = dyn_cast<ReduceScatterOp>(op); reduceScatterOp) {
     return createOperation(cache, createOp(cache, reduceScatterOp), debugString,
                            locInfo);
+  }
+  if (auto minimalMatmulStridedReduceScatterAsyncOp =
+          dyn_cast<MinimalMatmulStridedReduceScatterAsyncOp>(op);
+      minimalMatmulStridedReduceScatterAsyncOp) {
+    return createOperation(
+        cache, createOp(cache, minimalMatmulStridedReduceScatterAsyncOp),
+        debugString, locInfo);
   }
   if (auto allToAllDispatchOp = dyn_cast<AllToAllDispatchOp>(op);
       allToAllDispatchOp) {

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1219,6 +1219,9 @@ createOp(FlatbufferObjectCache &cache,
                  : std::nullopt);
   auto topology = toFlatbuffer(cache, op.getTopology());
   auto numLinks = toFlatbuffer(cache, op.getNumLinks());
+  auto numWorkersPerLink = toFlatbuffer(cache, op.getNumWorkersPerLink());
+  auto numBuffersPerChannel =
+      toFlatbuffer(cache, op.getNumBuffersPerChannel());
   // `memory_config` is schema-optional; skip serialization when unset so we do
   // not dereference a null MemoryConfigAttr in toFlatbuffer.
   ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig = 0;
@@ -1245,7 +1248,7 @@ createOp(FlatbufferObjectCache &cache,
           *cache.fbb, input, weight, bias, addcmulInput1, addcmulInput2,
           &multiDeviceSemaphore, barrierSemaphore, clusterAxis, scalar,
           topology, numLinks, memoryConfig, dtype, computeConfig,
-          op.getNumWorkersPerLink(), op.getNumBuffersPerChannel(), op.getDim(),
+          numWorkersPerLink, numBuffersPerChannel, op.getDim(),
           &outputs);
 }
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -38,6 +38,7 @@
 #include "ttnn/operations/eltwise/ternary/ternary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/embedding/embedding.hpp"
+#include "ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp"
 #include "ttnn/operations/experimental/ccl/moe/selective_reduce_combine/selective_reduce_combine.hpp"
 #include "ttnn/operations/experimental/conv3d/conv3d.hpp"
 #include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/distribute_tensor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/mesh_partition.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/point_to_point.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ccl/minimal_matmul_strided_reduce_scatter_async.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/reduce_scatter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/context/get_device.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv1d.cpp

--- a/runtime/lib/ttnn/operations/ccl/minimal_matmul_strided_reduce_scatter_async.cpp
+++ b/runtime/lib/ttnn/operations/ccl/minimal_matmul_strided_reduce_scatter_async.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/ccl/minimal_matmul_strided_reduce_scatter_async.h"
+#include "tt/runtime/detail/common/common.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp"
+
+namespace tt::runtime::ttnn::operations::ccl {
+void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
+         ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
+  const ::ttnn::Tensor &weight =
+      tensorPool.getTTNNTensorAndValidate(op->weight());
+
+  std::optional<::ttnn::Tensor> bias = std::nullopt;
+  if (op->bias()) {
+    bias = tensorPool.getTTNNTensorAndValidate(op->bias());
+  }
+
+  std::optional<::ttnn::Tensor> addcmulInput1 = std::nullopt;
+  if (op->addcmul_input1()) {
+    addcmulInput1 = tensorPool.getTTNNTensorAndValidate(op->addcmul_input1());
+  }
+
+  std::optional<::ttnn::Tensor> addcmulInput2 = std::nullopt;
+  if (op->addcmul_input2()) {
+    addcmulInput2 = tensorPool.getTTNNTensorAndValidate(op->addcmul_input2());
+  }
+
+  std::optional<float> scalar = std::nullopt;
+  if (op->scalar()) {
+    scalar = op->scalar().value();
+  }
+
+  // The async reduce-scatter is synchronized by the multi-device global
+  // semaphores plus an optional barrier semaphore.
+  std::vector<::ttnn::GlobalSemaphore> multiDeviceSemaphore;
+  for (const auto *semaphoreRef : *op->multi_device_semaphore()) {
+    multiDeviceSemaphore.push_back(
+        context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
+            semaphoreRef));
+  }
+
+  std::optional<::ttnn::GlobalSemaphore> barrierSemaphore = std::nullopt;
+  if (op->barrier_semaphore()) {
+    barrierSemaphore =
+        context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
+            op->barrier_semaphore());
+  }
+
+  // Topology is a required metal parameter; default to Ring when unset.
+  ::ttnn::ccl::Topology topology = ::ttnn::ccl::Topology::Ring;
+  if (op->topology()) {
+    topology = static_cast<::ttnn::ccl::Topology>(
+        ::tt::runtime::common::toMetalTopology(op->topology().value()));
+  }
+
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
+
+  std::optional<::ttnn::DataType> dtype = std::nullopt;
+  if (op->dtype()) {
+    dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*op->dtype());
+  }
+
+  uint32_t numLinks = op->num_links() ? op->num_links().value() : 1;
+
+  std::optional<uint32_t> clusterAxis = std::nullopt;
+  if (op->cluster_axis()) {
+    clusterAxis = op->cluster_axis().value();
+  }
+
+  // compute_kernel_config is a required tt-metal parameter. Build one from the
+  // op attribute when present, otherwise fall back to the device-default.
+  ::ttnn::DeviceComputeKernelConfig computeKernelConfig =
+      op->compute_config()
+          ? utils::createDeviceComputeKernelConfig(op->compute_config())
+          : ::ttnn::init_device_compute_kernel_config(
+                context.getMeshDevice().arch(), /*device_kernel_config=*/
+                std::nullopt);
+
+  // The reduce-scatter core-grid offset, `MinimalMatmulConfig`, fused
+  // activation, persistent buffers and FSDP path are not modeled by the
+  // compiler yet; pass their tt-metal defaults.
+  ::ttnn::CoreCoord reduceScatterCoreGridOffset{0, 0};
+
+  std::vector<::ttnn::Tensor> outputs =
+      ::ttnn::experimental::minimal_matmul_strided_reduce_scatter_async(
+          input, weight, static_cast<uint32_t>(op->dim()), multiDeviceSemaphore,
+          reduceScatterCoreGridOffset, computeKernelConfig, numLinks,
+          /*memory_config_mm=*/std::nullopt,
+          /*rs_output_mem_config=*/memoryConfig,
+          /*rs_intermediate_mem_config=*/std::nullopt, topology, clusterAxis,
+          bias, /*fused_activation=*/std::nullopt, /*config=*/std::nullopt,
+          barrierSemaphore, /*using_persistent_buffers=*/false,
+          /*sub_device_id=*/std::nullopt,
+          /*num_workers_per_link=*/
+          std::make_optional(op->num_workers_per_link()),
+          /*num_buffers_per_channel=*/
+          std::make_optional(op->num_buffers_per_channel()),
+          /*chunk_width_in_mm_blocks=*/std::nullopt,
+          /*optional_rs_output_tensor=*/std::nullopt,
+          /*fused_ternary_scalar=*/scalar, addcmulInput1, addcmulInput2, dtype);
+
+  const auto *outputRefs = op->outputs();
+  LOG_ASSERT(outputs.size() == outputRefs->size(),
+             "minimal_matmul_strided_reduce_scatter_async produced ",
+             outputs.size(), " outputs but the flatbuffer expects ",
+             outputRefs->size());
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    tensorPool.insertTTNNTensorAndValidate(outputRefs->Get(i), outputs[i]);
+  }
+}
+} // namespace tt::runtime::ttnn::operations::ccl

--- a/runtime/lib/ttnn/operations/ccl/minimal_matmul_strided_reduce_scatter_async.cpp
+++ b/runtime/lib/ttnn/operations/ccl/minimal_matmul_strided_reduce_scatter_async.cpp
@@ -13,10 +13,14 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp"
 #include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation_types.hpp"
+#include "ttnn/operations/data_movement/squeeze/squeeze.hpp"
+#include "ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
 
 #include <tt-metalium/constants.hpp>
 
 #include <algorithm>
+#include <cstdint>
+#include <optional>
 
 namespace tt::runtime::ttnn::operations::ccl {
 
@@ -32,16 +36,53 @@ uint32_t largestDivisorAtMost(uint32_t value, uint32_t cap) {
   }
   return 1;
 }
+
+// Metal Wan `RowParallelLinear` uses `ttnn.unsqueeze` (a view) so the kernel
+// can index scatter dim 3. Loop until rank 4 to cover 2D DiT activations.
+::ttnn::Tensor unsqueezeToRank4(::ttnn::Tensor tensor) {
+  while (tensor.logical_shape().rank() < 4) {
+    tensor = ::ttnn::unsqueeze(tensor, 0);
+  }
+  return tensor;
+}
+
+::ttnn::Tensor squeezeToRank(::ttnn::Tensor tensor, size_t rank) {
+  while (tensor.logical_shape().rank() > rank) {
+    tensor = ::ttnn::squeeze(tensor, 0);
+  }
+  return tensor;
+}
+
+// `ccl_manager.num_links` in metal Wan tests: BH Galaxy ring = 2, WH 4x8
+// ring = 4. Smaller meshes use 1. Same heuristic as AGMM 6a.
+uint32_t defaultNumLinks(const ::ttnn::MeshDevice &mesh) {
+  if (mesh.num_devices() < 32) {
+    return 1;
+  }
+  return mesh.arch() == ::tt::ARCH::BLACKHOLE ? 2u : 4u;
+}
+
+// `FusedMMRSConfig.get_params`: workers = rs_zone // (2 * num_links) - 1
+// where rs_zone is the cores below the matmul grid.
+uint32_t defaultWorkersPerLink(uint32_t rsZoneCapacity, uint32_t numLinks) {
+  uint32_t denom = 2 * std::max(numLinks, 1u);
+  if (rsZoneCapacity / denom < 2) {
+    return 1;
+  }
+  return rsZoneCapacity / denom - 1;
+}
 } // namespace
 
 void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  const ::ttnn::Tensor &input =
+  const ::ttnn::Tensor &inputIn =
       tensorPool.getTTNNTensorAndValidate(op->input());
   const ::ttnn::Tensor &weight =
       tensorPool.getTTNNTensorAndValidate(op->weight());
+  const size_t origInputRank = inputIn.logical_shape().rank();
+  ::ttnn::Tensor input = unsqueezeToRank4(inputIn);
 
   std::optional<::ttnn::Tensor> bias = std::nullopt;
   if (op->bias()) {
@@ -50,12 +91,14 @@ void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
 
   std::optional<::ttnn::Tensor> addcmulInput1 = std::nullopt;
   if (op->addcmul_input1()) {
-    addcmulInput1 = tensorPool.getTTNNTensorAndValidate(op->addcmul_input1());
+    addcmulInput1 = unsqueezeToRank4(
+        tensorPool.getTTNNTensorAndValidate(op->addcmul_input1()));
   }
 
   std::optional<::ttnn::Tensor> addcmulInput2 = std::nullopt;
   if (op->addcmul_input2()) {
-    addcmulInput2 = tensorPool.getTTNNTensorAndValidate(op->addcmul_input2());
+    addcmulInput2 = unsqueezeToRank4(
+        tensorPool.getTTNNTensorAndValidate(op->addcmul_input2()));
   }
 
   std::optional<float> scalar = std::nullopt;
@@ -95,7 +138,8 @@ void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
     dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*op->dtype());
   }
 
-  uint32_t numLinks = op->num_links() ? op->num_links().value() : 1;
+  uint32_t numLinks = op->num_links() ? op->num_links().value()
+                                      : defaultNumLinks(context.getMeshDevice());
 
   std::optional<uint32_t> clusterAxis = std::nullopt;
   if (op->cluster_axis()) {
@@ -188,21 +232,37 @@ void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
   // (offset convention from tt-metal's test: CoreCoord(0, mm_core_grid.y)).
   ::ttnn::CoreCoord reduceScatterCoreGridOffset{0, mmCoresY};
 
+  // Metal Wan `FusedMMRSConfig.get_params` (not the AGMM ColParallelLinear
+  // knobs). Mux cores are `2 * num_links`; drop links until that split fits
+  // the RS zone and workers stay >= 1. `num_buffers_per_channel` is None in
+  // the MMRS tables — pass nullopt unless the compiler set it. Do not pass
+  // nullopt for workers: the C++ wrapper does `value_or(1)` and that
+  // under-provisions the RS (deadlock / no overlap).
+  uint32_t rsZoneCapacity = (gridY - mmCoresY) * gridX;
+  while (numLinks > 1 && rsZoneCapacity / (2 * numLinks) < 2) {
+    --numLinks;
+  }
+  std::optional<uint32_t> numWorkersPerLink =
+      op->num_workers_per_link()
+          ? std::optional<uint32_t>(op->num_workers_per_link().value())
+          : std::optional<uint32_t>(
+                defaultWorkersPerLink(rsZoneCapacity, numLinks));
+  std::optional<uint32_t> numBuffersPerChannel = std::nullopt;
+  if (op->num_buffers_per_channel()) {
+    numBuffersPerChannel = op->num_buffers_per_channel().value();
+  }
+
   std::vector<::ttnn::Tensor> outputs =
       ::ttnn::experimental::minimal_matmul_strided_reduce_scatter_async(
-          input, weight, static_cast<uint32_t>(op->dim()), multiDeviceSemaphore,
+          input, weight, /*dim=*/3u, multiDeviceSemaphore,
           reduceScatterCoreGridOffset, computeKernelConfig, numLinks,
           /*memory_config_mm=*/std::nullopt,
           /*rs_output_mem_config=*/memoryConfig,
           /*rs_intermediate_mem_config=*/std::nullopt, topology, clusterAxis,
           bias, /*fused_activation=*/std::nullopt, matmulConfig,
           barrierSemaphore, /*using_persistent_buffers=*/false,
-          /*sub_device_id=*/std::nullopt,
-          // Pass nullopt so tt-metal computes its own RS worker/buffer counts,
-          // matching how its reference test invokes the kernel (forcing these
-          // to 1 under-provisions the RS workers and deadlocks).
-          /*num_workers_per_link=*/std::nullopt,
-          /*num_buffers_per_channel=*/std::nullopt,
+          /*sub_device_id=*/std::nullopt, numWorkersPerLink,
+          numBuffersPerChannel,
           /*chunk_width_in_mm_blocks=*/std::make_optional(chunkWidthInMmBlocks),
           /*optional_rs_output_tensor=*/std::nullopt,
           /*fused_ternary_scalar=*/scalar, addcmulInput1, addcmulInput2, dtype);
@@ -221,6 +281,7 @@ void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
              "minimal_matmul_strided_reduce_scatter_async flatbuffer expects 1 "
              "output, got ",
              outputRefs->size());
-  tensorPool.insertTTNNTensorAndValidate(outputRefs->Get(0), outputs.back());
+  tensorPool.insertTTNNTensorAndValidate(
+      outputRefs->Get(0), squeezeToRank(outputs.back(), origInputRank));
 }
 } // namespace tt::runtime::ttnn::operations::ccl

--- a/runtime/lib/ttnn/operations/ccl/minimal_matmul_strided_reduce_scatter_async.cpp
+++ b/runtime/lib/ttnn/operations/ccl/minimal_matmul_strided_reduce_scatter_async.cpp
@@ -12,8 +12,28 @@
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp"
+#include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation_types.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+#include <algorithm>
 
 namespace tt::runtime::ttnn::operations::ccl {
+
+namespace {
+// Largest divisor of `value` that is <= `cap` (and >= 1). Used to pick
+// core-grid extents that divide the tile counts evenly, as the kernels
+// require.
+uint32_t largestDivisorAtMost(uint32_t value, uint32_t cap) {
+  for (uint32_t d = std::min(value, cap); d >= 1; --d) {
+    if (value % d == 0) {
+      return d;
+    }
+  }
+  return 1;
+}
+} // namespace
+
 void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -91,10 +111,82 @@ void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
                 context.getMeshDevice().arch(), /*device_kernel_config=*/
                 std::nullopt);
 
-  // The reduce-scatter core-grid offset, `MinimalMatmulConfig`, fused
-  // activation, persistent buffers and FSDP path are not modeled by the
-  // compiler yet; pass their tt-metal defaults.
-  ::ttnn::CoreCoord reduceScatterCoreGridOffset{0, 0};
+  // tt-metal requires a MinimalMatmulConfig and the reduce-scatter cores must
+  // sit below the matmul grid. The compiler does not model this yet, so derive
+  // a functional (not perf-tuned) config from the problem shape.
+  // TODO(#0000): model MinimalMatmulConfig in the compiler and thread it here.
+  auto deviceGrid = context.getMeshDevice().compute_with_storage_grid_size();
+  uint32_t gridX = static_cast<uint32_t>(deviceGrid.x);
+  uint32_t gridY = static_cast<uint32_t>(deviceGrid.y);
+
+  // Tile counts. input is [1, 1, M, K/ring], weight is [1, 1, K/ring, N];
+  // the matmul output is [1, 1, M, N].
+  uint32_t mTiles = static_cast<uint32_t>(input.padded_shape()[-2] /
+                                          ::tt::constants::TILE_HEIGHT);
+  uint32_t kTiles = static_cast<uint32_t>(input.padded_shape()[-1] /
+                                          ::tt::constants::TILE_WIDTH);
+  uint32_t nTiles = static_cast<uint32_t>(weight.padded_shape()[-1] /
+                                          ::tt::constants::TILE_WIDTH);
+
+  // Fail cleanly on configurations tt-metal's fused kernel cannot run, rather
+  // than dispatching them and hanging the mesh (a device deadlock leaves the
+  // fabric wedged and needs a reset). Two known-bad cases:
+  //   1. A degenerate reduce-scatter ring: the kernel deadlocks on a 2-device
+  //      ring (nightly coverage uses an 8-device ring); it needs > 2 devices.
+  //   2. An N tile count the ring cannot scatter evenly.
+  if (clusterAxis.has_value()) {
+    const ::ttnn::MeshShape &meshShape = context.getMeshDevice().shape();
+    uint32_t ringSize = meshShape[static_cast<int32_t>(*clusterAxis)];
+    LOG_ASSERT(ringSize > 2,
+               "minimal_matmul_strided_reduce_scatter_async needs a "
+               "reduce-scatter ring of more than 2 devices (a 2-device ring "
+               "deadlocks in tt-metal's kernel); got ringSize=",
+               ringSize);
+    LOG_ASSERT(nTiles % ringSize == 0,
+               "minimal_matmul_strided_reduce_scatter_async needs the N tile "
+               "count (",
+               nTiles, ") divisible by the reduce-scatter ring size (",
+               ringSize, ") for an even scatter");
+  }
+
+  // N is split across the matmul grid's X axis, so grid.x must divide N tiles.
+  uint32_t mmCoresX = largestDivisorAtMost(nTiles, gridX);
+
+  // Reserve the bottom half of the compute grid for the reduce-scatter cores;
+  // tt-metal sizes the RS worker count itself, so half the rows leaves room.
+  LOG_ASSERT(gridY >= 2,
+             "minimal_matmul_strided_reduce_scatter_async needs a compute grid "
+             "with >= 2 rows; got gridY=",
+             gridY);
+  uint32_t availMMRows = std::max<uint32_t>(1, gridY / 2);
+
+  // M is split across the matmul grid's Y axis, so grid.y must divide M tiles.
+  uint32_t mmCoresY = largestDivisorAtMost(mTiles, availMMRows);
+
+  // N tiles handled by each matmul core (N parallelized across grid.x). In
+  // fused mode tt-metal splits this per-core width into blocks of a few tiles
+  // and streams one block at a time to the RS; a single wide N block breaks the
+  // RS chunking and the RS waits forever (deadlock). Match the reference
+  // configs: cap the N block at 4 tiles and tell the RS how many blocks make up
+  // a core's width via chunk_width_in_mm_blocks.
+  uint32_t mmNFullBlockWt = nTiles / mmCoresX;
+  uint32_t nBlock = largestDivisorAtMost(mmNFullBlockWt, 4);
+  uint32_t chunkWidthInMmBlocks = mmNFullBlockWt / nBlock;
+
+  ::ttnn::experimental::prim::MinimalMatmulConfig matmulConfig;
+  // M/K blocks are likewise capped at 4 tiles and must divide their per-core
+  // extents exactly.
+  matmulConfig.M_block_size = largestDivisorAtMost(mTiles / mmCoresY, 4);
+  matmulConfig.N_block_size = nBlock;
+  matmulConfig.K_block_size = largestDivisorAtMost(kTiles, 4);
+  matmulConfig.subblock_h = 1; // 1x1 subblock has no dst-register constraint
+  matmulConfig.subblock_w = 1;
+  matmulConfig.compute_with_storage_grid_size =
+      ::tt::tt_metal::CoreCoord{mmCoresX, mmCoresY};
+
+  // Reduce-scatter cores sit on the rows directly below the matmul grid
+  // (offset convention from tt-metal's test: CoreCoord(0, mm_core_grid.y)).
+  ::ttnn::CoreCoord reduceScatterCoreGridOffset{0, mmCoresY};
 
   std::vector<::ttnn::Tensor> outputs =
       ::ttnn::experimental::minimal_matmul_strided_reduce_scatter_async(
@@ -103,24 +195,32 @@ void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
           /*memory_config_mm=*/std::nullopt,
           /*rs_output_mem_config=*/memoryConfig,
           /*rs_intermediate_mem_config=*/std::nullopt, topology, clusterAxis,
-          bias, /*fused_activation=*/std::nullopt, /*config=*/std::nullopt,
+          bias, /*fused_activation=*/std::nullopt, matmulConfig,
           barrierSemaphore, /*using_persistent_buffers=*/false,
           /*sub_device_id=*/std::nullopt,
-          /*num_workers_per_link=*/
-          std::make_optional(op->num_workers_per_link()),
-          /*num_buffers_per_channel=*/
-          std::make_optional(op->num_buffers_per_channel()),
-          /*chunk_width_in_mm_blocks=*/std::nullopt,
+          // Pass nullopt so tt-metal computes its own RS worker/buffer counts,
+          // matching how its reference test invokes the kernel (forcing these
+          // to 1 under-provisions the RS workers and deadlocks).
+          /*num_workers_per_link=*/std::nullopt,
+          /*num_buffers_per_channel=*/std::nullopt,
+          /*chunk_width_in_mm_blocks=*/std::make_optional(chunkWidthInMmBlocks),
           /*optional_rs_output_tensor=*/std::nullopt,
           /*fused_ternary_scalar=*/scalar, addcmulInput1, addcmulInput2, dtype);
 
+  // tt-metal returns two tensors: {matmul_intermediate [.., N], reduce_scatter
+  // output [.., N/devices]} (see its reference test, which unpacks
+  // `(tt_mm_out, tt_rs_out)`). The compiler only models the reduce-scatter
+  // result, so bind that (the last output) to the single output ref; the matmul
+  // intermediate is unused by the graph and its buffer is reclaimed here.
   const auto *outputRefs = op->outputs();
-  LOG_ASSERT(outputs.size() == outputRefs->size(),
-             "minimal_matmul_strided_reduce_scatter_async produced ",
-             outputs.size(), " outputs but the flatbuffer expects ",
+  LOG_ASSERT(outputs.size() == 2,
+             "minimal_matmul_strided_reduce_scatter_async expected 2 outputs "
+             "{matmul_intermediate, reduce_scatter}, got ",
+             outputs.size());
+  LOG_ASSERT(outputRefs->size() == 1,
+             "minimal_matmul_strided_reduce_scatter_async flatbuffer expects 1 "
+             "output, got ",
              outputRefs->size());
-  for (size_t i = 0; i < outputs.size(); ++i) {
-    tensorPool.insertTTNNTensorAndValidate(outputRefs->Get(i), outputs[i]);
-  }
+  tensorPool.insertTTNNTensorAndValidate(outputRefs->Get(0), outputs.back());
 }
 } // namespace tt::runtime::ttnn::operations::ccl

--- a/runtime/lib/ttnn/operations/ccl/minimal_matmul_strided_reduce_scatter_async.h
+++ b/runtime/lib/ttnn/operations/ccl/minimal_matmul_strided_reduce_scatter_async.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CCL_MINIMAL_MATMUL_STRIDED_REDUCE_SCATTER_ASYNC_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CCL_MINIMAL_MATMUL_STRIDED_REDUCE_SCATTER_ASYNC_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::ccl {
+void run(const ::tt::target::ttnn::MinimalMatmulStridedReduceScatterAsyncOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::ccl
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -20,6 +20,7 @@
 #include "operations/ccl/all_to_all_dispatch_metadata.h"
 #include "operations/ccl/distribute_tensor.h"
 #include "operations/ccl/mesh_partition.h"
+#include "operations/ccl/minimal_matmul_strided_reduce_scatter_async.h"
 #include "operations/ccl/moe_compute.h"
 #include "operations/ccl/moe_expert_token_remap.h"
 #include "operations/ccl/moe_gpt.h"
@@ -544,6 +545,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::ReduceScatterOp: {
     return operations::ccl::run(op->type_as_ReduceScatterOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::MinimalMatmulStridedReduceScatterAsyncOp: {
+    return operations::ccl::run(
+        op->type_as_MinimalMatmulStridedReduceScatterAsyncOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::MeshPartitionOp: {
     return operations::ccl::run(op->type_as_MeshPartitionOp(), getContext());

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1405,6 +1405,12 @@ std::vector<tt::runtime::TensorRef> getOpOutputRefs(OpContext opContextHandle) {
     tensorRefs = {opContext.type_as_ReduceScatterOp()->out()};
     break;
   }
+  case ::tt::target::ttnn::OpType::MinimalMatmulStridedReduceScatterAsyncOp: {
+    tensorRefs = utils::convertFbTensorRefsToVector(
+        opContext.type_as_MinimalMatmulStridedReduceScatterAsyncOp()
+            ->outputs());
+    break;
+  }
   case ::tt::target::ttnn::OpType::MeshPartitionOp: {
     tensorRefs = {opContext.type_as_MeshPartitionOp()->out()};
     break;
@@ -2022,6 +2028,21 @@ std::vector<tt::runtime::TensorRef> getOpInputRefs(OpContext opContextHandle) {
   }
   case ::tt::target::ttnn::OpType::ReduceScatterOp: {
     tensorRefs = {opContext.type_as_ReduceScatterOp()->in()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::MinimalMatmulStridedReduceScatterAsyncOp: {
+    const auto *op =
+        opContext.type_as_MinimalMatmulStridedReduceScatterAsyncOp();
+    tensorRefs = {op->input(), op->weight()};
+    if (op->bias()) {
+      tensorRefs.push_back(op->bias());
+    }
+    if (op->addcmul_input1()) {
+      tensorRefs.push_back(op->addcmul_input1());
+    }
+    if (op->addcmul_input2()) {
+      tensorRefs.push_back(op->addcmul_input2());
+    }
     break;
   }
   case ::tt::target::ttnn::OpType::MeshPartitionOp: {

--- a/test/python/golden/ttir_ops/fusing/test_matmul_reduce_scatter_fusing.py
+++ b/test/python/golden/ttir_ops/fusing/test_matmul_reduce_scatter_fusing.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import torch
+from collections import OrderedDict
+from typing import Callable, List, Tuple
+
+import _ttmlir_runtime as tt_runtime
+from conftest import get_request_kwargs
+from builder.base.builder_utils import Operand, Shape, get_artifact_dir
+from builder.base.builder_enums import MeshShardDirection, MeshShardType, ReduceType
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import (
+    compile_ttir_to_flatbuffer,
+    compile_and_execute_ttir,
+)
+from test_utils import shape_str
+
+pytestmark = pytest.mark.frontend("ttir")
+
+# The TTIR MatmulReduceScatter fusing patterns rewrite
+#
+#   proj = reduce_scatter(matmul/linear(input, weight)[+ bias])
+#   [out  = residual + gate * proj]                     (gated-residual epilogue)
+#
+# into a `ttcore.composite "minimal_matmul_strided_reduce_scatter_async"`, which
+# TTNNResolveComposites then promotes to the typed
+# `ttnn.minimal_matmul_strided_reduce_scatter_async` op.
+#
+# This is the row-parallel FFN down-projection: the activation `[M, K]` and
+# weight `[K, N]` are both K-sharded across the cluster axis, each device
+# computes a partial `input @ weight`, and the reduce_scatter sums the partials
+# across ranks while scattering the result along N.
+#
+# This module has two kinds of tests:
+#   * test_matmul_reduce_scatter_fusing         -- compile-only IR check that the
+#     full TTIR -> TTNN pipeline emits the fused op (runs on any target).
+#   * test_matmul_reduce_scatter_fusing_execute -- runs the fused op on a real
+#     multi-chip mesh and PCC-checks it against the golden, i.e. verifies the
+#     fused matmul+collective is numerically correct on device.
+#
+# The individual compiler stages are also covered by lit tests
+# (test/ttmlir/Dialect/TTIR/fusing/matmul_reduce_scatter_fusing.mlir and
+# test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/*).
+
+FUSED_OP = "ttnn.minimal_matmul_strided_reduce_scatter_async"
+
+
+def _promote_options() -> List[str]:
+    """Pipeline options that force-promote the composite the fusing pattern
+    emits into the typed ttnn op. Without the optimizer/OpModel the default
+    (Auto) resolution inlines the composite back into matmul + reduce_scatter,
+    which would bypass the fused op.
+
+    Returns a fresh list on each call: the compile helper appends
+    system-desc-path/mesh-shape to this list in place, so a shared list would
+    accumulate duplicate options across compiles.
+    """
+    return ["composite-resolution=force-promote"]
+
+
+def _full_to_shard_device(builder: TTIRBuilder, input: Operand, dim: int) -> Operand:
+    """Shard `input` along `dim` across the mesh's second (y) axis."""
+    rank = len(builder._get_golden_tensor(input).shape)
+    num_devices = builder.mesh_shape[1]
+    shard_shape = [1] * rank
+    shard_shape[dim] = num_devices
+    return builder.mesh_shard(
+        input,
+        shard_direction=MeshShardDirection.FullToShard.value,
+        shard_type=MeshShardType.Devices.value,
+        shard_shape=shard_shape,
+        shard_dims=[-1, dim],
+    )
+
+
+def _shard_to_full_device(builder: TTIRBuilder, input: Operand, dim: int) -> Operand:
+    """Concatenate `input`'s shards along `dim` across the mesh's second (y) axis."""
+    rank = len(builder._get_golden_tensor(input).shape)
+    num_devices = builder.mesh_shape[1]
+    shard_shape = [1] * rank
+    shard_shape[dim] = num_devices
+    return builder.mesh_shard(
+        input,
+        shard_direction=MeshShardDirection.ShardToFull.value,
+        shard_type=MeshShardType.Devices.value,
+        shard_shape=shard_shape,
+        shard_dims=[-1, dim],
+    )
+
+
+def _full_to_shard_replicate(builder: TTIRBuilder, input: Operand) -> Operand:
+    return builder.mesh_shard(
+        input,
+        shard_direction=MeshShardDirection.FullToShard.value,
+        shard_type=MeshShardType.Replicate.value,
+        shard_shape=[1],
+        shard_dims=[-1],
+    )
+
+
+def _make_module(variant: str, m: int, k: int, n: int, cluster_axis: int) -> Callable:
+    """Return a TTIRBuilder module that builds the pre-fusion pattern.
+
+    tt-metal's minimal_matmul_strided_reduce_scatter kernel operates on 4D
+    tensors (it asserts a batch of 1 and scatters the innermost dim, dim 3), so
+    all operands are 4D `[1, 1, M/K/N ...]`. Activation `[1, 1, M, K]` and weight
+    `[1, 1, K, N]` are both K-sharded across the mesh; each device computes a
+    partial `input @ weight` and the reduce_scatter sums the partials across
+    ranks while scattering the result along N (dim 3).
+    `variant` selects the epilogue folded into the fused op:
+      - "matmul":            proj = reduce_scatter(matmul(x, W))
+      - "linear":            proj = reduce_scatter(linear(x, W, bias))  (row-broadcast bias)
+      - "addcmul":           out  = residual + gate * reduce_scatter(matmul(x, W))
+      - "addcmul_broadcast": as "addcmul" but gate is a row-broadcast `[1, 1, 1, N]`
+        (the per-channel gate DiT actually uses; the full-gate case is "addcmul").
+    """
+    dtype = torch.bfloat16
+    shapes: List[Shape] = [(1, 1, m, k), (1, 1, k, n)]
+    if variant == "linear":
+        shapes.append((1, 1, 1, n))  # bias
+    elif variant in ("addcmul", "addcmul_broadcast"):
+        gate_shape = (1, 1, 1, n) if variant == "addcmul_broadcast" else (1, 1, m, n)
+        shapes.extend([gate_shape, (1, 1, m, n)])  # gate, residual
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, [dtype] * len(shapes))
+        def matmul_reduce_scatter(*args):
+            operands = list(args[:-1])
+            b: TTIRBuilder = args[-1]
+            act, weight = operands[0], operands[1]
+
+            # Row-parallel: shard the contraction dim K of both operands
+            # (K is dim 3 of the activation, dim 2 of the weight).
+            act_sharded = _full_to_shard_device(b, act, dim=3)
+            weight_sharded = _full_to_shard_device(b, weight, dim=2)
+
+            if variant == "linear":
+                bias_replicated = _full_to_shard_replicate(b, operands[2])
+                proj = b.linear(act_sharded, weight_sharded, bias_replicated)
+            else:
+                proj = b.matmul(act_sharded, weight_sharded)
+
+            scattered = b.reduce_scatter(
+                proj,
+                reduce_type=ReduceType.Sum.value,
+                scatter_dim=3,
+                cluster_axis=cluster_axis,
+            )
+
+            if variant in ("addcmul", "addcmul_broadcast"):
+                # The gate/residual apply to the scattered output, so they are
+                # scattered along N (dim 3) the same way reduce_scatter is.
+                gate_sharded = _full_to_shard_device(b, operands[2], dim=3)
+                res_sharded = _full_to_shard_device(b, operands[3], dim=3)
+                gated = b.multiply(scattered, gate_sharded)
+                scattered = b.add(res_sharded, gated)
+
+            return _shard_to_full_device(b, scattered, dim=3)
+
+    return module
+
+
+def _assert_fused(ir: str, variant: str) -> None:
+    # The pattern must fuse into the typed op...
+    assert FUSED_OP in ir, f"expected {FUSED_OP} in compiled IR for variant={variant}"
+    # ...and the standalone matmul/collective it subsumes must be gone.
+    assert (
+        '"ttnn.reduce_scatter"' not in ir
+    ), "standalone ttnn.reduce_scatter should be fused away"
+    assert '"ttnn.matmul"' not in ir, "standalone ttnn.matmul should be fused away"
+
+
+def _compile_to_ttnn_ir(module, mesh_shape: Tuple[int, int], request) -> str:
+    """Run the TTIR -> TTNN pipeline and return the compiled TTNN IR text."""
+    kwargs = get_request_kwargs(request)
+    artifact_dir = get_artifact_dir(
+        kwargs["output_root"], "TTIRBuilder", kwargs["test_base"], make_dir=True
+    )
+    compile_ttir_to_flatbuffer(
+        module,
+        system_desc_path=kwargs["system_desc_path"],
+        artifact_dir=artifact_dir,
+        target="ttnn",
+        mesh_name="mesh",
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        pipeline_options=_promote_options(),
+        save_artifacts=True,
+    )
+    with open(os.path.join(artifact_dir, "ttnn_compiled.mlir"), "r") as f:
+        return f.read()
+
+
+# Only the row-broadcast gate ("addcmul_broadcast", `[1, N]`) fuses; the full
+# `[M, N]` gate ("addcmul") is intentionally left unfused (see
+# test_matmul_reduce_scatter_full_gate_not_fused and the isRowBroadcast guard in
+# MatmulReduceScatterFusingPattern.cpp).
+@pytest.mark.parametrize(
+    "variant",
+    ["matmul", "linear", "addcmul_broadcast"],
+    ids=["matmul", "linear", "addcmul_broadcast"],
+)
+@pytest.mark.parametrize("cluster_axis", [1])
+@pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=shape_str)
+def test_matmul_reduce_scatter_fusing(
+    variant: str,
+    cluster_axis: int,
+    mesh_shape: Tuple[int, int],
+    request,
+):
+    """Compile-only: the full TTIR -> TTNN pipeline emits the fused op.
+
+    A pure IR check (no execution), so it runs on any target regardless of how
+    many chips are physically present.
+    """
+    module = _make_module(variant, m=64, k=512, n=64, cluster_axis=cluster_axis)
+    ir = _compile_to_ttnn_ir(module, mesh_shape, request)
+    _assert_fused(ir, variant)
+
+
+# The fused addcmul epilogue applies the gate per-channel (broadcast across the
+# M/row dim), so a full `[M, N]` gate would be silently collapsed to its first
+# row. The isRowBroadcast guard in the fusing pattern must keep that case
+# unfused, leaving the primitive matmul + reduce_scatter + multiply + add in place.
+@pytest.mark.parametrize("cluster_axis", [1])
+@pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=shape_str)
+def test_matmul_reduce_scatter_full_gate_not_fused(
+    cluster_axis: int,
+    mesh_shape: Tuple[int, int],
+    request,
+):
+    """Compile-only: a full `[M, N]` gate must NOT fuse into the composite."""
+    module = _make_module("addcmul", m=64, k=512, n=64, cluster_axis=cluster_axis)
+    ir = _compile_to_ttnn_ir(module, mesh_shape, request)
+    assert FUSED_OP not in ir, f"full-gate addcmul must not fuse into {FUSED_OP}"
+    # It must fall back to the standalone matmul the guard declined to fuse.
+    assert '"ttnn.matmul"' in ir, "full-gate addcmul should leave a standalone matmul"
+
+
+# Only the variants that actually fuse are exercised on device; the full-gate
+# addcmul case is covered (compile-only) by test_matmul_reduce_scatter_full_gate_not_fused.
+@pytest.mark.parametrize(
+    "variant",
+    ["matmul", "linear", "addcmul_broadcast"],
+    ids=["matmul", "linear", "addcmul_broadcast"],
+)
+@pytest.mark.parametrize("cluster_axis", [1])
+# tt-metal's minimal_matmul_strided_reduce_scatter kernel is only exercised on a
+# full 8-device ring (its nightly tests use mesh (1, 8) exclusively); a
+# degenerate 2-device ring deadlocks. Use (1, 8) so the ring matches what the
+# kernel supports.
+@pytest.mark.parametrize("mesh_shape", [(1, 8)], ids=shape_str)
+@pytest.mark.parametrize("target", ["ttnn"])
+# The fused op pins topology=Ring, so the mesh must be opened with a ring fabric
+# (the conftest default FABRIC_1D is a line and the async reduce-scatter would
+# deadlock on the unrouted ring wrap-around edge).
+@pytest.mark.parametrize(
+    "fabric_config",
+    [tt_runtime.runtime.FabricConfig.FABRIC_1D_RING],
+    ids=["fabric_1d_ring"],
+)
+def test_matmul_reduce_scatter_fusing_execute(
+    variant: str,
+    cluster_axis: int,
+    mesh_shape: Tuple[int, int],
+    target: str,
+    fabric_config,
+    request,
+    device,
+):
+    """Run the fused matmul+reduce_scatter on a real multi-chip mesh and PCC-check it.
+
+    Verifies that fusing the collective into the matmul is numerically correct
+    end-to-end on device (compares against the unfused golden the builder
+    computes from the primitive matmul/reduce_scatter ops). Auto-deselected by
+    the conftest mesh filter when fewer than mesh_shape chips are present.
+
+    Shape: M=128, K=2048, N=512. K is chosen so the per-device contraction
+    after K-sharding across the 8-device ring is a non-degenerate 2048/8 = 256
+    (8 tiles) -- the reference kernel is only ever exercised with a full,
+    multi-tile K, and a 1-tile per-device K is degenerate. N_tiles (16) is
+    divisible by the ring size.
+    """
+    module = _make_module(variant, m=128, k=2048, n=512, cluster_axis=cluster_axis)
+
+    # check_pcc defaults to True; leave it implicit so it can't collide with the
+    # value get_request_kwargs may inject via --disable-pcc. Match tt-metal's own
+    # bar for this op (pcc > 0.9995); the builder harness has no relative-RMSE
+    # check, so the RMSE half of metal's criterion can't be mirrored here.
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target=target,
+        mesh_name="mesh",
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        pipeline_options=_promote_options(),
+        pcc=0.9995,
+    )

--- a/test/ttmlir/Dialect/TTIR/fusing/matmul_reduce_scatter_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/matmul_reduce_scatter_fusing.mlir
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttir-fusing %s | FileCheck %s
+
+// Fuses a reduce_scatter consuming a matmul/linear (optionally with a
+// gated-residual addcmul epilogue) at the TTIR level into a
+//   ttcore.composite "minimal_matmul_strided_reduce_scatter_async"
+// whose decomposition body holds the primitive form. Promotion to
+// ttnn.minimal_matmul_strided_reduce_scatter_async (or inlining the body)
+// happens later via TTNNResolveComposites.
+//
+// composite_attributes print in sorted key order, so the CHECK-SAME lines are
+// ordered: cluster_axis, has_addcmul, has_bias, scatter_dim[, scalar],
+// composite_name.
+
+// reduce_scatter(matmul(x, W)) -> composite. has_bias/has_addcmul both false.
+// CHECK-LABEL: func.func @matmul_reduce_scatter
+// CHECK: "ttcore.composite"
+// CHECK-SAME: has_addcmul = false
+// CHECK-SAME: has_bias = false
+// CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
+func.func @matmul_reduce_scatter(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>)
+    -> tensor<32x32xbf16> {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  return %1 : tensor<32x32xbf16>
+}
+
+// -----
+
+// reduce_scatter(linear(x, W, bias)) -> composite, bias carried through.
+// CHECK-LABEL: func.func @linear_reduce_scatter
+// CHECK: "ttcore.composite"
+// CHECK-SAME: has_bias = true
+// CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
+func.func @linear_reduce_scatter(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>, %bias: tensor<1x64xbf16>)
+    -> tensor<32x32xbf16> {
+  %0 = "ttir.linear"(%x, %w, %bias) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>, tensor<1x64xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  return %1 : tensor<32x32xbf16>
+}
+
+// -----
+
+// transpose_b set -> not fused (fused op does not model transpose).
+// CHECK-LABEL: func.func @no_fuse_transpose
+// CHECK: "ttir.matmul"
+// CHECK: "ttir.reduce_scatter"
+// CHECK-NOT: ttcore.composite
+func.func @no_fuse_transpose(%x: tensor<32x128xbf16>, %w: tensor<64x128xbf16>)
+    -> tensor<32x32xbf16> {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = true}> : (tensor<32x128xbf16>, tensor<64x128xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  return %1 : tensor<32x32xbf16>
+}
+
+// -----
+
+// matmul result has a second use -> not fused (would duplicate the matmul).
+// CHECK-LABEL: func.func @no_fuse_multiuse
+// CHECK-NOT: ttcore.composite
+func.func @no_fuse_multiuse(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>)
+    -> (tensor<32x32xbf16>, tensor<32x64xbf16>) {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  return %1, %0 : tensor<32x32xbf16>, tensor<32x64xbf16>
+}
+
+// -----
+
+// Gated-residual epilogue: residual + gate * reduce_scatter(matmul(x, W)) folds
+// the whole thing (matmul + reduce_scatter + multiply + add) into one composite,
+// with residual/gate mapped to the addcmul operands and scalar = 1.0.
+// CHECK-LABEL: func.func @matmul_reduce_scatter_addcmul
+// CHECK: "ttcore.composite"
+// CHECK-SAME: has_addcmul = true
+// CHECK-SAME: scalar = 1.000000e+00 : f32
+// CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
+func.func @matmul_reduce_scatter_addcmul(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>,
+                                         %gate: tensor<32x32xbf16>, %res: tensor<32x32xbf16>)
+    -> tensor<32x32xbf16> {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  %2 = "ttir.multiply"(%1, %gate) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %3 = "ttir.add"(%res, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  return %3 : tensor<32x32xbf16>
+}
+
+// -----
+
+// linear (with bias) + gated-residual epilogue, multiply operands reversed:
+// exercises the linear path and both commutative branches.
+// CHECK-LABEL: func.func @linear_reduce_scatter_addcmul
+// CHECK: "ttcore.composite"
+// CHECK-SAME: has_addcmul = true
+// CHECK-SAME: has_bias = true
+// CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
+func.func @linear_reduce_scatter_addcmul(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>, %bias: tensor<1x64xbf16>,
+                                         %gate: tensor<32x32xbf16>, %res: tensor<32x32xbf16>)
+    -> tensor<32x32xbf16> {
+  %0 = "ttir.linear"(%x, %w, %bias) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>, tensor<1x64xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  %2 = "ttir.multiply"(%gate, %1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %3 = "ttir.add"(%2, %res) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  return %3 : tensor<32x32xbf16>
+}
+
+// -----
+
+// The generated decomposition function is emitted and marked so fusing never
+// recurses into it.
+// CHECK: func.func private @minimal_matmul_strided_reduce_scatter_async_decomp
+// CHECK-SAME: attributes {tt.composite_decomposition}
+func.func @emit_decomp(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>)
+    -> tensor<32x32xbf16> {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  return %1 : tensor<32x32xbf16>
+}

--- a/test/ttmlir/Dialect/TTIR/fusing/matmul_reduce_scatter_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/matmul_reduce_scatter_fusing.mlir
@@ -165,15 +165,18 @@ func.func @addcmul_leading_unit_reshape(%x: tensor<32x128xbf16>, %w: tensor<128x
 
 // -----
 
-// Wan FF2: transpose_b + scatter + unsqueeze + post-scatter bias + gated residual.
-// The bias is D/tp after the scatter, so addcmul is not fused; matmul+RS still is.
+// Wan FF2: transpose_b + scatter + unsqueeze + post-scatter D/tp bias + gated
+// residual. Addcmul fuses as r + g*s (has_bias stays false); g*b is a small
+// multiply then a broadcast onto the residual (not a reshape of [1,1,N]).
 // CHECK-LABEL: func.func @wan_ff2_transpose_scatter_bias_gate
 // CHECK: "ttir.permute"
+// CHECK: "ttir.multiply"
+// CHECK: "ttir.broadcast"
 // CHECK: "ttcore.composite"
-// CHECK-SAME: has_addcmul = false
+// CHECK-SAME: has_addcmul = true
+// CHECK-SAME: has_bias = false
 // CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
 // CHECK: "ttir.add"
-// CHECK: "ttir.multiply"
 func.func @wan_ff2_transpose_scatter_bias_gate(%x: tensor<32x128xbf16>, %w: tensor<64x128xbf16>,
                                               %bias: tensor<1x1x32xbf16>, %gate: tensor<1x1x32xbf16>,
                                               %res: tensor<1x32x32xbf16>)

--- a/test/ttmlir/Dialect/TTIR/fusing/matmul_reduce_scatter_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/matmul_reduce_scatter_fusing.mlir
@@ -44,14 +44,28 @@ func.func @linear_reduce_scatter(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16
 
 // -----
 
-// transpose_b set -> not fused (fused op does not model transpose).
-// CHECK-LABEL: func.func @no_fuse_transpose
+// transpose_b is folded into a permute of the weight to [K, N], then fused.
+// CHECK-LABEL: func.func @fuse_transpose_b
+// CHECK: "ttir.permute"
+// CHECK: "ttcore.composite"
+// CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
+func.func @fuse_transpose_b(%x: tensor<32x128xbf16>, %w: tensor<64x128xbf16>)
+    -> tensor<32x32xbf16> {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = true}> : (tensor<32x128xbf16>, tensor<64x128xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  return %1 : tensor<32x32xbf16>
+}
+
+// -----
+
+// transpose_a is not modeled by the fused kernel.
+// CHECK-LABEL: func.func @no_fuse_transpose_a
 // CHECK: "ttir.matmul"
 // CHECK: "ttir.reduce_scatter"
 // CHECK-NOT: ttcore.composite
-func.func @no_fuse_transpose(%x: tensor<32x128xbf16>, %w: tensor<64x128xbf16>)
+func.func @no_fuse_transpose_a(%x: tensor<128x32xbf16>, %w: tensor<128x64xbf16>)
     -> tensor<32x32xbf16> {
-  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = true}> : (tensor<32x128xbf16>, tensor<64x128xbf16>) -> tensor<32x64xbf16>
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = true, transpose_b = false}> : (tensor<128x32xbf16>, tensor<128x64xbf16>) -> tensor<32x64xbf16>
   %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
   return %1 : tensor<32x32xbf16>
 }
@@ -128,6 +142,51 @@ func.func @no_fuse_full_gate(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>,
   %2 = "ttir.multiply"(%1, %gate) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   %3 = "ttir.add"(%res, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   return %3 : tensor<32x32xbf16>
+}
+
+// -----
+
+// DiT-style: 2D scatter, unsqueeze, then residual + broadcast gate.
+// CHECK-LABEL: func.func @addcmul_leading_unit_reshape
+// CHECK: "ttcore.composite"
+// CHECK-SAME: has_addcmul = true
+// CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
+func.func @addcmul_leading_unit_reshape(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>,
+                                       %gate: tensor<1x1x32xbf16>, %res: tensor<1x32x32xbf16>)
+    -> tensor<1x32x32xbf16> {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 32 : i32]}> : (tensor<32x32xbf16>) -> tensor<1x32x32xbf16>
+  %3 = "ttir.broadcast"(%gate) <{broadcast_dimensions = array<i64: 1, 32, 1>}> : (tensor<1x1x32xbf16>) -> tensor<1x32x32xbf16>
+  %4 = "ttir.multiply"(%2, %3) : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16>
+  %5 = "ttir.add"(%res, %4) : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16>
+  return %5 : tensor<1x32x32xbf16>
+}
+
+// -----
+
+// Wan FF2: transpose_b + scatter + unsqueeze + post-scatter bias + gated residual.
+// The bias is D/tp after the scatter, so addcmul is not fused; matmul+RS still is.
+// CHECK-LABEL: func.func @wan_ff2_transpose_scatter_bias_gate
+// CHECK: "ttir.permute"
+// CHECK: "ttcore.composite"
+// CHECK-SAME: has_addcmul = false
+// CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
+// CHECK: "ttir.add"
+// CHECK: "ttir.multiply"
+func.func @wan_ff2_transpose_scatter_bias_gate(%x: tensor<32x128xbf16>, %w: tensor<64x128xbf16>,
+                                              %bias: tensor<1x1x32xbf16>, %gate: tensor<1x1x32xbf16>,
+                                              %res: tensor<1x32x32xbf16>)
+    -> tensor<1x32x32xbf16> {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = true}> : (tensor<32x128xbf16>, tensor<64x128xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 32 : i32]}> : (tensor<32x32xbf16>) -> tensor<1x32x32xbf16>
+  %3 = "ttir.broadcast"(%bias) <{broadcast_dimensions = array<i64: 1, 32, 1>}> : (tensor<1x1x32xbf16>) -> tensor<1x32x32xbf16>
+  %4 = "ttir.add"(%2, %3) : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16>
+  %5 = "ttir.broadcast"(%gate) <{broadcast_dimensions = array<i64: 1, 32, 1>}> : (tensor<1x1x32xbf16>) -> tensor<1x32x32xbf16>
+  %6 = "ttir.multiply"(%4, %5) : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16>
+  %7 = "ttir.add"(%res, %6) : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16>
+  return %7 : tensor<1x32x32xbf16>
 }
 
 // -----

--- a/test/ttmlir/Dialect/TTIR/fusing/matmul_reduce_scatter_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/matmul_reduce_scatter_fusing.mlir
@@ -72,18 +72,19 @@ func.func @no_fuse_multiuse(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>)
 
 // Gated-residual epilogue: residual + gate * reduce_scatter(matmul(x, W)) folds
 // the whole thing (matmul + reduce_scatter + multiply + add) into one composite,
-// with residual/gate mapped to the addcmul operands and scalar = 1.0.
+// with residual/gate mapped to the addcmul operands and scalar = 1.0. The fused
+// kernel applies the gate per-channel, so it must be row-broadcast (`[1, N]`).
 // CHECK-LABEL: func.func @matmul_reduce_scatter_addcmul
 // CHECK: "ttcore.composite"
 // CHECK-SAME: has_addcmul = true
 // CHECK-SAME: scalar = 1.000000e+00 : f32
 // CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
 func.func @matmul_reduce_scatter_addcmul(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>,
-                                         %gate: tensor<32x32xbf16>, %res: tensor<32x32xbf16>)
+                                         %gate: tensor<1x32xbf16>, %res: tensor<32x32xbf16>)
     -> tensor<32x32xbf16> {
   %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>) -> tensor<32x64xbf16>
   %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
-  %2 = "ttir.multiply"(%1, %gate) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %2 = "ttir.multiply"(%1, %gate) : (tensor<32x32xbf16>, tensor<1x32xbf16>) -> tensor<32x32xbf16>
   %3 = "ttir.add"(%res, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   return %3 : tensor<32x32xbf16>
 }
@@ -98,19 +99,43 @@ func.func @matmul_reduce_scatter_addcmul(%x: tensor<32x128xbf16>, %w: tensor<128
 // CHECK-SAME: has_bias = true
 // CHECK-SAME: composite_name = "minimal_matmul_strided_reduce_scatter_async"
 func.func @linear_reduce_scatter_addcmul(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>, %bias: tensor<1x64xbf16>,
-                                         %gate: tensor<32x32xbf16>, %res: tensor<32x32xbf16>)
+                                         %gate: tensor<1x32xbf16>, %res: tensor<32x32xbf16>)
     -> tensor<32x32xbf16> {
   %0 = "ttir.linear"(%x, %w, %bias) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>, tensor<1x64xbf16>) -> tensor<32x64xbf16>
   %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
-  %2 = "ttir.multiply"(%gate, %1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %2 = "ttir.multiply"(%gate, %1) : (tensor<1x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   %3 = "ttir.add"(%2, %res) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   return %3 : tensor<32x32xbf16>
 }
 
 // -----
 
+// A full `[M, N]` gate must NOT fuse: the fused addcmul epilogue applies the
+// gate per-channel (broadcast across the M/row dim), so a full gate would be
+// silently collapsed to its first row. The guard leaves the primitive
+// matmul + reduce_scatter + multiply + add in place.
+// CHECK-LABEL: func.func @no_fuse_full_gate
+// CHECK: "ttir.matmul"
+// CHECK: "ttir.reduce_scatter"
+// CHECK: "ttir.multiply"
+// CHECK: "ttir.add"
+// CHECK-NOT: ttcore.composite
+func.func @no_fuse_full_gate(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>,
+                             %gate: tensor<32x32xbf16>, %res: tensor<32x32xbf16>)
+    -> tensor<32x32xbf16> {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  %2 = "ttir.multiply"(%1, %gate) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  %3 = "ttir.add"(%res, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+  return %3 : tensor<32x32xbf16>
+}
+
+// -----
+
 // The generated decomposition function is emitted and marked so fusing never
-// recurses into it.
+// recurses into it. (The CHECK-LABEL also bounds @no_fuse_full_gate's
+// CHECK-NOT above so it does not reach this function's legitimate composite.)
+// CHECK-LABEL: func.func @emit_decomp
 // CHECK: func.func private @minimal_matmul_strided_reduce_scatter_async_decomp
 // CHECK-SAME: attributes {tt.composite_decomposition}
 func.func @emit_decomp(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>)

--- a/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.mlir
+++ b/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.mlir
@@ -1,0 +1,68 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-allocate-distributed-op-semaphores -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+// Host-side compiler test for the TTNN-only
+// `minimal_matmul_strided_reduce_scatter_async` op. Exercises three compiler
+// stages with no silicon:
+//   1. the op verifier (runs on parse),
+//   2. the `--ttnn-allocate-distributed-op-semaphores` pass, which materializes
+//      the two reduce-scatter semaphores + barrier semaphore via the
+//      DistributedOpInterface when they are left unbound, and
+//   3. flatbuffer serialization (`ttmlir-translate --ttnn-to-flatbuffer`).
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+// Activation A[M=32, K=128] sharded along K across a 1x4 worker grid; the
+// semaphore pass derives the semaphore core range from this layout.
+#ttnn_layout_in = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x4>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (3,0)>]>>
+// Weight B[K=128, N=64].
+#ttnn_layout_w = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// Output [M=32, N=64].
+#ttnn_layout_out = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// Row-broadcast operands [*, N=64].
+#ttnn_layout_row = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module @test_minimal_matmul_strided_reduce_scatter_async attributes {} {
+  // Minimal form: just activation + weight, semaphores left unbound.
+  // CHECK-LABEL: func.func @minimal
+  func.func @minimal(
+      %input: tensor<32x128xbf16, #ttnn_layout_in>,
+      %weight: tensor<128x64xbf16, #ttnn_layout_w>)
+      -> tensor<32x64xbf16, #ttnn_layout_out> attributes {tt.function_type = "forward_device"} {
+    // CHECK: "ttnn.get_device"
+    // The pass allocates two reduce-scatter semaphores plus one barrier semaphore.
+    // CHECK-COUNT-3: "ttnn.create_global_semaphore"
+    // CHECK: "ttnn.minimal_matmul_strided_reduce_scatter_async"
+    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 2, 1, 1>
+    %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %0 = "ttnn.minimal_matmul_strided_reduce_scatter_async"(%input, %weight, %device) <{
+      cluster_axis = 1 : ui32,
+      operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 0, 0, 1>
+    }> : (tensor<32x128xbf16, #ttnn_layout_in>, tensor<128x64xbf16, #ttnn_layout_w>, !ttnn.device) -> tensor<32x64xbf16, #ttnn_layout_out>
+    return %0 : tensor<32x64xbf16, #ttnn_layout_out>
+  }
+
+  // Fused form: bias + gated residual (addcmul) epilogue, exercising every
+  // optional tensor operand through the verifier and flatbuffer serializer.
+  // CHECK-LABEL: func.func @fused
+  func.func @fused(
+      %input: tensor<32x128xbf16, #ttnn_layout_in>,
+      %weight: tensor<128x64xbf16, #ttnn_layout_w>,
+      %bias: tensor<1x64xbf16, #ttnn_layout_row>,
+      %res: tensor<32x64xbf16, #ttnn_layout_out>,
+      %gate: tensor<1x64xbf16, #ttnn_layout_row>)
+      -> tensor<32x64xbf16, #ttnn_layout_out> attributes {tt.function_type = "forward_device"} {
+    // CHECK-COUNT-3: "ttnn.create_global_semaphore"
+    // CHECK: "ttnn.minimal_matmul_strided_reduce_scatter_async"
+    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 2, 1, 1>
+    %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %0 = "ttnn.minimal_matmul_strided_reduce_scatter_async"(%input, %weight, %bias, %res, %gate, %device) <{
+      cluster_axis = 1 : ui32,
+      scalar = 5.000000e-01 : f32,
+      operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0, 0, 1>
+    }> : (tensor<32x128xbf16, #ttnn_layout_in>, tensor<128x64xbf16, #ttnn_layout_w>, tensor<1x64xbf16, #ttnn_layout_row>, tensor<32x64xbf16, #ttnn_layout_out>, tensor<1x64xbf16, #ttnn_layout_row>, !ttnn.device) -> tensor<32x64xbf16, #ttnn_layout_out>
+    return %0 : tensor<32x64xbf16, #ttnn_layout_out>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.mlir
+++ b/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.mlir
@@ -7,15 +7,17 @@
 // stages with no silicon:
 //   1. the op verifier (runs on parse),
 //   2. the `--ttnn-allocate-distributed-op-semaphores` pass, which materializes
-//      the two reduce-scatter semaphores + barrier semaphore via the
+//      the three reduce-scatter semaphores + barrier semaphore via the
 //      DistributedOpInterface when they are left unbound, and
 //   3. flatbuffer serialization (`ttmlir-translate --ttnn-to-flatbuffer`).
 
 #dram = #ttnn.buffer_type<dram>
 #l1 = #ttnn.buffer_type<l1>
 
-// Activation A[M=32, K=128] sharded along K across a 1x4 worker grid; the
-// semaphore pass derives the semaphore core range from this layout.
+// Activation A[M=32, K=128] sharded along K across a 1x4 worker grid. The
+// semaphore pass creates the global semaphores over the full device worker
+// grid (not the input's shard range), so every matmul/reduce-scatter core has
+// them.
 #ttnn_layout_in = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x4>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (3,0)>]>>
 // Weight B[K=128, N=64].
 #ttnn_layout_w = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
@@ -32,10 +34,10 @@ module @test_minimal_matmul_strided_reduce_scatter_async attributes {} {
       %weight: tensor<128x64xbf16, #ttnn_layout_w>)
       -> tensor<32x64xbf16, #ttnn_layout_out> attributes {tt.function_type = "forward_device"} {
     // CHECK: "ttnn.get_device"
-    // The pass allocates two reduce-scatter semaphores plus one barrier semaphore.
-    // CHECK-COUNT-3: "ttnn.create_global_semaphore"
+    // The pass allocates three reduce-scatter semaphores plus one barrier semaphore.
+    // CHECK-COUNT-4: "ttnn.create_global_semaphore"
     // CHECK: "ttnn.minimal_matmul_strided_reduce_scatter_async"
-    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 2, 1, 1>
+    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 3, 1, 1>
     %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
     %0 = "ttnn.minimal_matmul_strided_reduce_scatter_async"(%input, %weight, %device) <{
       cluster_axis = 1 : ui32,
@@ -54,9 +56,9 @@ module @test_minimal_matmul_strided_reduce_scatter_async attributes {} {
       %res: tensor<32x64xbf16, #ttnn_layout_out>,
       %gate: tensor<1x64xbf16, #ttnn_layout_row>)
       -> tensor<32x64xbf16, #ttnn_layout_out> attributes {tt.function_type = "forward_device"} {
-    // CHECK-COUNT-3: "ttnn.create_global_semaphore"
+    // CHECK-COUNT-4: "ttnn.create_global_semaphore"
     // CHECK: "ttnn.minimal_matmul_strided_reduce_scatter_async"
-    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 2, 1, 1>
+    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 3, 1, 1>
     %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
     %0 = "ttnn.minimal_matmul_strided_reduce_scatter_async"(%input, %weight, %bias, %res, %gate, %device) <{
       cluster_axis = 1 : ui32,

--- a/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_negative.mlir
@@ -1,0 +1,63 @@
+// RUN: not ttmlir-opt --split-input-file --ttcore-register-device %s 2>&1 | FileCheck %s
+// Negative unit tests for the ttnn.minimal_matmul_strided_reduce_scatter_async
+// verifier. Verifier only inspects operand shapes, so plain (unencoded)
+// tensors suffice.
+
+// Bound multi-device semaphores must come as an exact pair.
+module {
+  func.func @wrong_semaphore_count(%input: tensor<32x128xbf16>, %weight: tensor<128x64xbf16>) -> tensor<32x64xbf16> {
+    %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %sem = "ttnn.create_global_semaphore"(%device) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (3,0)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
+    // CHECK: error: 'ttnn.minimal_matmul_strided_reduce_scatter_async' op expects exactly two multi-device global semaphores, got 1
+    %0 = "ttnn.minimal_matmul_strided_reduce_scatter_async"(%input, %weight, %sem, %device) <{
+      cluster_axis = 1 : ui32,
+      operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1, 0, 1>
+    }> : (tensor<32x128xbf16>, tensor<128x64xbf16>, !ttnn.global_semaphore, !ttnn.device) -> tensor<32x64xbf16>
+    return %0 : tensor<32x64xbf16>
+  }
+}
+
+// -----
+
+// The gated-residual fusion requires both addcmul operands together.
+module {
+  func.func @addcmul_only_one(%input: tensor<32x128xbf16>, %weight: tensor<128x64xbf16>, %res: tensor<32x64xbf16>) -> tensor<32x64xbf16> {
+    %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    // CHECK: error: 'ttnn.minimal_matmul_strided_reduce_scatter_async' op addcmul_input1 and addcmul_input2 must both be present or both absent
+    %0 = "ttnn.minimal_matmul_strided_reduce_scatter_async"(%input, %weight, %res, %device) <{
+      cluster_axis = 1 : ui32,
+      operandSegmentSizes = array<i32: 1, 1, 0, 1, 0, 0, 0, 1>
+    }> : (tensor<32x128xbf16>, tensor<128x64xbf16>, tensor<32x64xbf16>, !ttnn.device) -> tensor<32x64xbf16>
+    return %0 : tensor<32x64xbf16>
+  }
+}
+
+// -----
+
+// Bias is row-broadcast: its last dim must equal the matmul width N.
+module {
+  func.func @bias_wrong_width(%input: tensor<32x128xbf16>, %weight: tensor<128x64xbf16>, %bias: tensor<1x32xbf16>) -> tensor<32x64xbf16> {
+    %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    // CHECK: error: 'ttnn.minimal_matmul_strided_reduce_scatter_async' op bias last dimension (32) must match weight's last dimension N (64)
+    %0 = "ttnn.minimal_matmul_strided_reduce_scatter_async"(%input, %weight, %bias, %device) <{
+      cluster_axis = 1 : ui32,
+      operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 0, 0, 1>
+    }> : (tensor<32x128xbf16>, tensor<128x64xbf16>, tensor<1x32xbf16>, !ttnn.device) -> tensor<32x64xbf16>
+    return %0 : tensor<32x64xbf16>
+  }
+}
+
+// -----
+
+// Input must be at least rank 2 (a matrix).
+module {
+  func.func @input_rank_too_low(%input: tensor<128xbf16>, %weight: tensor<128x64xbf16>) -> tensor<32x64xbf16> {
+    %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    // CHECK: error: 'ttnn.minimal_matmul_strided_reduce_scatter_async' op input tensor must have rank >= 2
+    %0 = "ttnn.minimal_matmul_strided_reduce_scatter_async"(%input, %weight, %device) <{
+      cluster_axis = 1 : ui32,
+      operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 0, 0, 1>
+    }> : (tensor<128xbf16>, tensor<128x64xbf16>, !ttnn.device) -> tensor<32x64xbf16>
+    return %0 : tensor<32x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_negative.mlir
@@ -3,12 +3,12 @@
 // verifier. Verifier only inspects operand shapes, so plain (unencoded)
 // tensors suffice.
 
-// Bound multi-device semaphores must come as an exact pair.
+// Bound multi-device semaphores must come as an exact triple.
 module {
   func.func @wrong_semaphore_count(%input: tensor<32x128xbf16>, %weight: tensor<128x64xbf16>) -> tensor<32x64xbf16> {
     %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
     %sem = "ttnn.create_global_semaphore"(%device) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (3,0)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
-    // CHECK: error: 'ttnn.minimal_matmul_strided_reduce_scatter_async' op expects exactly two multi-device global semaphores, got 1
+    // CHECK: error: 'ttnn.minimal_matmul_strided_reduce_scatter_async' op expects exactly three multi-device global semaphores, got 1
     %0 = "ttnn.minimal_matmul_strided_reduce_scatter_async"(%input, %weight, %sem, %device) <{
       cluster_axis = 1 : ui32,
       operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1, 0, 1>

--- a/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_resolve_composites.mlir
+++ b/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_resolve_composites.mlir
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttnn-resolve-composites="composite-resolution=inline" --split-input-file %s | FileCheck %s --check-prefix=INLINE
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-resolve-composites="composite-resolution=force-promote" --split-input-file %s | FileCheck %s --check-prefix=PROMOTE
+
+// Resolution of the `minimal_matmul_strided_reduce_scatter_async` composite
+// emitted by the TTIR MatmulReduceScatter fusing patterns:
+//   - inline        -> the decomposition body (ttnn.matmul + ttnn.reduce_scatter)
+//                      is spliced in and the composite is removed.
+//   - force-promote -> the composite becomes the typed
+//                      ttnn.minimal_matmul_strided_reduce_scatter_async op (the
+//                      build callback synthesizes the device and leaves
+//                      semaphores unbound for
+//                      TTNNAllocateDistributedOpSemaphores).
+
+#dram = #ttnn.buffer_type<dram>
+// Activation A[M=32, K=128].
+#a  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// Weight B[K=128, N=64].
+#w  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// Matmul output [M=32, N=64] (pre-scatter partial).
+#mm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// Reduce-scatter output [M=32, N=32] (scattered across 2 devices).
+#o  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// Plain matmul + reduce_scatter composite.
+// INLINE-LABEL: func.func @resolve_matmul
+// INLINE: "ttnn.matmul"
+// INLINE: "ttnn.reduce_scatter"
+// INLINE-NOT: ttcore.composite
+// INLINE-NOT: minimal_matmul_strided_reduce_scatter_async
+//
+// PROMOTE-LABEL: func.func @resolve_matmul
+// PROMOTE: "ttnn.minimal_matmul_strided_reduce_scatter_async"
+// PROMOTE-NOT: ttcore.composite
+func.func @resolve_matmul(%x: tensor<32x128xbf16, #a>, %w: tensor<128x64xbf16, #w>)
+    -> tensor<32x32xbf16, #o> {
+  %0 = "ttcore.composite"(%x, %w) <{
+      composite_attributes = {cluster_axis = 1 : ui32, has_addcmul = false, has_bias = false, scatter_dim = 1 : si32},
+      composite_name = "minimal_matmul_strided_reduce_scatter_async",
+      decomposition = @mmrs_matmul_decomp}> : (tensor<32x128xbf16, #a>, tensor<128x64xbf16, #w>) -> tensor<32x32xbf16, #o>
+  return %0 : tensor<32x32xbf16, #o>
+}
+func.func private @mmrs_matmul_decomp(%x: tensor<32x128xbf16, #a>, %w: tensor<128x64xbf16, #w>)
+    -> tensor<32x32xbf16, #o> attributes {tt.composite_decomposition} {
+  %0 = "ttnn.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16, #a>, tensor<128x64xbf16, #w>) -> tensor<32x64xbf16, #mm>
+  %1 = "ttnn.reduce_scatter"(%0) <{reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32, cluster_axis = 1 : ui32}> : (tensor<32x64xbf16, #mm>) -> tensor<32x32xbf16, #o>
+  return %1 : tensor<32x32xbf16, #o>
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#a  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#w  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#mm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#o  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// Gated-residual (addcmul) composite: has_addcmul + scalar carried through.
+// INLINE-LABEL: func.func @resolve_addcmul
+// INLINE: "ttnn.matmul"
+// INLINE: "ttnn.reduce_scatter"
+// INLINE: "ttnn.multiply"
+// INLINE: "ttnn.add"
+// INLINE-NOT: minimal_matmul_strided_reduce_scatter_async
+//
+// PROMOTE-LABEL: func.func @resolve_addcmul
+// PROMOTE: "ttnn.minimal_matmul_strided_reduce_scatter_async"
+// PROMOTE-SAME: scalar = 1.000000e+00 : f32
+// PROMOTE-NOT: ttcore.composite
+func.func @resolve_addcmul(%x: tensor<32x128xbf16, #a>, %w: tensor<128x64xbf16, #w>,
+                           %res: tensor<32x32xbf16, #o>, %gate: tensor<32x32xbf16, #o>)
+    -> tensor<32x32xbf16, #o> {
+  %0 = "ttcore.composite"(%x, %w, %res, %gate) <{
+      composite_attributes = {cluster_axis = 1 : ui32, has_addcmul = true, has_bias = false, scalar = 1.000000e+00 : f32, scatter_dim = 1 : si32},
+      composite_name = "minimal_matmul_strided_reduce_scatter_async",
+      decomposition = @mmrs_addcmul_decomp}> : (tensor<32x128xbf16, #a>, tensor<128x64xbf16, #w>, tensor<32x32xbf16, #o>, tensor<32x32xbf16, #o>) -> tensor<32x32xbf16, #o>
+  return %0 : tensor<32x32xbf16, #o>
+}
+func.func private @mmrs_addcmul_decomp(%x: tensor<32x128xbf16, #a>, %w: tensor<128x64xbf16, #w>,
+                                       %res: tensor<32x32xbf16, #o>, %gate: tensor<32x32xbf16, #o>)
+    -> tensor<32x32xbf16, #o> attributes {tt.composite_decomposition} {
+  %0 = "ttnn.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16, #a>, tensor<128x64xbf16, #w>) -> tensor<32x64xbf16, #mm>
+  %1 = "ttnn.reduce_scatter"(%0) <{reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32, cluster_axis = 1 : ui32}> : (tensor<32x64xbf16, #mm>) -> tensor<32x32xbf16, #o>
+  %2 = "ttnn.multiply"(%gate, %1) : (tensor<32x32xbf16, #o>, tensor<32x32xbf16, #o>) -> tensor<32x32xbf16, #o>
+  %3 = "ttnn.add"(%res, %2) : (tensor<32x32xbf16, #o>, tensor<32x32xbf16, #o>) -> tensor<32x32xbf16, #o>
+  return %3 : tensor<32x32xbf16, #o>
+}

--- a/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_resolve_composites.mlir
+++ b/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_resolve_composites.mlir
@@ -5,86 +5,73 @@
 // RUN: ttmlir-opt --ttnn-resolve-composites="composite-resolution=inline" --split-input-file %s | FileCheck %s --check-prefix=INLINE
 // RUN: ttmlir-opt --ttcore-register-device --ttnn-resolve-composites="composite-resolution=force-promote" --split-input-file %s | FileCheck %s --check-prefix=PROMOTE
 
-// Resolution of the `minimal_matmul_strided_reduce_scatter_async` composite
-// emitted by the TTIR MatmulReduceScatter fusing patterns:
-//   - inline        -> the decomposition body (ttnn.matmul + ttnn.reduce_scatter)
-//                      is spliced in and the composite is removed.
-//   - force-promote -> the composite becomes the typed
-//                      ttnn.minimal_matmul_strided_reduce_scatter_async op (the
-//                      build callback synthesizes the device and leaves
-//                      semaphores unbound for
-//                      TTNNAllocateDistributedOpSemaphores).
+// Resolution of the `minimal_matmul_strided_reduce_scatter_async` composite.
+// A 2D `[M, K]` activation must be unsqueezed to rank 4 before the typed
+// ttnn op (tt-metal indexes scatter dim 3) and the result squeezed back.
 
-#dram = #ttnn.buffer_type<dram>
-// Activation A[M=32, K=128].
-#a  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-// Weight B[K=128, N=64].
-#w  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-// Matmul output [M=32, N=64] (pre-scatter partial).
-#mm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-// Reduce-scatter output [M=32, N=32] (scattered across 2 devices).
-#o  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-
-// Plain matmul + reduce_scatter composite.
-// INLINE-LABEL: func.func @resolve_matmul
-// INLINE: "ttnn.matmul"
-// INLINE: "ttnn.reduce_scatter"
+// INLINE-LABEL: func.func @rank2_matmul_reduce_scatter
 // INLINE-NOT: ttcore.composite
 // INLINE-NOT: minimal_matmul_strided_reduce_scatter_async
-//
-// PROMOTE-LABEL: func.func @resolve_matmul
+// INLINE: "ttir.matmul"
+// INLINE: "ttir.reduce_scatter"
+
+// PROMOTE-LABEL: func.func @rank2_matmul_reduce_scatter
+// PROMOTE: "ttnn.reshape"
+// PROMOTE-SAME: shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]
 // PROMOTE: "ttnn.minimal_matmul_strided_reduce_scatter_async"
-// PROMOTE-NOT: ttcore.composite
-func.func @resolve_matmul(%x: tensor<32x128xbf16, #a>, %w: tensor<128x64xbf16, #w>)
-    -> tensor<32x32xbf16, #o> {
+// PROMOTE-SAME: dim = 3
+// PROMOTE: "ttnn.reshape"
+// PROMOTE-SAME: shape = [32 : i32, 32 : i32]
+func.func @rank2_matmul_reduce_scatter(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>)
+    -> tensor<32x32xbf16> {
+  %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %0 = "ttcore.composite"(%x, %w) <{
-      composite_attributes = {cluster_axis = 1 : ui32, has_addcmul = false, has_bias = false, scatter_dim = 1 : si32},
       composite_name = "minimal_matmul_strided_reduce_scatter_async",
-      decomposition = @mmrs_matmul_decomp}> : (tensor<32x128xbf16, #a>, tensor<128x64xbf16, #w>) -> tensor<32x32xbf16, #o>
-  return %0 : tensor<32x32xbf16, #o>
+      decomposition = @rank2_decomp,
+      composite_attributes = {
+        cluster_axis = 1 : ui32,
+        has_addcmul = false,
+        has_bias = false,
+        scatter_dim = 1 : si32
+      }
+    }> : (tensor<32x128xbf16>, tensor<128x64xbf16>) -> tensor<32x32xbf16>
+  return %0 : tensor<32x32xbf16>
 }
-func.func private @mmrs_matmul_decomp(%x: tensor<32x128xbf16, #a>, %w: tensor<128x64xbf16, #w>)
-    -> tensor<32x32xbf16, #o> attributes {tt.composite_decomposition} {
-  %0 = "ttnn.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16, #a>, tensor<128x64xbf16, #w>) -> tensor<32x64xbf16, #mm>
-  %1 = "ttnn.reduce_scatter"(%0) <{reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32, cluster_axis = 1 : ui32}> : (tensor<32x64xbf16, #mm>) -> tensor<32x32xbf16, #o>
-  return %1 : tensor<32x32xbf16, #o>
+
+func.func private @rank2_decomp(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>)
+    -> tensor<32x32xbf16> attributes {tt.composite_decomposition} {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16>, tensor<128x64xbf16>) -> tensor<32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<32x64xbf16>) -> tensor<32x32xbf16>
+  return %1 : tensor<32x32xbf16>
 }
 
 // -----
 
-#dram = #ttnn.buffer_type<dram>
-#a  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#w  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#mm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#o  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// Already rank-4: no leading reshape around the fused op.
 
-// Gated-residual (addcmul) composite: has_addcmul + scalar carried through.
-// INLINE-LABEL: func.func @resolve_addcmul
-// INLINE: "ttnn.matmul"
-// INLINE: "ttnn.reduce_scatter"
-// INLINE: "ttnn.multiply"
-// INLINE: "ttnn.add"
-// INLINE-NOT: minimal_matmul_strided_reduce_scatter_async
-//
-// PROMOTE-LABEL: func.func @resolve_addcmul
+// PROMOTE-LABEL: func.func @rank4_matmul_reduce_scatter
+// PROMOTE-NOT: "ttnn.reshape"
 // PROMOTE: "ttnn.minimal_matmul_strided_reduce_scatter_async"
-// PROMOTE-SAME: scalar = 1.000000e+00 : f32
-// PROMOTE-NOT: ttcore.composite
-func.func @resolve_addcmul(%x: tensor<32x128xbf16, #a>, %w: tensor<128x64xbf16, #w>,
-                           %res: tensor<32x32xbf16, #o>, %gate: tensor<32x32xbf16, #o>)
-    -> tensor<32x32xbf16, #o> {
-  %0 = "ttcore.composite"(%x, %w, %res, %gate) <{
-      composite_attributes = {cluster_axis = 1 : ui32, has_addcmul = true, has_bias = false, scalar = 1.000000e+00 : f32, scatter_dim = 1 : si32},
+// PROMOTE-SAME: dim = 3
+func.func @rank4_matmul_reduce_scatter(%x: tensor<1x1x32x128xbf16>, %w: tensor<128x64xbf16>)
+    -> tensor<1x1x32x32xbf16> {
+  %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %0 = "ttcore.composite"(%x, %w) <{
       composite_name = "minimal_matmul_strided_reduce_scatter_async",
-      decomposition = @mmrs_addcmul_decomp}> : (tensor<32x128xbf16, #a>, tensor<128x64xbf16, #w>, tensor<32x32xbf16, #o>, tensor<32x32xbf16, #o>) -> tensor<32x32xbf16, #o>
-  return %0 : tensor<32x32xbf16, #o>
+      decomposition = @rank4_decomp,
+      composite_attributes = {
+        cluster_axis = 1 : ui32,
+        has_addcmul = false,
+        has_bias = false,
+        scatter_dim = 3 : si32
+      }
+    }> : (tensor<1x1x32x128xbf16>, tensor<128x64xbf16>) -> tensor<1x1x32x32xbf16>
+  return %0 : tensor<1x1x32x32xbf16>
 }
-func.func private @mmrs_addcmul_decomp(%x: tensor<32x128xbf16, #a>, %w: tensor<128x64xbf16, #w>,
-                                       %res: tensor<32x32xbf16, #o>, %gate: tensor<32x32xbf16, #o>)
-    -> tensor<32x32xbf16, #o> attributes {tt.composite_decomposition} {
-  %0 = "ttnn.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<32x128xbf16, #a>, tensor<128x64xbf16, #w>) -> tensor<32x64xbf16, #mm>
-  %1 = "ttnn.reduce_scatter"(%0) <{reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32, cluster_axis = 1 : ui32}> : (tensor<32x64xbf16, #mm>) -> tensor<32x32xbf16, #o>
-  %2 = "ttnn.multiply"(%gate, %1) : (tensor<32x32xbf16, #o>, tensor<32x32xbf16, #o>) -> tensor<32x32xbf16, #o>
-  %3 = "ttnn.add"(%res, %2) : (tensor<32x32xbf16, #o>, tensor<32x32xbf16, #o>) -> tensor<32x32xbf16, #o>
-  return %3 : tensor<32x32xbf16, #o>
+
+func.func private @rank4_decomp(%x: tensor<1x1x32x128xbf16>, %w: tensor<128x64xbf16>)
+    -> tensor<1x1x32x32xbf16> attributes {tt.composite_decomposition} {
+  %0 = "ttir.matmul"(%x, %w) <{transpose_a = false, transpose_b = false}> : (tensor<1x1x32x128xbf16>, tensor<128x64xbf16>) -> tensor<1x1x32x64xbf16>
+  %1 = "ttir.reduce_scatter"(%0) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 3 : si32}> : (tensor<1x1x32x64xbf16>) -> tensor<1x1x32x32xbf16>
+  return %1 : tensor<1x1x32x32xbf16>
 }

--- a/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_resolve_composites.mlir
+++ b/test/ttmlir/Dialect/TTNN/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_resolve_composites.mlir
@@ -6,8 +6,8 @@
 // RUN: ttmlir-opt --ttcore-register-device --ttnn-resolve-composites="composite-resolution=force-promote" --split-input-file %s | FileCheck %s --check-prefix=PROMOTE
 
 // Resolution of the `minimal_matmul_strided_reduce_scatter_async` composite.
-// A 2D `[M, K]` activation must be unsqueezed to rank 4 before the typed
-// ttnn op (tt-metal indexes scatter dim 3) and the result squeezed back.
+// Rank-4 pad is a runtime view (`ttnn.unsqueeze`), not a compiler reshape.
+// CCL knobs are left unset for the runtime to fill like metal Wan.
 
 // INLINE-LABEL: func.func @rank2_matmul_reduce_scatter
 // INLINE-NOT: ttcore.composite
@@ -16,12 +16,9 @@
 // INLINE: "ttir.reduce_scatter"
 
 // PROMOTE-LABEL: func.func @rank2_matmul_reduce_scatter
-// PROMOTE: "ttnn.reshape"
-// PROMOTE-SAME: shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]
+// PROMOTE-NOT: "ttnn.reshape"
 // PROMOTE: "ttnn.minimal_matmul_strided_reduce_scatter_async"
-// PROMOTE-SAME: dim = 3
-// PROMOTE: "ttnn.reshape"
-// PROMOTE-SAME: shape = [32 : i32, 32 : i32]
+// PROMOTE-SAME: dim = 1
 func.func @rank2_matmul_reduce_scatter(%x: tensor<32x128xbf16>, %w: tensor<128x64xbf16>)
     -> tensor<32x32xbf16> {
   %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device


### PR DESCRIPTION
### Ticket
Resolves #8985  
Also explained in https://github.com/tenstorrent/tt-xla/discussions/5532 in detail why the ops are needed.

### Problem description
Needed to add the fused collective op **`ttnn.minimal_matmul_strided_reduce_scatter_async`** and a
TTIR-level fusion that produces it. It computes `input @ weight` with a minimal-matmul kernel, while it also reduce-scatters the partial products across `cluster_axis`, overlapping communication with compute, with optional fusing additions:
- **bias**: row-broadcast bias added to the matmul result.
- **gated residual (addcmul)**: `addcmul_input1 + scalar * (input @ weight + bias) * addcmul_input2`, used by DiT transformer blocks.

### What's changed
- **Dialect**: `TTNN_MinimalMatmulStridedReduceScatterAsyncOp` (`AttrSizedOperandSegments`,
  `TTNN_DistributedOpInterface`, `OpModelExempt`) with a verifier and semaphore
  materialization via the `DistributedOpInterface`
- **Serialization**: `ccl.fbs` / `program.fbs` schema + `TTNNToFlatbuffer`.
- **Runtime**: `operations/ccl/minimal_matmul_strided_reduce_scatter_async`, wired into the
  program executor and runtime.
- **TTIR patterns** (`MatmulReduceScatterFusing` / `MatmulReduceScatterAddcmulFusing`
  over `MatmulOp`/`LinearOp`) match `matmul/linear -> reduce_scatter  and optionally (multiply ->
  add)` .
- **`TTNNResolveComposites`** registers the composite

### Checklist
- [ ] New/Existing tests provide coverage for changes
