### PR TITLE
[TTNN] Stateful op-constraints in the L1 spill optimizer

### DIFF
--- a/.github/test_scripts/op_model.sh
+++ b/.github/test_scripts/op_model.sh
@@ -15,6 +15,8 @@ echo "Running op-model test MockDevice"
 $BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice
 echo "Running op-model tripwire tests"
 $BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires
+echo "Running allocator-backed stateful L1 spill tests"
+$BUILD_DIR/test/unittests/Optimizer/L1SpillManagementMockAllocatorTests
 
 echo
 echo "Run Optimizer Models Perf Tests"

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -169,6 +169,62 @@ private:
   llvm::DenseMap<uint64_t, AliasGroup> aliasGroups;
 };
 
+/// L1 memory tracker backed by tt-metal's stateful op-constraints query.
+///
+/// Reuses SumL1MemoryTracker's address simulation for eviction ordering and
+/// CB-overlap checks (inherited unchanged), but replaces the *fit decision*:
+/// validate() feeds the set of currently-live L1 allocations (as
+/// build-from-records) into the op-model's stateful query, so fragmentation and
+/// placement are modeled by tt-metal's real allocator rather than the scalar
+/// additional-L1 heuristic.
+///
+/// Live allocation records are keyed by Value. They are captured from the
+/// validation result (a `mutable` per-op stash filled in validate(), consumed
+/// in addTensor) and dropped when a tensor leaves L1 (removeTensor /
+/// removeTensorFromSizes, which the eviction path uses to spill to DRAM).
+struct MockAllocatorL1Tracker : SumL1MemoryTracker {
+  using RecordVec = llvm::SmallVector<op_model::OpModelAllocationRecord>;
+
+  /// Currently-live L1 allocations, keyed by the producing Value. Flattened
+  /// into the stateful query's initial state on each validate().
+  llvm::DenseMap<Value, RecordVec> liveRecords;
+
+  /// Records produced by the most recent successful validate(), keyed by op,
+  /// awaiting association with result Values at addTensor time. `mutable` so
+  /// the const validate() can populate it.
+  mutable llvm::DenseMap<Operation *, RecordVec> pendingRecords;
+
+  /// Stateful fit decision: build the initial allocator state from liveRecords
+  /// and route through the uncached getOpConstraintsWithState. Falls back to
+  /// stateless behavior for ops that don't override the stateful interface
+  /// method (their result carries no records).
+  op_constraint_validation::ValidationResult
+  validate(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+           const OpConfig &config) const;
+
+  void init(uint64_t l1BudgetPerCore);
+
+  /// Delegates address/size bookkeeping to the base, then records `result`'s
+  /// allocation from the pending stash (if the op produced records).
+  void addTensor(Value result, uint64_t l1SizePerCore);
+  void addTensorAtAddress(Value result, uint64_t l1SizePerCore,
+                          Value srcAtSameAddr);
+
+  /// Delegates to the base, then drops `result` from liveRecords (it has left
+  /// L1 — dead or spilled to DRAM).
+  void removeTensor(Value result);
+  void removeTensorFromSizes(Value result);
+
+  /// Snapshot carrying both the base address-sim snapshot and the live-records
+  /// map, so eviction replay restores the record set alongside addresses.
+  struct Snapshot {
+    SumL1MemoryTracker::Snapshot base;
+    llvm::DenseMap<Value, RecordVec> liveRecords;
+  };
+  Snapshot takeSnapshot() const;
+  void restoreSnapshot(const Snapshot &snapshot);
+};
+
 /// L1SpillManagement enforces L1 budget constraints using farthest-last-use
 /// eviction with validation-based budget enforcement.
 /// Each op is re-validated during the sweep using validateOperation() with
@@ -456,8 +512,9 @@ private:
   collectDownstreamConsumers(Operation *changed);
 };
 
-// Explicit instantiation declaration (definition in .cpp).
+// Explicit instantiation declarations (definitions in .cpp).
 extern template class L1SpillManagement<SumL1MemoryTracker>;
+extern template class L1SpillManagement<MockAllocatorL1Tracker>;
 
 } // namespace mlir::tt::ttnn
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -263,7 +263,7 @@ public:
   /// does not fail the pass).
   bool hasFailed() const { return compilationFailed; }
 
-private:
+protected:
   func::FuncOp func;
   ttcore::GridAttr deviceGrid;
   uint64_t l1BudgetPerCore;
@@ -334,13 +334,6 @@ private:
   /// placed; false means a still-live tensor has no contiguous fit
   /// (fragmentation).
   bool markEvictedAndRebuild(Value victim, size_t &campaignMin);
-
-  /// Restore the snapshot at `startIdx` and replay every non-skipped event in
-  /// [startIdx, end) top-down first-fit. Pre-checks `wouldAllocateAt` before
-  /// each fresh allocation so `allocateAddress`'s hard contract holds, and
-  /// returns false at the first no-fit (a still-live tensor has no contiguous
-  /// slot). Returns true iff every still-live tensor was placed.
-  bool replayFrom(size_t startIdx);
 
   /// Insert event at pos in l1EventLog and shift all allocEventIndex entries
   /// and addressSnapshots keys >= pos by 1, preserving the index invariants.
@@ -423,65 +416,39 @@ private:
   void processDeadTensors(int64_t pos, const ScheduleData &data);
 
 protected:
-  /// Hook: place a successfully-validated op's output. Returns the L1 size to
-  /// add to the live set (0 = demoted to DRAM). Default (address-sim path):
-  /// contiguous-fit + CB-overlap checks via ensureFitsL1.
-  virtual uint64_t
-  placeValidatedOutput(Operation *op, int64_t pos, ScheduleData &data,
-                       const op_constraint_validation::ValidationResult &result);
+  // --- Strategy hooks. Implemented by AddressSimSpillManagement (address-sim)
+  //     and StatefulL1SpillManagement (captured allocator state). ---
 
-  /// Hook: recover from an OOM validation result (evict live tensors or demote
-  /// self to DRAM). Default (address-sim path): handleOOM.
+  /// Place a successfully-validated op's output. Returns the L1 size to add to
+  /// the live set (0 = demoted to DRAM).
+  virtual uint64_t placeValidatedOutput(
+      Operation *op, int64_t pos, ScheduleData &data,
+      const op_constraint_validation::ValidationResult &result) = 0;
+
+  /// Recover from an OOM validation result (evict live tensors or demote self
+  /// to DRAM).
   virtual void
   recoverFromOOM(Operation *op, int64_t pos,
                  llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
-                 std::function<void(uint64_t)> addResultsToLiveSet);
+                 std::function<void(uint64_t)> addResultsToLiveSet) = 0;
 
-  /// Hook: commit one result tensor into the live set. Logs the alloc event,
-  /// adds it to the tracker (alias-or-fresh) and to the FLU heap. Default
-  /// (address-sim path): snapshot + addTensorAtAddress/addTensor.
+  /// Commit one result tensor into the live set: log the alloc event, add it to
+  /// the tracker (alias-or-fresh), and push it onto the FLU heap.
   virtual void commitAllocation(Value val, uint64_t perResultL1,
-                                ScheduleData &data);
+                                ScheduleData &data) = 0;
 
-private:
-  /// Check if the op's CB region (growing bottom-up) would overlap with any
-  /// live tensor or the speculative output tensor based on simulated L1
-  /// addresses. Uses min(speculativeOutputAddr, lowestOccupiedAddress) as
-  /// the effective lowest tensor address.
-  /// See: https://github.com/tenstorrent/tt-mlir/issues/7396
-  bool wouldCBsOverlapTensors(Operation *op, int64_t pos, uint64_t cbPeakUsage,
-                              uint64_t speculativeOutputAddr);
+  /// Handle an L1-output op that cannot be validated (a pre-decomposition
+  /// ToLayoutOp). Address-sim runs a fit check; the stateful path defers to the
+  /// consuming op's query.
+  virtual void handleUnvalidatedL1Output(Operation *op, int64_t pos,
+                                         ScheduleData &data,
+                                         uint64_t derivedL1) = 0;
 
-  /// Output cannot fit contiguously in the free list. Evict farthest-last-use
-  /// tensors until the output fits, then re-validate. Returns L1 bytes to add
-  /// to live set (0 if demoted to DRAM).
-  uint64_t handleNoFit(Operation *op, int64_t pos, ScheduleData &data,
-                       uint64_t outputL1Size);
+  /// Rebuild live-set state after an eviction marks events skipped, replaying
+  /// from `startIdx`. Returns true iff every still-live tensor was placed.
+  virtual bool replayFrom(size_t startIdx) = 0;
 
-  /// CB fragmentation recovery: evict tensors in the CB danger zone,
-  /// re-validate, or demote output to DRAM. Returns L1 bytes to add to live
-  /// set (0 if demoted).
-  uint64_t handleFragmentation(Operation *op, int64_t pos, ScheduleData &data,
-                               uint64_t cbPeakUsage, uint64_t outputL1Size);
-
-  /// Run contiguous-fit and CB-fragmentation checks on a validated op's
-  /// output. Returns the (possibly updated) L1 size to add to the live set,
-  /// or 0 if the output was demoted to DRAM.
-  uint64_t ensureFitsL1(Operation *op, int64_t pos, ScheduleData &data,
-                        uint64_t cbPeakUsage, uint64_t l1Size);
-
-  /// True when `op` is a view-eligible reshape whose source operand is still
-  /// resident in L1. Its output will alias the source's existing slot
-  /// (addTensorAtAddress) instead of carving a fresh one, so it consumes no
-  /// additional L1 and the fit / CB-overlap checks must not treat it as a
-  /// new allocation.
-  bool willAliasSourceInL1(Operation *op) const;
-
-  /// OOM recovery: evict farthest-last-use tensors or demote self to DRAM.
-  void handleOOM(Operation *op, int64_t pos,
-                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
-                 std::function<void(uint64_t)> addResultsToLiveSet);
-
+protected:
   /// Evict all live L1 tensors. Used when encountering ops without OpModel
   /// support — since we cannot know their L1 requirements, the only safe
   /// choice is a full flush. Spill ops are inserted right before triggerOp
@@ -489,17 +456,10 @@ private:
   void evictAllFromL1(int64_t pos, ScheduleData &data,
                       Operation *triggerOp = nullptr);
 
-  /// Evict live tensors (farthest-last-use first) until no tensor's simulated
-  /// address falls below the cushioned CB threshold. Replaces the former
-  /// evictTensorsBelow, which was incorrect after address rebuild (addresses
-  /// shift, making the threshold check stale).
-  void evictForCBOverlap(uint64_t cushionedCBUsage, int64_t pos,
-                         ScheduleData &data);
-
   /// Evict tensors (farthest-last-use first) until shouldStop() returns true
   /// or the live set is empty. Returns true if shouldStop was satisfied.
-  /// After each eviction, rebuilds address simulation and inserts reshards
-  /// for already-processed consumers.
+  /// After each eviction, rebuilds tracker state (via the replayFrom hook) and
+  /// inserts reshards for already-processed consumers.
   bool evictUntil(int64_t pos, ScheduleData &data,
                   std::function<bool()> shouldStop);
 
@@ -522,15 +482,6 @@ private:
   void insertReshardForConsumer(Operation *consumer, unsigned operandIdx,
                                 TTNNLayoutAttr originalL1Layout);
 
-  /// After demoting an op's output to DRAM, re-query op_model for the DRAM
-  /// config's cbPeakUsage and evict any live tensors that fall within the
-  /// (potentially larger) static CB region.  When output switches from
-  /// L1-sharded to DRAM, the output CB flips from globally_allocated (aliased
-  /// to the shard, not in the static CB region) to locally_allocated (bottom-up
-  /// in the static CB region), which can significantly increase the CB
-  /// footprint.
-  void evictForDramCBGrowth(Operation *op, int64_t pos, ScheduleData &data);
-
   /// Collect downstream consumers of an op, following through spill ops.
   static llvm::SmallVector<Operation *>
   collectDownstreamConsumers(Operation *changed);
@@ -540,22 +491,97 @@ private:
 extern template class L1SpillManagementBase<SumL1MemoryTracker>;
 extern template class L1SpillManagementBase<MockAllocatorL1Tracker>;
 
-/// Legacy spill manager: scalar-sum tracker + simulated top-down first-fit
-/// address model. Selected when `use-mock-allocator-state=false`. Behavior is
-/// the historical default; the base hooks (address-sim) are inherited unchanged.
-class SumL1SpillManagement final
-    : public L1SpillManagementBase<SumL1MemoryTracker> {
+/// Address-sim strategy: implements the spill hooks with the simulated top-down
+/// first-fit allocator (SumL1MemoryTracker's address model) and the
+/// contiguous-fit / CB-overlap fragmentation checks. Shared by the legacy Sum
+/// path and (transitionally) the Mock path until the stateful path lands.
+template <typename MemoryTracker>
+class AddressSimSpillManagement : public L1SpillManagementBase<MemoryTracker> {
 public:
-  using L1SpillManagementBase<SumL1MemoryTracker>::L1SpillManagementBase;
+  using L1SpillManagementBase<MemoryTracker>::L1SpillManagementBase;
+
+protected:
+  using Base = L1SpillManagementBase<MemoryTracker>;
+  using typename Base::L1Event;
+  using typename Base::ScheduleData;
+  // Base state + generic helpers the address-sim strategy reuses. (Dependent
+  // base: member names must be brought into scope explicitly.)
+  using Base::addressSnapshots;
+  using Base::allocEventIndex;
+  using Base::applyOutputConfig;
+  using Base::cbFragCushion;
+  using Base::collectDownstreamConsumers;
+  using Base::compilationFailed;
+  using Base::demoteToDram;
+  using Base::evictFarthestUse;
+  using Base::evictUntil;
+  using Base::evictValue;
+  using Base::extractOpConfigFromIR;
+  using Base::insertedReshardValues;
+  using Base::insertEventIntoLog;
+  using Base::insertReshardForConsumer;
+  using Base::insertReshardIntoSchedule;
+  using Base::l1BudgetPerCore;
+  using Base::l1EventLog;
+  using Base::liveSet;
+  using Base::liveValues;
+  using Base::markEvictedAndRebuild;
+  using Base::memoryTracker;
+  using Base::observer_;
+  using Base::spillToDram;
+
+  // Strategy hooks (address-sim implementations).
+  uint64_t placeValidatedOutput(
+      Operation *op, int64_t pos, ScheduleData &data,
+      const op_constraint_validation::ValidationResult &result) override;
+  void
+  recoverFromOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet) override;
+  void commitAllocation(Value val, uint64_t perResultL1,
+                        ScheduleData &data) override;
+  void handleUnvalidatedL1Output(Operation *op, int64_t pos, ScheduleData &data,
+                                 uint64_t derivedL1) override;
+  bool replayFrom(size_t startIdx) override;
+
+  // Address-simulation fit / fragmentation / CB-overlap helpers.
+  uint64_t ensureFitsL1(Operation *op, int64_t pos, ScheduleData &data,
+                        uint64_t cbPeakUsage, uint64_t l1Size);
+  uint64_t handleNoFit(Operation *op, int64_t pos, ScheduleData &data,
+                       uint64_t outputL1Size);
+  uint64_t handleFragmentation(Operation *op, int64_t pos, ScheduleData &data,
+                               uint64_t cbPeakUsage, uint64_t outputL1Size);
+  bool wouldCBsOverlapTensors(Operation *op, int64_t pos, uint64_t cbPeakUsage,
+                              uint64_t speculativeOutputAddr);
+  bool willAliasSourceInL1(Operation *op) const;
+  void handleOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet);
+  void evictForCBOverlap(uint64_t cushionedCBUsage, int64_t pos,
+                         ScheduleData &data);
+  void evictForDramCBGrowth(Operation *op, int64_t pos, ScheduleData &data);
+};
+
+extern template class AddressSimSpillManagement<SumL1MemoryTracker>;
+extern template class AddressSimSpillManagement<MockAllocatorL1Tracker>;
+
+/// Legacy spill manager: scalar-sum tracker + simulated top-down first-fit
+/// address model. Selected when `use-mock-allocator-state=false`.
+class SumL1SpillManagement final
+    : public AddressSimSpillManagement<SumL1MemoryTracker> {
+public:
+  using AddressSimSpillManagement<SumL1MemoryTracker>::AddressSimSpillManagement;
 };
 
 /// Stateful spill manager: fit / fragmentation / placement / CB-clash are all
 /// answered by tt-metal's captured allocator state. Selected by default
-/// (`use-mock-allocator-state=true`).
+/// (`use-mock-allocator-state=true`). (Transitionally still address-sim; the
+/// stateful hooks land in a later change.)
 class MockAllocatorSpillManagement final
-    : public L1SpillManagementBase<MockAllocatorL1Tracker> {
+    : public AddressSimSpillManagement<MockAllocatorL1Tracker> {
 public:
-  using L1SpillManagementBase<MockAllocatorL1Tracker>::L1SpillManagementBase;
+  using AddressSimSpillManagement<
+      MockAllocatorL1Tracker>::AddressSimSpillManagement;
 };
 
 } // namespace mlir::tt::ttnn

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -318,9 +318,38 @@ protected:
       return a.first < b.first; // max-heap: higher lastUse = higher priority
     }
   };
-  std::priority_queue<LiveEntry, std::vector<LiveEntry>, LiveEntryCompare>
-      liveSet;
+  using LiveSet =
+      std::priority_queue<LiveEntry, std::vector<LiveEntry>, LiveEntryCompare>;
+  LiveSet liveSet;
   llvm::DenseSet<Value> liveValues;
+
+  /// Full sweep state captured before processing a schedule position, so the
+  /// stateful eviction (StatefulL1SpillManagement) can rewind and re-run the
+  /// forward sweep from there. Bundles the tracker snapshot with the FLU heap
+  /// and live-value set (which are not cheaply re-derivable once eviction has
+  /// changed the L1-resident set).
+  struct SweepCheckpoint {
+    typename MemoryTracker::Snapshot tracker;
+    llvm::DenseSet<Value> liveValues;
+    LiveSet liveSet;
+  };
+  /// Per-position sweep checkpoints (stateful path only; keyed by schedule pos).
+  llvm::DenseMap<int64_t, SweepCheckpoint> sweepCheckpoints;
+
+  /// When set by the stateful recoverFromOOM, run() restores the checkpoint at
+  /// this position and re-runs the sweep from it.
+  std::optional<int64_t> pendingRewindTo;
+
+  /// True for spill strategies that rebuild allocator state by rewinding and
+  /// re-running the forward sweep (StatefulL1SpillManagement) rather than the
+  /// address-sim event-log replay. Gates checkpoint capture + rewind wiring so
+  /// the Sum/address-sim path stays byte-identical.
+  virtual bool usesRewindEviction() const { return false; }
+
+  /// Capture / restore the full sweep state (tracker snapshot + liveValues +
+  /// liveSet) at a schedule position. Used by the rewind eviction.
+  void captureCheckpoint(int64_t pos);
+  void restoreCheckpoint(int64_t pos);
 
   /// Event log entry for address reconstruction. Records every L1 allocation
   /// and deallocation in schedule order so that eviction can replay the full
@@ -617,6 +646,8 @@ public:
   using L1SpillManagementBase<MockAllocatorL1Tracker>::L1SpillManagementBase;
 
 protected:
+  bool usesRewindEviction() const override { return true; }
+
   uint64_t placeValidatedOutput(
       Operation *op, int64_t pos, ScheduleData &data,
       const op_constraint_validation::ValidationResult &result) override;

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -222,10 +222,9 @@ struct MockAllocatorL1Tracker {
 
   /// Query a single op in isolation with an explicit additionalL1Usage (no live
   /// records). Used by the eviction path's consumer-reshard probes.
-  op_constraint_validation::ValidationResult
-  validateBackendDirect(Operation *op,
-                        llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                        const OpConfig &config, uint64_t additionalL1Usage) const;
+  op_constraint_validation::ValidationResult validateBackendDirect(
+      Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+      const OpConfig &config, uint64_t additionalL1Usage) const;
 
   /// Associate `result`'s allocation record from the pending stash (positional:
   /// i-th tensor result <-> i-th output-buffer record). No-op if the op
@@ -272,8 +271,8 @@ template <typename MemoryTracker = SumL1MemoryTracker>
 class L1SpillManagementBase {
 public:
   L1SpillManagementBase(func::FuncOp func, ttcore::GridAttr deviceGrid,
-                    uint64_t l1BudgetPerCore,
-                    std::unique_ptr<L1SpillObserver> observer = nullptr);
+                        uint64_t l1BudgetPerCore,
+                        std::unique_ptr<L1SpillObserver> observer = nullptr);
 
   virtual ~L1SpillManagementBase() = default;
 
@@ -333,7 +332,8 @@ protected:
     llvm::DenseSet<Value> liveValues;
     LiveSet liveSet;
   };
-  /// Per-position sweep checkpoints (stateful path only; keyed by schedule pos).
+  /// Per-position sweep checkpoints (stateful path only; keyed by schedule
+  /// pos).
   llvm::DenseMap<int64_t, SweepCheckpoint> sweepCheckpoints;
 
   /// When set by the stateful recoverFromOOM, run() restores the checkpoint at
@@ -629,7 +629,8 @@ extern template class AddressSimSpillManagement<SumL1MemoryTracker>;
 class SumL1SpillManagement final
     : public AddressSimSpillManagement<SumL1MemoryTracker> {
 public:
-  using AddressSimSpillManagement<SumL1MemoryTracker>::AddressSimSpillManagement;
+  using AddressSimSpillManagement<
+      SumL1MemoryTracker>::AddressSimSpillManagement;
 };
 
 /// Stateful spill manager: fit / fragmentation / placement / CB-clash are all

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -171,22 +171,26 @@ private:
 
 /// L1 memory tracker backed by tt-metal's stateful op-constraints query.
 ///
-/// Reuses SumL1MemoryTracker's address simulation for eviction ordering and
-/// CB-overlap checks (inherited unchanged), but replaces the *fit decision*:
-/// validate() feeds the set of currently-live L1 allocations (as
-/// build-from-records) into the op-model's stateful query, so fragmentation and
-/// placement are modeled by tt-metal's real allocator rather than the scalar
-/// additional-L1 heuristic.
-///
-/// Live allocation records are keyed by Value. They are captured from the
-/// validation result (a `mutable` per-op stash filled in validate(), consumed
-/// in addTensor) and dropped when a tensor leaves L1 (removeTensor /
-/// removeTensorFromSizes, which the eviction path uses to spill to DRAM).
-struct MockAllocatorL1Tracker : SumL1MemoryTracker {
+/// Holds only the set of currently-live L1 allocation records (no address
+/// simulation). validate() flattens the live records into the op-model's
+/// stateful query, so fit / fragmentation / placement / CB-clash are all
+/// modeled by tt-metal's real allocator. Records are keyed by the producing
+/// Value; a view op's output aliases its source's buffer via `aliasOf` /
+/// `aliasRefcount` (record-level aliasing, no addresses), so it never adds a
+/// second record and the buffer stays live until the last aliaser dies.
+struct MockAllocatorL1Tracker {
   using RecordVec = llvm::SmallVector<op_model::OpModelAllocationRecord>;
 
-  /// Currently-live L1 allocations, keyed by the producing Value. Flattened
-  /// into the stateful query's initial state on each validate().
+  /// Backend validator hook (test-only). Same shape as SumL1MemoryTracker's:
+  /// when set, every validate()/validateBackendDirect() call forwards to it.
+  using BackendValidatorFn =
+      std::function<op_constraint_validation::ValidationResult(
+          Operation *, llvm::ArrayRef<TTNNLayoutAttr>, const OpConfig &,
+          uint64_t /*additionalL1*/)>;
+  BackendValidatorFn backendValidator;
+
+  /// Currently-live L1 allocations, keyed by the owning Value (an alias does
+  /// NOT get its own entry). Flattened into each validate()'s initial state.
   llvm::DenseMap<Value, RecordVec> liveRecords;
 
   /// Records produced by the most recent successful validate(), keyed by op,
@@ -194,32 +198,59 @@ struct MockAllocatorL1Tracker : SumL1MemoryTracker {
   /// the const validate() can populate it.
   mutable llvm::DenseMap<Operation *, RecordVec> pendingRecords;
 
-  /// Stateful fit decision: build the initial allocator state from liveRecords
-  /// and route through the uncached getOpConstraintsWithState. Falls back to
-  /// stateless behavior for ops that don't override the stateful interface
-  /// method (their result carries no records).
+  /// Maps a view-op output (aliaser) to the canonical Value that owns the
+  /// shared buffer's record.
+  llvm::DenseMap<Value, Value> aliasOf;
+
+  /// Per-owner count of live aliasers (including the owner itself). The owner's
+  /// record is dropped from liveRecords when this reaches zero.
+  llvm::DenseMap<Value, unsigned> aliasRefcount;
+
+  /// Optimizer per-core L1 budget (a ~0.95 cap minus reserved L1 — tighter than
+  /// the device's physical L1 that the query models). validate() enforces it as
+  /// a byte ceiling on top of the query so the optimizer keeps its headroom.
+  uint64_t l1Budget = 0;
+
+  void init(uint64_t l1BudgetPerCore);
+
+  /// Stateful fit decision: flatten liveRecords (deduped by owner) into the
+  /// op-model's stateful query and stash the resulting per-output records for
+  /// association at addTensor time.
   op_constraint_validation::ValidationResult
   validate(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
            const OpConfig &config) const;
 
-  void init(uint64_t l1BudgetPerCore);
+  /// Query a single op in isolation with an explicit additionalL1Usage (no live
+  /// records). Used by the eviction path's consumer-reshard probes.
+  op_constraint_validation::ValidationResult
+  validateBackendDirect(Operation *op,
+                        llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                        const OpConfig &config, uint64_t additionalL1Usage) const;
 
-  /// Delegates address/size bookkeeping to the base, then records `result`'s
-  /// allocation from the pending stash (if the op produced records).
+  /// Associate `result`'s allocation record from the pending stash (positional:
+  /// i-th tensor result <-> i-th output-buffer record). No-op if the op
+  /// produced no records. `l1SizePerCore` is unused (records carry sizes) and
+  /// kept only for interface parity with SumL1MemoryTracker.
   void addTensor(Value result, uint64_t l1SizePerCore);
-  void addTensorAtAddress(Value result, uint64_t l1SizePerCore,
-                          Value srcAtSameAddr);
 
-  /// Delegates to the base, then drops `result` from liveRecords (it has left
-  /// L1 — dead or spilled to DRAM).
+  /// Record `out` as an alias of `src`'s buffer: bump the owner's refcount and
+  /// add no new record.
+  void addTensorAlias(Value out, Value src);
+
+  /// Drop `result` from the live set (dead or spilled to DRAM): decrement its
+  /// owner's refcount and erase the record when it reaches zero.
   void removeTensor(Value result);
   void removeTensorFromSizes(Value result);
 
-  /// Snapshot carrying both the base address-sim snapshot and the live-records
-  /// map, so eviction replay restores the record set alongside addresses.
+  bool hasTensor(Value result) const;
+  uint64_t getTensorSize(Value result) const;
+  uint64_t getOccupiedL1() const;
+
+  /// Replay checkpoint: the live record set + alias bookkeeping.
   struct Snapshot {
-    SumL1MemoryTracker::Snapshot base;
     llvm::DenseMap<Value, RecordVec> liveRecords;
+    llvm::DenseMap<Value, Value> aliasOf;
+    llvm::DenseMap<Value, unsigned> aliasRefcount;
   };
   Snapshot takeSnapshot() const;
   void restoreSnapshot(const Snapshot &snapshot);
@@ -563,7 +594,6 @@ protected:
 };
 
 extern template class AddressSimSpillManagement<SumL1MemoryTracker>;
-extern template class AddressSimSpillManagement<MockAllocatorL1Tracker>;
 
 /// Legacy spill manager: scalar-sum tracker + simulated top-down first-fit
 /// address model. Selected when `use-mock-allocator-state=false`.
@@ -574,14 +604,31 @@ public:
 };
 
 /// Stateful spill manager: fit / fragmentation / placement / CB-clash are all
-/// answered by tt-metal's captured allocator state. Selected by default
-/// (`use-mock-allocator-state=true`). (Transitionally still address-sim; the
-/// stateful hooks land in a later change.)
-class MockAllocatorSpillManagement final
-    : public AddressSimSpillManagement<MockAllocatorL1Tracker> {
+/// answered by tt-metal's captured allocator state (no address simulation).
+/// Selected by default (`use-mock-allocator-state=true`). Eviction drops the
+/// victim's records and replays the surviving allocation history through the
+/// op-model, so the allocator re-flows addresses under the victim-free history
+/// (a stored record cannot simply be dropped: with_allocations pins buffers at
+/// their recorded addresses). The base is a non-dependent type here, so base
+/// members are reachable without using-declarations.
+class StatefulL1SpillManagement final
+    : public L1SpillManagementBase<MockAllocatorL1Tracker> {
 public:
-  using AddressSimSpillManagement<
-      MockAllocatorL1Tracker>::AddressSimSpillManagement;
+  using L1SpillManagementBase<MockAllocatorL1Tracker>::L1SpillManagementBase;
+
+protected:
+  uint64_t placeValidatedOutput(
+      Operation *op, int64_t pos, ScheduleData &data,
+      const op_constraint_validation::ValidationResult &result) override;
+  void
+  recoverFromOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet) override;
+  void commitAllocation(Value val, uint64_t perResultL1,
+                        ScheduleData &data) override;
+  void handleUnvalidatedL1Output(Operation *op, int64_t pos, ScheduleData &data,
+                                 uint64_t derivedL1) override;
+  bool replayFrom(size_t startIdx) override;
 };
 
 } // namespace mlir::tt::ttnn

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -43,7 +43,7 @@ struct SumL1MemoryTracker {
 
   /// Bypass input-overlap accounting and call the backend (or hook) with an
   /// explicit additionalL1Usage. Used by consumer-reshard probes and DRAM
-  /// CB re-queries inside L1SpillManagement — those call sites already know
+  /// CB re-queries inside L1SpillManagementBase — those call sites already know
   /// the L1 pressure they want to express.
   op_constraint_validation::ValidationResult validateBackendDirect(
       Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
@@ -225,7 +225,7 @@ struct MockAllocatorL1Tracker : SumL1MemoryTracker {
   void restoreSnapshot(const Snapshot &snapshot);
 };
 
-/// L1SpillManagement enforces L1 budget constraints using farthest-last-use
+/// L1SpillManagementBase enforces L1 budget constraints using farthest-last-use
 /// eviction with validation-based budget enforcement.
 /// Each op is re-validated during the sweep using validateOperation() with
 /// the sum of live tensor L1 sizes as additionalL1Usage. When validation
@@ -238,13 +238,13 @@ struct MockAllocatorL1Tracker : SumL1MemoryTracker {
 /// - Inserts ToMemoryConfigOp after spilled ops (L1 -> DRAM)
 /// - Reconnects uses to read from spilled tensor
 template <typename MemoryTracker = SumL1MemoryTracker>
-class L1SpillManagement {
+class L1SpillManagementBase {
 public:
-  L1SpillManagement(func::FuncOp func, ttcore::GridAttr deviceGrid,
+  L1SpillManagementBase(func::FuncOp func, ttcore::GridAttr deviceGrid,
                     uint64_t l1BudgetPerCore,
                     std::unique_ptr<L1SpillObserver> observer = nullptr);
 
-  virtual ~L1SpillManagement() = default;
+  virtual ~L1SpillManagementBase() = default;
 
   /// Run farthest-last-use eviction with validation-based enforcement and apply
   /// spills directly to the IR.
@@ -537,8 +537,26 @@ private:
 };
 
 // Explicit instantiation declarations (definitions in .cpp).
-extern template class L1SpillManagement<SumL1MemoryTracker>;
-extern template class L1SpillManagement<MockAllocatorL1Tracker>;
+extern template class L1SpillManagementBase<SumL1MemoryTracker>;
+extern template class L1SpillManagementBase<MockAllocatorL1Tracker>;
+
+/// Legacy spill manager: scalar-sum tracker + simulated top-down first-fit
+/// address model. Selected when `use-mock-allocator-state=false`. Behavior is
+/// the historical default; the base hooks (address-sim) are inherited unchanged.
+class SumL1SpillManagement final
+    : public L1SpillManagementBase<SumL1MemoryTracker> {
+public:
+  using L1SpillManagementBase<SumL1MemoryTracker>::L1SpillManagementBase;
+};
+
+/// Stateful spill manager: fit / fragmentation / placement / CB-clash are all
+/// answered by tt-metal's captured allocator state. Selected by default
+/// (`use-mock-allocator-state=true`).
+class MockAllocatorSpillManagement final
+    : public L1SpillManagementBase<MockAllocatorL1Tracker> {
+public:
+  using L1SpillManagementBase<MockAllocatorL1Tracker>::L1SpillManagementBase;
+};
 
 } // namespace mlir::tt::ttnn
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -244,6 +244,8 @@ public:
                     uint64_t l1BudgetPerCore,
                     std::unique_ptr<L1SpillObserver> observer = nullptr);
 
+  virtual ~L1SpillManagement() = default;
+
   /// Run farthest-last-use eviction with validation-based enforcement and apply
   /// spills directly to the IR.
   void run();
@@ -420,6 +422,28 @@ private:
   /// Remove result tensors whose last use was the previous position.
   void processDeadTensors(int64_t pos, const ScheduleData &data);
 
+protected:
+  /// Hook: place a successfully-validated op's output. Returns the L1 size to
+  /// add to the live set (0 = demoted to DRAM). Default (address-sim path):
+  /// contiguous-fit + CB-overlap checks via ensureFitsL1.
+  virtual uint64_t
+  placeValidatedOutput(Operation *op, int64_t pos, ScheduleData &data,
+                       const op_constraint_validation::ValidationResult &result);
+
+  /// Hook: recover from an OOM validation result (evict live tensors or demote
+  /// self to DRAM). Default (address-sim path): handleOOM.
+  virtual void
+  recoverFromOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet);
+
+  /// Hook: commit one result tensor into the live set. Logs the alloc event,
+  /// adds it to the tracker (alias-or-fresh) and to the FLU heap. Default
+  /// (address-sim path): snapshot + addTensorAtAddress/addTensor.
+  virtual void commitAllocation(Value val, uint64_t perResultL1,
+                                ScheduleData &data);
+
+private:
   /// Check if the op's CB region (growing bottom-up) would overlap with any
   /// live tensor or the speculative output tensor based on simulated L1
   /// addresses. Uses min(speculativeOutputAddr, lowestOccupiedAddress) as

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -213,6 +213,56 @@ struct MockAllocatorL1Tracker {
 
   void init(uint64_t l1BudgetPerCore);
 
+  /// Arm (or disarm) the static-CB headroom floor. `l1UnreservedBase` is the
+  /// address static circular buffers start growing up from on this chip
+  /// (ChipDescAttr::getL1UnreservedBase); `minHeadroom` seeds the high-water
+  /// mark so the floor is meaningful before the first big-CB op is queried. See
+  /// `cbHeadroomFloorEnabled` for why this is a multi-device-only guard, and
+  /// validate() for the check itself.
+  void armCBHeadroomFloor(uint64_t l1UnreservedBase, bool enabled,
+                          uint64_t minHeadroom = 0);
+
+  /// Byte address static circular buffers grow up from. Only read while the
+  /// headroom floor is armed.
+  uint64_t l1UnreservedBase = 0;
+
+  /// When set, validate() additionally requires every live L1 buffer to sit
+  /// above `l1UnreservedBase + cbHeadroomHighWater`.
+  ///
+  /// Why this exists, and why it is multi-device only: on a mesh compile the
+  /// stateful query does NOT see every program that will run on the device.
+  ///   * CCL / OpModelExempt ops have no op-model body, so their static CBs are
+  ///     never queried. The sweep flushes *tracked* L1 for them, which does not
+  ///     cover buffers it never tracked.
+  ///   * The op-model device is a 1x1 mesh with fabric DISABLED
+  ///     (SingletonDeviceContext's makeEnvDescriptor, blocked on
+  ///     tt-metal#44748), so the fabric / EDM L1 that a real mesh reserves on
+  ///     worker cores is missing from the modeled state.
+  ///   * Distributed-op semaphores are allocated after this pass
+  ///     (TTNNAllocateDistributedOpSemaphores).
+  ///   * tt-metal validates each program's static CB region against the
+  ///     device's GLOBALLY lowest occupied L1 address
+  ///     (ProgramImpl::validate_circular_buffer_region), which on a mesh
+  ///     workload also covers buffers owned by other graphs co-resident in the
+  ///     same process (e.g. vLLM precompiling several graphs back to back).
+  /// So a per-op query can certify "this op fits" while a program the model
+  /// never saw still aborts at launch with "Statically allocated circular
+  /// buffers ... clash with L1 buffers ...". Keeping a floor under the live
+  /// working set — sized by the largest static CB region this function is known
+  /// to need — is what the address-sim path gets from its CB-overlap check plus
+  /// cushion, and what the stateful path was missing.
+  ///
+  /// The guard can only ever spill more: a violation takes the existing
+  /// evict-and-refit path, and if nothing is evictable the op's output is
+  /// demoted to DRAM. It never fails the pass.
+  bool cbHeadroomFloorEnabled = false;
+
+  /// Running high-water mark of the static CB region this function is known to
+  /// need: max(seed, largest cbPeakUsage a successful query has reported).
+  /// Seeded by armCBHeadroomFloor so the floor already bites before the first
+  /// big-CB op is reached. Mutable so the const validate() can update it.
+  mutable uint64_t cbHeadroomHighWater = 0;
+
   /// Stateful fit decision: flatten liveRecords (deduped by owner) into the
   /// op-model's stateful query and stash the resulting per-output records for
   /// association at addTensor time.
@@ -244,6 +294,21 @@ struct MockAllocatorL1Tracker {
   bool hasTensor(Value result) const;
   uint64_t getTensorSize(Value result) const;
   uint64_t getOccupiedL1() const;
+
+  /// Lowest device address occupied by a live L1 record, or nullopt when no L1
+  /// record is live. Unlike SumL1MemoryTracker::getLowestOccupiedAddress (a
+  /// simulated top-down address in a [0, budget) space), these are the real
+  /// addresses tt-metal's allocator handed out in the stateful query, so they
+  /// are directly comparable with a program's static circular-buffer region
+  /// end -- which is what tt-metal itself compares against
+  /// (validate_circular_buffer_region in tt_metal/impl/program/program.cpp).
+  ///
+  /// `alsoConsider` lets a caller fold in records that are not live yet (an
+  /// op's own freshly-reported output allocations), which is the state the
+  /// device is in when that op's program launches.
+  std::optional<uint64_t> getLowestOccupiedL1Address(
+      llvm::ArrayRef<op_model::OpModelAllocationRecord> alsoConsider = {})
+      const;
 
   /// Replay checkpoint: the live record set + alias bookkeeping.
   struct Snapshot {
@@ -345,6 +410,12 @@ protected:
   /// address-sim event-log replay. Gates checkpoint capture + rewind wiring so
   /// the Sum/address-sim path stays byte-identical.
   virtual bool usesRewindEviction() const { return false; }
+
+  /// Strategy hook: apply tracker configuration that needs module-level
+  /// information (chip desc, mesh shape). Called at the top of run(), where
+  /// virtual dispatch is live (it is not, in the constructor). Default no-op so
+  /// the Sum/address-sim path stays byte-identical.
+  virtual void configureTracker() {}
 
   /// Capture / restore the full sweep state (tracker snapshot + liveValues +
   /// liveSet) at a schedule position. Used by the rewind eviction.
@@ -648,6 +719,8 @@ public:
 
 protected:
   bool usesRewindEviction() const override { return true; }
+
+  void configureTracker() override;
 
   uint64_t placeValidatedOutput(
       Operation *op, int64_t pos, ScheduleData &data,

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
@@ -76,6 +76,24 @@ struct SliceRuleBook : OpRuleBook {
 /// condition in tt-metal's reshape.cpp.
 bool canReshapeBeView(Operation *op);
 
+/// True if a `ttnn.pad` returns its input as a view (all-zero padding, same
+/// shape, or the TILE fast-path). Mirrors tt-metal's pad.cpp.
+bool canPadBeView(Operation *op);
+
+/// True if a `ttnn.repeat` with an all-ones repetition returns its input as a
+/// view. Mirrors tt-metal's repeat.cpp:196.
+bool canRepeatBeView(Operation *op);
+
+/// True if a `ttnn.permute` is a no-op (is_permute_nop) whose output memory
+/// config matches its input, so tt-metal returns the input as a view. Mirrors
+/// tt-metal's permute.cpp is_permute_nop.
+bool canPermuteBeView(Operation *op);
+
+/// True if `op` is realized by tt-metal as an input-aliasing (zero-copy) view:
+/// any of the per-op view predicates above. Used by the L1 spill pass to alias
+/// the op onto its source's L1 slot instead of tracking a fresh allocation.
+bool isAliasingViewOp(Operation *op);
+
 /// ReshapeOp, PermuteOp: reject width-sharded inputs, no reshards.
 /// View-eligible reshapes use NULL hint only (inherit input memory config).
 /// Non-view reshapes use non-sharded output hints.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -52,6 +52,16 @@ def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config"> {
     let arguments = (ins AnyRankedTensor:$input);
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -81,6 +91,13 @@ def TTNN_ToLayoutOp : TTNN_Op<"to_layout", [TTNN_LayoutOpInterface]> {
       // i.e. this to_layout actually performs a dtype conversion as part of
       // the layout change.
       bool hasDtypeChange();
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -100,6 +117,16 @@ def TTNN_TypecastOp : TTNN_Op<"typecast"> {
 
     let hasFolder = 1;
     let hasCanonicalizeMethod = 1;
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 }
 
 def TTNN_BitcastConvertOp : TTNN_Op<"bitcast_convert"> {
@@ -114,6 +141,16 @@ def TTNN_BitcastConvertOp : TTNN_Op<"bitcast_convert"> {
 
     let arguments = (ins AnyRankedTensor:$input);
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 }
 
 def TTNN_ToDeviceOp : TTNN_Op<"to_device", [OpModelExempt]> {
@@ -154,6 +191,17 @@ class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
         build($_builder, $_state, {input.getType()}, input);
       }]>
     ];
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints). Declared on the base so
+      // the out-of-line defs in the interface impl bind for every member.
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 }
 
 class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
@@ -172,6 +220,14 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
         return
           wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints). Declared on the base so
+      // the out-of-line defs in the interface impl bind for every member.
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -237,6 +293,13 @@ def TTNN_WhereOp : TTNN_ElementwiseTernaryOp<"where"> {
           wa::TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
                                                                         inputs);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -303,6 +366,13 @@ def TTNN_ErfOp : TTNN_ElementwiseUnaryOp<"erf"> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createErfOpOperandsWorkarounds(getInput().getType());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let description = [{
@@ -363,6 +433,13 @@ def TTNN_BitwiseNotOp : TTNN_ElementwiseUnaryOp<"bitwise_not"> {
           wa::TTNNOperandsWorkaroundsFactory::createUnaryBitwiseOpOperandsWorkarounds(
               this->getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -695,6 +772,22 @@ def TTNN_LogicalLeftShiftOp: TTNN_ElementwiseBinaryCompositeOp<"logical_left_shi
     on the elements of the first tensor by the corresponding shift amounts in the
     second tensor.
   }];
+
+  // Per-op extraClassDeclaration replaces the composite base's, so re-declare
+  // getOperandsWorkarounds here alongside the stateful constraint-query
+  // override (default delegates to the stateless getOpConstraints).
+  let extraClassDeclaration = [{
+    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+      return
+        wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(*this);
+    }
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
+
   let hasVerifier = 1;
 }
 
@@ -802,6 +895,16 @@ def TTNN_PowScalarOp : TTNN_ElementwiseBinaryCompositeScalarOp<"pow_scalar"> {
     Restriction: TTNN API supports expoenent ≥ 0 only.
   }];
 
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
+
   let hasVerifier = 1;
 }
 
@@ -860,11 +963,24 @@ class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemo
     }]>
   ];
 
+  // NOTE: getOpConstraintsWithState is declared HERE on the base (not per-op)
+  // and cascades to every member (Sum/Mean/Max/Min). A per-op
+  // extraClassDeclaration would SHADOW this base block and silently drop
+  // getOperandsWorkarounds (the si32->f32 reduction cast) -- see
+  // https://github.com/tenstorrent/tt-mlir/issues/8279. All base members are
+  // migrated (define getOpConstraintsWithState in TTNNOpModelInterface.cpp).
   let extraClassDeclaration = [{
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return
         wa::TTNNOperandsWorkaroundsFactory::createReductionOpOperandsWorkarounds(*this);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -952,6 +1068,14 @@ def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
       return wa::TTNNOperandsWorkaroundsFactory::
           createArgMaxOpOperandsWorkarounds();
     }
+
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let results = (outs AnyRankedTensor:$result);
@@ -990,6 +1114,14 @@ def TTNN_ProdOp : TTNN_Op<"prod"> {
       return
         wa::TTNNOperandsWorkaroundsFactory::createReduceProdOpOperandsWorkarounds();
     }
+
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1010,6 +1142,13 @@ def TTNN_EmbeddingOp : TTNN_Op<"embedding"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createEmbeddingOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1031,6 +1170,13 @@ def TTNN_UpdateCacheOp : TTNN_InplaceOp<"update_cache"> {
         RankedTensorType updateIndexType = getUpdateIndex().getType();
         return wa::TTNNOperandsWorkaroundsFactory::createUpdateCacheOpOperandsWorkarounds(updateIndexType);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
   let hasVerifier = 1;
@@ -1057,6 +1203,13 @@ def TTNN_PagedUpdateCacheOp : TTNN_InplaceOp<"paged_update_cache"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedUpdateCacheOpOperandsWorkarounds(this->getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1071,6 +1224,16 @@ def TTNN_FillCacheOp : TTNN_InplaceOp<"fill_cache"> {
   let arguments = (ins Arg<AnyRankedTensor, "cache tensor", [MemWrite]>:$cache,
                        AnyRankedTensor:$input,
                        I32Attr:$batch_offset);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
   let hasVerifier = 1;
 }
@@ -1090,6 +1253,13 @@ def TTNN_PagedFillCacheOp : TTNN_InplaceOp<"paged_fill_cache"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedFillCacheOpOperandsWorkarounds(getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1111,6 +1281,13 @@ def TTNN_EmbeddingBackwardOp : TTNN_Op<"embedding_bw"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createEmbeddingBackwardOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1138,6 +1315,16 @@ def TTNN_CumSumOp : TTNN_Op<"cumsum"> {
                        SI32Attr:$dim);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 }
 
 def TTNN_CumProdOp : TTNN_Op<"cumprod"> {
@@ -1162,6 +1349,16 @@ def TTNN_CumProdOp : TTNN_Op<"cumprod"> {
                        SI32Attr:$dim);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 }
 
 def TTNN_ConcatenateHeadsOp: TTNN_Op<"concatenate_heads"> {
@@ -1175,6 +1372,16 @@ def TTNN_ConcatenateHeadsOp: TTNN_Op<"concatenate_heads"> {
     let arguments = (ins AnyRankedTensor:$input);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1193,6 +1400,16 @@ def TTNN_NLPConcatHeadsDecodeOp: TTNN_Op<"nlp_concat_heads_decode"> {
                          UI32Attr:$num_heads);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1214,6 +1431,16 @@ def TTNN_SplitQueryKeyValueAndSplitHeadsOp: TTNN_Op<"split_query_key_value_and_s
     let results = (outs AnyRankedTensor:$query,
                         AnyRankedTensor:$key,
                         AnyRankedTensor:$value);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1246,6 +1473,16 @@ def TTNN_SoftmaxOp : TTNN_Op<"softmax", [TTNN_ComputeKernelConfigOpInterface]> {
               /*compute_config=*/nullptr);
       }]>
     ];
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1281,6 +1518,13 @@ def TTNN_SortOp : TTNN_Op<"sort"> {
       return
         wa::TTNNOperandsWorkaroundsFactory::createSortOpOperandsWorkarounds(*this);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1297,6 +1541,16 @@ def TTNN_TransposeOp : TTNN_Op<"transpose"> {
                          SI32Attr:$dim1);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1320,6 +1574,16 @@ def TTNN_RepeatInterleaveOp : TTNN_Op<"repeat_interleave"> {
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -1333,6 +1597,16 @@ def TTNN_ConcatOp : TTNN_Op<"concat"> {
                          SI32Attr:$dim);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1358,6 +1632,13 @@ def TTNN_ReshapeOp : TTNN_Op<"reshape"> {
         RankedTensorType inputType = getInput().getType();
         return wa::TTNNOperandsWorkaroundsFactory::createReshapeOpOperandsWorkarounds(inputType);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -1375,6 +1656,16 @@ def TTNN_RepeatOp : TTNN_Op<"repeat"> {
                          TTNN_ShapeAttr:$repeat_dims);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1409,6 +1700,13 @@ def TTNN_PadOp: TTNN_Op<"pad"> {
         wa::TTNNOperandsWorkaroundsFactory::createPadOpOperandsWorkarounds(
                                                     input, layoutAttr, padding);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 }
 
@@ -1432,6 +1730,13 @@ def TTNN_SliceStaticOp: TTNN_Op<"slice_static"> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createSliceStaticOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1458,6 +1763,13 @@ def TTNN_SliceDynamicOp: TTNN_Op<"slice_dynamic"> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createSliceDynamicOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1503,6 +1815,16 @@ def TTNN_LinearOp : TTNN_Op<"linear", [TTNN_ComputeKernelConfigOpInterface]> {
       }]>
     ];
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -1537,6 +1859,18 @@ def TTNN_MatmulOp : TTNN_Op<"matmul", [TTNN_ComputeKernelConfigOpInterface]> {
 
     let hasVerifier = 1;
     let hasCanonicalizer = 1;
+
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints). Declared here so the
+    // out-of-line MatmulOp::getOpConstraintsWithState in the interface impl
+    // binds and hides the trait default.
+    let extraClassDeclaration = [{
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
@@ -1848,6 +2182,13 @@ def TTNN_PrepareMoEComputeW0W1WeightsOp :
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPrepareMoEComputeW0W1WeightsOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1876,6 +2217,13 @@ def TTNN_PrepareMoEComputeW2WeightsOp :
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPrepareMoEComputeW2WeightsOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1962,6 +2310,16 @@ def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights", [TTNN_Comput
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -1989,6 +2347,16 @@ def TTNN_PrepareConv2dBiasOp : TTNN_Op<"prepare_conv2d_bias", [TTNN_ComputeKerne
                          OptionalAttr<TTNN_Conv2dSliceConfigAttr>:$conv2d_slice_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -2043,6 +2411,16 @@ def TTNN_PrepareConvTranspose2dWeightsOp : TTNN_Op<"prepare_conv_transpose2d_wei
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2070,6 +2448,16 @@ def TTNN_PrepareConvTranspose2dBiasOp : TTNN_Op<"prepare_conv_transpose2d_bias",
                          OptionalAttr<TTNN_Conv2dSliceConfigAttr>:$conv2d_slice_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -2233,6 +2621,13 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d", [TTNN_ComputeKernelConfigOpInterface]> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -2326,6 +2721,13 @@ def TTNN_Conv3dOp : TTNN_Op<"conv3d", [TTNN_ComputeKernelConfigOpInterface]> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConv3dOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -2414,6 +2816,13 @@ def TTNN_ConvTranspose2dOp : TTNN_Op<"conv_transpose2d", [TTNN_ComputeKernelConf
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -2458,6 +2867,13 @@ def TTNN_AvgPool2dOp : TTNN_Op<"avg_pool2d"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2489,6 +2905,13 @@ def TTNN_MaxPool2dOp : TTNN_Op<"max_pool2d"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2523,6 +2946,13 @@ def TTNN_MaxPool2dWithIndicesOp : TTNN_Op<"max_pool2d_with_indices"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPool2DWithIndicesOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2556,6 +2986,16 @@ def TTNN_BatchNormInferenceOp : TTNN_Op<"batch_norm_inference", [AttrSizedOperan
       }]>
     ];
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2588,6 +3028,16 @@ def TTNN_BatchNormTrainingOp : TTNN_Op<"batch_norm_training", [AttrSizedOperandS
       }]>
     ];
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2619,6 +3069,16 @@ def TTNN_RMSNormOp : TTNN_Op<"rms_norm", [AttrSizedOperandSegments, TTNN_Compute
               epsilon, /*compute_config=*/nullptr);
       }]>
     ];
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -2743,6 +3203,16 @@ def TTNN_RMSNormPreAllGatherOp :  TTNN_Op<"rms_norm_pre_all_gather",
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2804,6 +3274,16 @@ def TTNN_LayerNormOp : TTNN_Op<"layer_norm", [AttrSizedOperandSegments]> {
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2834,6 +3314,16 @@ def TTNN_LayerNormPreAllGatherOp : TTNN_Op<"layer_norm_pre_all_gather",
                          OptionalAttr<TTNN_LayerNormShardedMultiCoreProgramConfigAttr>:$program_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -2869,6 +3359,16 @@ def TTNN_LayerNormPostAllGatherOp : TTNN_Op<"layer_norm_post_all_gather",
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2895,6 +3395,14 @@ def TTNN_GroupNormOp : TTNN_Op<"group_norm", [AttrSizedOperandSegments]> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createGroupNormOpOperandsWorkarounds(this->getOperation());
       }
+
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2920,6 +3428,16 @@ def TTNN_ClampScalarOp : TTNN_Op<"clamp_scalar"> {
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 
 }
@@ -2943,6 +3461,16 @@ def TTNN_ClampTensorOp : TTNN_Op<"clamp_tensor"> {
                        AnyRankedTensor:$max);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
 }
 
@@ -3142,6 +3670,13 @@ def TTNN_ConstantOp : TTNN_CreationOp<"constant", [AllShapesMatch<["value", "res
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasCanonicalizer = 1;
@@ -3197,6 +3732,13 @@ def TTNN_ScatterOp : TTNN_Op<"scatter">{
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createScatterOpOperandsWorkarounds(getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -3225,6 +3767,13 @@ def TTNN_GatherOp : TTNN_Op<"gather"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createGatherOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -3321,6 +3870,15 @@ def TTNN_MeshPartitionOp: TTNN_Op<"mesh_partition"> {
                        SI32Attr:$dim,
                        OptionalAttr<UI32Attr>:$cluster_axis);
   let results = (outs AnyRankedTensor:$result);
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
   let hasVerifier = 1;
 }
 
@@ -3353,6 +3911,13 @@ def TTNN_PermuteOp : TTNN_Op<"permute"> {
             getInput().getType()
           );
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasFolder = 1;
@@ -3383,6 +3948,13 @@ def TTNN_UpsampleOp : TTNN_Op<"upsample"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createUpsampleOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -3497,6 +4069,16 @@ def TTNN_RequantizeOp : TTNN_Op<"requantize"> {
                          OptionalAttr<TTCore_DataTypeAttr>:$output_dtype);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -3739,6 +4321,16 @@ def TTNN_RotaryEmbeddingLlamaOp : TTNN_Op<"rotary_embedding_llama", [TTNN_Comput
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -3770,6 +4362,13 @@ def TTNN_RotaryEmbeddingOp : TTNN_Op<"rotary_embedding", [TTNN_ComputeKernelConf
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createRotaryEmbeddingOpOperandsWorkarounds(*this);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -3785,6 +4384,16 @@ def TTNN_NLPConcatHeadsOp : TTNN_Op<"nlp_concat_heads"> {
   let arguments = (ins AnyRankedTensor:$input);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
   let hasVerifier = 1;
 }
@@ -3824,6 +4433,16 @@ def NLPCreateQKVHeadsDecodeOp : TTNN_Op<"nlp_create_qkv_heads_decode"> {
   let results = (outs AnyRankedTensor:$query,
                       AnyRankedTensor:$key,
                       AnyRankedTensor:$value);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
   let hasVerifier = 1;
 }
@@ -3896,6 +4515,13 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createScaledDotProductAttentionDecodeOpOperandsWorkarounds(getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -3925,6 +4551,13 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedScaledDotProductAttentionDecodeOpOperandsWorkarounds(getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -3996,6 +4629,13 @@ def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_lat
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedFlashMultiLatentAttentionDecodeOpOperandsWorkarounds(getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4045,6 +4685,13 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createScaledDotProductAttentionOpOperandsWorkarounds(getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -4091,6 +4738,13 @@ def TTNN_FlashMlaPrefillOp : TTNN_Op<"flash_mla_prefill", [AttrSizedOperandSegme
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createFlashMlaPrefillOpOperandsWorkarounds(getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -4126,6 +4780,16 @@ def TTNN_GlobalAvgPool2dOp: TTNN_Op<"global_avg_pool2d">{
   let arguments = (ins AnyRankedTensor:$input);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
   let hasVerifier = 1;
 }
@@ -4261,6 +4925,13 @@ def TTNN_SamplingOp : TTNN_Op<"sampling"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds();
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4288,6 +4959,13 @@ def TTNN_TopKOp : TTNN_Op<"topk"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createTopKOpOperandsWorkarounds(*this);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4325,6 +5003,13 @@ def TTNN_TopKRouterGptOp : TTNN_Op<"topk_router_gpt"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createTopKRouterGptOpOperandsWorkarounds();
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -892,7 +892,7 @@ def TTNN_PowScalarOp : TTNN_ElementwiseBinaryCompositeScalarOp<"pow_scalar"> {
     // Output tensor: [4.0, 9.0, 16.0, 25.0]
     ```
 
-    Restriction: TTNN API supports expoenent ≥ 0 only.
+    Restriction: TTNN API supports exponent ≥ 0 only.
   }];
 
   let extraClassDeclaration = [{
@@ -4591,6 +4591,13 @@ def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_produc
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createChunkedScaledDotProductAttentionOpOperandsWorkarounds(getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.td
@@ -41,6 +41,23 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             /*methodBody=*/"",
             /*defaultImplementation=*/"return llvm::createStringError(\"Not Implemented\");"
         >,
+        InterfaceMethod<
+            /*desc=*/[{
+                Stateful variant of getOpConstraints used by the L1 spill path.
+                `liveRecords` describes the allocations already live in L1 (a
+                build-from-records snapshot); the op is evaluated on top of that
+                state via a query that bypasses the op-model constraint cache.
+                The default implementation ignores the state and delegates to the
+                (cached) stateless getOpConstraints, so ops become state-aware by
+                overriding this method. Passing an empty `liveRecords` is
+                equivalent to the stateless query.
+            }],
+            /*retTy=*/"llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>",
+            /*methodName=*/"getOpConstraintsWithState",
+            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const OpConfig&":$config, "llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>":$liveRecords),
+            /*methodBody=*/"",
+            /*defaultImplementation=*/"return $_op.getOpConstraints(inputs, config);"
+        >,
         ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -563,6 +563,15 @@ struct TTIRToTTNNCommonPipelineOptions
       llvm::cl::desc("Output directory for decision trace JSON files."),
       llvm::cl::init("ttrt-artifacts/decision_trace")};
 
+  // Greedy L1 spill: use the stateful (tt-metal MockAllocatorState-backed)
+  // memory tracker vs the scalar-heuristic tracker. Exposed here so it can be
+  // toggled without a rebuild (e.g. for stateful-vs-scalar A/B).
+  Option<bool> useMockAllocatorState{
+      *this, "use-mock-allocator-state",
+      llvm::cl::desc("Greedy L1 spill: use the stateful allocator-backed L1 "
+                     "tracker (true) vs the scalar-heuristic tracker (false)."),
+      llvm::cl::init(true)};
+
   // Enable per-op compile-time statistics from the greedy optimizer.
   Option<bool> enableCompileTimeStats{
       *this, "enable-compile-time-stats",

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -852,6 +852,10 @@ def TTNNGreedyL1SpillManagement : Pass<"ttnn-greedy-l1-spill-management", "::mli
     Option<"decisionTraceDir", "decision-trace-dir", "std::string",
            "\"ttrt-artifacts/decision_trace\"",
            "Directory for decision trace JSON output.">,
+    Option<"useMockAllocatorState", "use-mock-allocator-state", "bool", "true",
+           "Use tt-metal's stateful op-constraints query (MockAllocatorL1Tracker) "
+           "for fragmentation-accurate L1 fit decisions. When false, use the "
+           "scalar additional-L1 + CB-cushion tracker (SumL1MemoryTracker).">,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
+++ b/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
@@ -50,6 +50,11 @@ struct ValidationResult {
   // CB peak L1 usage from op_model. Only valid if Success.
   uint64_t cbPeakUsage = 0;
 
+  // Per-output allocation records from a stateful (build-from-records) query.
+  // Empty on the stateless path. The L1 spill path keeps these for still-live
+  // tensors and rebuilds allocator state from them.
+  llvm::SmallVector<op_model::OpModelAllocationRecord> outputAllocations;
+
   // Error message if status != Success.
   std::string errorMessage;
 
@@ -146,6 +151,16 @@ ValidationResult validateOperation(Operation *op,
                                    llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                                    const OpConfig &config,
                                    uint64_t additionalL1Usage = 0);
+
+// Stateful (build-from-records) validation for the L1 spill path. Routes to the
+// uncached getOpConstraintsWithState, evaluating the op against `liveRecords`
+// (the allocations already live in L1). An empty liveRecords is equivalent to
+// the stateless query.
+ValidationResult
+validateOperation(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                  const OpConfig &config,
+                  llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords,
+                  uint64_t additionalL1Usage = 0);
 
 // Test multiple attributes with all layouts.
 // op: Operation to validate.

--- a/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
@@ -11,6 +11,17 @@
 
 namespace mlir::tt::ttnn::op_model {
 
+// tt-mlir-side mirror of tt-metal's experimental::AllocationRecord. Kept as a
+// plain POD of dialect/scalar types so this broadly-included header stays free
+// of any tt-metalium include (which would pull a global ::tt into every
+// translation unit). Conversion to/from the metal type happens behind the
+// op-model boundary in TTNNOpModel.cpp.
+struct OpModelAllocationRecord {
+  tt::ttnn::BufferType bufferType = tt::ttnn::BufferType::L1;
+  uint64_t address = 0;
+  uint64_t sizePerBank = 0;
+};
+
 /*
  * OpConstraints struct is used to store the constraints of an operation.
  * It is returned by the getOpConstraints method of the OpModel interface.
@@ -27,20 +38,26 @@ struct OpConstraints {
   llvm::SmallVector<tt::ttnn::TTNNLayoutAttr>
       outputLayouts; // Layouts of all output tensors (one layout per output
                      // tensor)
+  // Per-output-buffer allocation records produced by a stateful
+  // (build-from-records) query. Empty on the stateless path. The L1 spill path
+  // keeps these for still-live tensors and rebuilds allocator state from them.
+  llvm::SmallVector<OpModelAllocationRecord> outputAllocations;
   // ---------------------------------------------------------------------------
   // Parameterized constructor, should be used in most cases
   OpConstraints(size_t cbPeak, size_t tensorPeak, size_t peakMemory,
                 size_t outputBuffer,
-                llvm::SmallVector<tt::ttnn::TTNNLayoutAttr> layouts)
+                llvm::SmallVector<tt::ttnn::TTNNLayoutAttr> layouts,
+                llvm::SmallVector<OpModelAllocationRecord> allocations = {})
       : cbL1PeakSize(cbPeak), tensorL1PeakSize(tensorPeak),
         peakL1MemorySize(peakMemory), outputL1BufferSize(outputBuffer),
-        outputLayouts(std::move(layouts)) {}
+        outputLayouts(std::move(layouts)),
+        outputAllocations(std::move(allocations)) {}
   // ---------------------------------------------------------------------------
   // Default constructor, should be used only when the default value is intended
   // to be used, eg. when TTMLIR_ENABLE_OPMODEL is not defined.
   OpConstraints()
       : cbL1PeakSize(0), tensorL1PeakSize(0), peakL1MemorySize(0),
-        outputL1BufferSize(0), outputLayouts({}) {}
+        outputL1BufferSize(0), outputLayouts({}), outputAllocations({}) {}
 };
 
 } // namespace mlir::tt::ttnn::op_model

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -12,6 +12,9 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Error.h"
 
+#include <memory>
+#include <optional>
+
 // Unwrap an llvm::Expected<T> expression: on success assign the value to `lhs`,
 // on failure propagate the error by returning it from the enclosing function.
 //
@@ -38,7 +41,36 @@
   _Pragma("clang diagnostic pop")
 // clang-format on
 
+// Forward declaration only. The full definition lives in tt-metalium
+// (experimental/mock_device/mock_allocator.hpp) and is only available when
+// TTMLIR_ENABLE_OPMODEL is defined. Declared here (rather than in the broadly
+// included TTNNOpConstraints.h) so the global ::tt name it introduces stays out
+// of translation units that do `using namespace mlir` and reference an
+// unqualified `tt` (which would otherwise become ambiguous with mlir::tt).
+namespace tt::tt_metal::experimental {
+class MockAllocatorState;
+} // namespace tt::tt_metal::experimental
+
 namespace mlir::tt::ttnn::op_model {
+
+using MockAllocatorState = ::tt::tt_metal::experimental::MockAllocatorState;
+
+// Build a MockAllocatorState representing the given live allocations, for the
+// stateful (build-from-records) constraint query. Returns null when
+// `liveRecords` is empty (equivalent to a stateless query). Confines all
+// tt-metalium interaction (extract + with_allocations + record conversion) to
+// the op-model boundary; callers pass/receive the opaque handle only.
+std::shared_ptr<MockAllocatorState>
+buildInitialState(llvm::ArrayRef<OpModelAllocationRecord> liveRecords);
+
+// Snapshot / restore the mock device's allocator state around a batch of
+// stateful spill queries. Those queries mutate the SHARED mock device and do
+// not restore it, which corrupts later stateless op-model queries (wrong
+// conv2d config, spurious pool/conv global-CB failures). Call snapshot before
+// the spill pass runs and restore after, so the device is byte-identical to
+// before -- matching what the stateless (scalar-spill) path leaves.
+void snapshotMockAllocatorState();
+void restoreMockAllocatorState();
 
 // Checks if the tensor layout is legal for the given tensor shape.
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
@@ -54,9 +86,17 @@ struct OpModel;
 
 template <typename OpT>
 struct UnaryEltwiseOpModel {
+  // Cache-facing (stateless) entry. Signature is kept exactly as the cache's
+  // getOrCompute invokes it (by function pointer), so it must not grow params.
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  // Stateful entry used by the L1 spill path; bypasses the op-model cache.
+  // initialState may be null (equivalent to the stateless query).
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -65,9 +105,15 @@ struct UnaryEltwiseOpModel {
 
 template <typename OpT>
 struct UnaryEltwiseWithFastApproxModeOpModel {
+  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  // Stateful entry (L1 spill path); bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -179,6 +225,10 @@ struct OpModel<SigmoidOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              TTNNLayoutAttr outputLayout);
@@ -195,6 +245,12 @@ struct OpModel<LeakyReluOp> {
                    TTNNLayoutAttr inputLayout, llvm::APFloat slope,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, llvm::APFloat slope,
+                            TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              llvm::APFloat slope,
@@ -207,10 +263,18 @@ struct OpModel<LeakyReluOp> {
 
 template <typename OpT>
 struct BinaryEltwiseOpModel {
+  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr);
+
+  // Stateful entry (L1 spill path); bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -220,10 +284,18 @@ struct BinaryEltwiseOpModel {
 
 template <typename OpT>
 struct BinaryCompositeOpModel {
+  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr);
+
+  // Stateful entry (L1 spill path); bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -313,6 +385,12 @@ struct OpModel<GeluBackwardOp> {
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       std::string approximate, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      std::string approximate, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
                llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -325,11 +403,19 @@ struct OpModel<GeluBackwardOp> {
 
 template <typename OpT>
 struct TernaryEltwiseOpModel {
+  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
       TTNNLayoutAttr outputLayout);
+
+  // Stateful entry (L1 spill path); bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -347,11 +433,18 @@ struct OpModel<WhereOp> : TernaryEltwiseOpModel<WhereOp> {};
 
 template <typename OpT>
 struct ReductionOpModel {
+  // Cache-facing (stateless) entry; signature unchanged for getOrCompute.
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
                    TTNNLayoutAttr outputLayout);
+
+  // Stateful entry used by the L1 spill path; bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -382,6 +475,11 @@ struct OpModel<ArgMaxOp> {
                    TTNNLayoutAttr inputLayout, std::optional<int32_t> dim,
                    bool keepDim, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              std::optional<int32_t> dim,
@@ -399,6 +497,11 @@ struct OpModel<ProdOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, std::optional<int64_t> dim,
                    bool keepDim, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -458,6 +561,16 @@ struct OpModel<RequantizeOp> {
       TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
       std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
+      llvm::ArrayRef<int64_t> inZeroPointShape,
+      TTNNLayoutAttr inZeroPointLayout, llvm::ArrayRef<int64_t> outScaleShape,
+      TTNNLayoutAttr outScaleLayout, llvm::ArrayRef<int64_t> outZeroPointShape,
+      TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
+      std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
@@ -479,6 +592,12 @@ struct OpModel<SoftmaxOp> {
                    TTNNLayoutAttr inputLayout, const int dimArg,
                    bool numericStable, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, const int dimArg,
+                            bool numericStable, TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              const int dimArg,
@@ -499,6 +618,13 @@ struct OpModel<ScatterOp> {
       int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
+      llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
+      int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
@@ -517,6 +643,11 @@ struct OpModel<ReshapeOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> outputShape,
@@ -534,6 +665,12 @@ struct OpModel<SliceStaticOp> {
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
                    llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
+      llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -554,6 +691,13 @@ struct OpModel<SliceDynamicOp> {
       std::optional<llvm::SmallVector<int64_t>> step,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
+      llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
+      std::optional<llvm::SmallVector<int64_t>> step,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
@@ -573,6 +717,11 @@ struct OpModel<BitcastConvertOp> {
                    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              ttcore::DataTypeAttr dtype,
@@ -590,6 +739,11 @@ struct OpModel<TypecastOp> {
                    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              ttcore::DataTypeAttr dtype,
@@ -605,6 +759,11 @@ struct OpModel<ToLayoutOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -622,6 +781,10 @@ struct OpModel<ToMemoryConfigOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              TTNNLayoutAttr outputLayout);
@@ -637,6 +800,12 @@ struct OpModel<ConcatOp> {
   getOpConstraints(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
                    std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
+                            std::vector<TTNNLayoutAttr> inputLayouts,
+                            const int dim, TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
@@ -654,6 +823,12 @@ struct OpModel<TransposeOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, const int dim0,
+                            const int dim1, TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -673,6 +848,11 @@ struct OpModel<CumSumOp> {
                    std::optional<ttcore::DataType> dtype,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      const int32_t dim, std::optional<ttcore::DataType> dtype,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                const int32_t dim, std::optional<ttcore::DataType> dtype,
@@ -691,6 +871,11 @@ struct OpModel<CumProdOp> {
                    std::optional<ttcore::DataType> dtype,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      const int32_t dim, std::optional<ttcore::DataType> dtype,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                const int32_t dim, std::optional<ttcore::DataType> dtype,
@@ -706,6 +891,10 @@ struct OpModel<ConcatenateHeadsOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -731,6 +920,20 @@ struct OpModel<ScaledDotProductAttentionDecodeOp> {
                    std::optional<llvm::APFloat> scale,
                    std::optional<SDPAProgramConfigAttr> programConfig,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+      std::optional<TTNNLayoutAttr> curPosTensorLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+      std::optional<TTNNLayoutAttr> attentionSinkLayout,
+      std::optional<llvm::APFloat> scale,
+      std::optional<SDPAProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -766,6 +969,22 @@ struct OpModel<PagedScaledDotProductAttentionDecodeOp> {
       std::optional<uint32_t> slidingWindowSize,
       std::optional<SDPAProgramConfigAttr> programConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+      std::optional<TTNNLayoutAttr> curPosTensorLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+      std::optional<TTNNLayoutAttr> attentionSinkLayout,
+      std::optional<llvm::APFloat> scale,
+      std::optional<uint32_t> slidingWindowSize,
+      std::optional<SDPAProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -803,6 +1022,21 @@ struct OpModel<PagedFlashMultiLatentAttentionDecodeOp> {
       std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
       std::optional<TTNNLayoutAttr> attentionSinkLayout,
       std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      std::optional<llvm::ArrayRef<int64_t>> valueShape,
+      std::optional<TTNNLayoutAttr> valueLayout, uint32_t headDimV,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+      std::optional<TTNNLayoutAttr> curPosTensorLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+      std::optional<TTNNLayoutAttr> attentionSinkLayout,
+      std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -862,6 +1096,18 @@ struct OpModel<ScaledDotProductAttentionOp> {
       std::optional<llvm::APFloat> scale,
       std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+      std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
+      std::optional<llvm::APFloat> scale,
+      std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
                llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
@@ -890,6 +1136,16 @@ struct OpModel<FlashMlaPrefillOp> {
       bool isCausal, std::optional<llvm::APFloat> scale,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      std::optional<llvm::ArrayRef<int64_t>> valueShape,
+      std::optional<TTNNLayoutAttr> valueLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
+      bool isCausal, std::optional<llvm::APFloat> scale,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
                llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
@@ -914,6 +1170,14 @@ struct OpModel<RotaryEmbeddingLlamaOp> {
       llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
       bool isDecodeMode, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+      llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+      llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
+      bool isDecodeMode, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
@@ -936,6 +1200,13 @@ struct OpModel<RotaryEmbeddingOp> {
                    TTNNLayoutAttr sinLayout, std::optional<uint32_t> tokenIndex,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+      llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+      std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
@@ -955,6 +1226,14 @@ struct OpModel<NLPCreateQKVHeadsDecodeOp> {
       std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
       std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
       std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
+      std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
+      std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
+      std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -978,6 +1257,13 @@ struct OpModel<SplitQueryKeyValueAndSplitHeadsOp> {
                    uint32_t numHeads, std::optional<uint32_t> numKVHeads,
                    bool transposeKey, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
+      std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
+      std::optional<uint32_t> numKVHeads, bool transposeKey,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
@@ -996,6 +1282,10 @@ struct OpModel<NLPConcatHeadsOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              TTNNLayoutAttr outputLayout);
@@ -1010,6 +1300,12 @@ struct OpModel<NLPConcatHeadsDecodeOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, uint32_t headDim,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, uint32_t headDim,
+                            TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1027,6 +1323,11 @@ struct OpModel<RepeatInterleaveOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const unsigned int repeats,
                    const int dim, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1046,6 +1347,11 @@ struct OpModel<RepeatOp> {
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> repeats,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              llvm::ArrayRef<int64_t> repeats,
@@ -1064,6 +1370,11 @@ struct OpModel<PadOp> {
                    llvm::APFloat padValue, bool multicore,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue,
@@ -1080,6 +1391,11 @@ struct OpModel<SortOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, int dim, bool descending,
                    bool stable, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
+      bool descending, bool stable, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1099,6 +1415,13 @@ struct OpModel<TopKRouterGptOp> {
       llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
       llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
       uint32_t numExperts, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
+      uint32_t numExperts, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1124,6 +1447,17 @@ struct OpModel<LinearOp> {
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
           std::nullopt);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
+      bool transposeA, bool transposeB,
+      std::optional<llvm::StringRef> activation,
+      std::optional<mlir::Attribute> programConfigAttr,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
                llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -1138,6 +1472,7 @@ struct OpModel<LinearOp> {
 
 template <>
 struct OpModel<MatmulOp> {
+  // Cache-facing (stateless) entry; signature unchanged for getOrCompute.
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -1146,6 +1481,16 @@ struct OpModel<MatmulOp> {
       std::optional<mlir::Attribute> programConfigAttr = std::nullopt,
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
           std::nullopt);
+
+  // Stateful entry used by the L1 spill path; bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
+      std::optional<llvm::StringRef> activation,
+      std::optional<mlir::Attribute> programConfigAttr,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -1175,6 +1520,12 @@ struct OpModel<FillCacheOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       uint32_t batchOffset, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      uint32_t batchOffset, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
                llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1193,6 +1544,13 @@ struct OpModel<UpdateCacheOp> {
       llvm::ArrayRef<int64_t> updateIndexShape,
       TTNNLayoutAttr updateIndexLayout, uint32_t batchOffset,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> updateIndexShape,
+      TTNNLayoutAttr updateIndexLayout, uint32_t batchOffset,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
@@ -1217,6 +1575,15 @@ struct OpModel<PagedUpdateCacheOp> {
       std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> updateIndexShape,
+      TTNNLayoutAttr updateIndexLayout,
+      std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
+      std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
                llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1240,6 +1607,14 @@ struct OpModel<PagedFillCacheOp> {
       std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
       std::optional<TTNNLayoutAttr> batchIdxLayout,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
+      std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
@@ -1270,6 +1645,20 @@ struct OpModel<Conv2dOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1345,6 +1734,21 @@ struct OpModel<Conv3dOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_depth,
+      uint32_t input_height, uint32_t input_width,
+      llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+      llvm::ArrayRef<int32_t> padding, uint32_t groups,
+      llvm::StringRef padding_mode,
+      std::optional<ttcore::DataTypeAttr> outputDtype,
+      std::optional<Conv3dConfigAttr> conv3dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -1380,6 +1784,19 @@ struct OpModel<ConvTranspose2dOp> {
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
+      uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -1414,6 +1831,21 @@ struct OpModel<PrepareConv2dWeightsOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+      MemoryConfigAttr inputMemConfig,
+      ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
+      int32_t inChannels, int32_t outChannels, int32_t batchSize,
+      int32_t inputHeight, int32_t inputWidth,
+      llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+      bool hasBias, int32_t groups, ttcore::DataType inputDtype,
+      std::optional<ttcore::DataType> outputDtype,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1434,6 +1866,19 @@ struct OpModel<PrepareConv2dBiasOp> {
       std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+      MemoryConfigAttr inputMemConfig,
+      ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
+      int32_t outChannels, int32_t batchSize, int32_t inputHeight,
+      int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, int32_t groups,
+      ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1456,6 +1901,21 @@ struct OpModel<PrepareConvTranspose2dWeightsOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+      MemoryConfigAttr inputMemConfig,
+      ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
+      int32_t inChannels, int32_t outChannels, int32_t batchSize,
+      int32_t inputHeight, int32_t inputWidth,
+      llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
+      llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
+      ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1477,6 +1937,20 @@ struct OpModel<PrepareConvTranspose2dBiasOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+      MemoryConfigAttr inputMemConfig,
+      ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
+      int32_t outChannels, int32_t batchSize, int32_t inputHeight,
+      int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, int32_t groups,
+      ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1493,6 +1967,15 @@ struct OpModel<PrepareMoEComputeW0W1WeightsOp> {
                    std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
                    std::optional<TTNNLayoutAttr> bias1Layout,
                    uint32_t hiddenSize, uint32_t intermediateSize);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> w0Shape, TTNNLayoutAttr w0Layout,
+      llvm::ArrayRef<int64_t> w1Shape, TTNNLayoutAttr w1Layout,
+      std::optional<llvm::ArrayRef<int64_t>> bias0Shape,
+      std::optional<TTNNLayoutAttr> bias0Layout,
+      std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
+      std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
+      uint32_t intermediateSize, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1506,6 +1989,12 @@ struct OpModel<PrepareMoEComputeW2WeightsOp> {
                    std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
                    std::optional<TTNNLayoutAttr> bias2Layout,
                    uint32_t hiddenSize, uint32_t intermediateSize);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
+      std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
+      std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
+      uint32_t intermediateSize, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1522,6 +2011,15 @@ struct OpModel<MaxPool2dOp> {
       llvm::ArrayRef<int32_t> dilation, bool ceilMode,
       bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+      bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1549,6 +2047,16 @@ struct OpModel<MaxPool2dWithIndicesOp> {
       bool reallocateHaloOutput, bool deallocateInput, bool returnIndices,
       std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+      bool reallocateHaloOutput, bool deallocateInput, bool returnIndices,
+      std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
@@ -1575,6 +2083,15 @@ struct OpModel<AvgPool2dOp> {
       bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+      bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
@@ -1595,6 +2112,11 @@ struct OpModel<GlobalAvgPool2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1620,6 +2142,18 @@ struct OpModel<BatchNormInferenceOp> {
                    std::optional<llvm::ArrayRef<int64_t>> biasShape,
                    std::optional<TTNNLayoutAttr> biasLayout,
                    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
+      std::optional<TTNNLayoutAttr> runningMeanLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
+      std::optional<TTNNLayoutAttr> runningVarLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1652,6 +2186,19 @@ struct OpModel<BatchNormTrainingOp> {
       std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
       llvm::APFloat momentum, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
+      std::optional<TTNNLayoutAttr> runningMeanLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
+      std::optional<TTNNLayoutAttr> runningVarLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      llvm::APFloat momentum, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
@@ -1681,6 +2228,16 @@ struct OpModel<RMSNormOp> {
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
           std::nullopt);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      TTNNLayoutAttr outputLayout,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<llvm::ArrayRef<int64_t>> weightShape,
@@ -1705,6 +2262,13 @@ struct OpModel<RMSNormPreAllGatherOp> {
       std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+      std::optional<TTNNLayoutAttr> residualInputLayout,
+      std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
@@ -1728,6 +2292,14 @@ struct OpModel<LayerNormOp> {
                    std::optional<TTNNLayoutAttr> biasLayout,
                    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> weightShape,
@@ -1750,6 +2322,15 @@ struct OpModel<LayerNormPreAllGatherOp> {
       std::optional<llvm::ArrayRef<int64_t>> recipShape,
       std::optional<TTNNLayoutAttr> recipLayout,
       std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+      std::optional<TTNNLayoutAttr> residualInputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> recipShape,
+      std::optional<TTNNLayoutAttr> recipLayout,
+      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1775,6 +2356,15 @@ struct OpModel<LayerNormPostAllGatherOp> {
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1803,6 +2393,17 @@ struct OpModel<GroupNormOp> {
                    std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
                    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
+      std::optional<TTNNLayoutAttr> inputMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
+      llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
@@ -1825,6 +2426,12 @@ struct OpModel<ClampScalarOp> {
                    TTNNLayoutAttr inputLayout, mlir::Attribute min,
                    mlir::Attribute max, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, mlir::Attribute min,
+                            mlir::Attribute max, TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              mlir::Attribute min,
@@ -1843,6 +2450,12 @@ struct OpModel<ClampTensorOp> {
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> minShape,
                    TTNNLayoutAttr minLayout, llvm::ArrayRef<int64_t> maxShape,
                    TTNNLayoutAttr maxLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
+      llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1863,6 +2476,11 @@ struct OpModel<PermuteOp> {
                    llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
@@ -1880,6 +2498,11 @@ struct OpModel<PowScalarOp> {
                    TTNNLayoutAttr inputLayout, mlir::Attribute exponent,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      mlir::Attribute exponent, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              mlir::Attribute exponent,
@@ -1896,6 +2519,11 @@ struct OpModel<UpsampleOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
                    llvm::StringRef mode, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      mlir::Attribute scaleFactor, llvm::StringRef mode,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1916,6 +2544,11 @@ struct OpModel<EmbeddingOp> {
                    llvm::ArrayRef<int64_t> weightShape,
                    TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -1934,6 +2567,12 @@ struct OpModel<EmbeddingBackwardOp> {
       llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -1951,6 +2590,12 @@ struct OpModel<GatherOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
       int32_t dim, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
+      int32_t dim, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2003,6 +2648,11 @@ template <>
 struct OpModel<ConstantOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(mlir::ElementsAttr value, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(mlir::ElementsAttr value,
+                            TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -2062,6 +2712,11 @@ struct OpModel<TopKOp> {
                    TTNNLayoutAttr inputLayout, int k, int dim, bool largest,
                    bool sorted, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int k,
+      int dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout, int k,
                                              int dim, bool largest, bool sorted,
@@ -2083,6 +2738,16 @@ struct OpModel<SamplingOp> {
                    llvm::ArrayRef<int64_t> pShape, TTNNLayoutAttr pLayout,
                    llvm::ArrayRef<int64_t> tempShape, TTNNLayoutAttr tempLayout,
                    std::optional<uint32_t> seed, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputValuesShape,
+      TTNNLayoutAttr inputValuesLayout,
+      llvm::ArrayRef<int64_t> inputIndicesShape,
+      TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
+      TTNNLayoutAttr kLayout, llvm::ArrayRef<int64_t> pShape,
+      TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
+      TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputValuesShape,
@@ -2106,6 +2771,11 @@ struct OpModel<MeshPartitionOp> {
                    TTNNLayoutAttr inputLayout, int32_t dim,
                    std::optional<uint32_t> clusterAxis,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t dim, std::optional<uint32_t> clusterAxis,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1069,6 +1069,16 @@ struct OpModel<ChunkedScaledDotProductAttentionOp> {
       std::optional<SDPAProgramConfigAttr> programConfig,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      llvm::ArrayRef<int64_t> chunkStartIdxShape,
+      TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
+      std::optional<SDPAProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
       llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1807,9 +1807,99 @@ void L1SpillManagement<MemoryTracker>::insertReshardForConsumer(
 }
 
 //===----------------------------------------------------------------------===//
+// MockAllocatorL1Tracker
+//===----------------------------------------------------------------------===//
+
+op_constraint_validation::ValidationResult
+MockAllocatorL1Tracker::validate(Operation *op,
+                                 llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                                 const OpConfig &config) const {
+  // Test-only hook takes precedence and is state-agnostic.
+  if (backendValidator) {
+    return backendValidator(op, inputLayouts, config, /*additionalL1Usage=*/0);
+  }
+
+  // Flatten the currently-live L1 allocations into the stateful query's initial
+  // state. additionalL1Usage is 0: the live set is encoded in the records, not
+  // a scalar. Ops that don't override the stateful interface method fall back
+  // to the (cached) stateless query and return no records.
+  llvm::SmallVector<op_model::OpModelAllocationRecord> flat;
+  for (const auto &entry : liveRecords) {
+    flat.append(entry.second.begin(), entry.second.end());
+  }
+
+  op_constraint_validation::ValidationResult result =
+      op_constraint_validation::validateOperation(op, inputLayouts, config,
+                                                  flat,
+                                                  /*additionalL1Usage=*/0);
+
+  // Stash this op's output records for association at addTensor time.
+  if (result.isSuccess() && !result.outputAllocations.empty()) {
+    pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
+                                   result.outputAllocations.end());
+  }
+  return result;
+}
+
+void MockAllocatorL1Tracker::init(uint64_t l1BudgetPerCore) {
+  SumL1MemoryTracker::init(l1BudgetPerCore);
+  liveRecords.clear();
+  pendingRecords.clear();
+}
+
+void MockAllocatorL1Tracker::addTensor(Value result, uint64_t l1SizePerCore) {
+  SumL1MemoryTracker::addTensor(result, l1SizePerCore);
+  // Associate the pending record for this result (positional: i-th tensor
+  // result <-> i-th output-buffer record). Ops that produced no records (not
+  // migrated to the stateful path) simply contribute nothing to the state.
+  Operation *op = result.getDefiningOp();
+  if (!op) {
+    return;
+  }
+  auto it = pendingRecords.find(op);
+  if (it == pendingRecords.end()) {
+    return;
+  }
+  const unsigned idx = mlir::cast<OpResult>(result).getResultNumber();
+  if (idx < it->second.size()) {
+    liveRecords[result] = RecordVec{it->second[idx]};
+  }
+}
+
+void MockAllocatorL1Tracker::addTensorAtAddress(Value result,
+                                                uint64_t l1SizePerCore,
+                                                Value srcAtSameAddr) {
+  // Alias (e.g. a reshape view): shares srcAtSameAddr's buffer, so it adds no
+  // new allocation to the state — do not add a record for `result` (that would
+  // double-count the same buffer). The base tracks the address alias group.
+  SumL1MemoryTracker::addTensorAtAddress(result, l1SizePerCore, srcAtSameAddr);
+}
+
+void MockAllocatorL1Tracker::removeTensor(Value result) {
+  SumL1MemoryTracker::removeTensor(result);
+  liveRecords.erase(result);
+}
+
+void MockAllocatorL1Tracker::removeTensorFromSizes(Value result) {
+  SumL1MemoryTracker::removeTensorFromSizes(result);
+  // Eviction spills to DRAM via this path: the tensor has left L1.
+  liveRecords.erase(result);
+}
+
+MockAllocatorL1Tracker::Snapshot MockAllocatorL1Tracker::takeSnapshot() const {
+  return Snapshot{SumL1MemoryTracker::takeSnapshot(), liveRecords};
+}
+
+void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
+  SumL1MemoryTracker::restoreSnapshot(snapshot.base);
+  liveRecords = snapshot.liveRecords;
+}
+
+//===----------------------------------------------------------------------===//
 // Explicit template instantiation
 //===----------------------------------------------------------------------===//
 
 template class L1SpillManagement<SumL1MemoryTracker>;
+template class L1SpillManagement<MockAllocatorL1Tracker>;
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1661,10 +1661,22 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
   auto result = memoryTracker.validateBackendDirect(op, inputLayouts, config,
                                                     /*additionalL1Usage=*/0);
   if (!result.isSuccess()) {
-    op->emitError("L1SpillManagement: DRAM output config failed validation "
-                  "after demotion (")
-        << result.errorMessage << "); this indicates a compiler bug";
-    compilationFailed = true;
+    // The op's demoted (DRAM-interleaved) output config does not validate given
+    // its current inputs. This is expected for layout-constrained ops: e.g.
+    // ttnn.typecast requires input and output memory layouts to match
+    // (typecast_device_op.cpp), so a DRAM-interleaved output paired with a
+    // still-sharded L1 input is rejected. Such an op cannot be CB-managed by
+    // demoting its output. Rather than abort the whole pass, leave the op as-is
+    // and let the downstream OperationValidationAndFallback pass reconcile the
+    // layout -- the same recovery the pass gets when this op-model error is
+    // classified as a plain backend error. Aborting here instead regresses
+    // models whose CB-vs-L1 clash lands on such an op
+    // (https://github.com/tenstorrent/tt-mlir/issues/9064).
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "    DRAM_CB_SKIP: {0} DRAM-output config failed validation "
+                 "after demotion ({1}); leaving op for downstream layout fixup",
+                 op->getName(),
+                 ttmlir::utils::firstNLines(result.errorMessage, 1));
     return;
   }
   if (result.cbPeakUsage == 0) {

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1884,6 +1884,16 @@ MockAllocatorL1Tracker::validate(Operation *op,
     // includes this op's inputs) + this op's output.
     uint64_t projected = getOccupiedL1() + result.outputL1Usage;
     if (l1Budget > 0 && projected > l1Budget) {
+      // Diagnostic: TTMLIR_SPILL_DEBUG=1 distinguishes a byte-cap OOM (this
+      // branch) from a device/CB OOM surfaced by the query itself (below), so
+      // an over-conservative spill can be attributed. See tt-mlir #9069 debug.
+      if (::getenv("TTMLIR_SPILL_DEBUG")) {
+        llvm::errs() << "[spill-debug] BYTE-CAP-OOM op=" << op->getName()
+                     << " occupied=" << getOccupiedL1()
+                     << " output=" << result.outputL1Usage
+                     << " projected=" << projected << " budget=" << l1Budget
+                     << "\n";
+      }
       return op_constraint_validation::ValidationResult::outOfMemoryError(
           "stateful: projected L1 (" + std::to_string(projected) +
           "B) exceeds optimizer budget (" + std::to_string(l1Budget) + "B)");
@@ -1893,6 +1903,13 @@ MockAllocatorL1Tracker::validate(Operation *op,
       pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
                                      result.outputAllocations.end());
     }
+  } else if (::getenv("TTMLIR_SPILL_DEBUG")) {
+    llvm::errs() << "[spill-debug] QUERY-NON-SUCCESS op=" << op->getName()
+                 << " status="
+                 << (result.isNotImplemented()      ? "NotImplemented"
+                     : result.isMetalBackendError() ? "BackendError"
+                                                    : "OOM/other")
+                 << " msg=" << result.errorMessage << "\n";
   }
   return result;
 }
@@ -2144,6 +2161,15 @@ bool StatefulL1SpillManagement::replayFrom(size_t startIdx) {
     if (isOOM) {
       TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                    "Replay: op no longer fits under victim-free history");
+      // Diagnostic (TTMLIR_SPILL_DEBUG=1): name the op whose replay re-query
+      // failed. Pair with the [spill-debug] BYTE-CAP-OOM / QUERY-NON-SUCCESS
+      // line from validate() to attribute the no-fit. See tt-mlir #9069.
+      if (::getenv("TTMLIR_SPILL_DEBUG")) {
+        llvm::errs() << "[spill-debug] REPLAY-NOFIT op=" << defOp->getName()
+                     << " isReshard="
+                     << (insertedReshardValues.count(tensor) ? "yes" : "no")
+                     << " msg=" << result.errorMessage << "\n";
+      }
       return false;
     }
     memoryTracker.addTensor(tensor, l1EventLog[i].sizePerCore);

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -610,9 +610,8 @@ void AddressSimSpillManagement<MemoryTracker>::recoverFromOOM(
 }
 
 template <typename MemoryTracker>
-void AddressSimSpillManagement<MemoryTracker>::commitAllocation(Value val,
-                                                        uint64_t perResultL1,
-                                                        ScheduleData &data) {
+void AddressSimSpillManagement<MemoryTracker>::commitAllocation(
+    Value val, uint64_t perResultL1, ScheduleData &data) {
   auto luIt = data.lastUsePositions.find(val);
   assert(luIt != data.lastUsePositions.end() &&
          "scheduled value missing its lastUsePositions entry");
@@ -624,7 +623,8 @@ void AddressSimSpillManagement<MemoryTracker>::commitAllocation(Value val,
   l1EventLog.push_back({L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
 
   // View-eligible reshape: alias src's buffer instead of carving a fresh slot.
-  // Must stay in sync with the willAliasSourceInL1 short-circuit in ensureFitsL1.
+  // Must stay in sync with the willAliasSourceInL1 short-circuit in
+  // ensureFitsL1.
   Operation *defOp = val.getDefiningOp();
   if (defOp && willAliasSourceInL1(defOp)) {
     memoryTracker.addTensorAtAddress(val, perResultL1, defOp->getOperand(0));
@@ -637,11 +637,9 @@ void AddressSimSpillManagement<MemoryTracker>::commitAllocation(Value val,
 }
 
 template <typename MemoryTracker>
-uint64_t AddressSimSpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
-                                                        int64_t pos,
-                                                        ScheduleData &data,
-                                                        uint64_t cbPeakUsage,
-                                                        uint64_t l1Size) {
+uint64_t AddressSimSpillManagement<MemoryTracker>::ensureFitsL1(
+    Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
+    uint64_t l1Size) {
   // A view-eligible reshape aliases its source's existing L1 slot
   // (addResultsToLiveSet uses addTensorAtAddress), so it consumes no fresh
   // L1. Skip the fit / CB-overlap checks that assume a new allocation —
@@ -744,7 +742,7 @@ void AddressSimSpillManagement<MemoryTracker>::handleOOM(
 
 template <typename MemoryTracker>
 void L1SpillManagementBase<MemoryTracker>::insertEventIntoLog(size_t pos,
-                                                          L1Event event) {
+                                                              L1Event event) {
   // Insert the event and shift every index >= pos in both index structures
   // so the invariant "addressSnapshots[i] = state before event i" and
   // "allocEventIndex[v] = i <=> l1EventLog[i] is v's kAlloc" are preserved.
@@ -870,14 +868,14 @@ bool L1SpillManagementBase<MemoryTracker>::evictValue(
   spillToDram(victim);
   memoryTracker.removeTensorFromSizes(victim);
 
-  // Rewind (stateful) path: the address-sim path frees the victim by marking its
-  // alloc event skipped in the replay; the rewind re-run has no such skip and
-  // re-processes the victim's op, which still produces L1. After the spill the
-  // victim's only remaining L1 use is the to_memory_config inserted right after
-  // it, so shorten its tracked lifetime to its own position — the re-run then
-  // frees it immediately (processDeadTensors) instead of keeping it live to its
-  // original far-future last use, which is what actually frees L1 for the op
-  // that triggered this eviction.
+  // Rewind (stateful) path: the address-sim path frees the victim by marking
+  // its alloc event skipped in the replay; the rewind re-run has no such skip
+  // and re-processes the victim's op, which still produces L1. After the spill
+  // the victim's only remaining L1 use is the to_memory_config inserted right
+  // after it, so shorten its tracked lifetime to its own position — the re-run
+  // then frees it immediately (processDeadTensors) instead of keeping it live
+  // to its original far-future last use, which is what actually frees L1 for
+  // the op that triggered this eviction.
   if (usesRewindEviction() && victimOp) {
     int64_t victimPos = data.positionMap.lookup(victimOp);
     auto luIt = data.lastUsePositions.find(victim);
@@ -1030,10 +1028,10 @@ bool L1SpillManagementBase<MemoryTracker>::evictValue(
         } else {
           // Future consumer, OR any consumer on the stateful rewind path:
           // insert the reshard into the schedule so the (re-run) forward sweep
-          // processes it as an ordinary op — querying and tracking its L1 buffer
-          // in schedule order. This is why the stateful path never leaves a
-          // reshard untracked (RCA #2). Each insertion shifts the consumer right
-          // by one, so advance consumerPos.
+          // processes it as an ordinary op — querying and tracking its L1
+          // buffer in schedule order. This is why the stateful path never
+          // leaves a reshard untracked (RCA #2). Each insertion shifts the
+          // consumer right by one, so advance consumerPos.
           insertReshardIntoSchedule(reshardOp, reshardResult,
                                     reshardSizePerCore, consumerPos, data);
           ++consumerPos;
@@ -1043,15 +1041,15 @@ bool L1SpillManagementBase<MemoryTracker>::evictValue(
   }
 
   // Stateful (rewind) path: allocator state is rebuilt by the rewind + re-run
-  // of the forward sweep driven by recoverFromOOM. No event-log replay here, and
-  // all reshards were routed into the schedule above.
+  // of the forward sweep driven by recoverFromOOM. No event-log replay here,
+  // and all reshards were routed into the schedule above.
   if (usesRewindEviction()) {
     return true;
   }
 
-  // Address-sim path: apply transient event insertions largest-position-first so
-  // earlier positions are not invalidated by later insertions, then rebuild via
-  // the first-fit replay.
+  // Address-sim path: apply transient event insertions largest-position-first
+  // so earlier positions are not invalidated by later insertions, then rebuild
+  // via the first-fit replay.
   llvm::sort(transientInsertions,
              [](const TransientInsertion &a, const TransientInsertion &b) {
                return a.pos > b.pos;
@@ -1107,8 +1105,8 @@ void L1SpillManagementBase<MemoryTracker>::insertReshardIntoSchedule(
   data.deathSchedule = std::move(newDeathSchedule);
 
   // Keep position-keyed sweep checkpoints (stateful rewind path) aligned across
-  // the insertion: keys >= consumerPos shift by +1, mirroring positionMap. Empty
-  // (a no-op) on the Sum path, which does not capture checkpoints.
+  // the insertion: keys >= consumerPos shift by +1, mirroring positionMap.
+  // Empty (a no-op) on the Sum path, which does not capture checkpoints.
   if (!sweepCheckpoints.empty()) {
     llvm::DenseMap<int64_t, SweepCheckpoint> shifted;
     shifted.reserve(sweepCheckpoints.size());
@@ -1158,7 +1156,8 @@ bool L1SpillManagementBase<MemoryTracker>::evictUntil(
   if (!rebuildPlacedAll) {
     Operation *blockedOp = data.schedule[pos];
     blockedOp->emitError(
-        "L1SpillManagementBase: a live tensor has no contiguous L1 placement even "
+        "L1SpillManagementBase: a live tensor has no contiguous L1 placement "
+        "even "
         "after evicting every spillable tensor (fragmentation: a non-evictable "
         "inserted reshard or irreducible working set cannot be relocated)");
     compilationFailed = true;
@@ -1173,10 +1172,8 @@ bool L1SpillManagementBase<MemoryTracker>::evictUntil(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t AddressSimSpillManagement<MemoryTracker>::handleNoFit(Operation *op,
-                                                       int64_t pos,
-                                                       ScheduleData &data,
-                                                       uint64_t outputL1Size) {
+uint64_t AddressSimSpillManagement<MemoryTracker>::handleNoFit(
+    Operation *op, int64_t pos, ScheduleData &data, uint64_t outputL1Size) {
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "    NO_FIT: output {0} bytes can't fit contiguously, evicting",
                outputL1Size);
@@ -1320,7 +1317,8 @@ uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
     }
     if (!fitsAfterSiblingSpill) {
       op->emitError(
-          "L1SpillManagementBase: sibling-operand spill left a live tensor with no "
+          "L1SpillManagementBase: sibling-operand spill left a live tensor "
+          "with no "
           "contiguous L1 placement (fragmentation cannot be resolved by "
           "demoting this op)");
       compilationFailed = true;
@@ -1625,9 +1623,9 @@ void L1SpillManagementBase<MemoryTracker>::run() {
       int64_t r = *pendingRewindTo;
       pendingRewindTo.reset();
       restoreCheckpoint(r);
-      // Drop stale checkpoints past the rewind point; the re-run recaptures them
-      // at each position it re-processes, so no checkpoint older than the current
-      // pass is ever restored.
+      // Drop stale checkpoints past the rewind point; the re-run recaptures
+      // them at each position it re-processes, so no checkpoint older than the
+      // current pass is ever restored.
       llvm::SmallVector<int64_t> stale;
       for (const auto &kv : sweepCheckpoints) {
         if (kv.first > r) {
@@ -1642,7 +1640,8 @@ void L1SpillManagementBase<MemoryTracker>::run() {
       // count. A runaway means a logic error (a re-added victim, a rewind that
       // makes no progress); fail loudly rather than spin.
       if (++rewindCount > kMaxRewinds) {
-        llvm_unreachable("stateful spill: rewind budget exceeded (no progress)");
+        llvm_unreachable(
+            "stateful spill: rewind budget exceeded (no progress)");
       }
       pos = r - 1; // ++pos brings the sweep to r
       continue;
@@ -1740,9 +1739,8 @@ void L1SpillManagementBase<MemoryTracker>::demoteToDram(Operation *op) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::evictAllFromL1(int64_t pos,
-                                                      ScheduleData &data,
-                                                      Operation *triggerOp) {
+void L1SpillManagementBase<MemoryTracker>::evictAllFromL1(
+    int64_t pos, ScheduleData &data, Operation *triggerOp) {
   llvm::SmallVector<Operation *> evictedOps;
   for (Value victim : liveValues) {
     uint64_t freedBytes = memoryTracker.getTensorSize(victim);
@@ -1993,16 +1991,6 @@ MockAllocatorL1Tracker::validate(Operation *op,
     // includes this op's inputs) + this op's output.
     uint64_t projected = getOccupiedL1() + result.outputL1Usage;
     if (l1Budget > 0 && projected > l1Budget) {
-      // Diagnostic: TTMLIR_SPILL_DEBUG=1 distinguishes a byte-cap OOM (this
-      // branch) from a device/CB OOM surfaced by the query itself (below), so
-      // an over-conservative spill can be attributed. See tt-mlir #9069 debug.
-      if (::getenv("TTMLIR_SPILL_DEBUG")) {
-        llvm::errs() << "[spill-debug] BYTE-CAP-OOM op=" << op->getName()
-                     << " occupied=" << getOccupiedL1()
-                     << " output=" << result.outputL1Usage
-                     << " projected=" << projected << " budget=" << l1Budget
-                     << "\n";
-      }
       return op_constraint_validation::ValidationResult::outOfMemoryError(
           "stateful: projected L1 (" + std::to_string(projected) +
           "B) exceeds optimizer budget (" + std::to_string(l1Budget) + "B)");
@@ -2012,13 +2000,6 @@ MockAllocatorL1Tracker::validate(Operation *op,
       pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
                                      result.outputAllocations.end());
     }
-  } else if (::getenv("TTMLIR_SPILL_DEBUG")) {
-    llvm::errs() << "[spill-debug] QUERY-NON-SUCCESS op=" << op->getName()
-                 << " status="
-                 << (result.isNotImplemented()      ? "NotImplemented"
-                     : result.isMetalBackendError() ? "BackendError"
-                                                    : "OOM/other")
-                 << " msg=" << result.errorMessage << "\n";
   }
   return result;
 }
@@ -2166,10 +2147,8 @@ void StatefulL1SpillManagement::commitAllocation(Value val,
          "scheduled value missing its lastUsePositions entry");
   int64_t resultLastUse = luIt->second;
 
-  // Log the alloc event and checkpoint the record set for eviction replay.
-  allocEventIndex[val] = l1EventLog.size();
-  addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
-  l1EventLog.push_back({L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
+  // No event log here: the stateful path rebuilds state by rewinding and
+  // re-running the sweep (per-position checkpoints), not via event-log replay.
 
   // View-eligible op whose source is still L1-resident: alias its buffer (no
   // new record). Otherwise associate this result's own output record.
@@ -2207,9 +2186,10 @@ void StatefulL1SpillManagement::recoverFromOOM(
     // genuinely-unplaceable working set). Degrade gracefully: demote this op's
     // output to DRAM and continue, rather than failing the pass.
     observer_->onSelfSpill(op, pos);
-    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "    DEMOTE SELF (stateful): {0} unplaceable after draining L1",
-                 ttmlir::opToString(op));
+    TTMLIR_DEBUG(
+        ttmlir::LogComponent::GreedyOptimizer,
+        "    DEMOTE SELF (stateful): {0} unplaceable after draining L1",
+        ttmlir::opToString(op));
     demoteToDram(op);
     return; // no rewind; sweep advances to pos+1
   }
@@ -2219,9 +2199,10 @@ void StatefulL1SpillManagement::recoverFromOOM(
   evictValue(victim, pos, data, unusedCampaign);
 
   // Rewind to the victim's own allocation position. Reshards insert at consumer
-  // positions (> victimPos, since a consumer follows its producer), so victimPos
-  // is the earliest position affected by this eviction. Re-read positionMap in
-  // case insertions shifted it (they should not, being after victimPos).
+  // positions (> victimPos, since a consumer follows its producer), so
+  // victimPos is the earliest position affected by this eviction. Re-read
+  // positionMap in case insertions shifted it (they should not, being after
+  // victimPos).
   int64_t victimPos = data.positionMap.lookup(victimOp);
   pendingRewindTo = victimPos;
 }

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -870,6 +870,26 @@ bool L1SpillManagementBase<MemoryTracker>::evictValue(
   spillToDram(victim);
   memoryTracker.removeTensorFromSizes(victim);
 
+  // Rewind (stateful) path: the address-sim path frees the victim by marking its
+  // alloc event skipped in the replay; the rewind re-run has no such skip and
+  // re-processes the victim's op, which still produces L1. After the spill the
+  // victim's only remaining L1 use is the to_memory_config inserted right after
+  // it, so shorten its tracked lifetime to its own position — the re-run then
+  // frees it immediately (processDeadTensors) instead of keeping it live to its
+  // original far-future last use, which is what actually frees L1 for the op
+  // that triggered this eviction.
+  if (usesRewindEviction() && victimOp) {
+    int64_t victimPos = data.positionMap.lookup(victimOp);
+    auto luIt = data.lastUsePositions.find(victim);
+    if (luIt != data.lastUsePositions.end() && luIt->second != victimPos) {
+      auto &oldBucket = data.deathSchedule[luIt->second];
+      oldBucket.erase(std::remove(oldBucket.begin(), oldBucket.end(), victim),
+                      oldBucket.end());
+    }
+    data.lastUsePositions[victim] = victimPos;
+    data.deathSchedule[victimPos].push_back(victim);
+  }
+
   // Restore the original L1-sharded layout for consumers that need it:
   // - Past consumers (pos < currentPos): always restore. They were already
   //   validated assuming L1-sharded input; without reshard the IR is broken.
@@ -971,7 +991,9 @@ bool L1SpillManagementBase<MemoryTracker>::evictValue(
                       originalL1Layout,
                       ttmlir::utils::volume(originalL1Layout.getGridShape()));
 
-        if (isPastConsumer) {
+        if (isPastConsumer && !usesRewindEviction()) {
+          // Address-sim path: bracket the reshard's transient occupation in the
+          // event log so replayFrom accounts for it.
           // Find the consumer's first and last output alloc event indices so
           // we can bracket the reshard's transient occupation in the log.
           size_t firstAllocIdx = std::numeric_limits<size_t>::max();
@@ -1006,9 +1028,12 @@ bool L1SpillManagementBase<MemoryTracker>::evictValue(
                  {L1Event::kAlloc, reshardResult, reshardSizePerCore, false}});
           }
         } else {
-          // Insert the reshard into the schedule so the forward sweep processes
-          // it naturally, adding it to liveValues and the tracker. Each
-          // insertion shifts the consumer right by one, so advance consumerPos.
+          // Future consumer, OR any consumer on the stateful rewind path:
+          // insert the reshard into the schedule so the (re-run) forward sweep
+          // processes it as an ordinary op — querying and tracking its L1 buffer
+          // in schedule order. This is why the stateful path never leaves a
+          // reshard untracked (RCA #2). Each insertion shifts the consumer right
+          // by one, so advance consumerPos.
           insertReshardIntoSchedule(reshardOp, reshardResult,
                                     reshardSizePerCore, consumerPos, data);
           ++consumerPos;
@@ -1017,8 +1042,16 @@ bool L1SpillManagementBase<MemoryTracker>::evictValue(
     }
   }
 
-  // Apply transient event insertions largest-position-first so earlier
-  // positions are not invalidated by later insertions.
+  // Stateful (rewind) path: allocator state is rebuilt by the rewind + re-run
+  // of the forward sweep driven by recoverFromOOM. No event-log replay here, and
+  // all reshards were routed into the schedule above.
+  if (usesRewindEviction()) {
+    return true;
+  }
+
+  // Address-sim path: apply transient event insertions largest-position-first so
+  // earlier positions are not invalidated by later insertions, then rebuild via
+  // the first-fit replay.
   llvm::sort(transientInsertions,
              [](const TransientInsertion &a, const TransientInsertion &b) {
                return a.pos > b.pos;
@@ -2116,103 +2149,51 @@ void StatefulL1SpillManagement::commitAllocation(Value val,
 
 void StatefulL1SpillManagement::recoverFromOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> /*tensorResults*/,
-    ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
+    ScheduleData &data, std::function<void(uint64_t)> /*addResultsToLiveSet*/) {
   observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
-  TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-               "    OOM (stateful): evicting until the query fits");
 
-  // Evict farthest-last-use tensors until the stateful re-query succeeds. Each
-  // eviction drops the victim's records and replays the surviving allocation
-  // history (replayFrom) so the allocator re-flows addresses under the
-  // victim-free history; fragmentation is decided by the query, never here.
-  auto config = extractOpConfigFromIR(op);
-  auto result = op_constraint_validation::ValidationResult::outOfMemoryError("");
-  bool fitsAfterEviction = evictUntil(pos, data, [&]() {
-    auto inputLayouts = utils::extractInputLayouts(op);
-    result = memoryTracker.validate(op, inputLayouts, config);
-    return result.isSuccess();
-  });
-  if (compilationFailed) {
-    return;
-  }
-
-  if (fitsAfterEviction) {
-    // Eviction may have inserted a reshard for `op`, shifting it past `pos`;
-    // bail so run()'s sweep reprocesses the reshard and then `op`.
-    if (data.schedule[pos] != op) {
-      return;
-    }
-    uint64_t l1Size = result.outputL1Usage;
-    if (l1Size > 0) {
-      addResultsToLiveSet(l1Size);
-      observer_->onLiveAdded(op, pos, l1Size, pos,
-                             memoryTracker.getOccupiedL1());
-    }
-  } else {
+  // Evict ONE farthest-last-use victim, then rewind and re-run the forward
+  // sweep. evictValue spills the victim to DRAM and routes its consumers'
+  // reshards into the schedule; the rewind (pendingRewindTo, honored by run())
+  // restores the checkpoint before the victim's allocation and re-runs the
+  // sweep from there. The victim re-processes as a briefly-live L1 buffer that
+  // is freed immediately (its shortened lifetime), the reshards process as
+  // ordinary schedule ops, and this op is re-reached and re-validated against
+  // the freed state. If it still OOMs, recoverFromOOM fires again for the next
+  // victim -- one eviction per rewind, monotonically shrinking the L1 working
+  // set. There is no separate replay: eviction reuses the one placement
+  // algorithm (the forward sweep), so it cannot diverge from it.
+  Value victim = evictFarthestUse();
+  if (!victim) {
+    // Nothing evictable remains (only non-evictable reshards / an irreducible,
+    // genuinely-unplaceable working set). Degrade gracefully: demote this op's
+    // output to DRAM and continue, rather than failing the pass.
     observer_->onSelfSpill(op, pos);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "    DEMOTE SELF (stateful): op exceeds budget alone");
+                 "    DEMOTE SELF (stateful): {0} unplaceable after draining L1",
+                 ttmlir::opToString(op));
     demoteToDram(op);
+    return; // no rewind; sweep advances to pos+1
   }
+
+  Operation *victimOp = victim.getDefiningOp();
+  size_t unusedCampaign = SIZE_MAX;
+  evictValue(victim, pos, data, unusedCampaign);
+
+  // Rewind to the victim's own allocation position. Reshards insert at consumer
+  // positions (> victimPos, since a consumer follows its producer), so victimPos
+  // is the earliest position affected by this eviction. Re-read positionMap in
+  // case insertions shifted it (they should not, being after victimPos).
+  int64_t victimPos = data.positionMap.lookup(victimOp);
+  pendingRewindTo = victimPos;
 }
 
-bool StatefulL1SpillManagement::replayFrom(size_t startIdx) {
-  auto snapIt = addressSnapshots.find(startIdx);
-  assert(snapIt != addressSnapshots.end() &&
-         "checkpoint not found for replay start index");
-  memoryTracker.restoreSnapshot(snapIt->second);
-
-  // Replay allocation events from startIdx forward under the (victim-free)
-  // history. Each surviving op is re-queried so the allocator assigns fresh
-  // addresses; the resulting record becomes its live-set entry.
-  for (size_t i = startIdx; i < l1EventLog.size(); ++i) {
-    if (l1EventLog[i].skipped) {
-      continue;
-    }
-    if (l1EventLog[i].kind == L1Event::kDealloc) {
-      memoryTracker.removeTensor(l1EventLog[i].tensor);
-      continue;
-    }
-    addressSnapshots[i] = memoryTracker.takeSnapshot();
-    Value tensor = l1EventLog[i].tensor;
-    Operation *defOp = tensor.getDefiningOp();
-    // View alias (src still L1-resident): consumes no fresh buffer.
-    if (defOp && isAliasingViewOp(defOp) &&
-        memoryTracker.hasTensor(defOp->getOperand(0))) {
-      memoryTracker.addTensorAlias(tensor, defOp->getOperand(0));
-      continue;
-    }
-    if (!defOp) {
-      continue;
-    }
-    // Re-query so the allocator re-flows this buffer's address without the
-    // evicted victim in the history.
-    auto inputLayouts = utils::extractInputLayouts(defOp);
-    auto config = extractOpConfigFromIR(defOp);
-    auto result = memoryTracker.validate(defOp, inputLayouts, config);
-    // A still-live op no longer fits (raw size or fragmentation): the caller
-    // (evictUntil) evicts more. Non-OOM outcomes (not-implemented / backend
-    // error, e.g. an unqueryable reshard) leave the buffer untracked but do not
-    // count as a placement failure.
-    bool isOOM = result.isError() && !result.isNotImplemented() &&
-                 !result.isMetalBackendError();
-    if (isOOM) {
-      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
-                   "Replay: op no longer fits under victim-free history");
-      // Diagnostic (TTMLIR_SPILL_DEBUG=1): name the op whose replay re-query
-      // failed. Pair with the [spill-debug] BYTE-CAP-OOM / QUERY-NON-SUCCESS
-      // line from validate() to attribute the no-fit. See tt-mlir #9069.
-      if (::getenv("TTMLIR_SPILL_DEBUG")) {
-        llvm::errs() << "[spill-debug] REPLAY-NOFIT op=" << defOp->getName()
-                     << " isReshard="
-                     << (insertedReshardValues.count(tensor) ? "yes" : "no")
-                     << " msg=" << result.errorMessage << "\n";
-      }
-      return false;
-    }
-    memoryTracker.addTensor(tensor, l1EventLog[i].sizePerCore);
-  }
-  return true;
+bool StatefulL1SpillManagement::replayFrom(size_t /*startIdx*/) {
+  // The stateful path rebuilds allocator state by rewinding and re-running the
+  // forward sweep (see recoverFromOOM), not via event-log replay. evictValue
+  // never calls markEvictedAndRebuild on this path, so this override is
+  // unreachable; it exists only to satisfy the pure-virtual base declaration.
+  llvm_unreachable("StatefulL1SpillManagement uses rewind, not replayFrom");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -266,11 +266,11 @@ SumL1MemoryTracker::wouldAllocateAt(uint64_t l1SizePerCore) const {
 }
 
 //===----------------------------------------------------------------------===//
-// L1SpillManagement
+// L1SpillManagementBase
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-L1SpillManagement<MemoryTracker>::L1SpillManagement(
+L1SpillManagementBase<MemoryTracker>::L1SpillManagementBase(
     func::FuncOp func, ttcore::GridAttr deviceGrid, uint64_t l1BudgetPerCore,
     std::unique_ptr<L1SpillObserver> observer)
     : func(func), deviceGrid(deviceGrid), l1BudgetPerCore(l1BudgetPerCore),
@@ -290,7 +290,7 @@ L1SpillManagement<MemoryTracker>::L1SpillManagement(
 
 template <typename MemoryTracker>
 OpConfig
-L1SpillManagement<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
+L1SpillManagementBase<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
   if (op->getNumResults() == 0) {
     return OpConfig{};
   }
@@ -336,7 +336,7 @@ L1SpillManagement<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
+Value L1SpillManagementBase<MemoryTracker>::evictFarthestUse() {
   while (!liveSet.empty()) {
     auto [lastUse, candidateVal] = liveSet.top();
     liveSet.pop();
@@ -363,7 +363,7 @@ Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::applyOutputConfig(
+void L1SpillManagementBase<MemoryTracker>::applyOutputConfig(
     Operation *op, const op_constraint_validation::ValidationResult &result) {
   TTNNLayoutAttr chosenLayout = result.getFirstActualOutputLayout();
   if (!chosenLayout) {
@@ -404,7 +404,7 @@ void L1SpillManagement<MemoryTracker>::applyOutputConfig(
 
 template <typename MemoryTracker>
 llvm::SmallVector<Operation *>
-L1SpillManagement<MemoryTracker>::collectDownstreamConsumers(
+L1SpillManagementBase<MemoryTracker>::collectDownstreamConsumers(
     Operation *changed) {
   // After spillToDram, a result may have a ToMemoryConfigOp user (spill op).
   // Follow through spill ops to find the actual downstream consumers.
@@ -428,7 +428,7 @@ L1SpillManagement<MemoryTracker>::collectDownstreamConsumers(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::revalidateConsumers(
+void L1SpillManagementBase<MemoryTracker>::revalidateConsumers(
     Operation *changedOp, int64_t currentPos,
     const llvm::DenseMap<Operation *, int64_t> &positionMap) {
   // Worklist of ops whose output changed — seed with the victim/changed op.
@@ -507,8 +507,8 @@ void L1SpillManagement<MemoryTracker>::revalidateConsumers(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-typename L1SpillManagement<MemoryTracker>::ScheduleData
-L1SpillManagement<MemoryTracker>::buildScheduleData() {
+typename L1SpillManagementBase<MemoryTracker>::ScheduleData
+L1SpillManagementBase<MemoryTracker>::buildScheduleData() {
   ScheduleData data;
 
   // Build schedule (ops in IR order = topological order). Include sink ops
@@ -546,7 +546,7 @@ L1SpillManagement<MemoryTracker>::buildScheduleData() {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::processDeadTensors(
+void L1SpillManagementBase<MemoryTracker>::processDeadTensors(
     int64_t pos, const ScheduleData &data) {
   auto it = data.deathSchedule.find(pos - 1);
   if (it == data.deathSchedule.end()) {
@@ -571,7 +571,7 @@ void L1SpillManagement<MemoryTracker>::processDeadTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::willAliasSourceInL1(
+bool L1SpillManagementBase<MemoryTracker>::willAliasSourceInL1(
     Operation *op) const {
   // isAliasingViewOp guarantees op is a view op (reshape/pad/repeat/permute)
   // that aliases its input operand(0). Use hasTensorAddress (not hasTensor):
@@ -588,21 +588,21 @@ bool L1SpillManagement<MemoryTracker>::willAliasSourceInL1(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::placeValidatedOutput(
+uint64_t L1SpillManagementBase<MemoryTracker>::placeValidatedOutput(
     Operation *op, int64_t pos, ScheduleData &data,
     const op_constraint_validation::ValidationResult &result) {
   return ensureFitsL1(op, pos, data, result.cbPeakUsage, result.outputL1Usage);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::recoverFromOOM(
+void L1SpillManagementBase<MemoryTracker>::recoverFromOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
     ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::commitAllocation(Value val,
+void L1SpillManagementBase<MemoryTracker>::commitAllocation(Value val,
                                                         uint64_t perResultL1,
                                                         ScheduleData &data) {
   auto luIt = data.lastUsePositions.find(val);
@@ -629,7 +629,7 @@ void L1SpillManagement<MemoryTracker>::commitAllocation(Value val,
 }
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
+uint64_t L1SpillManagementBase<MemoryTracker>::ensureFitsL1(Operation *op,
                                                         int64_t pos,
                                                         ScheduleData &data,
                                                         uint64_t cbPeakUsage,
@@ -666,7 +666,7 @@ uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::handleOOM(
+void L1SpillManagementBase<MemoryTracker>::handleOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
     ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
@@ -735,7 +735,7 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::insertEventIntoLog(size_t pos,
+void L1SpillManagementBase<MemoryTracker>::insertEventIntoLog(size_t pos,
                                                           L1Event event) {
   // Insert the event and shift every index >= pos in both index structures
   // so the invariant "addressSnapshots[i] = state before event i" and
@@ -759,7 +759,7 @@ void L1SpillManagement<MemoryTracker>::insertEventIntoLog(size_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(
+bool L1SpillManagementBase<MemoryTracker>::markEvictedAndRebuild(
     Value victim, size_t &campaignMin) {
   // O(1) lookup of victim's alloc event.
   auto idxIt = allocEventIndex.find(victim);
@@ -794,7 +794,7 @@ bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
+bool L1SpillManagementBase<MemoryTracker>::replayFrom(size_t startIdx) {
   auto snapIt = addressSnapshots.find(startIdx);
   assert(snapIt != addressSnapshots.end() &&
          "snapshot not found for replay start index");
@@ -842,7 +842,7 @@ bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::evictValue(
+bool L1SpillManagementBase<MemoryTracker>::evictValue(
     Value victim, int64_t pos, ScheduleData &data, size_t &campaignMin,
     Operation *skipReshardConsumer) {
   liveValues.erase(victim);
@@ -1027,7 +1027,7 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
+void L1SpillManagementBase<MemoryTracker>::insertReshardIntoSchedule(
     Operation *reshardOp, Value reshardResult, uint64_t reshardSizePerCore,
     int64_t consumerPos, ScheduleData &data) {
   // Register so evictFarthestUse and sibling eviction guards know not to
@@ -1067,7 +1067,7 @@ void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
 }
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::evictUntil(
+bool L1SpillManagementBase<MemoryTracker>::evictUntil(
     int64_t pos, ScheduleData &data, std::function<bool()> shouldStop) {
   // Helper: true if every remaining live value is a non-evictable inserted
   // reshard. Avoids exhausting the liveSet heap through stale entries when
@@ -1105,7 +1105,7 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
   if (!rebuildPlacedAll) {
     Operation *blockedOp = data.schedule[pos];
     blockedOp->emitError(
-        "L1SpillManagement: a live tensor has no contiguous L1 placement even "
+        "L1SpillManagementBase: a live tensor has no contiguous L1 placement even "
         "after evicting every spillable tensor (fragmentation: a non-evictable "
         "inserted reshard or irreducible working set cannot be relocated)");
     compilationFailed = true;
@@ -1120,7 +1120,7 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
+uint64_t L1SpillManagementBase<MemoryTracker>::handleNoFit(Operation *op,
                                                        int64_t pos,
                                                        ScheduleData &data,
                                                        uint64_t outputL1Size) {
@@ -1173,7 +1173,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
+uint64_t L1SpillManagementBase<MemoryTracker>::handleFragmentation(
     Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
     uint64_t outputL1Size) {
   // Add the same safety cushion as wouldCBsOverlapTensors to account for
@@ -1267,7 +1267,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
     }
     if (!fitsAfterSiblingSpill) {
       op->emitError(
-          "L1SpillManagement: sibling-operand spill left a live tensor with no "
+          "L1SpillManagementBase: sibling-operand spill left a live tensor with no "
           "contiguous L1 placement (fragmentation cannot be resolved by "
           "demoting this op)");
       compilationFailed = true;
@@ -1287,7 +1287,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
+bool L1SpillManagementBase<MemoryTracker>::wouldCBsOverlapTensors(
     Operation *op, int64_t pos, uint64_t cbPeakUsage,
     uint64_t speculativeOutputAddr) {
   // Check if the op's CB region (growing bottom-up from base) would overlap
@@ -1338,7 +1338,7 @@ bool L1SpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::run() {
+void L1SpillManagementBase<MemoryTracker>::run() {
   ScheduleData data = buildScheduleData();
 
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1552,7 +1552,7 @@ void L1SpillManagement<MemoryTracker>::run() {
 
 template <typename MemoryTracker>
 llvm::DenseMap<Value, int64_t>
-L1SpillManagement<MemoryTracker>::computeLastUsePositions(
+L1SpillManagementBase<MemoryTracker>::computeLastUsePositions(
     const llvm::SmallVector<Operation *> &schedule) {
   // Build position map.
   llvm::DenseMap<Operation *, int64_t> positionMap;
@@ -1593,7 +1593,7 @@ L1SpillManagement<MemoryTracker>::computeLastUsePositions(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::demoteToDram(Operation *op) {
+void L1SpillManagementBase<MemoryTracker>::demoteToDram(Operation *op) {
   for (auto opResult : op->getResults()) {
     auto tensorType = mlir::dyn_cast<RankedTensorType>(opResult.getType());
     if (!tensorType) {
@@ -1623,7 +1623,7 @@ void L1SpillManagement<MemoryTracker>::demoteToDram(Operation *op) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictAllFromL1(int64_t pos,
+void L1SpillManagementBase<MemoryTracker>::evictAllFromL1(int64_t pos,
                                                       ScheduleData &data,
                                                       Operation *triggerOp) {
   llvm::SmallVector<Operation *> evictedOps;
@@ -1662,7 +1662,7 @@ void L1SpillManagement<MemoryTracker>::evictAllFromL1(int64_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictForCBOverlap(
+void L1SpillManagementBase<MemoryTracker>::evictForCBOverlap(
     uint64_t cushionedCBUsage, int64_t pos, ScheduleData &data) {
   evictUntil(pos, data, [&]() {
     return cushionedCBUsage <= memoryTracker.getLowestOccupiedAddress();
@@ -1674,7 +1674,7 @@ void L1SpillManagement<MemoryTracker>::evictForCBOverlap(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
+void L1SpillManagementBase<MemoryTracker>::evictForDramCBGrowth(
     Operation *op, int64_t pos, ScheduleData &data) {
 
   auto inputLayouts = utils::extractInputLayouts(op);
@@ -1721,7 +1721,7 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
   // rather than emit IR that overflows L1 at runtime.
   if (!liveValues.empty() &&
       dramCBCushioned > memoryTracker.getLowestOccupiedAddress()) {
-    op->emitError("L1SpillManagement: ")
+    op->emitError("L1SpillManagementBase: ")
         << op->getName()
         << " requires an L1 input restored by an inserted reshard, but its "
            "circular-buffer region overlaps that reshard's L1 slot and the "
@@ -1736,19 +1736,19 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::spillToDram(Value result) {
+void L1SpillManagementBase<MemoryTracker>::spillToDram(Value result) {
   spillToDramImpl(result, /*insertBefore=*/nullptr);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::spillToDramBeforeTrigger(
+void L1SpillManagementBase<MemoryTracker>::spillToDramBeforeTrigger(
     Value result, Operation *triggerOp) {
   assert(triggerOp && "spillToDramBeforeTrigger requires a non-null trigger");
   spillToDramImpl(result, triggerOp);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::spillToDramImpl(
+void L1SpillManagementBase<MemoryTracker>::spillToDramImpl(
     Value result, Operation *insertBefore) {
   Operation *defOp = result.getDefiningOp();
   RankedTensorType tensorType = mlir::cast<RankedTensorType>(result.getType());
@@ -1810,7 +1810,7 @@ void L1SpillManagement<MemoryTracker>::spillToDramImpl(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::insertReshardForConsumer(
+void L1SpillManagementBase<MemoryTracker>::insertReshardForConsumer(
     Operation *consumer, unsigned operandIdx, TTNNLayoutAttr originalL1Layout) {
   Value spillOutput = consumer->getOperand(operandIdx);
   auto spillTensorType = mlir::cast<RankedTensorType>(spillOutput.getType());
@@ -1933,7 +1933,7 @@ void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
 // Explicit template instantiation
 //===----------------------------------------------------------------------===//
 
-template class L1SpillManagement<SumL1MemoryTracker>;
-template class L1SpillManagement<MockAllocatorL1Tracker>;
+template class L1SpillManagementBase<SumL1MemoryTracker>;
+template class L1SpillManagementBase<MockAllocatorL1Tracker>;
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1105,6 +1105,18 @@ void L1SpillManagementBase<MemoryTracker>::insertReshardIntoSchedule(
   }
   newDeathSchedule[reshardLastUse].push_back(reshardResult);
   data.deathSchedule = std::move(newDeathSchedule);
+
+  // Keep position-keyed sweep checkpoints (stateful rewind path) aligned across
+  // the insertion: keys >= consumerPos shift by +1, mirroring positionMap. Empty
+  // (a no-op) on the Sum path, which does not capture checkpoints.
+  if (!sweepCheckpoints.empty()) {
+    llvm::DenseMap<int64_t, SweepCheckpoint> shifted;
+    shifted.reserve(sweepCheckpoints.size());
+    for (auto &[k, cp] : sweepCheckpoints) {
+      shifted[k >= consumerPos ? k + 1 : k] = std::move(cp);
+    }
+    sweepCheckpoints = std::move(shifted);
+  }
 }
 
 template <typename MemoryTracker>
@@ -1412,6 +1424,13 @@ void L1SpillManagementBase<MemoryTracker>::run() {
 
   [[maybe_unused]] int64_t spillCount = 0;
 
+  // Rewind budget (stateful path): each eviction permanently moves a value from
+  // L1 to DRAM, so rewinds are bounded by the L1-resident count (<= schedule
+  // size). The generous cap is a runaway backstop, not a real limit.
+  int64_t rewindCount = 0;
+  const int64_t kMaxRewinds =
+      4 * static_cast<int64_t>(data.schedule.size()) + 64;
+
   // Farthest-last-use eviction sweep with validation-based enforcement.
   for (int64_t pos = 0; pos < static_cast<int64_t>(data.schedule.size());
        ++pos) {
@@ -1606,6 +1625,25 @@ void L1SpillManagementBase<MemoryTracker>::run() {
       int64_t r = *pendingRewindTo;
       pendingRewindTo.reset();
       restoreCheckpoint(r);
+      // Drop stale checkpoints past the rewind point; the re-run recaptures them
+      // at each position it re-processes, so no checkpoint older than the current
+      // pass is ever restored.
+      llvm::SmallVector<int64_t> stale;
+      for (const auto &kv : sweepCheckpoints) {
+        if (kv.first > r) {
+          stale.push_back(kv.first);
+        }
+      }
+      for (int64_t k : stale) {
+        sweepCheckpoints.erase(k);
+      }
+      // Safety net: each eviction permanently moves one value from L1 to DRAM,
+      // so the total number of rewinds is bounded by the L1-resident tensor
+      // count. A runaway means a logic error (a re-added victim, a rewind that
+      // makes no progress); fail loudly rather than spin.
+      if (++rewindCount > kMaxRewinds) {
+        llvm_unreachable("stateful spill: rewind budget exceeded (no progress)");
+      }
       pos = r - 1; // ++pos brings the sweep to r
       continue;
     }

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -571,7 +571,7 @@ void L1SpillManagementBase<MemoryTracker>::processDeadTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagementBase<MemoryTracker>::willAliasSourceInL1(
+bool AddressSimSpillManagement<MemoryTracker>::willAliasSourceInL1(
     Operation *op) const {
   // isAliasingViewOp guarantees op is a view op (reshape/pad/repeat/permute)
   // that aliases its input operand(0). Use hasTensorAddress (not hasTensor):
@@ -588,21 +588,29 @@ bool L1SpillManagementBase<MemoryTracker>::willAliasSourceInL1(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagementBase<MemoryTracker>::placeValidatedOutput(
+uint64_t AddressSimSpillManagement<MemoryTracker>::placeValidatedOutput(
     Operation *op, int64_t pos, ScheduleData &data,
     const op_constraint_validation::ValidationResult &result) {
   return ensureFitsL1(op, pos, data, result.cbPeakUsage, result.outputL1Usage);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::recoverFromOOM(
+void AddressSimSpillManagement<MemoryTracker>::handleUnvalidatedL1Output(
+    Operation *op, int64_t pos, ScheduleData &data, uint64_t derivedL1) {
+  // Pre-decomposition ToLayoutOp: no validation result, so CB peak is 0. Run
+  // the contiguous-fit check to make room if needed.
+  ensureFitsL1(op, pos, data, /*cbPeakUsage=*/0, derivedL1);
+}
+
+template <typename MemoryTracker>
+void AddressSimSpillManagement<MemoryTracker>::recoverFromOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
     ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::commitAllocation(Value val,
+void AddressSimSpillManagement<MemoryTracker>::commitAllocation(Value val,
                                                         uint64_t perResultL1,
                                                         ScheduleData &data) {
   auto luIt = data.lastUsePositions.find(val);
@@ -629,7 +637,7 @@ void L1SpillManagementBase<MemoryTracker>::commitAllocation(Value val,
 }
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagementBase<MemoryTracker>::ensureFitsL1(Operation *op,
+uint64_t AddressSimSpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
                                                         int64_t pos,
                                                         ScheduleData &data,
                                                         uint64_t cbPeakUsage,
@@ -666,7 +674,7 @@ uint64_t L1SpillManagementBase<MemoryTracker>::ensureFitsL1(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::handleOOM(
+void AddressSimSpillManagement<MemoryTracker>::handleOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
     ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
@@ -794,7 +802,7 @@ bool L1SpillManagementBase<MemoryTracker>::markEvictedAndRebuild(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagementBase<MemoryTracker>::replayFrom(size_t startIdx) {
+bool AddressSimSpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
   auto snapIt = addressSnapshots.find(startIdx);
   assert(snapIt != addressSnapshots.end() &&
          "snapshot not found for replay start index");
@@ -1120,7 +1128,7 @@ bool L1SpillManagementBase<MemoryTracker>::evictUntil(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagementBase<MemoryTracker>::handleNoFit(Operation *op,
+uint64_t AddressSimSpillManagement<MemoryTracker>::handleNoFit(Operation *op,
                                                        int64_t pos,
                                                        ScheduleData &data,
                                                        uint64_t outputL1Size) {
@@ -1173,7 +1181,7 @@ uint64_t L1SpillManagementBase<MemoryTracker>::handleNoFit(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagementBase<MemoryTracker>::handleFragmentation(
+uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
     Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
     uint64_t outputL1Size) {
   // Add the same safety cushion as wouldCBsOverlapTensors to account for
@@ -1287,7 +1295,7 @@ uint64_t L1SpillManagementBase<MemoryTracker>::handleFragmentation(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagementBase<MemoryTracker>::wouldCBsOverlapTensors(
+bool AddressSimSpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
     Operation *op, int64_t pos, uint64_t cbPeakUsage,
     uint64_t speculativeOutputAddr) {
   // Check if the op's CB region (growing bottom-up from base) would overlap
@@ -1412,7 +1420,7 @@ void L1SpillManagementBase<MemoryTracker>::run() {
                      memoryTracker.getOccupiedL1(), l1BudgetPerCore);
         // CBPeakUsage fixed to 0 as we have no validation result for ToLayoutOp
         // itself which is yet to be decomposed.
-        ensureFitsL1(op, pos, data, /*cbPeakUsage=*/0, derivedL1);
+        handleUnvalidatedL1Output(op, pos, data, derivedL1);
       }
 
       // Regardless of whether the ToLayoutOp's output is L1 or DRAM, we have no
@@ -1662,7 +1670,7 @@ void L1SpillManagementBase<MemoryTracker>::evictAllFromL1(int64_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::evictForCBOverlap(
+void AddressSimSpillManagement<MemoryTracker>::evictForCBOverlap(
     uint64_t cushionedCBUsage, int64_t pos, ScheduleData &data) {
   evictUntil(pos, data, [&]() {
     return cushionedCBUsage <= memoryTracker.getLowestOccupiedAddress();
@@ -1674,7 +1682,7 @@ void L1SpillManagementBase<MemoryTracker>::evictForCBOverlap(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::evictForDramCBGrowth(
+void AddressSimSpillManagement<MemoryTracker>::evictForDramCBGrowth(
     Operation *op, int64_t pos, ScheduleData &data) {
 
   auto inputLayouts = utils::extractInputLayouts(op);
@@ -1935,5 +1943,7 @@ void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
 
 template class L1SpillManagementBase<SumL1MemoryTracker>;
 template class L1SpillManagementBase<MockAllocatorL1Tracker>;
+template class AddressSimSpillManagement<SumL1MemoryTracker>;
+template class AddressSimSpillManagement<MockAllocatorL1Tracker>;
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1862,9 +1862,10 @@ MockAllocatorL1Tracker::validate(Operation *op,
   }
 
   // Flatten the currently-live L1 allocations into the stateful query's initial
-  // state. additionalL1Usage is 0: the live set is encoded in the records, not
-  // a scalar. Ops that don't override the stateful interface method fall back
-  // to the (cached) stateless query and return no records.
+  // state. Aliases share their owner's record (no separate entry), so there is
+  // no duplication. additionalL1Usage is 0: the live set is encoded in the
+  // records. Ops that don't override the stateful interface method fall back to
+  // the (cached) stateless query and return no records.
   llvm::SmallVector<op_model::OpModelAllocationRecord> flat;
   for (const auto &entry : liveRecords) {
     flat.append(entry.second.begin(), entry.second.end());
@@ -1875,22 +1876,48 @@ MockAllocatorL1Tracker::validate(Operation *op,
                                                   flat,
                                                   /*additionalL1Usage=*/0);
 
-  // Stash this op's output records for association at addTensor time.
-  if (result.isSuccess() && !result.outputAllocations.empty()) {
-    pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
-                                   result.outputAllocations.end());
+  if (result.isSuccess()) {
+    // The query decides fit / fragmentation / CB-clash on the device's physical
+    // L1, but the optimizer budget reserves headroom below that (a ~0.95 cap
+    // minus reserved). Enforce that byte ceiling here so the optimizer does not
+    // pack up to the full device L1: projected peak = currently-live L1 (which
+    // includes this op's inputs) + this op's output.
+    uint64_t projected = getOccupiedL1() + result.outputL1Usage;
+    if (l1Budget > 0 && projected > l1Budget) {
+      return op_constraint_validation::ValidationResult::outOfMemoryError(
+          "stateful: projected L1 (" + std::to_string(projected) +
+          "B) exceeds optimizer budget (" + std::to_string(l1Budget) + "B)");
+    }
+    // Stash this op's output records for association at addTensor time.
+    if (!result.outputAllocations.empty()) {
+      pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
+                                     result.outputAllocations.end());
+    }
   }
   return result;
 }
 
-void MockAllocatorL1Tracker::init(uint64_t l1BudgetPerCore) {
-  SumL1MemoryTracker::init(l1BudgetPerCore);
-  liveRecords.clear();
-  pendingRecords.clear();
+op_constraint_validation::ValidationResult
+MockAllocatorL1Tracker::validateBackendDirect(
+    Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+    const OpConfig &config, uint64_t additionalL1Usage) const {
+  if (backendValidator) {
+    return backendValidator(op, inputLayouts, config, additionalL1Usage);
+  }
+  return op_constraint_validation::validateOperation(op, inputLayouts, config,
+                                                     additionalL1Usage);
 }
 
-void MockAllocatorL1Tracker::addTensor(Value result, uint64_t l1SizePerCore) {
-  SumL1MemoryTracker::addTensor(result, l1SizePerCore);
+void MockAllocatorL1Tracker::init(uint64_t l1BudgetPerCore) {
+  l1Budget = l1BudgetPerCore;
+  liveRecords.clear();
+  pendingRecords.clear();
+  aliasOf.clear();
+  aliasRefcount.clear();
+}
+
+void MockAllocatorL1Tracker::addTensor(Value result,
+                                       uint64_t /*l1SizePerCore*/) {
   // Associate the pending record for this result (positional: i-th tensor
   // result <-> i-th output-buffer record). Ops that produced no records (not
   // migrated to the stateful path) simply contribute nothing to the state.
@@ -1905,36 +1932,223 @@ void MockAllocatorL1Tracker::addTensor(Value result, uint64_t l1SizePerCore) {
   const unsigned idx = mlir::cast<OpResult>(result).getResultNumber();
   if (idx < it->second.size()) {
     liveRecords[result] = RecordVec{it->second[idx]};
+    aliasOf[result] = result;
+    aliasRefcount[result] = 1;
   }
 }
 
-void MockAllocatorL1Tracker::addTensorAtAddress(Value result,
-                                                uint64_t l1SizePerCore,
-                                                Value srcAtSameAddr) {
-  // Alias (e.g. a reshape view): shares srcAtSameAddr's buffer, so it adds no
-  // new allocation to the state — do not add a record for `result` (that would
-  // double-count the same buffer). The base tracks the address alias group.
-  SumL1MemoryTracker::addTensorAtAddress(result, l1SizePerCore, srcAtSameAddr);
+void MockAllocatorL1Tracker::addTensorAlias(Value out, Value src) {
+  // A view op's output shares src's buffer: add no new record, just bump the
+  // owner's live-aliaser refcount so the record survives until the last
+  // aliaser dies.
+  auto ownerIt = aliasOf.find(src);
+  Value owner = ownerIt != aliasOf.end() ? ownerIt->second : src;
+  aliasOf[out] = owner;
+  ++aliasRefcount[owner];
 }
 
 void MockAllocatorL1Tracker::removeTensor(Value result) {
-  SumL1MemoryTracker::removeTensor(result);
-  liveRecords.erase(result);
+  auto ownerIt = aliasOf.find(result);
+  if (ownerIt == aliasOf.end()) {
+    // Untracked (op produced no records). Nothing to drop.
+    liveRecords.erase(result);
+    return;
+  }
+  Value owner = ownerIt->second;
+  aliasOf.erase(ownerIt);
+  auto rcIt = aliasRefcount.find(owner);
+  if (rcIt != aliasRefcount.end() && --rcIt->second == 0) {
+    aliasRefcount.erase(rcIt);
+    liveRecords.erase(owner);
+  }
 }
 
 void MockAllocatorL1Tracker::removeTensorFromSizes(Value result) {
-  SumL1MemoryTracker::removeTensorFromSizes(result);
-  // Eviction spills to DRAM via this path: the tensor has left L1.
-  liveRecords.erase(result);
+  // Records are the only size state, so the eviction spill path is identical to
+  // removeTensor.
+  removeTensor(result);
+}
+
+bool MockAllocatorL1Tracker::hasTensor(Value result) const {
+  return aliasOf.count(result) > 0;
+}
+
+uint64_t MockAllocatorL1Tracker::getTensorSize(Value result) const {
+  auto ownerIt = aliasOf.find(result);
+  Value owner = ownerIt != aliasOf.end() ? ownerIt->second : result;
+  auto it = liveRecords.find(owner);
+  if (it == liveRecords.end()) {
+    return 0;
+  }
+  uint64_t total = 0;
+  for (const auto &rec : it->second) {
+    if (rec.bufferType == BufferType::L1) {
+      total += rec.sizePerBank;
+    }
+  }
+  return total;
+}
+
+uint64_t MockAllocatorL1Tracker::getOccupiedL1() const {
+  uint64_t total = 0;
+  for (const auto &entry : liveRecords) {
+    for (const auto &rec : entry.second) {
+      if (rec.bufferType == BufferType::L1) {
+        total += rec.sizePerBank;
+      }
+    }
+  }
+  return total;
 }
 
 MockAllocatorL1Tracker::Snapshot MockAllocatorL1Tracker::takeSnapshot() const {
-  return Snapshot{SumL1MemoryTracker::takeSnapshot(), liveRecords};
+  return Snapshot{liveRecords, aliasOf, aliasRefcount};
 }
 
 void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
-  SumL1MemoryTracker::restoreSnapshot(snapshot.base);
   liveRecords = snapshot.liveRecords;
+  aliasOf = snapshot.aliasOf;
+  aliasRefcount = snapshot.aliasRefcount;
+}
+
+//===----------------------------------------------------------------------===//
+// StatefulL1SpillManagement (captured allocator state)
+//===----------------------------------------------------------------------===//
+
+uint64_t StatefulL1SpillManagement::placeValidatedOutput(
+    Operation *, int64_t, ScheduleData &,
+    const op_constraint_validation::ValidationResult &result) {
+  // Fit / fragmentation / CB-overlap are all answered by the stateful query, so
+  // a validated output is committed at its reported L1 size with no extra
+  // checks.
+  return result.outputL1Usage;
+}
+
+void StatefulL1SpillManagement::handleUnvalidatedL1Output(Operation *, int64_t,
+                                                          ScheduleData &,
+                                                          uint64_t) {
+  // Pre-decomposition ToLayoutOp: no query, and (as in the address-sim path) it
+  // is kept out of liveValues. Any real OOM surfaces at the consuming op's
+  // stateful query, so there is nothing to do here.
+}
+
+void StatefulL1SpillManagement::commitAllocation(Value val,
+                                                 uint64_t perResultL1,
+                                                 ScheduleData &data) {
+  auto luIt = data.lastUsePositions.find(val);
+  assert(luIt != data.lastUsePositions.end() &&
+         "scheduled value missing its lastUsePositions entry");
+  int64_t resultLastUse = luIt->second;
+
+  // Log the alloc event and checkpoint the record set for eviction replay.
+  allocEventIndex[val] = l1EventLog.size();
+  addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
+  l1EventLog.push_back({L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
+
+  // View-eligible op whose source is still L1-resident: alias its buffer (no
+  // new record). Otherwise associate this result's own output record.
+  Operation *defOp = val.getDefiningOp();
+  if (defOp && isAliasingViewOp(defOp) &&
+      memoryTracker.hasTensor(defOp->getOperand(0))) {
+    memoryTracker.addTensorAlias(val, defOp->getOperand(0));
+  } else {
+    memoryTracker.addTensor(val, perResultL1);
+  }
+
+  liveValues.insert(val);
+  liveSet.push({resultLastUse, val});
+}
+
+void StatefulL1SpillManagement::recoverFromOOM(
+    Operation *op, int64_t pos, llvm::ArrayRef<OpResult> /*tensorResults*/,
+    ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
+  observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
+  TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+               "    OOM (stateful): evicting until the query fits");
+
+  // Evict farthest-last-use tensors until the stateful re-query succeeds. Each
+  // eviction drops the victim's records and replays the surviving allocation
+  // history (replayFrom) so the allocator re-flows addresses under the
+  // victim-free history; fragmentation is decided by the query, never here.
+  auto config = extractOpConfigFromIR(op);
+  auto result = op_constraint_validation::ValidationResult::outOfMemoryError("");
+  bool fitsAfterEviction = evictUntil(pos, data, [&]() {
+    auto inputLayouts = utils::extractInputLayouts(op);
+    result = memoryTracker.validate(op, inputLayouts, config);
+    return result.isSuccess();
+  });
+  if (compilationFailed) {
+    return;
+  }
+
+  if (fitsAfterEviction) {
+    // Eviction may have inserted a reshard for `op`, shifting it past `pos`;
+    // bail so run()'s sweep reprocesses the reshard and then `op`.
+    if (data.schedule[pos] != op) {
+      return;
+    }
+    uint64_t l1Size = result.outputL1Usage;
+    if (l1Size > 0) {
+      addResultsToLiveSet(l1Size);
+      observer_->onLiveAdded(op, pos, l1Size, pos,
+                             memoryTracker.getOccupiedL1());
+    }
+  } else {
+    observer_->onSelfSpill(op, pos);
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "    DEMOTE SELF (stateful): op exceeds budget alone");
+    demoteToDram(op);
+  }
+}
+
+bool StatefulL1SpillManagement::replayFrom(size_t startIdx) {
+  auto snapIt = addressSnapshots.find(startIdx);
+  assert(snapIt != addressSnapshots.end() &&
+         "checkpoint not found for replay start index");
+  memoryTracker.restoreSnapshot(snapIt->second);
+
+  // Replay allocation events from startIdx forward under the (victim-free)
+  // history. Each surviving op is re-queried so the allocator assigns fresh
+  // addresses; the resulting record becomes its live-set entry.
+  for (size_t i = startIdx; i < l1EventLog.size(); ++i) {
+    if (l1EventLog[i].skipped) {
+      continue;
+    }
+    if (l1EventLog[i].kind == L1Event::kDealloc) {
+      memoryTracker.removeTensor(l1EventLog[i].tensor);
+      continue;
+    }
+    addressSnapshots[i] = memoryTracker.takeSnapshot();
+    Value tensor = l1EventLog[i].tensor;
+    Operation *defOp = tensor.getDefiningOp();
+    // View alias (src still L1-resident): consumes no fresh buffer.
+    if (defOp && isAliasingViewOp(defOp) &&
+        memoryTracker.hasTensor(defOp->getOperand(0))) {
+      memoryTracker.addTensorAlias(tensor, defOp->getOperand(0));
+      continue;
+    }
+    if (!defOp) {
+      continue;
+    }
+    // Re-query so the allocator re-flows this buffer's address without the
+    // evicted victim in the history.
+    auto inputLayouts = utils::extractInputLayouts(defOp);
+    auto config = extractOpConfigFromIR(defOp);
+    auto result = memoryTracker.validate(defOp, inputLayouts, config);
+    // A still-live op no longer fits (raw size or fragmentation): the caller
+    // (evictUntil) evicts more. Non-OOM outcomes (not-implemented / backend
+    // error, e.g. an unqueryable reshard) leave the buffer untracked but do not
+    // count as a placement failure.
+    bool isOOM = result.isError() && !result.isNotImplemented() &&
+                 !result.isMetalBackendError();
+    if (isOOM) {
+      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                   "Replay: op no longer fits under victim-free history");
+      return false;
+    }
+    memoryTracker.addTensor(tensor, l1EventLog[i].sizePerCore);
+  }
+  return true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1944,6 +2158,5 @@ void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
 template class L1SpillManagementBase<SumL1MemoryTracker>;
 template class L1SpillManagementBase<MockAllocatorL1Tracker>;
 template class AddressSimSpillManagement<SumL1MemoryTracker>;
-template class AddressSimSpillManagement<MockAllocatorL1Tracker>;
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -583,6 +583,51 @@ bool L1SpillManagement<MemoryTracker>::willAliasSourceInL1(
          memoryTracker.hasTensorAddress(op->getOperand(0));
 }
 
+//===----------------------------------------------------------------------===//
+// Hooks (default = address-sim path)
+//===----------------------------------------------------------------------===//
+
+template <typename MemoryTracker>
+uint64_t L1SpillManagement<MemoryTracker>::placeValidatedOutput(
+    Operation *op, int64_t pos, ScheduleData &data,
+    const op_constraint_validation::ValidationResult &result) {
+  return ensureFitsL1(op, pos, data, result.cbPeakUsage, result.outputL1Usage);
+}
+
+template <typename MemoryTracker>
+void L1SpillManagement<MemoryTracker>::recoverFromOOM(
+    Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
+    ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
+  handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
+}
+
+template <typename MemoryTracker>
+void L1SpillManagement<MemoryTracker>::commitAllocation(Value val,
+                                                        uint64_t perResultL1,
+                                                        ScheduleData &data) {
+  auto luIt = data.lastUsePositions.find(val);
+  assert(luIt != data.lastUsePositions.end() &&
+         "scheduled value missing its lastUsePositions entry");
+  int64_t resultLastUse = luIt->second;
+
+  // Snapshot before allocation and record event for replay.
+  allocEventIndex[val] = l1EventLog.size();
+  addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
+  l1EventLog.push_back({L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
+
+  // View-eligible reshape: alias src's buffer instead of carving a fresh slot.
+  // Must stay in sync with the willAliasSourceInL1 short-circuit in ensureFitsL1.
+  Operation *defOp = val.getDefiningOp();
+  if (defOp && willAliasSourceInL1(defOp)) {
+    memoryTracker.addTensorAtAddress(val, perResultL1, defOp->getOperand(0));
+  } else {
+    memoryTracker.addTensor(val, perResultL1);
+  }
+
+  liveValues.insert(val);
+  liveSet.push({resultLastUse, val});
+}
+
 template <typename MemoryTracker>
 uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
                                                         int64_t pos,
@@ -1420,30 +1465,7 @@ void L1SpillManagement<MemoryTracker>::run() {
       uint64_t perResultL1 =
           numTensorResults > 0 ? totalL1 / numTensorResults : 0;
       for (auto r : tensorResults) {
-        Value val = r;
-        auto luIt = data.lastUsePositions.find(val);
-        assert(luIt != data.lastUsePositions.end() &&
-               "scheduled value missing its lastUsePositions entry");
-        int64_t resultLastUse = luIt->second;
-        // Snapshot before allocation and record event for replay.
-        allocEventIndex[val] = l1EventLog.size();
-        addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
-        l1EventLog.push_back(
-            {L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
-
-        // View-eligible reshape: alias src's buffer instead of carving a
-        // fresh slot. See `addTensorAtAddress`. Must stay in sync with the
-        // willAliasSourceInL1 short-circuit in ensureFitsL1.
-        Operation *defOp = val.getDefiningOp();
-        if (defOp && willAliasSourceInL1(defOp)) {
-          memoryTracker.addTensorAtAddress(val, perResultL1,
-                                           defOp->getOperand(0));
-        } else {
-          memoryTracker.addTensor(val, perResultL1);
-        }
-
-        liveValues.insert(val);
-        liveSet.push({resultLastUse, val});
+        commitAllocation(r, perResultL1, data);
       }
     };
 
@@ -1468,14 +1490,13 @@ void L1SpillManagement<MemoryTracker>::run() {
     }
 
     if (result.isSuccess()) {
-      uint64_t l1Size = result.outputL1Usage;
-
       TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                    "    VALIDATION SUCCESS: op {0}, "
                    "cbPeakUsage={1}, outputL1={2} bytes",
-                   ttmlir::opToString(op), result.cbPeakUsage, l1Size);
+                   ttmlir::opToString(op), result.cbPeakUsage,
+                   result.outputL1Usage);
 
-      l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
+      uint64_t l1Size = placeValidatedOutput(op, pos, data, result);
       if (rewindIfScheduleShifted()) {
         continue;
       }
@@ -1508,7 +1529,7 @@ void L1SpillManagement<MemoryTracker>::run() {
       continue;
     }
 
-    handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
+    recoverFromOOM(op, pos, tensorResults, data, addResultsToLiveSet);
     if (rewindIfScheduleShifted()) {
       continue;
     }

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -573,12 +573,13 @@ void L1SpillManagement<MemoryTracker>::processDeadTensors(
 template <typename MemoryTracker>
 bool L1SpillManagement<MemoryTracker>::willAliasSourceInL1(
     Operation *op) const {
-  // canReshapeBeView already guarantees op is a ReshapeOp with operand(0).
-  // Use hasTensorAddress (not hasTensor): aliasing calls allocateAddressAt,
-  // which requires the source to occupy a simulated address slot. A tensor
-  // can be size-tracked but not address-tracked (e.g. zero-size or no-fit),
-  // in which case it cannot be aliased. This matches the replay path.
-  return canReshapeBeView(op) &&
+  // isAliasingViewOp guarantees op is a view op (reshape/pad/repeat/permute)
+  // that aliases its input operand(0). Use hasTensorAddress (not hasTensor):
+  // aliasing calls allocateAddressAt, which requires the source to occupy a
+  // simulated address slot. A tensor can be size-tracked but not
+  // address-tracked (e.g. zero-size or no-fit), in which case it cannot be
+  // aliased. This matches the replay path.
+  return isAliasingViewOp(op) &&
          memoryTracker.hasTensorAddress(op->getOperand(0));
 }
 
@@ -765,11 +766,11 @@ bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
       continue;
     }
     addressSnapshots[i] = memoryTracker.takeSnapshot();
-    // View-eligible reshape: alias if src is still address-tracked in this
-    // replay (consumes no fresh L1), otherwise fresh-allocate (the
-    // counterfactual when src was evicted to DRAM).
+    // View-eligible op (reshape/pad/repeat/permute): alias if src is still
+    // address-tracked in this replay (consumes no fresh L1), otherwise
+    // fresh-allocate (the counterfactual when src was evicted to DRAM).
     Operation *defOp = l1EventLog[i].tensor.getDefiningOp();
-    if (defOp && canReshapeBeView(defOp) &&
+    if (defOp && isAliasingViewOp(defOp) &&
         memoryTracker.hasTensorAddress(defOp->getOperand(0))) {
       memoryTracker.allocateAddressAt(l1EventLog[i].tensor,
                                       defOp->getOperand(0));

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1564,6 +1564,18 @@ void L1SpillManagementBase<MemoryTracker>::run() {
     }
 
     recoverFromOOM(op, pos, tensorResults, data, addResultsToLiveSet);
+    // Stateful eviction requests a rewind: restore the full sweep state at the
+    // victim's position and re-run the forward sweep from there (the victim now
+    // reads DRAM, inserted reshards are ordinary schedule ops, and this op is
+    // re-reached and re-validated against the freed state). Inert on the Sum
+    // path (never sets pendingRewindTo).
+    if (pendingRewindTo) {
+      int64_t r = *pendingRewindTo;
+      pendingRewindTo.reset();
+      restoreCheckpoint(r);
+      pos = r - 1; // ++pos brings the sweep to r
+      continue;
+    }
     if (rewindIfScheduleShifted()) {
       continue;
     }

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1346,6 +1346,25 @@ bool AddressSimSpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
+void L1SpillManagementBase<MemoryTracker>::captureCheckpoint(int64_t pos) {
+  SweepCheckpoint cp;
+  cp.tracker = memoryTracker.takeSnapshot();
+  cp.liveValues = liveValues;
+  cp.liveSet = liveSet;
+  sweepCheckpoints[pos] = std::move(cp);
+}
+
+template <typename MemoryTracker>
+void L1SpillManagementBase<MemoryTracker>::restoreCheckpoint(int64_t pos) {
+  auto it = sweepCheckpoints.find(pos);
+  assert(it != sweepCheckpoints.end() &&
+         "no sweep checkpoint at rewind position");
+  memoryTracker.restoreSnapshot(it->second.tracker);
+  liveValues = it->second.liveValues;
+  liveSet = it->second.liveSet;
+}
+
+template <typename MemoryTracker>
 void L1SpillManagementBase<MemoryTracker>::run() {
   ScheduleData data = buildScheduleData();
 
@@ -1369,6 +1388,13 @@ void L1SpillManagementBase<MemoryTracker>::run() {
       break;
     }
     Operation *op = data.schedule[pos];
+
+    // Snapshot the full sweep state entering this position so the stateful
+    // eviction can rewind here and re-run the forward sweep. No-op for the
+    // address-sim path.
+    if (usesRewindEviction()) {
+      captureCheckpoint(pos);
+    }
 
     // Eviction can insert a reshard for `op`, shifting `op` past `pos`. Rewind
     // to the first inserted reshard (always at `pos`) so the sweep processes it

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1409,6 +1409,10 @@ void L1SpillManagementBase<MemoryTracker>::restoreCheckpoint(int64_t pos) {
 
 template <typename MemoryTracker>
 void L1SpillManagementBase<MemoryTracker>::run() {
+  // Strategy-specific tracker configuration (needs virtual dispatch, so it
+  // cannot live in the constructor).
+  configureTracker();
+
   ScheduleData data = buildScheduleData();
 
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1963,25 +1967,27 @@ op_constraint_validation::ValidationResult
 MockAllocatorL1Tracker::validate(Operation *op,
                                  llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                                  const OpConfig &config) const {
-  // Test-only hook takes precedence and is state-agnostic.
-  if (backendValidator) {
-    return backendValidator(op, inputLayouts, config, /*additionalL1Usage=*/0);
-  }
-
-  // Flatten the currently-live L1 allocations into the stateful query's initial
-  // state. Aliases share their owner's record (no separate entry), so there is
-  // no duplication. additionalL1Usage is 0: the live set is encoded in the
-  // records. Ops that don't override the stateful interface method fall back to
-  // the (cached) stateless query and return no records.
-  llvm::SmallVector<op_model::OpModelAllocationRecord> flat;
-  for (const auto &entry : liveRecords) {
-    flat.append(entry.second.begin(), entry.second.end());
-  }
-
-  op_constraint_validation::ValidationResult result =
-      op_constraint_validation::validateOperation(op, inputLayouts, config,
-                                                  flat,
-                                                  /*additionalL1Usage=*/0);
+  // Run the query: the test-only hook when installed (state-agnostic), else the
+  // real stateful query. Either way the optimizer-policy checks below run on
+  // the result, so a test can drive them without a device.
+  op_constraint_validation::ValidationResult result = [&] {
+    if (backendValidator) {
+      return backendValidator(op, inputLayouts, config,
+                              /*additionalL1Usage=*/0);
+    }
+    // Flatten the currently-live L1 allocations into the stateful query's
+    // initial state. Aliases share their owner's record (no separate entry), so
+    // there is no duplication. additionalL1Usage is 0: the live set is encoded
+    // in the records. Ops that don't override the stateful interface method
+    // fall back to the (cached) stateless query and return no records.
+    llvm::SmallVector<op_model::OpModelAllocationRecord> flat;
+    for (const auto &entry : liveRecords) {
+      flat.append(entry.second.begin(), entry.second.end());
+    }
+    return op_constraint_validation::validateOperation(op, inputLayouts, config,
+                                                       flat,
+                                                       /*additionalL1Usage=*/0);
+  }();
 
   if (result.isSuccess()) {
     // The query decides fit / fragmentation / CB-clash on the device's physical
@@ -1994,6 +2000,30 @@ MockAllocatorL1Tracker::validate(Operation *op,
       return op_constraint_validation::ValidationResult::outOfMemoryError(
           "stateful: projected L1 (" + std::to_string(projected) +
           "B) exceeds optimizer budget (" + std::to_string(l1Budget) + "B)");
+    }
+    // Static-CB headroom floor (multi-device only; see
+    // `cbHeadroomFloorEnabled`). The query answers "does THIS op fit", but
+    // tt-metal validates EVERY program's static CB region against the device's
+    // globally lowest occupied L1 address -- including programs this model
+    // never queried (CCL/OpModelExempt ops, fabric, post-pass semaphores,
+    // co-resident graphs). Keep the live working set above
+    // `l1UnreservedBase + <largest CB region this function is known to need>`
+    // so those unmodeled CB regions still have somewhere to grow. A violation
+    // is reported as OOM, which routes run() to the same evict-and-refit
+    // recovery an allocator OOM or a reported CB clash takes.
+    if (cbHeadroomFloorEnabled) {
+      cbHeadroomHighWater = std::max(cbHeadroomHighWater, result.cbPeakUsage);
+      const uint64_t floor = l1UnreservedBase + cbHeadroomHighWater;
+      std::optional<uint64_t> lowest =
+          getLowestOccupiedL1Address(result.outputAllocations);
+      if (lowest && *lowest < floor) {
+        return op_constraint_validation::ValidationResult::outOfMemoryError(
+            "stateful: live L1 buffer at " + std::to_string(*lowest) +
+            "B sits below the static-CB headroom floor " +
+            std::to_string(floor) + "B (l1UnreservedBase " +
+            std::to_string(l1UnreservedBase) + "B + CB high-water " +
+            std::to_string(cbHeadroomHighWater) + "B)");
+      }
     }
     // Stash this op's output records for association at addTensor time.
     if (!result.outputAllocations.empty()) {
@@ -2021,6 +2051,12 @@ void MockAllocatorL1Tracker::init(uint64_t l1BudgetPerCore) {
   pendingRecords.clear();
   aliasOf.clear();
   aliasRefcount.clear();
+  // Deliberately NOT reset here: the static-CB headroom floor state
+  // (l1UnreservedBase / cbHeadroomFloorEnabled / cbHeadroomHighWater). This
+  // runs mid-sweep too — evictAllFromL1 calls it to drop every live record —
+  // and the largest static CB region the function needs does not change when L1
+  // is flushed. armCBHeadroomFloor (from run()'s configureTracker) owns that
+  // state.
 }
 
 void MockAllocatorL1Tracker::addTensor(Value result,
@@ -2128,6 +2164,34 @@ uint64_t MockAllocatorL1Tracker::getOccupiedL1() const {
   return total;
 }
 
+std::optional<uint64_t> MockAllocatorL1Tracker::getLowestOccupiedL1Address(
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> alsoConsider) const {
+  std::optional<uint64_t> lowest;
+  auto fold = [&lowest](const op_model::OpModelAllocationRecord &rec) {
+    if (rec.bufferType != BufferType::L1) {
+      return;
+    }
+    lowest = lowest ? std::min(*lowest, rec.address) : rec.address;
+  };
+  for (const auto &entry : liveRecords) {
+    for (const auto &rec : entry.second) {
+      fold(rec);
+    }
+  }
+  for (const auto &rec : alsoConsider) {
+    fold(rec);
+  }
+  return lowest;
+}
+
+void MockAllocatorL1Tracker::armCBHeadroomFloor(uint64_t unreservedBase,
+                                                bool enabled,
+                                                uint64_t minHeadroom) {
+  l1UnreservedBase = unreservedBase;
+  cbHeadroomFloorEnabled = enabled;
+  cbHeadroomHighWater = enabled ? minHeadroom : 0;
+}
+
 MockAllocatorL1Tracker::Snapshot MockAllocatorL1Tracker::takeSnapshot() const {
   return Snapshot{liveRecords, aliasOf, aliasRefcount};
 }
@@ -2142,11 +2206,38 @@ void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
 // StatefulL1SpillManagement (captured allocator state)
 //===----------------------------------------------------------------------===//
 
+void StatefulL1SpillManagement::configureTracker() {
+  // Arm the static-CB headroom floor on multi-device (mesh) compiles only. On a
+  // single-device compile the modeled device matches the real one closely
+  // enough that the per-op query is the whole story, and reserving headroom
+  // there would cost L1 for no benefit; on a mesh compile it demonstrably is
+  // not (see MockAllocatorL1Tracker::cbHeadroomFloorEnabled).
+  ttcore::DeviceAttr device = ttcore::lookupDevice(func);
+  const bool multiDevice =
+      device && ttmlir::utils::volume(device.getMeshShape()) > 1;
+  // Seed the headroom with the same cushion the address-sim path applies to its
+  // CB-overlap check (kCBFragCushionFraction of the budget), so the floor is
+  // already meaningful for the ops processed before the function's largest CB
+  // region has been observed.
+  memoryTracker.armCBHeadroomFloor(
+      ttcore::getOpChipDescAttr(func).getL1UnreservedBase(), multiDevice,
+      /*minHeadroom=*/cbFragCushion);
+  TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+               "L1 spill (stateful): static-CB headroom floor {0} "
+               "(l1UnreservedBase={1}, seed={2})",
+               multiDevice ? "armed (multi-device)" : "off (single device)",
+               memoryTracker.l1UnreservedBase,
+               memoryTracker.cbHeadroomHighWater);
+}
+
 uint64_t StatefulL1SpillManagement::placeValidatedOutput(
     Operation *, int64_t, ScheduleData &,
     const op_constraint_validation::ValidationResult &result) {
-  // Fit / fragmentation / CB-overlap are all answered by the stateful query, so
-  // a validated output is committed at its reported L1 size with no extra
+  // Fit / fragmentation / CB-overlap are all answered by the stateful query
+  // (plus the tracker's budget ceiling and, on a mesh compile, its static-CB
+  // headroom floor -- both applied in MockAllocatorL1Tracker::validate, which
+  // reports a violation as OOM). A result that reaches here is already
+  // validated, so its output is committed at the reported L1 size with no extra
   // checks.
   return result.outputL1Usage;
 }

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -2042,6 +2042,26 @@ void MockAllocatorL1Tracker::addTensor(Value result,
     aliasOf[result] = result;
     aliasRefcount[result] = 1;
   }
+  // The pending stash for `op` is only needed to associate its records to its
+  // tensor results, which happens right after the validate() that produced it
+  // (both the forward-sweep commit and the revalidation cascade call validate()
+  // immediately before addTensor()). Drop the entry once the op's last tensor
+  // result has been associated so pendingRecords does not accumulate a stale
+  // entry per op visited over the pass. Results are committed in ascending
+  // order in both paths, so once the highest-numbered tensor result is reached
+  // every earlier result of this op has already been associated, and no further
+  // addTensor() for `op` runs before its next validate() re-stashes -- so this
+  // never orphans an association.
+  bool isLastTensorResult = true;
+  for (unsigned i = idx + 1, e = op->getNumResults(); i < e; ++i) {
+    if (mlir::isa<RankedTensorType>(op->getResult(i).getType())) {
+      isLastTensorResult = false;
+      break;
+    }
+  }
+  if (isLastTensorResult) {
+    pendingRecords.erase(it);
+  }
 }
 
 void MockAllocatorL1Tracker::addTensorAlias(Value out, Value src) {

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -258,6 +258,171 @@ bool canReshapeBeView(Operation *op) {
   return true;
 }
 
+//===----------------------------------------------------------------------===//
+// View-op detection (input-aliasing / zero-copy ops)
+//
+// These predicates mirror tt-metal's decision to return the input tensor (or a
+// view built at the input's address) instead of allocating a fresh output.
+// The L1 spill pass uses `isAliasingViewOp` to alias such an op onto its
+// source's L1 slot (see MockAllocatorL1Tracker / addTensorAtAddress) rather
+// than tracking a fresh allocation. Under the stateful op-model query, an
+// aliasing op's output is reported at the weightless input's address 0, which
+// is not a re-installable allocation -- so mis-tracking it crashes
+// `with_allocations` (issue
+// https://github.com/tenstorrent/tt-mlir/issues/9054). Each predicate is
+// guarded by a tripwire unit test asserting that an op it classifies as a view
+// really does return address 0 from the mock op-model; if tt-metal drifts, the
+// tripwire fails and the predicate must be revisited.
+//===----------------------------------------------------------------------===//
+
+/// Check if a `ttnn.pad` returns its input as a view (no new allocation).
+/// Mirrors ttnn::pad: all-zero padding (pad.cpp:451), on-device same shape
+/// (pad.cpp:128), and the TILE fast-path where the padding stays within the
+/// existing tile padding so the tiled buffer is unchanged (pad.cpp:383).
+bool canPadBeView(Operation *op) {
+  auto pad = mlir::dyn_cast<PadOp>(op);
+  if (!pad) {
+    return false;
+  }
+  auto inputType =
+      mlir::dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  auto outputType =
+      mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!inputType || !outputType) {
+    return false;
+  }
+  llvm::ArrayRef<int32_t> padding = pad.getPadding(); // [lo0,hi0,lo1,hi1,...]
+
+  // (A) All-zero padding is a strict no-op regardless of layout/shape.
+  if (llvm::all_of(padding, [](int32_t p) { return p == 0; })) {
+    return true;
+  }
+
+  llvm::ArrayRef<int64_t> inShape = inputType.getShape();
+  llvm::ArrayRef<int64_t> outShape = outputType.getShape();
+  if (inShape.size() != outShape.size() || inShape.empty()) {
+    return false;
+  }
+
+  // (B) Same logical shape -> ttnn::pad returns the input.
+  if (inShape == outShape) {
+    return true;
+  }
+
+  // (C) TILE fast-path: only reachable for tiled layout, with zero front
+  // (before) padding, when the change is confined within the tile padding so
+  // the tiled (padded) buffer is byte-identical -- then ttnn::pad returns a
+  // view at the input's address. tt-metal's condition (pad.cpp:383):
+  //   !pad_upper_dims && padded[-1] unchanged && padded[-2] unchanged.
+  auto inputLayout = mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
+  if (!inputLayout || !inputLayout.isTiled()) {
+    return false;
+  }
+  // Front (low) padding must be zero on every dim (tt-metal TT_FATALs
+  // otherwise; certainly not a view).
+  for (size_t d = 0; d < padding.size() / 2; ++d) {
+    if (padding[2 * d] != 0) {
+      return false;
+    }
+  }
+  // Upper dims (everything but the last two) must be unchanged.
+  for (size_t i = 0; i + 2 < inShape.size(); ++i) {
+    if (inShape[i] != outShape[i]) {
+      return false;
+    }
+  }
+  auto roundUpTo = [](int64_t x, int64_t t) {
+    return llvm::divideCeil(x, t) * t;
+  };
+  int64_t inLast = inShape.back(), outLast = outShape.back();
+  int64_t inSecondLast = inShape[inShape.size() - 2];
+  int64_t outSecondLast = outShape[outShape.size() - 2];
+  return roundUpTo(inLast, TILE_WIDTH) == roundUpTo(outLast, TILE_WIDTH) &&
+         roundUpTo(inSecondLast, TILE_HEIGHT) ==
+             roundUpTo(outSecondLast, TILE_HEIGHT);
+}
+
+/// Check if a `ttnn.repeat` returns its input as a view: an all-ones
+/// repetition is a strict no-op (repeat.cpp:196 `return input_tensor`).
+bool canRepeatBeView(Operation *op) {
+  auto repeat = mlir::dyn_cast<RepeatOp>(op);
+  if (!repeat) {
+    return false;
+  }
+  llvm::ArrayRef<int64_t> repeatDims = repeat.getRepeatDims().getShape();
+  return llvm::all_of(repeatDims, [](int64_t r) { return r == 1; });
+}
+
+/// Check if a `ttnn.permute` is a no-op view. Mirrors tt-metal's
+/// `is_permute_nop` (permute.cpp:158): rank<=1, identity permutation, or a
+/// permutation that only moves size-1 dims (layout-aware: TILE fixes the last
+/// two dims, ROW_MAJOR the last). Permute-nop returns
+/// `to_memory_config(input, requested)`, so it aliases the input only when the
+/// requested (output) memory config equals the input's -- hence the extra
+/// buffer-type + memory-layout equality check.
+bool canPermuteBeView(Operation *op) {
+  auto permute = mlir::dyn_cast<PermuteOp>(op);
+  if (!permute) {
+    return false;
+  }
+  auto inputType =
+      mlir::dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  auto outputType =
+      mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!inputType || !outputType) {
+    return false;
+  }
+  llvm::ArrayRef<int64_t> dims = permute.getPermutation();
+  llvm::ArrayRef<int64_t> shape = inputType.getShape();
+  const int64_t rank = static_cast<int64_t>(shape.size());
+
+  bool isNop = false;
+  if (rank <= 1) {
+    isNop = true;
+  } else {
+    // Identity permutation.
+    bool identity = true;
+    for (int64_t i = 0; i < rank; ++i) {
+      if (dims[i] != i) {
+        identity = false;
+        break;
+      }
+    }
+    auto inputLayout = mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
+    bool tiled = inputLayout && inputLayout.isTiled();
+    // TILE: last two dims must stay; ROW_MAJOR: last dim must stay.
+    bool lastDimsFixed =
+        tiled ? (dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2)
+              : (dims[rank - 1] == rank - 1);
+    // Only size-1 dims moved (and shape therefore unchanged).
+    bool onlySize1Moved = true;
+    for (int64_t i = 0; i < rank; ++i) {
+      if (i != dims[i] && shape[i] > 1) {
+        onlySize1Moved = false;
+        break;
+      }
+    }
+    isNop = identity || (lastDimsFixed && onlySize1Moved);
+  }
+  if (!isNop) {
+    return false;
+  }
+
+  // Aliases the input only if the output memory config matches the input's.
+  auto inLayout = mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
+  auto outLayout = mlir::dyn_cast<TTNNLayoutAttr>(outputType.getEncoding());
+  if (!inLayout || !outLayout) {
+    return false;
+  }
+  return inLayout.getBufferType() == outLayout.getBufferType() &&
+         inLayout.getMemLayoutOpt() == outLayout.getMemLayoutOpt();
+}
+
+bool isAliasingViewOp(Operation *op) {
+  return canReshapeBeView(op) || canPadBeView(op) || canRepeatBeView(op) ||
+         canPermuteBeView(op);
+}
+
 LayoutFilterFn
 ReshapeRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
   // Reshape/Permute: width-sharded inputs round-trip through interleaved

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -138,6 +138,23 @@ getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getUnaryOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  // Stateful path bypasses opConstraintsCache: the result depends on the
+  // threaded live-allocation state, which the cache does not key on.
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<OpT>::getOpConstraintsWithState(
+      inputShape, inputs[0], opConfig.outputLayout, initialState.get());
+}
+
+template <typename OpT>
 llvm::Expected<size_t>
 getUnaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                   const OpConfig &opConfig) {
@@ -170,6 +187,30 @@ getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getBinaryOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA = op.getLhs().getType().getShape();
+  const auto inputShapeB = op.getRhs().getType().getShape();
+
+  ttcore::DataTypeAttr opDtypeAttr = nullptr;
+  if (auto dtypeOp = mlir::dyn_cast<TTNNDtypeOpInterface>(op.getOperation())) {
+    opDtypeAttr = dtypeOp.getDtypeAttr();
+  }
+
+  // Stateful path bypasses opConstraintsCache: the result depends on the
+  // threaded live-allocation state, which the cache does not key on.
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<OpT>::getOpConstraintsWithState(
+      inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout,
+      opDtypeAttr, initialState.get());
+}
+
+template <typename OpT>
 llvm::Expected<size_t>
 getBinaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                    const OpConfig &opConfig) {
@@ -196,6 +237,24 @@ getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, inputShapeA, inputs[0],
       inputShapeB, inputs[1], inputShapeC, inputs[2], opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getTernaryOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 3);
+
+  const auto inputShapeA = op.getFirst().getType().getShape();
+  const auto inputShapeB = op.getSecond().getType().getShape();
+  const auto inputShapeC = op.getThird().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<OpT>::getOpConstraintsWithState(
+      inputShapeA, inputs[0], inputShapeB, inputs[1], inputShapeC, inputs[2],
+      opConfig.outputLayout, initialState.get());
 }
 
 template <typename OpT>
@@ -226,6 +285,24 @@ getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getReductionOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+  const auto inputShape = op.getInput().getType().getShape();
+
+  // Stateful path bypasses opConstraintsCache: the result depends on the
+  // threaded live-allocation state, which the cache does not key on.
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<OpT>::getOpConstraintsWithState(
+      inputShape, inputs[0],
+      detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
+      op.getKeepDim(), opConfig.outputLayout, initialState.get());
+}
+
+template <typename OpT>
 llvm::Expected<size_t>
 getReductionOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                       const OpConfig &opConfig) {
@@ -251,6 +328,27 @@ getPoolingOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
       op.getChannels(), op.getKernelSize(), op.getStride(), op.getPadding(),
       op.getDilation(), op.getCeilMode(), op.getReallocateHaloOutput(),
       op.getConfigTensorsInDram(), opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getPoolingOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  // Stateful path bypasses opConstraintsCache: the result depends on the
+  // threaded live-allocation state, which the cache does not key on.
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<OpT>::getOpConstraintsWithState(
+      inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
+      op.getPadding(), op.getDilation(), op.getCeilMode(),
+      op.getReallocateHaloOutput(), op.getConfigTensorsInDram(),
+      opConfig.outputLayout, initialState.get());
 }
 
 template <typename OpT>
@@ -285,6 +383,29 @@ getMaxPool2dWithIndicesOpConstraints(OpT op,
       op.getDilation(), op.getCeilMode(), op.getReallocateHaloOutput(),
       /*deallocate_input*/ false, /*return_indices*/ true,
       op.getConfigTensorsInDram(), opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getMaxPool2dWithIndicesOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  // Stateful path bypasses opConstraintsCache: the result depends on the
+  // threaded live-allocation state, which the cache does not key on.
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<OpT>::getOpConstraintsWithState(
+      inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
+      op.getPadding(), op.getDilation(), op.getCeilMode(),
+      op.getReallocateHaloOutput(),
+      /*deallocate_input*/ false, /*return_indices*/ true,
+      op.getConfigTensorsInDram(), opConfig.outputLayout, initialState.get());
 }
 
 template <typename OpT>
@@ -367,6 +488,83 @@ llvm::Expected<size_t>
 ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                      const OpConfig &opConfig) {
   return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// Elementwise-unary family: stateful getOpConstraintsWithState overrides.
+// Uniform members route through the stateful helper (both UnaryEltwiseOpModel
+// and UnaryEltwiseWithFastApproxModeOpModel have migrated op-model bodies).
+// ErfOp and BitwiseNotOp provide their own per-op extraClassDeclaration in
+// tablegen (which declares getOpConstraintsWithState there), so they are
+// defined here via the same helper macro.
+//===----------------------------------------------------------------------===//
+
+#define TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(OP)                        \
+  llvm::Expected<op_model::OpConstraints> OP::getOpConstraintsWithState(       \
+      const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,     \
+      llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {         \
+    return detail::getUnaryOpConstraintsWithState(*this, inputs, opConfig,     \
+                                                  liveRecords);                \
+  }
+
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AbsOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ErfOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(BitwiseNotOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(CbrtOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(CeilOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(CosOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ExpOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ErfcOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(NegOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ReciprocalOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ReluOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(Relu6Op)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SinOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SqrtOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(RsqrtOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(HardsigmoidOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SiluOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(MishOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(LogOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AcosOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AsinOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AsinhOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AtanOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(Expm1Op)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(FloorOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(GeluOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(IsFiniteOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(Log1pOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(LogicalNotOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SignOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(TanOp)
+
+#undef TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE
+
+// SigmoidOp (bespoke op-model) has the standard unary
+// (inputShape, inputLayout, outputLayout) signature, so it routes through the
+// uniform stateful helper. LeakyReluOp carries an extra float parameter, so it
+// threads state through a bespoke query.
+llvm::Expected<op_model::OpConstraints> SigmoidOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getUnaryOpConstraintsWithState(*this, inputs, opConfig,
+                                                liveRecords);
+}
+
+llvm::Expected<op_model::OpConstraints> LeakyReluOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<LeakyReluOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getParameter(), opConfig.outputLayout,
+      initialState.get());
 }
 
 //===----------------------------------------------------------------------===//
@@ -926,6 +1124,58 @@ AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// Elementwise-binary family: stateful getOpConstraintsWithState overrides.
+// Declared on the shared TTNN_ElementwiseBinaryOp base (extraClassDeclaration),
+// so every member defines it here. The uniform BinaryEltwiseOpModel members
+// route through the stateful helper; GeluBackwardOp (bespoke op-model, extra
+// approximate arg) is not yet state-aware and delegates to the stateless query.
+//===----------------------------------------------------------------------===//
+
+#define TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(OP)                       \
+  llvm::Expected<op_model::OpConstraints> OP::getOpConstraintsWithState(       \
+      const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,     \
+      llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {         \
+    return detail::getBinaryOpConstraintsWithState(*this, inputs, opConfig,    \
+                                                   liveRecords);               \
+  }
+
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(AddOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(DivideOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(MultiplyOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(SubtractOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(EqualOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(NotEqualOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(GreaterEqualOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(GreaterThanOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LessEqualOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LessThanOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalAndOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalOrOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalXorOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalRightShiftOp)
+
+#undef TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE
+
+// GeluBackwardOp shares the binary tablegen base but has a bespoke op-model
+// (extra `approximate` arg), so it threads state through a bespoke query.
+llvm::Expected<op_model::OpConstraints>
+GeluBackwardOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA = getLhs().getType().getShape();
+  const auto inputShapeB = getRhs().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<GeluBackwardOp>::getOpConstraintsWithState(
+      inputShapeA, inputs[0], inputShapeB, inputs[1], getApproximate().str(),
+      opConfig.outputLayout, initialState.get());
+}
+
+//===----------------------------------------------------------------------===//
 // MultiplyOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -971,6 +1221,14 @@ llvm::Expected<size_t>
 LogicalLeftShiftOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
   return detail::getBinaryOpRuntime(*this, inputs, opConfig);
+}
+
+llvm::Expected<op_model::OpConstraints>
+LogicalLeftShiftOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getBinaryOpConstraintsWithState(*this, inputs, opConfig,
+                                                 liveRecords);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1095,6 +1353,30 @@ ScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       reduceType, opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> ScatterOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto indexShape = getIndex().getType().getShape();
+  const auto sourceShape = getSource().getType().getShape();
+
+  std::optional<ttcore::ReduceTypeAttr> reduceType =
+      ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
+  if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
+    reduceType =
+        ttcore::ReduceTypeAttr::get(getContext(), getScatterReduceType());
+  }
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ScatterOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], indexShape, inputs[1], sourceShape, inputs[2],
+      getDim(), reduceType, opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 ScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
@@ -1133,6 +1415,23 @@ GatherOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<GatherOp>::getOpConstraints, *this, inputShape,
       inputs[0], indexShape, inputs[1], dim, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> GatherOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 2);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto indexShape = getIndex().getType().getShape();
+  int32_t dim = getDim();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<GatherOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], indexShape, inputs[1], dim, opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1246,6 +1545,21 @@ PowScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PowScalarOp>::getOpConstraints, *this, inputShape,
       inputs[0], getRhs(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> PowScalarOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getLhs().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PowScalarOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getRhs(), opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1436,6 +1750,13 @@ WhereOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getTernaryOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> WhereOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getTernaryOpConstraintsWithState(*this, inputs, opConfig,
+                                                  liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // MeanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -1450,6 +1771,13 @@ llvm::Expected<size_t>
 MeanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                      const OpConfig &opConfig) {
   return getReductionOpRuntime(*this, inputs, opConfig);
+}
+
+llvm::Expected<op_model::OpConstraints> MeanOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
+                                            liveRecords);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1468,6 +1796,13 @@ MaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return getReductionOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> MaxOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
+                                            liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // MinOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -1482,6 +1817,13 @@ llvm::Expected<size_t>
 MinOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const OpConfig &opConfig) {
   return getReductionOpRuntime(*this, inputs, opConfig);
+}
+
+llvm::Expected<op_model::OpConstraints> MinOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
+                                            liveRecords);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1500,6 +1842,13 @@ SumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return getReductionOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> SumOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
+                                            liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // SoftmaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -1514,6 +1863,21 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SoftmaxOp>::getOpConstraints, *this, inputShape,
       inputs[0], getDimension(), getNumericStable(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> SoftmaxOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<SoftmaxOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getDimension(), getNumericStable(),
+      opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1546,6 +1910,22 @@ ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], outputShape, opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> ReshapeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto outputShape = getResult().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ReshapeOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], outputShape, opConfig.outputLayout,
+      initialState.get());
+}
+
 llvm::Expected<size_t>
 ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
@@ -1575,6 +1955,24 @@ SliceStaticOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
       detail::convertArrayAttrToSmallVec(getEnds()),
       detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+SliceStaticOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<SliceStaticOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
+      detail::convertArrayAttrToSmallVec(getEnds()),
+      detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1611,6 +2009,25 @@ SliceDynamicOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+SliceDynamicOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto beginsShape = getBegins().getType().getShape();
+  const auto endsShape = getEnds().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<SliceDynamicOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], beginsShape, inputs[1], endsShape, inputs[2],
+      detail::convertOptionalArrayAttrToSmallVec(getStep()),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 SliceDynamicOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
@@ -1644,6 +2061,25 @@ BitcastConvertOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<BitcastConvertOp>::getOpConstraints, *this, inputShape,
       inputs[0], dtype, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+BitcastConvertOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  ttcore::DataTypeAttr dtype =
+      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
+  assert(dtype && "BitcastConvertOp requires output dtype");
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<BitcastConvertOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], dtype, opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1685,6 +2121,29 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<TypecastOp>::getOpConstraints, *this, inputShape,
       inputs[0], dtype, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> TypecastOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  if (inputs[0].getBufferType() == BufferType::SystemMemory) {
+    return issueErrorForGetOpConstraints(
+        getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+  }
+
+  const auto inputShape = getInput().getType().getShape();
+
+  ttcore::DataTypeAttr dtype =
+      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
+  assert(dtype && "TypecastOp requires output dtype");
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<TypecastOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], dtype, opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1737,6 +2196,34 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], outputDtype, opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> ToLayoutOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+  assert(opConfig.outputLayout && "ToLayoutOp requires output layout");
+  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
+
+  const auto inputShape = getInput().getType().getShape();
+
+  // Only signal a dtype conversion to the op model when this to_layout is
+  // genuinely changing dtype. Use the resolved (candidate or intrinsic)
+  // output dtype, and compare it against the input dtype.
+  std::optional<ttcore::DataType> outputDtype = std::nullopt;
+  if (ttcore::DataTypeAttr dtype =
+          detail::resolveOutputDtype(getOperation(), opConfig.outputLayout)) {
+    if (dtype.getValue() != inputs[0].getDataType()) {
+      outputDtype = dtype.getValue();
+    }
+  }
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ToLayoutOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], outputDtype, opConfig.outputLayout,
+      initialState.get());
+}
+
 llvm::Expected<size_t>
 ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
@@ -1780,6 +2267,26 @@ ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+ToMemoryConfigOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  TTNNLayoutAttr outputLayout =
+      opConfig.outputLayout
+          ? opConfig.outputLayout
+          : mlir::cast<TTNNLayoutAttr>(getResult().getType().getEncoding());
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ToMemoryConfigOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 ToMemoryConfigOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                const OpConfig &opConfig) {
@@ -1818,6 +2325,25 @@ ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getDim(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> ConcatOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == getInputs().size());
+
+  std::vector<llvm::ArrayRef<int64_t>> inputShapes;
+  for (const Value &opInput : getInputs()) {
+    mlir::RankedTensorType inputType =
+        mlir::cast<mlir::RankedTensorType>(opInput.getType());
+    inputShapes.push_back(inputType.getShape());
+  }
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ConcatOp>::getOpConstraintsWithState(
+      inputShapes, inputs, getDim(), opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 ConcatOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                        const OpConfig &opConfig) {
@@ -1851,6 +2377,21 @@ TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> TransposeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<TransposeOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getDim0(), getDim1(), opConfig.outputLayout,
+      initialState.get());
+}
+
 llvm::Expected<size_t>
 TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
@@ -1878,6 +2419,21 @@ CumSumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<CumSumOp>::getOpConstraints, *this, inputShape,
       inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> CumSumOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<CumSumOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
+      opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1909,6 +2465,21 @@ CumProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> CumProdOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<CumProdOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 CumProdOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
@@ -1935,6 +2506,21 @@ ConcatenateHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ConcatenateHeadsOp>::getOpConstraints, *this,
       inputShape, inputs[0], opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ConcatenateHeadsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ConcatenateHeadsOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2052,6 +2638,33 @@ ScaledDotProductAttentionDecodeOp::getOpConstraints(
       sdpaArgs.curPosTensorLayout, sdpaArgs.attentionSinkShape,
       sdpaArgs.attentionSinkLayout, sdpaArgs.scale, sdpaArgs.programConfig,
       opConfig.outputLayout);
+  // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+}
+
+llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
+  assert(inputs.size() >= 3 && inputs.size() <= 6 &&
+         "ttnn::transformer::scaled_dot_product_attention_decode can have 3, "
+         "4, 5, or 6 input tensors");
+
+  ScaledDotProductAttentionDecodeArgs sdpaArgs =
+      unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ScaledDotProductAttentionDecodeOp>::
+      getOpConstraintsWithState(
+          sdpaArgs.queryShape, sdpaArgs.queryLayout, sdpaArgs.keyShape,
+          sdpaArgs.keyLayout, sdpaArgs.valueShape, sdpaArgs.valueLayout,
+          sdpaArgs.isCausal, sdpaArgs.attentionMaskShape,
+          sdpaArgs.attentionMaskLayout, sdpaArgs.curPosTensorShape,
+          sdpaArgs.curPosTensorLayout, sdpaArgs.attentionSinkShape,
+          sdpaArgs.attentionSinkLayout, sdpaArgs.scale, sdpaArgs.programConfig,
+          opConfig.outputLayout, initialState.get());
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
@@ -2186,6 +2799,36 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
+llvm::Expected<op_model::OpConstraints>
+PagedScaledDotProductAttentionDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
+  assert(inputs.size() >= 4 && inputs.size() <= 7 &&
+         "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
+         "7 input tensors");
+
+  PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
+      unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PagedScaledDotProductAttentionDecodeOp>::
+      getOpConstraintsWithState(
+          pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
+          pagedSdpaArgs.keyShape, pagedSdpaArgs.keyLayout,
+          pagedSdpaArgs.valueShape, pagedSdpaArgs.valueLayout,
+          pagedSdpaArgs.pageTableShape, pagedSdpaArgs.pageTableLayout,
+          pagedSdpaArgs.isCausal, pagedSdpaArgs.attentionMaskShape,
+          pagedSdpaArgs.attentionMaskLayout, pagedSdpaArgs.curPosTensorShape,
+          pagedSdpaArgs.curPosTensorLayout, pagedSdpaArgs.attentionSinkShape,
+          pagedSdpaArgs.attentionSinkLayout, pagedSdpaArgs.scale,
+          pagedSdpaArgs.slidingWindowSize, pagedSdpaArgs.programConfig,
+          opConfig.outputLayout, initialState.get());
+  // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+}
+
 llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   // See the comment in scaledDotProductAttentionDecodeOp::getOpConstraints for
@@ -2310,6 +2953,29 @@ PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
+llvm::Expected<op_model::OpConstraints>
+PagedFlashMultiLatentAttentionDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
+  PagedFlashMultiLatentAttentionDecodeArgs args =
+      unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PagedFlashMultiLatentAttentionDecodeOp>::
+      getOpConstraintsWithState(
+          args.queryShape, args.queryLayout, args.keyShape, args.keyLayout,
+          args.valueShape, args.valueLayout, args.headDimV, args.pageTableShape,
+          args.pageTableLayout, args.isCausal, args.attentionMaskShape,
+          args.attentionMaskLayout, args.curPosTensorShape,
+          args.curPosTensorLayout, args.attentionSinkShape,
+          args.attentionSinkLayout, args.scale, opConfig.outputLayout,
+          initialState.get());
+  // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+}
+
 llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
@@ -2407,6 +3073,45 @@ ScaledDotProductAttentionOp::getOpConstraints(
       attentionMaskShape, attentionMaskLayout, attentionSinkShape,
       attentionSinkLayout, isCausal, getScale(), getSlidingWindowSize(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() >= 3 && inputs.size() <= 5 &&
+         "ttnn::scaled_dot_product_attention can have 3 to 5 operands input "
+         "tensors (q, k, v, optional mask, optional attention_sink)");
+
+  const auto queryShape = getQuery().getType().getShape();
+  const auto keyShape = getKey().getType().getShape();
+  const auto valueShape = getValue().getType().getShape();
+
+  size_t idx = 3;
+  const std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape =
+      getAttentionMask()
+          ? std::make_optional(getAttentionMask().getType().getShape())
+          : std::nullopt;
+  const std::optional<TTNNLayoutAttr> attentionMaskLayout =
+      getAttentionMask() ? std::make_optional(inputs[idx++]) : std::nullopt;
+  const std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape =
+      getAttentionSink()
+          ? std::make_optional(getAttentionSink().getType().getShape())
+          : std::nullopt;
+  const std::optional<TTNNLayoutAttr> attentionSinkLayout =
+      getAttentionSink() ? std::make_optional(inputs[idx++]) : std::nullopt;
+
+  bool isCausal = getIsCausal();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ScaledDotProductAttentionOp>::
+      getOpConstraintsWithState(
+          queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
+          attentionMaskShape, attentionMaskLayout, attentionSinkShape,
+          attentionSinkLayout, isCausal, getScale(), getSlidingWindowSize(),
+          opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t> ScaledDotProductAttentionOp::getOpRuntime(
@@ -2508,6 +3213,26 @@ FlashMlaPrefillOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+FlashMlaPrefillOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() >= 2 && inputs.size() <= 4 &&
+         "ttnn::flash_mla_prefill can have 2 to 4 input tensors "
+         "(q, k, optional value, optional mask)");
+
+  FlashMlaPrefillArgs args = unpackFlashMlaPrefillArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<FlashMlaPrefillOp>::getOpConstraintsWithState(
+      args.queryShape, args.queryLayout, args.keyShape, args.keyLayout,
+      args.valueShape, args.valueLayout, args.attentionMaskShape,
+      args.attentionMaskLayout, args.headDimV, args.isCausal, getScale(),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 FlashMlaPrefillOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
@@ -2545,6 +3270,27 @@ RotaryEmbeddingLlamaOp::getOpConstraints(
       transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+RotaryEmbeddingLlamaOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 4);
+
+  auto inputShape = getInput().getType().getShape();
+  auto cosShape = getCosCache().getType().getShape();
+  auto sinShape = getSinCache().getType().getShape();
+  auto transMatShape = getTransMat().getType().getShape();
+  bool isDecodeMode = getIsDecodeMode();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<RotaryEmbeddingLlamaOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
+      transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout,
+      initialState.get());
+}
+
 llvm::Expected<size_t>
 RotaryEmbeddingLlamaOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
@@ -2580,6 +3326,25 @@ RotaryEmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<RotaryEmbeddingOp>::getOpConstraints, *this, inputShape,
       inputs[0], cosShape, inputs[1], sinShape, inputs[2], tokenIndex,
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+RotaryEmbeddingOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 3);
+
+  auto inputShape = getInput().getType().getShape();
+  auto cosShape = getCosCache().getType().getShape();
+  auto sinShape = getSinCache().getType().getShape();
+  auto tokenIndex = getTokenIndex();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<RotaryEmbeddingOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
+      tokenIndex, opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2623,6 +3388,31 @@ NLPCreateQKVHeadsDecodeOp::getOpConstraints(
       opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+NLPCreateQKVHeadsDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == (1 + (getBatchOffset() == nullptr ? 0 : 1)));
+
+  auto inputShape = getInput().getType().getShape();
+
+  std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape;
+  std::optional<TTNNLayoutAttr> batchOffsetEncoding;
+  if (inputs.size() == 2) {
+    batchOffsetShape = getBatchOffset().getType().getShape();
+    batchOffsetEncoding = inputs[1];
+  }
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<NLPCreateQKVHeadsDecodeOp>::
+      getOpConstraintsWithState(
+          inputShape, inputs[0], batchOffsetShape, batchOffsetEncoding,
+          getNumHeads(), getNumKvHeads(), getOverlapQkCoregrid(),
+          getSliceSize(), opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t> NLPCreateQKVHeadsDecodeOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == (1 + (getBatchOffset() == nullptr ? 0 : 1)));
@@ -2659,6 +3449,21 @@ NLPConcatHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+NLPConcatHeadsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<NLPConcatHeadsOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 NLPConcatHeadsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                const OpConfig &opConfig) {
@@ -2685,6 +3490,23 @@ NLPConcatHeadsDecodeOp::getOpConstraints(
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints, *this,
       inputShape, inputs[0], numHeads, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+NLPConcatHeadsDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+  uint32_t numHeads = getNumHeads();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<NLPConcatHeadsDecodeOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], numHeads, opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2724,6 +3546,33 @@ SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
       getNumKvHeads(), getTransposeKey(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+SplitQueryKeyValueAndSplitHeadsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == (1 + (getKvInputTensor() ? 1 : 0)));
+
+  auto inputShape = getInputTensor().getType().getShape();
+
+  // Handle optional kv input tensor
+  std::optional<llvm::ArrayRef<int64_t>> kvInputShape = std::nullopt;
+  std::optional<TTNNLayoutAttr> kvInputLayout = std::nullopt;
+
+  if (getKvInputTensor()) {
+    kvInputShape = getKvInputTensor().getType().getShape();
+    kvInputLayout = inputs[1];
+  }
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<SplitQueryKeyValueAndSplitHeadsOp>::
+      getOpConstraintsWithState(inputShape, inputs[0], kvInputShape,
+                                kvInputLayout, getNumHeads(), getNumKvHeads(),
+                                getTransposeKey(), opConfig.outputLayout,
+                                initialState.get());
+}
+
 llvm::Expected<size_t> SplitQueryKeyValueAndSplitHeadsOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == (1 + (getKvInputTensor() ? 1 : 0)));
@@ -2757,6 +3606,22 @@ RepeatInterleaveOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputShape, inputs[0], getRepeats(), getDim(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+RepeatInterleaveOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<RepeatInterleaveOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getRepeats(), getDim(), opConfig.outputLayout,
+      initialState.get());
+}
+
 llvm::Expected<size_t>
 RepeatInterleaveOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
@@ -2783,6 +3648,21 @@ RepeatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RepeatOp>::getOpConstraints, *this, inputShape,
       inputs[0], getRepeatDims().getShape(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> RepeatOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<RepeatOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getRepeatDims().getShape(), opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2813,6 +3693,21 @@ PadOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getPadding(), getValue(), getUseMulticore(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> PadOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PadOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getPadding(), getValue(), getUseMulticore(),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 PadOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const OpConfig &opConfig) {
@@ -2839,6 +3734,21 @@ SortOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SortOp>::getOpConstraints, *this, inputShape, inputs[0],
       getDim(), getDescending(), getStable(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> SortOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<SortOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getDim(), getDescending(), getStable(),
+      opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2869,6 +3779,21 @@ ArgMaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], getDim(), getKeepDim(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> ArgMaxOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ArgMaxOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getDim(), getKeepDim(), opConfig.outputLayout,
+      initialState.get());
+}
+
 llvm::Expected<size_t>
 ArgMaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                        const OpConfig &opConfig) {
@@ -2895,6 +3820,21 @@ ProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ProdOp>::getOpConstraints, *this, inputShape, inputs[0],
       getDimArg(), getKeepDim(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> ProdOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ProdOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getDimArg(), getKeepDim(), opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2955,6 +3895,25 @@ RequantizeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], inScaleShape, inputs[1], inZeroPointShape, inputs[2],
       outScaleShape, inputs[3], outZeroPointShape, inputs[4], getAxis(),
       getOutputDtype(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> RequantizeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 5);
+  const auto inputShape = getInput().getType().getShape();
+  const auto inScaleShape = getInScale().getType().getShape();
+  const auto inZeroPointShape = getInZeroPoint().getType().getShape();
+  const auto outScaleShape = getOutScale().getType().getShape();
+  const auto outZeroPointShape = getOutZeroPoint().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<RequantizeOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], inScaleShape, inputs[1], inZeroPointShape,
+      inputs[2], outScaleShape, inputs[3], outZeroPointShape, inputs[4],
+      getAxis(), getOutputDtype(), opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3036,6 +3995,39 @@ LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       attr.matmulProgramConfig, attr.computeKernelConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> LinearOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+
+  const auto inputShapeA = getA().getType().getShape();
+  const auto inputShapeB = getB().getType().getShape();
+
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<TTNNLayoutAttr> biasLayout;
+
+  if (inputs.size() == 3) {
+    biasShape = getBias().getType().getShape();
+    biasLayout = inputs[2];
+  }
+
+  // Convert activation attribute to optional StringRef
+  std::optional<llvm::StringRef> activation =
+      getActivation() ? std::make_optional(getActivation().value())
+                      : std::nullopt;
+
+  // Get matmul program config from opConfig if present, otherwise from op.
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<LinearOp>::getOpConstraintsWithState(
+      inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
+      opConfig.outputLayout, getTransposeA(), getTransposeB(), activation,
+      attr.matmulProgramConfig, attr.computeKernelConfig, initialState.get());
+}
+
 llvm::Expected<size_t>
 LinearOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                        const OpConfig &opConfig) {
@@ -3085,6 +4077,31 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       attr.computeKernelConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> MatmulOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA = getA().getType().getShape();
+  const auto inputShapeB = getB().getType().getShape();
+
+  std::optional<llvm::StringRef> activation =
+      getActivation() ? std::make_optional(getActivation().value())
+                      : std::nullopt;
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
+
+  // Reconstruct the allocator state from the live records (null when empty ->
+  // stateless query). This path intentionally bypasses opConstraintsCache: the
+  // result depends on the threaded state, which the cache does not key on.
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<MatmulOp>::getOpConstraintsWithState(
+      inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout,
+      getTransposeA(), getTransposeB(), activation, attr.matmulProgramConfig,
+      attr.computeKernelConfig, initialState.get());
+}
+
 llvm::Expected<size_t>
 MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                        const OpConfig &opConfig) {
@@ -3117,6 +4134,25 @@ TopKRouterGptOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], weightShape, inputs[1], biasShape, inputs[2],
       static_cast<uint32_t>(getK()), static_cast<uint32_t>(getNumExperts()),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+TopKRouterGptOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
+  const auto biasShape = getBias().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<TopKRouterGptOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], weightShape, inputs[1], biasShape, inputs[2],
+      static_cast<uint32_t>(getK()), static_cast<uint32_t>(getNumExperts()),
+      opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3179,6 +4215,32 @@ PrepareMoEComputeW0W1WeightsOp::getOpConstraints(
       bias1Shape, bias1Layout, getHiddenSize(), getIntermediateSize());
 }
 
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW0W1WeightsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  const bool hasBias = getBias_0() != nullptr;
+  assert(inputs.size() == (hasBias ? 4u : 2u));
+
+  std::optional<llvm::ArrayRef<int64_t>> bias0Shape, bias1Shape;
+  std::optional<TTNNLayoutAttr> bias0Layout, bias1Layout;
+  if (hasBias) {
+    bias0Shape = getBias_0().getType().getShape();
+    bias1Shape = getBias_1().getType().getShape();
+    bias0Layout = inputs[2];
+    bias1Layout = inputs[3];
+  }
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PrepareMoEComputeW0W1WeightsOp>::
+      getOpConstraintsWithState(
+          getW0().getType().getShape(), inputs[0], getW1().getType().getShape(),
+          inputs[1], bias0Shape, bias0Layout, bias1Shape, bias1Layout,
+          getHiddenSize(), getIntermediateSize(), initialState.get());
+}
+
 llvm::Expected<size_t> PrepareMoEComputeW0W1WeightsOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   return issueErrorForGetOpRuntime(
@@ -3206,6 +4268,29 @@ PrepareMoEComputeW2WeightsOp::getOpConstraints(
       op_model::OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints, *this,
       getW2().getType().getShape(), inputs[0], bias2Shape, bias2Layout,
       getHiddenSize(), getIntermediateSize());
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW2WeightsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  const bool hasBias = getBias_2() != nullptr;
+  assert(inputs.size() == (hasBias ? 2u : 1u));
+
+  std::optional<llvm::ArrayRef<int64_t>> bias2Shape;
+  std::optional<TTNNLayoutAttr> bias2Layout;
+  if (hasBias) {
+    bias2Shape = getBias_2().getType().getShape();
+    bias2Layout = inputs[1];
+  }
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PrepareMoEComputeW2WeightsOp>::
+      getOpConstraintsWithState(getW2().getType().getShape(), inputs[0],
+                                bias2Shape, bias2Layout, getHiddenSize(),
+                                getIntermediateSize(), initialState.get());
 }
 
 llvm::Expected<size_t> PrepareMoEComputeW2WeightsOp::getOpRuntime(
@@ -3253,6 +4338,22 @@ FillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> FillCacheOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 2);
+
+  auto cacheShape = getCache().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<FillCacheOp>::getOpConstraintsWithState(
+      cacheShape, inputs[0], inputShape, inputs[1], getBatchOffset(),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 FillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
@@ -3283,6 +4384,24 @@ UpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<UpdateCacheOp>::getOpConstraints, *this, cacheShape,
       inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
       getBatchOffset(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+UpdateCacheOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 3);
+
+  auto cacheShape = getCache().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
+  auto updateIndexShape = getUpdateIndex().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<UpdateCacheOp>::getOpConstraintsWithState(
+      cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
+      getBatchOffset(), opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3319,6 +4438,32 @@ PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<PagedUpdateCacheOp>::getOpConstraints, *this,
       cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
       pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedUpdateCacheOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() >= 3 && inputs.size() <= 4 &&
+         "PagedUpdateCacheOp must have 3 or 4 inputs");
+
+  auto cacheShape = getCache().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
+  auto updateIndexShape = getUpdateIndex().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> pageTableShape;
+  std::optional<TTNNLayoutAttr> pageTableLayout;
+  if (getPageTable()) {
+    pageTableShape = getPageTable().getType().getShape();
+    pageTableLayout = inputs[3];
+  }
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PagedUpdateCacheOp>::getOpConstraintsWithState(
+      cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
+      pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3364,6 +4509,31 @@ PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       batchIdxShape, batchIdxLayout, opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+PagedFillCacheOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() >= 3 && inputs.size() <= 4 &&
+         "PagedFillCacheOp must have 3 or 4 inputs");
+
+  auto cacheShape = getCache().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
+  auto pageTableShape = getPageTable().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> batchIdxShape;
+  std::optional<TTNNLayoutAttr> batchIdxLayout;
+  if (getBatchIdxTensor()) {
+    batchIdxShape = getBatchIdxTensor().getType().getShape();
+    batchIdxLayout = inputs[3];
+  }
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PagedFillCacheOp>::getOpConstraintsWithState(
+      cacheShape, inputs[0], inputShape, inputs[1], pageTableShape, inputs[2],
+      batchIdxShape, batchIdxLayout, opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 PagedFillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                const OpConfig &opConfig) {
@@ -3400,6 +4570,23 @@ SamplingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getK().getType().getShape(), inputs[2], getP().getType().getShape(),
       inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> SamplingOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 5);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<mlir::tt::ttnn::SamplingOp>::
+      getOpConstraintsWithState(
+          getInputValues().getType().getShape(), inputs[0],
+          getInputIndices().getType().getShape(), inputs[1],
+          getK().getType().getShape(), inputs[2], getP().getType().getShape(),
+          inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
+          opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3541,6 +4728,35 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getConv2dSliceConfigAttr(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> Conv2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<TTNNLayoutAttr> biasLayout;
+
+  if (inputs.size() == 3) {
+    biasShape = getBias().getType().getShape();
+    biasLayout = inputs[2];
+  }
+
+  Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<Conv2dOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getDilation(), getGroups(), attr.conv2dConfig,
+      attr.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                        const OpConfig &opConfig) {
@@ -3619,6 +4835,37 @@ Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
       getPadding(), getGroups(), getPaddingMode(), getDtypeAttr(),
       attr.conv3dConfig, attr.deviceComputeKernelConfig, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> Conv3dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+
+  const auto inputShape = getInput().getType().getShape();
+  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(this);
+  const auto weightShape = preparedWeight.getShape();
+  auto weightLayout = mlir::cast<TTNNLayoutAttr>(preparedWeight.getEncoding());
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<TTNNLayoutAttr> biasLayout;
+
+  if (inputs.size() == 3) {
+    biasShape = getBias().getType().getShape();
+    biasLayout = inputs[2];
+  }
+
+  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<Conv3dOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], weightShape, weightLayout, biasShape, biasLayout,
+      getInChannels(), getOutChannels(), getBatchSize(), getInputDepth(),
+      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
+      getPadding(), getGroups(), getPaddingMode(), getDtypeAttr(),
+      attr.conv3dConfig, attr.deviceComputeKernelConfig, opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3701,6 +4948,35 @@ ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getConv2dSliceConfig(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+ConvTranspose2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<TTNNLayoutAttr> biasLayout;
+
+  if (inputs.size() == 3) {
+    biasShape = getBias().getType().getShape();
+    biasLayout = inputs[2];
+  }
+
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ConvTranspose2dOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getOutputPadding(), getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
+      getConv2dSliceConfig(), opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 ConvTranspose2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
@@ -3752,6 +5028,29 @@ PrepareConv2dWeightsOp::getOpConstraints(
       opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+PrepareConv2dWeightsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const ::llvm::ArrayRef<int64_t> weightShape =
+      getWeightTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PrepareConv2dWeightsOp>::getOpConstraintsWithState(
+      inputs[0], weightShape, getInputMemoryConfig(), getInputTensorLayout(),
+      getWeightsFormat(), getInChannels(), getOutChannels(), getBatchSize(),
+      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
+      getPadding(), getDilation(), getHasBias(), getGroups(), getInputDtype(),
+      getOutputDtype(), conv2dAttrs.conv2dConfig,
+      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 PrepareConv2dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
@@ -3780,6 +5079,28 @@ PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
       conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConv2dBiasOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const ::llvm::ArrayRef<int64_t> biasShape =
+      getBiasTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PrepareConv2dBiasOp>::getOpConstraintsWithState(
+      inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
+      conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
+      opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3833,6 +5154,31 @@ PrepareConvTranspose2dWeightsOp::getOpConstraints(
       getMirrorKernel(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dWeightsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const ::llvm::ArrayRef<int64_t> weightShape =
+      getWeightTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PrepareConvTranspose2dWeightsOp>::
+      getOpConstraintsWithState(
+          inputs[0], weightShape, getInputMemoryConfig(),
+          getInputTensorLayout(), getWeightsFormat(), getInChannels(),
+          getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
+          getKernelSize(), getStride(), getPadding(), getOutputPadding(),
+          getDilation(), getHasBias(), getGroups(), getInputDtype(),
+          getOutputDtype(), conv2dAttrs.conv2dConfig,
+          conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfig(),
+          getMirrorKernel(), opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t> PrepareConvTranspose2dWeightsOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   return issueErrorForGetOpRuntime(
@@ -3862,6 +5208,29 @@ PrepareConvTranspose2dBiasOp::getOpConstraints(
       getConv2dSliceConfig(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dBiasOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const ::llvm::ArrayRef<int64_t> biasShape =
+      getBiasTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PrepareConvTranspose2dBiasOp>::
+      getOpConstraintsWithState(
+          inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
+          getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+          getInputWidth(), getKernelSize(), getStride(), getPadding(),
+          getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
+          conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
+          getConv2dSliceConfig(), opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t> PrepareConvTranspose2dBiasOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   return issueErrorForGetOpRuntime(
@@ -3884,6 +5253,13 @@ MaxPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getPoolingOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> MaxPool2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getPoolingOpConstraintsWithState(*this, inputs, opConfig,
+                                                  liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // MaxPool2dWithIndicesOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -3900,6 +5276,14 @@ MaxPool2dWithIndicesOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getMaxPool2dWithIndicesOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints>
+MaxPool2dWithIndicesOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getMaxPool2dWithIndicesOpConstraintsWithState(
+      *this, inputs, opConfig, liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // AvgPoo2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -3914,6 +5298,13 @@ llvm::Expected<size_t>
 AvgPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   return detail::getPoolingOpRuntime(*this, inputs, opConfig);
+}
+
+llvm::Expected<op_model::OpConstraints> AvgPool2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getPoolingOpConstraintsWithState(*this, inputs, opConfig,
+                                                  liveRecords);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3969,6 +5360,31 @@ llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
       optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+BatchNormInferenceOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 5 && "ttnn::batch_norm can only have 5 input tensors "
+                               "(representing main input tensor, "
+                               "running_mean, running_var, weight and bias).");
+
+  const auto inputShape = getInput().getType().getShape();
+
+  BatchNormOptionalArgs optionalArgs =
+      unpackBatchNormOptionalArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<BatchNormInferenceOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], optionalArgs.runningMeanShape,
+      optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
+      optionalArgs.runningVarLayout, optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
+      initialState.get());
+}
+
 llvm::Expected<size_t>
 BatchNormInferenceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
@@ -4017,6 +5433,34 @@ BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       optionalArgs.weightLayout, optionalArgs.biasShape,
       optionalArgs.biasLayout, getEpsilon(), getMomentum(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+BatchNormTrainingOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert((inputs.size() == 1 || inputs.size() == 5) &&
+         "ttnn::batch_norm_training can either have 1 input tensor "
+         "(representing the main input) or 5 input tensors (representing main "
+         "input tensor, running_mean, running_var, weight and bias). The "
+         "usage of this op with 2-4 input tensors is discouraged as it's "
+         "ambiguous.");
+
+  const auto inputShape = getInput().getType().getShape();
+
+  BatchNormOptionalArgs optionalArgs =
+      unpackBatchNormOptionalArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<BatchNormTrainingOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], optionalArgs.runningMeanShape,
+      optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
+      optionalArgs.runningVarLayout, optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, getEpsilon(), getMomentum(),
+      opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4095,6 +5539,28 @@ RMSNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       opConfig.outputLayout, computeKernelConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> RMSNormOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
+
+  RMSNormOptionalArgs optionalArgs = unpackRMSNormOptionalArgs(inputs, *this);
+
+  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+      getComputeConfigAttr()
+          ? std::optional<DeviceComputeKernelConfigAttr>(getComputeConfigAttr())
+          : std::nullopt;
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<RMSNormOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
+      computeKernelConfig, initialState.get());
+}
+
 llvm::Expected<size_t>
 RMSNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
@@ -4152,6 +5618,24 @@ llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
       inputShape, inputs[0], optionalArgs.residualInputShape,
       optionalArgs.residualInputLayout, dataTypeAttrToOptional(getDtypeAttr()),
       getUse_2dCoreGrid(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+RMSNormPreAllGatherOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
+
+  RMSNormPreAllGatherOptionalArgs optionalArgs =
+      unpackRMSNormPreAllGatherOptionalArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<RMSNormPreAllGatherOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], optionalArgs.residualInputShape,
+      optionalArgs.residualInputLayout, dataTypeAttrToOptional(getDtypeAttr()),
+      getUse_2dCoreGrid(), opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4215,6 +5699,24 @@ LayerNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], optionalArgs.weightShape, optionalArgs.weightLayout,
       optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> LayerNormOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
+
+  LayerNormOptionalArgs optionalArgs =
+      unpackLayerNormOptionalArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<LayerNormOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4281,6 +5783,25 @@ LayerNormPreAllGatherOp::getOpConstraints(
       opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+LayerNormPreAllGatherOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
+
+  LayerNormPreAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPreAllGatherOptionalArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<LayerNormPreAllGatherOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], optionalArgs.residualInputShape,
+      optionalArgs.residualInputLayout, optionalArgs.recipShape,
+      optionalArgs.recipLayout, dataTypeAttrToOptional(getDtypeAttr()),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 LayerNormPreAllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                       const OpConfig &opConfig) {
@@ -4344,6 +5865,26 @@ LayerNormPostAllGatherOp::getOpConstraints(
       inputShape, inputs[0], statsShape, inputs[1], optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
       optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+LayerNormPostAllGatherOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
+  const auto statsShape = getStats().getType().getShape();
+
+  LayerNormPostAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPostAllGatherOptionalArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], statsShape, inputs[1], optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t> LayerNormPostAllGatherOp::getOpRuntime(
@@ -4419,6 +5960,27 @@ GroupNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       getEpsilon(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> GroupNormOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(!inputs.empty() && "GroupNormOp requires at least input layout");
+
+  const auto inputShape = getInput().getType().getShape();
+
+  GroupNormOptionalArgs optionalArgs =
+      unpackGroupNormOptionalArgs(inputs, *this);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<GroupNormOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], optionalArgs.inputMaskShape,
+      optionalArgs.inputMaskLayout, optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, getNumGroups(), getEpsilon(),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 GroupNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
@@ -4452,6 +6014,22 @@ ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], getMinAttr(), getMaxAttr(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+ClampScalarOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ClampScalarOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getMinAttr(), getMaxAttr(), opConfig.outputLayout,
+      initialState.get());
+}
+
 llvm::Expected<size_t>
 ClampScalarOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
@@ -4479,6 +6057,23 @@ ClampTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<ClampTensorOp>::getOpConstraints, *this, inputShape,
       inputs[0], getMin().getType().getShape(), inputs[1],
       getMax().getType().getShape(), inputs[2], opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ClampTensorOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ClampTensorOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getMin().getType().getShape(), inputs[1],
+      getMax().getType().getShape(), inputs[2], opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4510,6 +6105,21 @@ PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], getPermutation(), getPadValue(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints> PermuteOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<PermuteOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getPermutation(), getPadValue(),
+      opConfig.outputLayout, initialState.get());
+}
+
 llvm::Expected<size_t>
 PermuteOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
@@ -4536,6 +6146,21 @@ UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<UpsampleOp>::getOpConstraints, *this, inputShape,
       inputs[0], getScaleFactor(), getMode(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> UpsampleOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<UpsampleOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getScaleFactor(), getMode(), opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4565,6 +6190,22 @@ EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<EmbeddingOp>::getOpConstraints, *this, inputShape,
       inputs[0], weightShape, inputs[1], opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> EmbeddingOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 2);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<EmbeddingOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], weightShape, inputs[1], opConfig.outputLayout,
+      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4597,6 +6238,24 @@ EmbeddingBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<EmbeddingBackwardOp>::getOpConstraints, *this,
       inputShape, inputs[0], weightShape, inputs[1], inGradientShape, inputs[2],
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+EmbeddingBackwardOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
+  const auto inGradientShape = getInGradient().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<EmbeddingBackwardOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], weightShape, inputs[1], inGradientShape, inputs[2],
+      opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4747,6 +6406,22 @@ MeshPartitionOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], getDim(), getClusterAxis(), opConfig.outputLayout);
 }
 
+llvm::Expected<op_model::OpConstraints>
+MeshPartitionOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<MeshPartitionOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getDim(), getClusterAxis(), opConfig.outputLayout,
+      initialState.get());
+}
+
 llvm::Expected<size_t>
 MeshPartitionOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
@@ -4771,6 +6446,18 @@ ConstantOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ConstantOp>::getOpConstraints, *this, getValue(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> ConstantOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 0);
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ConstantOp>::getOpConstraintsWithState(
+      getValue(), opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4850,6 +6537,22 @@ GlobalAvgPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<GlobalAvgPool2dOp>::getOpConstraints, *this, inputShape,
       inputs[0], dataTypeAttrToOptional(getDtypeAttr()), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+GlobalAvgPool2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<GlobalAvgPool2dOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], dataTypeAttrToOptional(getDtypeAttr()),
+      opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5089,6 +6792,20 @@ TopKOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<mlir::tt::ttnn::TopKOp>::getOpConstraints, *this,
       inputShape, inputs[0], getK(), getDim(), getLargest(), getSorted(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> TopKOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 1);
+  const auto inputShape = getInputTensor().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<mlir::tt::ttnn::TopKOp>::getOpConstraintsWithState(
+      inputShape, inputs[0], getK(), getDim(), getLargest(), getSorted(),
+      opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1877,31 +1877,31 @@ llvm::Expected<op_model::OpConstraints> SumOp::getOpConstraintsWithState(
 // SoftmaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+softmaxConstraintsImpl(SoftmaxOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDimension(), op.getNumericStable(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SoftmaxOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDimension(), getNumericStable(), opConfig.outputLayout);
+  return softmaxConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> SoftmaxOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<SoftmaxOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getDimension(), getNumericStable(),
-      opConfig.outputLayout, initialState.get());
+  return softmaxConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2121,48 +2121,40 @@ BitcastConvertOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TypecastOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+typecastConstraintsImpl(TypecastOp op,
+                        const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig,
+                        const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   if (inputs[0].getBufferType() == BufferType::SystemMemory) {
     return issueErrorForGetOpConstraints(
-        getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+        op.getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
   }
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
   ttcore::DataTypeAttr dtype =
-      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
+      detail::resolveOutputDtype(op.getOperation(), opConfig.outputLayout);
   assert(dtype && "TypecastOp requires output dtype");
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<TypecastOp>::getOpConstraints, *this, inputShape,
-      inputs[0], dtype, opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0], dtype,
+                                     opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return typecastConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> TypecastOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  if (inputs[0].getBufferType() == BufferType::SystemMemory) {
-    return issueErrorForGetOpConstraints(
-        getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
-  }
-
-  const auto inputShape = getInput().getType().getShape();
-
-  ttcore::DataTypeAttr dtype =
-      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
-  assert(dtype && "TypecastOp requires output dtype");
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<TypecastOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], dtype, opConfig.outputLayout, initialState.get());
+  return typecastConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2190,57 +2182,44 @@ TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ToLayoutOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+toLayoutConstraintsImpl(ToLayoutOp op,
+                        const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig,
+                        const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
   assert(opConfig.outputLayout && "ToLayoutOp requires output layout");
-  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
+  assert(opConfig.outputLayout.getLayout() == op.getLayoutAttr().getValue());
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
   // Only signal a dtype conversion to the op model when this to_layout is
   // genuinely changing dtype. Use the resolved (candidate or intrinsic)
   // output dtype, and compare it against the input dtype.
   std::optional<ttcore::DataType> outputDtype = std::nullopt;
-  if (ttcore::DataTypeAttr dtype =
-          detail::resolveOutputDtype(getOperation(), opConfig.outputLayout)) {
+  if (ttcore::DataTypeAttr dtype = detail::resolveOutputDtype(
+          op.getOperation(), opConfig.outputLayout)) {
     if (dtype.getValue() != inputs[0].getDataType()) {
       outputDtype = dtype.getValue();
     }
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ToLayoutOp>::getOpConstraints, *this, inputShape,
-      inputs[0], outputDtype, opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     outputDtype, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return toLayoutConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> ToLayoutOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-  assert(opConfig.outputLayout && "ToLayoutOp requires output layout");
-  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
-
-  const auto inputShape = getInput().getType().getShape();
-
-  // Only signal a dtype conversion to the op model when this to_layout is
-  // genuinely changing dtype. Use the resolved (candidate or intrinsic)
-  // output dtype, and compare it against the input dtype.
-  std::optional<ttcore::DataType> outputDtype = std::nullopt;
-  if (ttcore::DataTypeAttr dtype =
-          detail::resolveOutputDtype(getOperation(), opConfig.outputLayout)) {
-    if (dtype.getValue() != inputs[0].getDataType()) {
-      outputDtype = dtype.getValue();
-    }
-  }
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ToLayoutOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], outputDtype, opConfig.outputLayout,
-      initialState.get());
+  return toLayoutConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2269,41 +2248,39 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ToMemoryConfigOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+toMemoryConfigConstraintsImpl(ToMemoryConfigOp op,
+                              const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig,
+                              const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
   TTNNLayoutAttr outputLayout =
       opConfig.outputLayout
           ? opConfig.outputLayout
-          : mlir::cast<TTNNLayoutAttr>(getResult().getType().getEncoding());
+          : mlir::cast<TTNNLayoutAttr>(op.getResult().getType().getEncoding());
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ToMemoryConfigOp>::getOpConstraints, *this, inputShape,
-      inputs[0], outputLayout);
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                   const OpConfig &opConfig) {
+  return toMemoryConfigConstraintsImpl(*this, inputs, opConfig,
+                                       /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 ToMemoryConfigOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  TTNNLayoutAttr outputLayout =
-      opConfig.outputLayout
-          ? opConfig.outputLayout
-          : mlir::cast<TTNNLayoutAttr>(getResult().getType().getEncoding());
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ToMemoryConfigOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], outputLayout, initialState.get());
+  return toMemoryConfigConstraintsImpl(*this, inputs, opConfig,
+                                       initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2327,40 +2304,35 @@ ToMemoryConfigOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConcatOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  assert(inputs.size() == getInputs().size());
+static llvm::Expected<op_model::OpConstraints>
+concatConstraintsImpl(ConcatOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == op.getInputs().size());
 
   std::vector<llvm::ArrayRef<int64_t>> inputShapes;
-  for (const Value &opInput : getInputs()) {
+  for (const Value &opInput : op.getInputs()) {
     mlir::RankedTensorType inputType =
         mlir::cast<mlir::RankedTensorType>(opInput.getType());
     inputShapes.push_back(inputType.getShape());
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConcatOp>::getOpConstraints, *this, inputShapes, inputs,
-      getDim(), opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, inputShapes, inputs,
+                                     op.getDim(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return concatConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> ConcatOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == getInputs().size());
-
-  std::vector<llvm::ArrayRef<int64_t>> inputShapes;
-  for (const Value &opInput : getInputs()) {
-    mlir::RankedTensorType inputType =
-        mlir::cast<mlir::RankedTensorType>(opInput.getType());
-    inputShapes.push_back(inputType.getShape());
-  }
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ConcatOp>::getOpConstraintsWithState(
-      inputShapes, inputs, getDim(), opConfig.outputLayout, initialState.get());
+  return concatConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2384,31 +2356,32 @@ ConcatOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TransposeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+transposeConstraintsImpl(TransposeOp op,
+                         const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig,
+                         const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDim0(), op.getDim1(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<TransposeOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
+  return transposeConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> TransposeOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<TransposeOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getDim0(), getDim1(), opConfig.outputLayout,
-      initialState.get());
+  return transposeConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2427,32 +2400,31 @@ TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CumSumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+cumSumConstraintsImpl(CumSumOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getDim(),
+      dataTypeAttrToOptional(op.getDtypeAttr()), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 CumSumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<CumSumOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout);
+  return cumSumConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> CumSumOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<CumSumOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout, initialState.get());
+  return cumSumConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2471,32 +2443,31 @@ CumSumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CumProdOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+cumProdConstraintsImpl(CumProdOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getDim(),
+      dataTypeAttrToOptional(op.getDtypeAttr()), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 CumProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<CumProdOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout);
+  return cumProdConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> CumProdOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<CumProdOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout, initialState.get());
+  return cumProdConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2515,31 +2486,34 @@ CumProdOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConcatenateHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+concatenateHeadsConstraintsImpl(ConcatenateHeadsOp op,
+                                const std::vector<TTNNLayoutAttr> &inputs,
+                                const OpConfig &opConfig,
+                                const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ConcatenateHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConcatenateHeadsOp>::getOpConstraints, *this,
-      inputShape, inputs[0], opConfig.outputLayout);
+  return concatenateHeadsConstraintsImpl(*this, inputs, opConfig,
+                                         /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 ConcatenateHeadsOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ConcatenateHeadsOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], opConfig.outputLayout, initialState.get());
+  return concatenateHeadsConstraintsImpl(*this, inputs, opConfig,
+                                         initialState.get());
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2602,9 +2602,11 @@ unpackScaledDotProductAttentionDecodeArgs(
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints>
-ScaledDotProductAttentionDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+scaledDotProductAttentionDecodeConstraintsImpl(
+    ScaledDotProductAttentionDecodeOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   // Clang tidy falsley determines that the underling float data in the
   // llvm::APFloat is freed more than once as APFloat is passed by value and
   // then destroyed at the end of this function.
@@ -2619,12 +2621,11 @@ ScaledDotProductAttentionDecodeOp::getOpConstraints(
          "4, 5, or 6 input tensors");
 
   ScaledDotProductAttentionDecodeArgs sdpaArgs =
-      unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
+      unpackScaledDotProductAttentionDecodeArgs(inputs, op);
 
-  auto scale = getScale();
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints,
-      *this, sdpaArgs.queryShape, sdpaArgs.queryLayout, sdpaArgs.keyShape,
+  auto scale = op.getScale();
+  return detail::constraintsDispatch(
+      op, state, sdpaArgs.queryShape, sdpaArgs.queryLayout, sdpaArgs.keyShape,
       sdpaArgs.keyLayout, sdpaArgs.valueShape, sdpaArgs.valueLayout,
       sdpaArgs.isCausal, sdpaArgs.attentionMaskShape,
       sdpaArgs.attentionMaskLayout, sdpaArgs.curPosTensorShape,
@@ -2635,30 +2636,20 @@ ScaledDotProductAttentionDecodeOp::getOpConstraints(
 }
 
 llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionDecodeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return scaledDotProductAttentionDecodeConstraintsImpl(*this, inputs, opConfig,
+                                                        /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
 ScaledDotProductAttentionDecodeOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
-  assert(inputs.size() >= 3 && inputs.size() <= 6 &&
-         "ttnn::transformer::scaled_dot_product_attention_decode can have 3, "
-         "4, 5, or 6 input tensors");
-
-  ScaledDotProductAttentionDecodeArgs sdpaArgs =
-      unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ScaledDotProductAttentionDecodeOp>::
-      getOpConstraintsWithState(
-          sdpaArgs.queryShape, sdpaArgs.queryLayout, sdpaArgs.keyShape,
-          sdpaArgs.keyLayout, sdpaArgs.valueShape, sdpaArgs.valueLayout,
-          sdpaArgs.isCausal, sdpaArgs.attentionMaskShape,
-          sdpaArgs.attentionMaskLayout, sdpaArgs.curPosTensorShape,
-          sdpaArgs.curPosTensorLayout, sdpaArgs.attentionSinkShape,
-          sdpaArgs.attentionSinkLayout, sdpaArgs.scale, sdpaArgs.programConfig,
-          opConfig.outputLayout, initialState.get());
-  // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+  return scaledDotProductAttentionDecodeConstraintsImpl(*this, inputs, opConfig,
+                                                        initialState.get());
 }
 
 llvm::Expected<size_t> ScaledDotProductAttentionDecodeOp::getOpRuntime(
@@ -2764,9 +2755,11 @@ unpackPagedScaledDotProductAttentionDecodeArgs(
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints>
-PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+pagedScaledDotProductAttentionDecodeConstraintsImpl(
+    PagedScaledDotProductAttentionDecodeOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   // See the comment in scaledDotProductAttentionDecodeOp::getOpConstraints for
   // an explanation of this lint suppression.
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
@@ -2775,12 +2768,10 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
          "7 input tensors");
 
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
-      unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
+      unpackPagedScaledDotProductAttentionDecodeArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<
-          PagedScaledDotProductAttentionDecodeOp>::getOpConstraints,
-      *this, pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
+  return detail::constraintsDispatch(
+      op, state, pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
       pagedSdpaArgs.keyShape, pagedSdpaArgs.keyLayout, pagedSdpaArgs.valueShape,
       pagedSdpaArgs.valueLayout, pagedSdpaArgs.pageTableShape,
       pagedSdpaArgs.pageTableLayout, pagedSdpaArgs.isCausal,
@@ -2793,33 +2784,20 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
 }
 
 llvm::Expected<op_model::OpConstraints>
+PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return pagedScaledDotProductAttentionDecodeConstraintsImpl(
+      *this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
 PagedScaledDotProductAttentionDecodeOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
-  assert(inputs.size() >= 4 && inputs.size() <= 7 &&
-         "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
-         "7 input tensors");
-
-  PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
-      unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PagedScaledDotProductAttentionDecodeOp>::
-      getOpConstraintsWithState(
-          pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
-          pagedSdpaArgs.keyShape, pagedSdpaArgs.keyLayout,
-          pagedSdpaArgs.valueShape, pagedSdpaArgs.valueLayout,
-          pagedSdpaArgs.pageTableShape, pagedSdpaArgs.pageTableLayout,
-          pagedSdpaArgs.isCausal, pagedSdpaArgs.attentionMaskShape,
-          pagedSdpaArgs.attentionMaskLayout, pagedSdpaArgs.curPosTensorShape,
-          pagedSdpaArgs.curPosTensorLayout, pagedSdpaArgs.attentionSinkShape,
-          pagedSdpaArgs.attentionSinkLayout, pagedSdpaArgs.scale,
-          pagedSdpaArgs.slidingWindowSize, pagedSdpaArgs.programConfig,
-          opConfig.outputLayout, initialState.get());
-  // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+  return pagedScaledDotProductAttentionDecodeConstraintsImpl(
+      *this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
@@ -2926,47 +2904,41 @@ unpackPagedFlashMultiLatentAttentionDecodeArgs(
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints>
-PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
+    PagedFlashMultiLatentAttentionDecodeOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
 
   PagedFlashMultiLatentAttentionDecodeArgs args =
-      unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
+      unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<
-          PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints,
-      *this, args.queryShape, args.queryLayout, args.keyShape, args.keyLayout,
-      args.valueShape, args.valueLayout, args.headDimV, args.pageTableShape,
-      args.pageTableLayout, args.isCausal, args.attentionMaskShape,
-      args.attentionMaskLayout, args.curPosTensorShape, args.curPosTensorLayout,
-      args.attentionSinkShape, args.attentionSinkLayout, args.scale,
-      opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, args.queryShape, args.queryLayout, args.keyShape,
+      args.keyLayout, args.valueShape, args.valueLayout, args.headDimV,
+      args.pageTableShape, args.pageTableLayout, args.isCausal,
+      args.attentionMaskShape, args.attentionMaskLayout, args.curPosTensorShape,
+      args.curPosTensorLayout, args.attentionSinkShape, args.attentionSinkLayout,
+      args.scale, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
+      *this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 PagedFlashMultiLatentAttentionDecodeOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
-  PagedFlashMultiLatentAttentionDecodeArgs args =
-      unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PagedFlashMultiLatentAttentionDecodeOp>::
-      getOpConstraintsWithState(
-          args.queryShape, args.queryLayout, args.keyShape, args.keyLayout,
-          args.valueShape, args.valueLayout, args.headDimV, args.pageTableShape,
-          args.pageTableLayout, args.isCausal, args.attentionMaskShape,
-          args.attentionMaskLayout, args.curPosTensorShape,
-          args.curPosTensorLayout, args.attentionSinkShape,
-          args.attentionSinkLayout, args.scale, opConfig.outputLayout,
-          initialState.get());
-  // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+  return pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
+      *this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
@@ -2990,48 +2962,42 @@ llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
 // ChunkedScaledDotProductAttentionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ChunkedScaledDotProductAttentionOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+chunkedScaledDotProductAttentionConstraintsImpl(
+    ChunkedScaledDotProductAttentionOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 5 &&
          "ttnn::chunked_scaled_dot_product_attention has 5 input tensors "
          "(q, k, v, page_table, chunk_start_idx)");
 
-  const auto queryShape = getQuery().getType().getShape();
-  const auto keyShape = getKey().getType().getShape();
-  const auto valueShape = getValue().getType().getShape();
-  const auto pageTableShape = getPageTable().getType().getShape();
-  const auto chunkStartIdxShape = getChunkStartIdx().getType().getShape();
+  const auto queryShape = op.getQuery().getType().getShape();
+  const auto keyShape = op.getKey().getType().getShape();
+  const auto valueShape = op.getValue().getType().getShape();
+  const auto pageTableShape = op.getPageTable().getType().getShape();
+  const auto chunkStartIdxShape = op.getChunkStartIdx().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints,
-      *this, queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
-      pageTableShape, inputs[3], chunkStartIdxShape, inputs[4], getScale(),
-      getProgramConfig(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, queryShape, inputs[0], keyShape, inputs[1], valueShape,
+      inputs[2], pageTableShape, inputs[3], chunkStartIdxShape, inputs[4],
+      op.getScale(), op.getProgramConfig(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ChunkedScaledDotProductAttentionOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return chunkedScaledDotProductAttentionConstraintsImpl(
+      *this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 ChunkedScaledDotProductAttentionOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 5 &&
-         "ttnn::chunked_scaled_dot_product_attention has 5 input tensors "
-         "(q, k, v, page_table, chunk_start_idx)");
-
-  const auto queryShape = getQuery().getType().getShape();
-  const auto keyShape = getKey().getType().getShape();
-  const auto valueShape = getValue().getType().getShape();
-  const auto pageTableShape = getPageTable().getType().getShape();
-  const auto chunkStartIdxShape = getChunkStartIdx().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ChunkedScaledDotProductAttentionOp>::
-      getOpConstraintsWithState(
-          queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
-          pageTableShape, inputs[3], chunkStartIdxShape, inputs[4], getScale(),
-          getProgramConfig(), opConfig.outputLayout, initialState.get());
+  return chunkedScaledDotProductAttentionConstraintsImpl(
+      *this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t> ChunkedScaledDotProductAttentionOp::getOpRuntime(
@@ -3057,78 +3023,56 @@ llvm::Expected<size_t> ChunkedScaledDotProductAttentionOp::getOpRuntime(
 // ScaledDotProductAttentionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ScaledDotProductAttentionOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+scaledDotProductAttentionConstraintsImpl(
+    ScaledDotProductAttentionOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 3 && inputs.size() <= 5 &&
          "ttnn::scaled_dot_product_attention can have 3 to 5 operands input "
          "tensors (q, k, v, optional mask, optional attention_sink)");
 
-  const auto queryShape = getQuery().getType().getShape();
-  const auto keyShape = getKey().getType().getShape();
-  const auto valueShape = getValue().getType().getShape();
+  const auto queryShape = op.getQuery().getType().getShape();
+  const auto keyShape = op.getKey().getType().getShape();
+  const auto valueShape = op.getValue().getType().getShape();
 
   size_t idx = 3;
   const std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape =
-      getAttentionMask()
-          ? std::make_optional(getAttentionMask().getType().getShape())
+      op.getAttentionMask()
+          ? std::make_optional(op.getAttentionMask().getType().getShape())
           : std::nullopt;
   const std::optional<TTNNLayoutAttr> attentionMaskLayout =
-      getAttentionMask() ? std::make_optional(inputs[idx++]) : std::nullopt;
+      op.getAttentionMask() ? std::make_optional(inputs[idx++]) : std::nullopt;
   const std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape =
-      getAttentionSink()
-          ? std::make_optional(getAttentionSink().getType().getShape())
+      op.getAttentionSink()
+          ? std::make_optional(op.getAttentionSink().getType().getShape())
           : std::nullopt;
   const std::optional<TTNNLayoutAttr> attentionSinkLayout =
-      getAttentionSink() ? std::make_optional(inputs[idx++]) : std::nullopt;
+      op.getAttentionSink() ? std::make_optional(inputs[idx++]) : std::nullopt;
 
-  bool isCausal = getIsCausal();
+  bool isCausal = op.getIsCausal();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ScaledDotProductAttentionOp>::getOpConstraints, *this,
-      queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
-      attentionMaskShape, attentionMaskLayout, attentionSinkShape,
-      attentionSinkLayout, isCausal, getScale(), getSlidingWindowSize(),
+  return detail::constraintsDispatch(
+      op, state, queryShape, inputs[0], keyShape, inputs[1], valueShape,
+      inputs[2], attentionMaskShape, attentionMaskLayout, attentionSinkShape,
+      attentionSinkLayout, isCausal, op.getScale(), op.getSlidingWindowSize(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return scaledDotProductAttentionConstraintsImpl(*this, inputs, opConfig,
+                                                  /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 ScaledDotProductAttentionOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() >= 3 && inputs.size() <= 5 &&
-         "ttnn::scaled_dot_product_attention can have 3 to 5 operands input "
-         "tensors (q, k, v, optional mask, optional attention_sink)");
-
-  const auto queryShape = getQuery().getType().getShape();
-  const auto keyShape = getKey().getType().getShape();
-  const auto valueShape = getValue().getType().getShape();
-
-  size_t idx = 3;
-  const std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape =
-      getAttentionMask()
-          ? std::make_optional(getAttentionMask().getType().getShape())
-          : std::nullopt;
-  const std::optional<TTNNLayoutAttr> attentionMaskLayout =
-      getAttentionMask() ? std::make_optional(inputs[idx++]) : std::nullopt;
-  const std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape =
-      getAttentionSink()
-          ? std::make_optional(getAttentionSink().getType().getShape())
-          : std::nullopt;
-  const std::optional<TTNNLayoutAttr> attentionSinkLayout =
-      getAttentionSink() ? std::make_optional(inputs[idx++]) : std::nullopt;
-
-  bool isCausal = getIsCausal();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ScaledDotProductAttentionOp>::
-      getOpConstraintsWithState(
-          queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
-          attentionMaskShape, attentionMaskLayout, attentionSinkShape,
-          attentionSinkLayout, isCausal, getScale(), getSlidingWindowSize(),
-          opConfig.outputLayout, initialState.get());
+  return scaledDotProductAttentionConstraintsImpl(*this, inputs, opConfig,
+                                                  initialState.get());
 }
 
 llvm::Expected<size_t> ScaledDotProductAttentionOp::getOpRuntime(

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1374,50 +1374,41 @@ BitwiseXorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ScatterOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+scatterConstraintsImpl(ScatterOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto indexShape = op.getIndex().getType().getShape();
+  const auto sourceShape = op.getSource().getType().getShape();
+
+  std::optional<ttcore::ReduceTypeAttr> reduceType =
+      ttcore::ReduceTypeAttr::get(op.getContext(), ttcore::ReduceType::Invalid);
+  if (op.getScatterReduceType() != ttcore::ReduceType::Invalid) {
+    reduceType = ttcore::ReduceTypeAttr::get(op.getContext(),
+                                             op.getScatterReduceType());
+  }
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     indexShape, inputs[1], sourceShape,
+                                     inputs[2], op.getDim(), reduceType,
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto indexShape = getIndex().getType().getShape();
-  const auto sourceShape = getSource().getType().getShape();
-
-  std::optional<ttcore::ReduceTypeAttr> reduceType =
-      ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
-  if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
-    reduceType =
-        ttcore::ReduceTypeAttr::get(getContext(), getScatterReduceType());
-  }
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ScatterOp>::getOpConstraints, *this, inputShape,
-      inputs[0], indexShape, inputs[1], sourceShape, inputs[2], getDim(),
-      reduceType, opConfig.outputLayout);
+  return scatterConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> ScatterOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto indexShape = getIndex().getType().getShape();
-  const auto sourceShape = getSource().getType().getShape();
-
-  std::optional<ttcore::ReduceTypeAttr> reduceType =
-      ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
-  if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
-    reduceType =
-        ttcore::ReduceTypeAttr::get(getContext(), getScatterReduceType());
-  }
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ScatterOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], indexShape, inputs[1], sourceShape, inputs[2],
-      getDim(), reduceType, opConfig.outputLayout, initialState.get());
+  return scatterConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1446,35 +1437,33 @@ ScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GatherOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+gatherConstraintsImpl(GatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 2);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto indexShape = op.getIndex().getType().getShape();
+  int32_t dim = op.getDim();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     indexShape, inputs[1], dim,
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 GatherOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto indexShape = getIndex().getType().getShape();
-  int32_t dim = getDim();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GatherOp>::getOpConstraints, *this, inputShape,
-      inputs[0], indexShape, inputs[1], dim, opConfig.outputLayout);
+  return gatherConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> GatherOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 2);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto indexShape = getIndex().getType().getShape();
-  int32_t dim = getDim();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<GatherOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], indexShape, inputs[1], dim, opConfig.outputLayout,
-      initialState.get());
+  return gatherConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1570,31 +1559,31 @@ PowTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PowScalarOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+powScalarConstraintsImpl(PowScalarOp op,
+                         const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig,
+                         const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getLhs().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getRhs(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 PowScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getLhs().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PowScalarOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getRhs(), opConfig.outputLayout);
+  return powScalarConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> PowScalarOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getLhs().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PowScalarOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getRhs(), opConfig.outputLayout,
-      initialState.get());
+  return powScalarConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1931,34 +1920,32 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ReshapeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+reshapeConstraintsImpl(ReshapeOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  const auto outputShape = op.getResult().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     outputShape, opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  const auto outputShape = getResult().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ReshapeOp>::getOpConstraints, *this, inputShape,
-      inputs[0], outputShape, opConfig.outputLayout);
+  return reshapeConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> ReshapeOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto outputShape = getResult().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ReshapeOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], outputShape, opConfig.outputLayout,
-      initialState.get());
+  return reshapeConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1978,36 +1965,36 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SliceStaticOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+sliceStaticConstraintsImpl(SliceStaticOp op,
+                           const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig,
+                           const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0],
+      detail::convertArrayAttrToSmallVec(op.getBegins()),
+      detail::convertArrayAttrToSmallVec(op.getEnds()),
+      detail::convertArrayAttrToSmallVec(op.getStep()), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SliceStaticOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SliceStaticOp>::getOpConstraints, *this, inputShape,
-      inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
-      detail::convertArrayAttrToSmallVec(getEnds()),
-      detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout);
+  return sliceStaticConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 SliceStaticOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<SliceStaticOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
-      detail::convertArrayAttrToSmallVec(getEnds()),
-      detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout,
-      initialState.get());
+  return sliceStaticConstraintsImpl(*this, inputs, opConfig,
+                                    initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2028,39 +2015,37 @@ SliceStaticOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SliceDynamicOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+sliceDynamicConstraintsImpl(SliceDynamicOp op,
+                            const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig,
+                            const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto beginsShape = op.getBegins().getType().getShape();
+  const auto endsShape = op.getEnds().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], beginsShape, inputs[1], endsShape,
+      inputs[2], detail::convertOptionalArrayAttrToSmallVec(op.getStep()),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SliceDynamicOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto beginsShape = getBegins().getType().getShape();
-  const auto endsShape = getEnds().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SliceDynamicOp>::getOpConstraints, *this, inputShape,
-      inputs[0], beginsShape, inputs[1], endsShape, inputs[2],
-      detail::convertOptionalArrayAttrToSmallVec(getStep()),
-      opConfig.outputLayout);
+  return sliceDynamicConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 SliceDynamicOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto beginsShape = getBegins().getType().getShape();
-  const auto endsShape = getEnds().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<SliceDynamicOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], beginsShape, inputs[1], endsShape, inputs[2],
-      detail::convertOptionalArrayAttrToSmallVec(getStep()),
-      opConfig.outputLayout, initialState.get());
+  return sliceDynamicConstraintsImpl(*this, inputs, opConfig,
+                                     initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2082,39 +2067,38 @@ SliceDynamicOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // BitcastConvertOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
+static llvm::Expected<op_model::OpConstraints>
+bitcastConvertConstraintsImpl(BitcastConvertOp op,
+                              const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig,
+                              const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  ttcore::DataTypeAttr dtype =
+      detail::resolveOutputDtype(op.getOperation(), opConfig.outputLayout);
+  assert(dtype && "BitcastConvertOp requires output dtype");
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0], dtype,
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 BitcastConvertOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  ttcore::DataTypeAttr dtype =
-      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
-  assert(dtype && "BitcastConvertOp requires output dtype");
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<BitcastConvertOp>::getOpConstraints, *this, inputShape,
-      inputs[0], dtype, opConfig.outputLayout);
+  return bitcastConvertConstraintsImpl(*this, inputs, opConfig,
+                                       /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 BitcastConvertOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  ttcore::DataTypeAttr dtype =
-      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
-  assert(dtype && "BitcastConvertOp requires output dtype");
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<BitcastConvertOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], dtype, opConfig.outputLayout, initialState.get());
+  return bitcastConvertConstraintsImpl(*this, inputs, opConfig,
+                                       initialState.get());
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -5780,32 +5780,34 @@ GroupNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ClampScalarOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+clampScalarConstraintsImpl(ClampScalarOp op,
+                           const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig,
+                           const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getMinAttr(), op.getMaxAttr(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ClampScalarOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getMinAttr(), getMaxAttr(), opConfig.outputLayout);
+  return clampScalarConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 ClampScalarOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ClampScalarOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getMinAttr(), getMaxAttr(), opConfig.outputLayout,
-      initialState.get());
+  return clampScalarConstraintsImpl(*this, inputs, opConfig,
+                                    initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5824,34 +5826,35 @@ ClampScalarOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ClampTensorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+clampTensorConstraintsImpl(ClampTensorOp op,
+                           const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig,
+                           const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getMin().getType().getShape(),
+      inputs[1], op.getMax().getType().getShape(), inputs[2],
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ClampTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ClampTensorOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getMin().getType().getShape(), inputs[1],
-      getMax().getType().getShape(), inputs[2], opConfig.outputLayout);
+  return clampTensorConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 ClampTensorOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ClampTensorOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getMin().getType().getShape(), inputs[1],
-      getMax().getType().getShape(), inputs[2], opConfig.outputLayout,
-      initialState.get());
+  return clampTensorConstraintsImpl(*this, inputs, opConfig,
+                                    initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5871,31 +5874,31 @@ ClampTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PermuteOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+permuteConstraintsImpl(PermuteOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getPermutation(), op.getPadValue(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PermuteOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getPermutation(), getPadValue(), opConfig.outputLayout);
+  return permuteConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> PermuteOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PermuteOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getPermutation(), getPadValue(),
-      opConfig.outputLayout, initialState.get());
+  return permuteConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5914,31 +5917,32 @@ PermuteOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // UpsampleOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+upsampleConstraintsImpl(UpsampleOp op,
+                        const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig,
+                        const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getScaleFactor(), op.getMode(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<UpsampleOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getScaleFactor(), getMode(), opConfig.outputLayout);
+  return upsampleConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> UpsampleOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<UpsampleOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getScaleFactor(), getMode(), opConfig.outputLayout,
-      initialState.get());
+  return upsampleConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5957,33 +5961,33 @@ UpsampleOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EmbeddingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+embeddingConstraintsImpl(EmbeddingOp op,
+                         const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig,
+                         const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 2);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     weightShape, inputs[1],
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<EmbeddingOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, inputs[1], opConfig.outputLayout);
+  return embeddingConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> EmbeddingOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 2);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<EmbeddingOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], weightShape, inputs[1], opConfig.outputLayout,
-      initialState.get());
+  return embeddingConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -6003,37 +6007,37 @@ EmbeddingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EmbeddingBackwardOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+embeddingBackwardConstraintsImpl(EmbeddingBackwardOp op,
+                                 const std::vector<TTNNLayoutAttr> &inputs,
+                                 const OpConfig &opConfig,
+                                 const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
+  const auto inGradientShape = op.getInGradient().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     weightShape, inputs[1], inGradientShape,
+                                     inputs[2], opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 EmbeddingBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                       const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-  const auto inGradientShape = getInGradient().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<EmbeddingBackwardOp>::getOpConstraints, *this,
-      inputShape, inputs[0], weightShape, inputs[1], inGradientShape, inputs[2],
-      opConfig.outputLayout);
+  return embeddingBackwardConstraintsImpl(*this, inputs, opConfig,
+                                          /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 EmbeddingBackwardOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-  const auto inGradientShape = getInGradient().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<EmbeddingBackwardOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], weightShape, inputs[1], inGradientShape, inputs[2],
-      opConfig.outputLayout, initialState.get());
+  return embeddingBackwardConstraintsImpl(*this, inputs, opConfig,
+                                          initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -6172,32 +6176,35 @@ FullOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MeshPartitionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+meshPartitionConstraintsImpl(MeshPartitionOp op,
+                             const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig,
+                             const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDim(), op.getClusterAxis(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 MeshPartitionOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                   const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<MeshPartitionOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim(), getClusterAxis(), opConfig.outputLayout);
+  return meshPartitionConstraintsImpl(*this, inputs, opConfig,
+                                      /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 MeshPartitionOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<MeshPartitionOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getDim(), getClusterAxis(), opConfig.outputLayout,
-      initialState.get());
+  return meshPartitionConstraintsImpl(*this, inputs, opConfig,
+                                      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -6216,26 +6223,29 @@ MeshPartitionOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConstantOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+constantConstraintsImpl(ConstantOp op,
+                        const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig,
+                        const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 0);
+
+  return detail::constraintsDispatch(op, state, op.getValue(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ConstantOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  assert(inputs.size() == 0);
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConstantOp>::getOpConstraints, *this, getValue(),
-      opConfig.outputLayout);
+  return constantConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> ConstantOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 0);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ConstantOp>::getOpConstraintsWithState(
-      getValue(), opConfig.outputLayout, initialState.get());
+  return constantConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -6305,32 +6315,35 @@ DropoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GlobalAvgPool2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+globalAvgPool2dConstraintsImpl(GlobalAvgPool2dOp op,
+                               const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig,
+                               const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0],
+      dataTypeAttrToOptional(op.getDtypeAttr()), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 GlobalAvgPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                     const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GlobalAvgPool2dOp>::getOpConstraints, *this, inputShape,
-      inputs[0], dataTypeAttrToOptional(getDtypeAttr()), opConfig.outputLayout);
+  return globalAvgPool2dConstraintsImpl(*this, inputs, opConfig,
+                                        /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 GlobalAvgPool2dOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<GlobalAvgPool2dOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout, initialState.get());
+  return globalAvgPool2dConstraintsImpl(*this, inputs, opConfig,
+                                        initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -6561,29 +6574,29 @@ D2MSubgraphOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TopKOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+topKConstraintsImpl(TopKOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig,
+                    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+  const auto inputShape = op.getInputTensor().getType().getShape();
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getK(), op.getDim(), op.getLargest(),
+                                     op.getSorted(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 TopKOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-  const auto inputShape = getInputTensor().getType().getShape();
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<mlir::tt::ttnn::TopKOp>::getOpConstraints, *this,
-      inputShape, inputs[0], getK(), getDim(), getLargest(), getSorted(),
-      opConfig.outputLayout);
+  return topKConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> TopKOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-  const auto inputShape = getInputTensor().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<mlir::tt::ttnn::TopKOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getK(), getDim(), getLargest(), getSorted(),
-      opConfig.outputLayout, initialState.get());
+  return topKConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -31,6 +31,37 @@
 
 namespace mlir::tt::ttnn {
 
+//===----------------------------------------------------------------------===//
+// Stateful op-model migration policy (L1 spill)
+//
+// Ops that participate in the stateful, allocator-backed L1 spill pass override
+// the OpModel interface's getOpConstraintsWithState -- directly, via a per-op
+// extraClassDeclaration + out-of-line body, via a per-family helper macro
+// (e.g. TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE), or via a templated
+// *OpModel body. Every op that does NOT override it inherits the interface
+// default, which delegates to the stateless getOpConstraints
+// (buildInitialState({}) yields a null state -> plain stateless query). That
+// default is SAFE, not buggy: an unmigrated op is modeled exactly as before
+// this feature (no live-record state), never silently wrong -- only less
+// fragmentation-aware if it ever appears in the spill window.
+//
+// The ops below are INTENTIONALLY left on the stateless default as of this
+// change (they are creation / structural ops, or their stateful body has not
+// been needed by the models this pass targets). This list exists so future
+// readers can distinguish "intentionally stateless" from "accidentally
+// forgot" -- migrating any of them just means adding a getOpConstraintsWithState
+// override mirroring its stateless twin (see ChunkedScaledDotProductAttentionOp
+// for the pattern) and changes no existing behavior:
+//   * Creation / no-activation-input ops: ArangeOp, EmptyOp, FullOp, OnesOp,
+//     ZerosOp, RandOp.
+//   * Structural / bookkeeping ops: AssignOp, DeallocateOp, D2MSubgraphOp,
+//     DropoutOp, PrepareConv3dWeightsOp.
+//   * Elementwise binary-composite / bitwise binaries: Atan2Op, MaximumOp,
+//     MinimumOp, PowTensorOp, RemainderOp, BitwiseAndOp, BitwiseOrOp,
+//     BitwiseXorOp.
+//   * QuantizeOp, DequantizeOp, Conv1dOp, MoeGptOp, TanhOp.
+//===----------------------------------------------------------------------===//
+
 namespace detail {
 
 char OpNotSupportedError::ID = 0;
@@ -124,34 +155,54 @@ convertOptionalArrayAttrToSmallVec(std::optional<mlir::ArrayAttr> arrayAttr) {
   return convertArrayAttrToSmallVec(arrayAttr.value());
 }
 
+// Centralizes the cache-vs-bypass decision for every constraints query.
+//
+// The opConstraintsCache key is the op plus its args; liveRecords are
+// deliberately NOT part of the key. A stateful query (state != nullptr)
+// therefore MUST bypass the cache -- otherwise it would return a fit decision
+// cached under a different (or empty) live set, i.e. a stale-fit result. A
+// stateless query (state == nullptr) goes through the cache exactly as before.
+// Every op interface body routes through here so this invariant lives in one
+// place. Args are taken by value: they are cheap (ArrayRef views, attrs) and
+// each branch consumes them at most once.
+template <typename OpT, typename... Args>
+llvm::Expected<op_model::OpConstraints>
+constraintsDispatch(OpT op, const op_model::MockAllocatorState *state,
+                    Args... args) {
+  if (state) {
+    return op_model::OpModel<OpT>::getOpConstraintsWithState(args..., state);
+  }
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<OpT>::getOpConstraints, op, args...);
+}
+
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig) {
+getUnaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig,
+                        const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
-      opConfig.outputLayout);
+  return constraintsDispatch(op, state, inputShape, inputs[0],
+                             opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  return getUnaryConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
 }
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints> getUnaryOpConstraintsWithState(
     OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = op.getInput().getType().getShape();
-
-  // Stateful path bypasses opConstraintsCache: the result depends on the
-  // threaded live-allocation state, which the cache does not key on.
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<OpT>::getOpConstraintsWithState(
-      inputShape, inputs[0], opConfig.outputLayout, initialState.get());
+  return getUnaryConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -169,8 +220,9 @@ getUnaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                       const OpConfig &opConfig) {
+getBinaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig,
+                         const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = op.getLhs().getType().getShape();
@@ -181,33 +233,24 @@ getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
     opDtypeAttr = dtypeOp.getDtypeAttr();
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShapeA, inputs[0],
-      inputShapeB, inputs[1], opConfig.outputLayout, opDtypeAttr);
+  return constraintsDispatch(op, state, inputShapeA, inputs[0], inputShapeB,
+                             inputs[1], opConfig.outputLayout, opDtypeAttr);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig) {
+  return getBinaryConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
 }
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints> getBinaryOpConstraintsWithState(
     OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = op.getLhs().getType().getShape();
-  const auto inputShapeB = op.getRhs().getType().getShape();
-
-  ttcore::DataTypeAttr opDtypeAttr = nullptr;
-  if (auto dtypeOp = mlir::dyn_cast<TTNNDtypeOpInterface>(op.getOperation())) {
-    opDtypeAttr = dtypeOp.getDtypeAttr();
-  }
-
-  // Stateful path bypasses opConstraintsCache: the result depends on the
-  // threaded live-allocation state, which the cache does not key on.
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<OpT>::getOpConstraintsWithState(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout,
-      opDtypeAttr, initialState.get());
+  return getBinaryConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -226,35 +269,34 @@ getBinaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
+getTernaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig,
+                          const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 3);
 
   const auto inputShapeA = op.getFirst().getType().getShape();
   const auto inputShapeB = op.getSecond().getType().getShape();
   const auto inputShapeC = op.getThird().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShapeA, inputs[0],
-      inputShapeB, inputs[1], inputShapeC, inputs[2], opConfig.outputLayout);
+  return constraintsDispatch(op, state, inputShapeA, inputs[0], inputShapeB,
+                             inputs[1], inputShapeC, inputs[2],
+                             opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return getTernaryConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
 }
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints> getTernaryOpConstraintsWithState(
     OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 3);
-
-  const auto inputShapeA = op.getFirst().getType().getShape();
-  const auto inputShapeB = op.getSecond().getType().getShape();
-  const auto inputShapeC = op.getThird().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<OpT>::getOpConstraintsWithState(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], inputShapeC, inputs[2],
-      opConfig.outputLayout, initialState.get());
+  return getTernaryConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -274,32 +316,31 @@ getTernaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
+getReductionConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig,
+                            const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
   const auto inputShape = op.getInput().getType().getShape();
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
+  return constraintsDispatch(
+      op, state, inputShape, inputs[0],
       detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
       op.getKeepDim(), opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return getReductionConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
 }
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints> getReductionOpConstraintsWithState(
     OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-  const auto inputShape = op.getInput().getType().getShape();
-
-  // Stateful path bypasses opConstraintsCache: the result depends on the
-  // threaded live-allocation state, which the cache does not key on.
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<OpT>::getOpConstraintsWithState(
-      inputShape, inputs[0],
-      detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
-      op.getKeepDim(), opConfig.outputLayout, initialState.get());
+  return getReductionConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -316,39 +357,35 @@ getReductionOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getPoolingOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
+getPoolingConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig,
+                          const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
-      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
-      op.getChannels(), op.getKernelSize(), op.getStride(), op.getPadding(),
-      op.getDilation(), op.getCeilMode(), op.getReallocateHaloOutput(),
-      op.getConfigTensorsInDram(), opConfig.outputLayout);
+  return constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
+      op.getPadding(), op.getDilation(), op.getCeilMode(),
+      op.getReallocateHaloOutput(), op.getConfigTensorsInDram(),
+      opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getPoolingOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return getPoolingConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
 }
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints> getPoolingOpConstraintsWithState(
     OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = op.getInput().getType().getShape();
-
-  // Stateful path bypasses opConstraintsCache: the result depends on the
-  // threaded live-allocation state, which the cache does not key on.
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<OpT>::getOpConstraintsWithState(
-      inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
-      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
-      op.getPadding(), op.getDilation(), op.getCeilMode(),
-      op.getReallocateHaloOutput(), op.getConfigTensorsInDram(),
-      opConfig.outputLayout, initialState.get());
+  return getPoolingConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -369,20 +406,29 @@ getPoolingOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getMaxPool2dWithIndicesOpConstraints(OpT op,
-                                     const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
+getMaxPool2dWithIndicesConstraintsImpl(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
-      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
-      op.getChannels(), op.getKernelSize(), op.getStride(), op.getPadding(),
-      op.getDilation(), op.getCeilMode(), op.getReallocateHaloOutput(),
+  return constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
+      op.getPadding(), op.getDilation(), op.getCeilMode(),
+      op.getReallocateHaloOutput(),
       /*deallocate_input*/ false, /*return_indices*/ true,
       op.getConfigTensorsInDram(), opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getMaxPool2dWithIndicesOpConstraints(OpT op,
+                                     const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  return getMaxPool2dWithIndicesConstraintsImpl(op, inputs, opConfig,
+                                                /*state=*/nullptr);
 }
 
 template <typename OpT>
@@ -390,22 +436,10 @@ llvm::Expected<op_model::OpConstraints>
 getMaxPool2dWithIndicesOpConstraintsWithState(
     OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = op.getInput().getType().getShape();
-
-  // Stateful path bypasses opConstraintsCache: the result depends on the
-  // threaded live-allocation state, which the cache does not key on.
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<OpT>::getOpConstraintsWithState(
-      inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
-      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
-      op.getPadding(), op.getDilation(), op.getCeilMode(),
-      op.getReallocateHaloOutput(),
-      /*deallocate_input*/ false, /*return_indices*/ true,
-      op.getConfigTensorsInDram(), opConfig.outputLayout, initialState.get());
+  return getMaxPool2dWithIndicesConstraintsImpl(op, inputs, opConfig,
+                                                initialState.get());
 }
 
 template <typename OpT>
@@ -552,19 +586,25 @@ llvm::Expected<op_model::OpConstraints> SigmoidOp::getOpConstraintsWithState(
                                                 liveRecords);
 }
 
+static llvm::Expected<op_model::OpConstraints>
+leakyReluConstraintsImpl(LeakyReluOp op,
+                         const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig,
+                         const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getParameter(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints> LeakyReluOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<LeakyReluOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getParameter(), opConfig.outputLayout,
-      initialState.get());
+  return leakyReluConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1086,13 +1126,7 @@ ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 LeakyReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LeakyReluOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getParameter(), opConfig.outputLayout);
+  return leakyReluConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<size_t>
@@ -1158,21 +1192,30 @@ TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalRightShiftOp)
 
 // GeluBackwardOp shares the binary tablegen base but has a bespoke op-model
 // (extra `approximate` arg), so it threads state through a bespoke query.
+static llvm::Expected<op_model::OpConstraints>
+geluBackwardConstraintsImpl(GeluBackwardOp op,
+                            const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig,
+                            const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA = op.getLhs().getType().getShape();
+  const auto inputShapeB = op.getRhs().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShapeA, inputs[0],
+                                     inputShapeB, inputs[1],
+                                     op.getApproximate().str(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 GeluBackwardOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = getLhs().getType().getShape();
-  const auto inputShapeB = getRhs().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<GeluBackwardOp>::getOpConstraintsWithState(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], getApproximate().str(),
-      opConfig.outputLayout, initialState.get());
+  return geluBackwardConstraintsImpl(*this, inputs, opConfig,
+                                     initialState.get());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1471,15 +1514,7 @@ Atan2Op::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 GeluBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = getLhs().getType().getShape();
-  const auto inputShapeB = getRhs().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GeluBackwardOp>::getOpConstraints, getOperation(),
-      inputShapeA, inputs[0], inputShapeB, inputs[1], getApproximate().str(),
-      opConfig.outputLayout);
+  return geluBackwardConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<size_t>
@@ -3015,6 +3050,30 @@ ChunkedScaledDotProductAttentionOp::getOpConstraints(
       *this, queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
       pageTableShape, inputs[3], chunkStartIdxShape, inputs[4], getScale(),
       getProgramConfig(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ChunkedScaledDotProductAttentionOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  assert(inputs.size() == 5 &&
+         "ttnn::chunked_scaled_dot_product_attention has 5 input tensors "
+         "(q, k, v, page_table, chunk_start_idx)");
+
+  const auto queryShape = getQuery().getType().getShape();
+  const auto keyShape = getKey().getType().getShape();
+  const auto valueShape = getValue().getType().getShape();
+  const auto pageTableShape = getPageTable().getType().getShape();
+  const auto chunkStartIdxShape = getChunkStartIdx().getType().getShape();
+
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+
+  return op_model::OpModel<ChunkedScaledDotProductAttentionOp>::
+      getOpConstraintsWithState(
+          queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
+          pageTableShape, inputs[3], chunkStartIdxShape, inputs[4], getScale(),
+          getProgramConfig(), opConfig.outputLayout, initialState.get());
 }
 
 llvm::Expected<size_t> ChunkedScaledDotProductAttentionOp::getOpRuntime(

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3157,41 +3157,39 @@ unpackFlashMlaPrefillArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints>
-FlashMlaPrefillOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+flashMlaPrefillConstraintsImpl(FlashMlaPrefillOp op,
+                               const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig,
+                               const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 2 && inputs.size() <= 4 &&
          "ttnn::flash_mla_prefill can have 2 to 4 input tensors "
          "(q, k, optional value, optional mask)");
 
-  FlashMlaPrefillArgs args = unpackFlashMlaPrefillArgs(inputs, *this);
+  FlashMlaPrefillArgs args = unpackFlashMlaPrefillArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<FlashMlaPrefillOp>::getOpConstraints, *this,
-      args.queryShape, args.queryLayout, args.keyShape, args.keyLayout,
-      args.valueShape, args.valueLayout, args.attentionMaskShape,
-      args.attentionMaskLayout, args.headDimV, args.isCausal, getScale(),
+  return detail::constraintsDispatch(
+      op, state, args.queryShape, args.queryLayout, args.keyShape,
+      args.keyLayout, args.valueShape, args.valueLayout, args.attentionMaskShape,
+      args.attentionMaskLayout, args.headDimV, args.isCausal, op.getScale(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+FlashMlaPrefillOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig) {
+  return flashMlaPrefillConstraintsImpl(*this, inputs, opConfig,
+                                        /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 FlashMlaPrefillOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() >= 2 && inputs.size() <= 4 &&
-         "ttnn::flash_mla_prefill can have 2 to 4 input tensors "
-         "(q, k, optional value, optional mask)");
-
-  FlashMlaPrefillArgs args = unpackFlashMlaPrefillArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<FlashMlaPrefillOp>::getOpConstraintsWithState(
-      args.queryShape, args.queryLayout, args.keyShape, args.keyLayout,
-      args.valueShape, args.valueLayout, args.attentionMaskShape,
-      args.attentionMaskLayout, args.headDimV, args.isCausal, getScale(),
-      opConfig.outputLayout, initialState.get());
+  return flashMlaPrefillConstraintsImpl(*this, inputs, opConfig,
+                                        initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3214,42 +3212,39 @@ FlashMlaPrefillOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RotaryEmbeddingLlamaOp - TTNN Op Model Interface
 // ===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+rotaryEmbeddingLlamaConstraintsImpl(
+    RotaryEmbeddingLlamaOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 4);
+
+  auto inputShape = op.getInput().getType().getShape();
+  auto cosShape = op.getCosCache().getType().getShape();
+  auto sinShape = op.getSinCache().getType().getShape();
+  auto transMatShape = op.getTransMat().getType().getShape();
+  bool isDecodeMode = op.getIsDecodeMode();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], cosShape, inputs[1], sinShape,
+      inputs[2], transMatShape, inputs[3], isDecodeMode,
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RotaryEmbeddingLlamaOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  assert(inputs.size() == 4);
-
-  auto inputShape = getInput().getType().getShape();
-  auto cosShape = getCosCache().getType().getShape();
-  auto sinShape = getSinCache().getType().getShape();
-  auto transMatShape = getTransMat().getType().getShape();
-  bool isDecodeMode = getIsDecodeMode();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints, *this,
-      inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
-      transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
+  return rotaryEmbeddingLlamaConstraintsImpl(*this, inputs, opConfig,
+                                             /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 RotaryEmbeddingLlamaOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 4);
-
-  auto inputShape = getInput().getType().getShape();
-  auto cosShape = getCosCache().getType().getShape();
-  auto sinShape = getSinCache().getType().getShape();
-  auto transMatShape = getTransMat().getType().getShape();
-  bool isDecodeMode = getIsDecodeMode();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<RotaryEmbeddingLlamaOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
-      transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout,
-      initialState.get());
+  return rotaryEmbeddingLlamaConstraintsImpl(*this, inputs, opConfig,
+                                             initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3273,39 +3268,38 @@ RotaryEmbeddingLlamaOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RotaryEmbeddingOp - TTNN Op Model Interface
 //===-----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+rotaryEmbeddingConstraintsImpl(RotaryEmbeddingOp op,
+                               const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig,
+                               const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  auto inputShape = op.getInput().getType().getShape();
+  auto cosShape = op.getCosCache().getType().getShape();
+  auto sinShape = op.getSinCache().getType().getShape();
+  auto tokenIndex = op.getTokenIndex();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], cosShape, inputs[1], sinShape,
+      inputs[2], tokenIndex, opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RotaryEmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                     const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
-
-  auto inputShape = getInput().getType().getShape();
-  auto cosShape = getCosCache().getType().getShape();
-  auto sinShape = getSinCache().getType().getShape();
-  auto tokenIndex = getTokenIndex();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RotaryEmbeddingOp>::getOpConstraints, *this, inputShape,
-      inputs[0], cosShape, inputs[1], sinShape, inputs[2], tokenIndex,
-      opConfig.outputLayout);
+  return rotaryEmbeddingConstraintsImpl(*this, inputs, opConfig,
+                                        /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 RotaryEmbeddingOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 3);
-
-  auto inputShape = getInput().getType().getShape();
-  auto cosShape = getCosCache().getType().getShape();
-  auto sinShape = getSinCache().getType().getShape();
-  auto tokenIndex = getTokenIndex();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<RotaryEmbeddingOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
-      tokenIndex, opConfig.outputLayout, initialState.get());
+  return rotaryEmbeddingConstraintsImpl(*this, inputs, opConfig,
+                                        initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3328,50 +3322,42 @@ RotaryEmbeddingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // NLPCreateQKVHeadsDecodeOp - TTNN Op Model Interface
 // ===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-NLPCreateQKVHeadsDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  assert(inputs.size() == (1 + (getBatchOffset() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints>
+nLPCreateQKVHeadsDecodeConstraintsImpl(
+    NLPCreateQKVHeadsDecodeOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (1 + (op.getBatchOffset() == nullptr ? 0 : 1)));
 
-  auto inputShape = getInput().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
 
   std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape;
   std::optional<TTNNLayoutAttr> batchOffsetEncoding;
   if (inputs.size() == 2) {
-    batchOffsetShape = getBatchOffset().getType().getShape();
+    batchOffsetShape = op.getBatchOffset().getType().getShape();
     batchOffsetEncoding = inputs[1];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints, *this,
-      inputShape, inputs[0], batchOffsetShape, batchOffsetEncoding,
-      getNumHeads(), getNumKvHeads(), getOverlapQkCoregrid(), getSliceSize(),
-      opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], batchOffsetShape, batchOffsetEncoding,
+      op.getNumHeads(), op.getNumKvHeads(), op.getOverlapQkCoregrid(),
+      op.getSliceSize(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+NLPCreateQKVHeadsDecodeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return nLPCreateQKVHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
+                                                /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 NLPCreateQKVHeadsDecodeOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == (1 + (getBatchOffset() == nullptr ? 0 : 1)));
-
-  auto inputShape = getInput().getType().getShape();
-
-  std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape;
-  std::optional<TTNNLayoutAttr> batchOffsetEncoding;
-  if (inputs.size() == 2) {
-    batchOffsetShape = getBatchOffset().getType().getShape();
-    batchOffsetEncoding = inputs[1];
-  }
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<NLPCreateQKVHeadsDecodeOp>::
-      getOpConstraintsWithState(
-          inputShape, inputs[0], batchOffsetShape, batchOffsetEncoding,
-          getNumHeads(), getNumKvHeads(), getOverlapQkCoregrid(),
-          getSliceSize(), opConfig.outputLayout, initialState.get());
+  return nLPCreateQKVHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
+                                                initialState.get());
 }
 
 llvm::Expected<size_t> NLPCreateQKVHeadsDecodeOp::getOpRuntime(
@@ -3398,31 +3384,34 @@ llvm::Expected<size_t> NLPCreateQKVHeadsDecodeOp::getOpRuntime(
 // NLPConcatHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+nLPConcatHeadsConstraintsImpl(NLPConcatHeadsOp op,
+                              const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig,
+                              const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 NLPConcatHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<NLPConcatHeadsOp>::getOpConstraints, *this, inputShape,
-      inputs[0], opConfig.outputLayout);
+  return nLPConcatHeadsConstraintsImpl(*this, inputs, opConfig,
+                                       /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 NLPConcatHeadsOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<NLPConcatHeadsOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], opConfig.outputLayout, initialState.get());
+  return nLPConcatHeadsConstraintsImpl(*this, inputs, opConfig,
+                                       initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3440,34 +3429,34 @@ NLPConcatHeadsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // NLPConcatHeadsDecodeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
+static llvm::Expected<op_model::OpConstraints>
+nLPConcatHeadsDecodeConstraintsImpl(
+    NLPConcatHeadsDecodeOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  uint32_t numHeads = op.getNumHeads();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0], numHeads,
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 NLPConcatHeadsDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-  uint32_t numHeads = getNumHeads();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints, *this,
-      inputShape, inputs[0], numHeads, opConfig.outputLayout);
+  return nLPConcatHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
+                                             /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 NLPConcatHeadsDecodeOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-  uint32_t numHeads = getNumHeads();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<NLPConcatHeadsDecodeOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], numHeads, opConfig.outputLayout,
-      initialState.get());
+  return nLPConcatHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
+                                             initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3485,53 +3474,45 @@ NLPConcatHeadsDecodeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // SplitQueryKeyValueAndSplitHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
-llvm::Expected<op_model::OpConstraints>
-SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  assert(inputs.size() == (1 + (getKvInputTensor() ? 1 : 0)));
+static llvm::Expected<op_model::OpConstraints>
+splitQueryKeyValueAndSplitHeadsConstraintsImpl(
+    SplitQueryKeyValueAndSplitHeadsOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (1 + (op.getKvInputTensor() ? 1 : 0)));
 
-  auto inputShape = getInputTensor().getType().getShape();
+  auto inputShape = op.getInputTensor().getType().getShape();
 
   // Handle optional kv input tensor
   std::optional<llvm::ArrayRef<int64_t>> kvInputShape = std::nullopt;
   std::optional<TTNNLayoutAttr> kvInputLayout = std::nullopt;
 
-  if (getKvInputTensor()) {
-    kvInputShape = getKvInputTensor().getType().getShape();
+  if (op.getKvInputTensor()) {
+    kvInputShape = op.getKvInputTensor().getType().getShape();
     kvInputLayout = inputs[1];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints,
-      *this, inputShape, inputs[0], kvInputShape, kvInputLayout, getNumHeads(),
-      getNumKvHeads(), getTransposeKey(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], kvInputShape, kvInputLayout,
+      op.getNumHeads(), op.getNumKvHeads(), op.getTransposeKey(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return splitQueryKeyValueAndSplitHeadsConstraintsImpl(*this, inputs, opConfig,
+                                                        /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 SplitQueryKeyValueAndSplitHeadsOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == (1 + (getKvInputTensor() ? 1 : 0)));
-
-  auto inputShape = getInputTensor().getType().getShape();
-
-  // Handle optional kv input tensor
-  std::optional<llvm::ArrayRef<int64_t>> kvInputShape = std::nullopt;
-  std::optional<TTNNLayoutAttr> kvInputLayout = std::nullopt;
-
-  if (getKvInputTensor()) {
-    kvInputShape = getKvInputTensor().getType().getShape();
-    kvInputLayout = inputs[1];
-  }
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<SplitQueryKeyValueAndSplitHeadsOp>::
-      getOpConstraintsWithState(inputShape, inputs[0], kvInputShape,
-                                kvInputLayout, getNumHeads(), getNumKvHeads(),
-                                getTransposeKey(), opConfig.outputLayout,
-                                initialState.get());
+  return splitQueryKeyValueAndSplitHeadsConstraintsImpl(*this, inputs, opConfig,
+                                                        initialState.get());
 }
 
 llvm::Expected<size_t> SplitQueryKeyValueAndSplitHeadsOp::getOpRuntime(
@@ -3555,32 +3536,35 @@ llvm::Expected<size_t> SplitQueryKeyValueAndSplitHeadsOp::getOpRuntime(
 // RepeatInterleaveOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+repeatInterleaveConstraintsImpl(RepeatInterleaveOp op,
+                                const std::vector<TTNNLayoutAttr> &inputs,
+                                const OpConfig &opConfig,
+                                const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getRepeats(), op.getDim(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RepeatInterleaveOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RepeatInterleaveOp>::getOpConstraints, *this,
-      inputShape, inputs[0], getRepeats(), getDim(), opConfig.outputLayout);
+  return repeatInterleaveConstraintsImpl(*this, inputs, opConfig,
+                                         /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 RepeatInterleaveOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<RepeatInterleaveOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getRepeats(), getDim(), opConfig.outputLayout,
-      initialState.get());
+  return repeatInterleaveConstraintsImpl(*this, inputs, opConfig,
+                                         initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3599,31 +3583,31 @@ RepeatInterleaveOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RepeatOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+repeatConstraintsImpl(RepeatOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getRepeatDims().getShape(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RepeatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RepeatOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getRepeatDims().getShape(), opConfig.outputLayout);
+  return repeatConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> RepeatOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<RepeatOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getRepeatDims().getShape(), opConfig.outputLayout,
-      initialState.get());
+  return repeatConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3642,31 +3626,32 @@ RepeatOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PadOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+padConstraintsImpl(PadOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                   const OpConfig &opConfig,
+                   const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getPadding(), op.getValue(),
+                                     op.getUseMulticore(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 PadOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PadOp>::getOpConstraints, *this, inputShape, inputs[0],
-      getPadding(), getValue(), getUseMulticore(), opConfig.outputLayout);
+  return padConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> PadOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PadOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getPadding(), getValue(), getUseMulticore(),
-      opConfig.outputLayout, initialState.get());
+  return padConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3685,31 +3670,31 @@ PadOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SortOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+sortConstraintsImpl(SortOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig,
+                    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDim(), op.getDescending(),
+                                     op.getStable(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SortOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SortOp>::getOpConstraints, *this, inputShape, inputs[0],
-      getDim(), getDescending(), getStable(), opConfig.outputLayout);
+  return sortConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> SortOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<SortOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getDim(), getDescending(), getStable(),
-      opConfig.outputLayout, initialState.get());
+  return sortConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3728,31 +3713,31 @@ SortOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ArgMaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+argMaxConstraintsImpl(ArgMaxOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDim(), op.getKeepDim(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ArgMaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ArgMaxOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim(), getKeepDim(), opConfig.outputLayout);
+  return argMaxConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> ArgMaxOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ArgMaxOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getDim(), getKeepDim(), opConfig.outputLayout,
-      initialState.get());
+  return argMaxConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3771,31 +3756,31 @@ ArgMaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ProdOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+prodConstraintsImpl(ProdOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig,
+                    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDimArg(), op.getKeepDim(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ProdOp>::getOpConstraints, *this, inputShape, inputs[0],
-      getDimArg(), getKeepDim(), opConfig.outputLayout);
+  return prodConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> ProdOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ProdOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], getDimArg(), getKeepDim(), opConfig.outputLayout,
-      initialState.get());
+  return prodConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -5162,49 +5162,41 @@ unpackBatchNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+batchNormInferenceConstraintsImpl(
+    BatchNormInferenceOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 5 && "ttnn::batch_norm can only have 5 input tensors "
                                "(representing main input tensor, "
                                "running_mean, running_var, weight and bias).");
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
   BatchNormOptionalArgs optionalArgs =
-      unpackBatchNormOptionalArgs(inputs, *this);
+      unpackBatchNormOptionalArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<BatchNormInferenceOp>::getOpConstraints, *this,
-      inputShape, inputs[0], optionalArgs.runningMeanShape,
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.runningMeanShape,
       optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+      optionalArgs.biasLayout, op.getEpsilon(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return batchNormInferenceConstraintsImpl(*this, inputs, opConfig,
+                                           /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 BatchNormInferenceOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 5 && "ttnn::batch_norm can only have 5 input tensors "
-                               "(representing main input tensor, "
-                               "running_mean, running_var, weight and bias).");
-
-  const auto inputShape = getInput().getType().getShape();
-
-  BatchNormOptionalArgs optionalArgs =
-      unpackBatchNormOptionalArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<BatchNormInferenceOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], optionalArgs.runningMeanShape,
-      optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
-      optionalArgs.runningVarLayout, optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
-      initialState.get());
+  return batchNormInferenceConstraintsImpl(*this, inputs, opConfig,
+                                           initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5232,9 +5224,10 @@ BatchNormInferenceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // BatchNormTrainingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+batchNormTrainingConstraintsImpl(
+    BatchNormTrainingOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert((inputs.size() == 1 || inputs.size() == 5) &&
          "ttnn::batch_norm_training can either have 1 input tensor "
          "(representing the main input) or 5 input tensors (representing main "
@@ -5242,47 +5235,35 @@ BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
          "usage of this op with 2-4 input tensors is discouraged as it's "
          "ambiguous.");
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
   BatchNormOptionalArgs optionalArgs =
-      unpackBatchNormOptionalArgs(inputs, *this);
+      unpackBatchNormOptionalArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<BatchNormTrainingOp>::getOpConstraints, *this,
-      inputShape, inputs[0], optionalArgs.runningMeanShape,
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.runningMeanShape,
       optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), getMomentum(),
+      optionalArgs.biasLayout, op.getEpsilon(), op.getMomentum(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                      const OpConfig &opConfig) {
+  return batchNormTrainingConstraintsImpl(*this, inputs, opConfig,
+                                          /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 BatchNormTrainingOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert((inputs.size() == 1 || inputs.size() == 5) &&
-         "ttnn::batch_norm_training can either have 1 input tensor "
-         "(representing the main input) or 5 input tensors (representing main "
-         "input tensor, running_mean, running_var, weight and bias). The "
-         "usage of this op with 2-4 input tensors is discouraged as it's "
-         "ambiguous.");
-
-  const auto inputShape = getInput().getType().getShape();
-
-  BatchNormOptionalArgs optionalArgs =
-      unpackBatchNormOptionalArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<BatchNormTrainingOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], optionalArgs.runningMeanShape,
-      optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
-      optionalArgs.runningVarLayout, optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), getMomentum(),
-      opConfig.outputLayout, initialState.get());
+  return batchNormTrainingConstraintsImpl(*this, inputs, opConfig,
+                                          initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5341,46 +5322,39 @@ unpackRMSNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints>
+rMSNormConstraintsImpl(
+    RMSNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
+
+  RMSNormOptionalArgs optionalArgs = unpackRMSNormOptionalArgs(inputs, op);
+
+  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+      op.getComputeConfigAttr()
+          ? std::optional<DeviceComputeKernelConfigAttr>(
+                op.getComputeConfigAttr())
+          : std::nullopt;
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, op.getEpsilon(), opConfig.outputLayout,
+      computeKernelConfig);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RMSNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-
-  const auto inputShape = getInput().getType().getShape();
-
-  RMSNormOptionalArgs optionalArgs = unpackRMSNormOptionalArgs(inputs, *this);
-
-  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
-      getComputeConfigAttr()
-          ? std::optional<DeviceComputeKernelConfigAttr>(getComputeConfigAttr())
-          : std::nullopt;
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RMSNormOp>::getOpConstraints, *this, inputShape,
-      inputs[0], optionalArgs.weightShape, optionalArgs.weightLayout,
-      optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
-      opConfig.outputLayout, computeKernelConfig);
+  return rMSNormConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> RMSNormOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  const auto inputShape = getInput().getType().getShape();
-
-  RMSNormOptionalArgs optionalArgs = unpackRMSNormOptionalArgs(inputs, *this);
-
-  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
-      getComputeConfigAttr()
-          ? std::optional<DeviceComputeKernelConfigAttr>(getComputeConfigAttr())
-          : std::nullopt;
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<RMSNormOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
-      computeKernelConfig, initialState.get());
+  return rMSNormConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5427,37 +5401,36 @@ unpackRMSNormPreAllGatherOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-
-  const auto inputShape = getInput().getType().getShape();
+static llvm::Expected<op_model::OpConstraints>
+rMSNormPreAllGatherConstraintsImpl(
+    RMSNormPreAllGatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
 
   RMSNormPreAllGatherOptionalArgs optionalArgs =
-      unpackRMSNormPreAllGatherOptionalArgs(inputs, *this);
+      unpackRMSNormPreAllGatherOptionalArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RMSNormPreAllGatherOp>::getOpConstraints, *this,
-      inputShape, inputs[0], optionalArgs.residualInputShape,
-      optionalArgs.residualInputLayout, dataTypeAttrToOptional(getDtypeAttr()),
-      getUse_2dCoreGrid(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.residualInputShape,
+      optionalArgs.residualInputLayout,
+      dataTypeAttrToOptional(op.getDtypeAttr()), op.getUse_2dCoreGrid(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return rMSNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                            /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 RMSNormPreAllGatherOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  const auto inputShape = getInput().getType().getShape();
-
-  RMSNormPreAllGatherOptionalArgs optionalArgs =
-      unpackRMSNormPreAllGatherOptionalArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<RMSNormPreAllGatherOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], optionalArgs.residualInputShape,
-      optionalArgs.residualInputLayout, dataTypeAttrToOptional(getDtypeAttr()),
-      getUse_2dCoreGrid(), opConfig.outputLayout, initialState.get());
+  return rMSNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                            initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5507,38 +5480,33 @@ unpackLayerNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints>
+layerNormConstraintsImpl(
+    LayerNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
+
+  LayerNormOptionalArgs optionalArgs =
+      unpackLayerNormOptionalArgs(inputs, op);
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, op.getEpsilon(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 LayerNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-
-  const auto inputShape = getInput().getType().getShape();
-
-  LayerNormOptionalArgs optionalArgs =
-      unpackLayerNormOptionalArgs(inputs, *this);
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LayerNormOp>::getOpConstraints, *this, inputShape,
-      inputs[0], optionalArgs.weightShape, optionalArgs.weightLayout,
-      optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
-      opConfig.outputLayout);
+  return layerNormConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> LayerNormOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  const auto inputShape = getInput().getType().getShape();
-
-  LayerNormOptionalArgs optionalArgs =
-      unpackLayerNormOptionalArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<LayerNormOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
-      initialState.get());
+  return layerNormConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5588,40 +5556,37 @@ unpackLayerNormPreAllGatherOptionalArgs(
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints>
+layerNormPreAllGatherConstraintsImpl(
+    LayerNormPreAllGatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
+
+  LayerNormPreAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPreAllGatherOptionalArgs(inputs, op);
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.residualInputShape,
+      optionalArgs.residualInputLayout, optionalArgs.recipShape,
+      optionalArgs.recipLayout, dataTypeAttrToOptional(op.getDtypeAttr()),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 LayerNormPreAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-
-  const auto inputShape = getInput().getType().getShape();
-
-  LayerNormPreAllGatherOptionalArgs optionalArgs =
-      unpackLayerNormPreAllGatherOptionalArgs(inputs, *this);
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LayerNormPreAllGatherOp>::getOpConstraints, *this,
-      inputShape, inputs[0], optionalArgs.residualInputShape,
-      optionalArgs.residualInputLayout, optionalArgs.recipShape,
-      optionalArgs.recipLayout, dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout);
+  return layerNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                              /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 LayerNormPreAllGatherOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  const auto inputShape = getInput().getType().getShape();
-
-  LayerNormPreAllGatherOptionalArgs optionalArgs =
-      unpackLayerNormPreAllGatherOptionalArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<LayerNormPreAllGatherOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], optionalArgs.residualInputShape,
-      optionalArgs.residualInputLayout, optionalArgs.recipShape,
-      optionalArgs.recipLayout, dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout, initialState.get());
+  return layerNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                              initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5672,41 +5637,38 @@ unpackLayerNormPostAllGatherOptionalArgs(
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints>
+layerNormPostAllGatherConstraintsImpl(
+    LayerNormPostAllGatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto statsShape = op.getStats().getType().getShape();
+
+  LayerNormPostAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPostAllGatherOptionalArgs(inputs, op);
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], statsShape, inputs[1],
+      optionalArgs.weightShape, optionalArgs.weightLayout,
+      optionalArgs.biasShape, optionalArgs.biasLayout, op.getEpsilon(),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 LayerNormPostAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto statsShape = getStats().getType().getShape();
-
-  LayerNormPostAllGatherOptionalArgs optionalArgs =
-      unpackLayerNormPostAllGatherOptionalArgs(inputs, *this);
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraints, *this,
-      inputShape, inputs[0], statsShape, inputs[1], optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+  return layerNormPostAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                               /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 LayerNormPostAllGatherOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  const auto inputShape = getInput().getType().getShape();
-  const auto statsShape = getStats().getType().getShape();
-
-  LayerNormPostAllGatherOptionalArgs optionalArgs =
-      unpackLayerNormPostAllGatherOptionalArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], statsShape, inputs[1], optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
-      initialState.get());
+  return layerNormPostAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                               initialState.get());
 }
 
 llvm::Expected<size_t> LayerNormPostAllGatherOp::getOpRuntime(
@@ -5764,43 +5726,37 @@ unpackGroupNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints>
+groupNormConstraintsImpl(
+    GroupNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(!inputs.empty() && "GroupNormOp requires at least input layout");
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  GroupNormOptionalArgs optionalArgs =
+      unpackGroupNormOptionalArgs(inputs, op);
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.inputMaskShape,
+      optionalArgs.inputMaskLayout, optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, op.getNumGroups(), op.getEpsilon(),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 GroupNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(!inputs.empty() && "GroupNormOp requires at least input layout");
-
-  const auto inputShape = getInput().getType().getShape();
-
-  GroupNormOptionalArgs optionalArgs =
-      unpackGroupNormOptionalArgs(inputs, *this);
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GroupNormOp>::getOpConstraints, *this, inputShape,
-      inputs[0], optionalArgs.inputMaskShape, optionalArgs.inputMaskLayout,
-      optionalArgs.weightShape, optionalArgs.weightLayout,
-      optionalArgs.biasShape, optionalArgs.biasLayout, getNumGroups(),
-      getEpsilon(), opConfig.outputLayout);
+  return groupNormConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> GroupNormOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(!inputs.empty() && "GroupNormOp requires at least input layout");
-
-  const auto inputShape = getInput().getType().getShape();
-
-  GroupNormOptionalArgs optionalArgs =
-      unpackGroupNormOptionalArgs(inputs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<GroupNormOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], optionalArgs.inputMaskShape,
-      optionalArgs.inputMaskLayout, optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getNumGroups(), getEpsilon(),
-      opConfig.outputLayout, initialState.get());
+  return groupNormConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4584,59 +4584,45 @@ static Conv2dAttrs unpackConv2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-llvm::Expected<op_model::OpConstraints>
-Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints>
+conv2dConstraintsImpl(Conv2dOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
+    biasShape = op.getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
-  Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+  Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<Conv2dOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
-      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
-      getKernelSize(), getStride(), getPadding(), getDilation(), getGroups(),
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], weightShape, inputs[1], biasShape,
+      biasLayout, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
+      op.getInputHeight(), op.getInputWidth(), op.getKernelSize(),
+      op.getStride(), op.getPadding(), op.getDilation(), op.getGroups(),
       attr.conv2dConfig, attr.deviceComputeKernelConfig,
-      getConv2dSliceConfigAttr(), opConfig.outputLayout);
+      op.getConv2dSliceConfigAttr(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return conv2dConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> Conv2dOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-  std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<TTNNLayoutAttr> biasLayout;
-
-  if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
-    biasLayout = inputs[2];
-  }
-
-  Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<Conv2dOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), attr.conv2dConfig,
-      attr.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
-      opConfig.outputLayout, initialState.get());
+  return conv2dConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4688,66 +4674,50 @@ static Conv3dAttrs unpackConv3dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-llvm::Expected<op_model::OpConstraints>
-Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints>
+conv3dConstraintsImpl(Conv3dOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
   // tt-metal's conv3d kernel consumes the prepared 2D weight; the in-IR
   // weight may still be raw 5D (before TTNNPrepareConv3dWeights runs), so
   // pass the prepared shape/layout regardless of what's currently in IR.
-  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(this);
+  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(&op);
   const auto weightShape = preparedWeight.getShape();
   auto weightLayout = mlir::cast<TTNNLayoutAttr>(preparedWeight.getEncoding());
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
+    biasShape = op.getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
-  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, *this);
+  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<Conv3dOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, weightLayout, biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputDepth(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getGroups(), getPaddingMode(), getDtypeAttr(),
-      attr.conv3dConfig, attr.deviceComputeKernelConfig, opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], weightShape, weightLayout, biasShape,
+      biasLayout, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
+      op.getInputDepth(), op.getInputHeight(), op.getInputWidth(),
+      op.getKernelSize(), op.getStride(), op.getPadding(), op.getGroups(),
+      op.getPaddingMode(), op.getDtypeAttr(), attr.conv3dConfig,
+      attr.deviceComputeKernelConfig, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return conv3dConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> Conv3dOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
-
-  const auto inputShape = getInput().getType().getShape();
-  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(this);
-  const auto weightShape = preparedWeight.getShape();
-  auto weightLayout = mlir::cast<TTNNLayoutAttr>(preparedWeight.getEncoding());
-  std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<TTNNLayoutAttr> biasLayout;
-
-  if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
-    biasLayout = inputs[2];
-  }
-
-  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<Conv3dOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], weightShape, weightLayout, biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputDepth(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getGroups(), getPaddingMode(), getDtypeAttr(),
-      attr.conv3dConfig, attr.deviceComputeKernelConfig, opConfig.outputLayout,
-      initialState.get());
+  return conv3dConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4803,60 +4773,50 @@ static Conv2dAttrs unpackConv2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                      std::nullopt};
 }
 
-llvm::Expected<op_model::OpConstraints>
-ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints>
+convTranspose2dConstraintsImpl(ConvTranspose2dOp op,
+                               const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig,
+                               const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
+    biasShape = op.getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
   // If a conv config has been specified, use that. If not, read the op property
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConvTranspose2dOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
-      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
-      getKernelSize(), getStride(), getPadding(), getOutputPadding(),
-      getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
-      getConv2dSliceConfig(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], weightShape, inputs[1], biasShape,
+      biasLayout, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
+      op.getInputHeight(), op.getInputWidth(), op.getKernelSize(),
+      op.getStride(), op.getPadding(), op.getOutputPadding(), op.getDilation(),
+      op.getGroups(), conv2dAttrs.conv2dConfig, op.getConv2dSliceConfig(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig) {
+  return convTranspose2dConstraintsImpl(*this, inputs, opConfig,
+                                        /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 ConvTranspose2dOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-  std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<TTNNLayoutAttr> biasLayout;
-
-  if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
-    biasLayout = inputs[2];
-  }
-
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<ConvTranspose2dOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getOutputPadding(), getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
-      getConv2dSliceConfig(), opConfig.outputLayout, initialState.get());
+  return convTranspose2dConstraintsImpl(*this, inputs, opConfig,
+                                        initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4890,47 +4850,42 @@ ConvTranspose2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConv2dWeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareConv2dWeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+prepareConv2dWeightsConstraintsImpl(
+    PrepareConv2dWeightsOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> weightShape =
-      getWeightTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+      op.getWeightTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareConv2dWeightsOp>::getOpConstraints, *this,
-      inputs[0], weightShape, getInputMemoryConfig(), getInputTensorLayout(),
-      getWeightsFormat(), getInChannels(), getOutChannels(), getBatchSize(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getDilation(), getHasBias(), getGroups(), getInputDtype(),
-      getOutputDtype(), conv2dAttrs.conv2dConfig,
-      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
+  return detail::constraintsDispatch(
+      op, state, inputs[0], weightShape, op.getInputMemoryConfig(),
+      op.getInputTensorLayout(), op.getWeightsFormat(), op.getInChannels(),
+      op.getOutChannels(), op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getKernelSize(), op.getStride(), op.getPadding(),
+      op.getDilation(), op.getHasBias(), op.getGroups(), op.getInputDtype(),
+      op.getOutputDtype(), conv2dAttrs.conv2dConfig,
+      conv2dAttrs.deviceComputeKernelConfig, op.getConv2dSliceConfigAttr(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConv2dWeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareConv2dWeightsConstraintsImpl(*this, inputs, opConfig,
+                                             /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 PrepareConv2dWeightsOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const ::llvm::ArrayRef<int64_t> weightShape =
-      getWeightTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PrepareConv2dWeightsOp>::getOpConstraintsWithState(
-      inputs[0], weightShape, getInputMemoryConfig(), getInputTensorLayout(),
-      getWeightsFormat(), getInChannels(), getOutChannels(), getBatchSize(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getDilation(), getHasBias(), getGroups(), getInputDtype(),
-      getOutputDtype(), conv2dAttrs.conv2dConfig,
-      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
-      opConfig.outputLayout, initialState.get());
+  return prepareConv2dWeightsConstraintsImpl(*this, inputs, opConfig,
+                                             initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4944,45 +4899,41 @@ PrepareConv2dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConv2dBiasOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+prepareConv2dBiasConstraintsImpl(
+    PrepareConv2dBiasOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> biasShape =
-      getBiasTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+      op.getBiasTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareConv2dBiasOp>::getOpConstraints, *this,
-      inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
+  return detail::constraintsDispatch(
+      op, state, inputs[0], biasShape, op.getInputMemoryConfig(),
+      op.getInputTensorLayout(), op.getInChannels(), op.getOutChannels(),
+      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
+      op.getKernelSize(), op.getStride(), op.getPadding(), op.getDilation(),
+      op.getGroups(), op.getInputDtype(), op.getOutputDtype(),
       conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                      const OpConfig &opConfig) {
+  return prepareConv2dBiasConstraintsImpl(*this, inputs, opConfig,
+                                          /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 PrepareConv2dBiasOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const ::llvm::ArrayRef<int64_t> biasShape =
-      getBiasTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PrepareConv2dBiasOp>::getOpConstraintsWithState(
-      inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
-      conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
-      opConfig.outputLayout, initialState.get());
+  return prepareConv2dBiasConstraintsImpl(*this, inputs, opConfig,
+                                          initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5015,50 +4966,43 @@ PrepareConv3dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConvTranspose2dWeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareConvTranspose2dWeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+prepareConvTranspose2dWeightsConstraintsImpl(
+    PrepareConvTranspose2dWeightsOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> weightShape =
-      getWeightTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+      op.getWeightTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints,
-      *this, inputs[0], weightShape, getInputMemoryConfig(),
-      getInputTensorLayout(), getWeightsFormat(), getInChannels(),
-      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
-      getKernelSize(), getStride(), getPadding(), getOutputPadding(),
-      getDilation(), getHasBias(), getGroups(), getInputDtype(),
-      getOutputDtype(), conv2dAttrs.conv2dConfig,
-      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfig(),
-      getMirrorKernel(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputs[0], weightShape, op.getInputMemoryConfig(),
+      op.getInputTensorLayout(), op.getWeightsFormat(), op.getInChannels(),
+      op.getOutChannels(), op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getKernelSize(), op.getStride(), op.getPadding(),
+      op.getOutputPadding(), op.getDilation(), op.getHasBias(), op.getGroups(),
+      op.getInputDtype(), op.getOutputDtype(), conv2dAttrs.conv2dConfig,
+      conv2dAttrs.deviceComputeKernelConfig, op.getConv2dSliceConfig(),
+      op.getMirrorKernel(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dWeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareConvTranspose2dWeightsConstraintsImpl(*this, inputs, opConfig,
+                                                      /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 PrepareConvTranspose2dWeightsOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const ::llvm::ArrayRef<int64_t> weightShape =
-      getWeightTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PrepareConvTranspose2dWeightsOp>::
-      getOpConstraintsWithState(
-          inputs[0], weightShape, getInputMemoryConfig(),
-          getInputTensorLayout(), getWeightsFormat(), getInChannels(),
-          getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
-          getKernelSize(), getStride(), getPadding(), getOutputPadding(),
-          getDilation(), getHasBias(), getGroups(), getInputDtype(),
-          getOutputDtype(), conv2dAttrs.conv2dConfig,
-          conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfig(),
-          getMirrorKernel(), opConfig.outputLayout, initialState.get());
+  return prepareConvTranspose2dWeightsConstraintsImpl(*this, inputs, opConfig,
+                                                      initialState.get());
 }
 
 llvm::Expected<size_t> PrepareConvTranspose2dWeightsOp::getOpRuntime(
@@ -5071,46 +5015,42 @@ llvm::Expected<size_t> PrepareConvTranspose2dWeightsOp::getOpRuntime(
 // PrepareConvTranspose2dBiasOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareConvTranspose2dBiasOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+prepareConvTranspose2dBiasConstraintsImpl(
+    PrepareConvTranspose2dBiasOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> biasShape =
-      getBiasTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+      op.getBiasTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints, *this,
-      inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
+  return detail::constraintsDispatch(
+      op, state, inputs[0], biasShape, op.getInputMemoryConfig(),
+      op.getInputTensorLayout(), op.getInChannels(), op.getOutChannels(),
+      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
+      op.getKernelSize(), op.getStride(), op.getPadding(), op.getDilation(),
+      op.getGroups(), op.getInputDtype(), op.getOutputDtype(),
       conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
-      getConv2dSliceConfig(), opConfig.outputLayout);
+      op.getConv2dSliceConfig(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dBiasOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareConvTranspose2dBiasConstraintsImpl(*this, inputs, opConfig,
+                                                   /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 PrepareConvTranspose2dBiasOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 1);
-
-  const ::llvm::ArrayRef<int64_t> biasShape =
-      getBiasTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PrepareConvTranspose2dBiasOp>::
-      getOpConstraintsWithState(
-          inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
-          getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-          getInputWidth(), getKernelSize(), getStride(), getPadding(),
-          getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
-          conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
-          getConv2dSliceConfig(), opConfig.outputLayout, initialState.get());
+  return prepareConvTranspose2dBiasConstraintsImpl(*this, inputs, opConfig,
+                                                   initialState.get());
 }
 
 llvm::Expected<size_t> PrepareConvTranspose2dBiasOp::getOpRuntime(

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3826,40 +3826,37 @@ DequantizeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RequantizeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+requantizeConstraintsImpl(RequantizeOp op,
+                          const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig,
+                          const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 5);
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto inScaleShape = op.getInScale().getType().getShape();
+  const auto inZeroPointShape = op.getInZeroPoint().getType().getShape();
+  const auto outScaleShape = op.getOutScale().getType().getShape();
+  const auto outZeroPointShape = op.getOutZeroPoint().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], inScaleShape, inputs[1],
+      inZeroPointShape, inputs[2], outScaleShape, inputs[3], outZeroPointShape,
+      inputs[4], op.getAxis(), op.getOutputDtype(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RequantizeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                const OpConfig &opConfig) {
-  assert(inputs.size() == 5);
-  const auto inputShape = getInput().getType().getShape();
-  const auto inScaleShape = getInScale().getType().getShape();
-  const auto inZeroPointShape = getInZeroPoint().getType().getShape();
-  const auto outScaleShape = getOutScale().getType().getShape();
-  const auto outZeroPointShape = getOutZeroPoint().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RequantizeOp>::getOpConstraints, *this, inputShape,
-      inputs[0], inScaleShape, inputs[1], inZeroPointShape, inputs[2],
-      outScaleShape, inputs[3], outZeroPointShape, inputs[4], getAxis(),
-      getOutputDtype(), opConfig.outputLayout);
+  return requantizeConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> RequantizeOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 5);
-  const auto inputShape = getInput().getType().getShape();
-  const auto inScaleShape = getInScale().getType().getShape();
-  const auto inZeroPointShape = getInZeroPoint().getType().getShape();
-  const auto outScaleShape = getOutScale().getType().getShape();
-  const auto outZeroPointShape = getOutZeroPoint().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<RequantizeOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], inScaleShape, inputs[1], inZeroPointShape,
-      inputs[2], outScaleShape, inputs[3], outZeroPointShape, inputs[4],
-      getAxis(), getOutputDtype(), opConfig.outputLayout, initialState.get());
+  return requantizeConstraintsImpl(*this, inputs, opConfig,
+                                   initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3910,68 +3907,49 @@ static MatmulAttrs unpackMatmulAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-llvm::Expected<op_model::OpConstraints>
-LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints>
+linearConstraintsImpl(LinearOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShapeA = getA().getType().getShape();
-  const auto inputShapeB = getB().getType().getShape();
+  const auto inputShapeA = op.getA().getType().getShape();
+  const auto inputShapeB = op.getB().getType().getShape();
 
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
+    biasShape = op.getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
-      getActivation() ? std::make_optional(getActivation().value())
-                      : std::nullopt;
+      op.getActivation() ? std::make_optional(op.getActivation().value())
+                         : std::nullopt;
 
   // Get matmul program config from opConfig if present, otherwise from op.
-  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LinearOp>::getOpConstraints, *this, inputShapeA,
-      inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
-      opConfig.outputLayout, getTransposeA(), getTransposeB(), activation,
-      attr.matmulProgramConfig, attr.computeKernelConfig);
+  return detail::constraintsDispatch(
+      op, state, inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape,
+      biasLayout, opConfig.outputLayout, op.getTransposeA(), op.getTransposeB(),
+      activation, attr.matmulProgramConfig, attr.computeKernelConfig);
+}
+
+llvm::Expected<op_model::OpConstraints>
+LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return linearConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> LinearOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
-
-  const auto inputShapeA = getA().getType().getShape();
-  const auto inputShapeB = getB().getType().getShape();
-
-  std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<TTNNLayoutAttr> biasLayout;
-
-  if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
-    biasLayout = inputs[2];
-  }
-
-  // Convert activation attribute to optional StringRef
-  std::optional<llvm::StringRef> activation =
-      getActivation() ? std::make_optional(getActivation().value())
-                      : std::nullopt;
-
-  // Get matmul program config from opConfig if present, otherwise from op.
-  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<LinearOp>::getOpConstraintsWithState(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
-      opConfig.outputLayout, getTransposeA(), getTransposeB(), activation,
-      attr.matmulProgramConfig, attr.computeKernelConfig, initialState.get());
+  return linearConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4000,52 +3978,41 @@ LinearOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MatmulOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+matmulConstraintsImpl(MatmulOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 2);
 
-  const auto inputShapeA = getA().getType().getShape();
-  const auto inputShapeB = getB().getType().getShape();
+  const auto inputShapeA = op.getA().getType().getShape();
+  const auto inputShapeB = op.getB().getType().getShape();
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
-      getActivation() ? std::make_optional(getActivation().value())
-                      : std::nullopt;
+      op.getActivation() ? std::make_optional(op.getActivation().value())
+                         : std::nullopt;
 
   // Get matmul program config from opConfig if present, otherwise from op.
-  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<MatmulOp>::getOpConstraints, *this, inputShapeA,
-      inputs[0], inputShapeB, inputs[1], opConfig.outputLayout, getTransposeA(),
-      getTransposeB(), activation, attr.matmulProgramConfig,
-      attr.computeKernelConfig);
+  return detail::constraintsDispatch(
+      op, state, inputShapeA, inputs[0], inputShapeB, inputs[1],
+      opConfig.outputLayout, op.getTransposeA(), op.getTransposeB(), activation,
+      attr.matmulProgramConfig, attr.computeKernelConfig);
+}
+
+llvm::Expected<op_model::OpConstraints>
+MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return matmulConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> MatmulOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = getA().getType().getShape();
-  const auto inputShapeB = getB().getType().getShape();
-
-  std::optional<llvm::StringRef> activation =
-      getActivation() ? std::make_optional(getActivation().value())
-                      : std::nullopt;
-  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
-
-  // Reconstruct the allocator state from the live records (null when empty ->
-  // stateless query). This path intentionally bypasses opConstraintsCache: the
-  // result depends on the threaded state, which the cache does not key on.
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<MatmulOp>::getOpConstraintsWithState(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout,
-      getTransposeA(), getTransposeB(), activation, attr.matmulProgramConfig,
-      attr.computeKernelConfig, initialState.get());
+  return matmulConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4066,39 +4033,38 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TopKRouterGptOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+topKRouterGptConstraintsImpl(TopKRouterGptOp op,
+                             const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig,
+                             const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
+  const auto biasShape = op.getBias().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], weightShape, inputs[1], biasShape,
+      inputs[2], static_cast<uint32_t>(op.getK()),
+      static_cast<uint32_t>(op.getNumExperts()), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 TopKRouterGptOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                   const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-  const auto biasShape = getBias().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<TopKRouterGptOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, inputs[1], biasShape, inputs[2],
-      static_cast<uint32_t>(getK()), static_cast<uint32_t>(getNumExperts()),
-      opConfig.outputLayout);
+  return topKRouterGptConstraintsImpl(*this, inputs, opConfig,
+                                      /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 TopKRouterGptOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 3);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-  const auto biasShape = getBias().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<TopKRouterGptOp>::getOpConstraintsWithState(
-      inputShape, inputs[0], weightShape, inputs[1], biasShape, inputs[2],
-      static_cast<uint32_t>(getK()), static_cast<uint32_t>(getNumExperts()),
-      opConfig.outputLayout, initialState.get());
+  return topKRouterGptConstraintsImpl(*this, inputs, opConfig,
+                                      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4139,52 +4105,44 @@ MoeGptOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareMoEComputeW0W1WeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareMoEComputeW0W1WeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  const bool hasBias = getBias_0() != nullptr;
+static llvm::Expected<op_model::OpConstraints>
+prepareMoEComputeW0W1WeightsConstraintsImpl(
+    PrepareMoEComputeW0W1WeightsOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
+  const bool hasBias = op.getBias_0() != nullptr;
   assert(inputs.size() == (hasBias ? 4u : 2u));
 
   std::optional<llvm::ArrayRef<int64_t>> bias0Shape, bias1Shape;
   std::optional<TTNNLayoutAttr> bias0Layout, bias1Layout;
   if (hasBias) {
-    bias0Shape = getBias_0().getType().getShape();
-    bias1Shape = getBias_1().getType().getShape();
+    bias0Shape = op.getBias_0().getType().getShape();
+    bias1Shape = op.getBias_1().getType().getShape();
     bias0Layout = inputs[2];
     bias1Layout = inputs[3];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraints,
-      *this, getW0().getType().getShape(), inputs[0],
-      getW1().getType().getShape(), inputs[1], bias0Shape, bias0Layout,
-      bias1Shape, bias1Layout, getHiddenSize(), getIntermediateSize());
+  return detail::constraintsDispatch(
+      op, state, op.getW0().getType().getShape(), inputs[0],
+      op.getW1().getType().getShape(), inputs[1], bias0Shape, bias0Layout,
+      bias1Shape, bias1Layout, op.getHiddenSize(), op.getIntermediateSize());
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW0W1WeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareMoEComputeW0W1WeightsConstraintsImpl(*this, inputs, opConfig,
+                                                     /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 PrepareMoEComputeW0W1WeightsOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  const bool hasBias = getBias_0() != nullptr;
-  assert(inputs.size() == (hasBias ? 4u : 2u));
-
-  std::optional<llvm::ArrayRef<int64_t>> bias0Shape, bias1Shape;
-  std::optional<TTNNLayoutAttr> bias0Layout, bias1Layout;
-  if (hasBias) {
-    bias0Shape = getBias_0().getType().getShape();
-    bias1Shape = getBias_1().getType().getShape();
-    bias0Layout = inputs[2];
-    bias1Layout = inputs[3];
-  }
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PrepareMoEComputeW0W1WeightsOp>::
-      getOpConstraintsWithState(
-          getW0().getType().getShape(), inputs[0], getW1().getType().getShape(),
-          inputs[1], bias0Shape, bias0Layout, bias1Shape, bias1Layout,
-          getHiddenSize(), getIntermediateSize(), initialState.get());
+  return prepareMoEComputeW0W1WeightsConstraintsImpl(*this, inputs, opConfig,
+                                                     initialState.get());
 }
 
 llvm::Expected<size_t> PrepareMoEComputeW0W1WeightsOp::getOpRuntime(
@@ -4197,46 +4155,41 @@ llvm::Expected<size_t> PrepareMoEComputeW0W1WeightsOp::getOpRuntime(
 // PrepareMoEComputeW2WeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareMoEComputeW2WeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  const bool hasBias = getBias_2() != nullptr;
+static llvm::Expected<op_model::OpConstraints>
+prepareMoEComputeW2WeightsConstraintsImpl(
+    PrepareMoEComputeW2WeightsOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
+  const bool hasBias = op.getBias_2() != nullptr;
   assert(inputs.size() == (hasBias ? 2u : 1u));
 
   std::optional<llvm::ArrayRef<int64_t>> bias2Shape;
   std::optional<TTNNLayoutAttr> bias2Layout;
   if (hasBias) {
-    bias2Shape = getBias_2().getType().getShape();
+    bias2Shape = op.getBias_2().getType().getShape();
     bias2Layout = inputs[1];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints, *this,
-      getW2().getType().getShape(), inputs[0], bias2Shape, bias2Layout,
-      getHiddenSize(), getIntermediateSize());
+  return detail::constraintsDispatch(
+      op, state, op.getW2().getType().getShape(), inputs[0], bias2Shape,
+      bias2Layout, op.getHiddenSize(), op.getIntermediateSize());
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW2WeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareMoEComputeW2WeightsConstraintsImpl(*this, inputs, opConfig,
+                                                   /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 PrepareMoEComputeW2WeightsOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  const bool hasBias = getBias_2() != nullptr;
-  assert(inputs.size() == (hasBias ? 2u : 1u));
-
-  std::optional<llvm::ArrayRef<int64_t>> bias2Shape;
-  std::optional<TTNNLayoutAttr> bias2Layout;
-  if (hasBias) {
-    bias2Shape = getBias_2().getType().getShape();
-    bias2Layout = inputs[1];
-  }
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PrepareMoEComputeW2WeightsOp>::
-      getOpConstraintsWithState(getW2().getType().getShape(), inputs[0],
-                                bias2Shape, bias2Layout, getHiddenSize(),
-                                getIntermediateSize(), initialState.get());
+  return prepareMoEComputeW2WeightsConstraintsImpl(*this, inputs, opConfig,
+                                                   initialState.get());
 }
 
 llvm::Expected<size_t> PrepareMoEComputeW2WeightsOp::getOpRuntime(
@@ -4270,34 +4223,33 @@ DeallocateOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // FillCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+fillCacheConstraintsImpl(FillCacheOp op,
+                         const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig,
+                         const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 2);
+
+  auto cacheShape = op.getCache().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, cacheShape, inputs[0],
+                                     inputShape, inputs[1], op.getBatchOffset(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 FillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<FillCacheOp>::getOpConstraints, *this, cacheShape,
-      inputs[0], inputShape, inputs[1], getBatchOffset(),
-      opConfig.outputLayout);
+  return fillCacheConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> FillCacheOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 2);
-
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<FillCacheOp>::getOpConstraintsWithState(
-      cacheShape, inputs[0], inputShape, inputs[1], getBatchOffset(),
-      opConfig.outputLayout, initialState.get());
+  return fillCacheConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4317,37 +4269,36 @@ FillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // UpdateCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+updateCacheConstraintsImpl(UpdateCacheOp op,
+                           const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig,
+                           const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  auto cacheShape = op.getCache().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
+  auto updateIndexShape = op.getUpdateIndex().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape,
+      inputs[2], op.getBatchOffset(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 UpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
-
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-  auto updateIndexShape = getUpdateIndex().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<UpdateCacheOp>::getOpConstraints, *this, cacheShape,
-      inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
-      getBatchOffset(), opConfig.outputLayout);
+  return updateCacheConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 UpdateCacheOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 3);
-
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-  auto updateIndexShape = getUpdateIndex().getType().getShape();
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<UpdateCacheOp>::getOpConstraintsWithState(
-      cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
-      getBatchOffset(), opConfig.outputLayout, initialState.get());
+  return updateCacheConstraintsImpl(*this, inputs, opConfig,
+                                    initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4364,52 +4315,45 @@ UpdateCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       getBatchOffset(), opConfig.outputLayout);
 }
 
-llvm::Expected<op_model::OpConstraints>
-PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+pagedUpdateCacheConstraintsImpl(PagedUpdateCacheOp op,
+                                const std::vector<TTNNLayoutAttr> &inputs,
+                                const OpConfig &opConfig,
+                                const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedUpdateCacheOp must have 3 or 4 inputs");
 
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-  auto updateIndexShape = getUpdateIndex().getType().getShape();
+  auto cacheShape = op.getCache().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
+  auto updateIndexShape = op.getUpdateIndex().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> pageTableShape;
   std::optional<TTNNLayoutAttr> pageTableLayout;
-  if (getPageTable()) {
-    pageTableShape = getPageTable().getType().getShape();
+  if (op.getPageTable()) {
+    pageTableShape = op.getPageTable().getType().getShape();
     pageTableLayout = inputs[3];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PagedUpdateCacheOp>::getOpConstraints, *this,
-      cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
-      pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape,
+      inputs[2], pageTableShape, pageTableLayout, op.getShareCache(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  return pagedUpdateCacheConstraintsImpl(*this, inputs, opConfig,
+                                         /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 PagedUpdateCacheOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() >= 3 && inputs.size() <= 4 &&
-         "PagedUpdateCacheOp must have 3 or 4 inputs");
-
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-  auto updateIndexShape = getUpdateIndex().getType().getShape();
-  std::optional<llvm::ArrayRef<int64_t>> pageTableShape;
-  std::optional<TTNNLayoutAttr> pageTableLayout;
-  if (getPageTable()) {
-    pageTableShape = getPageTable().getType().getShape();
-    pageTableLayout = inputs[3];
-  }
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PagedUpdateCacheOp>::getOpConstraintsWithState(
-      cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
-      pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout,
-      initialState.get());
+  return pagedUpdateCacheConstraintsImpl(*this, inputs, opConfig,
+                                         initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4433,51 +4377,44 @@ PagedUpdateCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout);
 }
 
-llvm::Expected<op_model::OpConstraints>
-PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+pagedFillCacheConstraintsImpl(PagedFillCacheOp op,
+                              const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig,
+                              const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedFillCacheOp must have 3 or 4 inputs");
 
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-  auto pageTableShape = getPageTable().getType().getShape();
+  auto cacheShape = op.getCache().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
+  auto pageTableShape = op.getPageTable().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> batchIdxShape;
   std::optional<TTNNLayoutAttr> batchIdxLayout;
-  if (getBatchIdxTensor()) {
-    batchIdxShape = getBatchIdxTensor().getType().getShape();
+  if (op.getBatchIdxTensor()) {
+    batchIdxShape = op.getBatchIdxTensor().getType().getShape();
     batchIdxLayout = inputs[3];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PagedFillCacheOp>::getOpConstraints, *this, cacheShape,
-      inputs[0], inputShape, inputs[1], pageTableShape, inputs[2],
-      batchIdxShape, batchIdxLayout, opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, cacheShape, inputs[0], inputShape, inputs[1], pageTableShape,
+      inputs[2], batchIdxShape, batchIdxLayout, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                   const OpConfig &opConfig) {
+  return pagedFillCacheConstraintsImpl(*this, inputs, opConfig,
+                                       /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
 PagedFillCacheOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() >= 3 && inputs.size() <= 4 &&
-         "PagedFillCacheOp must have 3 or 4 inputs");
-
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-  auto pageTableShape = getPageTable().getType().getShape();
-  std::optional<llvm::ArrayRef<int64_t>> batchIdxShape;
-  std::optional<TTNNLayoutAttr> batchIdxLayout;
-  if (getBatchIdxTensor()) {
-    batchIdxShape = getBatchIdxTensor().getType().getShape();
-    batchIdxLayout = inputs[3];
-  }
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<PagedFillCacheOp>::getOpConstraintsWithState(
-      cacheShape, inputs[0], inputShape, inputs[1], pageTableShape, inputs[2],
-      batchIdxShape, batchIdxLayout, opConfig.outputLayout, initialState.get());
+  return pagedFillCacheConstraintsImpl(*this, inputs, opConfig,
+                                       initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4505,34 +4442,33 @@ PagedFillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SamplingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+samplingConstraintsImpl(SamplingOp op,
+                        const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig,
+                        const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 5);
+  return detail::constraintsDispatch(
+      op, state, op.getInputValues().getType().getShape(), inputs[0],
+      op.getInputIndices().getType().getShape(), inputs[1],
+      op.getK().getType().getShape(), inputs[2],
+      op.getP().getType().getShape(), inputs[3],
+      op.getTemp().getType().getShape(), inputs[4], op.getSeed(),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SamplingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  assert(inputs.size() == 5);
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<mlir::tt::ttnn::SamplingOp>::getOpConstraints, *this,
-      getInputValues().getType().getShape(), inputs[0],
-      getInputIndices().getType().getShape(), inputs[1],
-      getK().getType().getShape(), inputs[2], getP().getType().getShape(),
-      inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
-      opConfig.outputLayout);
+  return samplingConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints> SamplingOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  assert(inputs.size() == 5);
-
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-
-  return op_model::OpModel<mlir::tt::ttnn::SamplingOp>::
-      getOpConstraintsWithState(
-          getInputValues().getType().getShape(), inputs[0],
-          getInputIndices().getType().getShape(), inputs[1],
-          getK().getType().getShape(), inputs[2], getP().getType().getShape(),
-          inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
-          opConfig.outputLayout, initialState.get());
+  return samplingConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -49,9 +49,10 @@ namespace mlir::tt::ttnn {
 // change (they are creation / structural ops, or their stateful body has not
 // been needed by the models this pass targets). This list exists so future
 // readers can distinguish "intentionally stateless" from "accidentally
-// forgot" -- migrating any of them just means adding a getOpConstraintsWithState
-// override mirroring its stateless twin (see ChunkedScaledDotProductAttentionOp
-// for the pattern) and changes no existing behavior:
+// forgot" -- migrating any of them just means adding a
+// getOpConstraintsWithState override mirroring its stateless twin (see
+// ChunkedScaledDotProductAttentionOp for the pattern) and changes no existing
+// behavior:
 //   * Creation / no-activation-input ops: ArangeOp, EmptyOp, FullOp, OnesOp,
 //     ZerosOp, RandOp.
 //   * Structural / bookkeeping ops: AssignOp, DeallocateOp, D2MSubgraphOp,
@@ -405,8 +406,7 @@ getPoolingOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getMaxPool2dWithIndicesConstraintsImpl(
+llvm::Expected<op_model::OpConstraints> getMaxPool2dWithIndicesConstraintsImpl(
     OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
@@ -586,11 +586,9 @@ llvm::Expected<op_model::OpConstraints> SigmoidOp::getOpConstraintsWithState(
                                                 liveRecords);
 }
 
-static llvm::Expected<op_model::OpConstraints>
-leakyReluConstraintsImpl(LeakyReluOp op,
-                         const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig,
-                         const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> leakyReluConstraintsImpl(
+    LeakyReluOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -1192,20 +1190,17 @@ TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalRightShiftOp)
 
 // GeluBackwardOp shares the binary tablegen base but has a bespoke op-model
 // (extra `approximate` arg), so it threads state through a bespoke query.
-static llvm::Expected<op_model::OpConstraints>
-geluBackwardConstraintsImpl(GeluBackwardOp op,
-                            const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig,
-                            const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> geluBackwardConstraintsImpl(
+    GeluBackwardOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = op.getLhs().getType().getShape();
   const auto inputShapeB = op.getRhs().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShapeA, inputs[0],
-                                     inputShapeB, inputs[1],
-                                     op.getApproximate().str(),
-                                     opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShapeA, inputs[0], inputShapeB, inputs[1],
+      op.getApproximate().str(), opConfig.outputLayout);
 }
 
 llvm::Expected<op_model::OpConstraints>
@@ -1387,14 +1382,13 @@ scatterConstraintsImpl(ScatterOp op, const std::vector<TTNNLayoutAttr> &inputs,
   std::optional<ttcore::ReduceTypeAttr> reduceType =
       ttcore::ReduceTypeAttr::get(op.getContext(), ttcore::ReduceType::Invalid);
   if (op.getScatterReduceType() != ttcore::ReduceType::Invalid) {
-    reduceType = ttcore::ReduceTypeAttr::get(op.getContext(),
-                                             op.getScatterReduceType());
+    reduceType =
+        ttcore::ReduceTypeAttr::get(op.getContext(), op.getScatterReduceType());
   }
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     indexShape, inputs[1], sourceShape,
-                                     inputs[2], op.getDim(), reduceType,
-                                     opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], indexShape, inputs[1], sourceShape,
+      inputs[2], op.getDim(), reduceType, opConfig.outputLayout);
 }
 
 llvm::Expected<op_model::OpConstraints>
@@ -1503,7 +1497,8 @@ Atan2Op::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 GeluBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
-  return geluBackwardConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+  return geluBackwardConstraintsImpl(*this, inputs, opConfig,
+                                     /*state=*/nullptr);
 }
 
 llvm::Expected<size_t>
@@ -1559,11 +1554,9 @@ PowTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PowScalarOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-powScalarConstraintsImpl(PowScalarOp op,
-                         const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig,
-                         const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> powScalarConstraintsImpl(
+    PowScalarOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getLhs().getType().getShape();
@@ -1965,11 +1958,9 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SliceStaticOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-sliceStaticConstraintsImpl(SliceStaticOp op,
-                           const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig,
-                           const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> sliceStaticConstraintsImpl(
+    SliceStaticOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -2015,11 +2006,9 @@ SliceStaticOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SliceDynamicOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-sliceDynamicConstraintsImpl(SliceDynamicOp op,
-                            const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig,
-                            const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> sliceDynamicConstraintsImpl(
+    SliceDynamicOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 3);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -2035,7 +2024,8 @@ sliceDynamicConstraintsImpl(SliceDynamicOp op,
 llvm::Expected<op_model::OpConstraints>
 SliceDynamicOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
-  return sliceDynamicConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+  return sliceDynamicConstraintsImpl(*this, inputs, opConfig,
+                                     /*state=*/nullptr);
 }
 
 llvm::Expected<op_model::OpConstraints>
@@ -2067,11 +2057,9 @@ SliceDynamicOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // BitcastConvertOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
-static llvm::Expected<op_model::OpConstraints>
-bitcastConvertConstraintsImpl(BitcastConvertOp op,
-                              const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig,
-                              const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> bitcastConvertConstraintsImpl(
+    BitcastConvertOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -2121,11 +2109,9 @@ BitcastConvertOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TypecastOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-typecastConstraintsImpl(TypecastOp op,
-                        const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig,
-                        const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> typecastConstraintsImpl(
+    TypecastOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   if (inputs[0].getBufferType() == BufferType::SystemMemory) {
@@ -2182,11 +2168,9 @@ TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ToLayoutOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-toLayoutConstraintsImpl(ToLayoutOp op,
-                        const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig,
-                        const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> toLayoutConstraintsImpl(
+    ToLayoutOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
   assert(opConfig.outputLayout && "ToLayoutOp requires output layout");
   assert(opConfig.outputLayout.getLayout() == op.getLayoutAttr().getValue());
@@ -2248,11 +2232,9 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ToMemoryConfigOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-toMemoryConfigConstraintsImpl(ToMemoryConfigOp op,
-                              const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig,
-                              const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> toMemoryConfigConstraintsImpl(
+    ToMemoryConfigOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -2356,11 +2338,9 @@ ConcatOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TransposeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-transposeConstraintsImpl(TransposeOp op,
-                         const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig,
-                         const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> transposeConstraintsImpl(
+    TransposeOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -2486,11 +2466,9 @@ CumProdOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConcatenateHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-concatenateHeadsConstraintsImpl(ConcatenateHeadsOp op,
-                                const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig,
-                                const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> concatenateHeadsConstraintsImpl(
+    ConcatenateHeadsOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -2919,8 +2897,8 @@ pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
       args.keyLayout, args.valueShape, args.valueLayout, args.headDimV,
       args.pageTableShape, args.pageTableLayout, args.isCausal,
       args.attentionMaskShape, args.attentionMaskLayout, args.curPosTensorShape,
-      args.curPosTensorLayout, args.attentionSinkShape, args.attentionSinkLayout,
-      args.scale, opConfig.outputLayout);
+      args.curPosTensorLayout, args.attentionSinkShape,
+      args.attentionSinkLayout, args.scale, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
@@ -3157,11 +3135,9 @@ unpackFlashMlaPrefillArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-flashMlaPrefillConstraintsImpl(FlashMlaPrefillOp op,
-                               const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig,
-                               const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> flashMlaPrefillConstraintsImpl(
+    FlashMlaPrefillOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 2 && inputs.size() <= 4 &&
          "ttnn::flash_mla_prefill can have 2 to 4 input tensors "
          "(q, k, optional value, optional mask)");
@@ -3170,9 +3146,9 @@ flashMlaPrefillConstraintsImpl(FlashMlaPrefillOp op,
 
   return detail::constraintsDispatch(
       op, state, args.queryShape, args.queryLayout, args.keyShape,
-      args.keyLayout, args.valueShape, args.valueLayout, args.attentionMaskShape,
-      args.attentionMaskLayout, args.headDimV, args.isCausal, op.getScale(),
-      opConfig.outputLayout);
+      args.keyLayout, args.valueShape, args.valueLayout,
+      args.attentionMaskShape, args.attentionMaskLayout, args.headDimV,
+      args.isCausal, op.getScale(), opConfig.outputLayout);
 }
 
 llvm::Expected<op_model::OpConstraints>
@@ -3213,9 +3189,10 @@ FlashMlaPrefillOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ===----------------------------------------------------------------------===//
 
 static llvm::Expected<op_model::OpConstraints>
-rotaryEmbeddingLlamaConstraintsImpl(
-    RotaryEmbeddingLlamaOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+rotaryEmbeddingLlamaConstraintsImpl(RotaryEmbeddingLlamaOp op,
+                                    const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig,
+                                    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 4);
 
   auto inputShape = op.getInput().getType().getShape();
@@ -3226,8 +3203,7 @@ rotaryEmbeddingLlamaConstraintsImpl(
 
   return detail::constraintsDispatch(
       op, state, inputShape, inputs[0], cosShape, inputs[1], sinShape,
-      inputs[2], transMatShape, inputs[3], isDecodeMode,
-      opConfig.outputLayout);
+      inputs[2], transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
 }
 
 llvm::Expected<op_model::OpConstraints>
@@ -3268,11 +3244,9 @@ RotaryEmbeddingLlamaOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RotaryEmbeddingOp - TTNN Op Model Interface
 //===-----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-rotaryEmbeddingConstraintsImpl(RotaryEmbeddingOp op,
-                               const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig,
-                               const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> rotaryEmbeddingConstraintsImpl(
+    RotaryEmbeddingOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 3);
 
   auto inputShape = op.getInput().getType().getShape();
@@ -3280,9 +3254,9 @@ rotaryEmbeddingConstraintsImpl(RotaryEmbeddingOp op,
   auto sinShape = op.getSinCache().getType().getShape();
   auto tokenIndex = op.getTokenIndex();
 
-  return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], cosShape, inputs[1], sinShape,
-      inputs[2], tokenIndex, opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0], cosShape,
+                                     inputs[1], sinShape, inputs[2], tokenIndex,
+                                     opConfig.outputLayout);
 }
 
 llvm::Expected<op_model::OpConstraints>
@@ -3384,11 +3358,9 @@ llvm::Expected<size_t> NLPCreateQKVHeadsDecodeOp::getOpRuntime(
 // NLPConcatHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-nLPConcatHeadsConstraintsImpl(NLPConcatHeadsOp op,
-                              const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig,
-                              const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> nLPConcatHeadsConstraintsImpl(
+    NLPConcatHeadsOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   auto inputShape = op.getInput().getType().getShape();
@@ -3430,9 +3402,10 @@ NLPConcatHeadsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // NLPConcatHeadsDecodeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 static llvm::Expected<op_model::OpConstraints>
-nLPConcatHeadsDecodeConstraintsImpl(
-    NLPConcatHeadsDecodeOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+nLPConcatHeadsDecodeConstraintsImpl(NLPConcatHeadsDecodeOp op,
+                                    const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig,
+                                    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -3536,11 +3509,9 @@ llvm::Expected<size_t> SplitQueryKeyValueAndSplitHeadsOp::getOpRuntime(
 // RepeatInterleaveOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-repeatInterleaveConstraintsImpl(RepeatInterleaveOp op,
-                                const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig,
-                                const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> repeatInterleaveConstraintsImpl(
+    RepeatInterleaveOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -3634,10 +3605,9 @@ padConstraintsImpl(PadOp op, const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getPadding(), op.getValue(),
-                                     op.getUseMulticore(),
-                                     opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getPadding(), op.getValue(),
+      op.getUseMulticore(), opConfig.outputLayout);
 }
 
 llvm::Expected<op_model::OpConstraints>
@@ -3826,11 +3796,9 @@ DequantizeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RequantizeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-requantizeConstraintsImpl(RequantizeOp op,
-                          const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig,
-                          const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> requantizeConstraintsImpl(
+    RequantizeOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 5);
   const auto inputShape = op.getInput().getType().getShape();
   const auto inScaleShape = op.getInScale().getType().getShape();
@@ -3855,8 +3823,7 @@ llvm::Expected<op_model::OpConstraints> RequantizeOp::getOpConstraintsWithState(
     llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
   std::shared_ptr<op_model::MockAllocatorState> initialState =
       op_model::buildInitialState(liveRecords);
-  return requantizeConstraintsImpl(*this, inputs, opConfig,
-                                   initialState.get());
+  return requantizeConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4033,11 +4000,9 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TopKRouterGptOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-topKRouterGptConstraintsImpl(TopKRouterGptOp op,
-                             const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig,
-                             const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> topKRouterGptConstraintsImpl(
+    TopKRouterGptOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 3);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -4157,9 +4122,8 @@ llvm::Expected<size_t> PrepareMoEComputeW0W1WeightsOp::getOpRuntime(
 
 static llvm::Expected<op_model::OpConstraints>
 prepareMoEComputeW2WeightsConstraintsImpl(
-    PrepareMoEComputeW2WeightsOp op,
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
+    PrepareMoEComputeW2WeightsOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   const bool hasBias = op.getBias_2() != nullptr;
   assert(inputs.size() == (hasBias ? 2u : 1u));
 
@@ -4223,11 +4187,9 @@ DeallocateOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // FillCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-fillCacheConstraintsImpl(FillCacheOp op,
-                         const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig,
-                         const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> fillCacheConstraintsImpl(
+    FillCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 2);
 
   auto cacheShape = op.getCache().getType().getShape();
@@ -4269,11 +4231,9 @@ FillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // UpdateCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-updateCacheConstraintsImpl(UpdateCacheOp op,
-                           const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig,
-                           const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> updateCacheConstraintsImpl(
+    UpdateCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 3);
 
   auto cacheShape = op.getCache().getType().getShape();
@@ -4315,11 +4275,9 @@ UpdateCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       getBatchOffset(), opConfig.outputLayout);
 }
 
-static llvm::Expected<op_model::OpConstraints>
-pagedUpdateCacheConstraintsImpl(PagedUpdateCacheOp op,
-                                const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig,
-                                const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> pagedUpdateCacheConstraintsImpl(
+    PagedUpdateCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedUpdateCacheOp must have 3 or 4 inputs");
 
@@ -4333,10 +4291,10 @@ pagedUpdateCacheConstraintsImpl(PagedUpdateCacheOp op,
     pageTableLayout = inputs[3];
   }
 
-  return detail::constraintsDispatch(
-      op, state, cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape,
-      inputs[2], pageTableShape, pageTableLayout, op.getShareCache(),
-      opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, cacheShape, inputs[0],
+                                     inputShape, inputs[1], updateIndexShape,
+                                     inputs[2], pageTableShape, pageTableLayout,
+                                     op.getShareCache(), opConfig.outputLayout);
 }
 
 llvm::Expected<op_model::OpConstraints>
@@ -4377,11 +4335,9 @@ PagedUpdateCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout);
 }
 
-static llvm::Expected<op_model::OpConstraints>
-pagedFillCacheConstraintsImpl(PagedFillCacheOp op,
-                              const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig,
-                              const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> pagedFillCacheConstraintsImpl(
+    PagedFillCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedFillCacheOp must have 3 or 4 inputs");
 
@@ -4442,18 +4398,15 @@ PagedFillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SamplingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-samplingConstraintsImpl(SamplingOp op,
-                        const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig,
-                        const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> samplingConstraintsImpl(
+    SamplingOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 5);
   return detail::constraintsDispatch(
       op, state, op.getInputValues().getType().getShape(), inputs[0],
       op.getInputIndices().getType().getShape(), inputs[1],
-      op.getK().getType().getShape(), inputs[2],
-      op.getP().getType().getShape(), inputs[3],
-      op.getTemp().getType().getShape(), inputs[4], op.getSeed(),
+      op.getK().getType().getShape(), inputs[2], op.getP().getType().getShape(),
+      inputs[3], op.getTemp().getType().getShape(), inputs[4], op.getSeed(),
       opConfig.outputLayout);
 }
 
@@ -4773,11 +4726,9 @@ static Conv2dAttrs unpackConv2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                      std::nullopt};
 }
 
-static llvm::Expected<op_model::OpConstraints>
-convTranspose2dConstraintsImpl(ConvTranspose2dOp op,
-                               const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig,
-                               const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> convTranspose2dConstraintsImpl(
+    ConvTranspose2dOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -4851,9 +4802,10 @@ ConvTranspose2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 
 static llvm::Expected<op_model::OpConstraints>
-prepareConv2dWeightsConstraintsImpl(
-    PrepareConv2dWeightsOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+prepareConv2dWeightsConstraintsImpl(PrepareConv2dWeightsOp op,
+                                    const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig,
+                                    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> weightShape =
@@ -4899,8 +4851,7 @@ PrepareConv2dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConv2dBiasOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-prepareConv2dBiasConstraintsImpl(
+static llvm::Expected<op_model::OpConstraints> prepareConv2dBiasConstraintsImpl(
     PrepareConv2dBiasOp op, const std::vector<TTNNLayoutAttr> &inputs,
     const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
@@ -5017,9 +4968,8 @@ llvm::Expected<size_t> PrepareConvTranspose2dWeightsOp::getOpRuntime(
 
 static llvm::Expected<op_model::OpConstraints>
 prepareConvTranspose2dBiasConstraintsImpl(
-    PrepareConvTranspose2dBiasOp op,
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
+    PrepareConvTranspose2dBiasOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> biasShape =
@@ -5163,17 +5113,17 @@ unpackBatchNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 static llvm::Expected<op_model::OpConstraints>
-batchNormInferenceConstraintsImpl(
-    BatchNormInferenceOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+batchNormInferenceConstraintsImpl(BatchNormInferenceOp op,
+                                  const std::vector<TTNNLayoutAttr> &inputs,
+                                  const OpConfig &opConfig,
+                                  const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 5 && "ttnn::batch_norm can only have 5 input tensors "
                                "(representing main input tensor, "
                                "running_mean, running_var, weight and bias).");
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  BatchNormOptionalArgs optionalArgs =
-      unpackBatchNormOptionalArgs(inputs, op);
+  BatchNormOptionalArgs optionalArgs = unpackBatchNormOptionalArgs(inputs, op);
 
   return detail::constraintsDispatch(
       op, state, inputShape, inputs[0], optionalArgs.runningMeanShape,
@@ -5224,8 +5174,7 @@ BatchNormInferenceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // BatchNormTrainingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-batchNormTrainingConstraintsImpl(
+static llvm::Expected<op_model::OpConstraints> batchNormTrainingConstraintsImpl(
     BatchNormTrainingOp op, const std::vector<TTNNLayoutAttr> &inputs,
     const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert((inputs.size() == 1 || inputs.size() == 5) &&
@@ -5237,8 +5186,7 @@ batchNormTrainingConstraintsImpl(
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  BatchNormOptionalArgs optionalArgs =
-      unpackBatchNormOptionalArgs(inputs, op);
+  BatchNormOptionalArgs optionalArgs = unpackBatchNormOptionalArgs(inputs, op);
 
   return detail::constraintsDispatch(
       op, state, inputShape, inputs[0], optionalArgs.runningMeanShape,
@@ -5323,18 +5271,17 @@ unpackRMSNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 static llvm::Expected<op_model::OpConstraints>
-rMSNormConstraintsImpl(
-    RMSNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+rMSNormConstraintsImpl(RMSNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
   const auto inputShape = op.getInput().getType().getShape();
 
   RMSNormOptionalArgs optionalArgs = unpackRMSNormOptionalArgs(inputs, op);
 
   std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
-      op.getComputeConfigAttr()
-          ? std::optional<DeviceComputeKernelConfigAttr>(
-                op.getComputeConfigAttr())
-          : std::nullopt;
+      op.getComputeConfigAttr() ? std::optional<DeviceComputeKernelConfigAttr>(
+                                      op.getComputeConfigAttr())
+                                : std::nullopt;
 
   return detail::constraintsDispatch(
       op, state, inputShape, inputs[0], optionalArgs.weightShape,
@@ -5402,9 +5349,10 @@ unpackRMSNormPreAllGatherOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 static llvm::Expected<op_model::OpConstraints>
-rMSNormPreAllGatherConstraintsImpl(
-    RMSNormPreAllGatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+rMSNormPreAllGatherConstraintsImpl(RMSNormPreAllGatherOp op,
+                                   const std::vector<TTNNLayoutAttr> &inputs,
+                                   const OpConfig &opConfig,
+                                   const op_model::MockAllocatorState *state) {
   const auto inputShape = op.getInput().getType().getShape();
 
   RMSNormPreAllGatherOptionalArgs optionalArgs =
@@ -5480,14 +5428,12 @@ unpackLayerNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-layerNormConstraintsImpl(
+static llvm::Expected<op_model::OpConstraints> layerNormConstraintsImpl(
     LayerNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
     const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   const auto inputShape = op.getInput().getType().getShape();
 
-  LayerNormOptionalArgs optionalArgs =
-      unpackLayerNormOptionalArgs(inputs, op);
+  LayerNormOptionalArgs optionalArgs = unpackLayerNormOptionalArgs(inputs, op);
 
   return detail::constraintsDispatch(
       op, state, inputShape, inputs[0], optionalArgs.weightShape,
@@ -5726,16 +5672,14 @@ unpackGroupNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-groupNormConstraintsImpl(
+static llvm::Expected<op_model::OpConstraints> groupNormConstraintsImpl(
     GroupNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
     const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(!inputs.empty() && "GroupNormOp requires at least input layout");
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  GroupNormOptionalArgs optionalArgs =
-      unpackGroupNormOptionalArgs(inputs, op);
+  GroupNormOptionalArgs optionalArgs = unpackGroupNormOptionalArgs(inputs, op);
 
   return detail::constraintsDispatch(
       op, state, inputShape, inputs[0], optionalArgs.inputMaskShape,
@@ -5780,11 +5724,9 @@ GroupNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ClampScalarOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-clampScalarConstraintsImpl(ClampScalarOp op,
-                           const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig,
-                           const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> clampScalarConstraintsImpl(
+    ClampScalarOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -5826,11 +5768,9 @@ ClampScalarOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ClampTensorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-clampTensorConstraintsImpl(ClampTensorOp op,
-                           const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig,
-                           const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> clampTensorConstraintsImpl(
+    ClampTensorOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 3);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -5917,11 +5857,9 @@ PermuteOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // UpsampleOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-upsampleConstraintsImpl(UpsampleOp op,
-                        const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig,
-                        const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> upsampleConstraintsImpl(
+    UpsampleOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -5961,11 +5899,9 @@ UpsampleOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EmbeddingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-embeddingConstraintsImpl(EmbeddingOp op,
-                         const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig,
-                         const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> embeddingConstraintsImpl(
+    EmbeddingOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 2);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -6007,11 +5943,9 @@ EmbeddingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EmbeddingBackwardOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-embeddingBackwardConstraintsImpl(EmbeddingBackwardOp op,
-                                 const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig,
-                                 const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> embeddingBackwardConstraintsImpl(
+    EmbeddingBackwardOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 3);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -6176,11 +6110,9 @@ FullOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MeshPartitionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-meshPartitionConstraintsImpl(MeshPartitionOp op,
-                             const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig,
-                             const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> meshPartitionConstraintsImpl(
+    MeshPartitionOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
@@ -6223,11 +6155,9 @@ MeshPartitionOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConstantOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-constantConstraintsImpl(ConstantOp op,
-                        const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig,
-                        const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> constantConstraintsImpl(
+    ConstantOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 0);
 
   return detail::constraintsDispatch(op, state, op.getValue(),
@@ -6315,18 +6245,16 @@ DropoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GlobalAvgPool2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-globalAvgPool2dConstraintsImpl(GlobalAvgPool2dOp op,
-                               const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig,
-                               const op_model::MockAllocatorState *state) {
+static llvm::Expected<op_model::OpConstraints> globalAvgPool2dConstraintsImpl(
+    GlobalAvgPool2dOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0],
-      dataTypeAttrToOptional(op.getDtypeAttr()), opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     dataTypeAttrToOptional(op.getDtypeAttr()),
+                                     opConfig.outputLayout);
 }
 
 llvm::Expected<op_model::OpConstraints>

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -153,6 +153,7 @@ void createTTNNPipelineAnalysisPasses(
       TTNNGreedyL1SpillManagementOptions spillOptions;
       spillOptions.enableDecisionTrace = options.enableDecisionTrace;
       spillOptions.decisionTraceDir = options.decisionTraceDir;
+      spillOptions.useMockAllocatorState = options.useMockAllocatorState;
 
       bool memLayoutEnabled = options.memoryLayoutAnalysisEnabled;
       pm.addPass(createDevicePassesWrapper(

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -118,14 +118,14 @@ public:
         // queries (conv2d config search, pool/conv constraint checks in
         // OperationValidationAndFallback) see the exact device state main sees.
         op_model::snapshotMockAllocatorState();
-        L1SpillManagement<MockAllocatorL1Tracker> spill(
-            func, deviceGrid, l1BudgetPerCore, std::move(observer));
+        MockAllocatorSpillManagement spill(func, deviceGrid, l1BudgetPerCore,
+                                           std::move(observer));
         spill.run();
         op_model::restoreMockAllocatorState();
         return finalize(spill);
       }
-      L1SpillManagement<SumL1MemoryTracker> spill(
-          func, deviceGrid, l1BudgetPerCore, std::move(observer));
+      SumL1SpillManagement spill(func, deviceGrid, l1BudgetPerCore,
+                                 std::move(observer));
       spill.run();
       return finalize(spill);
     });

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -21,6 +21,12 @@
 #include "mlir/Pass/Pass.h"
 #include "llvm/Support/ErrorHandling.h"
 
+namespace mlir::tt::ttnn::op_model {
+// Defined in TTNNOpModel.cpp (behind the op-model / tt-metalium boundary).
+void snapshotMockAllocatorState();
+void restoreMockAllocatorState();
+} // namespace mlir::tt::ttnn::op_model
+
 namespace mlir::tt::ttnn {
 
 #define GEN_PASS_DEF_TTNNGREEDYL1SPILLMANAGEMENT
@@ -66,43 +72,62 @@ public:
         observer = std::make_unique<DecisionTraceObserver>();
       }
 
+      // Post-run finalize, shared by both tracker instantiations.
+      auto finalize = [&](auto &spill) -> WalkResult {
+        // run() emits a diagnostic but cannot fail the pass on its own; surface
+        // any unrecoverable condition (e.g. an op whose CBs overlap a required
+        // inserted-reshard input) as a pass failure. Interrupt the walk too:
+        // the pass is already doomed, so don't keep mutating later
+        // forward-device funcs.
+        if (spill.hasFailed()) {
+          signalPassFailure();
+          return WalkResult::interrupt();
+        }
+
+        // Sync D2M subgraph function types to match dispatch op's current
+        // inputs (e.g. after spill, operand types may have changed to DRAM).
+        d2m_optimizer_utils::syncAllD2MFuncTypes(func);
+
+        // Merge spill management data into the existing decision trace JSON.
+        if (enableDecisionTrace) {
+          if (const DecisionTrace *dt =
+                  spill.getObserver()->getDecisionTrace()) {
+            if (DecisionTrace::mergeSpillTrace(decisionTraceDir, func.getName(),
+                                               *dt)) {
+              TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                           "Merged spill management trace into {0}/{1}",
+                           decisionTraceDir, func.getName());
+            } else {
+              TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                           "Failed to merge spill management trace for func "
+                           "{0}; layout propagation may not have written a "
+                           "decision trace to {1}.",
+                           func.getName(), decisionTraceDir);
+            }
+          }
+        }
+        return WalkResult::advance();
+      };
+
+      // Default: stateful, fragmentation-accurate L1 tracking backed by
+      // tt-metal's MockAllocatorState. Toggle off to fall back to the
+      // scalar-heuristic tracker.
+      if (useMockAllocatorState) {
+        // The stateful spill queries mutate the shared mock device's allocator.
+        // Snapshot it before and restore it after, so later stateless op-model
+        // queries (conv2d config search, pool/conv constraint checks in
+        // OperationValidationAndFallback) see the exact device state main sees.
+        op_model::snapshotMockAllocatorState();
+        L1SpillManagement<MockAllocatorL1Tracker> spill(
+            func, deviceGrid, l1BudgetPerCore, std::move(observer));
+        spill.run();
+        op_model::restoreMockAllocatorState();
+        return finalize(spill);
+      }
       L1SpillManagement<SumL1MemoryTracker> spill(
           func, deviceGrid, l1BudgetPerCore, std::move(observer));
       spill.run();
-
-      // run() emits a diagnostic but cannot fail the pass on its own; surface
-      // any unrecoverable condition (e.g. an op whose CBs overlap a required
-      // inserted-reshard input) as a pass failure. Interrupt the walk too: the
-      // pass is already doomed, so don't keep mutating later forward-device
-      // funcs.
-      if (spill.hasFailed()) {
-        signalPassFailure();
-        return WalkResult::interrupt();
-      }
-
-      // Sync D2M subgraph function types to match dispatch op's current inputs
-      // (e.g. after spill, operand types may have changed to DRAM).
-      d2m_optimizer_utils::syncAllD2MFuncTypes(func);
-
-      // Merge spill management data into the existing decision trace JSON.
-      if (enableDecisionTrace) {
-        if (const DecisionTrace *dt = spill.getObserver()->getDecisionTrace()) {
-          if (DecisionTrace::mergeSpillTrace(decisionTraceDir, func.getName(),
-                                             *dt)) {
-            TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
-                         "Merged spill management trace into {0}/{1}",
-                         decisionTraceDir, func.getName());
-          } else {
-            TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
-                         "Failed to merge spill management trace for func "
-                         "{0}; layout propagation may not have written a "
-                         "decision trace to {1}.",
-                         func.getName(), decisionTraceDir);
-          }
-        }
-      }
-
-      return WalkResult::advance();
+      return finalize(spill);
     });
 #endif
   }

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -118,7 +118,7 @@ public:
         // queries (conv2d config search, pool/conv constraint checks in
         // OperationValidationAndFallback) see the exact device state main sees.
         op_model::snapshotMockAllocatorState();
-        MockAllocatorSpillManagement spill(func, deviceGrid, l1BudgetPerCore,
+        StatefulL1SpillManagement spill(func, deviceGrid, l1BudgetPerCore,
                                            std::move(observer));
         spill.run();
         op_model::restoreMockAllocatorState();

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -12,6 +12,7 @@
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/FunctionTypes.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
+#include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
 #include "ttmlir/Support/Logger.h"
 #include "ttmlir/Utils.h"
 
@@ -19,13 +20,8 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/ErrorHandling.h"
-
-namespace mlir::tt::ttnn::op_model {
-// Defined in TTNNOpModel.cpp (behind the op-model / tt-metalium boundary).
-void snapshotMockAllocatorState();
-void restoreMockAllocatorState();
-} // namespace mlir::tt::ttnn::op_model
 
 namespace mlir::tt::ttnn {
 
@@ -113,15 +109,24 @@ public:
       // tt-metal's MockAllocatorState. Toggle off to fall back to the
       // scalar-heuristic tracker.
       if (useMockAllocatorState) {
-        // The stateful spill queries mutate the shared mock device's allocator.
-        // Snapshot it before and restore it after, so later stateless op-model
-        // queries (conv2d config search, pool/conv constraint checks in
-        // OperationValidationAndFallback) see the exact device state main sees.
-        op_model::snapshotMockAllocatorState();
         StatefulL1SpillManagement spill(func, deviceGrid, l1BudgetPerCore,
-                                           std::move(observer));
-        spill.run();
-        op_model::restoreMockAllocatorState();
+                                        std::move(observer));
+        {
+          // The stateful spill queries mutate the shared mock device's
+          // allocator. Snapshot it before and restore it after, so later
+          // stateless op-model queries (conv2d config search, pool/conv
+          // constraint checks in OperationValidationAndFallback) see the exact
+          // device state main sees. RAII: restore must run even if spill.run()
+          // throws or a future early-return is added between the snapshot and
+          // here -- otherwise a corrupted shared mock device leaks into every
+          // subsequent stateless query. The guard fires at this inner scope's
+          // exit, i.e. right after run() and before finalize(), matching the
+          // original explicit-restore ordering.
+          op_model::snapshotMockAllocatorState();
+          auto restoreGuard = llvm::make_scope_exit(
+              []() noexcept { op_model::restoreMockAllocatorState(); });
+          spill.run();
+        }
         return finalize(spill);
       }
       SumL1SpillManagement spill(func, deviceGrid, l1BudgetPerCore,

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -132,16 +132,28 @@ checkConstraintsResult(Operation *contextOp,
                        ttmlir::utils::firstNLines(errorMsg, 8));
           // The stateful (build-from-records) query places the currently-live
           // tensors at real addresses, so an op that does not fit surfaces as a
-          // tt-metal allocator exception ("Out of Memory: Not enough space
-          // ...") from the backend rather than via the peak-usage budget check
-          // below. Classify that as OOM (not a hard backend error) so the L1
-          // spill pass takes the evict-and-refit recovery -- the same path the
-          // scalar tracker's soft OOM takes. Demoting straight to DRAM instead
-          // skips config fallback and can leave a numerically-wrong op config
+          // tt-metal exception from the backend rather than via the peak-usage
+          // budget check below. Two flavors are really L1-pressure conditions,
+          // both recoverable by the L1 spill pass's evict-and-refit path (the
+          // same path the scalar tracker's soft OOM takes):
+          //   1. Allocator exhaustion: "Out of Memory: Not enough space ...".
+          //   2. A CB-vs-L1 overlap: "Statically allocated circular buffers ...
+          //      clash with L1 buffers ..." -- the op's static circular-buffer
+          //      region collides with a still-live L1 input (e.g. a large
+          //      height-sharded conv activation). Evicting that L1 input to DRAM
+          //      and refitting resolves it.
+          // Classify both as OOM so run() calls handleOOM (which spills the
+          // offending L1 input) instead of the metalBackendError branch, which
+          // only demotes the op's *output* to DRAM -- useless here, since the
+          // clash is with the input -- leaving a layout that throws at runtime
+          // (https://github.com/tenstorrent/tt-mlir/issues/9064). Demoting
+          // straight to DRAM also skips config fallback and can leave a
+          // numerically-wrong op config
           // (https://github.com/tenstorrent/tt-mlir/issues/9045). A genuine
-          // backend constraint (unsupported config, etc.) carries no "Out of
-          // Memory" marker and still routes to metalBackendError.
-          if (errorMsg.find("Out of Memory") != std::string::npos) {
+          // backend constraint (unsupported config, etc.) carries neither
+          // marker and still routes to metalBackendError.
+          if (errorMsg.find("Out of Memory") != std::string::npos ||
+              errorMsg.find("clash with L1 buffers") != std::string::npos) {
             result = ValidationResult::outOfMemoryError(
                 ttmlir::utils::firstNLines(errorMsg, 8));
           } else {

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -39,9 +39,10 @@ llvm::StringRef validationStatusToString(ValidationStatus status) {
   return "Unknown";
 }
 
-static ValidationResult
-validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                    const OpConfig &config, uint64_t additionalL1Usage);
+static ValidationResult validateConstraints(
+    Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+    const OpConfig &config, uint64_t additionalL1Usage, bool useState = false,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords = {});
 
 //----------- Public API implementations ----------
 
@@ -50,6 +51,15 @@ ValidationResult validateOperation(Operation *op,
                                    const OpConfig &config,
                                    uint64_t additionalL1Usage) {
   return validateConstraints(op, inputLayouts, config, additionalL1Usage);
+}
+
+ValidationResult
+validateOperation(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                  const OpConfig &config,
+                  llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords,
+                  uint64_t additionalL1Usage) {
+  return validateConstraints(op, inputLayouts, config, additionalL1Usage,
+                             /*useState=*/true, liveRecords);
 }
 
 std::vector<ValidationResult>
@@ -120,14 +130,31 @@ checkConstraintsResult(Operation *contextOp,
           TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
                        "OpModel constraints failed: {}",
                        ttmlir::utils::firstNLines(errorMsg, 8));
-          result = ValidationResult::metalBackendError(
-              ttmlir::utils::firstNLines(errorMsg, 8));
+          // The stateful (build-from-records) query places the currently-live
+          // tensors at real addresses, so an op that does not fit surfaces as a
+          // tt-metal allocator exception ("Out of Memory: Not enough space
+          // ...") from the backend rather than via the peak-usage budget check
+          // below. Classify that as OOM (not a hard backend error) so the L1
+          // spill pass takes the evict-and-refit recovery -- the same path the
+          // scalar tracker's soft OOM takes. Demoting straight to DRAM instead
+          // skips config fallback and can leave a numerically-wrong op config
+          // (https://github.com/tenstorrent/tt-mlir/issues/9045). A genuine
+          // backend constraint (unsupported config, etc.) carries no "Out of
+          // Memory" marker and still routes to metalBackendError.
+          if (errorMsg.find("Out of Memory") != std::string::npos) {
+            result = ValidationResult::outOfMemoryError(
+                ttmlir::utils::firstNLines(errorMsg, 8));
+          } else {
+            result = ValidationResult::metalBackendError(
+                ttmlir::utils::firstNLines(errorMsg, 8));
+          }
         });
     return result;
   }
 
   auto [cbPeakUsage, l1BuffersPeakUsage, overallPeakL1Usage,
-        outputTensorUsagePerCore, outputLayouts] = constraints.get();
+        outputTensorUsagePerCore, outputLayouts, outputAllocations] =
+      constraints.get();
 
   uint64_t effectiveL1Limit = utils::getUsableL1PerCore(contextOp);
   uint64_t totalL1Usage = overallPeakL1Usage + additionalL1Usage;
@@ -151,15 +178,18 @@ checkConstraintsResult(Operation *contextOp,
                overallPeakL1Usage, cbPeakUsage, l1BuffersPeakUsage,
                outputTensorUsagePerCore);
 
-  return ValidationResult::success(0, outputLayouts, outputTensorUsagePerCore,
-                                   cbPeakUsage);
+  ValidationResult result = ValidationResult::success(
+      0, outputLayouts, outputTensorUsagePerCore, cbPeakUsage);
+  result.outputAllocations = std::move(outputAllocations);
+  return result;
 }
 
 // ----------- Core constraint validation implementation ----------
 
-static ValidationResult
-validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                    const OpConfig &config, uint64_t additionalL1Usage) {
+static ValidationResult validateConstraints(
+    Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+    const OpConfig &config, uint64_t additionalL1Usage, bool useState,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
 
   // Check that operation supports OpModel interface.
   auto backend = mlir::dyn_cast<OpModel>(op);
@@ -201,8 +231,13 @@ validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
   }
   TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation, "Output config {}", config);
 
+  // Stateful path (L1 spill): route through the uncached
+  // getOpConstraintsWithState so the query is evaluated against the live
+  // allocation set. Stateless path (beam search): the cached getOpConstraints.
   llvm::Expected<ttnn::op_model::OpConstraints> l1UsageExp =
-      backend.getOpConstraints(inputLayouts, config);
+      useState
+          ? backend.getOpConstraintsWithState(inputLayouts, config, liveRecords)
+          : backend.getOpConstraints(inputLayouts, config);
 
   return checkConstraintsResult(op, std::move(l1UsageExp), additionalL1Usage);
 }

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -140,8 +140,8 @@ checkConstraintsResult(Operation *contextOp,
           //   2. A CB-vs-L1 overlap: "Statically allocated circular buffers ...
           //      clash with L1 buffers ..." -- the op's static circular-buffer
           //      region collides with a still-live L1 input (e.g. a large
-          //      height-sharded conv activation). Evicting that L1 input to DRAM
-          //      and refitting resolves it.
+          //      height-sharded conv activation). Evicting that L1 input to
+          //      DRAM and refitting resolves it.
           // Classify both as OOM so run() calls handleOOM (which spills the
           // offending L1 input) instead of the metalBackendError branch, which
           // only demotes the op's *output* to DRAM -- useless here, since the

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -52,6 +52,10 @@ namespace mlir::tt::ttnn::op_model {
 #define QUERY_OP_CONSTRAINTS(op, device, ...)                                  \
   ::ttnn::graph::query_op_constraints(WRAP_OP(op), device, __VA_ARGS__)
 
+#define QUERY_OP_CONSTRAINTS_WITH_STATE(op, device, state, ...)                \
+  ::ttnn::graph::query_op_constraints_with_optional_state(WRAP_OP(op), device,  \
+                                                          state, __VA_ARGS__)
+
 #define QUERY_OP_RUNTIME(op, device, ...)                                      \
   ::ttnn::graph::query_op_runtime(WRAP_OP(op), device, __VA_ARGS__)
 // clang-format on
@@ -97,12 +101,20 @@ executeConstraintQuery(Callable &callable) {
     device->disable_and_clear_program_cache();
     query = callable();
   } catch (const std::exception &e) {
-    // We expect that query will handle exceptions and set error message. If
-    // not, we should not continue.
-    // TODO(rpavlovicTT): This should be a TT_FATAL.
+    // The query can throw from the backend allocator itself (e.g. the stateful
+    // override_mock_allocator_state failing to apply the accumulated live
+    // records to the target L1 layout) rather than returning a failed status.
+    // Surface the message and degrade to an error result so the spill manager's
+    // fallback (demote-to-DRAM / handleOOM) can recover, instead of aborting.
+    // The message is classified downstream in OpConstraintValidation
+    // (see https://github.com/tenstorrent/tt-mlir/issues/9045): an "Out of
+    // Memory" substring becomes an OOM result, anything else a backend error.
     llvm::errs() << "Exception thrown during op constraints query: " << e.what()
                  << "\n";
-    assert(false && "Exception thrown during op constraints query");
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        std::string("Exception thrown during op constraints query: ") +
+            e.what());
   }
 
   if (query.status != ::ttnn::graph::ExecutionStatus::Success) {
@@ -167,6 +179,124 @@ llvm::Expected<OpConstraints> getOpConstraints(MLIRContext *context,
                        response.resource_usage.peak_memory_usage_per_core,
                        response.resource_usage.l1_output_buffer_per_core,
                        layoutAttrs);
+}
+
+/**
+ * @brief Stateful variant of executeConstraintQuery.
+ *
+ * Mirrors executeConstraintQuery exactly (same ProgramCacheState +
+ * disable_and_clear_program_cache + LogLevelGuard + try/catch), but the
+ * callable yields a QueryOutput (response + new allocator state). Validation is
+ * performed against query.response, and the whole QueryOutput is returned on
+ * success.
+ *
+ * @param callable A callable object that performs the stateful query.
+ * @return A QueryOutput if successful, or an error.
+ */
+template <class Callable>
+llvm::Expected<::ttnn::graph::QueryOutput>
+executeConstraintQueryWithState(Callable &callable) {
+  ::ttnn::graph::QueryOutput query;
+  try {
+    auto *device = SingletonDeviceContext::getInstance().getDevice();
+    ::ttnn::graph::detail::LogLevelGuard log_guard(
+        spdlog::level::level_enum::off);
+    ProgramCacheState pcState(device);
+    device->disable_and_clear_program_cache();
+    query = callable();
+  } catch (const std::exception &e) {
+    // The query can throw from the backend allocator itself (e.g. the stateful
+    // override_mock_allocator_state failing to apply the accumulated live
+    // records to the target L1 layout) rather than returning a failed status.
+    // Surface the message and degrade to an error result so the spill manager's
+    // fallback (demote-to-DRAM / handleOOM) can recover, instead of aborting.
+    // The message is classified downstream in OpConstraintValidation
+    // (see https://github.com/tenstorrent/tt-mlir/issues/9045): an "Out of
+    // Memory" substring becomes an OOM result, anything else a backend error.
+    llvm::errs() << "Exception thrown during op constraints query: " << e.what()
+                 << "\n";
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        std::string("Exception thrown during op constraints query: ") +
+            e.what());
+  }
+
+  if (query.response.status != ::ttnn::graph::ExecutionStatus::Success) {
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "Op constraint query failed with error: " +
+            query.response.error_message.value_or("<error message not set>"));
+  }
+
+  if (!query.response.output_tensor_specs.has_value() ||
+      query.response.output_tensor_specs->empty()) {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "Op constraint query missing output tensor");
+  }
+
+  return query;
+}
+
+/**
+ * @brief Stateful variant of getOpConstraints.
+ *
+ * Mirrors getOpConstraints but runs the stateful query path: it reads
+ * out.response for the resource usage + output tensor specs (identical logic to
+ * getOpConstraints). The build-from-records allocations
+ * (out.output_allocations) will be surfaced on OpConstraints in the
+ * validation-plumbing task; the optimizer consumes those per-output records,
+ * not new_state.
+ *
+ * @param context The MLIRContext to use for creating the TTNNLayoutAttr for the
+ * output tensor.
+ * @param callable A callable object that performs the stateful query.
+ * @return An OpConstraints or an error.
+ */
+template <class Callable>
+llvm::Expected<OpConstraints> getOpConstraintsWithState(MLIRContext *context,
+                                                        Callable &callable) {
+
+  llvm::Expected<::ttnn::graph::QueryOutput> query =
+      executeConstraintQueryWithState<Callable>(callable);
+  if (auto error = query.takeError()) {
+    return error;
+  }
+
+  ::ttnn::graph::QueryOutput out = query.get();
+
+  // The worker grid used to build interleaved output layouts is sourced from
+  // the open device rather than threaded in from the IR: the two are equivalent
+  // (the system desc that produced the IR's DeviceAttr is itself derived from
+  // this grid), and this is the only place the value is consumed. The context
+  // caches it across device open/reset, so this is a cheap lookup.
+  const llvm::ArrayRef<int64_t> deviceGrid =
+      SingletonDeviceContext::getInstance().getComputeGridShape();
+
+  llvm::SmallVector<TTNNLayoutAttr> layoutAttrs;
+  for (const auto &outputTensorSpec :
+       out.response.output_tensor_specs.value()) {
+    layoutAttrs.push_back(conversion::getLayoutAttrFromTensorSpec(
+        context, outputTensorSpec, deviceGrid));
+  }
+
+  // Build-from-records: surface each output buffer's placement as a tt-mlir
+  // mirror of tt-metal's AllocationRecord. The L1 spill path keeps these for
+  // still-live tensors and rebuilds allocator state from them (it does not
+  // thread new_state).
+  llvm::SmallVector<OpModelAllocationRecord> outputAllocations;
+  outputAllocations.reserve(out.output_allocations.size());
+  for (const auto &record : out.output_allocations) {
+    outputAllocations.push_back(
+        OpModelAllocationRecord{conversion::getBufferType(record.buffer_type),
+                                static_cast<uint64_t>(record.address),
+                                static_cast<uint64_t>(record.size_per_bank)});
+  }
+
+  return OpConstraints(out.response.resource_usage.cb_peak_size_per_core,
+                       out.response.resource_usage.l1_buffers_peak_per_core,
+                       out.response.resource_usage.peak_memory_usage_per_core,
+                       out.response.resource_usage.l1_output_buffer_per_core,
+                       layoutAttrs, std::move(outputAllocations));
 }
 
 template <class Callable>
@@ -550,6 +680,105 @@ inline bool programCarriesFusedActivation(
 
 } // namespace detail
 #endif // TTMLIR_ENABLE_OPMODEL
+
+std::shared_ptr<MockAllocatorState>
+buildInitialState(llvm::ArrayRef<OpModelAllocationRecord> liveRecords) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  // Build a mock allocator state even when there are no live allocations.
+  // An empty state gives the same fit decision as the stateless query, but it
+  // routes through the stateful (with_initial_state) query branch, which is the
+  // ONLY branch that reports output_allocations. The spill path bootstraps its
+  // record set from those per-op allocations; returning nullptr here would take
+  // the stateless branch (no allocations reported), so the record set could
+  // never seed off the first op and every subsequent query would also see an
+  // empty live set -- a permanent, silent degradation to stateless behavior.
+  std::vector<::tt::tt_metal::experimental::AllocationRecord> metalRecords;
+  metalRecords.reserve(liveRecords.size());
+  for (const OpModelAllocationRecord &record : liveRecords) {
+    metalRecords.push_back(::tt::tt_metal::experimental::AllocationRecord{
+        conversion::getBufferType(record.bufferType),
+        static_cast<::tt::tt_metal::DeviceAddr>(record.address),
+        static_cast<::tt::tt_metal::DeviceAddr>(record.sizePerBank)});
+  }
+
+  // RCA diagnostic (https://github.com/tenstorrent/tt-mlir/issues/9045
+  // follow-up): the Blackhole llama crash is override_mock_allocator_state
+  // failing to apply this record set to the target L1 layout. Set
+  // TTMLIR_SPILL_STATE_DEBUG=1 to dump the record set built for each stateful
+  // query; the last set printed before an "Exception thrown during op
+  // constraints query" line is the one that failed to apply.
+  if (::getenv("TTMLIR_SPILL_STATE_DEBUG")) {
+    uint64_t l1Total = 0;
+    for (const OpModelAllocationRecord &record : liveRecords) {
+      if (record.bufferType == BufferType::L1) {
+        l1Total += record.sizePerBank;
+      }
+    }
+    llvm::errs() << "[spill-state] applying " << liveRecords.size()
+                 << " live records (L1 total/bank=" << l1Total << "B):\n";
+    for (const OpModelAllocationRecord &record : liveRecords) {
+      llvm::errs() << "[spill-state]   bufferType="
+                   << static_cast<int>(record.bufferType)
+                   << " address=" << record.address
+                   << " sizePerBank=" << record.sizePerBank << "\n";
+    }
+  }
+
+  // The base state is a bank-config donor extracted from the open (mock)
+  // device; with_allocations replaces its regions with `metalRecords`,
+  // reproducing real placement/fragmentation at those addresses.
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  ::tt::tt_metal::experimental::MockAllocatorState base =
+      ::tt::tt_metal::experimental::extract_mock_allocator_state(*device);
+  return std::make_shared<MockAllocatorState>(
+      base.with_allocations(metalRecords));
+#else
+  return nullptr;
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+namespace {
+// Snapshot of the mock allocator state taken before a batch of stateful spill
+// queries, so it can be restored exactly afterward. Single mock device per
+// compile; snapshot is always paired with a restore by the spill pass.
+std::optional<::tt::tt_metal::experimental::MockAllocatorState>
+    g_spillAllocatorSnapshot;
+} // namespace
+#endif
+
+void snapshotMockAllocatorState() {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  auto *device = SingletonDeviceContext::getInstance().getDevice();
+  if (::tt::tt_metal::experimental::get_mock_allocator(*device) == nullptr) {
+    g_spillAllocatorSnapshot.reset();
+    return;
+  }
+  g_spillAllocatorSnapshot =
+      ::tt::tt_metal::experimental::extract_mock_allocator_state(*device);
+#endif
+}
+
+void restoreMockAllocatorState() {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  if (!g_spillAllocatorSnapshot.has_value()) {
+    return;
+  }
+  // The stateful (build-from-records) query mutates the SHARED mock device's
+  // allocator (override_mock_allocator_state) and does not restore it. Restore
+  // the exact pre-spill snapshot so later stateless op-model queries (e.g. the
+  // conv2d config search in OperationValidationAndFallback, or pool/conv
+  // constraint queries) run against the same clean device main sees. A partial
+  // reset (clearing allocations only) is NOT enough: residual allocator state
+  // flips op-model validity (e.g. makes conv2d act_block_h_override=0
+  // spuriously legal), producing wrong configs and corrupt output.
+  auto *device = SingletonDeviceContext::getInstance().getDevice();
+  ::tt::tt_metal::experimental::override_mock_allocator_state(
+      *device, *g_spillAllocatorSnapshot);
+  g_spillAllocatorSnapshot.reset();
+#endif
+}
 
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
                                  TTNNLayoutAttr layout,
@@ -994,11 +1223,44 @@ OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
     std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
     uint32_t intermediateSize) {
-#ifdef TTMLIR_ENABLE_OPMODEL
-  auto query = makePrepareMoEComputeW0W1WeightsQuery(
+  return getOpConstraintsWithState(
       w0Shape, w0Layout, w1Shape, w1Layout, bias0Shape, bias0Layout, bias1Shape,
-      bias1Layout, hiddenSize, intermediateSize);
-  return operation::getOpConstraints(w0Layout.getContext(), query);
+      bias1Layout, hiddenSize, intermediateSize, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> w0Shape, TTNNLayoutAttr w0Layout,
+    llvm::ArrayRef<int64_t> w1Shape, TTNNLayoutAttr w1Layout,
+    std::optional<llvm::ArrayRef<int64_t>> bias0Shape,
+    std::optional<TTNNLayoutAttr> bias0Layout,
+    std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
+    std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
+    uint32_t intermediateSize, const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto query = [=]() {
+    ::ttnn::TensorSpec w0Spec = conversion::getTensorSpec(w0Shape, w0Layout);
+    ::ttnn::TensorSpec w1Spec = conversion::getTensorSpec(w1Shape, w1Layout);
+    std::optional<::ttnn::TensorSpec> b0Spec;
+    if (bias0Shape && bias0Layout) {
+      b0Spec = conversion::getTensorSpec(*bias0Shape, *bias0Layout);
+    }
+    std::optional<::ttnn::TensorSpec> b1Spec;
+    if (bias1Shape && bias1Layout) {
+      b1Spec = conversion::getTensorSpec(*bias1Shape, *bias1Layout);
+    }
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        moeComputePackW0W1, device, initialStateOpt, w0Spec, w1Spec, b0Spec,
+        b1Spec, hiddenSize, intermediateSize, device);
+  };
+  return operation::getOpConstraintsWithState(w0Layout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1010,10 +1272,36 @@ OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
     std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
     uint32_t intermediateSize) {
+  return getOpConstraintsWithState(w2Shape, w2Layout, bias2Shape, bias2Layout,
+                                   hiddenSize, intermediateSize,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
+    std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
+    std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
+    uint32_t intermediateSize, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto query = makePrepareMoEComputeW2WeightsQuery(
-      w2Shape, w2Layout, bias2Shape, bias2Layout, hiddenSize, intermediateSize);
-  return operation::getOpConstraints(w2Layout.getContext(), query);
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto query = [=]() {
+    ::ttnn::TensorSpec w2Spec = conversion::getTensorSpec(w2Shape, w2Layout);
+    std::optional<::ttnn::TensorSpec> b2Spec;
+    if (bias2Shape && bias2Layout) {
+      b2Spec = conversion::getTensorSpec(*bias2Shape, *bias2Layout);
+    }
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        moeComputePackW2, device, initialStateOpt, w2Spec, b2Spec, hiddenSize,
+        intermediateSize, device);
+  };
+  return operation::getOpConstraintsWithState(w2Layout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1023,11 +1311,26 @@ OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints(
 // Unary Eltwise Ops
 //===----------------------------------------------------------------------===//
 
+// Cache-facing stateless entry. Its signature must stay exactly as the op-model
+// cache's getOrCompute invokes it (by function pointer), so it cannot grow
+// params; it forwards to the shared stateful body with a null state. The null
+// path runs query_op_constraints_with_optional_state(nullopt), which metal
+// dispatches straight to the stateless query.
 template <typename OpTy>
 llvm::Expected<OpConstraints>
 UnaryEltwiseOpModel<OpTy>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                                             TTNNLayoutAttr inputLayout,
                                             TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+// Shared body. Stateful entry (L1 spill path); bypasses the op-model cache.
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+UnaryEltwiseOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
 
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1037,14 +1340,18 @@ UnaryEltwiseOpModel<OpTy>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpec,
         detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1081,6 +1388,15 @@ llvm::Expected<OpConstraints>
 UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1091,14 +1407,18 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
 
   bool fastApproxMode = true;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, fastApproxMode,
-        detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpec,
+        fastApproxMode, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1173,6 +1493,13 @@ llvm::Expected<OpConstraints>
 OpModel<SigmoidOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                                      TTNNLayoutAttr inputLayout,
                                      TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SigmoidOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1186,14 +1513,18 @@ OpModel<SigmoidOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       static_cast<int32_t>(::ttnn::operations::unary::VecMode::RC);
   auto sigmoidMode = ::ttnn::operations::unary::SigmoidMode::ACCURATE;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::sigmoid, device, inputSpec, vectorMode,
-                                sigmoidMode,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::sigmoid, device, initialStateOpt, inputSpec, vectorMode,
+        sigmoidMode, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1235,6 +1566,14 @@ OpModel<SigmoidOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::APFloat slope, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, slope, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::APFloat slope, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1243,15 +1582,19 @@ llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto leakyReluOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::leaky_relu, device, inputSpec,
-                                slope.convertToFloat(),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::leaky_relu, device, initialStateOpt, inputSpec,
+        slope.convertToFloat(), detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     leakyReluOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              leakyReluOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1290,6 +1633,18 @@ llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputLayout, opDtypeAttr,
+                                   /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+BinaryEltwiseOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1310,14 +1665,18 @@ llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
-                                               device, inputSpecA, inputSpecB,
-                                               outputDType, outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpecA,
+        inputSpecB, outputDType, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1362,7 +1721,19 @@ template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr /*opDtypeAttr*/) {
+    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputLayout, opDtypeAttr,
+                                   /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+BinaryCompositeOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr /*opDtypeAttr*/,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1378,14 +1749,18 @@ llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
-                                               device, inputSpecA, inputSpecB,
-                                               outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(detail::getOpSymbol<OpTy>(), device,
+                                           initialStateOpt, inputSpecA,
+                                           inputSpecB, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1458,6 +1833,17 @@ llvm::Expected<OpConstraints> OpModel<GeluBackwardOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     std::string approximate, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, approximate, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<GeluBackwardOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    std::string approximate, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1473,14 +1859,18 @@ llvm::Expected<OpConstraints> OpModel<GeluBackwardOp>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::gelu_bw, device,
-                                inputSpecA, inputSpecB, approximate,
-                                outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::gelu_bw, device, initialStateOpt, inputSpecA,
+        inputSpecB, approximate, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1524,6 +1914,14 @@ llvm::Expected<size_t> OpModel<GeluBackwardOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute exponent, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, exponent,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute exponent, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1533,11 +1931,15 @@ llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Helper lambda to create the query with any exponent value type.
   auto powScalarQuery = [=](auto convertedExponent) {
     return [=]() {
-      return QUERY_OP_CONSTRAINTS(
-          ::ttnn::pow, device, inputSpec, convertedExponent,
+      return QUERY_OP_CONSTRAINTS_WITH_STATE(
+          ::ttnn::pow, device, initialStateOpt, inputSpec, convertedExponent,
           detail::getNullableMemoryConfig(outputLayout));
     };
   };
@@ -1547,12 +1949,14 @@ llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
   if (auto value = mlir::dyn_cast<mlir::IntegerAttr>(exponent)) {
     int32_t convertedExponent = static_cast<int32_t>(value.getInt());
     auto query = powScalarQuery(convertedExponent);
-    return operation::getOpConstraints(inputLayout.getContext(), query);
+    return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                                query);
   }
   if (auto value = mlir::dyn_cast<mlir::FloatAttr>(exponent)) {
     float convertedExponent = value.getValue().convertToFloat();
     auto query = powScalarQuery(convertedExponent);
-    return operation::getOpConstraints(inputLayout.getContext(), query);
+    return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                                query);
   }
   return llvm::createStringError("Invalid exponent");
 #else
@@ -1609,6 +2013,18 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, inputShapeC, inputLayoutC,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+TernaryEltwiseOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1628,14 +2044,18 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
-                                               device, inputSpecA, inputSpecB,
-                                               inputSpecC, outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpecA,
+        inputSpecB, inputSpecC, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1691,6 +2111,15 @@ llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dimArg, keepDim,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1707,17 +2136,21 @@ llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
     dimArgConverted = std::nullopt;
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, dimArgConverted,
-        keepDim, detail::getNullableMemoryConfig(outputLayout),
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpec,
+        dimArgConverted, keepDim, detail::getNullableMemoryConfig(outputLayout),
         /*compute_kernel_config=*/std::nullopt,
         /*scalar=*/1.0f, /*correction=*/true,
         /*sub_core_grids=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1817,6 +2250,15 @@ template struct NamedFullOpModel<OnesOp>;
 llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int dimArg, bool numericStable, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dimArg,
+                                   numericStable, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int dimArg, bool numericStable, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1825,15 +2267,21 @@ llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto softmaxOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::softmax, device, inputSpec, dimArg,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                std::nullopt, // compute_kernel_config,
-                                numericStable);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::softmax, device, initialStateOpt, inputSpec, dimArg,
+        detail::getNullableMemoryConfig(outputLayout),
+        std::nullopt, // compute_kernel_config,
+        numericStable);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), softmaxOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              softmaxOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1873,6 +2321,17 @@ llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
     int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, indexShape, indexLayout, sourceShape,
+      sourceLayout, dim, optReduction, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
+    llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
+    int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1892,15 +2351,21 @@ llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
   // Convert optReduction to ScatterReductionType enum
   auto optReductionType = conversion::getScatterReductionType(optReduction);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   //  Create query closure
   auto scatterOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::scatter, device, inputSpec, dim, indexSpec, sourceSpec,
-        detail::getNullableMemoryConfig(outputLayout), optReductionType,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::scatter, device, initialStateOpt, inputSpec, dim, indexSpec,
+        sourceSpec, detail::getNullableMemoryConfig(outputLayout),
+        optReductionType,
         /* sub_core_grid */ std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), scatterOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              scatterOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1950,6 +2415,14 @@ llvm::Expected<size_t> OpModel<ScatterOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputShape,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1958,14 +2431,20 @@ llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto reshapeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::reshape, device, inputSpec,
-                                conversion::getShape(outputShape),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::reshape, device, initialStateOpt, inputSpec,
+        conversion::getShape(outputShape),
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), reshapeOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              reshapeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2002,6 +2481,15 @@ llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
     llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, begins, ends, step,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
+    llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2022,15 +2510,20 @@ llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
   ttsl::Span<const int> endsSpan = ::ttsl::make_const_span(endsVec);
   ttsl::Span<const int> stepSpan = ::ttsl::make_const_span(stepVec);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto sliceOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::slice, device, inputSpec, beginsSpan,
-                                endsSpan, stepSpan,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                std::nullopt, std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::slice, device, initialStateOpt, inputSpec, beginsSpan, endsSpan,
+        stepSpan, detail::getNullableMemoryConfig(outputLayout), std::nullopt,
+        std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), sliceOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              sliceOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2084,6 +2577,18 @@ llvm::Expected<OpConstraints> OpModel<SliceDynamicOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
     std::optional<llvm::SmallVector<int64_t>> step,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, beginsShape,
+                                   beginsLayout, endsShape, endsLayout, step,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<SliceDynamicOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
+    llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
+    std::optional<llvm::SmallVector<int64_t>> step, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2109,13 +2614,20 @@ llvm::Expected<OpConstraints> OpModel<SliceDynamicOp>::getOpConstraints(
   // Default values in tt-metal:
   std::optional<::ttnn::TensorSpec> outputSpec = std::nullopt;
   std::optional<float> padValue = std::nullopt;
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure to make a call to the static version of the op:
   auto sliceOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::slice, device, inputSpec, beginsVec, endsVec, stepVec,
-        detail::getNullableMemoryConfig(outputLayout), outputSpec, padValue);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::slice, device, initialStateOpt, inputSpec, beginsVec, endsVec,
+        stepVec, detail::getNullableMemoryConfig(outputLayout), outputSpec,
+        padValue);
   };
-  return operation::getOpConstraints(inputLayout.getContext(), sliceOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              sliceOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2173,6 +2685,15 @@ llvm::Expected<size_t> OpModel<SliceDynamicOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dtype, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<BitcastConvertOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2181,14 +2702,20 @@ llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto bitcastOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::bitcast, device, inputSpec,
-                                conversion::getDataType(dtype.getValue()),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::bitcast, device, initialStateOpt, inputSpec,
+        conversion::getDataType(dtype.getValue()),
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), bitcastOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              bitcastOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2224,6 +2751,14 @@ llvm::Expected<size_t> OpModel<BitcastConvertOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dtype, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2232,14 +2767,20 @@ llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto typecastOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::typecast, device, inputSpec,
-                                conversion::getDataType(dtype.getValue()),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::typecast, device, initialStateOpt, inputSpec,
+        conversion::getDataType(dtype.getValue()),
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), typecastOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              typecastOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2275,6 +2816,14 @@ llvm::Expected<size_t> OpModel<TypecastOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputDtype,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2290,14 +2839,19 @@ llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
     dtype = std::nullopt;
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto toLayoutOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::to_layout, device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::to_layout, device, initialStateOpt, inputSpec,
         conversion::getPageLayout(outputLayout.getLayout()), dtype,
         detail::getNullableMemoryConfig(outputLayout));
   };
-  return operation::getOpConstraints(inputLayout.getContext(), toLayoutOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              toLayoutOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2342,6 +2896,14 @@ llvm::Expected<OpConstraints>
 OpModel<ToMemoryConfigOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                                             TTNNLayoutAttr inputLayout,
                                             TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ToMemoryConfigOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2350,15 +2912,19 @@ OpModel<ToMemoryConfigOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto toMemoryConfigOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::to_memory_config, device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::to_memory_config, device, initialStateOpt, inputSpec,
         conversion::getMemoryConfig(MemoryConfigAttr::get(outputLayout)));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     toMemoryConfigOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              toMemoryConfigOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2395,6 +2961,14 @@ llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
     std::vector<llvm::ArrayRef<int64_t>> inputShapes,
     std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShapes, inputLayouts, dim, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraintsWithState(
+    std::vector<llvm::ArrayRef<int64_t>> inputShapes,
+    std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2410,14 +2984,19 @@ llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
     inputSpecs.push_back(std::move(_push_tmp));
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto concatOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::concat, device, inputSpecs, dim,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::concat, device, initialStateOpt, inputSpecs, dim,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayouts[0].getContext(),
-                                     concatOpQuery);
+  return operation::getOpConstraintsWithState(inputLayouts[0].getContext(),
+                                              concatOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2460,6 +3039,14 @@ llvm::Expected<size_t> OpModel<ConcatOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int dim0, const int dim1, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim0, dim1,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int dim0, const int dim1, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2468,16 +3055,20 @@ llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto transposeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::transpose, device, inputSpec,
-                                static_cast<int64_t>(dim0),
-                                static_cast<int64_t>(dim1),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::transpose, device, initialStateOpt, inputSpec,
+        static_cast<int64_t>(dim0), static_cast<int64_t>(dim1),
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     transposeOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              transposeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2515,6 +3106,14 @@ llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int32_t dim, std::optional<ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, dtype,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int32_t dim, std::optional<ttcore::DataType> dtype,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2528,14 +3127,19 @@ llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
     ttnnDtype = conversion::getDataType(*dtype);
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto cumSumOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::cumsum, device, inputSpec, dim,
-                                ttnnDtype, false, std::nullopt,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::cumsum, device, initialStateOpt, inputSpec, dim, ttnnDtype,
+        false, std::nullopt, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), cumSumOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              cumSumOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2579,6 +3183,14 @@ llvm::Expected<OpConstraints> OpModel<CumProdOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int32_t dim, std::optional<ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, dtype,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<CumProdOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int32_t dim, std::optional<ttcore::DataType> dtype,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2592,14 +3204,20 @@ llvm::Expected<OpConstraints> OpModel<CumProdOp>::getOpConstraints(
     ttnnDtype = conversion::getDataType(*dtype);
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto cumProdOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::cumprod, device, inputSpec, dim,
-                                ttnnDtype, /*reverse_order=*/false,
-                                /*optional_out=*/std::nullopt,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::cumprod, device, initialStateOpt, inputSpec, dim, ttnnDtype,
+        /*reverse_order=*/false,
+        /*optional_out=*/std::nullopt,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), cumProdOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              cumProdOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2643,6 +3261,14 @@ OpModel<CumProdOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ConcatenateHeadsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2651,15 +3277,19 @@ llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto concatenateHeadsOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::transformer::concatenate_heads, device,
-                                inputSpec,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::transformer::concatenate_heads, device, initialStateOpt,
+        inputSpec, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     concatenateHeadsOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              concatenateHeadsOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2707,6 +3337,27 @@ OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
     std::optional<llvm::APFloat> scale,
     std::optional<SDPAProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      isCausal, attentionMaskShape, attentionMaskLayout, curPosTensorShape,
+      curPosTensorLayout, attentionSinkShape, attentionSinkLayout, scale,
+      programConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+    std::optional<TTNNLayoutAttr> curPosTensorLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+    std::optional<TTNNLayoutAttr> attentionSinkLayout,
+    std::optional<llvm::APFloat> scale,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2743,18 +3394,23 @@ OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
   auto sdpaProgramConfigConverted =
       conversion::getSDPAProgramConfig(programConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto scaledDotProductAttentionDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::scaled_dot_product_attention_decode, device,
-        querySpec, keySpec, valueSpec, isCausal, attentionMaskSpec, curPosEmpty,
-        curPosTensorSpec, attentionSinkSpec, scaleFloat, slidingWindowSize,
+        initialStateOpt, querySpec, keySpec, valueSpec, isCausal,
+        attentionMaskSpec, curPosEmpty, curPosTensorSpec, attentionSinkSpec,
+        scaleFloat, slidingWindowSize,
         detail::getNullableMemoryConfig(outputLayout),
         sdpaProgramConfigConverted,
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     scaledDotProductAttentionDecodeOpQuery);
+  return operation::getOpConstraintsWithState(
+      queryLayout.getContext(), scaledDotProductAttentionDecodeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2840,6 +3496,30 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
     std::optional<uint32_t> slidingWindowSize,
     std::optional<SDPAProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      pageTableShape, pageTableLayout, isCausal, attentionMaskShape,
+      attentionMaskLayout, curPosTensorShape, curPosTensorLayout,
+      attentionSinkShape, attentionSinkLayout, scale, slidingWindowSize,
+      programConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+    std::optional<TTNNLayoutAttr> curPosTensorLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+    std::optional<TTNNLayoutAttr> attentionSinkLayout,
+    std::optional<llvm::APFloat> scale,
+    std::optional<uint32_t> slidingWindowSize,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2872,17 +3552,21 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
   std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
       sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::paged_scaled_dot_product_attention_decode, device,
-        querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
+        initialStateOpt, querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
         attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
         slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
         sdpaProgramConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(
+  return operation::getOpConstraintsWithState(
       queryLayout.getContext(), pagedScaledDotProductAttentionDecodeOpQuery);
 #else
   return OpConstraints{};
@@ -2985,6 +3669,29 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
     std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      headDimV, pageTableShape, pageTableLayout, isCausal, attentionMaskShape,
+      attentionMaskLayout, curPosTensorShape, curPosTensorLayout,
+      attentionSinkShape, attentionSinkLayout, scale, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    std::optional<llvm::ArrayRef<int64_t>> valueShape,
+    std::optional<TTNNLayoutAttr> valueLayout, uint32_t headDimV,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+    std::optional<TTNNLayoutAttr> curPosTensorLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+    std::optional<TTNNLayoutAttr> attentionSinkLayout,
+    std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3016,18 +3723,23 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
   std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
       programConfig = getPagedFlashMlaDecodeProgramConfig(device);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto pagedFlashMlaDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::paged_flash_multi_latent_attention_decode, device,
-        querySpec, keySpec, valueSpec, headDimV, pageTableSpec, isCausal,
-        attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
+        initialStateOpt, querySpec, keySpec, valueSpec, headDimV, pageTableSpec,
+        isCausal, attentionMaskSpec, curPosTensorSpec, attentionSinkSpec,
+        scaleFloat,
         /*slidingWindowSize=*/std::nullopt,
         detail::getNullableMemoryConfig(outputLayout), programConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     pagedFlashMlaDecodeOpQuery);
+  return operation::getOpConstraintsWithState(queryLayout.getContext(),
+                                              pagedFlashMlaDecodeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3212,6 +3924,25 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
     std::optional<llvm::APFloat> scale,
     std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      attentionMaskShape, attentionMaskLayout, attentionSinkShape,
+      attentionSinkLayout, isCausal, scale, slidingWindowSize, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ScaledDotProductAttentionOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+    std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
+    std::optional<llvm::APFloat> scale,
+    std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3235,17 +3966,22 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto scaledDotProductAttentionOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::transformer::scaled_dot_product_attention, device, querySpec,
-        keySpec, valueSpec, attentionMaskSpec, isCausal, scaleFloat,
-        slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::transformer::scaled_dot_product_attention, device,
+        initialStateOpt, querySpec, keySpec, valueSpec, attentionMaskSpec,
+        isCausal, scaleFloat, slidingWindowSize,
+        detail::getNullableMemoryConfig(outputLayout),
         /*program_config=*/std::nullopt,
         /*compute_kernel_config=*/std::nullopt, attentionSinkSpec);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     scaledDotProductAttentionOpQuery);
+  return operation::getOpConstraintsWithState(queryLayout.getContext(),
+                                              scaledDotProductAttentionOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3313,6 +4049,22 @@ llvm::Expected<OpConstraints> OpModel<FlashMlaPrefillOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
     bool isCausal, std::optional<llvm::APFloat> scale,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      attentionMaskShape, attentionMaskLayout, headDimV, isCausal, scale,
+      outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<FlashMlaPrefillOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    std::optional<llvm::ArrayRef<int64_t>> valueShape,
+    std::optional<TTNNLayoutAttr> valueLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
+    bool isCausal, std::optional<llvm::APFloat> scale,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3332,17 +4084,21 @@ llvm::Expected<OpConstraints> OpModel<FlashMlaPrefillOp>::getOpConstraints(
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto flashMlaPrefillOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::transformer::flash_mla_prefill, device,
-                                querySpec, keySpec, headDimV, valueSpec,
-                                attentionMaskSpec, isCausal, scaleFloat,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*program_config=*/std::nullopt,
-                                /*compute_kernel_config=*/std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::transformer::flash_mla_prefill, device, initialStateOpt,
+        querySpec, keySpec, headDimV, valueSpec, attentionMaskSpec, isCausal,
+        scaleFloat, detail::getNullableMemoryConfig(outputLayout),
+        /*program_config=*/std::nullopt,
+        /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     flashMlaPrefillOpQuery);
+  return operation::getOpConstraintsWithState(queryLayout.getContext(),
+                                              flashMlaPrefillOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3400,6 +4156,20 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
     llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
     bool isDecodeMode, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, cosShape, cosLayout,
+                                   sinShape, sinLayout, transMatShape,
+                                   transMatLayout, isDecodeMode, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<RotaryEmbeddingLlamaOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+    llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+    llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
+    bool isDecodeMode, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3415,15 +4185,19 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
       ::ttnn::TensorSpec transMatSpec,
       detail::convertToTensorSpec(device, transMatShape, transMatLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto rotaryEmbeddingLlamaOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding_llama,
-                                device, inputSpec, cosSpec, sinSpec,
-                                transMatSpec, isDecodeMode,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::rotary_embedding_llama, device, initialStateOpt,
+        inputSpec, cosSpec, sinSpec, transMatSpec, isDecodeMode,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     rotaryEmbeddingLlamaOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              rotaryEmbeddingLlamaOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3473,6 +4247,18 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
     std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, cosShape, cosLayout,
+                                   sinShape, sinLayout, tokenIndex,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<RotaryEmbeddingOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+    llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+    std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3485,14 +4271,19 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
                    detail::convertToTensorSpec(device, sinShape, sinLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto rotaryEmbeddingOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding, device,
-                                inputSpec, cosSpec, sinSpec, tokenIndex,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::rotary_embedding, device, initialStateOpt,
+        inputSpec, cosSpec, sinSpec, tokenIndex,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     rotaryEmbeddingOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              rotaryEmbeddingOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3538,6 +4329,20 @@ OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
     std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
     std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, batchOffsetShape,
+                                   batchOffsetLayout, numHeads, numKVHeads,
+                                   overlapQKCoregrid, sliceSize, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
+    std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
+    std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
+    std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3552,19 +4357,23 @@ OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors =
       std::nullopt;
   auto nlpCreateQKVHeadsDecode = [&]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::nlp_create_qkv_heads_decode, device, inputSpec,
-        numHeads, numKVHeads, optionalOutputTensors,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::nlp_create_qkv_heads_decode, device,
+        initialStateOpt, inputSpec, numHeads, numKVHeads, optionalOutputTensors,
         std::optional<const bool>(overlapQKCoregrid), batchOffsetSpec,
         sliceSize, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     nlpCreateQKVHeadsDecode);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              nlpCreateQKVHeadsDecode);
 
 #else
   return OpConstraints{};
@@ -3618,6 +4427,18 @@ OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
     std::optional<uint32_t> numKVHeads, bool transposeKey,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, inputKVShape, inputKVLayout, numHeads,
+      numKVHeads, transposeKey, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
+    std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
+    std::optional<uint32_t> numKVHeads, bool transposeKey,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3633,16 +4454,20 @@ OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
                                                  inputKVLayout.value()));
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto splitQueryKeyValueAndSplitHeadsOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::split_query_key_value_and_split_heads, device,
-        inputSpec, inputKVSpec, numHeads, numKVHeads, transposeKey,
-        detail::getNullableMemoryConfig(outputLayout));
+        initialStateOpt, inputSpec, inputKVSpec, numHeads, numKVHeads,
+        transposeKey, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     splitQueryKeyValueAndSplitHeadsOpQuery);
+  return operation::getOpConstraintsWithState(
+      inputLayout.getContext(), splitQueryKeyValueAndSplitHeadsOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3690,6 +4515,14 @@ llvm::Expected<OpConstraints>
 OpModel<NLPConcatHeadsOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                                             TTNNLayoutAttr inputLayout,
                                             TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<NLPConcatHeadsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3698,15 +4531,19 @@ OpModel<NLPConcatHeadsOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto nlpConcatHeadsOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::nlp_concat_heads, device,
-                                inputSpec,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::nlp_concat_heads, device, initialStateOpt,
+        inputSpec, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     nlpConcatHeadsOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              nlpConcatHeadsOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3743,6 +4580,15 @@ OpModel<NLPConcatHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     uint32_t numHeads, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, numHeads,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<NLPConcatHeadsDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    uint32_t numHeads, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3767,16 +4613,20 @@ llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
     }
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto nlpConcatHeadsDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::nlp_concat_heads_decode, device, inputSpec,
-        numHeads, detail::getNullableMemoryConfig(outputLayout),
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::nlp_concat_heads_decode, device, initialStateOpt,
+        inputSpec, numHeads, detail::getNullableMemoryConfig(outputLayout),
         std::optional<::tt::tt_metal::Tensor>(std::nullopt), subCoreGrids);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     nlpConcatHeadsDecodeOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              nlpConcatHeadsDecodeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3826,6 +4676,15 @@ llvm::Expected<size_t> OpModel<NLPConcatHeadsDecodeOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, repeats, dim,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<RepeatInterleaveOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3834,15 +4693,19 @@ llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto repeatInterleaveOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::repeat_interleave, device, inputSpec,
-                                repeats, dim,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::repeat_interleave, device, initialStateOpt, inputSpec, repeats,
+        dim, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     repeatInterleaveOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              repeatInterleaveOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3878,6 +4741,14 @@ llvm::Expected<size_t> OpModel<RepeatInterleaveOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, repeats,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3897,13 +4768,19 @@ llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
   ::ttsl::SmallVector<uint32_t> repeatVec(repeatShape.cbegin(),
                                           repeatShape.cend());
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto repeatOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::repeat, device, inputSpec, repeatVec,
-                                outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(::ttnn::repeat, device,
+                                           initialStateOpt, inputSpec,
+                                           repeatVec, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), repeatOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              repeatOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3979,6 +4856,15 @@ llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, padding, padValue,
+                                   multicore, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3990,14 +4876,20 @@ llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
   // Convert padding to PadSpecDim format
   auto paddingSpec = convertPadding(padding);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto padOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::pad, device, inputSpec, paddingSpec,
-                                padValue.convertToFloat(), multicore,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::pad, device, initialStateOpt, inputSpec, paddingSpec,
+        padValue.convertToFloat(), multicore,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), padOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              padOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4037,6 +4929,15 @@ llvm::Expected<size_t> OpModel<PadOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
     bool descending, bool stable, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, descending,
+                                   stable, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
+    bool descending, bool stable, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4045,14 +4946,19 @@ llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto sortOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::sort, device, inputSpec, dim,
-                                descending, stable,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::sort, device, initialStateOpt, inputSpec, dim, descending,
+        stable, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), sortOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              sortOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4091,6 +4997,19 @@ llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
     uint32_t numExperts, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, biasShape, biasLayout, k,
+                                   numExperts, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<TopKRouterGptOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
+    uint32_t numExperts, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4106,13 +5025,18 @@ llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::ttnn::TensorSpec biasSpec,
                    detail::convertToTensorSpec(device, biasShape, biasLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto topKRouterGptQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::topk_router_gpt, device,
-                                inputSpec, weightSpec, biasSpec, k, numExperts);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::topk_router_gpt, device, initialStateOpt,
+        inputSpec, weightSpec, biasSpec, k, numExperts);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     topKRouterGptQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              topKRouterGptQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4155,6 +5079,14 @@ llvm::Expected<size_t> OpModel<TopKRouterGptOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, keepDim,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4163,14 +5095,20 @@ llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto argMaxOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::argmax, device, inputSpec, dim, keepDim, std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout), std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::argmax, device, initialStateOpt, inputSpec, dim, keepDim,
+        std::nullopt, detail::getNullableMemoryConfig(outputLayout),
+        std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), argMaxOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              argMaxOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4206,6 +5144,14 @@ llvm::Expected<size_t> OpModel<ArgMaxOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, keepDim,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4214,13 +5160,19 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto prodOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::prod, device, inputSpec, dim, keepDim,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::prod, device, initialStateOpt, inputSpec, dim, keepDim,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), prodOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              prodOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4342,6 +5294,22 @@ llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> outZeroPointShape,
     TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
     std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, inScaleShape, inScaleLayout, inZeroPointShape,
+      inZeroPointLayout, outScaleShape, outScaleLayout, outZeroPointShape,
+      outZeroPointLayout, axis, outputDtype, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
+    llvm::ArrayRef<int64_t> inZeroPointShape, TTNNLayoutAttr inZeroPointLayout,
+    llvm::ArrayRef<int64_t> outScaleShape, TTNNLayoutAttr outScaleLayout,
+    llvm::ArrayRef<int64_t> outZeroPointShape,
+    TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
+    std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4377,16 +5345,21 @@ llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
 
   auto requantizeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::requantize, device, inputSpec, inScaleSpec, inZeroPointSpec,
-        outScaleSpec, outZeroPointSpec, axis, outputDType, outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::requantize, device, initialStateOpt, inputSpec, inScaleSpec,
+        inZeroPointSpec, outScaleSpec, outZeroPointSpec, axis, outputDType,
+        outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     requantizeOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              requantizeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4460,6 +5433,21 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
     bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
     std::optional<mlir::Attribute> programConfigAttr,
     std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
+  return getOpConstraintsWithState(
+      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, biasShape,
+      biasLayout, outputLayout, transposeA, transposeB, activation,
+      programConfigAttr, computeKernelConfig, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
+    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4498,18 +5486,23 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
       computeKernelConfigConverted =
           conversion::getDeviceComputeKernelConfig(computeKernelConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto linearOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor, transposeA,
-        transposeB, outputMemoryConfig, outputDType, programConfig,
-        activationStr, computeKernelConfigConverted,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::linear, device, initialStateOpt, inputSpecA, inputSpecB,
+        biasTensor, transposeA, transposeB, outputMemoryConfig, outputDType,
+        programConfig, activationStr, computeKernelConfigConverted,
         /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
         /*optional_output_tensor=*/std::nullopt,
         /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), linearOpQuery);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(),
+                                              linearOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4566,6 +5559,9 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//
+// Cache-facing stateless entry; signature fixed for getOrCompute. Forwards to
+// the shared stateful body with a null state (metal dispatches nullopt to the
+// stateless query).
 llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -4573,6 +5569,22 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
     std::optional<llvm::StringRef> activation,
     std::optional<mlir::Attribute> programConfigAttr,
     std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputLayout, transposeA,
+                                   transposeB, activation, programConfigAttr,
+                                   computeKernelConfig,
+                                   /*initialState=*/nullptr);
+}
+
+// Shared body. Stateful entry (L1 spill path); bypasses the op-model cache.
+llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
+    std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4604,17 +5616,22 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
       computeKernelConfigConverted =
           conversion::getDeviceComputeKernelConfig(computeKernelConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto matmulOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::matmul, device, inputSpecA, inputSpecB, transposeA, transposeB,
-        outputMemoryConfig, outputDType, programConfig, activationStr,
-        computeKernelConfigConverted, /*core_grid=*/std::nullopt,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::matmul, device, initialStateOpt, inputSpecA, inputSpecB,
+        transposeA, transposeB, outputMemoryConfig, outputDType, programConfig,
+        activationStr, computeKernelConfigConverted, /*core_grid=*/std::nullopt,
         /*output_tile=*/std::nullopt, /*optional_output_tensor=*/std::nullopt,
         /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), matmulOpQuery);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(),
+                                              matmulOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4695,6 +5712,16 @@ llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     uint32_t batchOffset, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(cacheShape, cacheLayout, inputShape,
+                                   inputLayout, batchOffset, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    uint32_t batchOffset, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4706,13 +5733,18 @@ llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto fillCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::fill_cache, device, cacheSpec,
-                                inputSpec, batchOffset);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(::ttnn::fill_cache, device,
+                                           initialStateOpt, cacheSpec,
+                                           inputSpec, batchOffset);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(),
-                                     fillCacheOpQuery);
+  return operation::getOpConstraintsWithState(cacheLayout.getContext(),
+                                              fillCacheOpQuery);
 
 #else
   return llvm::createStringError("Not Implemented");
@@ -4754,6 +5786,17 @@ llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
     uint32_t batchOffset, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      cacheShape, cacheLayout, inputShape, inputLayout, updateIndexShape,
+      updateIndexLayout, batchOffset, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
+    uint32_t batchOffset, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4780,14 +5823,19 @@ llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraints(
   (void)updateIndexShape;
   (void)updateIndexLayout;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto updateCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::update_cache, device, cacheSpec,
-                                inputSpec, updateIdx, batchOffset,
-                                /*compute_kernel_config=*/std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::update_cache, device, initialStateOpt, cacheSpec, inputSpec,
+        updateIdx, batchOffset,
+        /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(),
-                                     updateCacheOpQuery);
+  return operation::getOpConstraintsWithState(cacheLayout.getContext(),
+                                              updateCacheOpQuery);
 
 #else
   return llvm::createStringError("Not Implemented");
@@ -4838,6 +5886,20 @@ llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
     std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      cacheShape, cacheLayout, inputShape, inputLayout, updateIndexShape,
+      updateIndexLayout, pageTableShape, pageTableLayout, shareCache,
+      outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PagedUpdateCacheOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
+    std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
+    std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -4861,17 +5923,22 @@ llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
         detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout));
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   std::vector<uint32_t> emptyUpdateIndex = {};
   auto pagedUpdateCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::paged_update_cache, device, cacheSpec, inputSpec,
-        emptyUpdateIndex, updateIndexSpec, shareCache, pageTableSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::paged_update_cache, device, initialStateOpt,
+        cacheSpec, inputSpec, emptyUpdateIndex, updateIndexSpec, shareCache,
+        pageTableSpec,
         /*batch_offset=*/0,
         /*compute_kernel_config=*/std::nullopt, /*mesh_coords=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(),
-                                     pagedUpdateCacheOpQuery);
+  return operation::getOpConstraintsWithState(cacheLayout.getContext(),
+                                              pagedUpdateCacheOpQuery);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4931,6 +5998,20 @@ llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
     std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
     std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(cacheShape, cacheLayout, inputShape,
+                                   inputLayout, pageTableShape, pageTableLayout,
+                                   batchIdxShape, batchIdxLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PagedFillCacheOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
+    std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4953,16 +6034,20 @@ llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
         detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout));
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto pagedFillCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::paged_fill_cache, device, cacheSpec, inputSpec,
-        pageTableSpec, batchIdxSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::paged_fill_cache, device, initialStateOpt,
+        cacheSpec, inputSpec, pageTableSpec, batchIdxSpec,
         /*batch_offset=*/0,
         /*compute_kernel_config=*/std::nullopt, /*mesh_coords=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(),
-                                     pagedFillCacheOpQuery);
+  return operation::getOpConstraintsWithState(cacheLayout.getContext(),
+                                              pagedFillCacheOpQuery);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5026,6 +6111,27 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
+      in_channels, out_channels, batch_size, input_height, input_width,
+      kernel_size, stride, padding, dilation, groups, conv2dConfig,
+      deviceComputeKernelConfig, conv2dSliceConfig, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Prepare weight tensor first.
   llvm::Expected<::ttnn::TensorSpec> preparedWeightExp =
@@ -5074,11 +6180,15 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
   std::optional<::ttnn::Conv2dSliceConfig> sliceConfigConverted =
       conversion::getConv2dSliceConfig(conv2dSliceConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto conv2dOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::conv2d, device, inputSpec, weightSpec, device, in_channels,
-        out_channels, batch_size, input_height, input_width,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::conv2d, device, initialStateOpt, inputSpec, weightSpec, device,
+        in_channels, out_channels, batch_size, input_height, input_width,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         detail::reorderPool2dPadding(padding),
@@ -5090,7 +6200,8 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
         /*return_weights_and_bias=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), conv2dOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              conv2dOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5518,6 +6629,28 @@ llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
     std::optional<Conv3dConfigAttr> conv3dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
+      in_channels, out_channels, batch_size, input_depth, input_height,
+      input_width, kernel_size, stride, padding, groups, padding_mode,
+      outputDtype, conv3dConfig, deviceComputeKernelConfig, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_depth,
+    uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, uint32_t groups,
+    llvm::StringRef padding_mode,
+    std::optional<ttcore::DataTypeAttr> outputDtype,
+    std::optional<Conv3dConfigAttr> conv3dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5532,9 +6665,14 @@ llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
   }
   auto specs = specsExp.get();
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto conv3dOpQuery = [=, &specs]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::conv3d, device, specs.inputSpec, specs.weightSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::conv3d, device, initialStateOpt, specs.inputSpec,
+        specs.weightSpec,
         std::optional<::tt::tt_metal::distributed::MeshDevice *>(device),
         specs.biasSpec, specs.config, specs.dtype, specs.outputChannels,
         specs.kernelSize, specs.stride, specs.padding,
@@ -5543,7 +6681,8 @@ llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
         specs.deviceComputeKernelConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), conv3dOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              conv3dOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5609,6 +6748,26 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
     uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
+      in_channels, out_channels, batch_size, input_height, input_width,
+      kernel_size, stride, padding, output_padding, dilation, groups,
+      conv2dConfig, conv2dSliceConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ConvTranspose2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
+    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Prepare weight tensor first.
   llvm::Expected<::ttnn::TensorSpec> preparedWeightExp =
@@ -5652,11 +6811,16 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
   std::optional<::ttnn::Conv2dSliceConfig> conv2dSliceConfigConverted =
       conversion::getConv2dSliceConfig(conv2dSliceConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto convTranspose2dOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::conv_transpose2d, device, inputSpec, weightSpec, device,
-        in_channels, out_channels, batch_size, input_height, input_width,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::conv_transpose2d, device, initialStateOpt, inputSpec,
+        weightSpec, device, in_channels, out_channels, batch_size, input_height,
+        input_width,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
@@ -5671,8 +6835,8 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
         /*return_weights_and_bias=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     convTranspose2dOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              convTranspose2dOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5776,6 +6940,28 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      weightLayout, weightShape, inputMemConfig, inputTensorLayout,
+      weightsFormat, inChannels, outChannels, batchSize, inputHeight,
+      inputWidth, kernelSize, stride, padding, dilation, hasBias, groups,
+      inputDtype, outputDtype, conv2dConfig, deviceComputeKernelConfig,
+      conv2dSliceConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareConv2dWeightsOp>::getOpConstraintsWithState(
+    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    bool hasBias, int32_t groups, ttcore::DataType inputDtype,
+    std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5796,10 +6982,15 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
   std::optional<::ttnn::Conv2dSliceConfig> sliceConfigConverted =
       conversion::getConv2dSliceConfig(conv2dSliceConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto prepareConv2dWeightsQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
+    return ::ttnn::graph::query_op_constraints_with_optional_state(
         &::ttnn::operations::conv::conv2d::prepare_conv_weights, device,
-        weightTensor, conversion::getMemoryConfig(inputMemConfig),
+        initialStateOpt, weightTensor,
+        conversion::getMemoryConfig(inputMemConfig),
         conversion::getPageLayout(inputTensorLayout), weightsFormat.str(),
         inChannels, outChannels, batchSize, inputHeight, inputWidth,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
@@ -5812,8 +7003,8 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
         sliceConfigConverted);
   };
 
-  return operation::getOpConstraints(weightLayout.getContext(),
-                                     prepareConv2dWeightsQuery);
+  return operation::getOpConstraintsWithState(weightLayout.getContext(),
+                                              prepareConv2dWeightsQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5834,6 +7025,25 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
     std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      biasLayout, biasShape, inputMemConfig, inputTensorLayout, inChannels,
+      outChannels, batchSize, inputHeight, inputWidth, kernelSize, stride,
+      padding, dilation, groups, inputDtype, outputDtype, conv2dConfig,
+      deviceComputeKernelConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareConv2dBiasOp>::getOpConstraintsWithState(
+    TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5853,10 +7063,15 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
 
   std::optional<::ttnn::Conv2dSliceConfig> sliceConfig = std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto prepareConv2dWeightsQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
+    return ::ttnn::graph::query_op_constraints_with_optional_state(
         &::ttnn::operations::conv::conv2d::prepare_conv_bias, device,
-        biasTensor, conversion::getMemoryConfig(inputMemConfig),
+        initialStateOpt, biasTensor,
+        conversion::getMemoryConfig(inputMemConfig),
         conversion::getPageLayout(inputTensorLayout), inChannels, outChannels,
         batchSize, inputHeight, inputWidth,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
@@ -5869,8 +7084,8 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
         sliceConfig);
   };
 
-  return operation::getOpConstraints(biasLayout.getContext(),
-                                     prepareConv2dWeightsQuery);
+  return operation::getOpConstraintsWithState(biasLayout.getContext(),
+                                              prepareConv2dWeightsQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5894,6 +7109,29 @@ OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      weightLayout, weightShape, inputMemConfig, inputTensorLayout,
+      weightsFormat, inChannels, outChannels, batchSize, inputHeight,
+      inputWidth, kernelSize, stride, padding, output_padding, dilation,
+      hasBias, groups, inputDtype, outputDtype, conv2dConfig,
+      deviceComputeKernelConfig, conv2dSliceConfig, mirrorKernel, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraintsWithState(
+    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
+    llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5911,11 +7149,16 @@ OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
     convertedOutputDtype = conversion::getDataType(outputDtype.value());
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto prepareConvTranspose2dWeightsQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
+    return ::ttnn::graph::query_op_constraints_with_optional_state(
         &::ttnn::operations::conv::conv_transpose2d::
             prepare_conv_transpose2d_weights,
-        device, weightTensor, conversion::getMemoryConfig(inputMemConfig),
+        device, initialStateOpt, weightTensor,
+        conversion::getMemoryConfig(inputMemConfig),
         conversion::getPageLayout(inputTensorLayout), weightsFormat.str(),
         inChannels, outChannels, batchSize, inputHeight, inputWidth,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
@@ -5929,8 +7172,8 @@ OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
         conversion::getConv2dSliceConfig(conv2dSliceConfig), mirrorKernel);
   };
 
-  return operation::getOpConstraints(weightLayout.getContext(),
-                                     prepareConvTranspose2dWeightsQuery);
+  return operation::getOpConstraintsWithState(
+      weightLayout.getContext(), prepareConvTranspose2dWeightsQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5953,6 +7196,27 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      biasLayout, biasShape, inputMemConfig, inputTensorLayout, inChannels,
+      outChannels, batchSize, inputHeight, inputWidth, kernelSize, stride,
+      padding, dilation, groups, inputDtype, outputDtype, conv2dConfig,
+      deviceComputeKernelConfig, conv2dSliceConfig, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraintsWithState(
+    TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5970,11 +7234,16 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
     convertedOutputDtype = conversion::getDataType(outputDtype.value());
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto prepareConvTranspose2dBiasQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
+    return ::ttnn::graph::query_op_constraints_with_optional_state(
         &::ttnn::operations::conv::conv_transpose2d::
             prepare_conv_transpose2d_bias,
-        device, biasTensor, conversion::getMemoryConfig(inputMemConfig),
+        device, initialStateOpt, biasTensor,
+        conversion::getMemoryConfig(inputMemConfig),
         conversion::getPageLayout(inputTensorLayout), inChannels, outChannels,
         batchSize, inputHeight, inputWidth,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
@@ -5987,8 +7256,8 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
         conversion::getConv2dSliceConfig(conv2dSliceConfig));
   };
 
-  return operation::getOpConstraints(biasLayout.getContext(),
-                                     prepareConvTranspose2dBiasQuery);
+  return operation::getOpConstraintsWithState(biasLayout.getContext(),
+                                              prepareConvTranspose2dBiasQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6004,6 +7273,21 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
     llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
     llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
     std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
+      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+      reallocateHaloOutput, configTensorsInDram, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
+    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6021,11 +7305,15 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto maxPool2DQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::max_pool2d, device, inputSpec, batchSizeU, inputHeightU,
-        inputWidthU, inputChannelsU,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::max_pool2d, device, initialStateOpt, inputSpec, batchSizeU,
+        inputHeightU, inputWidthU, inputChannelsU,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         detail::reorderPool2dPadding(padding),
@@ -6038,7 +7326,8 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
         configTensorsInDram.value_or(false) /* config_tensors_in_dram */);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), maxPool2DQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              maxPool2DQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6101,6 +7390,23 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
     llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
     bool deallocateInput, bool returnIndices,
     std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
+      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+      reallocateHaloOutput, deallocateInput, returnIndices, configTensorsInDram,
+      outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<MaxPool2dWithIndicesOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
+    bool deallocateInput, bool returnIndices,
+    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6118,12 +7424,16 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   // When return_indices=true, tt-metal requires ROW_MAJOR layout and BFLOAT16
   auto maxPool2DWithIndicesQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::max_pool2d, device, inputSpec, batchSizeU, inputHeightU,
-        inputWidthU, inputChannelsU,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::max_pool2d, device, initialStateOpt, inputSpec, batchSizeU,
+        inputHeightU, inputWidthU, inputChannelsU,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         detail::reorderPool2dPadding(padding),
@@ -6135,8 +7445,8 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
         ::ttnn::Layout::ROW_MAJOR, configTensorsInDram.value_or(false));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     maxPool2DWithIndicesQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              maxPool2DWithIndicesQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6199,6 +7509,21 @@ llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
     llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
     llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
     std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
+      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+      reallocateHaloOutput, configTensorsInDram, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
+    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6223,11 +7548,15 @@ llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
   std::optional<::ttnn::DeviceComputeKernelConfig> computeKernelConfig =
       std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto avgPool2DQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::avg_pool2d, device, inputSpec, batchSizeU, inputHeightU,
-        inputWidthU, inputChannelsU,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::avg_pool2d, device, initialStateOpt, inputSpec, batchSizeU,
+        inputHeightU, inputWidthU, inputChannelsU,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         detail::reorderPool2dPadding(padding), ceilMode, countIncludePad,
@@ -6239,7 +7568,8 @@ llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
         configTensorsInDram.value_or(false) /* config_tensors_in_dram */);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), avgPool2DQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              avgPool2DQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6304,6 +7634,15 @@ llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<mlir::tt::ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dtype, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<GlobalAvgPool2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<mlir::tt::ttcore::DataType> dtype,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6331,11 +7670,15 @@ llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
       outputLayout ? conversion::getPageLayout(outputLayout)
                    : ::ttnn::Layout::TILE;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto globalAvgPool2DQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::avg_pool2d, device, inputSpec, batchSize, inputHeight,
-        inputWidth, inputChannels,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::avg_pool2d, device, initialStateOpt, inputSpec, batchSize,
+        inputHeight, inputWidth, inputChannels,
         /*kernel_size=*/std::array<uint32_t, 2>{inputHeight, inputWidth},
         /*stride=*/std::array<uint32_t, 2>{1, 1},
         /*padding=*/std::array<uint32_t, 2>{0, 0},
@@ -6348,8 +7691,8 @@ llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
         outputDType, outputPageLayout, false /* config_tensors_in_dram */);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     globalAvgPool2DQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              globalAvgPool2DQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6423,6 +7766,24 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, runningMeanShape, runningMeanLayout,
+      runningVarShape, runningVarLayout, weightShape, weightLayout, biasShape,
+      biasLayout, epsilon, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<BatchNormInferenceOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
+    std::optional<TTNNLayoutAttr> runningMeanLayout,
+    std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
+    std::optional<TTNNLayoutAttr> runningVarLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6451,15 +7812,20 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
   bool training = false;
   float momentum = 0.1f;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto batchNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::batch_norm, device, inputSpec, runningMeanSpec, runningVarSpec,
-        training, epsilon.convertToFloat(), momentum, weightSpec, biasSpec,
-        outputSpec, detail::getNullableMemoryConfig(outputLayout),
-        computeKernelConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::batch_norm, device, initialStateOpt, inputSpec, runningMeanSpec,
+        runningVarSpec, training, epsilon.convertToFloat(), momentum,
+        weightSpec, biasSpec, outputSpec,
+        detail::getNullableMemoryConfig(outputLayout), computeKernelConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), batchNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              batchNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6534,6 +7900,25 @@ llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     llvm::APFloat momentum, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, runningMeanShape, runningMeanLayout,
+      runningVarShape, runningVarLayout, weightShape, weightLayout, biasShape,
+      biasLayout, epsilon, momentum, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<BatchNormTrainingOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
+    std::optional<TTNNLayoutAttr> runningMeanLayout,
+    std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
+    std::optional<TTNNLayoutAttr> runningVarLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    llvm::APFloat momentum, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6561,15 +7946,20 @@ llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
   // For training mode
   bool training = true;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto batchNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::batch_norm, device, inputSpec, runningMeanSpec, runningVarSpec,
-        training, epsilon.convertToFloat(), momentum.convertToFloat(),
-        weightSpec, biasSpec, outputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::batch_norm, device, initialStateOpt, inputSpec, runningMeanSpec,
+        runningVarSpec, training, epsilon.convertToFloat(),
+        momentum.convertToFloat(), weightSpec, biasSpec, outputSpec,
         detail::getNullableMemoryConfig(outputLayout), computeKernelConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), batchNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              batchNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6640,6 +8030,21 @@ llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout,
     std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, biasShape, biasLayout, epsilon,
+                                   outputLayout, computeKernelConfig,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6660,16 +8065,21 @@ llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
       computeKernelConfigConverted =
           conversion::getDeviceComputeKernelConfig(computeKernelConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto rmsNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::rms_norm, device, inputSpec, epsilon.convertToFloat(),
-        weightSpec, biasSpec, residualInputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::rms_norm, device, initialStateOpt, inputSpec,
+        epsilon.convertToFloat(), weightSpec, biasSpec, residualInputSpec,
         detail::getNullableMemoryConfig(outputLayout),
         /*program_config=*/std::nullopt, computeKernelConfigConverted);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), rmsNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              rmsNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6728,6 +8138,18 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> residualInputLayout,
     std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, residualInputShape,
+                                   residualInputLayout, dtype, use2DCoreGrid,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<RMSNormPreAllGatherOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+    std::optional<TTNNLayoutAttr> residualInputLayout,
+    std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6745,9 +8167,13 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
     metalDtype = conversion::getDataType(dtype.value());
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        ::ttnn::rms_norm_pre_all_gather, device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::rms_norm_pre_all_gather, device, initialStateOpt, inputSpec,
         /*dtype=*/metalDtype,
         /*residual_input_tensor=*/residualInputSpec,
         /*compute_kernel_config=*/std::nullopt,
@@ -6756,7 +8182,7 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
         /*use_2d_core_grid=*/use2DCoreGrid);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 
 #else
   return OpConstraints{};
@@ -6813,6 +8239,19 @@ llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, biasShape, biasLayout, epsilon,
+                                   outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6828,16 +8267,21 @@ llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
 
   std::optional<::ttnn::TensorSpec> residualInputSpec = std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto layerNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::layer_norm, device, inputSpec, epsilon.convertToFloat(),
-        weightSpec, biasSpec, residualInputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::layer_norm, device, initialStateOpt, inputSpec,
+        epsilon.convertToFloat(), weightSpec, biasSpec, residualInputSpec,
         detail::getNullableMemoryConfig(outputLayout),
         /*program_config=*/std::nullopt,
         /*compute_kernel_config=*/std::nullopt, /*recip_tensor=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), layerNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              layerNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6893,6 +8337,21 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> recipShape,
     std::optional<TTNNLayoutAttr> recipLayout,
     std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, residualInputShape,
+                                   residualInputLayout, recipShape, recipLayout,
+                                   dtype, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<LayerNormPreAllGatherOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+    std::optional<TTNNLayoutAttr> residualInputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> recipShape,
+    std::optional<TTNNLayoutAttr> recipLayout,
+    std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6912,9 +8371,13 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
     metalDtype = conversion::getDataType(dtype.value());
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        ::ttnn::layer_norm_pre_all_gather, device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::layer_norm_pre_all_gather, device, initialStateOpt, inputSpec,
         /*dtype=*/metalDtype,
         /*residual_input_tensor=*/residualInputSpec,
         /*compute_kernel_config=*/std::nullopt,
@@ -6923,7 +8386,7 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
         /*recip_tensor=*/recipSpec);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6985,6 +8448,21 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, statsShape,
+                                   statsLayout, weightShape, weightLayout,
+                                   biasShape, biasLayout, epsilon, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<LayerNormPostAllGatherOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7002,17 +8480,21 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
   std::optional<::ttnn::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto query = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::layer_norm_post_all_gather, device,
-                                inputSpec, statsSpec, epsilon.convertToFloat(),
-                                weightSpec, biasSpec,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*compute_kernel_config=*/std::nullopt,
-                                /*program_config=*/std::nullopt,
-                                /*dtype=*/std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::layer_norm_post_all_gather, device, initialStateOpt, inputSpec,
+        statsSpec, epsilon.convertToFloat(), weightSpec, biasSpec,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*compute_kernel_config=*/std::nullopt,
+        /*program_config=*/std::nullopt,
+        /*dtype=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7072,6 +8554,22 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
     llvm::APFloat epsilon, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, inputMaskShape,
+                                   inputMaskLayout, weightShape, weightLayout,
+                                   biasShape, biasLayout, numGroups, epsilon,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
+    std::optional<TTNNLayoutAttr> inputMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
+    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7091,23 +8589,28 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
   int numGroupsInt = static_cast<int>(numGroups);
   float epsilonFloat = epsilon.convertToFloat();
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto groupNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::group_norm, device, inputSpec,
-                                numGroupsInt, epsilonFloat, inputMaskSpec,
-                                weightSpec, biasSpec,
-                                /*reciprocals=*/std::nullopt,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*dtype=*/std::nullopt,
-                                /*core_grid=*/std::nullopt,
-                                /*inplace=*/std::nullopt,
-                                /*output_layout=*/std::nullopt,
-                                /*num_out_blocks=*/std::nullopt,
-                                /*compute_kernel_config=*/std::nullopt,
-                                /*negative_mask=*/std::nullopt,
-                                /*use_welford=*/false);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::group_norm, device, initialStateOpt, inputSpec, numGroupsInt,
+        epsilonFloat, inputMaskSpec, weightSpec, biasSpec,
+        /*reciprocals=*/std::nullopt,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*dtype=*/std::nullopt,
+        /*core_grid=*/std::nullopt,
+        /*inplace=*/std::nullopt,
+        /*output_layout=*/std::nullopt,
+        /*num_out_blocks=*/std::nullopt,
+        /*compute_kernel_config=*/std::nullopt,
+        /*negative_mask=*/std::nullopt,
+        /*use_welford=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), groupNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              groupNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7183,6 +8686,14 @@ clampAttrToVariant(mlir::Attribute attr) {
 llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute min, mlir::Attribute max, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, min, max,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute min, mlir::Attribute max, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7196,13 +8707,18 @@ llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
   auto minVariant = clampAttrToVariant(min);
   auto maxVariant = clampAttrToVariant(max);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto clampScalarQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::clamp, device, inputSpec, minVariant,
-                                maxVariant, memConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(::ttnn::clamp, device,
+                                           initialStateOpt, inputSpec,
+                                           minVariant, maxVariant, memConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     clampScalarQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              clampScalarQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7243,6 +8759,16 @@ llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
     llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, minShape, minLayout,
+                                   maxShape, maxLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
+    llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7258,15 +8784,19 @@ llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::ttnn::TensorSpec maxSpec,
                    detail::convertToTensorSpec(device, maxShape, maxLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto clampTensorQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::clamp, device, inputSpec, minSpec,
-                                maxSpec,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::clamp, device, initialStateOpt, inputSpec, minSpec, maxSpec,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     clampTensorQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              clampTensorQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7311,6 +8841,15 @@ llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, permutation,
+                                   padValue, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7325,14 +8864,19 @@ llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto permuteQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::permute, device, inputSpec, dims,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                defaultedPadValue);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::permute, device, initialStateOpt, inputSpec, dims,
+        detail::getNullableMemoryConfig(outputLayout), defaultedPadValue);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), permuteQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              permuteQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7377,6 +8921,14 @@ llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute scaleFactor, llvm::StringRef mode,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, scaleFactor, mode,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute scaleFactor, llvm::StringRef mode,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7403,15 +8955,21 @@ llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto upsampleQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::upsample, device, inputSpec,
-                                convertedScaleFactor, std::string(mode),
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*compute_kernel_config=*/std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::upsample, device, initialStateOpt, inputSpec,
+        convertedScaleFactor, std::string(mode),
+        detail::getNullableMemoryConfig(outputLayout),
+        /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), upsampleQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              upsampleQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7491,6 +9049,15 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7516,15 +9083,19 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraints(
                          conversion::getDataType(outputLayout.getDataType()))
                    : std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto embeddingOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::embedding, device, embeddingOpArgs.inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::embedding, device, initialStateOpt, embeddingOpArgs.inputSpec,
         embeddingOpArgs.weightSpec, padToken, layout, embeddingsType, dtype,
         detail::getNullableMemoryConfig(outputLayout), std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     embeddingOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              embeddingOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7581,6 +9152,18 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, inGradientShape,
+                                   inGradientLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<EmbeddingBackwardOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7597,15 +9180,20 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
       ::ttnn::TensorSpec inGradientSpec,
       detail::convertToTensorSpec(device, inGradientShape, inGradientLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto embeddingBackwardOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::embedding_bw, device, inputSpec, weightSpec, inGradientSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::embedding_bw, device, initialStateOpt, inputSpec, weightSpec,
+        inGradientSpec,
         /*dtype*/ std::nullopt, detail::getNullableMemoryConfig(outputLayout),
         /*optional_output_tensor*/ std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     embeddingBackwardOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              embeddingBackwardOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7654,6 +9242,15 @@ llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout, int32_t dim,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, indexShape,
+                                   indexLayout, dim, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout, int32_t dim,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7665,15 +9262,21 @@ llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
       ::ttnn::TensorSpec indexSpec,
       detail::convertToTensorSpec(device, indexShape, indexLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto gatherOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::gather, device, inputSpec, static_cast<int8_t>(dim), indexSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::gather, device, initialStateOpt, inputSpec,
+        static_cast<int8_t>(dim), indexSpec,
         /*sparse_grad=*/false, detail::getNullableMemoryConfig(outputLayout),
         /*optional_output_tensor=*/std::nullopt,
         /*sub_core_grids=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), gatherOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              gatherOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -8034,6 +9637,13 @@ auto dispatchGetRawData(mlir::ElementsAttr value, Func &&func)
 llvm::Expected<OpConstraints>
 OpModel<ConstantOp>::getOpConstraints(mlir::ElementsAttr value,
                                       TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(value, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ConstantOp>::getOpConstraintsWithState(
+    mlir::ElementsAttr value, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -8042,14 +9652,18 @@ OpModel<ConstantOp>::getOpConstraints(mlir::ElementsAttr value,
   if (outputLayout) {
     metalLayout = conversion::getPageLayout(outputLayout);
   }
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
   auto func = [&](auto rawData) {
     auto constantOpQuery = [=]() {
-      return QUERY_OP_CONSTRAINTS(
-          ::ttnn::from_buffer, device, rawData, getShape(value),
-          getDataType(value), device, metalLayout,
+      return QUERY_OP_CONSTRAINTS_WITH_STATE(
+          ::ttnn::from_buffer, device, initialStateOpt, rawData,
+          getShape(value), getDataType(value), device, metalLayout,
           detail::getNullableMemoryConfig(outputLayout));
     };
-    return operation::getOpConstraints(value.getContext(), constantOpQuery);
+    return operation::getOpConstraintsWithState(value.getContext(),
+                                                constantOpQuery);
   };
   return dispatchGetRawData(value, func);
 #else
@@ -8136,6 +9750,15 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t k,
     int32_t dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, k, dim, largest,
+                                   sorted, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t k,
+    int32_t dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -8145,16 +9768,21 @@ llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto topKQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::topk, device, inputSpec,
-                                static_cast<uint32_t>(k),
-                                static_cast<int8_t>(dim), largest, sorted,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                std::nullopt, std::nullopt, std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::topk, device, initialStateOpt, inputSpec,
+        static_cast<uint32_t>(k), static_cast<int8_t>(dim), largest, sorted,
+        detail::getNullableMemoryConfig(outputLayout), std::nullopt,
+        std::nullopt, std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), topKQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              topKQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -8199,6 +9827,20 @@ llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
     TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
     TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputValuesShape, inputValuesLayout, inputIndicesShape,
+      inputIndicesLayout, kShape, kLayout, pShape, pLayout, tempShape,
+      tempLayout, seed, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputValuesShape, TTNNLayoutAttr inputValuesLayout,
+    llvm::ArrayRef<int64_t> inputIndicesShape,
+    TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
+    TTNNLayoutAttr kLayout, llvm::ArrayRef<int64_t> pShape,
+    TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
+    TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -8232,14 +9874,18 @@ llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::ttnn::TensorSpec tempSpec,
                    detail::convertToTensorSpec(device, tempShape, tempLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto samplingQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::sampling, device, valuesSpec,
-                                indicesSpec, kSpec, pSpec, tempSpec, seed,
-                                std::nullopt, std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::sampling, device, initialStateOpt, valuesSpec, indicesSpec,
+        kSpec, pSpec, tempSpec, seed, std::nullopt, std::nullopt);
   };
 
-  return operation::getOpConstraints(inputValuesLayout.getContext(),
-                                     samplingQuery);
+  return operation::getOpConstraintsWithState(inputValuesLayout.getContext(),
+                                              samplingQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -8303,6 +9949,15 @@ llvm::Expected<size_t> OpModel<SamplingOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t dim,
     std::optional<uint32_t> clusterAxis, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, clusterAxis,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<MeshPartitionOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t dim,
+    std::optional<uint32_t> clusterAxis, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -8312,15 +9967,19 @@ llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto meshPartitionOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::mesh_partition, device, inputSpec, dim,
-                                clusterAxis,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::mesh_partition, device, initialStateOpt, inputSpec, dim,
+        clusterAxis, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     meshPartitionOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              meshPartitionOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -743,6 +743,15 @@ namespace {
 // Snapshot of the mock allocator state taken before a batch of stateful spill
 // queries, so it can be restored exactly afterward. Single mock device per
 // compile; snapshot is always paired with a restore by the spill pass.
+//
+// INVARIANT: this file-global relies on strictly sequential, non-reentrant use.
+// The op-model / SingletonDeviceContext layer is single-threaded per compile
+// (there is one shared mock device), and the only writer is the greedy L1 spill
+// pass, which brackets exactly one spill run with snapshot -> (queries) ->
+// restore via an RAII guard (see GreedyL1SpillManagement.cpp). There is no
+// nesting: a second snapshotMockAllocatorState() before the matching restore
+// would overwrite the pending snapshot and silently lose the original state.
+// Do not call these from a reentrant / concurrent context.
 std::optional<::tt::tt_metal::experimental::MockAllocatorState>
     g_spillAllocatorSnapshot;
 } // namespace
@@ -3820,6 +3829,22 @@ OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints(
     TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
     std::optional<SDPAProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      pageTableShape, pageTableLayout, chunkStartIdxShape, chunkStartIdxLayout,
+      scale, programConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    llvm::ArrayRef<int64_t> chunkStartIdxShape,
+    TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3844,17 +3869,21 @@ OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints(
   std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
       sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto chunkedScaledDotProductAttentionOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::chunked_scaled_dot_product_attention, device,
-        querySpec, keySpec, valueSpec, pageTableSpec, chunkStartIdxSpec,
-        scaleFloat, detail::getNullableMemoryConfig(outputLayout),
-        sdpaProgramConfig,
+        initialStateOpt, querySpec, keySpec, valueSpec, pageTableSpec,
+        chunkStartIdxSpec, scaleFloat,
+        detail::getNullableMemoryConfig(outputLayout), sdpaProgramConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     chunkedScaledDotProductAttentionOpQuery);
+  return operation::getOpConstraintsWithState(
+      queryLayout.getContext(), chunkedScaledDotProductAttentionOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -744,7 +744,7 @@ namespace {
 // queries, so it can be restored exactly afterward. Single mock device per
 // compile; snapshot is always paired with a restore by the spill pass.
 //
-// INVARIANT: this file-global relies on strictly sequential, non-reentrant use.
+// INVARIANT: this state relies on strictly sequential, non-reentrant use.
 // The op-model / SingletonDeviceContext layer is single-threaded per compile
 // (there is one shared mock device), and the only writer is the greedy L1 spill
 // pass, which brackets exactly one spill run with snapshot -> (queries) ->
@@ -752,8 +752,15 @@ namespace {
 // nesting: a second snapshotMockAllocatorState() before the matching restore
 // would overwrite the pending snapshot and silently lose the original state.
 // Do not call these from a reentrant / concurrent context.
-std::optional<::tt::tt_metal::experimental::MockAllocatorState>
-    g_spillAllocatorSnapshot;
+//
+// Held in a function-local static rather than a namespace-scope global so the
+// mutable state stays encapsulated behind this accessor.
+std::optional<::tt::tt_metal::experimental::MockAllocatorState> &
+spillAllocatorSnapshot() {
+  static std::optional<::tt::tt_metal::experimental::MockAllocatorState>
+      snapshot;
+  return snapshot;
+}
 } // namespace
 #endif
 
@@ -761,17 +768,17 @@ void snapshotMockAllocatorState() {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto *device = SingletonDeviceContext::getInstance().getDevice();
   if (::tt::tt_metal::experimental::get_mock_allocator(*device) == nullptr) {
-    g_spillAllocatorSnapshot.reset();
+    spillAllocatorSnapshot().reset();
     return;
   }
-  g_spillAllocatorSnapshot =
+  spillAllocatorSnapshot() =
       ::tt::tt_metal::experimental::extract_mock_allocator_state(*device);
 #endif
 }
 
 void restoreMockAllocatorState() {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  if (!g_spillAllocatorSnapshot.has_value()) {
+  if (!spillAllocatorSnapshot().has_value()) {
     return;
   }
   // The stateful (build-from-records) query mutates the SHARED mock device's
@@ -784,8 +791,8 @@ void restoreMockAllocatorState() {
   // spuriously legal), producing wrong configs and corrupt output.
   auto *device = SingletonDeviceContext::getInstance().getDevice();
   ::tt::tt_metal::experimental::override_mock_allocator_state(
-      *device, *g_spillAllocatorSnapshot);
-  g_spillAllocatorSnapshot.reset();
+      *device, *spillAllocatorSnapshot());
+  spillAllocatorSnapshot().reset();
 #endif
 }
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -89,7 +89,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
 
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
@@ -131,7 +132,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
 
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
@@ -390,7 +392,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -548,8 +551,8 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
       tensorShape, inputLayout_dram, -1, false, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_EQ(outputSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
@@ -1029,8 +1032,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
 
     if (expectedLegal) {
-      auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-            outputLayoutResults] = constraintsExp.get();
+      auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutResults,
+            outputAllocationsResults] = constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -1168,8 +1171,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
 
     if (expectedLegal) {
-      auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-            outputLayoutResults] = constraintsExp.get();
+      auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutResults,
+            outputAllocationsResults] = constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -1775,7 +1778,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
 
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
@@ -1820,7 +1824,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
 
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
@@ -1878,7 +1883,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -2218,7 +2224,8 @@ TEST_P(OpModelPowScalarParam, PowScalarParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
 
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
@@ -2301,7 +2308,8 @@ TEST_P(OpModelLinearParam, LinearParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (expectedLegal) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -2522,7 +2530,8 @@ TEST_P(OpModelMatmulParam, MatmulParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (expectedLegal) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -2755,7 +2764,8 @@ TEST_P(OpModelConv2dParam, Conv2d) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2871,7 +2881,8 @@ TEST_P(OpModelConv1dParam, Conv1d) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2984,7 +2995,8 @@ TEST_P(OpModelConvTranspose2dParam, ConvTranspose2d) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -3093,7 +3105,8 @@ TEST_P(OpModelConv3dParam, Conv3d) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     // Conv3d (experimental) ignores the requested L1 output memory config and
     // forces output to DRAM (copies input's memory config). Therefore:
     // - outputSize (l1_output_buffer_per_core) = 0 (output is in DRAM, not L1)
@@ -3197,7 +3210,8 @@ protected:
 
     if (constraintsExp) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GT(cbSize, 0);
       EXPECT_GT(l1PeakSize, 0);
       EXPECT_EQ(outputSize, 0);
@@ -3301,7 +3315,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -3416,7 +3431,8 @@ TEST_P(OpModelLeakyReluParam, LeakyReluParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3483,7 +3499,8 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3530,7 +3547,8 @@ TEST_F(OpModelTest, ClampScalarInt32DtypePreserved) {
       << "Constraints failed: " << llvm::toString(constraintsExp.takeError());
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBacks] = constraintsExp.get();
+              outputLayoutReadBacks, outputAllocationsReadBacks] =
+      constraintsExp.get();
   ASSERT_FALSE(outputLayoutReadBacks.empty());
   ExpectLayoutsEQ(outputLayout, outputLayoutReadBacks[0]);
 }
@@ -3576,7 +3594,8 @@ TEST_P(OpModelClampTensorParam, ClampTensorParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3647,7 +3666,8 @@ TEST_P(OpModelPermuteParam, PermuteParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3728,7 +3748,8 @@ TEST_P(OpModelUpsampleParam, UpsampleParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -3786,7 +3807,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -3851,8 +3873,8 @@ TEST_F(OpModelTest, EmbeddingBackwardOp) {
       inputShape, inputLayout, weightShape, weightLayout, inGradientShape,
       inGradientLayout, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(totalPeakSize, 0);
@@ -3876,8 +3898,8 @@ TEST_F(OpModelTest, Where) {
       inputTensorShape, inputLayout, inputTensorShape, inputLayout,
       inputTensorShape, inputLayout, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -3901,8 +3923,8 @@ TEST_F(OpModelTest, EmptyOp) {
       ttnn::op_model::OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints(
           inputTensorShape, dtype, layout, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_EQ(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -3927,8 +3949,8 @@ TEST_F(OpModelTest, ArangeOp) {
       ttnn::op_model::OpModel<mlir::tt::ttnn::ArangeOp>::getOpConstraints(
           startAttr, endAttr, stepAttr, dtype, inputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   // Basic assertions to verify the op constraints are computed
   EXPECT_EQ(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
@@ -3959,7 +3981,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-            outputLayoutReadBacks] = constraintsExp.get();
+            outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -3993,8 +4016,8 @@ TEST_F(OpModelTest, FullOp) {
           shapeAttr, builder.getI32IntegerAttr(0), std::nullopt, std::nullopt,
           outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_EQ(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(totalPeakSize, 0);
@@ -4064,7 +4087,8 @@ TEST_P(OpModelPrepareConv2dWeightsParam, PrepareConv2dWeights) {
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBacks] = constraintsExp.get();
+              outputLayoutReadBacks, outputAllocationsReadBacks] =
+      constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(totalPeakSize, 0);
@@ -4155,7 +4179,8 @@ TEST_P(OpModelPrepareConv2dBiasParam, PrepareConv2dBias) {
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBacks] = constraintsExp.get();
+              outputLayoutReadBacks, outputAllocationsReadBacks] =
+      constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(totalPeakSize, 0);
@@ -4298,7 +4323,8 @@ TEST_P(OpModelBatchNormParam, BatchNormParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4468,7 +4494,8 @@ TEST_P(OpModelRMSNormParam, RMSNormParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4599,7 +4626,8 @@ TEST_P(OpModelRMSNormPreAllGatherParam, RMSNormPreAllGatherParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4721,7 +4749,8 @@ TEST_P(OpModelLayerNormParam, LayerNormParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4859,7 +4888,8 @@ TEST_P(OpModelLayerNormPreAllGatherParam, LayerNormPreAllGatherParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4986,7 +5016,8 @@ TEST_P(OpModelLayerNormPostAllGatherParam, LayerNormPostAllGatherParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -5121,7 +5152,8 @@ TEST_P(OpModelGroupNormParam, GroupNormParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBack] = constraintsExp.get();
+                outputLayoutReadBack, outputAllocationsReadBack] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -5215,7 +5247,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-            outputLayoutReadBacks] = constraintsExp.get();
+            outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -5698,7 +5731,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -5852,7 +5886,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -6008,7 +6043,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -6233,7 +6269,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -6553,7 +6590,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -6676,7 +6714,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -7030,7 +7069,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -7160,7 +7200,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -7280,7 +7321,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -6862,7 +6862,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocations] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -2464,8 +2464,8 @@ TEST_F(OpModelBase, ChunkedScaledDotProductAttentionOpInterface) {
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(chunkedSdpAttention), OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -136,8 +136,8 @@ TEST_P(UnaryOpModelTest, TestOpInterface) {
   auto constraintsExp = getOpConstraints(op);
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -172,8 +172,8 @@ TEST_P(UnaryOpModelTest, TestOpInterfaceNullOutput) {
   ASSERT_EQ(static_cast<bool>(constraintsExp),
             params.expectedResult.expectedLegal);
 
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GE(totalPeakSize, 0);
@@ -376,8 +376,8 @@ TEST_P(BinaryOpModelTest, TestOpInterface) {
   auto constraintsExp = getOpConstraints(op);
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -413,8 +413,8 @@ TEST_P(BinaryOpModelTest, TestOpInterfaceNullOutput) {
   ASSERT_EQ(static_cast<bool>(constraintsExp),
             params.expectedResult.expectedLegal);
 
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GE(totalPeakSize, 0);
@@ -465,7 +465,8 @@ TEST_P(BinaryBitwiseOpModelTest, TestOpInterface) {
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize,
-               outputLayoutReadBack] = constraintsExp.get();
+               outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GE(totalPeakSize, 0);
@@ -620,8 +621,8 @@ TEST_F(OpModelBase, PowScalarOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
@@ -672,8 +673,8 @@ TEST_F(OpModelBase, BitwiseNotOpInterface) {
   auto constraintsExp = getOpConstraints(bitwiseNot.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -731,8 +732,8 @@ TEST_F(OpModelBase, LogicalRightShiftOpInterface) {
   auto constraintsExp = getOpConstraints(logicalRightShift.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -789,8 +790,8 @@ TEST_F(OpModelBase, LogicalLeftShiftOpInterface) {
   auto constraintsExp = getOpConstraints(logicalLeftShift.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -822,8 +823,8 @@ TEST_F(OpModelBase, SqrtOpInterface) {
   auto constraintsExp = getOpConstraints(sqrt.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -854,8 +855,8 @@ TEST_F(OpModelBase, SigmoidOpInterface) {
   auto constraintsExp = getOpConstraints(sigmoid.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -886,8 +887,8 @@ TEST_F(OpModelBase, SoftmaxOpInterface) {
   auto constraintsExp = getOpConstraints(softmax.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -924,8 +925,8 @@ TEST_F(OpModelBase, LinearOpInterface) {
   auto constraintsExp = getOpConstraints(linear.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -964,8 +965,8 @@ TEST_F(OpModelBase, LinearOpInterfaceNullOutput) {
       getInputLayouts(linear), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -1028,8 +1029,8 @@ TEST_F(OpModelBase, MatmulOpInterface) {
   auto constraintsExp = getOpConstraints(matmul.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1065,8 +1066,8 @@ TEST_F(OpModelBase, MatmulOpInterfaceNullOutput) {
       getInputLayouts(matmul), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -1131,8 +1132,8 @@ void testReductionOp(OpModelBase *testFixture, mlir::OpBuilder &builder,
   auto constraintsExp = (testFixture->*getOpConstraintsFn)(op.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -1221,7 +1222,7 @@ TEST_F(OpModelBase, ArgMaxOpInterface) {
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
     const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize,
-                 outputLayoutReadBack] = l1;
+                 outputLayoutReadBack, outputAllocationsReadBack] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -1254,8 +1255,8 @@ TEST_F(OpModelBase, ProdOpInterface) {
   auto constraintsExp = getOpConstraints(prod.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -1290,8 +1291,8 @@ TEST_F(OpModelBase, ScatterOpInterface) {
   auto constraintsExp = getOpConstraints(scatter.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -1331,8 +1332,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
   auto constraintsExp = getOpConstraints(reshape.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1351,8 +1352,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
   auto cachedConstraintsExp = getOpConstraints(reshape.getOperation());
   if (cachedConstraintsExp) {
     auto l1 = cachedConstraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1398,8 +1399,8 @@ TEST_F(OpModelBase, SliceStaticOpInterface) {
   auto constraintsExp = getOpConstraints(sliceStaticOp.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1444,8 +1445,8 @@ TEST_F(OpModelBase, SliceDynamicOpInterface) {
   auto constraintsExp = getOpConstraints(sliceDynamicOp.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -1491,8 +1492,8 @@ TEST_F(OpModelBase, toLayoutOp) {
       std::vector{layoutDRAMRowMajor}, layoutDRAMTiled);
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -1533,8 +1534,8 @@ TEST_F(OpModelBase, toMemoryConfigOp) {
       backend.getOpConstraints(std::vector{inputLayout_L1Tiled}, OpConfig());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -1572,8 +1573,8 @@ TEST_F(OpModelBase, concatOp) {
   auto constraintsExp = getOpConstraints(concatOp.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1605,8 +1606,8 @@ TEST_F(OpModelBase, transposeOp) {
   auto constraintsExp = getOpConstraints(transpose.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1639,8 +1640,8 @@ TEST_F(OpModelBase, cumSumOp) {
   auto constraintsExp = getOpConstraints(cumSum.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1673,8 +1674,8 @@ TEST_F(OpModelBase, cumProdOp) {
   auto constraintsExp = getOpConstraints(cumProd.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1711,8 +1712,8 @@ TEST_F(OpModelBase, TopKOp) {
   auto constraintsExp = getOpConstraints(topK.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1755,8 +1756,8 @@ TEST_F(OpModelBase, ConcatenateHeadsOpInterface) {
   auto constraintsExp = getOpConstraints(concatenateHeads.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1800,8 +1801,8 @@ TEST_F(OpModelBase, RotaryEmbeddingLlamaOpInterface) {
   auto constraintsExp = getOpConstraints(rotaryEmbeddingLlama.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1841,8 +1842,8 @@ TEST_F(OpModelBase, RotaryEmbeddingOpInterface) {
   auto constraintsExp = getOpConstraints(rotaryEmbedding.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1898,8 +1899,8 @@ TEST_F(OpModelBase, NLPCreateQKVHeadsDecodeOpInterface) {
       getOpConstraints(nlpCreateQKVHeadsDecode.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -1949,8 +1950,8 @@ TEST_F(OpModelBase, SplitQueryKeyValueAndSplitHeadsOpInterface) {
 
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2030,8 +2031,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionDecodeOpInterface) {
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(sdpAttentionDecode), OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2114,8 +2115,8 @@ TEST_F(OpModelBase,
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(sdpAttentionDecode), OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2206,8 +2207,8 @@ TEST_F(OpModelBase, DISABLED_PagedScaledDotProductAttentionDecodeOpInterface) {
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(sdpAttentionDecode), OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2297,8 +2298,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionOpInterface) {
   auto constraintsExp = backend.getOpConstraints(getInputLayouts(sdpAttention),
                                                  OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2377,8 +2378,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionOpInterfaceWithAttentionSink) {
   auto constraintsExp = backend.getOpConstraints(getInputLayouts(sdpAttention),
                                                  OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2515,8 +2516,8 @@ TEST_F(OpModelBase, NLPConcatHeadsOpInterface) {
   auto constraintsExp = getOpConstraints(nlpConcatHeads.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2550,8 +2551,8 @@ TEST_F(OpModelBase, repeatInterleaveOp) {
   auto constraintsExp = getOpConstraints(repeatInterleave.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -2587,8 +2588,8 @@ TEST_F(OpModelBase, repeatOp) {
   auto constraintsExp = getOpConstraints(repeat.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2623,8 +2624,8 @@ TEST_F(OpModelBase, padOp) {
   auto constraintsExp = getOpConstraints(pad.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2660,8 +2661,8 @@ TEST_F(OpModelBase, sortOp) {
   auto constraintsExp = getOpConstraints(sort.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2732,8 +2733,8 @@ TEST_F(OpModelBase, maxPool2dWithIndicesOp) {
   auto constraintsExp = getOpConstraints(maxPool2dWithIndices.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2763,8 +2764,8 @@ TEST_F(OpModelBase, typecastOp) {
   auto constraintsExp = getOpConstraints(typecast.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2800,8 +2801,8 @@ TEST_F(OpModelBase, bitcastConvertOp) {
   auto constraintsExp = getOpConstraints(bitcastConvert.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2864,8 +2865,8 @@ TEST_F(OpModelBase, Conv2dInterface) {
   // test Conv2dOp interface
   auto constraintsExp = getOpConstraints(conv2d.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -2927,8 +2928,8 @@ TEST_F(OpModelBase, Conv1dInterface) {
   // test Conv1dOp interface
   auto constraintsExp = getOpConstraints(conv1d.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -3119,8 +3120,8 @@ TEST_F(OpModelBase, Conv2dInterfaceNullOutput) {
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(conv2d), OpConfig(/*outputLayout=*/nullptr));
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -3280,8 +3281,8 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
       OpConfig(getOutputLayout(conv2d),
                Conv2dAttrs{goodConvConfig, std::nullopt}));
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -3345,8 +3346,8 @@ TEST_F(OpModelBase, conv2dInterfaceComputeKernelConfig) {
       OpConfig(getOutputLayout(conv2d), opConfigAttrs));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -3410,8 +3411,8 @@ TEST_F(OpModelBase, Conv3dInterface) {
   // test Conv3dOp interface
   auto constraintsExp = getOpConstraints(conv3d.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   // Conv3d (experimental) ignores the requested L1 output memory config and
   // forces output to DRAM (copies input's memory config). Therefore:
   // - outputSize (l1_output_buffer_per_core) = 0 (output is in DRAM, not L1)
@@ -3522,8 +3523,8 @@ TEST_F(OpModelBase, Conv3dInterfaceConfigs) {
   ASSERT_TRUE(static_cast<bool>(goodConstraintsExp))
       << llvm::toString(goodConstraintsExp.takeError());
   {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        goodConstraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = goodConstraintsExp.get();
     EXPECT_GT(cbSize, 0);
   }
 
@@ -3541,8 +3542,8 @@ TEST_F(OpModelBase, Conv3dInterfaceConfigs) {
   ASSERT_TRUE(static_cast<bool>(fallbackConstraintsExp))
       << llvm::toString(fallbackConstraintsExp.takeError());
   {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        fallbackConstraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = fallbackConstraintsExp.get();
     EXPECT_GT(cbSize, 0);
   }
 }
@@ -3606,8 +3607,8 @@ TEST_F(OpModelBase, ConvTranspose2dInterfaceConfigs) {
       OpConfig(getOutputLayout(convTranspose2d),
                Conv2dAttrs{goodConvConfig, std::nullopt}));
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -3712,8 +3713,8 @@ TEST_F(OpModelBase, PrepareConv2dWeightsTest) {
 
   auto constraintsExp = getOpConstraints(prepareConv2dWeights.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_EQ(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -3832,8 +3833,8 @@ TEST_F(OpModelBase, PrepareConv2dBiasTest) {
 
   auto constraintsExp = getOpConstraints(prepareConv2dBias.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_EQ(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -3906,8 +3907,8 @@ TEST_F(OpModelBase, maxPool2DOp) {
              << llvm::toString(constraintsExp.takeError()) << std::endl;
     }
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3974,8 +3975,8 @@ TEST_F(OpModelBase, avgPool2DOp) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
   auto l1 = constraintsExp.get();
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      l1;
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = l1;
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4016,7 +4017,7 @@ TEST_F(OpModelBase, globalAvgPool2dOp) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
   auto l1 = constraintsExp.get();
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts, outputAllocations] =
       l1;
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -4054,8 +4055,8 @@ TEST_F(OpModelBase, LeakyReluOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4087,7 +4088,8 @@ TEST_F(OpModelBase, GeluBackwardOp) {
            << llvm::toString(constraintsExpNone.takeError()) << std::endl;
   }
   const auto &[cbSizeNone, l1PeakSizeNone, totalPeakSizeNone, outputSizeNone,
-               outputLayoutNone] = constraintsExpNone.get();
+               outputLayoutNone, outputAllocationsNone] =
+      constraintsExpNone.get();
   EXPECT_EQ(cbSizeNone, 12288);
   EXPECT_EQ(l1PeakSizeNone, 6144);
   EXPECT_EQ(outputSizeNone, 2048);
@@ -4114,7 +4116,8 @@ TEST_F(OpModelBase, GeluBackwardOp) {
            << llvm::toString(constraintsExpTanh.takeError()) << std::endl;
   }
   const auto &[cbSizeTanh, l1PeakSizeTanh, totalPeakSizeTanh, outputSizeTanh,
-               outputLayoutTanh] = constraintsExpTanh.get();
+               outputLayoutTanh, outputAllocationsTanh] =
+      constraintsExpTanh.get();
   EXPECT_EQ(cbSizeTanh, 12288);
   EXPECT_EQ(l1PeakSizeTanh, 6144);
   EXPECT_EQ(outputSizeTanh, 2048);
@@ -4153,8 +4156,8 @@ TEST_F(OpModelBase, clampScalarOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4185,8 +4188,8 @@ TEST_F(OpModelBase, clampTensorOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4216,8 +4219,8 @@ TEST_F(OpModelBase, permuteOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4265,8 +4268,8 @@ TEST_F(OpModelBase, upsampleOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -4300,8 +4303,8 @@ TEST_F(OpModelBase, EmbeddingOpInterface) {
   auto constraintsExp = getOpConstraints(embedding.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4341,8 +4344,8 @@ TEST_F(OpModelBase, EmbeddingOpNullOutputLayout) {
       getInputLayouts(embedding), OpConfig(/*outputLayout=*/nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4387,8 +4390,8 @@ TEST_F(OpModelBase, EmbeddingBackwardOp) {
   auto constraintsExp = getOpConstraints(embeddingBackward.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4514,8 +4517,8 @@ TEST_F(OpModelBase, WhereOpInterface) {
   auto constraintsExp = getOpConstraints(where.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4562,7 +4565,8 @@ TEST_F(OpModelBase, batchNormOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4616,7 +4620,8 @@ TEST_F(OpModelBase, batchNormOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4659,7 +4664,8 @@ TEST_F(OpModelBase, batchNormOpTraining) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
 
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBack] = constraintsExp.get();
+                outputLayoutReadBack, outputAllocationsReadBack] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4694,7 +4700,8 @@ TEST_F(OpModelBase, batchNormOpTrainingMinimal) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
 
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBack] = constraintsExp.get();
+                outputLayoutReadBack, outputAllocationsReadBack] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4749,7 +4756,8 @@ TEST_F(OpModelBase, batchNormOpTrainingL1Memory) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
 
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBack] = constraintsExp.get();
+                outputLayoutReadBack, outputAllocationsReadBack] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4790,7 +4798,8 @@ TEST_F(OpModelBase, rmsNormOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4824,7 +4833,8 @@ TEST_F(OpModelBase, rmsNormOpMinimal) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4873,7 +4883,8 @@ TEST_F(OpModelBase, rmsNormOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4909,7 +4920,8 @@ TEST_F(OpModelBase, rmsNormPreAllGatherOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4946,7 +4958,8 @@ TEST_F(OpModelBase, rmsNormPreAllGatherOpWithResidual) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4986,7 +4999,8 @@ TEST_F(OpModelBase, rmsNormPreAllGatherOpWithL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5026,7 +5040,8 @@ TEST_F(OpModelBase, layerNormOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5060,7 +5075,8 @@ TEST_F(OpModelBase, layerNormOpMinimal) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5109,7 +5125,8 @@ TEST_F(OpModelBase, layerNormOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5143,7 +5160,8 @@ TEST_F(OpModelBase, layerNormPreAllGatherOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5178,7 +5196,8 @@ TEST_F(OpModelBase, layerNormPreAllGatherOpWithResidual) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5216,7 +5235,8 @@ TEST_F(OpModelBase, layerNormPreAllGatherOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5256,7 +5276,8 @@ TEST_F(OpModelBase, layerNormPostAllGatherOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5292,7 +5313,8 @@ TEST_F(OpModelBase, layerNormPostAllGatherOpMinimal) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5343,7 +5365,8 @@ TEST_F(OpModelBase, layerNormPostAllGatherOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5388,7 +5411,8 @@ TEST_F(OpModelBase, groupNormOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5440,7 +5464,8 @@ TEST_F(OpModelBase, groupNormOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5481,8 +5506,8 @@ TEST_F(OpModelBase, EmptyOpInterface) {
   auto constraintsExp = getOpConstraints(empty.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -5515,8 +5540,8 @@ TEST_F(OpModelBase, ArangeOpInterface) {
       backend.getOpConstraints(getInputLayouts(arange), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5559,8 +5584,8 @@ TEST_P(NamedFullOpModelTest, TestOpInterface) {
       backend.getOpConstraints(getInputLayouts(op), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -5610,8 +5635,8 @@ TEST_F(OpModelBase, FullOpInterface) {
       backendI.getOpConstraints(getInputLayouts(fullInt), OpConfig(nullptr));
   if (constraintsExpI) {
     auto l1 = constraintsExpI.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5630,8 +5655,8 @@ TEST_F(OpModelBase, FullOpInterface) {
       backendF.getOpConstraints(getInputLayouts(fullF), OpConfig(nullptr));
   if (constraintsExpF) {
     auto l1 = constraintsExpF.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5665,8 +5690,8 @@ TEST_F(OpModelBase, ConstantOpInterface) {
                                                  OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -5704,8 +5729,8 @@ TEST_F(OpModelBase, ConstantOpInterfaceBF16) {
                                                  OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -5740,8 +5765,8 @@ TEST_F(OpModelBase, ConstantOpInterfaceNullOutputLayout) {
       backend.getOpConstraints(getInputLayouts(constant), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5777,8 +5802,8 @@ TEST_F(OpModelBase, RandOpInterface) {
       backend.getOpConstraints(getInputLayouts(randOp), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5801,8 +5826,8 @@ TEST_F(OpModelBase, RandOpInterface) {
       getInputLayouts(randOpCustom), OpConfig(nullptr));
   if (constraintsExpCustom) {
     auto l1 = constraintsExpCustom.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5860,8 +5885,8 @@ TEST_F(OpModelBase, FillCacheOpInterface) {
       getInputLayouts(fillCache.getOperation()), OpConfig());
   if (constraintsExp) {
     auto constraints = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraints;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = constraints;
     // Basic validation that constraints are reasonable
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
@@ -5910,8 +5935,8 @@ TEST_F(OpModelBase, UpdateCacheOpInterface) {
       getInputLayouts(updateCache.getOperation()), OpConfig());
   if (constraintsExp) {
     auto constraints = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraints;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = constraints;
     // Basic validation that constraints are reasonable
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
@@ -5970,8 +5995,8 @@ TEST_F(OpModelBase, PagedUpdateCacheOpInterface) {
       getInputLayouts(pagedUpdateCacheOp.getOperation()), OpConfig());
   if (constraintsExp) {
     auto constraints = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraints;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = constraints;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -6029,8 +6054,8 @@ TEST_F(OpModelBase, PagedFillCacheOpInterface) {
       getInputLayouts(pagedFillCacheOp.getOperation()), OpConfig());
   if (constraintsExp) {
     auto constraints = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraints;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = constraints;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -6085,8 +6110,8 @@ TEST_F(OpModelBase, QuantizeOpInterface) {
       getInputLayouts(quantizeOp), OpConfig(getOutputLayout(quantizeOp)));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6141,8 +6166,8 @@ TEST_F(OpModelBase, QuantizeOpInterfaceNullOutput) {
       getInputLayouts(quantizeOp), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6210,8 +6235,8 @@ TEST_F(OpModelBase, RequantizeOpInterface) {
       getInputLayouts(requantizeOp), OpConfig(getOutputLayout(requantizeOp)));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6280,8 +6305,8 @@ TEST_F(OpModelBase, RequantizeOpInterfaceNullOutput) {
       getInputLayouts(requantizeOp), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6336,8 +6361,8 @@ TEST_F(OpModelBase, DequantizeOpInterface) {
       getInputLayouts(dequantizeOp), OpConfig(getOutputLayout(dequantizeOp)));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6393,8 +6418,8 @@ TEST_F(OpModelBase, DequantizeOpInterfaceNullOutput) {
       getInputLayouts(dequantizeOp), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6438,8 +6463,8 @@ TEST_F(OpModelBase, AssignOpInterface) {
       backend.getOpConstraints({inputLayout}, OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -6478,8 +6503,8 @@ TEST_F(OpModelBase, AssignOpInterfaceL1Output) {
       backend.getOpConstraints({inputLayout}, OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -6521,8 +6546,8 @@ TEST_F(OpModelBase, AssignOpInterfaceWithOutputDtype) {
       backend.getOpConstraints({inputLayout}, OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -6554,8 +6579,8 @@ TEST_F(OpModelBase, DropoutOpInterface) {
       backend.getOpConstraints(getInputLayouts(dropoutOp), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -6576,8 +6601,8 @@ TEST_F(OpModelBase, DropoutOpInterface) {
       getInputLayouts(dropoutOpCustom), OpConfig(nullptr));
   if (constraintsExpCustom) {
     auto l1 = constraintsExpCustom.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -6713,8 +6738,8 @@ TEST_F(OpModelBase, GatherOpInterface) {
 
   auto constraintsExp = getOpConstraints(gatherOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -6796,8 +6821,8 @@ TEST_F(OpModelBase, PagedFlashMultiLatentAttentionDecodeOpInterface) {
 
   auto constraintsExp = getOpConstraints(mlaOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -6893,8 +6918,8 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterface) {
 
   auto constraintsExp = getOpConstraints(mlaOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -6953,8 +6978,8 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterfaceWithValue) {
 
   auto constraintsExp = getOpConstraints(mlaOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -7014,8 +7039,8 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterfaceWithMask) {
 
   auto constraintsExp = getOpConstraints(mlaOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -7090,8 +7115,8 @@ TEST_F(OpModelBase, SamplingOp) {
 
   auto constraintsExp = getOpConstraints(samplingOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     // outputSize is l1_output_buffer_per_core; ttnn::sampling's signature

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -46,3 +46,36 @@ target_link_libraries(L1SpillManagementTests
     MLIRTTNNAnalysis
     MLIRTTNNValidation
 )
+
+if (TTMLIR_ENABLE_OPMODEL)
+    # Allocator-backed stateful spill tests. Standalone binary (custom main()
+    # registering MockDeviceEnvironment) rather than add_mlir_unittest, so it is
+    # NOT wired into MLIRUnitTests/check-ttmlir -- it needs the op-model lib and
+    # a mock device, matching the TestOpModelLibMockDevice convention. Runs
+    # HW-free (mock device) on any box with the op-model build.
+    add_executable(L1SpillManagementMockAllocatorTests
+        TestL1SpillManagementMockAllocator.cpp
+    )
+
+    target_compile_options(L1SpillManagementMockAllocatorTests
+        PRIVATE
+        -fno-rtti
+    )
+
+    target_include_directories(L1SpillManagementMockAllocatorTests
+        PUBLIC
+        ${PROJECT_SOURCE_DIR}/test/unittests/OpModel/TTNN/
+    )
+
+    target_link_libraries(L1SpillManagementMockAllocatorTests
+        PRIVATE
+        gtest
+        TTNNOpModelLib
+        MLIRTTCoreDialect
+        MLIRTTNNDialect
+        MLIRTTTransforms
+        MLIRTTNNAnalysis
+        MLIRTTNNValidation
+        TTMLIRTestUtils
+    )
+endif()

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -52,7 +52,9 @@ if (TTMLIR_ENABLE_OPMODEL)
     # registering MockDeviceEnvironment) rather than add_mlir_unittest, so it is
     # NOT wired into MLIRUnitTests/check-ttmlir -- it needs the op-model lib and
     # a mock device, matching the TestOpModelLibMockDevice convention. Runs
-    # HW-free (mock device) on any box with the op-model build.
+    # HW-free (mock device) on any box with the op-model build. Invoked in CI by
+    # .github/test_scripts/op_model.sh (alongside the other mock-device gtest
+    # binaries), since check-ttmlir does not run it.
     add_executable(L1SpillManagementMockAllocatorTests
         TestL1SpillManagementMockAllocator.cpp
     )

--- a/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
+++ b/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
@@ -29,7 +29,7 @@ namespace mlir::tt::ttnn::test {
 //
 // Reuses every IR-builder, layout, observer, and inspection helper from
 // L1SpillTestFixture unchanged. Adds runMock(), which drives
-// MockAllocatorSpillManagement WITHOUT installing a fake
+// StatefulL1SpillManagement WITHOUT installing a fake
 // validator, so the allocator-backed (stateful op-model) path executes.
 //===----------------------------------------------------------------------===//
 class L1SpillMockAllocatorFixture : public L1SpillTestFixture {
@@ -41,7 +41,7 @@ public:
   /// Pass instance kept alive as a fixture member so the observer (owned by the
   /// pass) outlives runMock() and stays reachable via the returned pointer, and
   /// so getMockTracker() can inspect final tracker state after the run.
-  std::unique_ptr<MockAllocatorSpillManagement> passMock;
+  std::unique_ptr<StatefulL1SpillManagement> passMock;
 
   /// Run the allocator-backed pass on `func`. No backendValidator is installed,
   /// so MockAllocatorL1Tracker::validate() issues real (uncached) stateful
@@ -53,7 +53,7 @@ public:
     auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
     ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
 
-    passMock = std::make_unique<MockAllocatorSpillManagement>(
+    passMock = std::make_unique<StatefulL1SpillManagement>(
         func, deviceGrid, l1BudgetPerCore, std::move(obs));
     // Intentionally leave backendValidator unset -> real op-model path.
     passMock->run();

--- a/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
+++ b/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
@@ -29,7 +29,7 @@ namespace mlir::tt::ttnn::test {
 //
 // Reuses every IR-builder, layout, observer, and inspection helper from
 // L1SpillTestFixture unchanged. Adds runMock(), which drives
-// L1SpillManagement<MockAllocatorL1Tracker> WITHOUT installing a fake
+// MockAllocatorSpillManagement WITHOUT installing a fake
 // validator, so the allocator-backed (stateful op-model) path executes.
 //===----------------------------------------------------------------------===//
 class L1SpillMockAllocatorFixture : public L1SpillTestFixture {
@@ -41,7 +41,7 @@ public:
   /// Pass instance kept alive as a fixture member so the observer (owned by the
   /// pass) outlives runMock() and stays reachable via the returned pointer, and
   /// so getMockTracker() can inspect final tracker state after the run.
-  std::unique_ptr<L1SpillManagement<MockAllocatorL1Tracker>> passMock;
+  std::unique_ptr<MockAllocatorSpillManagement> passMock;
 
   /// Run the allocator-backed pass on `func`. No backendValidator is installed,
   /// so MockAllocatorL1Tracker::validate() issues real (uncached) stateful
@@ -53,7 +53,7 @@ public:
     auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
     ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
 
-    passMock = std::make_unique<L1SpillManagement<MockAllocatorL1Tracker>>(
+    passMock = std::make_unique<MockAllocatorSpillManagement>(
         func, deviceGrid, l1BudgetPerCore, std::move(obs));
     // Intentionally leave backendValidator unset -> real op-model path.
     passMock->run();

--- a/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
+++ b/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Fixture for exercising the *real* stateful path of MockAllocatorL1Tracker:
+// liveRecords -> buildInitialState -> getOpConstraintsWithState ->
+// tt-metal build-from-records -> output_allocations -> pendingRecords/Snapshot.
+//
+// Unlike L1SpillTestFixture (which injects a synthetic backendValidator and
+// never touches the op-model), this fixture leaves backendValidator NULL so
+// MockAllocatorL1Tracker::validate() routes through the real op-model. The
+// op-model runs against a MOCK DEVICE (no silicon), configured once per binary
+// by MockDeviceEnvironment. Requires TTMLIR_ENABLE_OPMODEL.
+//
+// The test binary's main() MUST register the mock device environment:
+//   ::testing::AddGlobalTestEnvironment(new MockDeviceEnvironment());
+
+#ifndef TEST_UNITTESTS_OPTIMIZER_L1SPILLMOCKALLOCATORFIXTURE_H
+#define TEST_UNITTESTS_OPTIMIZER_L1SPILLMOCKALLOCATORFIXTURE_H
+
+#include "L1SpillTestFixture.h"
+
+#include <memory>
+
+namespace mlir::tt::ttnn::test {
+
+//===----------------------------------------------------------------------===//
+// L1SpillMockAllocatorFixture
+//
+// Reuses every IR-builder, layout, observer, and inspection helper from
+// L1SpillTestFixture unchanged. Adds runMock(), which drives
+// L1SpillManagement<MockAllocatorL1Tracker> WITHOUT installing a fake
+// validator, so the allocator-backed (stateful op-model) path executes.
+//===----------------------------------------------------------------------===//
+class L1SpillMockAllocatorFixture : public L1SpillTestFixture {
+public:
+  struct MockRunResult {
+    RecordingObserver *observer;
+  };
+
+  /// Pass instance kept alive as a fixture member so the observer (owned by the
+  /// pass) outlives runMock() and stays reachable via the returned pointer, and
+  /// so getMockTracker() can inspect final tracker state after the run.
+  std::unique_ptr<L1SpillManagement<MockAllocatorL1Tracker>> passMock;
+
+  /// Run the allocator-backed pass on `func`. No backendValidator is installed,
+  /// so MockAllocatorL1Tracker::validate() issues real (uncached) stateful
+  /// op-model queries against the mock device.
+  MockRunResult runMock() {
+    auto obs = std::make_unique<RecordingObserver>();
+    auto *rawObs = obs.get();
+
+    auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
+    ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
+
+    passMock = std::make_unique<L1SpillManagement<MockAllocatorL1Tracker>>(
+        func, deviceGrid, l1BudgetPerCore, std::move(obs));
+    // Intentionally leave backendValidator unset -> real op-model path.
+    passMock->run();
+    return {rawObs};
+  }
+
+  MockAllocatorL1Tracker &getMockTracker() {
+    return passMock->getMemoryTracker();
+  }
+
+  bool mockPassFailed() const { return passMock && passMock->hasFailed(); }
+
+  /// Number of currently-live allocation records the tracker is holding.
+  /// After a completed run, this reflects tensors still resident in L1.
+  size_t liveRecordCount() { return getMockTracker().liveRecords.size(); }
+};
+
+} // namespace mlir::tt::ttnn::test
+
+#endif // TEST_UNITTESTS_OPTIMIZER_L1SPILLMOCKALLOCATORFIXTURE_H

--- a/test/unittests/Optimizer/L1SpillTestFixture.h
+++ b/test/unittests/Optimizer/L1SpillTestFixture.h
@@ -217,6 +217,15 @@ public:
         .buildWithCanonicalCorePlacement(deviceAttr);
   }
 
+  TTNNLayoutAttr makeL1Interleaved(llvm::ArrayRef<int64_t> shape) {
+    auto elemType = mlir::tt::ttcore::TileType::get(builder.getBF16Type());
+    auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
+    return TTNNLayoutAttr::Builder(&context, shape, elemType)
+        .setBufferType(BufferType::L1)
+        .setMemoryLayout(TensorMemoryLayout::Interleaved)
+        .buildWithCanonicalCorePlacement(deviceAttr);
+  }
+
   mlir::RankedTensorType tensorType(llvm::ArrayRef<int64_t> shape,
                                     TTNNLayoutAttr layout) {
     return mlir::RankedTensorType::get(shape, builder.getBF16Type(), layout);
@@ -267,6 +276,35 @@ public:
     auto op = builder.create<ReshapeOp>(builder.getUnknownLoc(), outType, input,
                                         shapeAttr);
     setL1Usage(op.getOperation(), l1UsageBytes);
+    return op.getOperation();
+  }
+
+  /// Add a zero-fill PadOp matching FillCacheInputPadRewritePattern's scrub
+  /// pad. `padding` is low/high per dim (2 * rank), as in ttnn.pad.
+  mlir::Operation *addPad(mlir::Value input, mlir::RankedTensorType outType,
+                          llvm::ArrayRef<int32_t> padding) {
+    auto op = builder.create<PadOp>(builder.getUnknownLoc(), outType, input,
+                                    llvm::SmallVector<int32_t>(padding),
+                                    /*value=*/llvm::APFloat(0.0f),
+                                    /*use_multicore=*/true);
+    return op.getOperation();
+  }
+
+  /// Add a RepeatOp with the given per-dim repetition factors.
+  mlir::Operation *addRepeat(mlir::Value input, mlir::RankedTensorType outType,
+                             llvm::ArrayRef<int64_t> repeatDims) {
+    auto op = builder.create<RepeatOp>(builder.getUnknownLoc(), outType, input,
+                                       ShapeAttr::get(&context, repeatDims));
+    return op.getOperation();
+  }
+
+  /// Add a PermuteOp with the given permutation.
+  mlir::Operation *addPermute(mlir::Value input, mlir::RankedTensorType outType,
+                              llvm::ArrayRef<int64_t> permutation) {
+    auto op =
+        builder.create<PermuteOp>(builder.getUnknownLoc(), outType, input,
+                                  builder.getDenseI64ArrayAttr(permutation),
+                                  /*pad_value=*/mlir::FloatAttr());
     return op.getOperation();
   }
 

--- a/test/unittests/Optimizer/L1SpillTestFixture.h
+++ b/test/unittests/Optimizer/L1SpillTestFixture.h
@@ -127,7 +127,7 @@ public:
 //  - MLIR context with TTCore + TTNN + Func dialects loaded.
 //  - Helpers to build a func::FuncOp with typed TTNN op graphs.
 //  - Per-op test configuration (setL1Usage, forceOOM, forceNotImplemented).
-//  - run() to construct and drive L1SpillManagement<SumL1MemoryTracker> with
+//  - run() to construct and drive SumL1SpillManagement with
 //    a backend validator lambda built from perOpConfigs.
 //  - Post-run assertion helpers that inspect the mutated IR.
 //===----------------------------------------------------------------------===//
@@ -411,13 +411,13 @@ public:
   /// Pass instance kept alive as a fixture member so the observer (owned by
   /// the pass via unique_ptr) outlives run() and stays accessible through
   /// the returned raw pointer.
-  std::unique_ptr<L1SpillManagement<SumL1MemoryTracker>> pass;
+  std::unique_ptr<SumL1SpillManagement> pass;
 
   struct RunResult {
     RecordingObserver *observer;
   };
 
-  /// Run L1SpillManagement<SumL1MemoryTracker> on `func` with the test
+  /// Run SumL1SpillManagement on `func` with the test
   /// validator installed.
   RunResult run() {
     auto obs = std::make_unique<RecordingObserver>();
@@ -426,7 +426,7 @@ public:
     auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
     ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
 
-    pass = std::make_unique<L1SpillManagement<SumL1MemoryTracker>>(
+    pass = std::make_unique<SumL1SpillManagement>(
         func, deviceGrid, l1BudgetPerCore, std::move(obs));
     pass->getMemoryTracker().backendValidator = makeValidator();
     pass->run();

--- a/test/unittests/Optimizer/L1SpillTestFixture.h
+++ b/test/unittests/Optimizer/L1SpillTestFixture.h
@@ -152,13 +152,28 @@ public:
   };
   llvm::DenseMap<mlir::Operation *, PerOpConfig> perOpConfigs;
 
+  /// Mesh shape the test device is registered with. Default {} registers a
+  /// single-device mesh. Override in a fixture that needs multi-device-only
+  /// behavior (e.g. StatefulL1SpillManagement's static-CB headroom floor, which
+  /// is armed only on a mesh compile).
+  virtual llvm::SmallVector<int64_t> deviceMeshShape() const { return {}; }
+
   void SetUp() override {
     context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
     context.loadDialect<TTNNDialect>();
     context.loadDialect<mlir::func::FuncDialect>();
     module = mlir::ModuleOp::create(builder.getUnknownLoc());
     builder.setInsertionPointToStart(&module->getBodyRegion().front());
-    mlir::tt::ttcore::registerDevice(module.get());
+    llvm::SmallVector<int64_t> meshShape = deviceMeshShape();
+    mlir::tt::ttcore::registerDevice(
+        module.get(), mlir::tt::ttcore::Arch::WormholeB0, meshShape);
+  }
+
+  /// Address static circular buffers grow up from on the registered chip. The
+  /// stateful headroom floor is expressed relative to it.
+  uint64_t l1UnreservedBase() {
+    return mlir::tt::ttcore::getOpChipDescAttr(module.get())
+        .getL1UnreservedBase();
   }
 
   void TearDown() override {}
@@ -431,6 +446,58 @@ public:
     pass->getMemoryTracker().backendValidator = makeValidator();
     pass->run();
     return {rawObs};
+  }
+
+  // --- Stateful (record-backed) pass execution, still device-free ---
+
+  /// StatefulL1SpillManagement instance, kept alive for post-run inspection.
+  std::unique_ptr<StatefulL1SpillManagement> statefulPass;
+
+  /// Drive StatefulL1SpillManagement with the synthetic validator, extended to
+  /// hand back allocation records so the record-address logic (the static-CB
+  /// headroom floor, getLowestOccupiedL1Address) is exercised without a device.
+  ///
+  /// The synthesized addresses mimic tt-metal's top-down L1 allocator over
+  /// [l1UnreservedBase, l1UnreservedBase + l1BudgetPerCore): an output of size
+  /// S placed while `occupied` bytes are live lands at
+  ///   base + budget - (occupied + S)
+  /// i.e. the more L1 is already live, the lower the new buffer sits — which is
+  /// exactly the pressure the floor guards against.
+  RunResult runStateful() {
+    auto obs = std::make_unique<RecordingObserver>();
+    auto *rawObs = obs.get();
+
+    auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
+    ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
+
+    statefulPass = std::make_unique<StatefulL1SpillManagement>(
+        func, deviceGrid, l1BudgetPerCore, std::move(obs));
+
+    auto inner = makeValidator();
+    uint64_t base = l1UnreservedBase();
+    uint64_t budget = l1BudgetPerCore;
+    StatefulL1SpillManagement *pass = statefulPass.get();
+    statefulPass->getMemoryTracker().backendValidator =
+        [inner, base, budget, pass](
+            mlir::Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+            const OpConfig &config, uint64_t additionalL1) -> ValidationResult {
+      ValidationResult result = inner(op, inputLayouts, config, additionalL1);
+      if (!result.isSuccess() || result.outputL1Usage == 0) {
+        return result;
+      }
+      uint64_t occupied = pass->getMemoryTracker().getOccupiedL1();
+      uint64_t top = occupied + result.outputL1Usage;
+      uint64_t address = top <= budget ? base + budget - top : base;
+      result.outputAllocations.push_back(op_model::OpModelAllocationRecord{
+          BufferType::L1, address, result.outputL1Usage});
+      return result;
+    };
+    statefulPass->run();
+    return {rawObs};
+  }
+
+  MockAllocatorL1Tracker &getStatefulTracker() {
+    return statefulPass->getMemoryTracker();
   }
 
   // --- IR inspection helpers ---

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -854,3 +854,111 @@ TEST_F(FragmentationTrackerTest, WouldAllocateAtReportsNoFitAndRoundTrips) {
   EXPECT_EQ(tracker.getOccupiedL1(), 60 * kKiB);
   EXPECT_FALSE(tracker.wouldAllocateAt(60 * kKiB).has_value());
 }
+
+//===----------------------------------------------------------------------===//
+// StatefulCBHeadroomFloor tests
+//
+// Regression coverage for the multi-device static-CB headroom floor. On QB2
+// (Blackhole, 1x4 tensor-parallel mesh) vllm_qwen2_5_coder_32b_instruct_qb2_tp
+// aborted at program launch with
+//   "Statically allocated circular buffers in program 226024 clash with L1
+//    buffers on core range [0-0 - 0-0]. L1 buffer allocated at 447488 and
+//    static circular buffer region ends at 471808"
+// The stateful sweep had certified every op it queried (tt-metal runs its own
+// CB-vs-L1 check inside the query, and #9064's fix routes a reported clash to
+// the evict-and-refit recovery), but tt-metal validates EVERY program's CB
+// region against the device's globally lowest occupied L1 address -- including
+// programs the model never queried. The floor keeps the live working set above
+// l1UnreservedBase + the largest CB region the function is known to need, so
+// those unmodeled CB regions still fit. It is armed on mesh compiles only.
+//===----------------------------------------------------------------------===//
+
+// 1x2 mesh: the floor is armed.
+class StatefulMeshHeadroomTest : public L1SpillTestFixture {
+  llvm::SmallVector<int64_t> deviceMeshShape() const override { return {1, 2}; }
+};
+
+// Same graph, single device: the floor is disarmed and behavior is unchanged.
+class StatefulSingleDeviceHeadroomTest : public L1SpillTestFixture {};
+
+// opA (600 KiB) stays live across opB, so opB's own 600 KiB output is placed
+// low -- at base + 102400, below opB's own 300 KiB static CB region. Both fit
+// the byte budget (1200 KiB <= 1300 KiB), so only the address-level floor can
+// catch it. Expect the floor to report OOM, evict opA and spill it to DRAM,
+// after which opB is placed high enough to clear its CB region.
+TEST_F(StatefulMeshHeadroomTest, LowAddressOutputBelowCBFloorEvicts) {
+  l1BudgetPerCore = 1300 * kKiB;
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opA = addUnary(args[0], tt, /*l1UsageBytes=*/600 * kKiB);
+  auto *opB = addUnary(opA->getResult(0), tt, /*l1UsageBytes=*/600 * kKiB);
+  setL1Usage(opB, /*l1=*/600 * kKiB, /*cb=*/300 * kKiB);
+  finishFunc({opB->getResult(0)});
+
+  auto [obs] = runStateful();
+
+  EXPECT_FALSE(obs->ooms.empty())
+      << "static-CB headroom floor should report OOM for opB";
+  ASSERT_FALSE(obs->evictions.empty());
+  EXPECT_EQ(obs->evictions[0].victim, opA);
+  EXPECT_EQ(countSpills(), 1u) << "expected one spill-to-DRAM for opA";
+  EXPECT_TRUE(wasSpilled(opA->getResult(0)));
+}
+
+// Identical graph on a single-device mesh: the floor is not armed, so the pass
+// keeps both tensors in L1 exactly as before this guard existed.
+TEST_F(StatefulSingleDeviceHeadroomTest, FloorDisarmedOnSingleDevice) {
+  l1BudgetPerCore = 1300 * kKiB;
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opA = addUnary(args[0], tt, /*l1UsageBytes=*/600 * kKiB);
+  auto *opB = addUnary(opA->getResult(0), tt, /*l1UsageBytes=*/600 * kKiB);
+  setL1Usage(opB, /*l1=*/600 * kKiB, /*cb=*/300 * kKiB);
+  finishFunc({opB->getResult(0)});
+
+  auto [obs] = runStateful();
+
+  EXPECT_TRUE(obs->ooms.empty())
+      << "single-device compile must not arm the floor";
+  EXPECT_TRUE(obs->evictions.empty());
+  EXPECT_EQ(countSpills(), 0u);
+  EXPECT_TRUE(resultIsL1(opA->getResult(0)));
+}
+
+// getLowestOccupiedL1Address is the address the floor compares against: the
+// minimum over live L1 records, optionally folding in records that are not live
+// yet (an op's own freshly reported output, which IS allocated by the time that
+// op's program launches). DRAM records never participate.
+TEST_F(StatefulSingleDeviceHeadroomTest, LowestOccupiedL1AddressFoldsExtras) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+  auto args = beginFunc({tt, tt});
+  finishFunc({args[0]});
+
+  mlir::tt::ttnn::MockAllocatorL1Tracker tracker;
+  tracker.init(l1BudgetPerCore);
+  EXPECT_FALSE(tracker.getLowestOccupiedL1Address().has_value());
+
+  tracker.liveRecords[args[0]] = {
+      mlir::tt::ttnn::op_model::OpModelAllocationRecord{
+          mlir::tt::ttnn::BufferType::L1,
+          /*address=*/900000,
+          /*sizePerBank=*/1024}};
+  tracker.liveRecords[args[1]] = {
+      mlir::tt::ttnn::op_model::OpModelAllocationRecord{
+          mlir::tt::ttnn::BufferType::DRAM,
+          /*address=*/16,
+          /*sizePerBank=*/1024}};
+  ASSERT_TRUE(tracker.getLowestOccupiedL1Address().has_value());
+  EXPECT_EQ(*tracker.getLowestOccupiedL1Address(), 900000u)
+      << "DRAM records must not lower the L1 floor";
+
+  llvm::SmallVector<mlir::tt::ttnn::op_model::OpModelAllocationRecord> extra = {
+      {mlir::tt::ttnn::BufferType::L1, /*address=*/400000,
+       /*sizePerBank=*/2048}};
+  EXPECT_EQ(*tracker.getLowestOccupiedL1Address(extra), 400000u);
+}

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -290,6 +290,60 @@ TEST_F(MockAllocatorTrackerTest, TrackerAliasRefcountKeepsBufferLive) {
 }
 
 //===----------------------------------------------------------------------===//
+// ReshardedPastConsumerTrackedDuringEviction
+//
+// Regression for tt-mlir #9087: the stateful eviction rewinds and re-runs the
+// forward sweep, and past-consumer reshards are routed through the schedule so
+// they are tracked (not the old event-log bracketing that left DRAM-output
+// consumers untracked). Build a graph where the farthest-last-use victim (opV)
+// has a PAST consumer (cPast, scheduled before the OOM-triggering op): evicting
+// opV must insert an L1 reshard before cPast, compile cleanly (no hard-fail),
+// and leave cPast reading L1.
+//===----------------------------------------------------------------------===//
+class MockAllocatorReshardTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorReshardTest, ReshardedPastConsumerTrackedDuringEviction) {
+  l1BudgetPerCore = 700 * kKiB; // 2 x 256 KiB fit; a 3rd trips OOM
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opV = addUnary(args[0], tt, 0);          // victim (long-lived)
+  auto *cPast = addUnary(opV->getResult(0), tt, 0); // PAST consumer of opV
+  auto *cPastU = addUnary(cPast->getResult(0), tt, 0); // cPast dies here
+  auto *mid1 = addUnary(args[0], tt, 0);
+  auto *mid2 = addUnary(mid1->getResult(0), tt, 0); // OOM trigger; mid1 dies here
+  auto *tailV = addUnary(opV->getResult(0), tt, 0); // opV's farthest use
+  finishFunc(
+      {cPastU->getResult(0), mid2->getResult(0), tailV->getResult(0)});
+
+  runMock();
+
+  // A reshard is a ToMemoryConfigOp that writes L1 (the inverse of a spill).
+  size_t reshardsToL1 = 0;
+  func.walk([&](mlir::tt::ttnn::ToMemoryConfigOp op) {
+    auto rt = mlir::dyn_cast<mlir::RankedTensorType>(op.getResult().getType());
+    auto enc =
+        rt ? mlir::dyn_cast_or_null<mlir::tt::ttnn::TTNNLayoutAttr>(
+                 rt.getEncoding())
+           : nullptr;
+    if (enc && enc.hasL1BufferType()) {
+      ++reshardsToL1;
+    }
+  });
+
+  EXPECT_FALSE(mockPassFailed())
+      << "past-consumer reshard must not hard-fail the pass";
+  EXPECT_TRUE(wasSpilled(opV->getResult(0)))
+      << "farthest-last-use victim opV must be spilled";
+  EXPECT_GT(reshardsToL1, 0u)
+      << "opV's past consumer must get an L1 reshard inserted";
+  // cPast reads its reshard's L1 output.
+  EXPECT_TRUE(resultIsL1(cPast->getOperand(0)))
+      << "past consumer's input must be resharded back to L1";
+}
+
+//===----------------------------------------------------------------------===//
 // View-op tripwires (https://github.com/tenstorrent/tt-mlir/issues/9054)
 //
 // The L1 spill pass classifies certain ops (reshape/pad/repeat/permute) as

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -22,6 +22,11 @@
 #include "L1SpillMockAllocatorFixture.h"
 #include "MockDeviceFixture.h"
 
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h"
+#include "ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h"
+#include "ttmlir/OpModel/TTNN/TTNNOpConstraints.h"
+
 #include "gtest/gtest.h"
 
 #include <cstdint>
@@ -233,6 +238,104 @@ TEST_F(MockAllocatorCalibrationTest, PerCoreSizeMatchesConstant) {
   EXPECT_EQ(obs->lives.front().opL1Usage, kOpL1)
       << "mock op-model per-core L1 changed; update kOpL1 and re-derive "
          "budgets";
+}
+
+//===----------------------------------------------------------------------===//
+// View-op tripwires (https://github.com/tenstorrent/tt-mlir/issues/9054)
+//
+// The L1 spill pass classifies certain ops (reshape/pad/repeat/permute) as
+// input-aliasing views via `isAliasingViewOp` and aliases them onto their
+// source's L1 slot instead of tracking a fresh allocation. tt-metal signals
+// such a view by reporting the op's output buffer at the weightless input's
+// address 0 under the stateful op-model query. These tripwires pin that
+// contract: for each op our predicate calls a view, the mock op-model query
+// MUST report an L1 output allocation at address 0. If tt-metal drifts (a
+// classified-view op starts returning a real non-zero address), the tripwire
+// fails -- our `isAliasingViewOp` is then stale and must be adjusted, because
+// the spill pass would otherwise alias (undercount) a real allocation.
+//===----------------------------------------------------------------------===//
+
+// True if the op's stateful op-model query (empty live set = the op's own
+// query) reports an output buffer placed in L1 at address 0.
+static bool queryReportsL1Address0(mlir::Operation *op,
+                                   mlir::tt::ttnn::TTNNLayoutAttr inLayout,
+                                   mlir::tt::ttnn::TTNNLayoutAttr outLayout) {
+  auto result = mlir::tt::ttnn::op_constraint_validation::validateOperation(
+      op, /*inputLayouts=*/{inLayout}, mlir::tt::ttnn::OpConfig(outLayout),
+      /*liveRecords=*/
+      llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>{},
+      /*additionalL1Usage=*/0);
+  EXPECT_TRUE(result.isSuccess()) << "stateful op-model query should succeed";
+  for (const auto &r : result.outputAllocations) {
+    if (r.bufferType == mlir::tt::ttnn::BufferType::L1 && r.address == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+class MockAllocatorViewTripwireTest : public L1SpillMockAllocatorFixture {};
+
+// Pad: the FillCacheInputPadRewritePattern scrub pad from the llama_3_2_1b
+// repro (seq_len 18 -> 32, TILE fast-path view).
+TEST_F(MockAllocatorViewTripwireTest, PadViewReportsL1Address0) {
+  llvm::SmallVector<int64_t> inShape = {1, 8, 18, 64};
+  llvm::SmallVector<int64_t> outShape = {1, 8, 32, 64};
+  auto inLayout = makeL1Interleaved(inShape);
+  auto outLayout = makeL1Interleaved(outShape);
+  auto args = beginFunc({tensorType(inShape, inLayout)});
+  auto *pad = addPad(args[0], tensorType(outShape, outLayout),
+                     /*padding=*/{0, 0, 0, 0, 0, 14, 0, 0});
+  finishFunc({pad->getResult(0)});
+
+  EXPECT_TRUE(mlir::tt::ttnn::canPadBeView(pad));
+  EXPECT_TRUE(mlir::tt::ttnn::isAliasingViewOp(pad));
+  EXPECT_TRUE(queryReportsL1Address0(pad, inLayout, outLayout))
+      << "TILE-view ttnn.pad must report an L1 output at address 0";
+}
+
+// Repeat: an all-ones repetition is a strict no-op (repeat.cpp:196).
+TEST_F(MockAllocatorViewTripwireTest, RepeatAllOnesViewReportsL1Address0) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 32, 64};
+  auto layout = makeL1Interleaved(shape);
+  auto tt = tensorType(shape, layout);
+  auto args = beginFunc({tt});
+  auto *repeat = addRepeat(args[0], tt, /*repeatDims=*/{1, 1, 1, 1});
+  finishFunc({repeat->getResult(0)});
+
+  EXPECT_TRUE(mlir::tt::ttnn::canRepeatBeView(repeat));
+  EXPECT_TRUE(mlir::tt::ttnn::isAliasingViewOp(repeat));
+  EXPECT_TRUE(queryReportsL1Address0(repeat, layout, layout))
+      << "all-ones ttnn.repeat must report an L1 output at address 0";
+}
+
+// Permute: an identity permutation with unchanged memory config is a no-op.
+TEST_F(MockAllocatorViewTripwireTest, PermuteNopViewReportsL1Address0) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 32, 64};
+  auto layout = makeL1Interleaved(shape);
+  auto tt = tensorType(shape, layout);
+  auto args = beginFunc({tt});
+  auto *permute = addPermute(args[0], tt, /*permutation=*/{0, 1, 2, 3});
+  finishFunc({permute->getResult(0)});
+
+  EXPECT_TRUE(mlir::tt::ttnn::canPermuteBeView(permute));
+  EXPECT_TRUE(mlir::tt::ttnn::isAliasingViewOp(permute));
+  EXPECT_TRUE(queryReportsL1Address0(permute, layout, layout))
+      << "identity ttnn.permute must report an L1 output at address 0";
+}
+
+// Negative: a real (non-view) pad that grows a tile dim must NOT be classified
+// a view.
+TEST_F(MockAllocatorViewTripwireTest, RealPadIsNotAView) {
+  llvm::SmallVector<int64_t> inShape = {1, 1, 32, 64};
+  llvm::SmallVector<int64_t> outShape = {1, 1, 64, 64}; // +1 full tile row
+  auto args = beginFunc({tensorType(inShape, makeL1Interleaved(inShape))});
+  auto *pad = addPad(args[0], tensorType(outShape, makeL1Interleaved(outShape)),
+                     /*padding=*/{0, 0, 0, 0, 0, 32, 0, 0});
+  finishFunc({pad->getResult(0)});
+
+  EXPECT_FALSE(mlir::tt::ttnn::canPadBeView(pad))
+      << "a pad that adds a full tile row is a real allocation, not a view";
 }
 
 } // namespace

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -241,6 +241,55 @@ TEST_F(MockAllocatorCalibrationTest, PerCoreSizeMatchesConstant) {
 }
 
 //===----------------------------------------------------------------------===//
+// TrackerAliasRefcountKeepsBufferLive
+//
+// Device-free unit test of MockAllocatorL1Tracker's record-level view aliasing:
+// a view output shares its source's buffer (no second record), and the buffer
+// stays live until the last aliaser dies. Exercises addTensor / addTensorAlias
+// / removeTensor / getOccupiedL1 directly, without the op-model query.
+//===----------------------------------------------------------------------===//
+class MockAllocatorTrackerTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorTrackerTest, TrackerAliasRefcountKeepsBufferLive) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+  auto args = beginFunc({tt});
+  auto *ownerOp = addUnary(args[0], tt, 0);
+  auto *viewOp = addUnary(ownerOp->getResult(0), tt, 0);
+  finishFunc({viewOp->getResult(0)});
+
+  mlir::Value owner = ownerOp->getResult(0);
+  mlir::Value view = viewOp->getResult(0);
+
+  constexpr uint64_t kBufBytes = 2048;
+  mlir::tt::ttnn::MockAllocatorL1Tracker t;
+  t.init(/*l1BudgetPerCore=*/100u * kKiB * 1024u);
+  // Seed the owner's record as if a stateful query had produced it.
+  t.pendingRecords[ownerOp] = mlir::tt::ttnn::MockAllocatorL1Tracker::RecordVec{
+      mlir::tt::ttnn::op_model::OpModelAllocationRecord{
+          mlir::tt::ttnn::BufferType::L1, /*address=*/0,
+          /*sizePerBank=*/kBufBytes}};
+
+  t.addTensor(owner, /*l1SizePerCore=*/0);
+  EXPECT_TRUE(t.hasTensor(owner));
+  EXPECT_EQ(t.getOccupiedL1(), kBufBytes);
+
+  t.addTensorAlias(view, owner);
+  EXPECT_TRUE(t.hasTensor(view));
+  EXPECT_EQ(t.getOccupiedL1(), kBufBytes)
+      << "alias shares the owner buffer (no duplicate record)";
+
+  t.removeTensor(owner);
+  EXPECT_EQ(t.getOccupiedL1(), kBufBytes)
+      << "buffer stays live while an aliaser remains";
+  EXPECT_TRUE(t.hasTensor(view));
+
+  t.removeTensor(view);
+  EXPECT_EQ(t.getOccupiedL1(), 0u) << "last aliaser gone -> buffer freed";
+  EXPECT_FALSE(t.hasTensor(view));
+}
+
+//===----------------------------------------------------------------------===//
 // View-op tripwires (https://github.com/tenstorrent/tt-mlir/issues/9054)
 //
 // The L1 spill pass classifies certain ops (reshape/pad/repeat/permute) as

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -308,14 +308,14 @@ TEST_F(MockAllocatorReshardTest, ReshardedPastConsumerTrackedDuringEviction) {
   auto tt = tensorType(shape, makeL1Sharded(shape));
 
   auto args = beginFunc({tt});
-  auto *opV = addUnary(args[0], tt, 0);          // victim (long-lived)
-  auto *cPast = addUnary(opV->getResult(0), tt, 0); // PAST consumer of opV
+  auto *opV = addUnary(args[0], tt, 0);                // victim (long-lived)
+  auto *cPast = addUnary(opV->getResult(0), tt, 0);    // PAST consumer of opV
   auto *cPastU = addUnary(cPast->getResult(0), tt, 0); // cPast dies here
   auto *mid1 = addUnary(args[0], tt, 0);
-  auto *mid2 = addUnary(mid1->getResult(0), tt, 0); // OOM trigger; mid1 dies here
+  auto *mid2 =
+      addUnary(mid1->getResult(0), tt, 0); // OOM trigger; mid1 dies here
   auto *tailV = addUnary(opV->getResult(0), tt, 0); // opV's farthest use
-  finishFunc(
-      {cPastU->getResult(0), mid2->getResult(0), tailV->getResult(0)});
+  finishFunc({cPastU->getResult(0), mid2->getResult(0), tailV->getResult(0)});
 
   runMock();
 
@@ -323,10 +323,9 @@ TEST_F(MockAllocatorReshardTest, ReshardedPastConsumerTrackedDuringEviction) {
   size_t reshardsToL1 = 0;
   func.walk([&](mlir::tt::ttnn::ToMemoryConfigOp op) {
     auto rt = mlir::dyn_cast<mlir::RankedTensorType>(op.getResult().getType());
-    auto enc =
-        rt ? mlir::dyn_cast_or_null<mlir::tt::ttnn::TTNNLayoutAttr>(
-                 rt.getEncoding())
-           : nullptr;
+    auto enc = rt ? mlir::dyn_cast_or_null<mlir::tt::ttnn::TTNNLayoutAttr>(
+                        rt.getEncoding())
+                  : nullptr;
     if (enc && enc.hasL1BufferType()) {
       ++reshardsToL1;
     }

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the allocator-backed stateful L1 spill path
+// (MockAllocatorL1Tracker). These run against a MOCK DEVICE (no silicon),
+// configured once per binary by MockDeviceEnvironment, and exercise the real
+// op-model query path end to end:
+//
+//   liveRecords -> buildInitialState -> getOpConstraintsWithState
+//     -> tt-metal build-from-records -> output_allocations
+//     -> pendingRecords -> addTensor association -> Snapshot on eviction.
+//
+// Unlike TestL1SpillManagement.cpp (synthetic backendValidator, no device),
+// nothing is injected here: sizes and fit decisions come from the real
+// op-model / mock allocator. Each 1024x1024 bf16 tile, height-sharded on an
+// {8,1} grid, is 256 KiB per core (2 MiB / 8 cores) -- budgets below are
+// expressed as multiples of that.
+//
+// Guarded by TTMLIR_ENABLE_OPMODEL at the CMake level.
+
+#include "L1SpillMockAllocatorFixture.h"
+#include "MockDeviceFixture.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdint>
+
+using namespace mlir::tt::ttnn::test;
+
+namespace {
+
+// Per-core L1 footprint of one 1024x1024 bf16 height-sharded {8,1} tensor, as
+// computed by the real mock op-model (verified empirically).
+constexpr uint64_t kOpL1 = 256 * kKiB;
+
+//===----------------------------------------------------------------------===//
+// SmallGraphNoSpill
+//
+// Baseline for the real op-model path: a small graph well under device L1 must
+// produce zero spills, and every op must report the true 256 KiB/core size
+// (proving the op-model actually ran -- the fake `l1UsageBytes` arg is
+// ignored).
+//===----------------------------------------------------------------------===//
+class MockAllocatorNoSpillTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorNoSpillTest, SmallGraphNoSpill) {
+  l1BudgetPerCore = 100u * kKiB * 1024u; // 100 MiB: fixture budget never binds
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opA = addUnary(args[0], tt, 0);
+  auto *opB = addUnary(opA->getResult(0), tt, 0);
+  auto *opC = addBinary(opA->getResult(0), opB->getResult(0), tt, 0);
+  finishFunc({opC->getResult(0)});
+
+  auto [obs] = runMock();
+
+  EXPECT_FALSE(mockPassFailed());
+  EXPECT_EQ(countSpills(), 0u) << "graph fits comfortably; no spill expected";
+  EXPECT_EQ(obs->ooms.size(), 0u);
+  // Real op-model sizes were used (not the ignored fake arg).
+  ASSERT_FALSE(obs->lives.empty());
+  for (const auto &l : obs->lives) {
+    EXPECT_EQ(l.opL1Usage, kOpL1)
+        << "op-model must report the real per-core L1 size";
+  }
+  // All three outputs stay resident in L1 (nothing was pushed out).
+  EXPECT_TRUE(resultIsL1(opA->getResult(0)));
+  EXPECT_TRUE(resultIsL1(opB->getResult(0)));
+  EXPECT_TRUE(resultIsL1(opC->getResult(0)));
+}
+
+//===----------------------------------------------------------------------===//
+// FarthestLastUseVictimSpilled
+//
+// Farthest-last-use eviction driven through the allocator-backed tracker.
+// Three 256 KiB producers are kept simultaneously live; a tight fixture budget
+// admits two but not three, so creating the third trips OOM and the pass evicts
+// the farthest-last-use victim (spill-to-DRAM). Exercises the full stateful
+// machinery under eviction: liveRecords flattening into each stateful query,
+// Snapshot capture, and record-restore during the eviction replay.
+//===----------------------------------------------------------------------===//
+class MockAllocatorSpillTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorSpillTest, FarthestLastUseVictimSpilled) {
+  l1BudgetPerCore = 700 * kKiB; // ~2.7 producers: 2 fit, the 3rd trips OOM
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opA = addUnary(args[0], tt, 0);
+  auto *opB = addUnary(args[0], tt, 0);
+  auto *opPressure = addUnary(args[0], tt, 0);
+  // Consumers in reverse order so opA has the farthest last-use -> evicted.
+  auto *useB = addUnary(opB->getResult(0), tt, 0);
+  auto *useA = addUnary(opA->getResult(0), tt, 0);
+  finishFunc(
+      {opPressure->getResult(0), useB->getResult(0), useA->getResult(0)});
+
+  auto [obs] = runMock();
+
+  EXPECT_FALSE(mockPassFailed());
+  ASSERT_GE(obs->evictions.size(), 1u) << "3x256 KiB > 700 KiB must spill";
+  EXPECT_EQ(obs->evictions.front().victim, opA)
+      << "farthest-last-use victim must be opA";
+  EXPECT_TRUE(wasSpilled(opA->getResult(0)));
+  EXPECT_FALSE(wasSpilled(opB->getResult(0)));
+  EXPECT_TRUE(resultIsL1(opB->getResult(0)));
+}
+
+//===----------------------------------------------------------------------===//
+// OverSubscriptionSpills
+//
+// Sixteen 256 KiB producers are kept simultaneously live (4 MiB) against a
+// realistic ~1.25 MiB per-core L1 budget (matching how a real compile sets the
+// budget to the device L1). The stateful tracker must resolve the
+// over-subscription by spilling (evict + refit), not crash and not cram
+// everything into L1. Exercises the allocator-backed tracker under heavy L1
+// pressure end to end.
+//
+// NOTE: an earlier version used a 100 MiB fixture budget to isolate the
+// device-L1 gate via the old "OOM-as-backend-error -> demote" path. That path
+// was removed by https://github.com/tenstorrent/tt-mlir/issues/9045 (a
+// fragmentation OOM from the stateful query is now classified as OOM and taken
+// through evict+refit, like the scalar tracker), so the budget is now set to a
+// realistic value where base-sim and device agree, as in a real compile.
+//===----------------------------------------------------------------------===//
+class MockAllocatorDeviceL1Test : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorDeviceL1Test, OverSubscriptionSpills) {
+  l1BudgetPerCore = 5 * kOpL1; // ~1.25 MiB: ~5 producers fit, rest must spill
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  constexpr int kNumProducers = 16; // 16 x 256 KiB = 4 MiB >> budget
+  auto args = beginFunc({tt});
+  llvm::SmallVector<mlir::Operation *> producers;
+  for (int i = 0; i < kNumProducers; ++i) {
+    producers.push_back(addUnary(args[0], tt, 0));
+  }
+  // Consume in reverse so every producer stays live through the last creation.
+  llvm::SmallVector<mlir::Value> rets;
+  for (int i = kNumProducers - 1; i >= 0; --i) {
+    rets.push_back(addUnary(producers[i]->getResult(0), tt, 0)->getResult(0));
+  }
+  finishFunc(rets);
+
+  runMock();
+
+  // A spilled producer keeps its L1 result type; the spill is a separate
+  // ToMemoryConfig(->DRAM) op, so wasSpilled() (not resultIsL1) is the right
+  // predicate for "this producer's data was pushed to DRAM".
+  size_t spilledProducers = 0;
+  for (auto *p : producers) {
+    if (wasSpilled(p->getResult(0))) {
+      ++spilledProducers;
+    }
+  }
+
+  EXPECT_FALSE(mockPassFailed());
+  // 4 MiB of live producers cannot fit a ~1.25 MiB budget -> the tracker must
+  // spill some to DRAM.
+  EXPECT_GT(countSpills(), 0u)
+      << "over-subscription (4 MiB into ~1.25 MiB) must spill to DRAM";
+  EXPECT_GT(spilledProducers, 0u)
+      << "some producers must be spilled to DRAM under over-subscription";
+}
+
+//===----------------------------------------------------------------------===//
+// SequentialChainFreesRecords
+//
+// Complement to the accumulation test: a long chain where each tensor dies one
+// step after birth. If the tracker frees live records on tensor death
+// (MockAllocatorL1Tracker::removeTensor -> liveRecords.erase), at most two
+// tensors are ever live, occupancy stays ~512 KiB, and nothing leaves L1 --
+// even though the chain's total footprint (10 x 256 KiB = 2.5 MiB) exceeds
+// device L1. A broken free path would accumulate and force spills/demotions.
+//===----------------------------------------------------------------------===//
+class MockAllocatorFreeTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorFreeTest, DeadTensorsFreeRecordsNoSpill) {
+  l1BudgetPerCore = 100u * kKiB * 1024u; // 100 MiB: fixture budget never binds
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  constexpr int kChainLen = 10; // 10 x 256 KiB = 2.5 MiB total > device L1
+  auto args = beginFunc({tt});
+  mlir::Operation *prev = nullptr;
+  llvm::SmallVector<mlir::Operation *> ops;
+  for (int i = 0; i < kChainLen; ++i) {
+    mlir::Value in = prev ? prev->getResult(0) : args[0];
+    prev = addUnary(in, tt, 0);
+    ops.push_back(prev);
+  }
+  finishFunc({prev->getResult(0)});
+
+  auto [obs] = runMock();
+
+  EXPECT_FALSE(mockPassFailed());
+  EXPECT_EQ(countSpills(), 0u)
+      << "sequential chain frees each tensor before the next -> no spill";
+  EXPECT_TRUE(obs->demotions.empty());
+  // Every op stays in L1: peak residency never exceeded device capacity because
+  // dead tensors released their records.
+  for (auto *op : ops) {
+    EXPECT_TRUE(resultIsL1(op->getResult(0)))
+        << "no op should leave L1 in a self-freeing chain";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// PerCoreSizeMatchesConstant
+//
+// Pins the calibration constant: if tt-metal changes tensor sizing, this fails
+// loudly and points at the fix (update kOpL1 and re-derive the budgets above).
+//===----------------------------------------------------------------------===//
+class MockAllocatorCalibrationTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorCalibrationTest, PerCoreSizeMatchesConstant) {
+  l1BudgetPerCore = 100u * kKiB * 1024u;
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opA = addUnary(args[0], tt, 0);
+  finishFunc({opA->getResult(0)});
+
+  auto [obs] = runMock();
+
+  ASSERT_EQ(obs->lives.size(), 1u);
+  EXPECT_EQ(obs->lives.front().opL1Usage, kOpL1)
+      << "mock op-model per-core L1 changed; update kOpL1 and re-derive "
+         "budgets";
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MockDeviceEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -475,9 +475,9 @@ TEST_F(MockAllocatorViewTripwireTest, RealPadIsNotAView) {
 // with an EMPTY live-record set has to be byte-for-byte equivalent to the plain
 // stateless query (buildInitialState({}) -> null state -> constraintsDispatch
 // takes the cached stateless path). This is the invariant the whole
-// stateless-through-the-stateful-API design and the interface constraintsDispatch
-// helper rely on; assert it directly so a future change to buildInitialState or
-// the dispatch cannot silently diverge the two paths.
+// stateless-through-the-stateful-API design and the interface
+// constraintsDispatch helper rely on; assert it directly so a future change to
+// buildInitialState or the dispatch cannot silently diverge the two paths.
 //===----------------------------------------------------------------------===//
 class MockAllocatorStatelessEquivalenceTest
     : public L1SpillMockAllocatorFixture {};
@@ -491,8 +491,9 @@ TEST_F(MockAllocatorStatelessEquivalenceTest, EmptyRecordsMatchesStateless) {
   finishFunc({op->getResult(0)});
 
   const mlir::tt::ttnn::OpConfig config(layout);
-  const auto stateless = mlir::tt::ttnn::op_constraint_validation::
-      validateOperation(op, /*inputLayouts=*/{layout}, config);
+  const auto stateless =
+      mlir::tt::ttnn::op_constraint_validation::validateOperation(
+          op, /*inputLayouts=*/{layout}, config);
   const auto statefulEmpty =
       mlir::tt::ttnn::op_constraint_validation::validateOperation(
           op, /*inputLayouts=*/{layout}, config,

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -468,6 +468,47 @@ TEST_F(MockAllocatorViewTripwireTest, RealPadIsNotAView) {
       << "a real (non-view) pad must not be classified as an aliasing view";
 }
 
+//===----------------------------------------------------------------------===//
+// StatelessUnchangedByStatefulRouting
+//
+// The stateful op-model routing must not perturb the stateless result: a query
+// with an EMPTY live-record set has to be byte-for-byte equivalent to the plain
+// stateless query (buildInitialState({}) -> null state -> constraintsDispatch
+// takes the cached stateless path). This is the invariant the whole
+// stateless-through-the-stateful-API design and the interface constraintsDispatch
+// helper rely on; assert it directly so a future change to buildInitialState or
+// the dispatch cannot silently diverge the two paths.
+//===----------------------------------------------------------------------===//
+class MockAllocatorStatelessEquivalenceTest
+    : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorStatelessEquivalenceTest, EmptyRecordsMatchesStateless) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto layout = makeL1Sharded(shape);
+  auto tt = tensorType(shape, layout);
+  auto args = beginFunc({tt});
+  auto *op = addUnary(args[0], tt, 0);
+  finishFunc({op->getResult(0)});
+
+  const mlir::tt::ttnn::OpConfig config(layout);
+  const auto stateless = mlir::tt::ttnn::op_constraint_validation::
+      validateOperation(op, /*inputLayouts=*/{layout}, config);
+  const auto statefulEmpty =
+      mlir::tt::ttnn::op_constraint_validation::validateOperation(
+          op, /*inputLayouts=*/{layout}, config,
+          /*liveRecords=*/
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>{});
+
+  EXPECT_EQ(stateless.isSuccess(), statefulEmpty.isSuccess())
+      << "empty-records stateful query must match the stateless status";
+  ASSERT_TRUE(stateless.isSuccess())
+      << "baseline stateless query must succeed for this op";
+  EXPECT_EQ(stateless.outputL1Usage, statefulEmpty.outputL1Usage);
+  EXPECT_EQ(stateless.cbPeakUsage, statefulEmpty.cbPeakUsage);
+  EXPECT_EQ(stateless.getFirstActualOutputLayout(),
+            statefulEmpty.getFirstActualOutputLayout());
+}
+
 } // namespace
 
 int main(int argc, char **argv) {

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -174,7 +174,7 @@ TEST_F(MockAllocatorDeviceL1Test, OverSubscriptionSpills) {
 }
 
 //===----------------------------------------------------------------------===//
-// SequentialChainFreesRecords
+// DeadTensorsFreeRecordsNoSpill
 //
 // Complement to the accumulation test: a long chain where each tensor dies one
 // step after birth. If the tracker frees live records on tensor death
@@ -367,7 +367,13 @@ static bool queryReportsL1Address0(mlir::Operation *op,
       /*liveRecords=*/
       llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>{},
       /*additionalL1Usage=*/0);
+  // Fatal for this helper: a failed query has no meaningful outputAllocations,
+  // so record the failure and stop rather than falling through to `return
+  // false` (which would misreport as "no L1 address-0 output").
   EXPECT_TRUE(result.isSuccess()) << "stateful op-model query should succeed";
+  if (!result.isSuccess()) {
+    return false;
+  }
   for (const auto &r : result.outputAllocations) {
     if (r.bufferType == mlir::tt::ttnn::BufferType::L1 && r.address == 0) {
       return true;
@@ -426,6 +432,24 @@ TEST_F(MockAllocatorViewTripwireTest, PermuteNopViewReportsL1Address0) {
       << "identity ttnn.permute must report an L1 output at address 0";
 }
 
+// Reshape: the primary view op. A reshape that keeps the last two dims (only
+// reinterpreting the leading dims) is a zero-copy view (reshape.cpp:378-384).
+TEST_F(MockAllocatorViewTripwireTest, ReshapeViewReportsL1Address0) {
+  llvm::SmallVector<int64_t> inShape = {2, 1, 32, 64};
+  llvm::SmallVector<int64_t> outShape = {1, 2, 32, 64}; // last two dims fixed
+  auto inLayout = makeL1Interleaved(inShape);
+  auto outLayout = makeL1Interleaved(outShape);
+  auto args = beginFunc({tensorType(inShape, inLayout)});
+  auto *reshape = addReshape(args[0], tensorType(outShape, outLayout),
+                             /*l1UsageBytes=*/0);
+  finishFunc({reshape->getResult(0)});
+
+  EXPECT_TRUE(mlir::tt::ttnn::canReshapeBeView(reshape));
+  EXPECT_TRUE(mlir::tt::ttnn::isAliasingViewOp(reshape));
+  EXPECT_TRUE(queryReportsL1Address0(reshape, inLayout, outLayout))
+      << "view-eligible ttnn.reshape must report an L1 output at address 0";
+}
+
 // Negative: a real (non-view) pad that grows a tile dim must NOT be classified
 // a view.
 TEST_F(MockAllocatorViewTripwireTest, RealPadIsNotAView) {
@@ -438,12 +462,17 @@ TEST_F(MockAllocatorViewTripwireTest, RealPadIsNotAView) {
 
   EXPECT_FALSE(mlir::tt::ttnn::canPadBeView(pad))
       << "a pad that adds a full tile row is a real allocation, not a view";
+  // ...and it must not be picked up by the unified aliasing-view predicate the
+  // spill pass keys on (else it would alias/undercount a real allocation).
+  EXPECT_FALSE(mlir::tt::ttnn::isAliasingViewOp(pad))
+      << "a real (non-view) pad must not be classified as an aliasing view";
 }
 
 } // namespace
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - GTest takes ownership.
   ::testing::AddGlobalTestEnvironment(new MockDeviceEnvironment());
   return RUN_ALL_TESTS();
 }

--- a/test/unittests/Validation/TestOpConstraintValidation.cpp
+++ b/test/unittests/Validation/TestOpConstraintValidation.cpp
@@ -21,6 +21,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
 
 #include "gtest/gtest.h"
 
@@ -456,6 +457,53 @@ TEST_F(OpConstraintValidationTest, ValidationStatusOutOfMemoryError) {
   EXPECT_FALSE(result.isSuccess());
   EXPECT_FALSE(result.isNotImplemented());
   EXPECT_FALSE(result.errorMessage.empty());
+}
+
+// Regression test for https://github.com/tenstorrent/tt-mlir/issues/9064:
+// The stateful (build-from-records) op-model query places live tensors at real
+// addresses, so an op whose static circular buffers overlap a still-live L1
+// input surfaces the tt-metal CB-clash exception ("Statically allocated
+// circular buffers ... clash with L1 buffers ...").  This is an L1-pressure
+// condition recoverable by evict-and-refit, so checkConstraintsResult must
+// classify it as OutOfMemoryError (routing the spill pass to handleOOM), NOT
+// MetalBackendError (which only demotes the op's output to DRAM and leaves the
+// clashing L1 input in place -> runtime crash).
+TEST_F(OpConstraintValidationTest, ClashWithL1BuffersClassifiedAsOOM) {
+  auto addOp = createMockAddOp();
+
+  llvm::Expected<op_model::OpConstraints> clashError =
+      llvm::make_error<llvm::StringError>(
+          "TT_THROW @ program.cpp:1612: tt::exception\n"
+          "Statically allocated circular buffers in program 42 clash with L1 "
+          "buffers on core range [0-0 - 7-7]. L1 buffer allocated at 253952 "
+          "and static circular buffer region ends at 646208",
+          llvm::inconvertibleErrorCode());
+
+  auto result = op_constraint_validation::checkConstraintsResult(
+      addOp.getOperation(), std::move(clashError));
+
+  EXPECT_EQ(result.status,
+            op_constraint_validation::ValidationStatus::OutOfMemoryError);
+  EXPECT_TRUE(result.isError());
+}
+
+// Companion to the above: a genuine backend constraint error (carrying neither
+// the "Out of Memory" nor the "clash with L1 buffers" marker) must remain a
+// MetalBackendError so the op is demoted rather than sent through evict-refit.
+TEST_F(OpConstraintValidationTest, GenericBackendErrorStaysBackendError) {
+  auto addOp = createMockAddOp();
+
+  llvm::Expected<op_model::OpConstraints> backendError =
+      llvm::make_error<llvm::StringError>(
+          "Unsupported data type combination for op",
+          llvm::inconvertibleErrorCode());
+
+  auto result = op_constraint_validation::checkConstraintsResult(
+      addOp.getOperation(), std::move(backendError));
+
+  EXPECT_EQ(result.status,
+            op_constraint_validation::ValidationStatus::MetalBackendError);
+  EXPECT_TRUE(result.isError());
 }
 
 // Test ValidationStatus::UnmatchedReferenceConfig


### PR DESCRIPTION
## Essence

The greedy L1 **spill** pass currently decides "does this op fit in L1?" with a
scalar heuristic (sum of tensor sizes + a CB cushion). This PR lets it instead
ask **tt-metal's real mock allocator** — feeding the currently-live L1 tensors
(as allocation records) into a stateful op-model query, so fit / fragmentation /
placement are modeled accurately. It is gated behind the option
**`use-mock-allocator-state` (default on)** and only changes the **spill** path;
beam-search keeps its cached, stateless query.

## Commits

1. **Stateful op-constraints in the L1 spill optimizer** — the feature (op-model
   stateful query + optimizer tracker + toggle).
2. **Treat pad/repeat/permute views as input-aliases** — Tier-1 view aliasing
   (`Fixes #9054`).
3. **Classify CB-vs-L1 clash as OOM** so the pass evict+refits (`Fixes #9064`).
4. **OpModel gtest binding fix** for the new 6-field `OpConstraints`.

## Main pieces (by layer)

**1. Op-model — the new stateful query** (the bulk)
- `lib/OpModel/TTNN/TTNNOpModel.cpp` — per-op `getOpConstraintsWithState` bodies,
  `buildInitialState` (`with_allocations` from live records), allocator
  snapshot/restore, `output_allocations` → records.
- `include/ttmlir/OpModel/TTNN/TTNNOpModel.h`,
  `include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h` — declarations + the
  `OpModelAllocationRecord` POD and `OpConstraints.outputAllocations` (all
  tt-metalium types kept behind the op_model boundary).

**2. Interface / tablegen — per-op dispatch** (the migration)
- `lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp` — every op migrated: one
  real stateful body per family + one-line forwarders; the stateless
  `getOpConstraints` stays a byte-identical cache path.
- `include/ttmlir/Dialect/TTNN/IR/TTNNOps.td`,
  `include/ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.td` — the interface
  method + per-family `extraClassDeclaration` wiring.

**3. Optimizer — consuming it in the spill pass**
- `lib/Dialect/TTNN/Analysis/L1SpillManagement.{cpp,h}` — `MockAllocatorL1Tracker`
  (composes the scalar tracker; threads live records per query, frees on death;
  snapshot/restore) + the `isAliasingViewOp` view-alias wiring.
- `lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp` — the
  toggle branch + snapshot/restore around the spill run.
- `lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.{cpp,h}` —
  `canPadBeView`/`canRepeatBeView`/`canPermuteBeView` + `isAliasingViewOp`.

**4. Validation — fit + error classification**
- `lib/Dialect/TTNN/Validation/OpConstraintValidation.{cpp,h}` — stateful
  `validateOperation` overload; `checkConstraintsResult` classifies both
  allocator-OOM and the CB-clash exception as OOM → evict+refit;
  `cbPeakUsage` / `outputAllocations` on the result.

**5. Pipeline plumbing**
- `include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h`,
  `lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp`,
  `include/ttmlir/Dialect/TTNN/Transforms/Passes.td` — the `use-mock-allocator-state`
  option.

**6. Tests**
- `test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp` (+ fixtures) —
  mock-device spill tests and the view **tripwires**.
- `test/unittests/Validation/TestOpConstraintValidation.cpp` — CB-clash
  classification tests.
- `test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp`,
  `test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp` — updates for the 6-field
  `OpConstraints`.

## Correctness fixes carried

- **`Fixes #9054`** — view ops (`pad`/`repeat`/`permute`) that tt-metal realizes as
  zero-copy views are aliased in the tracker, avoiding a phantom L1-address-0
  record that crashed `with_allocations`.
- **`Fixes #9064`** — a static-CB-vs-live-L1-input clash is reclassified from a hard
  backend error to OOM, so the pass spills the offending input instead of
  crashing at runtime (fixed the n150 segformer / mobilenetv2 / gemma failures).

## Validation

Unit: `L1SpillManagementTests`, `L1SpillManagementMockAllocatorTests`
(mock-device, HW-free), `ValidationTests`; TTNN optimizer lit. Perf: n150 + p150
`Performance Benchmark` sweeps — target LLMs (llama 1b/3b/8b, qwen, mistral, phi,
falcon) pass and the n150 CB-clash regressions (segformer, mobilenetv2,
gemma-1.1-2b) are resolved by the #9064 fix. A confirming n150+p150 sweep on the
final commit is in progress before marking ready.
