### PR TITLE
[TTNN] Add file-level doc comments to greedy optimizer passes

### DIFF
--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -2,6 +2,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// TTNNGreedyL1SpillManagement: the follow-up stage of the greedy memory-layout
+// optimizer that runs after layout propagation has assigned L1/DRAM layouts.
+// Its job is to enforce the per-core L1 memory budget: layout propagation may
+// have placed more tensors in L1 than physically fit at some point in the
+// schedule, so this pass walks each forward device function and, using a
+// farthest-last-use eviction strategy, spills L1 tensors back to DRAM until
+// every op re-validates within budget. The eviction and validation logic lives
+// in the L1SpillManagement analysis; this pass computes the budget, runs the
+// analysis per function, and propagates its result and failure state.
+//
+// Key inputs:
+//   - The ModuleOp IR; only forward device functions are processed.
+//   - The worker grid from the device description.
+//   - The usable L1 budget per core, derived from the chip descriptor's usable
+//     L1 size minus the reserved usage and tensor usage cap.
+//   - Backend op-constraint validation, which re-checks each op against the
+//     running L1 pressure; the pass is only functional when built with
+//     TTMLIR_ENABLE_OPMODEL.
+//   - Pass options enableDecisionTrace and decisionTraceDir.
+//
+// Key outputs (all mutations of the module in place):
+//   - ToMemoryConfigOp ops inserted after spilled ops to move tensors from L1
+//     to DRAM, with consuming uses reconnected to read the spilled tensor.
+//   - D2M subgraph function types re-synced to match dispatch operand types
+//     that changed to DRAM as a result of spilling.
+//   - A pass failure signalled (and the module walk interrupted) when the
+//     analysis reports an unrecoverable condition.
+//   - Optionally, spill-management data merged into the decision-trace JSON
+//     produced earlier by layout propagation.
+
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
@@ -2,6 +2,45 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// TTNNGreedyMemoryLayoutPropagation: the first stage of the greedy
+// memory-layout optimizer. Its job is to choose a concrete memory layout
+// (buffer type and memory space: DRAM vs. L1, interleaved vs. sharded, tile
+// vs. row-major) for the output of every tensor-producing op in each forward
+// device function, propagating those choices across data-dependency edges so
+// that producer/consumer layouts agree and inserting reshards where they must
+// differ. The actual edge-based search (greedy when beam width is 1, beam
+// search when it is larger) lives in the MemoryLayoutPropagation analysis;
+// this pass wires up its inputs, runs it per function, and applies the result
+// to the IR.
+//
+// Key inputs:
+//   - The ModuleOp IR; only functions identified as forward device functions
+//     are processed.
+//   - The worker grid queried from the system/device description.
+//   - A chain of analyses that build the space of legal per-op configurations:
+//     ScalarDataTypeAnalysis (scalar types in use), LegalTensorLayoutAnalysis
+//     (all legal layouts per tensor type), and per-op LegalOpLayoutAnalysis and
+//     LegalOpConfigAnalysis (legal OpConfigs, including Conv2d/Conv3d configs).
+//   - Pass options controlling the search and the candidate space:
+//     maxLegalLayouts, rowMajorEnabled, beamWidth, maxInputCandidatesPerOperand,
+//     maxReshardCandidatesPerType, enableL1ShardingLayouts, the
+//     overrideOutputLayout / overrideConv2dConfig / overrideConv3dConfig
+//     override maps, and the enableDecisionTrace / enableCompileTimeStats
+//     diagnostics toggles.
+//   - Backend op-model validation, which scores candidate layouts; the pass is
+//     only functional when built with TTMLIR_ENABLE_OPMODEL.
+//
+// Key outputs (all mutations of the module in place):
+//   - A final output layout assigned to each processed op, applied to the IR by
+//     the propagation analysis.
+//   - Reshard ops inserted on operand edges where a consumer's chosen input
+//     layout differs from the producer's output layout.
+//   - Default L1Full slice config applied to Conv2d ops prior to validation.
+//   - D2M subgraph function types re-synced to match dispatch operand types
+//     that changed as a result of reshard insertion.
+//   - Optionally, a decision-trace JSON per function or compile-time statistics
+//     at DEBUG level (the two are mutually exclusive; decision trace wins).
+
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"


### PR DESCRIPTION
## Summary
Adds file-level doc comment blocks to the two main source files of the greedy
memory-layout optimizer, documenting each pass's **purpose**, **key inputs**,
and **key outputs**. This is a **comments-only** change — no behavioral,
include, or formatting changes.

- `GreedyMemoryLayoutPropagation.cpp` — the first optimizer stage: chooses a
  concrete memory layout (DRAM/L1, interleaved/sharded, tile/row-major) for
  every tensor-producing op output in each forward device function via greedy
  or beam search, propagating choices across data-dependency edges and
  inserting reshards where operand layouts differ. Documents the analysis
  chain it drives (ScalarDataType, LegalTensorLayout, LegalOpLayout,
  LegalOpConfig), the pass options, OpModel dependency, and the IR mutations it
  applies (assigned layouts, reshards, Conv slice config, D2M func-type sync,
  optional decision-trace/compile-time-stats output).
- `GreedyL1SpillManagement.cpp` — the follow-up stage that enforces the
  per-core L1 budget after layout propagation using farthest-last-use eviction,
  spilling L1 tensors to DRAM. Documents the L1 budget derivation, OpModel
  validation dependency, options, and the IR mutations (inserted
  `ToMemoryConfigOp` L1→DRAM spills, reconnected uses, D2M func-type sync, pass
  failure signalling, decision-trace merge).

The comment blocks are placed after the SPDX license header and before the
first `#include`, following the project's LLVM comment style.

## Test plan
Comments-only change. Verified the two changed translation units compile
cleanly with an OpModel-enabled build (targeted `ninja` build of both
`GreedyMemoryLayoutPropagation.cpp.o` and `GreedyL1SpillManagement.cpp.o`,
exit 0). `git diff` confirms the change is purely added comment lines (69
insertions, 0 deletions, no code changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)