### PR TITLE
[StableHLOToTTIR] Restrict conv1d routing to single-degenerate 2D convs

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -1925,17 +1925,24 @@ private:
     auto kernelSpatialDims = dn.getKernelSpatialDimensions();
     auto outputSpatialDims = dn.getOutputSpatialDimensions();
 
-    // Find the degenerate spatial index (input and kernel extent both 1).
+    // A framework conv1d lowered to 2D has exactly one size-1 spatial dim; the
+    // other carries the sequence. Count them to distinguish that from a genuine
+    // pointwise 2D conv (both dims size-1, e.g. a 1x1 conv on a [N,C,1,1]
+    // squeeze-excite tensor), which has no 1D axis and must stay conv2d --
+    // rerouting it would needlessly host-move the weight and break trace hoist.
     int degIdx = -1;
+    int numDegenerate = 0;
     for (int i = 0; i < static_cast<int>(NUM_SPATIAL_DIMS); ++i) {
       if (inputType.getShape()[inputSpatialDims[i]] == 1 &&
           weightType.getShape()[kernelSpatialDims[i]] == 1) {
-        degIdx = i;
-        break;
+        if (degIdx < 0) {
+          degIdx = i;
+        }
+        ++numDegenerate;
       }
     }
-    if (degIdx < 0) {
-      return Value(); // genuine 2D conv.
+    if (degIdx < 0 || numDegenerate == static_cast<int>(NUM_SPATIAL_DIMS)) {
+      return Value(); // no 1D axis, or genuinely pointwise 2D -> keep conv2d.
     }
     int realIdx = 1 - degIdx; // the other of the two spatial dims.
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/convolution_decomposition.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/convolution_decomposition.mlir
@@ -74,4 +74,26 @@ module @test_convolution {
       } : (tensor<1x8x1x20xbf16>, tensor<8x1x1x4xbf16>) -> tensor<1x8x1x23xbf16>
     return %0 : tensor<1x8x1x23xbf16>
   }
+
+  // Test a genuine 2D pointwise (1x1) conv on a [N,C,1,1] tensor, as produced
+  // by the squeeze-and-excitation blocks in EfficientNet/VovNet (a global
+  // average pool feeding a 1x1 conv). BOTH spatial dims are size 1, so there
+  // is no real 1D axis; it must stay a conv2d and NOT be routed to conv1d
+  // (which would move the weight parameter to host and break trace hoisting,
+  // tt-mlir #9076).
+  func.func @test_pointwise_2d_not_conv1d(%arg0: tensor<1x8x1x1xbf16>, %arg1: tensor<16x8x1x1xbf16>) -> tensor<1x16x1x1xbf16> {
+    // CHECK-LABEL: @test_pointwise_2d_not_conv1d
+    // CHECK: "ttir.conv2d"
+    // CHECK-NOT: "ttir.conv1d"
+    %0 = stablehlo.convolution(%arg0, %arg1)
+      dim_numbers = [b, f, 0, 1]x[o, i, 0, 1]->[b, f, 0, 1],
+      window = {
+        stride = [1, 1],
+        pad = [[0, 0], [0, 0]]
+      } {
+        feature_group_count = 1 : i64,
+        batch_group_count = 1 : i64
+      } : (tensor<1x8x1x1xbf16>, tensor<16x8x1x1xbf16>) -> tensor<1x16x1x1xbf16>
+    return %0 : tensor<1x16x1x1xbf16>
+  }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/convolution_decomposition.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/convolution_decomposition.mlir
@@ -75,12 +75,9 @@ module @test_convolution {
     return %0 : tensor<1x8x1x23xbf16>
   }
 
-  // Test a genuine 2D pointwise (1x1) conv on a [N,C,1,1] tensor, as produced
-  // by the squeeze-and-excitation blocks in EfficientNet/VovNet (a global
-  // average pool feeding a 1x1 conv). BOTH spatial dims are size 1, so there
-  // is no real 1D axis; it must stay a conv2d and NOT be routed to conv1d
-  // (which would move the weight parameter to host and break trace hoisting,
-  // tt-mlir #9076).
+  // A genuine 2D pointwise (1x1) conv on a [N,C,1,1] tensor (both spatial dims
+  // size 1) must stay a conv2d and NOT be routed to conv1d. See
+  // https://github.com/tenstorrent/tt-mlir/issues/9076.
   func.func @test_pointwise_2d_not_conv1d(%arg0: tensor<1x8x1x1xbf16>, %arg1: tensor<16x8x1x1xbf16>) -> tensor<1x16x1x1xbf16> {
     // CHECK-LABEL: @test_pointwise_2d_not_conv1d
     // CHECK: "ttir.conv2d"


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/9076)

### Problem description
Fixes #9076. EfficientNet and VovNet started failing in nightly benchmarks (n150 + p150) after the MLIR uplift, at compile time:
```
error: Device-resident argument 50 must already be in device memory
ERR| Failed to run TTIRToTTNNCommon pipeline
```
The degenerate-2D→conv1d routing added in ff14c69 (tryEmitDegenerate2dAsConv1d) was meant to catch framework-lowered conv1ds  a 2D convolution with a single size-1 spatial dim. But it also matched genuine 2D pointwise convs where both spatial dims are size-1: the 1×1 conv on a [N,C,1,1] globally-pooled tensor in squeeze-and-excitation blocks (EfficientNet SqueezeExcite, VovNet EffectiveSEModule). Rerouting those to conv1d triggers the conv host-row-major weight workaround, which moves the weight  a device-resident parameter to host. Trace hoisting (enabled for benchmarks) then finds a parameter that's supposed to be on device sitting in host memory and aborts.
### What's changed

- tryEmitDegenerate2dAsConv1d now counts the degenerate spatial dims. A framework conv1d has exactly one (the other axis carries the sequence); when both are size-1 there is no 1D axis, so it's left as conv2d. Single-degenerate convs (e.g. the Qwen3.5 gated-delta depthwise conv1d) are unaffected.
- Added lit test @test_pointwise_2d_not_conv1d covering the [1,8,1,1]×[16,8,1,1] SE-block shape.

### Checklist
- [ ] New/Existing tests provide coverage for changes
