### PR TITLE
[TTNN] Fix performance-unnecessary-value-param in ShardSolver constructor

### DIFF
--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -70,7 +70,7 @@ ShardSolver::ShardSolver(
       legalConfigs(&legalConfigs), shardSpecs(&shardSpecs),
       shardedOps(&shardedOps), memReconfigEdges(overrideReshardEdges),
       overrideOutputLayout(overrideOutputLayout),
-      customCheckShardCompatible(customCheckShardCompatible) {
+      customCheckShardCompatible(std::move(customCheckShardCompatible)) {
   pathSets.reserve(shardSpecs.size());
   pathSetIds.reserve(shardSpecs.size());
   bitsets.reserve(shardedOps.size());


### PR DESCRIPTION
## What

Fixes one low-risk clang-tidy warning in the TTNN optimizer analysis code. No functional/behavioral change.

- **Warning:** `performance-unnecessary-value-param` (clang-tidy)
- **File changed:** `lib/Dialect/TTNN/Analysis/ShardSolver.cpp`

## Details

The `ShardSolver` constructor takes the `customCheckShardCompatible` `std::function` by value (which is the correct choice for the pass-by-value-and-move idiom) but then **copies** it into the member in the initializer list rather than moving it. The parameter is not used after member initialization, so the copy is unnecessary.

```diff
-      customCheckShardCompatible(customCheckShardCompatible) {
+      customCheckShardCompatible(std::move(customCheckShardCompatible)) {
```

`<utility>` is already directly included (line 36) and `std::move` is already used elsewhere in the file, so no new include is needed. Behavior is identical — the member ends up holding the same callable; it is moved rather than copied.

## Before / after evidence

Both from `clang-tidy -p build` (repo `.clang-tidy` builds the optimizer clean under `-Wall -Wextra -Wpedantic -Werror`; this finding surfaces under the broader `performance-*` check set).

**Before:**
```
lib/Dialect/TTNN/Analysis/ShardSolver.cpp:73:34: warning: parameter 'customCheckShardCompatible' is passed by value and only copied once; consider moving it to avoid unnecessary copies [performance-unnecessary-value-param]
```

**After** — re-running `clang-tidy --checks='-*,performance-unnecessary-value-param'` on the file reports no finding at `ShardSolver.cpp:73` (only an unrelated hit in `include/ttmlir/Utils.h` remains, out of scope).

**Build:** `ninja -C build MLIRTTNNAnalysis` succeeds cleanly (target compiles under `-Werror`, links `libMLIRTTNNAnalysis.a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)