### PR TITLE
DecomposeCustomCallTuples: flatten tuple-returning custom_calls for Shardy

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/DecomposeCustomCallTuples.cpp
+++ b/lib/Dialect/StableHLO/Transforms/DecomposeCustomCallTuples.cpp
@@ -42,6 +42,49 @@ public:
         rewriter.eraseOp(op);
       }
     }
+
+    // Shardy propagation can't traverse tuple types, so flatten multi-output
+    // custom_calls (XLA encodes them as one tuple result) to multi-result form
+    // before it runs. Rewrite 1 misses these: the tuple is the custom_call's
+    // own result, not a separate stablehlo.tuple op.
+    SmallVector<mlir::stablehlo::CustomCallOp> tupleCustomCalls;
+    getOperation().walk([&](mlir::stablehlo::CustomCallOp op) {
+      if (op.getNumResults() != 1) {
+        return;
+      }
+      if (!isa<mlir::TupleType>(op.getResult(0).getType())) {
+        return;
+      }
+      // Only decompose when every use is a get_tuple_element; anything that
+      // consumes the tuple directly would need it rematerialized.
+      for (mlir::Operation *user : op.getResult(0).getUsers()) {
+        if (!isa<mlir::stablehlo::GetTupleElementOp>(user)) {
+          return;
+        }
+      }
+      tupleCustomCalls.push_back(op);
+    });
+
+    for (auto op : tupleCustomCalls) {
+      auto tupleType = cast<mlir::TupleType>(op.getResult(0).getType());
+      SmallVector<mlir::Type> newResultTypes(tupleType.begin(),
+                                             tupleType.end());
+
+      rewriter.setInsertionPoint(op);
+      mlir::OperationState state(op.getLoc(), op->getName().getStringRef());
+      state.addOperands(op->getOperands());
+      state.addTypes(newResultTypes);
+      state.addAttributes(op->getAttrs());
+      mlir::Operation *newOp = rewriter.create(state);
+
+      for (OpOperand &use :
+           llvm::make_early_inc_range(op.getResult(0).getUses())) {
+        auto getTupleOp =
+            cast<mlir::stablehlo::GetTupleElementOp>(use.getOwner());
+        rewriter.replaceOp(getTupleOp, newOp->getResult(getTupleOp.getIndex()));
+      }
+      rewriter.eraseOp(op);
+    }
   }
 };
 } // namespace mlir::tt::stablehlo


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/9082)

### Problem description
The DecomposeCustomCallTuples pass is documented to "convert tuple-returning custom_call ops to multi-result ops so that Shardy can propagate through them (Shardy does not support tuple types)." However, its implementation only handled explicit stablehlo.tuple construction ops it did not handle stablehlo.custom_call ops whose single result is itself a tuple<...>.

Multi-output custom calls (e.g. tt.all_to_all_dispatch, tt.moe_expert_token_remap) are encoded by XLA as a single tuple-typed result consumed via get_tuple_element. When Shardy propagation must traverse one e.g. in a monolithic sharded MoE graph where the op sits mid-graph among unannotated values compilation aborts:

```
error: Shardy propagation doesn't support tuples:
       'tuple<tensor<1x8x512x2048xbf16>, tensor<1x8x512x8xi64>>'
  at  stablehlo.custom_call @tt.all_to_all_dispatch(...) -> tuple<...>
```
This blocks sharded Mixture-of-Experts models that route through the expert-parallel dispatch/combine custom calls whenever propagation needs to cross those ops.

### What's changed

- Added a second rewrite to DecomposeCustomCallTuplesPass (lib/Dialect/StableHLO/Transforms/DecomposeCustomCallTuples.cpp): it walks every stablehlo.custom_call whose single result is a TupleType, rebuilds it as an equivalent multi-result custom_call (result types = the tuple's element types, operands and attributes preserved), and rewires each get_tuple_element user to the corresponding individual result, then erases the original op.
- Guarded: the rewrite only fires when every use of the tuple result is a get_tuple_element, so it can't leave a dangling tuple that something else consumes.

### Checklist
- [ ] New/Existing tests provide coverage for changes
