### PR TITLE
Uplift third_party/tt-metal to d49ded17509f38c70e109387e7b25965780f484b 2026-07-20

### DIFF
--- a/runtime/lib/ttnn/operations/ccl/all_gather.cpp
+++ b/runtime/lib/ttnn/operations/ccl/all_gather.cpp
@@ -41,9 +41,10 @@ void run(const ::tt::target::ttnn::AllGatherOp *op, ProgramContext &context) {
         ::tt::runtime::common::toMetalTopology(op->topology().value()));
   }
 
-  ::ttnn::Tensor out = ::ttnn::all_gather(
-      input, allGatherDim, clusterAxis, subDeviceId, outputMemoryConfig,
-      optionalOutputTensor, numLinks, topology);
+  ::ttnn::Tensor out =
+      ::ttnn::all_gather(input, allGatherDim, clusterAxis, outputMemoryConfig,
+                         optionalOutputTensor, subDeviceId,
+                         /*sub_core_grid=*/std::nullopt, numLinks, topology);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "f1f4ff75579ebd7a69c7da52d45368f273026d85")
+set(TT_METAL_VERSION "d49ded17509f38c70e109387e7b25965780f484b")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the d49ded17509f38c70e109387e7b25965780f484b



### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/29832816481
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):