### PR TITLE
[Optimizer] Keep CCL op inputs/outputs interleaved via a rule book

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
@@ -106,6 +106,27 @@ struct MeshPartitionRuleBook : OpRuleBook {
                  const std::vector<OpConfig> &legalConfigs) const override;
 };
 
+/// AllGatherOp / ReduceScatterOp / AllReduceOp: keep CCL op inputs and outputs
+/// interleaved (L1 or DRAM), never L1-sharded.
+///
+/// The op-model constraint query validates a CCL op's sharded tensor spec
+/// against the PER-DEVICE tensor shape (the shape carried in the TTNN IR). At
+/// runtime, a mesh tensor that remains sharded on a non-cluster mesh axis
+/// carries the GLOBAL logical shape, and metal builds the CCL output TensorSpec
+/// from that global shape. So an L1-sharded CCL input/output the query accepts
+/// (per-device shard grid fits) can fail metal's shard-grid-fit at runtime
+/// (global shard grid overflows the core rows/cols; TT_FATAL @ tensor_spec.cpp).
+/// Until tt-mlir tracks per-value mesh distribution and can validate the global
+/// shard grid (issue #TODO_CCL_SHARDED_MESH), keep CCL layouts interleaved so
+/// the optimizer never offers a layout the runtime can't build.
+struct CCLRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+  bool shouldExploreReshards() const override;
+  OutputHints
+  getOutputHints(Operation *op,
+                 const std::vector<OpConfig> &legalConfigs) const override;
+};
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_DATAMOVEMENTRULES_H

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
@@ -107,18 +107,20 @@ struct MeshPartitionRuleBook : OpRuleBook {
 };
 
 /// AllGatherOp / ReduceScatterOp / AllReduceOp: keep CCL op inputs and outputs
-/// interleaved (L1 or DRAM), never L1-sharded.
+/// interleaved (L1 or DRAM), never sharded.
 ///
 /// The op-model constraint query validates a CCL op's sharded tensor spec
 /// against the PER-DEVICE tensor shape (the shape carried in the TTNN IR). At
 /// runtime, a mesh tensor that remains sharded on a non-cluster mesh axis
 /// carries the GLOBAL logical shape, and metal builds the CCL output TensorSpec
-/// from that global shape. So an L1-sharded CCL input/output the query accepts
+/// from that global shape. So a sharded CCL input/output the query accepts
 /// (per-device shard grid fits) can fail metal's shard-grid-fit at runtime
-/// (global shard grid overflows the core rows/cols; TT_FATAL @ tensor_spec.cpp).
-/// Until tt-mlir tracks per-value mesh distribution and can validate the global
-/// shard grid (issue #TODO_CCL_SHARDED_MESH), keep CCL layouts interleaved so
-/// the optimizer never offers a layout the runtime can't build.
+/// (global shard grid overflows the core rows/cols; TT_FATAL @
+/// tensor_spec.cpp). The concrete crash observed is L1-sharded, but
+/// DRAM-sharded is rejected for the same reason; only interleaved layouts are
+/// safe. Until tt-mlir tracks per-value mesh distribution and can validate the
+/// global shard grid (TODO(rpavlovicTT, #9070)), keep CCL layouts interleaved
+/// so the optimizer never offers a layout the runtime can't build.
 struct CCLRuleBook : OpRuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
   bool shouldExploreReshards() const override;

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -323,10 +323,12 @@ OutputHints MeshPartitionRuleBook::getOutputHints(
 // CCLRuleBook (all_gather / reduce_scatter / all_reduce)
 //===----------------------------------------------------------------------===//
 
-LayoutFilterFn CCLRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
-  // Reject L1-sharded CCL inputs: the op-model validates the per-device shard
+LayoutFilterFn
+CCLRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
+  // Reject all sharded CCL inputs: the op-model validates the per-device shard
   // grid, but the runtime mesh tensor carries the global shape and can overflow
-  // the core grid. Interleaved (L1 or DRAM) is safe. See #TODO_CCL_SHARDED_MESH.
+  // the core grid. Interleaved (L1 or DRAM) is safe. See TODO(rpavlovicTT,
+  // #9070).
   return layout_filter_utils::rejectAllSharded;
 }
 
@@ -335,9 +337,9 @@ bool CCLRuleBook::shouldExploreReshards() const { return false; }
 OutputHints
 CCLRuleBook::getOutputHints(Operation * /*op*/,
                             const std::vector<OpConfig> &legalConfigs) const {
-  // Non-sharded output only (interleaved L1 or DRAM). An L1-sharded CCL output
+  // Non-sharded output only (interleaved L1 or DRAM). A sharded CCL output
   // can pass the per-device constraint query but fail metal's global
-  // shard-grid-fit at runtime. See #TODO_CCL_SHARDED_MESH.
+  // shard-grid-fit at runtime. See TODO(rpavlovicTT, #9070).
   return layout_filter_utils::nonShardedOutputHints(legalConfigs);
 }
 

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -319,4 +319,26 @@ OutputHints MeshPartitionRuleBook::getOutputHints(
   return layout_filter_utils::dramInterleavedOnlyOutputHints(legalConfigs);
 }
 
+//===----------------------------------------------------------------------===//
+// CCLRuleBook (all_gather / reduce_scatter / all_reduce)
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn CCLRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
+  // Reject L1-sharded CCL inputs: the op-model validates the per-device shard
+  // grid, but the runtime mesh tensor carries the global shape and can overflow
+  // the core grid. Interleaved (L1 or DRAM) is safe. See #TODO_CCL_SHARDED_MESH.
+  return layout_filter_utils::rejectAllSharded;
+}
+
+bool CCLRuleBook::shouldExploreReshards() const { return false; }
+
+OutputHints
+CCLRuleBook::getOutputHints(Operation * /*op*/,
+                            const std::vector<OpConfig> &legalConfigs) const {
+  // Non-sharded output only (interleaved L1 or DRAM). An L1-sharded CCL output
+  // can pass the per-device constraint query but fail metal's global
+  // shard-grid-fit at runtime. See #TODO_CCL_SHARDED_MESH.
+  return layout_filter_utils::nonShardedOutputHints(legalConfigs);
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -83,6 +83,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static SplitQKVRuleBook splitQKV;
   static RmsNormRuleBook rmsNorm;
   static MeshPartitionRuleBook meshPartition;
+  static CCLRuleBook ccl;
   static MoeRuleBook moe;
   static FillCacheRuleBook fillCache;
   static PagedFillCacheRuleBook pagedFillCache;
@@ -125,6 +126,9 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(SplitQueryKeyValueAndSplitHeadsOp::getOperationName(), &splitQKV);
     reg(RMSNormOp::getOperationName(), &rmsNorm);
     reg(MeshPartitionOp::getOperationName(), &meshPartition);
+    reg(AllGatherOp::getOperationName(), &ccl);
+    reg(ReduceScatterOp::getOperationName(), &ccl);
+    reg(AllReduceOp::getOperationName(), &ccl);
     reg(PrepareMoEComputeW0W1WeightsOp::getOperationName(), &moe);
     reg(PrepareMoEComputeW2WeightsOp::getOperationName(), &moe);
     reg(FillCacheOp::getOperationName(), &fillCache);


### PR DESCRIPTION
Adds `CCLRuleBook` for `all_gather` / `reduce_scatter` / `all_reduce`, keeping their inputs and outputs interleaved (L1 or DRAM), never L1-sharded.

**Why:** the op-model constraint query validates a CCL op's sharded layout against the *per-device* tensor shape, but at runtime a mesh tensor sharded on a non-cluster mesh axis carries the *global* shape. Metal builds the CCL output `TensorSpec` from that global shape and can fail its shard-grid-fit check (`tensor_spec.cpp`) — a sharded layout the query accepted crashes at runtime. This stops the optimizer from ever offering such a layout.

Mirrors the existing `SliceRuleBook` / `MeshPartitionRuleBook` pattern (`rejectAllSharded` input filter, `nonShardedOutputHints`, `shouldExploreReshards=false`). Interleaved CCL is unaffected.

Re-enabling valid L1-sharded CCL on multi-axis meshes needs per-value mesh-distribution tracking; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
