### PR TITLE
[TT-Lang] Turn TT-Lang ops back to DPS style and rematerialize custom_sharding_rule in RegisterCustomShardingRule

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -83,6 +83,17 @@ def RegisterUserShardingRulePass : Pass<"register-user-sharding-rule", "::mlir::
     is present and non-empty but does not parse into an #sdy.op_sharding_rule,
     the pass fails with an error.
 
+    The promoted rule is always non-custom, even if the user wrote it as
+    `custom`. Shardy's is_custom_rule bit only exempts a rule from
+    removeShardingRules and makes InsertExplicitReshards skip the op;
+    it does not affect propagation. Keeping it set would
+    therefore suppress the operand reshards a user rule needs. Instead, user
+    rules follow the same lifecycle as the built-in C++ rules: propagation
+    consumes and then strips the attribute, and RegisterCustomShardingRulePass
+    recreates the rule on demand from the frontend attribute through
+    ShardingRuleOpInterface from the "xla.sdy.custom_sharding_rule", so later
+    passes still see it.
+
     This pass is intended to run before any Shardy sharding propagation passes.
   }];
 

--- a/include/ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h
@@ -14,6 +14,9 @@ namespace mlir::tt::sharding_utils {
 // SDY sharding related string definitions.
 inline constexpr llvm::StringRef kXlaSdyShardingAttr = "xla.sdy.sharding";
 inline constexpr llvm::StringRef kXlaSdyMeshesAttr = "xla.sdy.meshes";
+// NOTE: This attribute is used to store custom user-provided sharding rules.
+// and used for rematerializing sharding rules after shardy drops them.
+// Do not delete this attribute until after shardy has finished.
 inline constexpr llvm::StringRef kXlaSdyCustomShardingRuleAttr =
     "xla.sdy.custom_sharding_rule";
 inline constexpr llvm::StringRef kDefaultMeshName = "mesh";

--- a/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
@@ -218,6 +218,23 @@ std::optional<mlir::DenseElementsAttr> tryGetPeriodicShardSlice(
 // Check if the operation has Shardy-sharded inputs or outputs.
 bool opHasShardySharding(mlir::Operation *op);
 
+// Return the serialized user-provided sharding rule carried by `op` in its
+// "xla.sdy.custom_sharding_rule" frontend attribute, or an empty StringRef if
+// the op carries no rule. An attribute that is present but empty (or
+// whitespace-only) counts as no rule, so the op falls back to Shardy's default
+// handling rather than being treated as malformed.
+llvm::StringRef getUserShardingRuleStr(mlir::Operation *op);
+
+// Parse `ruleStr` into an OpShardingRuleAttr, returning a null attribute if it
+// does not parse.
+//
+// NOTE: The "is_custom_rule" bit is always set to false on the result. By
+// setting it to false it can be dropped by sdy-user-priority-propagate and
+// rematerialized later, through ShardingRuleOpInterface, by
+// insert-explicit-reshards.
+mlir::sdy::OpShardingRuleAttr parseUserShardingRule(llvm::StringRef ruleStr,
+                                                    mlir::MLIRContext *context);
+
 #endif // #ifdef TTMLIR_ENABLE_STABLEHLO
 
 } // namespace mlir::tt::shardy_utils

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -10003,6 +10003,12 @@ namespace {
 // `mhlo.frontend_attributes` onto the op so it survives the TTIR pipeline
 // (in particular Shardy / shape refinement on adjacent ops) with the right
 // number of typed operands and results.
+//
+// The SHLO custom_call is functional: operands are the "in"-tagged tensors
+// only (so Shardy can refine result types without a DPS init mismatch).
+// TTIR requires destination-passing style (`arg_roles == in* out+`), so this
+// pattern reintroduces one `ttir.empty` per result — typed from the
+// *post-Shardy* result — as the trailing DPS init operands.
 class StableHLOTTLangOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
   using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
@@ -10017,11 +10023,9 @@ public:
       return failure();
     }
 
-    if (adaptor.getOperands().empty() || srcOp.getResults().empty()) {
+    if (srcOp.getResults().empty()) {
       return rewriter.notifyMatchFailure(
-          srcOp,
-          "tt.tt_lang_op custom call must have at least one operand and one "
-          "result.");
+          srcOp, "tt.tt_lang_op custom call must have at least one result.");
     }
 
     mlir::DictionaryAttr frontendAttributes =
@@ -10072,8 +10076,65 @@ public:
       resultTypes.push_back(converted);
     }
 
+    // Parse logical DPS roles. SHLO is functional: operands must be exactly
+    // the "in"-tagged tensors. DPS "out" buffers are synthesized below from
+    // post-Shardy result types.
+    SmallVector<StringRef> roleTokens;
+    argRolesAttr.getValue().split(roleTokens, ',');
+    size_t inCount = 0;
+    size_t outCount = 0;
+    for (StringRef token : roleTokens) {
+      StringRef trimmed = token.trim();
+      if (trimmed == "in") {
+        ++inCount;
+      } else if (trimmed == "out") {
+        ++outCount;
+      } else {
+        return rewriter.notifyMatchFailure(
+            srcOp, "tt.tt_lang_op `arg_roles` token must be \"in\" or \"out\".");
+      }
+    }
+    if (outCount == 0 || outCount != resultTypes.size()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "tt.tt_lang_op number of \"out\" roles must be non-zero and "
+                 "match number of results.");
+    }
+
+    auto shloOperands = adaptor.getOperands();
+    if (shloOperands.size() == inCount + outCount) {
+      return rewriter.notifyMatchFailure(
+          srcOp,
+          "tt.tt_lang_op legacy DPS-on-SHLO form is not supported: custom "
+          "call operands must be the \"in\" tensors only (#operands == "
+          "#in); DPS \"out\" inits are synthesized during conversion.");
+    }
+    if (shloOperands.size() != inCount) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "tt.tt_lang_op operand count must equal number of \"in\" "
+                 "roles in `arg_roles`.");
+    }
+    if (inCount == 0) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "tt.tt_lang_op requires at least one \"in\" role; pure-out "
+                 "kernels are not supported on the functional SHLO path.");
+    }
+
+    SmallVector<Value> ttirOperands;
+    ttirOperands.append(shloOperands.begin(), shloOperands.end());
+    for (Type resultType : resultTypes) {
+      auto ranked = dyn_cast<RankedTensorType>(resultType);
+      if (!ranked) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "tt.tt_lang_op result must be a ranked tensor to "
+                   "synthesize a DPS init.");
+      }
+      ttirOperands.push_back(rewriter.create<ttir::EmptyOp>(
+          srcOp.getLoc(), ranked.getShape(), ranked.getElementType(),
+          ranked.getEncoding()));
+    }
+
     rewriter.replaceOpWithNewOp<ttir::TTLangOp>(srcOp, resultTypes,
-                                                adaptor.getOperands(),
+                                                ttirOperands,
                                                 /*kernel_id=*/kernelIdAttr,
                                                 /*version_tag=*/versionTagAttr,
                                                 /*arg_roles=*/argRolesAttr,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -10091,7 +10091,8 @@ public:
         ++outCount;
       } else {
         return rewriter.notifyMatchFailure(
-            srcOp, "tt.tt_lang_op `arg_roles` token must be \"in\" or \"out\".");
+            srcOp,
+            "tt.tt_lang_op `arg_roles` token must be \"in\" or \"out\".");
       }
     }
     if (outCount == 0 || outCount != resultTypes.size()) {

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -6,6 +6,7 @@
 #include "shardy/dialect/sdy/transforms/propagation/op_sharding_rule_builder.h"
 #include "stablehlo/dialect/StablehloOps.h"
 #include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
+#include "ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h"
 #include "ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
@@ -1811,6 +1812,21 @@ private:
     auto shardOpFunc = customCallShardingRules.lookup(target);
     if (shardOpFunc) {
       return shardOpFunc(op);
+    }
+
+    // Check if xla.sdy.custom_sharding_rule is present and parse it.
+    // ShardingRuleOpInterface is invoked whenever createOpShardingRule is
+    // called. Since shardy sometimes drop sharding rules and rematerializes it
+    // later, for example insert-explicit-reshards, we need a way to restore
+    // custom user-provided sharding rules.
+    if (llvm::StringRef ruleStr = shardy_utils::getUserShardingRuleStr(op);
+        !ruleStr.empty()) {
+      // The rule string was already validated by
+      // RegisterUserShardingRulePass, so a parse failure here is not possible.
+      if (auto rule =
+              shardy_utils::parseUserShardingRule(ruleStr, op.getContext())) {
+        return rule;
+      }
     }
 
     op.getOperation()->emitWarning()

--- a/lib/Dialect/StableHLO/Transforms/RegisterUserShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterUserShardingRule.cpp
@@ -10,6 +10,8 @@
 #include "ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h"
 
 #include "mlir/AsmParser/AsmParser.h"
+#include "ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h"
+
 #include "mlir/IR/BuiltinAttributes.h"
 
 namespace mlir::tt::stablehlo {
@@ -25,22 +27,14 @@ public:
 
   void runOnOperation() final {
     getOperation().walk([&](mlir::stablehlo::CustomCallOp op) {
-      auto frontendAttrs = op->getAttrOfType<mlir::DictionaryAttr>(
-          gspmd_utils::kFrontendAttributesAttr);
-      if (!frontendAttrs) {
+      // Absent, or present-but-empty, rule: the op has no custom rule and
+      // falls back to Shardy's default handling (replication).
+      llvm::StringRef ruleStr = shardy_utils::getUserShardingRuleStr(op);
+      if (ruleStr.empty()) {
         return;
       }
 
-      // If attribute is defined but empty, fall back to Shardy's default
-      // handling (replication)
-      auto ruleStrAttr = frontendAttrs.getAs<mlir::StringAttr>(
-          sharding_utils::kXlaSdyCustomShardingRuleAttr);
-      if (!ruleStrAttr || ruleStrAttr.getValue().trim().empty()) {
-        return;
-      }
-
-      auto rule = mlir::dyn_cast_or_null<mlir::sdy::OpShardingRuleAttr>(
-          mlir::parseAttribute(ruleStrAttr.getValue(), &getContext()));
+      auto rule = shardy_utils::parseUserShardingRule(ruleStr, &getContext());
       if (!rule) {
         op.emitError() << "failed to parse '"
                        << sharding_utils::kXlaSdyCustomShardingRuleAttr

--- a/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
+++ b/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
+#include "mlir/AsmParser/AsmParser.h"
 #include "mlir/IR/IRMapping.h"
 #include "llvm/Support/Error.h"
 
@@ -1238,6 +1239,40 @@ bool opHasShardySharding(mlir::Operation *op) {
   }
 
   return false;
+}
+
+llvm::StringRef getUserShardingRuleStr(mlir::Operation *op) {
+  auto frontendAttrs = op->getAttrOfType<mlir::DictionaryAttr>(
+      gspmd_utils::kFrontendAttributesAttr);
+  if (!frontendAttrs) {
+    return {};
+  }
+
+  auto ruleStrAttr = frontendAttrs.getAs<mlir::StringAttr>(
+      sharding_utils::kXlaSdyCustomShardingRuleAttr);
+  if (!ruleStrAttr) {
+    return {};
+  }
+
+  llvm::StringRef ruleStr = ruleStrAttr.getValue().trim();
+  return ruleStr.empty() ? llvm::StringRef() : ruleStr;
+}
+
+mlir::sdy::OpShardingRuleAttr
+parseUserShardingRule(llvm::StringRef ruleStr, mlir::MLIRContext *context) {
+  auto rule = mlir::dyn_cast_or_null<mlir::sdy::OpShardingRuleAttr>(
+      mlir::parseAttribute(ruleStr, context));
+  if (!rule || !rule.isCustom()) {
+    return rule;
+  }
+
+  // Rebuild through the builder that omits `is_custom_rule`, which defaults it
+  // to false.
+  return mlir::sdy::OpShardingRuleAttr::get(
+      context, rule.getFactorSizes(), rule.getOperandMappings(),
+      rule.getResultMappings(), rule.getReductionFactors(),
+      rule.getNeedReplicationFactors(), rule.getPermutationFactors(),
+      rule.getBlockedPropagationFactors());
 }
 
 #endif // #ifdef TTMLIR_ENABLE_STABLEHLO

--- a/test/ttmlir/Conversion/StableHLOToTTIR/tt_lang_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/tt_lang_op.mlir
@@ -2,81 +2,83 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// Verifies that `stablehlo.custom_call @tt.tt_lang_op` is lowered to
-// `ttir.tt_lang_op`, with all four metadata attributes (`kernel_id`,
-// `version_tag`, `arg_roles`, `shard_spec`) lifted from
-// `mhlo.frontend_attributes` onto the new op, and that operand / result
-// types are preserved verbatim.
+// Verifies that a *functional* `stablehlo.custom_call @tt.tt_lang_op`
+// (operands = "in" tensors only) is lowered to DPS `ttir.tt_lang_op`, with
+// one `ttir.empty` synthesized per result as the trailing DPS init, and
+// that metadata (`kernel_id`, `version_tag`, `arg_roles`, `shard_spec`) is
+// lifted from `mhlo.frontend_attributes` onto the new op.
+//
+// Legacy DPS-on-SHLO (outs as custom_call operands) is intentionally rejected
+// by the conversion pattern and is not covered here.
 
 module {
-  // One `in` operand + one `out` operand (pre-allocated buffer) -> one result.
-  // No shard spec.
+  // Functional SHLO: one `in` operand -> one result. Conversion synthesizes
+  // a matching `ttir.empty` DPS init from the result type.
   func.func @tt_lang_op_simple(
-      %arg0: tensor<1x32xf32>,
-      %arg1: tensor<1x32xf32>) -> tensor<1x32xf32> {
+      %arg0: tensor<1x32xf32>) -> tensor<1x32xf32> {
     // CHECK-LABEL: func.func @tt_lang_op_simple
-    // CHECK: ttir.tt_lang_op
+    // CHECK: %[[OUT:.*]] = ttir.empty() : tensor<1x32xf32>
+    // CHECK: ttir.tt_lang_op(%{{.*}}, %[[OUT]])
     // CHECK-SAME: arg_roles = "in,out"
     // CHECK-SAME: kernel_id = "pkg.softmax::v1"
     // CHECK-SAME: version_tag = "1.0"
     // shard_spec defaults to "" and is elided when empty.
     // CHECK-NOT: shard_spec
-    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
       api_version = 0 : i32,
       mhlo.frontend_attributes = {
         kernel_id = "pkg.softmax::v1",
         version_tag = "1.0",
         arg_roles = "in,out"
       }
-    } : (tensor<1x32xf32>, tensor<1x32xf32>) -> tensor<1x32xf32>
+    } : (tensor<1x32xf32>) -> tensor<1x32xf32>
     return %0 : tensor<1x32xf32>
   }
 
-  // Two inputs (one tagged `out`), one output, with shard_spec set.
+  // Same functional shape with shard_spec set.
   func.func @tt_lang_op_with_shard_spec(
-      %arg0: tensor<8x16xbf16>,
-      %arg1: tensor<8x16xbf16>) -> tensor<8x16xbf16> {
+      %arg0: tensor<8x16xbf16>) -> tensor<8x16xbf16> {
     // CHECK-LABEL: func.func @tt_lang_op_with_shard_spec
-    // CHECK: ttir.tt_lang_op
+    // CHECK: %[[OUT:.*]] = ttir.empty() : tensor<8x16xbf16>
+    // CHECK: ttir.tt_lang_op(%{{.*}}, %[[OUT]])
     // CHECK-SAME: arg_roles = "in,out"
     // CHECK-SAME: kernel_id = "pkg.fused_add::v2"
     // CHECK-SAME: shard_spec = "{\22axis\22:0}"
     // CHECK-SAME: version_tag = "2.1"
-    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
       api_version = 0 : i32,
       mhlo.frontend_attributes = {
         kernel_id = "pkg.fused_add::v2",
         version_tag = "2.1",
         arg_roles = "in,out",
-        shard_spec = "{\22axis\22:0}"
+        shard_spec = "{\"axis\":0}"
       }
-    } : (tensor<8x16xbf16>, tensor<8x16xbf16>) -> tensor<8x16xbf16>
+    } : (tensor<8x16xbf16>) -> tensor<8x16xbf16>
     return %0 : tensor<8x16xbf16>
   }
 
-  // Multi-output kernel: three operands (two `in`, one `out`) plus a second
-  // result that the kernel writes to. The number of `out` tokens in
-  // `arg_roles` matches the number of stablehlo results.
+  // Multi-output: two functional `in` operands, two results. Conversion
+  // synthesizes one `ttir.empty` per result; `arg_roles` still lists the
+  // logical DPS outs.
   func.func @tt_lang_op_multi_out(
       %arg0: tensor<4x4xf32>,
-      %arg1: tensor<4x4xf32>,
-      %arg2: tensor<4x4xf32>,
-      %arg3: tensor<4xf32>)
+      %arg1: tensor<4x4xf32>)
       -> (tensor<4x4xf32>, tensor<4xf32>) {
     // CHECK-LABEL: func.func @tt_lang_op_multi_out
-    // CHECK: ttir.tt_lang_op
+    // CHECK: %[[OUT0:.*]] = ttir.empty() : tensor<4x4xf32>
+    // CHECK: %[[OUT1:.*]] = ttir.empty() : tensor<4xf32>
+    // CHECK: ttir.tt_lang_op(%{{.*}}, %{{.*}}, %[[OUT0]], %[[OUT1]])
     // CHECK-SAME: arg_roles = "in,in,out,out"
     // CHECK-SAME: kernel_id = "pkg.dual_out::v1"
     // CHECK-SAME: version_tag = "1.0"
-    %0:2 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1, %arg2, %arg3) {
+    %0:2 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
       api_version = 0 : i32,
       mhlo.frontend_attributes = {
         kernel_id = "pkg.dual_out::v1",
         version_tag = "1.0",
         arg_roles = "in,in,out,out"
       }
-    } : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4xf32>)
-        -> (tensor<4x4xf32>, tensor<4xf32>)
+    } : (tensor<4x4xf32>, tensor<4x4xf32>) -> (tensor<4x4xf32>, tensor<4xf32>)
     return %0#0, %0#1 : tensor<4x4xf32>, tensor<4xf32>
   }
 }

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/tt_lang_custom_rule.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/tt_lang_custom_rule.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-pipeline -o %t.mlir %s 2>%t.err
 // RUN: FileCheck %s --input-file=%t.mlir
+// RUN: FileCheck %s --check-prefix=NORULE --input-file=%t.mlir
 // RUN: FileCheck %s --check-prefix=ERR --input-file=%t.err
 
 // End-to-end coverage for user-provided `xla.sdy.custom_sharding_rule` rules on a
@@ -18,6 +19,12 @@
 // `tt.tt_lang_op` has no built-in sharding rule, so the custom rule is the only
 // thing that can shard the result: the sharded (4x16) result in @with_rule is
 // what makes the test discriminating.
+//
+// The promoted rule is normalized to non-custom, so propagation strips it from
+// the IR exactly like it strips the built-in rules. Nothing should carry an
+// sdy.sharding_rule attribute into the final output; the rule is instead
+// recreated on demand from the frontend attribute via ShardingRuleOpInterface.
+// NORULE-NOT: sdy.sharding_rule =
 
 sdy.mesh @mesh = <["x"=2]>
 
@@ -30,10 +37,8 @@ sdy.mesh @mesh = <["x"=2]>
 // CHECK: sdy.manual_computation(%arg0, %arg1)
 // CHECK-SAME: in_shardings=[<@mesh, [{"x"}, {}]>, <@mesh, [{"x"}, {}]>]
 // CHECK-SAME: out_shardings=[<@mesh, [{"x"}, {}]>]
-// ...the string rule was parsed into a typed, reprinted sdy.op_sharding_rule...
-// CHECK: stablehlo.custom_call @tt.tt_lang_op
-// CHECK-SAME: sdy.sharding_rule = #sdy.op_sharding_rule<([i, j], [i, j])->([i, j]) {i=8, j=16}, custom>
 // ...and UpdateGlobalToLocalShapes halves dim 0 (8 -> 4) on operands AND result.
+// CHECK: stablehlo.custom_call @tt.tt_lang_op
 // CHECK-SAME: (tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
 // CHECK: sdy.return %{{.*}} : tensor<4x16xf32>
 func.func @with_rule(

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/tt_lang_custom_rule_reshard.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/tt_lang_custom_rule_reshard.mlir
@@ -1,0 +1,73 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --register-custom-sharding-rule --register-user-sharding-rule \
+// RUN:   --sdy-user-priority-propagate --insert-explicit-reshards \
+// RUN:   -split-input-file -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// A user-provided rule must make operand alignment work the same way a built-in
+// C++ rule (e.g. RMSNorm's) does: when propagation gives the result a sharding
+// that an operand does not have, InsertExplicitReshards has to insert an
+// sdy.reshard on that operand.
+//
+// That only happens if the rule is still reachable *after* propagation, which
+// requires two things working together:
+//
+//   1. The rule is non-custom. Shardy's removeShardingRules strips non-custom
+//      rules at the end of propagation, and InsertExplicitReshards bails out on
+//      rules that are custom (b/434668939). So a rule kept custom would survive
+//      the strip but then be skipped, and never produce a reshard.
+//
+//   2. Once stripped, the rule can be recreated. getOrCreateShardingRule falls
+//      back to ShardingRuleOpInterface, which re-parses the frontend attribute
+//      for targets with no built-in rule.
+
+sdy.mesh @mesh = <["x"=2]>
+
+// %arg0 is sharded on dim 0 and %arg1 is explicitly replicated. The rule makes
+// dim 0 a shared factor, so the result picks up "x" from %arg0 and %arg1 has to
+// be resharded to match.
+//
+// CHECK-LABEL: func.func @operand_needs_reshard
+// CHECK: %[[RESHARD:.*]] = sdy.reshard %arg1 <@mesh, [{"x"}, {}]>
+// CHECK: stablehlo.custom_call @tt.tt_lang_op(%arg0, %[[RESHARD]])
+// CHECK-SAME: sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{"x", ?}, {?}]>]>
+func.func @operand_needs_reshard(
+    %arg0: tensor<512x64xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>},
+    %arg1: tensor<512x64xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>})
+    -> tensor<512x64xf32> {
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      arg_roles = "in,in,out",
+      "xla.sdy.custom_sharding_rule" = "#sdy.op_sharding_rule<([i, j], [i, j]) -> ([i, j]) {i=512, j=64}>"
+    }
+  } : (tensor<512x64xf32>, tensor<512x64xf32>) -> tensor<512x64xf32>
+  return %0 : tensor<512x64xf32>
+}
+
+// -----
+
+sdy.mesh @mesh = <["x"=2]>
+
+// Same graph, but the user wrote the rule as `custom`. The promote pass
+// normalizes that away, so the reshard is still inserted. Without the
+// normalization the rule would stay on the op and be skipped, silently leaving
+// %arg1 unaligned with the sharded result.
+//
+// CHECK-LABEL: func.func @custom_flag_is_normalized_away
+// CHECK: sdy.reshard %arg1 <@mesh, [{"x"}, {}]>
+// The normalized rule is non-custom, so propagation strips it.
+// CHECK-NOT: sdy.sharding_rule =
+func.func @custom_flag_is_normalized_away(
+    %arg0: tensor<512x64xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>},
+    %arg1: tensor<512x64xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>})
+    -> tensor<512x64xf32> {
+  %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+    api_version = 0 : i32,
+    mhlo.frontend_attributes = {
+      arg_roles = "in,in,out",
+      "xla.sdy.custom_sharding_rule" = "#sdy.op_sharding_rule<([i, j], [i, j]) -> ([i, j]) {i=512, j=64}, custom>"
+    }
+  } : (tensor<512x64xf32>, tensor<512x64xf32>) -> tensor<512x64xf32>
+  return %0 : tensor<512x64xf32>
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4708)

### Problem description
This PR bundles two related pieces of TT-Lang/Shardy work:

1. **DPS vs. functional TT-Lang ops.** The definition of TT-Lang ops in XLA was changed to be functional instead of DPS, because Shardy does not keep the output operand and the function result consistent during propagation.
2. **Custom sharding rules were skipped by `InsertExplicitReshards`.** A user-provided `xla.sdy.custom_sharding_rule`, once promoted to the `sdy.sharding_rule` op attribute, was kept marked `custom` so it would survive Shardy's `removeShardingRules` at the end of propagation. But Shardy's `InsertExplicitReshards` pass unconditionally skips any op whose rule is `custom` (`TODO(b/434668939)`), so an operand whose sharding didn't match the propagated result sharding was silently left unaligned instead of getting an `sdy.reshard`.

### What's changed
1. Turns the functional definition of TT-Lang ops back into DPS style by adding back output operands that adhere to the `arg_roles` attribute (`StableHLOToTTIRPatterns.cpp`).
2. Normalizes promoted user sharding rules to non-custom (`is_custom_rule=false`) so they follow the same propagate-then-strip-then-recreate lifecycle as the built-in C++ rules:
   - `RegisterUserShardingRulePass` clears the `custom` flag when promoting `xla.sdy.custom_sharding_rule` to the `sdy.sharding_rule` op attribute.
   - `RegisterCustomShardingRule`'s `ShardingRuleOpInterface` fallback re-parses `xla.sdy.custom_sharding_rule` to recreate the rule after propagation strips it, so `InsertExplicitReshards` (and any other post-propagation consumer) can see and act on it again.

### Checklist
- [x] New/Existing tests provide coverage for changes
