### PR TITLE
[optimizer] Stateful L1 spill: reuse recorded survivor placement in replayFrom (#9087)

### DIFF
--- a/docs/superpowers/plans/2026-07-21-stateful-spill-full-captured-state.md
+++ b/docs/superpowers/plans/2026-07-21-stateful-spill-full-captured-state.md
@@ -1,0 +1,312 @@
+# Stateful L1 Spill — Fully Leverage Captured State — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** On the stateful spill path, let the captured tt-metal allocator state
+answer fit/fragmentation/placement/CB-clash entirely; delete the address
+*simulator* and explicit fit/frag/CB reasoning; keep the `SumL1MemoryTracker`
+path byte-identical behind `use-mock-allocator-state=false`.
+
+**Architecture:** Extract `L1SpillManagementBase<MemoryTracker>` (shared sweep,
+IR-mutation, FLU, event-log framework, replay *driver*) with virtual hooks; two
+subclasses — `SumL1SpillManagement` (keeps the address simulator) and
+`StatefulL1SpillManagement` (op-query replay, no addresses). Slim
+`MockAllocatorL1Tracker` so it no longer inherits `SumL1MemoryTracker`.
+
+**Tech Stack:** C++17, MLIR/LLVM, tt-metalium mock-allocator experimental API,
+GoogleTest unit tests, CMake/Ninja.
+
+## Global Constraints
+
+- Build: `source env/activate && cmake --build build -- -j$(nproc)` (OpModel ON).
+- `cmake --build build` does NOT rebuild unittests — always rebuild the test
+  target explicitly (`--target L1SpillManagementTests`,
+  `--target L1SpillManagementMockAllocatorTests`, `--target ValidationTests`).
+- Do NOT pipe `source env/activate` (subshell loses exports).
+- LLVM code style; follow the surrounding file.
+- The `use-mock-allocator-state=false` (Sum) path MUST stay behavior-identical;
+  existing `L1SpillManagementTests` are the guard.
+- Mock-device unit tests are HW-free (open/close mock device in fixture SetUp).
+
+---
+
+## File structure
+
+- `include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h` — declares the two
+  trackers, `L1SpillManagementBase<T>` + virtual hooks, and the two subclasses.
+- `lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp` — definitions; base methods,
+  Sum subclass (address sim + fit/frag/CB), Stateful subclass (op-query replay).
+- `lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp` —
+  pass driver: instantiate `StatefulL1SpillManagement` / `SumL1SpillManagement`.
+- `test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp` — new
+  stateful eviction/replay tests.
+
+---
+
+### Task 1: Add virtual hook seams to the current class (no behavior change)
+
+Introduce the three primary hooks as `virtual` methods on the *current*
+`L1SpillManagement<MemoryTracker>` template, with bodies that call today's exact
+code. This is a pure seam: both instantiations still behave identically because
+the default hook bodies ARE the current inline logic lifted out of `run()`.
+
+**Files:**
+- Modify: `include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h`
+- Modify: `lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp`
+
+**Interfaces produced:**
+- `virtual uint64_t placeValidatedOutput(Operation *op, int64_t pos, ScheduleData &data, const op_constraint_validation::ValidationResult &result)` — returns L1 size to add (0 = demoted); default body = today's `ensureFitsL1(op,pos,data,result.cbPeakUsage,result.outputL1Usage)`.
+- `virtual void recoverFromOOM(Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet)` — default body = today's `handleOOM(...)` (rename the existing body into this hook; keep `handleOOM` deleted or as the Sum override in Task 3).
+- `virtual void commitAllocation(Value val, uint64_t perResultL1, ScheduleData &data)` — default body = today's per-result block inside `addResultsToLiveSet` (event-log push + snapshot + `willAliasSourceInL1`?addTensorAtAddress:addTensor + liveSet/liveValues insert).
+
+- [ ] **Step 1:** In `run()`, replace the inline `ensureFitsL1(...)` success-branch call with `placeValidatedOutput(op, pos, data, result)`; replace the `handleOOM(...)` call with `recoverFromOOM(...)`; rewrite the `addResultsToLiveSet` lambda body to loop calling `commitAllocation(val, perResultL1, data)`.
+- [ ] **Step 2:** Move the current `ensureFitsL1` success-path body into `placeValidatedOutput` (it calls `ensureFitsL1` internally — leave `ensureFitsL1` in place for now). Move the `handleOOM` body into `recoverFromOOM` (leave a thin `handleOOM` that forwards, or inline). Move the per-result commit block into `commitAllocation`.
+- [ ] **Step 3: Build.** Run `cmake --build build -- -j$(nproc)`. Expected: 0 errors.
+- [ ] **Step 4: Guard tests.** `cmake --build build --target L1SpillManagementTests L1SpillManagementMockAllocatorTests && ./build/test/unittests/Optimizer/L1SpillManagementTests && ./build/test/unittests/Optimizer/L1SpillManagementMockAllocatorTests`. Expected: all PASS (behavior unchanged — this is a pure seam).
+- [ ] **Step 5: Commit.** `git add -A && git commit -m "[optimizer] Introduce spill hook seams (no behavior change)"`
+
+---
+
+### Task 2: Rename to `L1SpillManagementBase`, add two subclasses (still both address-sim)
+
+Rename the template class to `L1SpillManagementBase<MemoryTracker>`. Create
+`SumL1SpillManagement : L1SpillManagementBase<SumL1MemoryTracker>` and
+`MockAllocatorSpillManagement : L1SpillManagementBase<MockAllocatorL1Tracker>`,
+both initially inheriting the default hooks (still address-sim; Mock tracker
+still inherits Sum tracker). Update explicit instantiations + pass driver. No
+behavior change yet — this only splits the type so Task 3/4 can diverge hooks.
+
+**Files:**
+- Modify: `include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h`
+- Modify: `lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp`
+- Modify: `lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp`
+
+**Interfaces produced:**
+- `template <typename MemoryTracker> class L1SpillManagementBase { ... };`
+- `class SumL1SpillManagement final : public L1SpillManagementBase<SumL1MemoryTracker> { using L1SpillManagementBase::L1SpillManagementBase; };`
+- `class MockAllocatorSpillManagement final : public L1SpillManagementBase<MockAllocatorL1Tracker> { using L1SpillManagementBase::L1SpillManagementBase; };`
+
+- [ ] **Step 1:** Rename `L1SpillManagement` → `L1SpillManagementBase` throughout `.h`/`.cpp` (class, ctor, all `L1SpillManagement<MemoryTracker>::` qualifiers). Make hooks and `run()`/`hasFailed()`/`getObserver()`/`getMemoryTracker()` accessible to subclasses (protected where needed).
+- [ ] **Step 2:** Add the two `final` subclasses in the `.h` inheriting the ctor. Replace the two `extern template class` lines with `extern template class L1SpillManagementBase<SumL1MemoryTracker>;` and `extern template class L1SpillManagementBase<MockAllocatorL1Tracker>;`. In `.cpp` update the explicit instantiations identically.
+- [ ] **Step 3:** In `GreedyL1SpillManagement.cpp`, change `L1SpillManagement<MockAllocatorL1Tracker>` → `MockAllocatorSpillManagement` and `L1SpillManagement<SumL1MemoryTracker>` → `SumL1SpillManagement`.
+- [ ] **Step 4: Build.** `cmake --build build -- -j$(nproc)`. Expected: 0 errors.
+- [ ] **Step 5: Guard tests.** Same two test binaries as Task 1 Step 4. Expected: all PASS.
+- [ ] **Step 6: Commit.** `git add -A && git commit -m "[optimizer] Split spill manager into base + Sum/Mock subclasses"`
+
+---
+
+### Task 3: Move address-sim + fit/frag/CB into `SumL1SpillManagement`
+
+Move the address-simulation-specific members and methods off the base into
+`SumL1SpillManagement`, so the base no longer references the address simulator.
+The base keeps: sweep, IR mutation, FLU, event log framework
+(`l1EventLog`/`campaignMin`/`allocEventIndex`/`insertEventIntoLog`/checkpoint
+map), and the `replayFrom`/`markEvictedAndRebuild`/`evictValue`/`evictUntil`
+*drivers* — but the per-event alloc/dealloc action and the "fits?" check become
+`virtual` hooks. Sum overrides them with the address-sim logic (moved verbatim).
+
+**Files:**
+- Modify: `include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h`
+- Modify: `lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp`
+
+**Interfaces produced (new virtual hooks on base, Sum overrides):**
+- `virtual bool replayFrom(size_t startIdx)` — base default asserts (must override); Sum override = current `replayFrom` body.
+- `virtual uint64_t placeValidatedOutput(...)` — Sum override = current `ensureFitsL1`-based body.
+- `virtual void recoverFromOOM(...)` — Sum override = current `handleOOM` body.
+- `virtual void commitAllocation(Value, uint64_t, ScheduleData &)` — Sum override = current block using `willAliasSourceInL1`/`addTensorAtAddress`/`addTensor` + snapshot push.
+
+- [ ] **Step 1:** Move these methods' declarations+definitions from base to `SumL1SpillManagement`: `ensureFitsL1`, `handleNoFit`, `handleFragmentation`, `wouldCBsOverlapTensors`, `evictForCBOverlap`, `evictForDramCBGrowth`, `willAliasSourceInL1`, and `replayFrom` (as the override). Keep `cbFragCushion` on Sum only. These use `SumL1MemoryTracker` address APIs (`wouldAllocateAt`, `allocateAddress`, `hasTensorAddress`), which are valid because `MockAllocatorL1Tracker` still inherits them for now.
+- [ ] **Step 2:** In the base, make `replayFrom`, `placeValidatedOutput`, `recoverFromOOM`, `commitAllocation` pure-virtual (`= 0`) or virtual-with-assert. `evictValue`/`markEvictedAndRebuild`/`evictUntil` stay on the base and call `replayFrom(...)` through the vtable.
+- [ ] **Step 3:** Give `SumL1SpillManagement` overrides of the four hooks whose bodies are the code moved/lifted in Task 1–2 (address-sim behavior). Verify `commitAllocation`'s event-log push (`allocEventIndex`/`addressSnapshots`/`l1EventLog`) stays in the base (shared) and only the tracker call (`addTensor`/`addTensorAtAddress`) is in the override — OR keep the whole block in Sum's override and have Stateful's override write its own event-log push. Choose: **event-log push stays in base `commitAllocation` non-virtual prologue; the tracker-add is the virtual part** (`virtual void trackAllocation(Value,uint64_t)`), so both paths share event logging. Adjust interfaces accordingly.
+- [ ] **Step 4: Build.** Expected: 0 errors. (`MockAllocatorSpillManagement` still uses Sum's overrides? No — subclasses don't share overrides. Temporarily give `MockAllocatorSpillManagement` the SAME overrides by having both subclasses inherit an intermediate `AddressSimSpillManagement<T>` that holds the address-sim overrides. Mock stays on address sim until Task 5.)
+- [ ] **Step 5: Guard tests.** Both binaries PASS (behavior unchanged for both paths).
+- [ ] **Step 6: Commit.** `git add -A && git commit -m "[optimizer] Move address-sim + fit/frag/CB into Sum path; base is address-agnostic"`
+
+---
+
+### Task 4: Slim `MockAllocatorL1Tracker` (stop inheriting `SumL1MemoryTracker`)
+
+Rewrite the tracker to hold only `liveRecords` + `pendingRecords` + record-level
+alias maps + a `RecordVec`-set `Snapshot`. Remove address-sim inheritance.
+
+**Files:**
+- Modify: `include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h`
+- Modify: `lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp`
+- Test: `test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp`
+
+**Interfaces produced:**
+```cpp
+struct MockAllocatorL1Tracker {
+  using RecordVec = llvm::SmallVector<op_model::OpModelAllocationRecord>;
+  llvm::DenseMap<Value, RecordVec> liveRecords;
+  mutable llvm::DenseMap<Operation *, RecordVec> pendingRecords;
+  llvm::DenseMap<Value, Value> aliasOf;          // aliaser -> canonical owner
+  llvm::DenseMap<Value, unsigned> aliasRefcount; // owner  -> # live aliasers (incl self)
+
+  SumL1MemoryTracker::BackendValidatorFn backendValidator; // keep test hook shape
+  void init(uint64_t l1BudgetPerCore);
+  op_constraint_validation::ValidationResult
+  validate(Operation *, llvm::ArrayRef<TTNNLayoutAttr>, const OpConfig &) const;
+  void addTensor(Value result, uint64_t l1SizePerCore);
+  void addTensorAlias(Value out, Value src);
+  void removeTensor(Value result);
+  void removeTensorFromSizes(Value result); // == removeTensor for records
+  bool hasTensor(Value result) const;
+  uint64_t getTensorSize(Value result) const; // sum of this value's record sizes
+  uint64_t getOccupiedL1() const;             // sum over liveRecords (dedup aliases)
+  struct Snapshot { llvm::DenseMap<Value, RecordVec> liveRecords;
+                    llvm::DenseMap<Value, Value> aliasOf;
+                    llvm::DenseMap<Value, unsigned> aliasRefcount; };
+  Snapshot takeSnapshot() const; void restoreSnapshot(const Snapshot &);
+};
+```
+- `validate()` flattens `liveRecords` into a single `RecordVec` (dedupe by canonical owner via `aliasOf`), calls the stateful path (backendValidator hook when set, else `op_constraint_validation::validateOperation(op, inputs, config, flatRecords, /*additionalL1=*/0)`), stashes `result.outputAllocations` into `pendingRecords[op]`.
+- `addTensor` moves `pendingRecords[op][result.getResultNumber()]` → `liveRecords[result]`; sets `aliasRefcount[result]=1`, `aliasOf[result]=result`.
+- `addTensorAlias(out, src)`: `Value owner = aliasOf.lookup(src)` (fallback `src`); `aliasOf[out]=owner`; `++aliasRefcount[owner]`; NO record for `out`.
+- `removeTensor(v)`: `Value owner=aliasOf[v]; if(--aliasRefcount[owner]==0){ liveRecords.erase(owner); aliasRefcount.erase(owner);} aliasOf.erase(v);` (if `v==owner` but refcount>0, keep the record under owner — handle owner death while aliasers live by leaving the record under `owner` key; since owner==v only when it is its own alias, and refcount tracks all, erasing the record only at 0 is correct as long as the record is stored under `owner`).
+
+- [ ] **Step 1: Write failing test** in `TestL1SpillManagementMockAllocator.cpp`:
+```cpp
+TEST_F(L1SpillMockAllocatorFixture, TrackerAliasRefcountKeepsBufferLive) {
+  MockAllocatorL1Tracker t;
+  t.init(kL1Budget);
+  // owner + one alias; buffer stays live until both die.
+  Value owner = /* mkValue(...) */; Value view = /* mkValue(...) */;
+  t.pendingRecords[owner.getDefiningOp()] = {rec(/*L1*/, 0, 2048)};
+  t.addTensor(owner, 2048);
+  t.addTensorAlias(view, owner);
+  EXPECT_EQ(t.getOccupiedL1(), 2048u);   // deduped, one buffer
+  t.removeTensor(owner);
+  EXPECT_EQ(t.getOccupiedL1(), 2048u);   // alias still holds it
+  t.removeTensor(view);
+  EXPECT_EQ(t.getOccupiedL1(), 0u);
+}
+```
+- [ ] **Step 2: Run, expect FAIL to compile** (`addTensorAlias`/new shape not present).
+- [ ] **Step 3:** Rewrite `MockAllocatorL1Tracker` to the interface above; delete its inheritance of `SumL1MemoryTracker` and the old `addTensorAtAddress`/base `Snapshot`.
+- [ ] **Step 4:** Build the tracker changes only enough to compile the test file will fail elsewhere (base still references address APIs on the Mock tracker via the intermediate `AddressSimSpillManagement`). That is fixed in Task 5. To keep Task 4 self-contained and green, gate: DO Task 5 in the same commit if the build cannot be green with Mock still on the address-sim intermediate. (See Task 5 note — Tasks 4 and 5 land together.)
+- [ ] **Step 5: Commit** with Task 5.
+
+---
+
+### Task 5: `StatefulL1SpillManagement` — op-query replay hooks
+
+Give the Mock path its own subclass with the stateful hooks; remove it from the
+address-sim intermediate. This is what makes the build green after Task 4.
+
+**Files:**
+- Modify: `include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h`
+- Modify: `lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp`
+- Modify: `lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp`
+
+**Interfaces produced:**
+- `class StatefulL1SpillManagement final : public L1SpillManagementBase<MockAllocatorL1Tracker>` overriding `placeValidatedOutput`, `recoverFromOOM`, `commitAllocation`'s `trackAllocation`, and `replayFrom`.
+
+Hook bodies:
+- `trackAllocation(val, size)`: if `willAliasView(val)` (see below) → `memoryTracker.addTensorAlias(val, val.getDefiningOp()->getOperand(0))`; else `memoryTracker.addTensor(val, size)`. `willAliasView(op)` = `isAliasingViewOp(defOp) && memoryTracker.liveRecords.count(defOp->getOperand(0)|owner)`.
+- `placeValidatedOutput(op,pos,data,result)`: return `result.outputL1Usage` unchanged (NO fit/frag/CB check). (The base still calls `commitAllocation` afterwards.)
+- `recoverFromOOM(...)`: the drop-and-replay loop:
+```cpp
+auto config = extractOpConfigFromIR(op);
+auto result = op_constraint_validation::ValidationResult::outOfMemoryError("");
+bool fits = evictUntil(pos, data, [&]{
+  auto inputs = utils::extractInputLayouts(op);
+  result = memoryTracker.validate(op, inputs, config);
+  return result.isSuccess();
+});
+if (compilationFailed) return;
+if (fits) {
+  uint64_t l1 = result.outputL1Usage;
+  if (data.schedule[pos] != op) return;   // reshard shifted op; sweep reprocesses
+  if (l1 > 0) { addResultsToLiveSet(l1); observer_->onLiveAdded(op,pos,l1,pos,memoryTracker.getOccupiedL1()); }
+} else { observer_->onSelfSpill(op,pos); demoteToDram(op); }
+```
+  (`evictUntil`/`evictValue`/`markEvictedAndRebuild` are the shared base drivers;
+  they call `replayFrom` through the vtable.)
+- `replayFrom(startIdx)` (stateful): restore the `RecordVec`-set checkpoint at
+  `startIdx`, then walk `[startIdx, end)`:
+```cpp
+memoryTracker.restoreSnapshot(checkpoints[startIdx]);  // RecordVec-set
+for (size_t i = startIdx; i < l1EventLog.size(); ++i) {
+  auto &e = l1EventLog[i];
+  if (e.skipped) continue;
+  if (e.kind == L1Event::kDealloc) { memoryTracker.removeTensor(e.tensor); continue; }
+  checkpoints[i] = memoryTracker.takeSnapshot();
+  Operation *defOp = e.tensor.getDefiningOp();
+  Value src = defOp ? defOp->getOperand(0) : Value();
+  if (defOp && isAliasingViewOp(defOp) && memoryTracker.hasTensor(src)) {
+    memoryTracker.addTensorAlias(e.tensor, src); continue;
+  }
+  auto inputs = utils::extractInputLayouts(defOp);
+  auto cfg = extractOpConfigFromIR(defOp);
+  auto r = memoryTracker.validate(defOp, inputs, cfg);   // re-query under new history
+  if (!r.isSuccess()) return false;                      // still-live op no longer fits
+  memoryTracker.addTensor(e.tensor, r.outputL1Usage);    // commit fresh record
+}
+return true;
+```
+  Note: the base's `addressSnapshots` map is renamed generically to
+  `checkpoints` of type `DenseMap<size_t, typename MemoryTracker::Snapshot>` (it
+  already is `MemoryTracker::Snapshot`), so no base change beyond the rename.
+
+- [ ] **Step 1: Write failing test** `EvictionRebuildsLiveSetByReplay` in `TestL1SpillManagementMockAllocator.cpp`: schedule three L1 ops A,B,C where A+B+C exceed budget and C's last use is nearest; drive `run()`; assert the farthest-use victim (A or B) is spilled to DRAM (a `ToMemoryConfigOp` appears) and the surviving live set re-validates clean (no `hasFailed()`).
+- [ ] **Step 2: Run, expect FAIL** (Mock path still address-sim / not compiling after Task 4).
+- [ ] **Step 3:** Add `StatefulL1SpillManagement` with the four overrides above; rename base `addressSnapshots` → `checkpoints`; point the pass driver's mock branch at `StatefulL1SpillManagement`; remove `MockAllocatorL1Tracker` from the address-sim intermediate so only `SumL1SpillManagement` uses it.
+- [ ] **Step 4: Build.** `cmake --build build -- -j$(nproc)`. Expected: 0 errors.
+- [ ] **Step 5: Run tests.** `cmake --build build --target L1SpillManagementTests L1SpillManagementMockAllocatorTests ValidationTests` then run all three binaries. Expected: Sum tests unchanged PASS; new + existing Mock tests PASS.
+- [ ] **Step 6: Commit.** `git add -A && git commit -m "[optimizer] Stateful spill path: op-query replay, drop address simulator"`
+
+---
+
+### Task 6: Edge-case tests — reshard-past-consumer, multi-result, view tripwire, ToLayout
+
+**Files:**
+- Test: `test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp`
+
+- [ ] **Step 1:** Add `ReshardPastConsumerDuringStatefulEviction` — a victim with a
+  past L1-requiring consumer; after eviction assert a reshard (`ToMemoryConfigOp`
+  back to L1) is inserted before that consumer AND the current op re-validates
+  clean; assert the reshard value is not a live record at the current op.
+- [ ] **Step 2:** Add `MultiResultOpPerResultRecords` — an op with two L1 results;
+  assert each result gets its own `liveRecords` entry sourced from
+  `output_allocations` (not an even split).
+- [ ] **Step 3:** Keep/port the existing `MockAllocatorViewTripwireTest` cases so
+  they run against the slimmed tracker (view op query returns aliased/zero
+  address; `isAliasingViewOp` keeps it off a fresh record; `getOccupiedL1`
+  unchanged by the view).
+- [ ] **Step 4:** Add `ToLayoutL1OutputNoRegression` — a `ToLayoutOp` with L1
+  output followed by its consumer; assert `run()` does not fail and the consumer
+  validates (OOM, if any, surfaces at the consumer, not the ToLayoutOp).
+- [ ] **Step 5: Run** `L1SpillManagementMockAllocatorTests`. Expected: all PASS.
+- [ ] **Step 6: Commit.** `git add -A && git commit -m "[optimizer] Stateful spill edge-case tests"`
+
+---
+
+### Task 7: Integration — lit + local models + sweeps
+
+- [ ] **Step 1:** `llvm-lit test/ttmlir/Dialect/TTNN/optimizer/ -v`. Expected: all pass.
+- [ ] **Step 2:** `cmake --build build --target check-ttmlir`. Expected: pass.
+- [ ] **Step 3:** Trigger n150 + p150 `Performance Benchmark` sweeps on the branch
+  head (via the xla-perf-pipeline flow). Record run IDs; gate marking the PR ready
+  on green sweeps (target LLMs + the #9064 CB-clash models).
+- [ ] **Step 4:** Update the PR body's "Essence" to note the spill path now derives
+  fit/frag/CB entirely from captured state (no address simulator on the stateful
+  path). Commit doc-only change if PR body is tracked in-repo; otherwise update via
+  `gh pr edit`.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** base+subclass structure (T1–3), slimmed tracker + record
+  aliasing (T4), op-query replay + drop-and-rebuild eviction (T5), reshard/
+  multi-result/view/ToLayout edges (T6), Sum byte-identical guard (every task's
+  Step "guard tests"), testing + sweeps (T6/T7). All spec sections mapped.
+- **Ordering risk:** Tasks 4+5 must land in one commit (the slimmed tracker breaks
+  the address-sim intermediate for Mock until the stateful subclass replaces it).
+  This is called out explicitly in T4 Step 4 / T5.
+- **Type consistency:** hook names (`placeValidatedOutput`, `recoverFromOOM`,
+  `trackAllocation`, `replayFrom`), tracker methods (`addTensorAlias`,
+  `removeTensor`, `takeSnapshot`), and the `checkpoints` rename are used
+  identically across tasks.

--- a/docs/superpowers/specs/2026-07-21-stateful-spill-full-captured-state-design.md
+++ b/docs/superpowers/specs/2026-07-21-stateful-spill-full-captured-state-design.md
@@ -1,0 +1,212 @@
+# Refactor the L1 spill pass to fully leverage captured allocator state
+
+## Problem
+
+The greedy L1 spill pass runs two memory models at once. `SumL1MemoryTracker`
+simulates a top-down first-fit allocator (a `freeList`, per-tensor addresses,
+alias groups) to approximate fit / fragmentation / CB-overlap. The newer
+`MockAllocatorL1Tracker` feeds the currently-live L1 buffers as allocation
+records into tt-metal's *real* stateful op-model query, which models placement
+and fragmentation accurately. Today the mock tracker **inherits** the sum
+tracker and reuses its simulated addresses for eviction ordering and CB-overlap
+checks — so the pass reasons about two allocators at once. That dual model is
+the direct source of the #9064 CB-vs-L1 clash friction: the simulated address
+and the real fit decision diverge.
+
+Goal: on the stateful path, let the captured allocator state answer fit,
+fragmentation, placement, and CB-clash entirely. Remove the address *simulator*
+and all explicit fragmentation/CB reasoning from the spill pass. Keep the
+`SumL1MemoryTracker` path intact as a legacy fallback behind
+`use-mock-allocator-state=false`.
+
+## Key constraint discovered
+
+`tt::tt_metal::experimental::MockAllocatorState` exposes only:
+- `with_allocations(vector<AllocationRecord>) const` — reconstructs a state with
+  buffers pinned at the **explicit addresses in the records** (it does not
+  re-flow / reassign),
+- `extract_mock_allocator_state` / `override_mock_allocator_state`,
+- read-only `total_allocated_size`, `lowest_occupied(BufferType)`.
+
+There is **no** `allocate(size)` primitive. The allocator only ever *assigns* a
+fresh address inside an op query (`output_allocations`).
+
+Consequence: the records we hold for still-live tensors were assigned by the
+allocator **with the eventual victim present in the history**. Evicting a tensor
+allocated at some earlier position rewrites history — in the victim-free
+counterfactual, every buffer allocated after it would land at a different
+address. Because `with_allocations` pins addresses verbatim, we cannot fake this
+by dropping the victim's record; that produces a state (survivors pinned high, a
+phantom hole where the victim was) the real allocator never produces. **Eviction
+must rebuild the surviving live set's records under the victim-free history.**
+
+## Chosen approach
+
+### Structure: shared base class + two subclasses
+
+Extract `L1SpillManagementBase<MemoryTracker>` holding everything the two paths
+share; the current class becomes the Sum subclass; a new small subclass drives
+the stateful path.
+
+```
+L1SpillManagementBase<MemoryTracker>
+  shared state:  func, deviceGrid, l1Budget, observer_, memoryTracker,
+                 liveSet (FLU max-heap), liveValues, ScheduleData
+  shared infra:  buildScheduleData, computeLastUsePositions, processDeadTensors,
+                 evictFarthestUse, evictAllFromL1, spillToDram(+Impl/BeforeTrigger),
+                 demoteToDram, insertReshardForConsumer, insertReshardIntoSchedule,
+                 revalidateConsumers, collectDownstreamConsumers, applyOutputConfig,
+                 extractOpConfigFromIR;
+                 the run() forward-sweep skeleton;
+                 the event-log framework: l1EventLog, campaignMin, allocEventIndex,
+                 insertEventIntoLog, the checkpoint map, the replayFrom DRIVER,
+                 and the evict -> replay -> recheck loop.
+  hooks:         placeValidatedOutput(op,pos,data,result,tensorResults)
+                 recoverFromOOM(op,pos,tensorResults,data)
+                 commitAllocation(val,size)          // add one result to live state
+                 replayAllocEvent / replayDeallocEvent // per-event rebuild action
+                 stillFits()                          // per-alloc fit predicate
+
+  SumL1SpillManagement : the address simulator (freeList, tensorAddresses,
+     wouldAllocateAt, getLowestOccupiedAddress, alias groups) plus the explicit
+     fit/frag/CB methods (ensureFitsL1, handleNoFit, handleFragmentation,
+     wouldCBsOverlapTensors, evictForCBOverlap, evictForDramCBGrowth). Its hooks
+     reproduce today's exact behavior -> use-mock-allocator-state=false is
+     byte-for-byte identical.
+
+  StatefulL1SpillManagement : NO address simulator, NO explicit fit/frag/CB.
+     placeValidatedOutput = just commit the output (no fit check).
+     recoverFromOOM       = evict FLU victim -> spill+reshard -> mark skipped
+                            -> replayFrom(campaignMin) -> re-query current op; loop.
+     replay action        = re-run the stateful op-model query for the surviving
+                            op, take output_allocations as its fresh record.
+     stillFits()          = the re-query returned success (not OOM).
+```
+
+The `run()` skeleton (dead-tensor processing, `ToLayoutOp`/sink/`NotImplemented`
+handling, `validate()`, then success / backend-error / OOM branch dispatch)
+lives once in the base and calls the hooks. Both paths log allocation order into
+the shared event log; only the per-event replay *action* and the checkpoint
+payload type differ.
+
+### The slimmed stateful tracker
+
+`MockAllocatorL1Tracker` stops inheriting `SumL1MemoryTracker` and holds only:
+
+```
+struct MockAllocatorL1Tracker {
+  DenseMap<Value, RecordVec> liveRecords;              // the real live-set state
+  mutable DenseMap<Operation*, RecordVec> pendingRecords; // const validate() -> addTensor handoff
+  DenseMap<Value, Value>    aliasOf;                   // viewOutput -> canonical buffer owner
+  DenseMap<Value, unsigned> aliasRefcount;             // owner -> # live aliasers
+
+  ValidationResult validate(op, inputs, config) const; // flatten liveRecords (dedupe aliases) -> stateful query
+  void addTensor(Value, size);                          // liveRecords[v] = pendingRecords[op][idx]
+  void addTensorAlias(Value out, Value src);            // alias, bump refcount, no new record
+  void removeTensor(Value);                             // drop record / decrement refcount
+  uint64_t getOccupiedL1() const;                       // sum of live record sizes (logging/observer)
+
+  struct Snapshot { DenseMap<Value,RecordVec> liveRecords; /* + alias maps */ };
+  Snapshot takeSnapshot() const;  void restoreSnapshot(const Snapshot&);
+};
+```
+
+Gone from the tracker: `freeList`, `tensorAddresses`, `aliasGroups`,
+`wouldAllocateAt`, `getLowestOccupiedAddress`, `allocateAddress`, the first-fit
+simulator. The `Snapshot` payload is a `RecordVec` set (a replay checkpoint), not
+address-sim state.
+
+`pendingRecords` stays: `validate()` is `const` and called speculatively many
+times before commit, so per-output records are stashed per-op and moved to
+`liveRecords[result]` at `addTensor` (the commit point), keyed positionally by
+`result.getResultNumber()`.
+
+**Aliasing** is record-level, not address-level: a view op's output shares its
+source's buffer, so we never emit a second record for it, dedupe by canonical
+owner when flattening `liveRecords` into the query state, and keep the buffer
+live until the last aliaser dies (refcount). `isAliasingViewOp` (#9054) drives
+`addTensorAlias` in place of the old `addTensorAtAddress`.
+
+### Eviction: rebuild-by-replay
+
+When `validate()` returns OOM, `recoverFromOOM` loops:
+
+```
+loop:
+  victim = evictFarthestUse()          // FLU policy, shared
+  if no victim: demoteToDram(op); return  // self-demote as last resort
+  evictValue(victim, ...)              // spill victim to DRAM + reshard past consumers (shared IR)
+  mark victim's alloc event skipped; fold its index into campaignMin
+  replayFrom(campaignMin)              // rebuild surviving records under victim-free history
+  result = tracker.validate(op, ...)   // re-query with the rebuilt live set
+  if result.isSuccess():
+    placeValidatedOutput(...); return
+  // else still OOM (raw size OR fragmentation, per the query) -> loop
+```
+
+`replayFrom(campaignMin)` (stateful override) starts from the checkpoint
+captured just before `campaignMin` and walks `[campaignMin, end)`:
+- **kAlloc, not skipped, not alias**: re-run the stateful op-model query for that
+  op (input layouts + config from *current* IR, so spills are reflected), take
+  `output_allocations` as the value's fresh record, add to the accumulated set.
+- **kAlloc, alias**: alias the source's record (no query).
+- **kAlloc, skipped**: skip (evicted).
+- **kDealloc**: drop the value's records from the accumulated set.
+
+After the walk, the accumulated set is the current live set under the victim-free
+history. Termination: each iteration removes one tensor from a finite live set,
+ending at self-demote.
+
+Correctness of the tricky cases falls out of ordered replay:
+- **Reshard for a past consumer** (position >= `campaignMin`) gets its own
+  alloc+dealloc events, so it is re-queried into the accumulated set during its
+  live window and dropped before the current op — transient L1 pressure is
+  accounted for, but it does not appear in the current op's live set.
+- **Multi-result** ops use real per-result records instead of the even-split
+  approximation.
+- **View ops** replay via alias, matching the happy path.
+
+## Edge cases
+
+- **`ToLayoutOp` with L1 output** (pre-decomposition, unqueryable): the Sum path
+  runs a `cbPeakUsage=0` fit check. The stateful path has no `ensureFitsL1`; the
+  op stays out of `liveValues` exactly as today, and any real OOM surfaces at the
+  *next* op's stateful query (which sees the L1 input). Pinned down by a
+  no-regression test rather than assumed.
+- **`NotImplemented`** ops -> `evictAllFromL1` (shared, unchanged).
+- **Non-OOM backend error** -> `demoteToDram` (shared, unchanged). The #9064
+  CB-clash classification (clash -> OOM) is unchanged and now flows through the
+  generic evict -> replay -> re-query loop.
+
+## Known cost
+
+Happy path (no eviction) = one query per op, unchanged. Op-query replay fires
+only inside eviction campaigns, bounded to `[campaignMin, pos]` by the
+checkpoint. Op-model queries are the optimizer's dominant cost, so
+eviction-heavy funcs pay more than the Sum path did. The replay action is behind
+a hook, so a future cheap `allocate(size)/free` primitive on `MockAllocatorState`
+could replace op-query replay with buffer-level replay with no pass-side change.
+(Ships-today path is op-query replay, per decision.)
+
+## Testing
+
+Extend `test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp`
+(mock-device, HW-free):
+1. eviction-with-replay: post-eviction live set re-queries clean.
+2. reshard-past-consumer during a stateful eviction.
+3. multi-result op -> per-result records.
+4. view-alias tripwires still hold (query returns aliased/zero address for view
+   ops; our `isAliasingViewOp` keeps them off a fresh record).
+5. `ToLayoutOp`-L1 no-regression.
+6. Sum path unchanged: existing `L1SpillManagementTests` stay green (byte-identical
+   behavior for `use-mock-allocator-state=false`).
+
+Plus: TTNN optimizer lit, and n150 + p150 `Performance Benchmark` sweeps as the
+integration gate before marking ready.
+
+## Non-goals
+
+- Retiring the `SumL1MemoryTracker` path (kept as legacy fallback).
+- Adding the cheap `allocate/free` tt-metal primitive (future optimization; the
+  hook boundary is left in place for it).
+- Changing beam-search, which keeps its cached stateless query.

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -263,7 +263,7 @@ public:
   /// does not fail the pass).
   bool hasFailed() const { return compilationFailed; }
 
-private:
+protected:
   func::FuncOp func;
   ttcore::GridAttr deviceGrid;
   uint64_t l1BudgetPerCore;
@@ -334,13 +334,6 @@ private:
   /// placed; false means a still-live tensor has no contiguous fit
   /// (fragmentation).
   bool markEvictedAndRebuild(Value victim, size_t &campaignMin);
-
-  /// Restore the snapshot at `startIdx` and replay every non-skipped event in
-  /// [startIdx, end) top-down first-fit. Pre-checks `wouldAllocateAt` before
-  /// each fresh allocation so `allocateAddress`'s hard contract holds, and
-  /// returns false at the first no-fit (a still-live tensor has no contiguous
-  /// slot). Returns true iff every still-live tensor was placed.
-  bool replayFrom(size_t startIdx);
 
   /// Insert event at pos in l1EventLog and shift all allocEventIndex entries
   /// and addressSnapshots keys >= pos by 1, preserving the index invariants.
@@ -423,65 +416,39 @@ private:
   void processDeadTensors(int64_t pos, const ScheduleData &data);
 
 protected:
-  /// Hook: place a successfully-validated op's output. Returns the L1 size to
-  /// add to the live set (0 = demoted to DRAM). Default (address-sim path):
-  /// contiguous-fit + CB-overlap checks via ensureFitsL1.
-  virtual uint64_t
-  placeValidatedOutput(Operation *op, int64_t pos, ScheduleData &data,
-                       const op_constraint_validation::ValidationResult &result);
+  // --- Strategy hooks. Implemented by AddressSimSpillManagement (address-sim)
+  //     and StatefulL1SpillManagement (captured allocator state). ---
 
-  /// Hook: recover from an OOM validation result (evict live tensors or demote
-  /// self to DRAM). Default (address-sim path): handleOOM.
+  /// Place a successfully-validated op's output. Returns the L1 size to add to
+  /// the live set (0 = demoted to DRAM).
+  virtual uint64_t placeValidatedOutput(
+      Operation *op, int64_t pos, ScheduleData &data,
+      const op_constraint_validation::ValidationResult &result) = 0;
+
+  /// Recover from an OOM validation result (evict live tensors or demote self
+  /// to DRAM).
   virtual void
   recoverFromOOM(Operation *op, int64_t pos,
                  llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
-                 std::function<void(uint64_t)> addResultsToLiveSet);
+                 std::function<void(uint64_t)> addResultsToLiveSet) = 0;
 
-  /// Hook: commit one result tensor into the live set. Logs the alloc event,
-  /// adds it to the tracker (alias-or-fresh) and to the FLU heap. Default
-  /// (address-sim path): snapshot + addTensorAtAddress/addTensor.
+  /// Commit one result tensor into the live set: log the alloc event, add it to
+  /// the tracker (alias-or-fresh), and push it onto the FLU heap.
   virtual void commitAllocation(Value val, uint64_t perResultL1,
-                                ScheduleData &data);
+                                ScheduleData &data) = 0;
 
-private:
-  /// Check if the op's CB region (growing bottom-up) would overlap with any
-  /// live tensor or the speculative output tensor based on simulated L1
-  /// addresses. Uses min(speculativeOutputAddr, lowestOccupiedAddress) as
-  /// the effective lowest tensor address.
-  /// See: https://github.com/tenstorrent/tt-mlir/issues/7396
-  bool wouldCBsOverlapTensors(Operation *op, int64_t pos, uint64_t cbPeakUsage,
-                              uint64_t speculativeOutputAddr);
+  /// Handle an L1-output op that cannot be validated (a pre-decomposition
+  /// ToLayoutOp). Address-sim runs a fit check; the stateful path defers to the
+  /// consuming op's query.
+  virtual void handleUnvalidatedL1Output(Operation *op, int64_t pos,
+                                         ScheduleData &data,
+                                         uint64_t derivedL1) = 0;
 
-  /// Output cannot fit contiguously in the free list. Evict farthest-last-use
-  /// tensors until the output fits, then re-validate. Returns L1 bytes to add
-  /// to live set (0 if demoted to DRAM).
-  uint64_t handleNoFit(Operation *op, int64_t pos, ScheduleData &data,
-                       uint64_t outputL1Size);
+  /// Rebuild live-set state after an eviction marks events skipped, replaying
+  /// from `startIdx`. Returns true iff every still-live tensor was placed.
+  virtual bool replayFrom(size_t startIdx) = 0;
 
-  /// CB fragmentation recovery: evict tensors in the CB danger zone,
-  /// re-validate, or demote output to DRAM. Returns L1 bytes to add to live
-  /// set (0 if demoted).
-  uint64_t handleFragmentation(Operation *op, int64_t pos, ScheduleData &data,
-                               uint64_t cbPeakUsage, uint64_t outputL1Size);
-
-  /// Run contiguous-fit and CB-fragmentation checks on a validated op's
-  /// output. Returns the (possibly updated) L1 size to add to the live set,
-  /// or 0 if the output was demoted to DRAM.
-  uint64_t ensureFitsL1(Operation *op, int64_t pos, ScheduleData &data,
-                        uint64_t cbPeakUsage, uint64_t l1Size);
-
-  /// True when `op` is a view-eligible reshape whose source operand is still
-  /// resident in L1. Its output will alias the source's existing slot
-  /// (addTensorAtAddress) instead of carving a fresh one, so it consumes no
-  /// additional L1 and the fit / CB-overlap checks must not treat it as a
-  /// new allocation.
-  bool willAliasSourceInL1(Operation *op) const;
-
-  /// OOM recovery: evict farthest-last-use tensors or demote self to DRAM.
-  void handleOOM(Operation *op, int64_t pos,
-                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
-                 std::function<void(uint64_t)> addResultsToLiveSet);
-
+protected:
   /// Evict all live L1 tensors. Used when encountering ops without OpModel
   /// support — since we cannot know their L1 requirements, the only safe
   /// choice is a full flush. Spill ops are inserted right before triggerOp
@@ -489,17 +456,10 @@ private:
   void evictAllFromL1(int64_t pos, ScheduleData &data,
                       Operation *triggerOp = nullptr);
 
-  /// Evict live tensors (farthest-last-use first) until no tensor's simulated
-  /// address falls below the cushioned CB threshold. Replaces the former
-  /// evictTensorsBelow, which was incorrect after address rebuild (addresses
-  /// shift, making the threshold check stale).
-  void evictForCBOverlap(uint64_t cushionedCBUsage, int64_t pos,
-                         ScheduleData &data);
-
   /// Evict tensors (farthest-last-use first) until shouldStop() returns true
   /// or the live set is empty. Returns true if shouldStop was satisfied.
-  /// After each eviction, rebuilds address simulation and inserts reshards
-  /// for already-processed consumers.
+  /// After each eviction, rebuilds tracker state (via the replayFrom hook) and
+  /// inserts reshards for already-processed consumers.
   bool evictUntil(int64_t pos, ScheduleData &data,
                   std::function<bool()> shouldStop);
 
@@ -522,15 +482,6 @@ private:
   void insertReshardForConsumer(Operation *consumer, unsigned operandIdx,
                                 TTNNLayoutAttr originalL1Layout);
 
-  /// After demoting an op's output to DRAM, re-query op_model for the DRAM
-  /// config's cbPeakUsage and evict any live tensors that fall within the
-  /// (potentially larger) static CB region.  When output switches from
-  /// L1-sharded to DRAM, the output CB flips from globally_allocated (aliased
-  /// to the shard, not in the static CB region) to locally_allocated (bottom-up
-  /// in the static CB region), which can significantly increase the CB
-  /// footprint.
-  void evictForDramCBGrowth(Operation *op, int64_t pos, ScheduleData &data);
-
   /// Collect downstream consumers of an op, following through spill ops.
   static llvm::SmallVector<Operation *>
   collectDownstreamConsumers(Operation *changed);
@@ -540,22 +491,97 @@ private:
 extern template class L1SpillManagementBase<SumL1MemoryTracker>;
 extern template class L1SpillManagementBase<MockAllocatorL1Tracker>;
 
-/// Legacy spill manager: scalar-sum tracker + simulated top-down first-fit
-/// address model. Selected when `use-mock-allocator-state=false`. Behavior is
-/// the historical default; the base hooks (address-sim) are inherited unchanged.
-class SumL1SpillManagement final
-    : public L1SpillManagementBase<SumL1MemoryTracker> {
+/// Address-sim strategy: implements the spill hooks with the simulated top-down
+/// first-fit allocator (SumL1MemoryTracker's address model) and the
+/// contiguous-fit / CB-overlap fragmentation checks. Shared by the legacy Sum
+/// path and (transitionally) the Mock path until the stateful path lands.
+template <typename MemoryTracker>
+class AddressSimSpillManagement : public L1SpillManagementBase<MemoryTracker> {
 public:
-  using L1SpillManagementBase<SumL1MemoryTracker>::L1SpillManagementBase;
+  using L1SpillManagementBase<MemoryTracker>::L1SpillManagementBase;
+
+protected:
+  using Base = L1SpillManagementBase<MemoryTracker>;
+  using typename Base::L1Event;
+  using typename Base::ScheduleData;
+  // Base state + generic helpers the address-sim strategy reuses. (Dependent
+  // base: member names must be brought into scope explicitly.)
+  using Base::addressSnapshots;
+  using Base::allocEventIndex;
+  using Base::applyOutputConfig;
+  using Base::cbFragCushion;
+  using Base::collectDownstreamConsumers;
+  using Base::compilationFailed;
+  using Base::demoteToDram;
+  using Base::evictFarthestUse;
+  using Base::evictUntil;
+  using Base::evictValue;
+  using Base::extractOpConfigFromIR;
+  using Base::insertedReshardValues;
+  using Base::insertEventIntoLog;
+  using Base::insertReshardForConsumer;
+  using Base::insertReshardIntoSchedule;
+  using Base::l1BudgetPerCore;
+  using Base::l1EventLog;
+  using Base::liveSet;
+  using Base::liveValues;
+  using Base::markEvictedAndRebuild;
+  using Base::memoryTracker;
+  using Base::observer_;
+  using Base::spillToDram;
+
+  // Strategy hooks (address-sim implementations).
+  uint64_t placeValidatedOutput(
+      Operation *op, int64_t pos, ScheduleData &data,
+      const op_constraint_validation::ValidationResult &result) override;
+  void
+  recoverFromOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet) override;
+  void commitAllocation(Value val, uint64_t perResultL1,
+                        ScheduleData &data) override;
+  void handleUnvalidatedL1Output(Operation *op, int64_t pos, ScheduleData &data,
+                                 uint64_t derivedL1) override;
+  bool replayFrom(size_t startIdx) override;
+
+  // Address-simulation fit / fragmentation / CB-overlap helpers.
+  uint64_t ensureFitsL1(Operation *op, int64_t pos, ScheduleData &data,
+                        uint64_t cbPeakUsage, uint64_t l1Size);
+  uint64_t handleNoFit(Operation *op, int64_t pos, ScheduleData &data,
+                       uint64_t outputL1Size);
+  uint64_t handleFragmentation(Operation *op, int64_t pos, ScheduleData &data,
+                               uint64_t cbPeakUsage, uint64_t outputL1Size);
+  bool wouldCBsOverlapTensors(Operation *op, int64_t pos, uint64_t cbPeakUsage,
+                              uint64_t speculativeOutputAddr);
+  bool willAliasSourceInL1(Operation *op) const;
+  void handleOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet);
+  void evictForCBOverlap(uint64_t cushionedCBUsage, int64_t pos,
+                         ScheduleData &data);
+  void evictForDramCBGrowth(Operation *op, int64_t pos, ScheduleData &data);
+};
+
+extern template class AddressSimSpillManagement<SumL1MemoryTracker>;
+extern template class AddressSimSpillManagement<MockAllocatorL1Tracker>;
+
+/// Legacy spill manager: scalar-sum tracker + simulated top-down first-fit
+/// address model. Selected when `use-mock-allocator-state=false`.
+class SumL1SpillManagement final
+    : public AddressSimSpillManagement<SumL1MemoryTracker> {
+public:
+  using AddressSimSpillManagement<SumL1MemoryTracker>::AddressSimSpillManagement;
 };
 
 /// Stateful spill manager: fit / fragmentation / placement / CB-clash are all
 /// answered by tt-metal's captured allocator state. Selected by default
-/// (`use-mock-allocator-state=true`).
+/// (`use-mock-allocator-state=true`). (Transitionally still address-sim; the
+/// stateful hooks land in a later change.)
 class MockAllocatorSpillManagement final
-    : public L1SpillManagementBase<MockAllocatorL1Tracker> {
+    : public AddressSimSpillManagement<MockAllocatorL1Tracker> {
 public:
-  using L1SpillManagementBase<MockAllocatorL1Tracker>::L1SpillManagementBase;
+  using AddressSimSpillManagement<
+      MockAllocatorL1Tracker>::AddressSimSpillManagement;
 };
 
 } // namespace mlir::tt::ttnn

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -171,22 +171,26 @@ private:
 
 /// L1 memory tracker backed by tt-metal's stateful op-constraints query.
 ///
-/// Reuses SumL1MemoryTracker's address simulation for eviction ordering and
-/// CB-overlap checks (inherited unchanged), but replaces the *fit decision*:
-/// validate() feeds the set of currently-live L1 allocations (as
-/// build-from-records) into the op-model's stateful query, so fragmentation and
-/// placement are modeled by tt-metal's real allocator rather than the scalar
-/// additional-L1 heuristic.
-///
-/// Live allocation records are keyed by Value. They are captured from the
-/// validation result (a `mutable` per-op stash filled in validate(), consumed
-/// in addTensor) and dropped when a tensor leaves L1 (removeTensor /
-/// removeTensorFromSizes, which the eviction path uses to spill to DRAM).
-struct MockAllocatorL1Tracker : SumL1MemoryTracker {
+/// Holds only the set of currently-live L1 allocation records (no address
+/// simulation). validate() flattens the live records into the op-model's
+/// stateful query, so fit / fragmentation / placement / CB-clash are all
+/// modeled by tt-metal's real allocator. Records are keyed by the producing
+/// Value; a view op's output aliases its source's buffer via `aliasOf` /
+/// `aliasRefcount` (record-level aliasing, no addresses), so it never adds a
+/// second record and the buffer stays live until the last aliaser dies.
+struct MockAllocatorL1Tracker {
   using RecordVec = llvm::SmallVector<op_model::OpModelAllocationRecord>;
 
-  /// Currently-live L1 allocations, keyed by the producing Value. Flattened
-  /// into the stateful query's initial state on each validate().
+  /// Backend validator hook (test-only). Same shape as SumL1MemoryTracker's:
+  /// when set, every validate()/validateBackendDirect() call forwards to it.
+  using BackendValidatorFn =
+      std::function<op_constraint_validation::ValidationResult(
+          Operation *, llvm::ArrayRef<TTNNLayoutAttr>, const OpConfig &,
+          uint64_t /*additionalL1*/)>;
+  BackendValidatorFn backendValidator;
+
+  /// Currently-live L1 allocations, keyed by the owning Value (an alias does
+  /// NOT get its own entry). Flattened into each validate()'s initial state.
   llvm::DenseMap<Value, RecordVec> liveRecords;
 
   /// Records produced by the most recent successful validate(), keyed by op,
@@ -194,32 +198,59 @@ struct MockAllocatorL1Tracker : SumL1MemoryTracker {
   /// the const validate() can populate it.
   mutable llvm::DenseMap<Operation *, RecordVec> pendingRecords;
 
-  /// Stateful fit decision: build the initial allocator state from liveRecords
-  /// and route through the uncached getOpConstraintsWithState. Falls back to
-  /// stateless behavior for ops that don't override the stateful interface
-  /// method (their result carries no records).
+  /// Maps a view-op output (aliaser) to the canonical Value that owns the
+  /// shared buffer's record.
+  llvm::DenseMap<Value, Value> aliasOf;
+
+  /// Per-owner count of live aliasers (including the owner itself). The owner's
+  /// record is dropped from liveRecords when this reaches zero.
+  llvm::DenseMap<Value, unsigned> aliasRefcount;
+
+  /// Optimizer per-core L1 budget (a ~0.95 cap minus reserved L1 — tighter than
+  /// the device's physical L1 that the query models). validate() enforces it as
+  /// a byte ceiling on top of the query so the optimizer keeps its headroom.
+  uint64_t l1Budget = 0;
+
+  void init(uint64_t l1BudgetPerCore);
+
+  /// Stateful fit decision: flatten liveRecords (deduped by owner) into the
+  /// op-model's stateful query and stash the resulting per-output records for
+  /// association at addTensor time.
   op_constraint_validation::ValidationResult
   validate(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
            const OpConfig &config) const;
 
-  void init(uint64_t l1BudgetPerCore);
+  /// Query a single op in isolation with an explicit additionalL1Usage (no live
+  /// records). Used by the eviction path's consumer-reshard probes.
+  op_constraint_validation::ValidationResult
+  validateBackendDirect(Operation *op,
+                        llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                        const OpConfig &config, uint64_t additionalL1Usage) const;
 
-  /// Delegates address/size bookkeeping to the base, then records `result`'s
-  /// allocation from the pending stash (if the op produced records).
+  /// Associate `result`'s allocation record from the pending stash (positional:
+  /// i-th tensor result <-> i-th output-buffer record). No-op if the op
+  /// produced no records. `l1SizePerCore` is unused (records carry sizes) and
+  /// kept only for interface parity with SumL1MemoryTracker.
   void addTensor(Value result, uint64_t l1SizePerCore);
-  void addTensorAtAddress(Value result, uint64_t l1SizePerCore,
-                          Value srcAtSameAddr);
 
-  /// Delegates to the base, then drops `result` from liveRecords (it has left
-  /// L1 — dead or spilled to DRAM).
+  /// Record `out` as an alias of `src`'s buffer: bump the owner's refcount and
+  /// add no new record.
+  void addTensorAlias(Value out, Value src);
+
+  /// Drop `result` from the live set (dead or spilled to DRAM): decrement its
+  /// owner's refcount and erase the record when it reaches zero.
   void removeTensor(Value result);
   void removeTensorFromSizes(Value result);
 
-  /// Snapshot carrying both the base address-sim snapshot and the live-records
-  /// map, so eviction replay restores the record set alongside addresses.
+  bool hasTensor(Value result) const;
+  uint64_t getTensorSize(Value result) const;
+  uint64_t getOccupiedL1() const;
+
+  /// Replay checkpoint: the live record set + alias bookkeeping.
   struct Snapshot {
-    SumL1MemoryTracker::Snapshot base;
     llvm::DenseMap<Value, RecordVec> liveRecords;
+    llvm::DenseMap<Value, Value> aliasOf;
+    llvm::DenseMap<Value, unsigned> aliasRefcount;
   };
   Snapshot takeSnapshot() const;
   void restoreSnapshot(const Snapshot &snapshot);
@@ -563,7 +594,6 @@ protected:
 };
 
 extern template class AddressSimSpillManagement<SumL1MemoryTracker>;
-extern template class AddressSimSpillManagement<MockAllocatorL1Tracker>;
 
 /// Legacy spill manager: scalar-sum tracker + simulated top-down first-fit
 /// address model. Selected when `use-mock-allocator-state=false`.
@@ -574,14 +604,31 @@ public:
 };
 
 /// Stateful spill manager: fit / fragmentation / placement / CB-clash are all
-/// answered by tt-metal's captured allocator state. Selected by default
-/// (`use-mock-allocator-state=true`). (Transitionally still address-sim; the
-/// stateful hooks land in a later change.)
-class MockAllocatorSpillManagement final
-    : public AddressSimSpillManagement<MockAllocatorL1Tracker> {
+/// answered by tt-metal's captured allocator state (no address simulation).
+/// Selected by default (`use-mock-allocator-state=true`). Eviction drops the
+/// victim's records and replays the surviving allocation history through the
+/// op-model, so the allocator re-flows addresses under the victim-free history
+/// (a stored record cannot simply be dropped: with_allocations pins buffers at
+/// their recorded addresses). The base is a non-dependent type here, so base
+/// members are reachable without using-declarations.
+class StatefulL1SpillManagement final
+    : public L1SpillManagementBase<MockAllocatorL1Tracker> {
 public:
-  using AddressSimSpillManagement<
-      MockAllocatorL1Tracker>::AddressSimSpillManagement;
+  using L1SpillManagementBase<MockAllocatorL1Tracker>::L1SpillManagementBase;
+
+protected:
+  uint64_t placeValidatedOutput(
+      Operation *op, int64_t pos, ScheduleData &data,
+      const op_constraint_validation::ValidationResult &result) override;
+  void
+  recoverFromOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet) override;
+  void commitAllocation(Value val, uint64_t perResultL1,
+                        ScheduleData &data) override;
+  void handleUnvalidatedL1Output(Operation *op, int64_t pos, ScheduleData &data,
+                                 uint64_t derivedL1) override;
+  bool replayFrom(size_t startIdx) override;
 };
 
 } // namespace mlir::tt::ttnn

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -43,7 +43,7 @@ struct SumL1MemoryTracker {
 
   /// Bypass input-overlap accounting and call the backend (or hook) with an
   /// explicit additionalL1Usage. Used by consumer-reshard probes and DRAM
-  /// CB re-queries inside L1SpillManagement — those call sites already know
+  /// CB re-queries inside L1SpillManagementBase — those call sites already know
   /// the L1 pressure they want to express.
   op_constraint_validation::ValidationResult validateBackendDirect(
       Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
@@ -225,7 +225,7 @@ struct MockAllocatorL1Tracker : SumL1MemoryTracker {
   void restoreSnapshot(const Snapshot &snapshot);
 };
 
-/// L1SpillManagement enforces L1 budget constraints using farthest-last-use
+/// L1SpillManagementBase enforces L1 budget constraints using farthest-last-use
 /// eviction with validation-based budget enforcement.
 /// Each op is re-validated during the sweep using validateOperation() with
 /// the sum of live tensor L1 sizes as additionalL1Usage. When validation
@@ -238,13 +238,13 @@ struct MockAllocatorL1Tracker : SumL1MemoryTracker {
 /// - Inserts ToMemoryConfigOp after spilled ops (L1 -> DRAM)
 /// - Reconnects uses to read from spilled tensor
 template <typename MemoryTracker = SumL1MemoryTracker>
-class L1SpillManagement {
+class L1SpillManagementBase {
 public:
-  L1SpillManagement(func::FuncOp func, ttcore::GridAttr deviceGrid,
+  L1SpillManagementBase(func::FuncOp func, ttcore::GridAttr deviceGrid,
                     uint64_t l1BudgetPerCore,
                     std::unique_ptr<L1SpillObserver> observer = nullptr);
 
-  virtual ~L1SpillManagement() = default;
+  virtual ~L1SpillManagementBase() = default;
 
   /// Run farthest-last-use eviction with validation-based enforcement and apply
   /// spills directly to the IR.
@@ -537,8 +537,26 @@ private:
 };
 
 // Explicit instantiation declarations (definitions in .cpp).
-extern template class L1SpillManagement<SumL1MemoryTracker>;
-extern template class L1SpillManagement<MockAllocatorL1Tracker>;
+extern template class L1SpillManagementBase<SumL1MemoryTracker>;
+extern template class L1SpillManagementBase<MockAllocatorL1Tracker>;
+
+/// Legacy spill manager: scalar-sum tracker + simulated top-down first-fit
+/// address model. Selected when `use-mock-allocator-state=false`. Behavior is
+/// the historical default; the base hooks (address-sim) are inherited unchanged.
+class SumL1SpillManagement final
+    : public L1SpillManagementBase<SumL1MemoryTracker> {
+public:
+  using L1SpillManagementBase<SumL1MemoryTracker>::L1SpillManagementBase;
+};
+
+/// Stateful spill manager: fit / fragmentation / placement / CB-clash are all
+/// answered by tt-metal's captured allocator state. Selected by default
+/// (`use-mock-allocator-state=true`).
+class MockAllocatorSpillManagement final
+    : public L1SpillManagementBase<MockAllocatorL1Tracker> {
+public:
+  using L1SpillManagementBase<MockAllocatorL1Tracker>::L1SpillManagementBase;
+};
 
 } // namespace mlir::tt::ttnn
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -244,6 +244,8 @@ public:
                     uint64_t l1BudgetPerCore,
                     std::unique_ptr<L1SpillObserver> observer = nullptr);
 
+  virtual ~L1SpillManagement() = default;
+
   /// Run farthest-last-use eviction with validation-based enforcement and apply
   /// spills directly to the IR.
   void run();
@@ -420,6 +422,28 @@ private:
   /// Remove result tensors whose last use was the previous position.
   void processDeadTensors(int64_t pos, const ScheduleData &data);
 
+protected:
+  /// Hook: place a successfully-validated op's output. Returns the L1 size to
+  /// add to the live set (0 = demoted to DRAM). Default (address-sim path):
+  /// contiguous-fit + CB-overlap checks via ensureFitsL1.
+  virtual uint64_t
+  placeValidatedOutput(Operation *op, int64_t pos, ScheduleData &data,
+                       const op_constraint_validation::ValidationResult &result);
+
+  /// Hook: recover from an OOM validation result (evict live tensors or demote
+  /// self to DRAM). Default (address-sim path): handleOOM.
+  virtual void
+  recoverFromOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet);
+
+  /// Hook: commit one result tensor into the live set. Logs the alloc event,
+  /// adds it to the tracker (alias-or-fresh) and to the FLU heap. Default
+  /// (address-sim path): snapshot + addTensorAtAddress/addTensor.
+  virtual void commitAllocation(Value val, uint64_t perResultL1,
+                                ScheduleData &data);
+
+private:
   /// Check if the op's CB region (growing bottom-up) would overlap with any
   /// live tensor or the speculative output tensor based on simulated L1
   /// addresses. Uses min(speculativeOutputAddr, lowestOccupiedAddress) as

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -233,6 +233,13 @@ struct MockAllocatorL1Tracker {
   /// kept only for interface parity with SumL1MemoryTracker.
   void addTensor(Value result, uint64_t l1SizePerCore);
 
+  /// Re-add `result` from a previously-captured allocation record set, verbatim
+  /// (no query). Mirrors addTensor's live-set bookkeeping but sources the record
+  /// from the caller instead of pendingRecords. Used by eviction replay to
+  /// restore a survivor at its forward-sweep placement without re-querying it
+  /// (see StatefulL1SpillManagement::replayFrom / tt-mlir #9087).
+  void addRecordedTensor(Value result, const RecordVec &records);
+
   /// Record `out` as an alias of `src`'s buffer: bump the owner's refcount and
   /// add no new record.
   void addTensorAlias(Value out, Value src);
@@ -629,6 +636,15 @@ protected:
   void handleUnvalidatedL1Output(Operation *op, int64_t pos, ScheduleData &data,
                                  uint64_t derivedL1) override;
   bool replayFrom(size_t startIdx) override;
+
+private:
+  /// Forward-sweep allocation records captured at commit time, keyed by the
+  /// producing Value. Eviction replay re-adds a survivor from here instead of
+  /// re-querying it: re-querying a survivor against the reconstructed,
+  /// address-pinned live set can spuriously report a *fragmentation* OOM (the
+  /// bytes fit but no contiguous block), a set the forward sweep and the device
+  /// placed fine — the false no-fit that made phi-2 hard-fail on n150 (#9087).
+  llvm::DenseMap<Value, MockAllocatorL1Tracker::RecordVec> committedRecords;
 };
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1884,6 +1884,16 @@ MockAllocatorL1Tracker::validate(Operation *op,
     // includes this op's inputs) + this op's output.
     uint64_t projected = getOccupiedL1() + result.outputL1Usage;
     if (l1Budget > 0 && projected > l1Budget) {
+      // Diagnostic: TTMLIR_SPILL_DEBUG=1 distinguishes a byte-cap OOM (this
+      // branch) from a device/CB OOM surfaced by the query itself (below), so
+      // an over-conservative spill can be attributed. See tt-mlir #9069 debug.
+      if (::getenv("TTMLIR_SPILL_DEBUG")) {
+        llvm::errs() << "[spill-debug] BYTE-CAP-OOM op=" << op->getName()
+                     << " occupied=" << getOccupiedL1()
+                     << " output=" << result.outputL1Usage
+                     << " projected=" << projected << " budget=" << l1Budget
+                     << "\n";
+      }
       return op_constraint_validation::ValidationResult::outOfMemoryError(
           "stateful: projected L1 (" + std::to_string(projected) +
           "B) exceeds optimizer budget (" + std::to_string(l1Budget) + "B)");
@@ -1893,6 +1903,13 @@ MockAllocatorL1Tracker::validate(Operation *op,
       pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
                                      result.outputAllocations.end());
     }
+  } else if (::getenv("TTMLIR_SPILL_DEBUG")) {
+    llvm::errs() << "[spill-debug] QUERY-NON-SUCCESS op=" << op->getName()
+                 << " status="
+                 << (result.isNotImplemented()      ? "NotImplemented"
+                     : result.isMetalBackendError() ? "BackendError"
+                                                    : "OOM/other")
+                 << " msg=" << result.errorMessage << "\n";
   }
   return result;
 }
@@ -2144,6 +2161,15 @@ bool StatefulL1SpillManagement::replayFrom(size_t startIdx) {
     if (isOOM) {
       TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                    "Replay: op no longer fits under victim-free history");
+      // Diagnostic (TTMLIR_SPILL_DEBUG=1): name the op whose replay re-query
+      // failed. Pair with the [spill-debug] BYTE-CAP-OOM / QUERY-NON-SUCCESS
+      // line from validate() to attribute the no-fit. See tt-mlir #9069.
+      if (::getenv("TTMLIR_SPILL_DEBUG")) {
+        llvm::errs() << "[spill-debug] REPLAY-NOFIT op=" << defOp->getName()
+                     << " isReshard="
+                     << (insertedReshardValues.count(tensor) ? "yes" : "no")
+                     << " msg=" << result.errorMessage << "\n";
+      }
       return false;
     }
     memoryTracker.addTensor(tensor, l1EventLog[i].sizePerCore);

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1858,7 +1858,17 @@ MockAllocatorL1Tracker::validate(Operation *op,
                                  const OpConfig &config) const {
   // Test-only hook takes precedence and is state-agnostic.
   if (backendValidator) {
-    return backendValidator(op, inputLayouts, config, /*additionalL1Usage=*/0);
+    op_constraint_validation::ValidationResult result =
+        backendValidator(op, inputLayouts, config, /*additionalL1Usage=*/0);
+    // Mirror the real path below: stash the output records so addTensor can
+    // associate them and the record-based live set / eviction replay behave
+    // as they do against the op-model. Lets tests drive the stateful path
+    // (including replayFrom) without a device.
+    if (result.isSuccess() && !result.outputAllocations.empty()) {
+      pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
+                                     result.outputAllocations.end());
+    }
+    return result;
   }
 
   // Flatten the currently-live L1 allocations into the stateful query's initial
@@ -1952,6 +1962,16 @@ void MockAllocatorL1Tracker::addTensor(Value result,
     aliasOf[result] = result;
     aliasRefcount[result] = 1;
   }
+}
+
+void MockAllocatorL1Tracker::addRecordedTensor(Value result,
+                                               const RecordVec &records) {
+  // Restore a survivor from its captured forward-sweep record set without a
+  // query (see the header note and replayFrom). Same live-set bookkeeping as
+  // addTensor: the value owns its own buffer at the recorded address/size.
+  liveRecords[result] = records;
+  aliasOf[result] = result;
+  aliasRefcount[result] = 1;
 }
 
 void MockAllocatorL1Tracker::addTensorAlias(Value out, Value src) {
@@ -2070,6 +2090,14 @@ void StatefulL1SpillManagement::commitAllocation(Value val,
     memoryTracker.addTensorAlias(val, defOp->getOperand(0));
   } else {
     memoryTracker.addTensor(val, perResultL1);
+    // Capture the forward-sweep allocation record (address + size) so eviction
+    // replay can re-add this survivor at its validated placement instead of
+    // re-querying it (#9087). Empty when the op produced no records (not on the
+    // stateful path) — those events fall back to a re-query in replayFrom.
+    auto recIt = memoryTracker.liveRecords.find(val);
+    if (recIt != memoryTracker.liveRecords.end() && !recIt->second.empty()) {
+      committedRecords[val] = recIt->second;
+    }
   }
 
   liveValues.insert(val);
@@ -2125,8 +2153,10 @@ bool StatefulL1SpillManagement::replayFrom(size_t startIdx) {
   memoryTracker.restoreSnapshot(snapIt->second);
 
   // Replay allocation events from startIdx forward under the (victim-free)
-  // history. Each surviving op is re-queried so the allocator assigns fresh
-  // addresses; the resulting record becomes its live-set entry.
+  // history. A survivor with a captured forward-sweep record is restored at
+  // that recorded placement (no re-query); only events without a captured
+  // record (e.g. inserted reshards) are re-queried so the allocator assigns
+  // fresh addresses.
   for (size_t i = startIdx; i < l1EventLog.size(); ++i) {
     if (l1EventLog[i].skipped) {
       continue;
@@ -2145,6 +2175,20 @@ bool StatefulL1SpillManagement::replayFrom(size_t startIdx) {
       continue;
     }
     if (!defOp) {
+      continue;
+    }
+    // Survivor already validated by the forward sweep: re-add it from its
+    // captured record instead of re-querying. Re-querying rebuilds tt-metal's
+    // allocator from the reconstructed, address-pinned live set, which can
+    // report a *fragmentation* OOM (bytes fit, no contiguous block) for a set
+    // the sweep -- and the device -- placed fine. That false no-fit made the
+    // pass wrongly exhaust eviction and hard-fail (tt-mlir #9087). The record
+    // set is a validated subset of a fitting sweep state (minus the evicted
+    // victim), so its capacity is guaranteed; only genuinely-new events below
+    // (no captured record) still need a placing query.
+    auto committedIt = committedRecords.find(tensor);
+    if (committedIt != committedRecords.end()) {
+      memoryTracker.addRecordedTensor(tensor, committedIt->second);
       continue;
     }
     // Re-query so the allocator re-flows this buffer's address without the

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -266,11 +266,11 @@ SumL1MemoryTracker::wouldAllocateAt(uint64_t l1SizePerCore) const {
 }
 
 //===----------------------------------------------------------------------===//
-// L1SpillManagement
+// L1SpillManagementBase
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-L1SpillManagement<MemoryTracker>::L1SpillManagement(
+L1SpillManagementBase<MemoryTracker>::L1SpillManagementBase(
     func::FuncOp func, ttcore::GridAttr deviceGrid, uint64_t l1BudgetPerCore,
     std::unique_ptr<L1SpillObserver> observer)
     : func(func), deviceGrid(deviceGrid), l1BudgetPerCore(l1BudgetPerCore),
@@ -290,7 +290,7 @@ L1SpillManagement<MemoryTracker>::L1SpillManagement(
 
 template <typename MemoryTracker>
 OpConfig
-L1SpillManagement<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
+L1SpillManagementBase<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
   if (op->getNumResults() == 0) {
     return OpConfig{};
   }
@@ -336,7 +336,7 @@ L1SpillManagement<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
+Value L1SpillManagementBase<MemoryTracker>::evictFarthestUse() {
   while (!liveSet.empty()) {
     auto [lastUse, candidateVal] = liveSet.top();
     liveSet.pop();
@@ -363,7 +363,7 @@ Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::applyOutputConfig(
+void L1SpillManagementBase<MemoryTracker>::applyOutputConfig(
     Operation *op, const op_constraint_validation::ValidationResult &result) {
   TTNNLayoutAttr chosenLayout = result.getFirstActualOutputLayout();
   if (!chosenLayout) {
@@ -404,7 +404,7 @@ void L1SpillManagement<MemoryTracker>::applyOutputConfig(
 
 template <typename MemoryTracker>
 llvm::SmallVector<Operation *>
-L1SpillManagement<MemoryTracker>::collectDownstreamConsumers(
+L1SpillManagementBase<MemoryTracker>::collectDownstreamConsumers(
     Operation *changed) {
   // After spillToDram, a result may have a ToMemoryConfigOp user (spill op).
   // Follow through spill ops to find the actual downstream consumers.
@@ -428,7 +428,7 @@ L1SpillManagement<MemoryTracker>::collectDownstreamConsumers(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::revalidateConsumers(
+void L1SpillManagementBase<MemoryTracker>::revalidateConsumers(
     Operation *changedOp, int64_t currentPos,
     const llvm::DenseMap<Operation *, int64_t> &positionMap) {
   // Worklist of ops whose output changed — seed with the victim/changed op.
@@ -507,8 +507,8 @@ void L1SpillManagement<MemoryTracker>::revalidateConsumers(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-typename L1SpillManagement<MemoryTracker>::ScheduleData
-L1SpillManagement<MemoryTracker>::buildScheduleData() {
+typename L1SpillManagementBase<MemoryTracker>::ScheduleData
+L1SpillManagementBase<MemoryTracker>::buildScheduleData() {
   ScheduleData data;
 
   // Build schedule (ops in IR order = topological order). Include sink ops
@@ -546,7 +546,7 @@ L1SpillManagement<MemoryTracker>::buildScheduleData() {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::processDeadTensors(
+void L1SpillManagementBase<MemoryTracker>::processDeadTensors(
     int64_t pos, const ScheduleData &data) {
   auto it = data.deathSchedule.find(pos - 1);
   if (it == data.deathSchedule.end()) {
@@ -571,7 +571,7 @@ void L1SpillManagement<MemoryTracker>::processDeadTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::willAliasSourceInL1(
+bool L1SpillManagementBase<MemoryTracker>::willAliasSourceInL1(
     Operation *op) const {
   // isAliasingViewOp guarantees op is a view op (reshape/pad/repeat/permute)
   // that aliases its input operand(0). Use hasTensorAddress (not hasTensor):
@@ -588,21 +588,21 @@ bool L1SpillManagement<MemoryTracker>::willAliasSourceInL1(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::placeValidatedOutput(
+uint64_t L1SpillManagementBase<MemoryTracker>::placeValidatedOutput(
     Operation *op, int64_t pos, ScheduleData &data,
     const op_constraint_validation::ValidationResult &result) {
   return ensureFitsL1(op, pos, data, result.cbPeakUsage, result.outputL1Usage);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::recoverFromOOM(
+void L1SpillManagementBase<MemoryTracker>::recoverFromOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
     ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::commitAllocation(Value val,
+void L1SpillManagementBase<MemoryTracker>::commitAllocation(Value val,
                                                         uint64_t perResultL1,
                                                         ScheduleData &data) {
   auto luIt = data.lastUsePositions.find(val);
@@ -629,7 +629,7 @@ void L1SpillManagement<MemoryTracker>::commitAllocation(Value val,
 }
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
+uint64_t L1SpillManagementBase<MemoryTracker>::ensureFitsL1(Operation *op,
                                                         int64_t pos,
                                                         ScheduleData &data,
                                                         uint64_t cbPeakUsage,
@@ -666,7 +666,7 @@ uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::handleOOM(
+void L1SpillManagementBase<MemoryTracker>::handleOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
     ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
@@ -735,7 +735,7 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::insertEventIntoLog(size_t pos,
+void L1SpillManagementBase<MemoryTracker>::insertEventIntoLog(size_t pos,
                                                           L1Event event) {
   // Insert the event and shift every index >= pos in both index structures
   // so the invariant "addressSnapshots[i] = state before event i" and
@@ -759,7 +759,7 @@ void L1SpillManagement<MemoryTracker>::insertEventIntoLog(size_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(
+bool L1SpillManagementBase<MemoryTracker>::markEvictedAndRebuild(
     Value victim, size_t &campaignMin) {
   // O(1) lookup of victim's alloc event.
   auto idxIt = allocEventIndex.find(victim);
@@ -794,7 +794,7 @@ bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
+bool L1SpillManagementBase<MemoryTracker>::replayFrom(size_t startIdx) {
   auto snapIt = addressSnapshots.find(startIdx);
   assert(snapIt != addressSnapshots.end() &&
          "snapshot not found for replay start index");
@@ -842,7 +842,7 @@ bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::evictValue(
+bool L1SpillManagementBase<MemoryTracker>::evictValue(
     Value victim, int64_t pos, ScheduleData &data, size_t &campaignMin,
     Operation *skipReshardConsumer) {
   liveValues.erase(victim);
@@ -1027,7 +1027,7 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
+void L1SpillManagementBase<MemoryTracker>::insertReshardIntoSchedule(
     Operation *reshardOp, Value reshardResult, uint64_t reshardSizePerCore,
     int64_t consumerPos, ScheduleData &data) {
   // Register so evictFarthestUse and sibling eviction guards know not to
@@ -1067,7 +1067,7 @@ void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
 }
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::evictUntil(
+bool L1SpillManagementBase<MemoryTracker>::evictUntil(
     int64_t pos, ScheduleData &data, std::function<bool()> shouldStop) {
   // Helper: true if every remaining live value is a non-evictable inserted
   // reshard. Avoids exhausting the liveSet heap through stale entries when
@@ -1105,7 +1105,7 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
   if (!rebuildPlacedAll) {
     Operation *blockedOp = data.schedule[pos];
     blockedOp->emitError(
-        "L1SpillManagement: a live tensor has no contiguous L1 placement even "
+        "L1SpillManagementBase: a live tensor has no contiguous L1 placement even "
         "after evicting every spillable tensor (fragmentation: a non-evictable "
         "inserted reshard or irreducible working set cannot be relocated)");
     compilationFailed = true;
@@ -1120,7 +1120,7 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
+uint64_t L1SpillManagementBase<MemoryTracker>::handleNoFit(Operation *op,
                                                        int64_t pos,
                                                        ScheduleData &data,
                                                        uint64_t outputL1Size) {
@@ -1173,7 +1173,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
+uint64_t L1SpillManagementBase<MemoryTracker>::handleFragmentation(
     Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
     uint64_t outputL1Size) {
   // Add the same safety cushion as wouldCBsOverlapTensors to account for
@@ -1267,7 +1267,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
     }
     if (!fitsAfterSiblingSpill) {
       op->emitError(
-          "L1SpillManagement: sibling-operand spill left a live tensor with no "
+          "L1SpillManagementBase: sibling-operand spill left a live tensor with no "
           "contiguous L1 placement (fragmentation cannot be resolved by "
           "demoting this op)");
       compilationFailed = true;
@@ -1287,7 +1287,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
+bool L1SpillManagementBase<MemoryTracker>::wouldCBsOverlapTensors(
     Operation *op, int64_t pos, uint64_t cbPeakUsage,
     uint64_t speculativeOutputAddr) {
   // Check if the op's CB region (growing bottom-up from base) would overlap
@@ -1338,7 +1338,7 @@ bool L1SpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::run() {
+void L1SpillManagementBase<MemoryTracker>::run() {
   ScheduleData data = buildScheduleData();
 
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1552,7 +1552,7 @@ void L1SpillManagement<MemoryTracker>::run() {
 
 template <typename MemoryTracker>
 llvm::DenseMap<Value, int64_t>
-L1SpillManagement<MemoryTracker>::computeLastUsePositions(
+L1SpillManagementBase<MemoryTracker>::computeLastUsePositions(
     const llvm::SmallVector<Operation *> &schedule) {
   // Build position map.
   llvm::DenseMap<Operation *, int64_t> positionMap;
@@ -1593,7 +1593,7 @@ L1SpillManagement<MemoryTracker>::computeLastUsePositions(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::demoteToDram(Operation *op) {
+void L1SpillManagementBase<MemoryTracker>::demoteToDram(Operation *op) {
   for (auto opResult : op->getResults()) {
     auto tensorType = mlir::dyn_cast<RankedTensorType>(opResult.getType());
     if (!tensorType) {
@@ -1623,7 +1623,7 @@ void L1SpillManagement<MemoryTracker>::demoteToDram(Operation *op) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictAllFromL1(int64_t pos,
+void L1SpillManagementBase<MemoryTracker>::evictAllFromL1(int64_t pos,
                                                       ScheduleData &data,
                                                       Operation *triggerOp) {
   llvm::SmallVector<Operation *> evictedOps;
@@ -1662,7 +1662,7 @@ void L1SpillManagement<MemoryTracker>::evictAllFromL1(int64_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictForCBOverlap(
+void L1SpillManagementBase<MemoryTracker>::evictForCBOverlap(
     uint64_t cushionedCBUsage, int64_t pos, ScheduleData &data) {
   evictUntil(pos, data, [&]() {
     return cushionedCBUsage <= memoryTracker.getLowestOccupiedAddress();
@@ -1674,7 +1674,7 @@ void L1SpillManagement<MemoryTracker>::evictForCBOverlap(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
+void L1SpillManagementBase<MemoryTracker>::evictForDramCBGrowth(
     Operation *op, int64_t pos, ScheduleData &data) {
 
   auto inputLayouts = utils::extractInputLayouts(op);
@@ -1721,7 +1721,7 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
   // rather than emit IR that overflows L1 at runtime.
   if (!liveValues.empty() &&
       dramCBCushioned > memoryTracker.getLowestOccupiedAddress()) {
-    op->emitError("L1SpillManagement: ")
+    op->emitError("L1SpillManagementBase: ")
         << op->getName()
         << " requires an L1 input restored by an inserted reshard, but its "
            "circular-buffer region overlaps that reshard's L1 slot and the "
@@ -1736,19 +1736,19 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::spillToDram(Value result) {
+void L1SpillManagementBase<MemoryTracker>::spillToDram(Value result) {
   spillToDramImpl(result, /*insertBefore=*/nullptr);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::spillToDramBeforeTrigger(
+void L1SpillManagementBase<MemoryTracker>::spillToDramBeforeTrigger(
     Value result, Operation *triggerOp) {
   assert(triggerOp && "spillToDramBeforeTrigger requires a non-null trigger");
   spillToDramImpl(result, triggerOp);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::spillToDramImpl(
+void L1SpillManagementBase<MemoryTracker>::spillToDramImpl(
     Value result, Operation *insertBefore) {
   Operation *defOp = result.getDefiningOp();
   RankedTensorType tensorType = mlir::cast<RankedTensorType>(result.getType());
@@ -1810,7 +1810,7 @@ void L1SpillManagement<MemoryTracker>::spillToDramImpl(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::insertReshardForConsumer(
+void L1SpillManagementBase<MemoryTracker>::insertReshardForConsumer(
     Operation *consumer, unsigned operandIdx, TTNNLayoutAttr originalL1Layout) {
   Value spillOutput = consumer->getOperand(operandIdx);
   auto spillTensorType = mlir::cast<RankedTensorType>(spillOutput.getType());
@@ -1933,7 +1933,7 @@ void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
 // Explicit template instantiation
 //===----------------------------------------------------------------------===//
 
-template class L1SpillManagement<SumL1MemoryTracker>;
-template class L1SpillManagement<MockAllocatorL1Tracker>;
+template class L1SpillManagementBase<SumL1MemoryTracker>;
+template class L1SpillManagementBase<MockAllocatorL1Tracker>;
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -571,7 +571,7 @@ void L1SpillManagementBase<MemoryTracker>::processDeadTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagementBase<MemoryTracker>::willAliasSourceInL1(
+bool AddressSimSpillManagement<MemoryTracker>::willAliasSourceInL1(
     Operation *op) const {
   // isAliasingViewOp guarantees op is a view op (reshape/pad/repeat/permute)
   // that aliases its input operand(0). Use hasTensorAddress (not hasTensor):
@@ -588,21 +588,29 @@ bool L1SpillManagementBase<MemoryTracker>::willAliasSourceInL1(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagementBase<MemoryTracker>::placeValidatedOutput(
+uint64_t AddressSimSpillManagement<MemoryTracker>::placeValidatedOutput(
     Operation *op, int64_t pos, ScheduleData &data,
     const op_constraint_validation::ValidationResult &result) {
   return ensureFitsL1(op, pos, data, result.cbPeakUsage, result.outputL1Usage);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::recoverFromOOM(
+void AddressSimSpillManagement<MemoryTracker>::handleUnvalidatedL1Output(
+    Operation *op, int64_t pos, ScheduleData &data, uint64_t derivedL1) {
+  // Pre-decomposition ToLayoutOp: no validation result, so CB peak is 0. Run
+  // the contiguous-fit check to make room if needed.
+  ensureFitsL1(op, pos, data, /*cbPeakUsage=*/0, derivedL1);
+}
+
+template <typename MemoryTracker>
+void AddressSimSpillManagement<MemoryTracker>::recoverFromOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
     ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::commitAllocation(Value val,
+void AddressSimSpillManagement<MemoryTracker>::commitAllocation(Value val,
                                                         uint64_t perResultL1,
                                                         ScheduleData &data) {
   auto luIt = data.lastUsePositions.find(val);
@@ -629,7 +637,7 @@ void L1SpillManagementBase<MemoryTracker>::commitAllocation(Value val,
 }
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagementBase<MemoryTracker>::ensureFitsL1(Operation *op,
+uint64_t AddressSimSpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
                                                         int64_t pos,
                                                         ScheduleData &data,
                                                         uint64_t cbPeakUsage,
@@ -666,7 +674,7 @@ uint64_t L1SpillManagementBase<MemoryTracker>::ensureFitsL1(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::handleOOM(
+void AddressSimSpillManagement<MemoryTracker>::handleOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
     ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
@@ -794,7 +802,7 @@ bool L1SpillManagementBase<MemoryTracker>::markEvictedAndRebuild(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagementBase<MemoryTracker>::replayFrom(size_t startIdx) {
+bool AddressSimSpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
   auto snapIt = addressSnapshots.find(startIdx);
   assert(snapIt != addressSnapshots.end() &&
          "snapshot not found for replay start index");
@@ -1120,7 +1128,7 @@ bool L1SpillManagementBase<MemoryTracker>::evictUntil(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagementBase<MemoryTracker>::handleNoFit(Operation *op,
+uint64_t AddressSimSpillManagement<MemoryTracker>::handleNoFit(Operation *op,
                                                        int64_t pos,
                                                        ScheduleData &data,
                                                        uint64_t outputL1Size) {
@@ -1173,7 +1181,7 @@ uint64_t L1SpillManagementBase<MemoryTracker>::handleNoFit(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagementBase<MemoryTracker>::handleFragmentation(
+uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
     Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
     uint64_t outputL1Size) {
   // Add the same safety cushion as wouldCBsOverlapTensors to account for
@@ -1287,7 +1295,7 @@ uint64_t L1SpillManagementBase<MemoryTracker>::handleFragmentation(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagementBase<MemoryTracker>::wouldCBsOverlapTensors(
+bool AddressSimSpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
     Operation *op, int64_t pos, uint64_t cbPeakUsage,
     uint64_t speculativeOutputAddr) {
   // Check if the op's CB region (growing bottom-up from base) would overlap
@@ -1412,7 +1420,7 @@ void L1SpillManagementBase<MemoryTracker>::run() {
                      memoryTracker.getOccupiedL1(), l1BudgetPerCore);
         // CBPeakUsage fixed to 0 as we have no validation result for ToLayoutOp
         // itself which is yet to be decomposed.
-        ensureFitsL1(op, pos, data, /*cbPeakUsage=*/0, derivedL1);
+        handleUnvalidatedL1Output(op, pos, data, derivedL1);
       }
 
       // Regardless of whether the ToLayoutOp's output is L1 or DRAM, we have no
@@ -1662,7 +1670,7 @@ void L1SpillManagementBase<MemoryTracker>::evictAllFromL1(int64_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::evictForCBOverlap(
+void AddressSimSpillManagement<MemoryTracker>::evictForCBOverlap(
     uint64_t cushionedCBUsage, int64_t pos, ScheduleData &data) {
   evictUntil(pos, data, [&]() {
     return cushionedCBUsage <= memoryTracker.getLowestOccupiedAddress();
@@ -1674,7 +1682,7 @@ void L1SpillManagementBase<MemoryTracker>::evictForCBOverlap(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagementBase<MemoryTracker>::evictForDramCBGrowth(
+void AddressSimSpillManagement<MemoryTracker>::evictForDramCBGrowth(
     Operation *op, int64_t pos, ScheduleData &data) {
 
   auto inputLayouts = utils::extractInputLayouts(op);
@@ -1935,5 +1943,7 @@ void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
 
 template class L1SpillManagementBase<SumL1MemoryTracker>;
 template class L1SpillManagementBase<MockAllocatorL1Tracker>;
+template class AddressSimSpillManagement<SumL1MemoryTracker>;
+template class AddressSimSpillManagement<MockAllocatorL1Tracker>;
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1862,9 +1862,10 @@ MockAllocatorL1Tracker::validate(Operation *op,
   }
 
   // Flatten the currently-live L1 allocations into the stateful query's initial
-  // state. additionalL1Usage is 0: the live set is encoded in the records, not
-  // a scalar. Ops that don't override the stateful interface method fall back
-  // to the (cached) stateless query and return no records.
+  // state. Aliases share their owner's record (no separate entry), so there is
+  // no duplication. additionalL1Usage is 0: the live set is encoded in the
+  // records. Ops that don't override the stateful interface method fall back to
+  // the (cached) stateless query and return no records.
   llvm::SmallVector<op_model::OpModelAllocationRecord> flat;
   for (const auto &entry : liveRecords) {
     flat.append(entry.second.begin(), entry.second.end());
@@ -1875,22 +1876,48 @@ MockAllocatorL1Tracker::validate(Operation *op,
                                                   flat,
                                                   /*additionalL1Usage=*/0);
 
-  // Stash this op's output records for association at addTensor time.
-  if (result.isSuccess() && !result.outputAllocations.empty()) {
-    pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
-                                   result.outputAllocations.end());
+  if (result.isSuccess()) {
+    // The query decides fit / fragmentation / CB-clash on the device's physical
+    // L1, but the optimizer budget reserves headroom below that (a ~0.95 cap
+    // minus reserved). Enforce that byte ceiling here so the optimizer does not
+    // pack up to the full device L1: projected peak = currently-live L1 (which
+    // includes this op's inputs) + this op's output.
+    uint64_t projected = getOccupiedL1() + result.outputL1Usage;
+    if (l1Budget > 0 && projected > l1Budget) {
+      return op_constraint_validation::ValidationResult::outOfMemoryError(
+          "stateful: projected L1 (" + std::to_string(projected) +
+          "B) exceeds optimizer budget (" + std::to_string(l1Budget) + "B)");
+    }
+    // Stash this op's output records for association at addTensor time.
+    if (!result.outputAllocations.empty()) {
+      pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
+                                     result.outputAllocations.end());
+    }
   }
   return result;
 }
 
-void MockAllocatorL1Tracker::init(uint64_t l1BudgetPerCore) {
-  SumL1MemoryTracker::init(l1BudgetPerCore);
-  liveRecords.clear();
-  pendingRecords.clear();
+op_constraint_validation::ValidationResult
+MockAllocatorL1Tracker::validateBackendDirect(
+    Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+    const OpConfig &config, uint64_t additionalL1Usage) const {
+  if (backendValidator) {
+    return backendValidator(op, inputLayouts, config, additionalL1Usage);
+  }
+  return op_constraint_validation::validateOperation(op, inputLayouts, config,
+                                                     additionalL1Usage);
 }
 
-void MockAllocatorL1Tracker::addTensor(Value result, uint64_t l1SizePerCore) {
-  SumL1MemoryTracker::addTensor(result, l1SizePerCore);
+void MockAllocatorL1Tracker::init(uint64_t l1BudgetPerCore) {
+  l1Budget = l1BudgetPerCore;
+  liveRecords.clear();
+  pendingRecords.clear();
+  aliasOf.clear();
+  aliasRefcount.clear();
+}
+
+void MockAllocatorL1Tracker::addTensor(Value result,
+                                       uint64_t /*l1SizePerCore*/) {
   // Associate the pending record for this result (positional: i-th tensor
   // result <-> i-th output-buffer record). Ops that produced no records (not
   // migrated to the stateful path) simply contribute nothing to the state.
@@ -1905,36 +1932,223 @@ void MockAllocatorL1Tracker::addTensor(Value result, uint64_t l1SizePerCore) {
   const unsigned idx = mlir::cast<OpResult>(result).getResultNumber();
   if (idx < it->second.size()) {
     liveRecords[result] = RecordVec{it->second[idx]};
+    aliasOf[result] = result;
+    aliasRefcount[result] = 1;
   }
 }
 
-void MockAllocatorL1Tracker::addTensorAtAddress(Value result,
-                                                uint64_t l1SizePerCore,
-                                                Value srcAtSameAddr) {
-  // Alias (e.g. a reshape view): shares srcAtSameAddr's buffer, so it adds no
-  // new allocation to the state — do not add a record for `result` (that would
-  // double-count the same buffer). The base tracks the address alias group.
-  SumL1MemoryTracker::addTensorAtAddress(result, l1SizePerCore, srcAtSameAddr);
+void MockAllocatorL1Tracker::addTensorAlias(Value out, Value src) {
+  // A view op's output shares src's buffer: add no new record, just bump the
+  // owner's live-aliaser refcount so the record survives until the last
+  // aliaser dies.
+  auto ownerIt = aliasOf.find(src);
+  Value owner = ownerIt != aliasOf.end() ? ownerIt->second : src;
+  aliasOf[out] = owner;
+  ++aliasRefcount[owner];
 }
 
 void MockAllocatorL1Tracker::removeTensor(Value result) {
-  SumL1MemoryTracker::removeTensor(result);
-  liveRecords.erase(result);
+  auto ownerIt = aliasOf.find(result);
+  if (ownerIt == aliasOf.end()) {
+    // Untracked (op produced no records). Nothing to drop.
+    liveRecords.erase(result);
+    return;
+  }
+  Value owner = ownerIt->second;
+  aliasOf.erase(ownerIt);
+  auto rcIt = aliasRefcount.find(owner);
+  if (rcIt != aliasRefcount.end() && --rcIt->second == 0) {
+    aliasRefcount.erase(rcIt);
+    liveRecords.erase(owner);
+  }
 }
 
 void MockAllocatorL1Tracker::removeTensorFromSizes(Value result) {
-  SumL1MemoryTracker::removeTensorFromSizes(result);
-  // Eviction spills to DRAM via this path: the tensor has left L1.
-  liveRecords.erase(result);
+  // Records are the only size state, so the eviction spill path is identical to
+  // removeTensor.
+  removeTensor(result);
+}
+
+bool MockAllocatorL1Tracker::hasTensor(Value result) const {
+  return aliasOf.count(result) > 0;
+}
+
+uint64_t MockAllocatorL1Tracker::getTensorSize(Value result) const {
+  auto ownerIt = aliasOf.find(result);
+  Value owner = ownerIt != aliasOf.end() ? ownerIt->second : result;
+  auto it = liveRecords.find(owner);
+  if (it == liveRecords.end()) {
+    return 0;
+  }
+  uint64_t total = 0;
+  for (const auto &rec : it->second) {
+    if (rec.bufferType == BufferType::L1) {
+      total += rec.sizePerBank;
+    }
+  }
+  return total;
+}
+
+uint64_t MockAllocatorL1Tracker::getOccupiedL1() const {
+  uint64_t total = 0;
+  for (const auto &entry : liveRecords) {
+    for (const auto &rec : entry.second) {
+      if (rec.bufferType == BufferType::L1) {
+        total += rec.sizePerBank;
+      }
+    }
+  }
+  return total;
 }
 
 MockAllocatorL1Tracker::Snapshot MockAllocatorL1Tracker::takeSnapshot() const {
-  return Snapshot{SumL1MemoryTracker::takeSnapshot(), liveRecords};
+  return Snapshot{liveRecords, aliasOf, aliasRefcount};
 }
 
 void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
-  SumL1MemoryTracker::restoreSnapshot(snapshot.base);
   liveRecords = snapshot.liveRecords;
+  aliasOf = snapshot.aliasOf;
+  aliasRefcount = snapshot.aliasRefcount;
+}
+
+//===----------------------------------------------------------------------===//
+// StatefulL1SpillManagement (captured allocator state)
+//===----------------------------------------------------------------------===//
+
+uint64_t StatefulL1SpillManagement::placeValidatedOutput(
+    Operation *, int64_t, ScheduleData &,
+    const op_constraint_validation::ValidationResult &result) {
+  // Fit / fragmentation / CB-overlap are all answered by the stateful query, so
+  // a validated output is committed at its reported L1 size with no extra
+  // checks.
+  return result.outputL1Usage;
+}
+
+void StatefulL1SpillManagement::handleUnvalidatedL1Output(Operation *, int64_t,
+                                                          ScheduleData &,
+                                                          uint64_t) {
+  // Pre-decomposition ToLayoutOp: no query, and (as in the address-sim path) it
+  // is kept out of liveValues. Any real OOM surfaces at the consuming op's
+  // stateful query, so there is nothing to do here.
+}
+
+void StatefulL1SpillManagement::commitAllocation(Value val,
+                                                 uint64_t perResultL1,
+                                                 ScheduleData &data) {
+  auto luIt = data.lastUsePositions.find(val);
+  assert(luIt != data.lastUsePositions.end() &&
+         "scheduled value missing its lastUsePositions entry");
+  int64_t resultLastUse = luIt->second;
+
+  // Log the alloc event and checkpoint the record set for eviction replay.
+  allocEventIndex[val] = l1EventLog.size();
+  addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
+  l1EventLog.push_back({L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
+
+  // View-eligible op whose source is still L1-resident: alias its buffer (no
+  // new record). Otherwise associate this result's own output record.
+  Operation *defOp = val.getDefiningOp();
+  if (defOp && isAliasingViewOp(defOp) &&
+      memoryTracker.hasTensor(defOp->getOperand(0))) {
+    memoryTracker.addTensorAlias(val, defOp->getOperand(0));
+  } else {
+    memoryTracker.addTensor(val, perResultL1);
+  }
+
+  liveValues.insert(val);
+  liveSet.push({resultLastUse, val});
+}
+
+void StatefulL1SpillManagement::recoverFromOOM(
+    Operation *op, int64_t pos, llvm::ArrayRef<OpResult> /*tensorResults*/,
+    ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
+  observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
+  TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+               "    OOM (stateful): evicting until the query fits");
+
+  // Evict farthest-last-use tensors until the stateful re-query succeeds. Each
+  // eviction drops the victim's records and replays the surviving allocation
+  // history (replayFrom) so the allocator re-flows addresses under the
+  // victim-free history; fragmentation is decided by the query, never here.
+  auto config = extractOpConfigFromIR(op);
+  auto result = op_constraint_validation::ValidationResult::outOfMemoryError("");
+  bool fitsAfterEviction = evictUntil(pos, data, [&]() {
+    auto inputLayouts = utils::extractInputLayouts(op);
+    result = memoryTracker.validate(op, inputLayouts, config);
+    return result.isSuccess();
+  });
+  if (compilationFailed) {
+    return;
+  }
+
+  if (fitsAfterEviction) {
+    // Eviction may have inserted a reshard for `op`, shifting it past `pos`;
+    // bail so run()'s sweep reprocesses the reshard and then `op`.
+    if (data.schedule[pos] != op) {
+      return;
+    }
+    uint64_t l1Size = result.outputL1Usage;
+    if (l1Size > 0) {
+      addResultsToLiveSet(l1Size);
+      observer_->onLiveAdded(op, pos, l1Size, pos,
+                             memoryTracker.getOccupiedL1());
+    }
+  } else {
+    observer_->onSelfSpill(op, pos);
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "    DEMOTE SELF (stateful): op exceeds budget alone");
+    demoteToDram(op);
+  }
+}
+
+bool StatefulL1SpillManagement::replayFrom(size_t startIdx) {
+  auto snapIt = addressSnapshots.find(startIdx);
+  assert(snapIt != addressSnapshots.end() &&
+         "checkpoint not found for replay start index");
+  memoryTracker.restoreSnapshot(snapIt->second);
+
+  // Replay allocation events from startIdx forward under the (victim-free)
+  // history. Each surviving op is re-queried so the allocator assigns fresh
+  // addresses; the resulting record becomes its live-set entry.
+  for (size_t i = startIdx; i < l1EventLog.size(); ++i) {
+    if (l1EventLog[i].skipped) {
+      continue;
+    }
+    if (l1EventLog[i].kind == L1Event::kDealloc) {
+      memoryTracker.removeTensor(l1EventLog[i].tensor);
+      continue;
+    }
+    addressSnapshots[i] = memoryTracker.takeSnapshot();
+    Value tensor = l1EventLog[i].tensor;
+    Operation *defOp = tensor.getDefiningOp();
+    // View alias (src still L1-resident): consumes no fresh buffer.
+    if (defOp && isAliasingViewOp(defOp) &&
+        memoryTracker.hasTensor(defOp->getOperand(0))) {
+      memoryTracker.addTensorAlias(tensor, defOp->getOperand(0));
+      continue;
+    }
+    if (!defOp) {
+      continue;
+    }
+    // Re-query so the allocator re-flows this buffer's address without the
+    // evicted victim in the history.
+    auto inputLayouts = utils::extractInputLayouts(defOp);
+    auto config = extractOpConfigFromIR(defOp);
+    auto result = memoryTracker.validate(defOp, inputLayouts, config);
+    // A still-live op no longer fits (raw size or fragmentation): the caller
+    // (evictUntil) evicts more. Non-OOM outcomes (not-implemented / backend
+    // error, e.g. an unqueryable reshard) leave the buffer untracked but do not
+    // count as a placement failure.
+    bool isOOM = result.isError() && !result.isNotImplemented() &&
+                 !result.isMetalBackendError();
+    if (isOOM) {
+      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                   "Replay: op no longer fits under victim-free history");
+      return false;
+    }
+    memoryTracker.addTensor(tensor, l1EventLog[i].sizePerCore);
+  }
+  return true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1944,6 +2158,5 @@ void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
 template class L1SpillManagementBase<SumL1MemoryTracker>;
 template class L1SpillManagementBase<MockAllocatorL1Tracker>;
 template class AddressSimSpillManagement<SumL1MemoryTracker>;
-template class AddressSimSpillManagement<MockAllocatorL1Tracker>;
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -583,6 +583,51 @@ bool L1SpillManagement<MemoryTracker>::willAliasSourceInL1(
          memoryTracker.hasTensorAddress(op->getOperand(0));
 }
 
+//===----------------------------------------------------------------------===//
+// Hooks (default = address-sim path)
+//===----------------------------------------------------------------------===//
+
+template <typename MemoryTracker>
+uint64_t L1SpillManagement<MemoryTracker>::placeValidatedOutput(
+    Operation *op, int64_t pos, ScheduleData &data,
+    const op_constraint_validation::ValidationResult &result) {
+  return ensureFitsL1(op, pos, data, result.cbPeakUsage, result.outputL1Usage);
+}
+
+template <typename MemoryTracker>
+void L1SpillManagement<MemoryTracker>::recoverFromOOM(
+    Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
+    ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
+  handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
+}
+
+template <typename MemoryTracker>
+void L1SpillManagement<MemoryTracker>::commitAllocation(Value val,
+                                                        uint64_t perResultL1,
+                                                        ScheduleData &data) {
+  auto luIt = data.lastUsePositions.find(val);
+  assert(luIt != data.lastUsePositions.end() &&
+         "scheduled value missing its lastUsePositions entry");
+  int64_t resultLastUse = luIt->second;
+
+  // Snapshot before allocation and record event for replay.
+  allocEventIndex[val] = l1EventLog.size();
+  addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
+  l1EventLog.push_back({L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
+
+  // View-eligible reshape: alias src's buffer instead of carving a fresh slot.
+  // Must stay in sync with the willAliasSourceInL1 short-circuit in ensureFitsL1.
+  Operation *defOp = val.getDefiningOp();
+  if (defOp && willAliasSourceInL1(defOp)) {
+    memoryTracker.addTensorAtAddress(val, perResultL1, defOp->getOperand(0));
+  } else {
+    memoryTracker.addTensor(val, perResultL1);
+  }
+
+  liveValues.insert(val);
+  liveSet.push({resultLastUse, val});
+}
+
 template <typename MemoryTracker>
 uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
                                                         int64_t pos,
@@ -1420,30 +1465,7 @@ void L1SpillManagement<MemoryTracker>::run() {
       uint64_t perResultL1 =
           numTensorResults > 0 ? totalL1 / numTensorResults : 0;
       for (auto r : tensorResults) {
-        Value val = r;
-        auto luIt = data.lastUsePositions.find(val);
-        assert(luIt != data.lastUsePositions.end() &&
-               "scheduled value missing its lastUsePositions entry");
-        int64_t resultLastUse = luIt->second;
-        // Snapshot before allocation and record event for replay.
-        allocEventIndex[val] = l1EventLog.size();
-        addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
-        l1EventLog.push_back(
-            {L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
-
-        // View-eligible reshape: alias src's buffer instead of carving a
-        // fresh slot. See `addTensorAtAddress`. Must stay in sync with the
-        // willAliasSourceInL1 short-circuit in ensureFitsL1.
-        Operation *defOp = val.getDefiningOp();
-        if (defOp && willAliasSourceInL1(defOp)) {
-          memoryTracker.addTensorAtAddress(val, perResultL1,
-                                           defOp->getOperand(0));
-        } else {
-          memoryTracker.addTensor(val, perResultL1);
-        }
-
-        liveValues.insert(val);
-        liveSet.push({resultLastUse, val});
+        commitAllocation(r, perResultL1, data);
       }
     };
 
@@ -1468,14 +1490,13 @@ void L1SpillManagement<MemoryTracker>::run() {
     }
 
     if (result.isSuccess()) {
-      uint64_t l1Size = result.outputL1Usage;
-
       TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                    "    VALIDATION SUCCESS: op {0}, "
                    "cbPeakUsage={1}, outputL1={2} bytes",
-                   ttmlir::opToString(op), result.cbPeakUsage, l1Size);
+                   ttmlir::opToString(op), result.cbPeakUsage,
+                   result.outputL1Usage);
 
-      l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
+      uint64_t l1Size = placeValidatedOutput(op, pos, data, result);
       if (rewindIfScheduleShifted()) {
         continue;
       }
@@ -1508,7 +1529,7 @@ void L1SpillManagement<MemoryTracker>::run() {
       continue;
     }
 
-    handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
+    recoverFromOOM(op, pos, tensorResults, data, addResultsToLiveSet);
     if (rewindIfScheduleShifted()) {
       continue;
     }

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -118,14 +118,14 @@ public:
         // queries (conv2d config search, pool/conv constraint checks in
         // OperationValidationAndFallback) see the exact device state main sees.
         op_model::snapshotMockAllocatorState();
-        L1SpillManagement<MockAllocatorL1Tracker> spill(
-            func, deviceGrid, l1BudgetPerCore, std::move(observer));
+        MockAllocatorSpillManagement spill(func, deviceGrid, l1BudgetPerCore,
+                                           std::move(observer));
         spill.run();
         op_model::restoreMockAllocatorState();
         return finalize(spill);
       }
-      L1SpillManagement<SumL1MemoryTracker> spill(
-          func, deviceGrid, l1BudgetPerCore, std::move(observer));
+      SumL1SpillManagement spill(func, deviceGrid, l1BudgetPerCore,
+                                 std::move(observer));
       spill.run();
       return finalize(spill);
     });

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -118,7 +118,7 @@ public:
         // queries (conv2d config search, pool/conv constraint checks in
         // OperationValidationAndFallback) see the exact device state main sees.
         op_model::snapshotMockAllocatorState();
-        MockAllocatorSpillManagement spill(func, deviceGrid, l1BudgetPerCore,
+        StatefulL1SpillManagement spill(func, deviceGrid, l1BudgetPerCore,
                                            std::move(observer));
         spill.run();
         op_model::restoreMockAllocatorState();

--- a/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
+++ b/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
@@ -29,7 +29,7 @@ namespace mlir::tt::ttnn::test {
 //
 // Reuses every IR-builder, layout, observer, and inspection helper from
 // L1SpillTestFixture unchanged. Adds runMock(), which drives
-// MockAllocatorSpillManagement WITHOUT installing a fake
+// StatefulL1SpillManagement WITHOUT installing a fake
 // validator, so the allocator-backed (stateful op-model) path executes.
 //===----------------------------------------------------------------------===//
 class L1SpillMockAllocatorFixture : public L1SpillTestFixture {
@@ -41,7 +41,7 @@ public:
   /// Pass instance kept alive as a fixture member so the observer (owned by the
   /// pass) outlives runMock() and stays reachable via the returned pointer, and
   /// so getMockTracker() can inspect final tracker state after the run.
-  std::unique_ptr<MockAllocatorSpillManagement> passMock;
+  std::unique_ptr<StatefulL1SpillManagement> passMock;
 
   /// Run the allocator-backed pass on `func`. No backendValidator is installed,
   /// so MockAllocatorL1Tracker::validate() issues real (uncached) stateful
@@ -53,7 +53,7 @@ public:
     auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
     ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
 
-    passMock = std::make_unique<MockAllocatorSpillManagement>(
+    passMock = std::make_unique<StatefulL1SpillManagement>(
         func, deviceGrid, l1BudgetPerCore, std::move(obs));
     // Intentionally leave backendValidator unset -> real op-model path.
     passMock->run();

--- a/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
+++ b/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
@@ -29,7 +29,7 @@ namespace mlir::tt::ttnn::test {
 //
 // Reuses every IR-builder, layout, observer, and inspection helper from
 // L1SpillTestFixture unchanged. Adds runMock(), which drives
-// L1SpillManagement<MockAllocatorL1Tracker> WITHOUT installing a fake
+// MockAllocatorSpillManagement WITHOUT installing a fake
 // validator, so the allocator-backed (stateful op-model) path executes.
 //===----------------------------------------------------------------------===//
 class L1SpillMockAllocatorFixture : public L1SpillTestFixture {
@@ -41,7 +41,7 @@ public:
   /// Pass instance kept alive as a fixture member so the observer (owned by the
   /// pass) outlives runMock() and stays reachable via the returned pointer, and
   /// so getMockTracker() can inspect final tracker state after the run.
-  std::unique_ptr<L1SpillManagement<MockAllocatorL1Tracker>> passMock;
+  std::unique_ptr<MockAllocatorSpillManagement> passMock;
 
   /// Run the allocator-backed pass on `func`. No backendValidator is installed,
   /// so MockAllocatorL1Tracker::validate() issues real (uncached) stateful
@@ -53,7 +53,7 @@ public:
     auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
     ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
 
-    passMock = std::make_unique<L1SpillManagement<MockAllocatorL1Tracker>>(
+    passMock = std::make_unique<MockAllocatorSpillManagement>(
         func, deviceGrid, l1BudgetPerCore, std::move(obs));
     // Intentionally leave backendValidator unset -> real op-model path.
     passMock->run();

--- a/test/unittests/Optimizer/L1SpillTestFixture.h
+++ b/test/unittests/Optimizer/L1SpillTestFixture.h
@@ -433,6 +433,33 @@ public:
     return {rawObs};
   }
 
+  /// Stateful-path pass instance, kept alive for post-run inspection.
+  std::unique_ptr<StatefulL1SpillManagement> statefulPass;
+
+  /// Drive StatefulL1SpillManagement (the record-based / captured-allocator
+  /// path) with a synthetic MockAllocatorL1Tracker backendValidator. Because
+  /// the validator short-circuits the op-model, this exercises the stateful
+  /// live-set / eviction-replay machinery with NO device and NO op-model --
+  /// letting a plain unit test reproduce replay behavior deterministically.
+  RunResult
+  runStatefulSynthetic(MockAllocatorL1Tracker::BackendValidatorFn validator) {
+    auto obs = std::make_unique<RecordingObserver>();
+    auto *rawObs = obs.get();
+
+    auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
+    ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
+
+    statefulPass = std::make_unique<StatefulL1SpillManagement>(
+        func, deviceGrid, l1BudgetPerCore, std::move(obs));
+    statefulPass->getMemoryTracker().backendValidator = std::move(validator);
+    statefulPass->run();
+    return {rawObs};
+  }
+
+  bool statefulPassFailed() const {
+    return statefulPass && statefulPass->hasFailed();
+  }
+
   // --- IR inspection helpers ---
 
   /// Count ToMemoryConfigOp that write to DRAM (i.e. spills inserted by pass).

--- a/test/unittests/Optimizer/L1SpillTestFixture.h
+++ b/test/unittests/Optimizer/L1SpillTestFixture.h
@@ -127,7 +127,7 @@ public:
 //  - MLIR context with TTCore + TTNN + Func dialects loaded.
 //  - Helpers to build a func::FuncOp with typed TTNN op graphs.
 //  - Per-op test configuration (setL1Usage, forceOOM, forceNotImplemented).
-//  - run() to construct and drive L1SpillManagement<SumL1MemoryTracker> with
+//  - run() to construct and drive SumL1SpillManagement with
 //    a backend validator lambda built from perOpConfigs.
 //  - Post-run assertion helpers that inspect the mutated IR.
 //===----------------------------------------------------------------------===//
@@ -411,13 +411,13 @@ public:
   /// Pass instance kept alive as a fixture member so the observer (owned by
   /// the pass via unique_ptr) outlives run() and stays accessible through
   /// the returned raw pointer.
-  std::unique_ptr<L1SpillManagement<SumL1MemoryTracker>> pass;
+  std::unique_ptr<SumL1SpillManagement> pass;
 
   struct RunResult {
     RecordingObserver *observer;
   };
 
-  /// Run L1SpillManagement<SumL1MemoryTracker> on `func` with the test
+  /// Run SumL1SpillManagement on `func` with the test
   /// validator installed.
   RunResult run() {
     auto obs = std::make_unique<RecordingObserver>();
@@ -426,7 +426,7 @@ public:
     auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
     ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
 
-    pass = std::make_unique<L1SpillManagement<SumL1MemoryTracker>>(
+    pass = std::make_unique<SumL1SpillManagement>(
         func, deviceGrid, l1BudgetPerCore, std::move(obs));
     pass->getMemoryTracker().backendValidator = makeValidator();
     pass->run();

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -854,3 +854,91 @@ TEST_F(FragmentationTrackerTest, WouldAllocateAtReportsNoFitAndRoundTrips) {
   EXPECT_EQ(tracker.getOccupiedL1(), 60 * kKiB);
   EXPECT_FALSE(tracker.wouldAllocateAt(60 * kKiB).has_value());
 }
+
+//===----------------------------------------------------------------------===//
+// StatefulReplayReusesRecordTest (tt-mlir #9087)
+//
+// Regression for the microsoft_phi-2 n150 hard-fail. On the stateful spill path
+// eviction replays the surviving allocation history. Before the fix, each
+// survivor was RE-QUERIED during replay; a re-query rebuilds the allocator from
+// the reconstructed, address-pinned live set and can report a *fragmentation*
+// OOM (bytes fit, no contiguous block) for a survivor the forward sweep placed
+// fine -- the false no-fit that made the pass wrongly evict a placeable tensor
+// and, on the tight n150 grid, exhaust eviction and hard-fail compilation.
+//
+// The fix re-adds a survivor from its captured forward-sweep record instead of
+// re-querying it, so a placeable set is never wrongly rejected.
+//
+// This test drives the stateful path with a synthetic backend validator (no
+// device / op-model), so it reproduces the replay behavior deterministically:
+//   - producer `p0` is the farthest-last-use victim (evicted first, so the
+//     replay campaign starts at its alloc index and `s` is a replayed survivor);
+//   - survivor `s` validates fine on the forward sweep but its *replay*
+//     re-query returns OOM (the fragmentation false-no-fit);
+//   - trigger `t` OOMs until `p0` is evicted, then fits.
+// Before the fix, `s`'s replay re-query OOMs and eviction spills `s` to DRAM.
+// After, `s` is restored from its record and stays resident in L1.
+//===----------------------------------------------------------------------===//
+class StatefulReplayReusesRecordTest : public L1SpillTestFixture {};
+
+TEST_F(StatefulReplayReusesRecordTest, ReplayReusesRecordForRefusedSurvivor) {
+  l1BudgetPerCore = 1300 * kKiB;
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *p0 = addUnary(args[0], tt, 0); // victim: farthest last-use
+  auto *s = addUnary(args[0], tt, 0);  // survivor: replay re-query OOMs
+  auto *t = addUnary(args[0], tt, 0);  // trigger: initial OOM, then fits
+  auto *useS = addUnary(s->getResult(0), tt, 0);
+  auto *useP0 = addUnary(p0->getResult(0), tt, 0); // p0 dies after s -> farther
+  finishFunc(
+      {t->getResult(0), useS->getResult(0), useP0->getResult(0)});
+
+  auto counts = std::make_shared<llvm::DenseMap<mlir::Operation *, int>>();
+  mlir::Operation *sOp = s;
+  mlir::Operation *tOp = t;
+  constexpr uint64_t kRec = 256 * kKiB;
+
+  auto validator =
+      [counts, sOp, tOp](
+          mlir::Operation *op,
+          llvm::ArrayRef<mlir::tt::ttnn::TTNNLayoutAttr> /*inputLayouts*/,
+          const mlir::tt::ttnn::OpConfig & /*config*/,
+          uint64_t /*additionalL1*/) -> ValidationResult {
+    int n = ++(*counts)[op];
+    mlir::tt::ttnn::TTNNLayoutAttr layout;
+    if (op->getNumResults() > 0) {
+      if (auto rt =
+              mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType())) {
+        layout = mlir::dyn_cast_or_null<mlir::tt::ttnn::TTNNLayoutAttr>(
+            rt.getEncoding());
+      }
+    }
+    // Survivor: placeable on the forward sweep (n==1), refused on the replay
+    // re-query (n>=2). This is the fragmentation false-no-fit under test.
+    if (op == sOp && n >= 2) {
+      return ValidationResult::outOfMemoryError("replay re-query no-fit");
+    }
+    // Trigger: OOM until the victim is evicted (first two queries: the forward
+    // sweep and the first eviction re-check), then fits.
+    if (op == tOp && n <= 2) {
+      return ValidationResult::outOfMemoryError("initial pressure");
+    }
+    ValidationResult r = ValidationResult::success(0, layout, kRec, 0);
+    r.outputAllocations = {mlir::tt::ttnn::op_model::OpModelAllocationRecord{
+        mlir::tt::ttnn::BufferType::L1, /*address=*/0, /*sizePerBank=*/kRec}};
+    return r;
+  };
+
+  runStatefulSynthetic(validator);
+
+  EXPECT_FALSE(statefulPassFailed())
+      << "placeable set wrongly rejected (tt-mlir #9087)";
+  // The survivor must stay resident: the fix restores it from its recorded
+  // placement instead of re-querying (which would refuse it and spill it).
+  EXPECT_FALSE(wasSpilled(s->getResult(0)))
+      << "placeable survivor wrongly spilled to DRAM: replay re-queried it "
+         "instead of reusing its recorded placement (tt-mlir #9087)";
+  EXPECT_TRUE(resultIsL1(s->getResult(0)));
+}

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -241,6 +241,55 @@ TEST_F(MockAllocatorCalibrationTest, PerCoreSizeMatchesConstant) {
 }
 
 //===----------------------------------------------------------------------===//
+// TrackerAliasRefcountKeepsBufferLive
+//
+// Device-free unit test of MockAllocatorL1Tracker's record-level view aliasing:
+// a view output shares its source's buffer (no second record), and the buffer
+// stays live until the last aliaser dies. Exercises addTensor / addTensorAlias
+// / removeTensor / getOccupiedL1 directly, without the op-model query.
+//===----------------------------------------------------------------------===//
+class MockAllocatorTrackerTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorTrackerTest, TrackerAliasRefcountKeepsBufferLive) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+  auto args = beginFunc({tt});
+  auto *ownerOp = addUnary(args[0], tt, 0);
+  auto *viewOp = addUnary(ownerOp->getResult(0), tt, 0);
+  finishFunc({viewOp->getResult(0)});
+
+  mlir::Value owner = ownerOp->getResult(0);
+  mlir::Value view = viewOp->getResult(0);
+
+  constexpr uint64_t kBufBytes = 2048;
+  mlir::tt::ttnn::MockAllocatorL1Tracker t;
+  t.init(/*l1BudgetPerCore=*/100u * kKiB * 1024u);
+  // Seed the owner's record as if a stateful query had produced it.
+  t.pendingRecords[ownerOp] = mlir::tt::ttnn::MockAllocatorL1Tracker::RecordVec{
+      mlir::tt::ttnn::op_model::OpModelAllocationRecord{
+          mlir::tt::ttnn::BufferType::L1, /*address=*/0,
+          /*sizePerBank=*/kBufBytes}};
+
+  t.addTensor(owner, /*l1SizePerCore=*/0);
+  EXPECT_TRUE(t.hasTensor(owner));
+  EXPECT_EQ(t.getOccupiedL1(), kBufBytes);
+
+  t.addTensorAlias(view, owner);
+  EXPECT_TRUE(t.hasTensor(view));
+  EXPECT_EQ(t.getOccupiedL1(), kBufBytes)
+      << "alias shares the owner buffer (no duplicate record)";
+
+  t.removeTensor(owner);
+  EXPECT_EQ(t.getOccupiedL1(), kBufBytes)
+      << "buffer stays live while an aliaser remains";
+  EXPECT_TRUE(t.hasTensor(view));
+
+  t.removeTensor(view);
+  EXPECT_EQ(t.getOccupiedL1(), 0u) << "last aliaser gone -> buffer freed";
+  EXPECT_FALSE(t.hasTensor(view));
+}
+
+//===----------------------------------------------------------------------===//
 // View-op tripwires (https://github.com/tenstorrent/tt-mlir/issues/9054)
 //
 // The L1 spill pass classifies certain ops (reshape/pad/repeat/permute) as


### PR DESCRIPTION
## Summary

Fixes tt-mlir #9087: on the stateful L1-spill refactor (this PR's base branch, PR #9069), **microsoft_phi-2 hard-failed compilation on n150** (8×8 grid) — the greedy spill pass emitted `L1SpillManagementBase: a live tensor has no contiguous L1 placement even after evicting every spillable tensor` on an inserted reshard (`add.1513_mem_reconfig`). It passed on p150 (Blackhole) and pre-refactor on n150, so a **placeable** set was being wrongly rejected — an over-conservative, arch-specific regression.

## Reproduced failure (n150, local on-device)

Exact issue repro command on the branch tip (`ebbabd48da`), phi-2 TTIR from tt-xla run `29829513070`:

```
TTMLIR_SPILL_DEBUG=1 ttmlir-opt \
  "--ttir-to-ttnn-backend-pipeline=system-desc-path=.../system_desc.ttsys optimization-level=2 use-mock-allocator-state=true experimental-weight-dtype=bfp_bf8 experimental-kv-cache-dtype=bfp_bf8" \
  <phi2_ttir>.mlir -o /dev/null
```

**Which debug line fired: `QUERY-NON-SUCCESS`** (not `BYTE-CAP-OOM`). The `REPLAY-NOFIT` on `ttnn.to_memory_config` was caused by the op-model query itself:

```
[spill-debug] QUERY-NON-SUCCESS op=ttnn.to_memory_config status=OOM/other
  msg=... bank_manager.cpp:462: false
  Out of Memory: ... each bank needs 305152 B ... (allocated: 786432, free: 541632, largest free block: 254912)
[spill-debug] REPLAY-NOFIT op=ttnn.to_memory_config isReshard=no ...
error: loc("add.1513_mem_reconfig"): L1SpillManagementBase: a live tensor has no contiguous L1 placement ...
```
It's a **fragmentation** OOM: `free 541632 B` is ample but the `largest free block` (254912 B) is < the needed 305152 B/bank on the tight n150 per-bank layout.

## Root cause

`StatefulL1SpillManagement::replayFrom` re-queried **every surviving op** through the op-model during eviction replay. The stateful query rebuilds tt-metal's allocator from the reconstructed, **address-pinned** live records (`with_allocations` pins buffers at recorded addresses), so it reports a fragmentation OOM for a survivor the forward sweep — and the device — placed fine. The pre-refactor `AddressSimSpillManagement::replayFrom` re-packed via first-fit and never re-queried survivors, so it never hit this false no-fit. The spurious survivor no-fit made `evictUntil` exhaust eviction and `signalPassFailure`.

## Fix (and why it is not a correctness weakening)

Matches the pre-refactor address-sim intent, per the issue's `QUERY-NON-SUCCESS` decision ("reuse the recorded size like the old address-sim path"):

- Capture each op's forward-sweep allocation record at commit time (`committedRecords`).
- During replay, **re-add a survivor from its captured record instead of re-querying it**. Events with no captured record (inserted reshards) are still placed via a query.

This does **not** let genuinely-unplaceable sets through:
- The re-added record set is a validated subset of a state that already fit during the forward sweep (minus the evicted victim), so its capacity is guaranteed — it only stops *rejecting a placeable set*.
- The **current** op's fit is still decided by the real stateful query, so a genuinely over-subscribed op still drives eviction and, if it truly cannot fit, degrades gracefully to DRAM (`demoteToDram`) — never a hard-fail, never a silent mis-place.

A small test-seam change makes the `MockAllocatorL1Tracker` synthetic `backendValidator` stash `pendingRecords` like the real path, so the record-based replay can be exercised device-free.

## Before / after on n150 (local, authorized)

| | hard-fail (`no contiguous L1 placement`) | REPLAY-NOFIT | compile |
|---|---|---|---|
| **before** (base tip) | 1 | 6 | ❌ failed |
| **after** (this PR) | 0 | 0 | ✅ exit 0, valid TTNN module (27262 ttnn ops) |

## Regression test

`test/unittests/Optimizer/TestL1SpillManagement.cpp` → `StatefulReplayReusesRecordTest.ReplayReusesRecordForRefusedSurvivor`: drives the stateful path with a synthetic validator where a survivor validates on the forward sweep but its **replay re-query** is refused (the fragmentation false-no-fit). **Fails before this change** (`wasSpilled(survivor) == true` — the placeable survivor is wrongly spilled to DRAM), **passes after**. Deterministic, device-free.

- `L1SpillManagementTests`: 21/21 pass (incl. new test)
- `L1SpillManagementMockAllocatorTests` (real op-model): 10/10 pass

## Notes

Unrelated CI-runner fabric flakes (`topology_mapper.cpp` / "Engine core initialization failed" on shuffling models) noted in the issue are not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)