### PR TITLE
[TTNN] Make optimizer "Unsupported op type" diagnostic actionable

### DIFF
--- a/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
@@ -414,7 +414,13 @@ void LegalOpConfigAnalysis::fillOpSpecificAttrs() {
         }
       })
       .Default([](Operation *op) -> void {
-        op->emitError("Unsupported op type");
+        op->emitError()
+            << "LegalOpConfigAnalysis: no fillOpSpecificAttrs handler for op "
+               "type '"
+            << op->getName()
+            << "'; this op is not supported by the TTNN optimizer's "
+               "op-specific config generation. Add a TypeSwitch case for it in "
+               "LegalOpConfigAnalysis::fillOpSpecificAttrs().";
         llvm::llvm_unreachable_internal("Unsupported op type");
       });
 }


### PR DESCRIPTION
## Summary

Improves one vague diagnostic in the TTNN optimizer so it is actionable. **Text-only change — no behavioral change.**

## File changed
`lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp` — the `Default` case of `LegalOpConfigAnalysis::fillOpSpecificAttrs()`.

## Before → after

Before:
```cpp
op->emitError("Unsupported op type");
```

After:
```cpp
op->emitError()
    << "LegalOpConfigAnalysis: no fillOpSpecificAttrs handler for op "
       "type '"
    << op->getName()
    << "'; this op is not supported by the TTNN optimizer's "
       "op-specific config generation. Add a TypeSwitch case for it in "
       "LegalOpConfigAnalysis::fillOpSpecificAttrs().";
```

The new message states **what** (no handler for this op type), **which op** (interpolated `op->getName()`, already in scope), and **how to fix** (add a `TypeSwitch` case in `fillOpSpecificAttrs()`).

## No behavioral change
Only the diagnostic text changes. Same control flow (still the `Default` branch), same trigger condition, same severity (`emitError`), and the same subsequent `llvm::llvm_unreachable_internal("Unsupported op type")` is left untouched. The only added context is `op->getName()`, which was already available in scope.

## Build evidence
Configured and built the affected target in this worktree:

- Changed object compiled clean: `obj.MLIRTTNNAnalysis.dir/LegalOpConfigAnalysis.cpp.o`
- Full library built clean: `ninja -C build obj.MLIRTTNNAnalysis` → `[28/28]` with no errors/warnings.

No on-device execution was run; functional verification is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)