### PR TITLE
[d2m] topk refactored non-power-of-2 path for k > 32

### DIFF
--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3647,11 +3647,20 @@ public:
           Value output = blockArgs[1];
           std::size_t outShardRank =
               cast<RankedTensorType>(output.getType()).getRank();
+          int64_t inReductionExtent = cast<RankedTensorType>(input.getType())
+                                          .getShape()[extractProjectDim];
 
+          // The input map must stay non-invertible, or linalg infers the loop
+          // bound from the full input extent and rejects the smaller output
+          // shard. With lastStride=1, `dim * lastStride` folds to an identity
+          // map, so we wrap it in `mod inReductionExtent` to stay
+          // non-invertible without changing the in-range read indices
           AffineExpr projExpr =
               outputReductionTiles == 1
                   ? rewriter.getAffineConstantExpr(0)
-                  : rewriter.getAffineDimExpr(extractProjectDim) * lastStride;
+                  : (rewriter.getAffineDimExpr(extractProjectDim) *
+                     lastStride) %
+                        inReductionExtent;
           SmallVector<AffineExpr> mapFirstExprs;
           for (std::size_t i = 0; i < outShardRank; ++i) {
             mapFirstExprs.push_back(i == extractProjectDim
@@ -3710,10 +3719,8 @@ public:
 
     int64_t reductionDimSize = inputType.getShape()[dim];
 
-    // Logical shape for the value input. When the reduction dim is padded to a
-    // power-of-2 tile count (for large-k cases), this shape grows to match the
-    // arange/index buffer, since topk d2m.generic requires compatible operand
-    // shapes.
+    // Logical shape for the value input, used to type the arange/index
+    // buffer since topk d2m.generic requires compatible operand shapes.
     SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
                                           inputType.getShape().end());
 
@@ -3735,58 +3742,10 @@ public:
           op,
           "D2M topk requires at least 2 tiles along the reduction dimension");
     }
-    // For k>32 with a non-pow2 tile count, the reduction dim is padded to the
-    // next power of 2, so lastStride must use the padded count (not
-    // numReductionTiles/2).
-    int64_t nextPow2 = 1;
-    while (nextPow2 < numReductionTiles) {
-      nextPow2 <<= 1;
-    }
-    int64_t paddedNumReductionTiles = (k > 32) ? nextPow2 : numReductionTiles;
-    int64_t lastStride = paddedNumReductionTiles / 2;
-
-    // For k>32 with a non-pow2 tile count, pad the logical input shape to
-    // paddedNumReductionTiles*32 so GridSelection derives the correct tile
-    // count, then mask the padding region with -inf so those tiles are never
-    // top-k.
-    if (paddedNumReductionTiles != numReductionTiles) {
-      constexpr int64_t kTileDim = 32;
-      int64_t paddedDimElems = paddedNumReductionTiles * kTileDim;
-
-      // Build a padded logical type with the reduction dim grown to
-      // paddedDimElems.
-      SmallVector<int64_t> paddedLogicalShape(inputType.getShape().begin(),
-                                              inputType.getShape().end());
-      paddedLogicalShape[dim] = paddedDimElems;
-      auto paddedLogicalType =
-          RankedTensorType::get(paddedLogicalShape, inputType.getElementType());
-
-      Value paddedLayouted = createOptimalLayoutOp(
-          adaptor.getInputTensor(), memorySpaces[0], /*tiled=*/true,
-          /*noCollapse=*/false, rewriter, ttcore::OOBVal::Undef,
-          paddedLogicalType);
-
-      // Mask with the real logical shape so padding cols/rows get -inf.
-      auto paddedLayoutedType =
-          cast<RankedTensorType>(paddedLayouted.getType());
-      auto maskOutput =
-          rewriter.create<d2m::EmptyOp>(loc, paddedLayoutedType.getShape(),
-                                        paddedLayoutedType.getElementType(),
-                                        paddedLayoutedType.getEncoding());
-      SmallVector<int64_t> realLogicalShape(inputType.getShape().begin(),
-                                            inputType.getShape().end());
-      paddedLayouted =
-          rewriter
-              .create<d2m::MaskOp>(loc, paddedLayouted, maskOutput,
-                                   realLogicalShape, ttcore::OOBVal::NegInf)
-              .getResult();
-
-      layoutedInput = paddedLayouted;
-      layoutedType = cast<RankedTensorType>(layoutedInput.getType());
-      metalLayout = cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
-      deviceShape = layoutedType.getShape();
-      topkLogicalShape[dim] = paddedDimElems;
-    }
+    // D2MDecomposeTopk's left-fold keeps the accumulator at canonical tiles
+    // (winner=0, loser=1), so extract always reads tile j from input tile j
+    // (lastStride=1)
+    int64_t lastStride = 1;
 
     Type f32Type = f32TileType.getElementType();
     auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -56,9 +56,8 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
 
     int32_t logk = floorLog2(k);
 
-    // When k>32 the result spans 2 tiles, requiring a 3-sub-merge reduction.
-    // TTIRToD2M pads the reduction dim to a power-of-2 tile count (-inf fill),
-    // so the large-k path always sees a power-of-2 tile count.
+    // When k>32 the result spans 2 tiles. The large-k path left-folds over
+    // the reduction tiles, so it handles any tile count without padding.
     bool useLargeK = (k > 32);
     int64_t dimIdx = op.getDim();
     int64_t numTilesInner = inputShape[dimIdx];
@@ -108,7 +107,6 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     Value trueVal = i1Val(true);
     Value falseVal = i1Val(false);
     Value numTilesIdx = idxVal(numTilesInner);
-    Value logWtIdx = idxVal(logWt);
 
     Value reductionStrideIdx = idxVal(reductionStride);
     Value ntStrideIdx = idxVal(ntStride);
@@ -149,88 +147,85 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
           tB, boolAttr(false), /*is_group_end=*/i1Val(true), rfo);
     };
 
-    // useLargeK is fixed per rewrite (derived from k), so the large-k and
-    // small-k paths are emitted as two independent loop structures.
     if (useLargeK) {
-      // Level 0 is emitted unrolled, then levels [1,logWt) are emitted in a
-      // single scf.for loop, each with a fixed body.
-      auto emitInnerBody = [&](Value mIterIdx, bool isFirstLevel) {
-        Value distanceIdx =
-            rewriter.create<arith::ShLIOp>(loc, oneIdx, mIterIdx);
-        Value innerUB =
-            rewriter.create<arith::SubIOp>(loc, numTilesIdx, distanceIdx);
-        Value innerStep =
-            rewriter.create<arith::MulIOp>(loc, distanceIdx, idxVal(2));
-        auto innerLoop =
-            rewriter.create<scf::ForOp>(loc, zeroIdx, innerUB, innerStep);
-        rewriter.setInsertionPointToStart(innerLoop.getBody());
+      // Left-fold: keeps a running 2-tile accumulator, with the winner always
+      // in tile 0 and the loser always in tile 1, so extraction never needs
+      // to track which tile is which. This works for any tile count without
+      // power-of-2 padding, at ~2 sort-merge-rebuilds per tile: folding in a
+      // complete pair takes a 3-sort-merge-rebuild, folding in a lone tail tile
+      // takes a 2-sort-merge-rebuild.
+      Value accWin = zeroIdx;
+      Value accLos = oneIdx;
 
-        // rA/rB are raw reduction indices; tileA/tileB are flat after adding
-        // ntOffset.
-        Value baseIdx = innerLoop.getInductionVar();
-        Value rA = baseIdx;
-        Value rB = rewriter.create<arith::AddIOp>(loc, baseIdx, distanceIdx);
-        Value tileA = flat(rA);
-        Value tileB = flat(rB);
+      // Build the initial accumulator from reduction tiles 0 and 1.
+      emitSortMergeRebuild(flat(accWin), flat(accLos), /*mergeK=*/k,
+                           /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
+                           /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                           /*skipSecond=*/0, /*rfo=*/falseVal);
 
-        if (isFirstLevel) {
-          // Level 0: emit a single sort-merge-rebuild.
-          emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
-                               /*sortStartPhase=*/zeroI32,
-                               /*sortEndPhase=*/logk - 1,
-                               /*mergeIter=*/zeroI32, /*skipSecond=*/0,
-                               /*rfo=*/falseVal);
-        } else {
-          // Levels > 0: DST only holds 2 tiles at a time, so we cannot merge
-          // all 4 tiles directly; instead, we use 3 sub-merges.
-          // prevDist is the stride from the previous level: distance / 2.
-          Value prevDistIdx =
-              rewriter.create<arith::ShRUIOp>(loc, distanceIdx, oneIdx);
+      // Fold in every COMPLETE right pair (t, t+1) for t = 2, 4, ... The upper
+      // bound excludes an odd trailing tile, which is handled after the loop.
+      int64_t completeUB = numTilesInner - (numTilesInner % 2);
+      if (completeUB > 2) {
+        auto foldLoop = rewriter.create<scf::ForOp>(
+            loc, idxVal(2), idxVal(completeUB), idxVal(2));
+        rewriter.setInsertionPointToStart(foldLoop.getBody());
+        Value tIdx = foldLoop.getInductionVar();
+        Value tPlus1 = rewriter.create<arith::AddIOp>(loc, tIdx, oneIdx);
 
-          // Loser indices derive from rA/rB to avoid double-applying the
-          // ntOffset.
-          Value rALoser = rewriter.create<arith::AddIOp>(loc, rA, prevDistIdx);
-          Value rBLoser = rewriter.create<arith::AddIOp>(loc, rB, prevDistIdx);
-          Value tileALoser = flat(rALoser);
-          Value tileBLoser = flat(rBLoser);
+        // Build the complete right block q = (t, t+1) from raw input.
+        emitSortMergeRebuild(flat(tIdx), flat(tPlus1), /*mergeK=*/k,
+                             /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
+                             /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                             /*skipSecond=*/0, /*rfo=*/falseVal);
 
-          // Step 1: Merge the winner tiles (tileA, tileB) from the previous
-          // iteration; tileA holds the best-k across both afterward.
-          emitSortMergeRebuild(tileA, tileB, /*mergeK=*/k, /*rebuildK=*/k, logk,
-                               /*sortStartPhase=*/zeroI32,
-                               /*sortEndPhase=*/logk - 1,
-                               /*mergeIter=*/zeroI32, /*skipSecond=*/0,
-                               /*rfo=*/trueVal);
+        // 3-sub-merge combine of acc=(0, 1) with q=(t, t+1). All operands were
+        // previously packed, so rfo=true.
+        // Step 1: winners (0, t) -> tile 0 holds the global top-k; t holds the
+        // losers of the winner tiles.
+        emitSortMergeRebuild(flat(accWin), flat(tIdx), /*mergeK=*/k,
+                             /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
+                             /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                             /*skipSecond=*/0, /*rfo=*/trueVal);
+        // Step 2: losers (1, t+1) -> tile 1 holds the best of the loser tiles.
+        emitSortMergeRebuild(flat(accLos), flat(tPlus1), /*mergeK=*/k,
+                             /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
+                             /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                             /*skipSecond=*/0, /*rfo=*/trueVal);
+        // Step 3: (1, t) -> tile 1 holds the final rank-(k/2..k). Writing the
+        // winner back to tile 1 (not t) keeps the accumulator canonical at
+        // (0, 1).
+        emitSortMergeRebuild(flat(accLos), flat(tIdx), /*mergeK=*/k,
+                             /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
+                             /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                             /*skipSecond=*/0, /*rfo=*/trueVal);
 
-          // Step 2: Merge the loser tiles; (tileALoser) holds the best-k
-          // across both losers afterward.
-          emitSortMergeRebuild(tileALoser, tileBLoser, /*mergeK=*/k,
-                               /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
-                               /*sortEndPhase=*/logk - 1,
-                               /*mergeIter=*/zeroI32, /*skipSecond=*/0,
-                               /*rfo=*/trueVal);
+        rewriter.setInsertionPointAfter(foldLoop);
+      }
 
-          // Step 3: Merge winners against losers; tileB holds the final
-          // top-k across all four tiles afterward.
-          emitSortMergeRebuild(tileB, tileALoser, /*mergeK=*/k,
-                               /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
-                               /*sortEndPhase=*/logk - 1,
-                               /*mergeIter=*/zeroI32, /*skipSecond=*/0,
-                               /*rfo=*/trueVal);
-        }
-
-        rewriter.setInsertionPointAfter(innerLoop);
-      };
-
-      // Level 0 loop: exactly one iteration (mIterIdx == 0), run unrolled.
-      emitInnerBody(zeroIdx, /*isFirstLevel=*/true);
-
-      // Levels [1, logWt): outer loop with fixed body.
-      auto outerLoop =
-          rewriter.create<scf::ForOp>(loc, oneIdx, logWtIdx, oneIdx);
-      rewriter.setInsertionPointToStart(outerLoop.getBody());
-      emitInnerBody(outerLoop.getInductionVar(), /*isFirstLevel=*/false);
-      rewriter.setInsertionPointAfter(outerLoop);
+      // Odd tile count: fold in the lone trailing tile with a winner-only
+      // 2-sub-merge. This keeps the accumulator canonical at (0, 1).
+      if (numTilesInner % 2 == 1) {
+        Value tailIdx = idxVal(numTilesInner - 1);
+        // Prime the raw tail tile into a valid sorted run (sorts one tile;
+        // tileA==tileB is harmless).
+        rewriter.create<TileTopkLocalSortOp>(
+            loc, inputValues, bufIdxFilled, outValues, outIndices,
+            /*idir=*/i32Attr(0), /*i_end_phase=*/i32Attr(logk - 1),
+            /*i_start_phase=*/zeroI32, /*tileA=*/flat(tailIdx),
+            /*tileB=*/flat(tailIdx), /*is_group_start=*/boolAttr(true),
+            /*is_group_end=*/i1Val(true), /*rfo=*/falseVal);
+        // Step A: winners (0, tail) -> tile 0 holds the global top-k.
+        emitSortMergeRebuild(flat(accWin), flat(tailIdx), /*mergeK=*/k,
+                             /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
+                             /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                             /*skipSecond=*/0, /*rfo=*/trueVal);
+        // Step B: (1, tail) -> tile 1 holds the final rank-(k/2..k).
+        emitSortMergeRebuild(flat(accLos), flat(tailIdx), /*mergeK=*/k,
+                             /*rebuildK=*/k, logk, /*sortStartPhase=*/zeroI32,
+                             /*sortEndPhase=*/logk - 1, /*mergeIter=*/zeroI32,
+                             /*skipSecond=*/0, /*rfo=*/trueVal);
+      }
     } else {
       // Level 0 is emitted unrolled, levels [1,logWt-1) run in a middle
       // scf.for loop (if logWt > 1), and level logWt-1 is emitted unrolled

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -58,7 +58,9 @@ def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors):
         pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
         # Large target dim (many tiles in reduction)
         pytest.param((32, 1376), 16, -1, id="32x1376_k16_dim1"),
-        pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
+        pytest.param((1760, 32), 16, 0, id="1760x32_k16_dim0"),
+        pytest.param((32, 1376), 64, -1, id="32x1376_k64_dim1"),
+        pytest.param((1760, 32), 64, 0, id="1760x32_k64_dim0"),
         # Ragged (non-power-of-2 tile count)
         pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
         pytest.param((1536, 32), 16, 0, id="1536x32_k16_dim0"),

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
@@ -66,33 +66,33 @@ module {
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
   }
 
-  // ---- Large k (k>32), 2 tiles: direct sort-merge-rebuild ----
+  // ---- Large k (k>32): left-fold accumulator over reduction tiles ----
 
-  // 32x128 with k=64: useLargeK=true, logk=6. Wt=2, logWt=1.
-  // Note: We use 32x128 (k < num_elements=128) to avoid a bug where
-  // k==num_elements causes a shape mismatch in createExtractGeneric.
+  // 32x64 with k=64: 2 reduction tiles. Builds a single 2-tile accumulator
+  // (tiles 0,1) with no fold loop, since there are no complete right pairs.
   // CHECK-LABEL: func @decompose_k64_2tiles
-  func.func @decompose_k64_2tiles(%arg0: tensor<32x128xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
+  func.func @decompose_k64_2tiles(%arg0: tensor<32x64xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
     // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 128
+    // CHECK-SAME: num_elements = 64
 
-    // Single scf.for with sort-merge-rebuild.
+    // Non-target loop wraps the whole merge tree.
     // CHECK: scf.for
+    // Initial accumulator from tiles (0,1): sort-merge-rebuild.
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 64
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64{{.*}}logk = 6
 
-    %values, %indices = "ttir.topk"(%arg0) <{k = 64 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x128xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>)
+    %values, %indices = "ttir.topk"(%arg0) <{k = 64 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x64xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>)
     return %values, %indices : tensor<32x64xf32>, tensor<32x64xsi32>
   }
 
-  // ---- Large k (k>32), 4 tiles: 3-sub-merge tree on later iterations ----
+  // ---- Large k (k>32), 4 tiles: left-fold with one complete right pair ----
 
-  // 32x128 with k=64: Wt=4, logWt=2.
-  // Iter 0: pairs (0,1)(2,3) — direct sort-merge-rebuild (isFirst).
-  // Iter 1: pair (0,2) — 3-sub-merge tree.
+  // 32x128 with k=64: 4 reduction tiles. One fold-loop trip combines the
+  // accumulator (0,1) with the complete right pair (2,3) via a build plus a
+  // 3-sub-merge, keeping the accumulator canonical at (0,1).
   // CHECK-LABEL: func @decompose_k64_4tiles
   func.func @decompose_k64_4tiles(%arg0: tensor<32x128xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
@@ -100,30 +100,122 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 128
 
-    // Level 0 is emitted unrolled: direct sort-merge-rebuild.
+    // Outer scf.for is the non-target-row loop (one row here).
     // CHECK: scf.for
-    // CHECK: scf.for
+    // Initial accumulator built from tiles (0,1).
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 64
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
-    // Levels [1, logWt) run in a separate scf.for: 3-sub-merge (winners,
-    // losers, winners-vs-losers).
+    // Fold loop over complete right pairs.
     // CHECK: scf.for
-    // CHECK: scf.for
+    // Build the complete right pair (2,3) from raw input.
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // 3-sub-merge combine of acc=(0,1) with the pair.
     // Sub 1: merge winner tiles.
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 64
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
-    // Sub 2: merge loser tiles.
+    // Sub 2: merge losers.
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 64
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
-    // Sub 3: merge winners vs losers.
+    // Sub 3: merge losers vs winners, writing back to tile 1.
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 64
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
 
     %values, %indices = "ttir.topk"(%arg0) <{k = 64 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x128xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>)
+    return %values, %indices : tensor<32x64xf32>, tensor<32x64xsi32>
+  }
+
+  // ---- Large k (k>32), 6 tiles: left-fold with two complete right pairs ----
+
+  // 32x192 with k=64: 6 reduction tiles (even). The fold loop runs twice, once
+  // per complete right pair (2,3) and (4,5), each a build plus a 3-sub-merge.
+  // No power-of-2 padding is needed and there is no odd tail.
+  // CHECK-LABEL: func @decompose_k64_6tiles
+  func.func @decompose_k64_6tiles(%arg0: tensor<32x192xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
+    // CHECK-NOT: d2m.topk_block
+
+    // CHECK: d2m.arange_block
+    // CHECK-SAME: num_elements = 192
+
+    // Outer scf.for is the non-target-row loop.
+    // CHECK: scf.for
+    // Initial accumulator from tiles (0,1).
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // Fold loop (2 trips) over complete right pairs.
+    // CHECK: scf.for
+    // Build the complete right pair.
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // 3-sub-merge combine. Sub 1: winners.
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // Sub 2: losers.
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // Sub 3: losers vs winners.
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+
+    %values, %indices = "ttir.topk"(%arg0) <{k = 64 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x192xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>)
+    return %values, %indices : tensor<32x64xf32>, tensor<32x64xsi32>
+  }
+
+  // ---- Large k (k>32), 5 tiles: odd tile count → tail fold ----
+
+  // 32x160 with k=64: 5 reduction tiles (odd). Seed (0,1), the fold loop runs
+  // once for the complete pair (2,3), then tile 4 is folded in as a lone tail
+  // with a 2-sub-merge (preceded by a prime that sorts the raw tail tile).
+  // CHECK-LABEL: func @decompose_k64_5tiles
+  func.func @decompose_k64_5tiles(%arg0: tensor<32x160xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
+    // CHECK-NOT: d2m.topk_block
+
+    // CHECK: d2m.arange_block
+    // CHECK-SAME: num_elements = 160
+
+    // Outer scf.for is the non-target-row loop.
+    // CHECK: scf.for
+    // Initial accumulator from tiles (0,1).
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // Fold loop over the one complete right pair (2,3): build + 3-sub-merge.
+    // CHECK: scf.for
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // Odd tail (tile 4), emitted after the fold loop. First prime the raw tail
+    // tile into a valid sorted run with a standalone local_sort.
+    // CHECK: d2m.tile_topk_local_sort
+    // 2-sub-merge combine. Step A: winners (0, tail).
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+    // Step B: losers vs tail (1, tail).
+    // CHECK: d2m.tile_topk_local_sort
+    // CHECK: d2m.tile_topk_merge{{.*}}k = 64
+    // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
+
+    %values, %indices = "ttir.topk"(%arg0) <{k = 64 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x160xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>)
     return %values, %indices : tensor<32x64xf32>, tensor<32x64xsi32>
   }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The k > 32 path for topk was previously padding to the next power-of-2 tile count to match the merge tree implementation. This caused a problem in the extreme cases where the padded input took up much more space and required much more sort-merge-rebuild ops than required.

### What's changed
The new approach implements a left-fold accumulator strategy that efficiently handles any tile count (even or odd) without padding, and updates both the lowering logic and test coverage accordingly.


**TopK lowering and decomposition improvements:**

* Reworked the large-k TopK lowering in `D2MTopKRewriter` to eliminate power-of-2 tile count padding. The new logic always uses `lastStride=1` and ensures the input map remains non-invertible by wrapping the affine map in a modulo operation, avoiding shape mismatches and unnecessary padding. 
* Updated the decomposition pattern in `DecomposeTopk.cpp` to implement a left-fold accumulator for large-k cases. This approach handles any number of tiles (even or odd) by folding in complete right pairs with a 3-sub-merge and handling an odd tail tile with a 2-sub-merge, removing the previous merge tree logic that required power-of-2 padding.

### Checklist
- [ ] New/Existing tests provide coverage for changes
