### PR TITLE
[D2M] Recover flattened embedding index shape during lowering

### DIFF
--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -33,6 +33,7 @@
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
@@ -4094,6 +4095,97 @@ public:
   }
 };
 
+class ExpandFlattenedEmbeddingIndicesForD2M
+    : public OpRewritePattern<ttir::EmbeddingOp> {
+public:
+  using OpRewritePattern<ttir::EmbeddingOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttir::EmbeddingOp op,
+                                PatternRewriter &rewriter) const override {
+    RankedTensorType flattenedIndicesType = op.getInput().getType();
+    RankedTensorType flattenedResultType = op.getType();
+    if (!flattenedIndicesType.hasStaticShape() ||
+        flattenedIndicesType.getRank() != 1 ||
+        !flattenedResultType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(
+          op, "embedding indices are not a static rank-1 tensor");
+    }
+
+    auto findExpandedSource = [&](Value value, bool requireTypecast) -> Value {
+      while (auto reshape = value.getDefiningOp<ttir::ReshapeOp>()) {
+        value = reshape.getInput();
+        auto type = mlir::dyn_cast<RankedTensorType>(value.getType());
+        if (type && type.hasStaticShape() && type.getRank() == 2 &&
+            type.getNumElements() == flattenedIndicesType.getNumElements() &&
+            (!requireTypecast ||
+             value.getDefiningOp<ttir::TypecastOp>() != nullptr)) {
+          return value;
+        }
+      }
+      return {};
+    };
+
+    Value expandedIndices;
+    if (auto typecast = op.getInput().getDefiningOp<ttir::TypecastOp>()) {
+      Value expandedInput =
+          findExpandedSource(typecast.getInput(), /*requireTypecast=*/false);
+      if (!expandedInput) {
+        return rewriter.notifyMatchFailure(
+            op, "embedding typecast has no expanded reshape source");
+      }
+
+      auto expandedInputType =
+          mlir::cast<RankedTensorType>(expandedInput.getType());
+      auto expandedCastType = RankedTensorType::get(
+          expandedInputType.getShape(), flattenedIndicesType.getElementType(),
+          expandedInputType.getEncoding());
+      expandedIndices = rewriter.create<ttir::TypecastOp>(
+          typecast.getLoc(), expandedCastType, expandedInput,
+          typecast.getConservativeFolding());
+    } else {
+      expandedIndices =
+          findExpandedSource(op.getInput(), /*requireTypecast=*/true);
+      if (!expandedIndices ||
+          mlir::cast<RankedTensorType>(expandedIndices.getType())
+                  .getElementType() != flattenedIndicesType.getElementType()) {
+        return rewriter.notifyMatchFailure(
+            op, "embedding indices have no expanded typecast source");
+      }
+    }
+
+    RankedTensorType expandedIndicesType =
+        mlir::cast<RankedTensorType>(expandedIndices.getType());
+    RankedTensorType weightType = op.getWeight().getType();
+    SmallVector<int64_t> expandedResultShape(expandedIndicesType.getShape());
+    expandedResultShape.push_back(weightType.getShape().back());
+    auto expandedResultType = RankedTensorType::get(
+        expandedResultShape, flattenedResultType.getElementType(),
+        flattenedResultType.getEncoding());
+    Value expandedEmbedding = rewriter.create<ttir::EmbeddingOp>(
+        op.getLoc(), expandedResultType, expandedIndices, op.getWeight());
+
+    if (op->hasOneUse()) {
+      if (auto restoringReshape =
+              mlir::dyn_cast<ttir::ReshapeOp>(*op->getUsers().begin())) {
+        if (restoringReshape.getType().getShape() ==
+            expandedResultType.getShape()) {
+          rewriter.replaceOp(restoringReshape, expandedEmbedding);
+          rewriter.eraseOp(op);
+          return success();
+        }
+      }
+    }
+
+    SmallVector<int32_t> flattenedResultShape(
+        flattenedResultType.getShape().begin(),
+        flattenedResultType.getShape().end());
+    rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
+        op, flattenedResultType, expandedEmbedding,
+        rewriter.getI32ArrayAttr(flattenedResultShape));
+    return success();
+  }
+};
+
 class D2MEmbeddingOpRewriter : public OpConversionPattern<ttir::EmbeddingOp>,
                                D2MNamedRewriterCommon {
 public:
@@ -5958,6 +6050,23 @@ public:
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type t) { return t; });
+
+    SmallVector<Operation *> embeddingOps;
+    module.walk([&](ttir::EmbeddingOp op) {
+      embeddingOps.push_back(op.getOperation());
+    });
+
+    RewritePatternSet d2mNormalizationPatterns(ctx);
+    d2mNormalizationPatterns.add<ExpandFlattenedEmbeddingIndicesForD2M>(ctx);
+    FrozenRewritePatternSet frozenPatterns(std::move(d2mNormalizationPatterns));
+    GreedyRewriteConfig config;
+    config.setStrictness(GreedyRewriteStrictness::ExistingOps)
+        .enableFolding(false)
+        .enableConstantCSE(false);
+    if (failed(applyOpPatternsGreedily(embeddingOps, frozenPatterns, config))) {
+      signalPassFailure();
+      return;
+    }
 
     RewritePatternSet patterns(ctx);
     populateTTIRToD2MPatterns(ctx, patterns, typeConverter,

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -4097,8 +4097,7 @@ public:
 
 // Frontend legalization may flatten embedding indices even when surrounding
 // reshapes retain a rank-2 logical shape. D2M needs that shape to distribute
-// indices across both grid dimensions, so recover it here without changing the
-// shared TTIR canonical form used by other backends.
+// indices across both grid dimensions, so recover it before grid selection.
 class ExpandFlattenedEmbeddingIndicesForD2M
     : public OpRewritePattern<ttir::EmbeddingOp> {
 public:

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -4095,6 +4095,10 @@ public:
   }
 };
 
+// Frontend legalization may flatten embedding indices even when surrounding
+// reshapes retain a rank-2 logical shape. D2M needs that shape to distribute
+// indices across both grid dimensions, so recover it here without changing the
+// shared TTIR canonical form used by other backends.
 class ExpandFlattenedEmbeddingIndicesForD2M
     : public OpRewritePattern<ttir::EmbeddingOp> {
 public:
@@ -4125,6 +4129,8 @@ public:
       return {};
     };
 
+    // Frontends can place the index typecast before or after the flattening
+    // reshape, so recover the same logical shape from either ordering.
     Value expandedIndices;
     if (auto typecast = op.getInput().getDefiningOp<ttir::TypecastOp>()) {
       Value expandedInput =
@@ -6051,6 +6057,9 @@ public:
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type t) { return t; });
 
+    // Keep this normalization local to embeddings present at pass entry. A
+    // module-wide greedy walk can otherwise rewrite unrelated TTIR before
+    // dialect conversion.
     SmallVector<Operation *> embeddingOps;
     module.walk([&](ttir::EmbeddingOp op) {
       embeddingOps.push_back(op.getOperation());

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection_embedding.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection_embedding.mlir
@@ -54,4 +54,38 @@ module {
     %0 = "ttir.embedding"(%indices, %weight) : (tensor<1x4xi32>, tensor<16x16xf32>) -> tensor<1x4x16xf32>
     return %0 : tensor<1x4x16xf32>
   }
+
+  func.func @embedding_flatten_then_typecast_restore(
+      %indices: tensor<32x18xi64>,
+      %weight: tensor<128256x4096xbf16>) -> tensor<32x18x4096xbf16> {
+    // AFTER-LABEL: func.func @embedding_flatten_then_typecast_restore
+    // AFTER: %[[WEIGHT:.*]] = d2m.to_layout %arg1
+    // AFTER: %[[GENERIC:.*]] = d2m.generic
+    // AFTER-SAME: grid = #ttcore.grid<8x8
+    // AFTER: d2m.embedding
+    // AFTER-SAME: <576, 4096>
+    // AFTER-SAME: {indicesShape = array<i64: 32, 18>}
+    %0 = "ttir.reshape"(%indices) <{shape = [1 : i32, 32 : i32, 18 : i32]}> : (tensor<32x18xi64>) -> tensor<1x32x18xi64>
+    %1 = "ttir.reshape"(%0) <{shape = [576 : i32]}> : (tensor<1x32x18xi64>) -> tensor<576xi64>
+    %2 = "ttir.typecast"(%1) <{conservative_folding = true}> : (tensor<576xi64>) -> tensor<576xui32>
+    %3 = "ttir.embedding"(%2, %weight) : (tensor<576xui32>, tensor<128256x4096xbf16>) -> tensor<576x4096xbf16>
+    %4 = "ttir.reshape"(%3) <{shape = [32 : i32, 18 : i32, 4096 : i32]}> : (tensor<576x4096xbf16>) -> tensor<32x18x4096xbf16>
+    return %4 : tensor<32x18x4096xbf16>
+  }
+
+  func.func @embedding_typecast_then_flatten(
+      %indices: tensor<32x18xsi32>,
+      %weight: tensor<128256x4096xbf16>) -> tensor<576x4096xbf16> {
+    // AFTER-LABEL: func.func @embedding_typecast_then_flatten
+    // AFTER: %[[WEIGHT:.*]] = d2m.to_layout %arg1
+    // AFTER: %[[GENERIC:.*]] = d2m.generic
+    // AFTER-SAME: grid = #ttcore.grid<8x8
+    // AFTER: d2m.embedding
+    // AFTER-SAME: <576, 4096>
+    // AFTER-SAME: {indicesShape = array<i64: 32, 18>}
+    %0 = "ttir.typecast"(%indices) <{conservative_folding = false}> : (tensor<32x18xsi32>) -> tensor<32x18xui32>
+    %1 = "ttir.reshape"(%0) <{shape = [576 : i32]}> : (tensor<32x18xui32>) -> tensor<576xui32>
+    %2 = "ttir.embedding"(%1, %weight) : (tensor<576xui32>, tensor<128256x4096xbf16>) -> tensor<576x4096xbf16>
+    return %2 : tensor<576x4096xbf16>
+  }
 }


### PR DESCRIPTION
## Summary
- Recover rank-2 logical embedding indices only in the TTIR-to-D2M lowering path.
- Handle both flatten/typecast orderings while preserving the typecast folding policy.
- Eliminate the matching result restore reshape when possible.
- Scope greedy rewriting to existing embedding roots so unrelated TTIR is neither folded nor eliminated.
- Verify the Llama 3 8B `[32, 18]` index shape lowers with `indicesShape = [32, 18]` on an `8x8` grid.

This supersedes #9056 and keeps the transformation target-specific rather than changing shared TTIR canonicalization.

## Testing
- `llvm-lit -a test/ttmlir/Dialect/D2M/Transforms/grid_selection_embedding.mlir test/ttmlir/Conversion/TTIRToD2M/embedding_types.mlir test/ttmlir/Conversion/TTIRToD2M/alignments.mlir test/ttmlir/Conversion/TTIRToD2M/named_to_generic.mlir`
- `pre-commit run --all-files`
- Full `llvm-lit -sv build/test`: 1543 passed, 646 unsupported; the two remaining failures are StableHLO complex-conversion tests whose passes are not registered in this clean build configuration.