### PR TITLE
[EmitPy] Fix multi-chip CPU-hoisted functions by capturing the device mesh shape

### DIFF
--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -207,6 +207,17 @@ def ConvertTTIRCPUToEmitPy : Pass<"convert-ttir-cpu-to-emitpy", "::mlir::ModuleO
                            "mlir::tt::ttir::TTIRDialect"];
 }
 
+def CaptureMeshShape : Pass<"capture-mesh-shape", "::mlir::ModuleOp"> {
+  let summary = "Stamp the device mesh shape onto CPU-hoisted functions";
+  let description = [{
+    Reads the device mesh shape from the `ttcore.device` op in the device module
+    and stamps it as the `ttcore.device_mesh_shape` attribute on each
+    CPU-hoisted (`forward_cpu`) function in the CPU module.
+  }];
+  let constructor = "createCaptureMeshShapePass()";
+  let dependentDialects = ["mlir::tt::ttcore::TTCoreDialect"];
+}
+
 def ConvertTTNNToEmitPy : Pass<"convert-ttnn-to-emitpy", "::mlir::ModuleOp"> {
   let summary = "Convert TTNN dialect to EmitPy dialect.";
   let constructor = "createConvertTTNNToEmitPyPass()";

--- a/include/ttmlir/Conversion/TTIRToEmitPy/TTIRToEmitPy.h
+++ b/include/ttmlir/Conversion/TTIRToEmitPy/TTIRToEmitPy.h
@@ -13,6 +13,10 @@
 
 namespace mlir::tt {
 
+// Pre-pass for ConvertTTIRCPUToEmitPy: stamps the device mesh shape onto the
+// CPU-hoisted functions.
+std::unique_ptr<OperationPass<ModuleOp>> createCaptureMeshShapePass();
+
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRCPUToEmitPyPass();
 
 } // namespace mlir::tt

--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -24,6 +24,9 @@ constexpr inline llvm::StringLiteral g_originalActivationNamesAttrName =
 constexpr inline llvm::StringLiteral g_originalWeightNamesAttrName =
     "ttcore.original_weight_names";
 
+constexpr inline llvm::StringLiteral g_deviceMeshShapeAttrName =
+    "ttcore.device_mesh_shape";
+
 class DeviceOp;
 class DeviceAttr;
 class SystemDescAttr;

--- a/lib/Conversion/TTIRToEmitPy/CMakeLists.txt
+++ b/lib/Conversion/TTIRToEmitPy/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_conversion_library(TTMLIRTTIRToEmitPy
+  CaptureMeshShape.cpp
   TTIRCPUToEmitPyPass.cpp
 
   ADDITIONAL_HEADER_DIRS
@@ -9,5 +10,6 @@ add_mlir_conversion_library(TTMLIRTTIRToEmitPy
 
   LINK_LIBS PUBLIC
   MLIREmitPyDialect
+  MLIRTTCoreDialect
   MLIRTTIRDialect
 )

--- a/lib/Conversion/TTIRToEmitPy/CaptureMeshShape.cpp
+++ b/lib/Conversion/TTIRToEmitPy/CaptureMeshShape.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// CaptureMeshShape pass.
+//
+// A pre-pass for the ConvertTTIRCPUToEmitPy conversion. It runs before the
+// TTNN->EmitPy conversion erases the `ttcore.device` op, reads the device mesh
+// shape, and stamps it as the `ttcore.device_mesh_shape` attribute on each
+// `forward_cpu` function. The emitted CPU-hoisted execution helper
+// (`utils.execute_cpu_hoisted_function`) needs the mesh shape to split and
+// reassemble multi-device tensors, but by the time the CPU module is lowered
+// the device op is gone; capturing it here as metadata makes it available
+// independent of pass ordering, without polluting the flatbuffer path. No-op
+// for single-chip (empty mesh shape).
+//
+
+#include "ttmlir/Conversion/TTIRToEmitPy/TTIRToEmitPy.h"
+
+#include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/FunctionTypes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_CAPTUREMESHSHAPE
+#include "ttmlir/Conversion/Passes.h.inc"
+} // namespace mlir::tt::ttir
+
+namespace {
+
+// Returns the inner ModuleOp wrapped by the WrapperOp (a
+// ttcore.device_module or ttcore.cpu_module) in `rootModule`, or nullptr if no
+// such wrapper is present.
+template <typename WrapperOp>
+static ModuleOp getInnerModule(ModuleOp rootModule) {
+  for (Operation &op : rootModule.getBodyRegion().front()) {
+    if (auto wrapper = dyn_cast<WrapperOp>(op)) {
+      ModuleOp inner = dyn_cast_if_present<ModuleOp>(
+          wrapper.getBodyRegion().front().front());
+      TT_assertv(inner, "module wrapper must have a single ModuleOp child");
+      return inner;
+    }
+  }
+  return nullptr;
+}
+
+struct CaptureMeshShape
+    : public ::mlir::tt::ttir::impl::CaptureMeshShapeBase<CaptureMeshShape> {
+  using ::mlir::tt::ttir::impl::CaptureMeshShapeBase<
+      CaptureMeshShape>::CaptureMeshShapeBase;
+
+  void runOnOperation() final {
+    ModuleOp rootModule = getOperation();
+
+    // Nothing to do if there are no CPU-hoisted functions.
+    ModuleOp cpuInnerModule = getInnerModule<ttcore::CPUModuleOp>(rootModule);
+    if (!cpuInnerModule) {
+      return;
+    }
+
+    // Past this point CPU-hoisted functions exist, so they were hoisted out of
+    // a device module whose device op is still present.
+    ModuleOp deviceInnerModule =
+        getInnerModule<ttcore::DeviceModuleOp>(rootModule);
+    TT_assertv(deviceInnerModule,
+               "CPU module present but device module missing. Run "
+               "tt::WrapDeviceModulePass before this pass.");
+
+    ttcore::DeviceOp deviceOp =
+        deviceInnerModule.lookupSymbol<ttcore::DeviceOp>(
+            ttcore::getDefaultDeviceName());
+    TT_assertv(deviceOp,
+               "Device module has no device op. Run TTCoreRegisterDevicePass "
+               "before this pass.");
+
+    llvm::ArrayRef<int64_t> meshShape = deviceOp.getDeviceAttr().getMeshShape();
+    if (meshShape.empty()) {
+      // Single-chip: no mesh to shard over, so no mesh_shape is needed.
+      return;
+    }
+
+    auto meshShapeAttr = OpBuilder(&getContext()).getI64ArrayAttr(meshShape);
+    for (func::FuncOp func : cpuInnerModule.getOps<func::FuncOp>()) {
+      if (ttmlir::utils::isForwardCPUFunc(func)) {
+        func->setAttr(ttcore::g_deviceMeshShapeAttrName, meshShapeAttr);
+      }
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir::tt {
+
+std::unique_ptr<OperationPass<ModuleOp>> createCaptureMeshShapePass() {
+  return std::make_unique<CaptureMeshShape>();
+}
+
+} // namespace mlir::tt

--- a/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
+++ b/lib/Conversion/TTIRToEmitPy/TTIRCPUToEmitPyPass.cpp
@@ -22,6 +22,7 @@
 #include "ttmlir/Dialect/EmitPy/IR/EmitPyAttrs.h"
 #include "ttmlir/Dialect/EmitPy/IR/EmitPyOps.h"
 #include "ttmlir/Dialect/EmitPy/IR/EmitPyTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/FunctionTypes.h"
 
@@ -1019,6 +1020,19 @@ public:
   }
 };
 
+// Formats a 2-D mesh-shape attribute as a Python tuple literal, e.g. "(4, 8)".
+static std::string formatMeshShapeTuple(ArrayAttr meshShapeAttr) {
+  assert(meshShapeAttr.size() == 2 && "expected a 2-D device mesh shape");
+  std::string literal;
+  llvm::raw_string_ostream os(literal);
+  os << "(";
+  llvm::interleaveComma(meshShapeAttr, os, [&](Attribute dim) {
+    os << mlir::cast<IntegerAttr>(dim).getInt();
+  });
+  os << ")";
+  return literal;
+}
+
 // Wraps each in-place-lowered (now torch-typed) CPU-hoisted function in a
 // ttnn-typed wrapper that defers to utils.execute_cpu_hoisted_function, with
 // the torch body emitted as a nested `<name>_impl` def. Given
@@ -1095,6 +1109,19 @@ static void wrapAndNest(ModuleOp module) {
                                     emitpy::OpaqueAttr::get(ctx, implName)};
     SmallVector<Attribute> callKwargs{StringAttr::get(ctx, ""),
                                       StringAttr::get(ctx, "")};
+    // The mesh shape (stamped by CaptureMeshShape) is passed so the helper can
+    // split/reassemble multi-device tensors. This is required in the
+    // module-export path, where the device is provided by the caller (the host
+    // program the module is linked into, e.g. tt-xla) as an injected argument
+    // and `ttnn.get_device` is stripped, so the DeviceGetter singleton in
+    // utils.py is never populated and the mesh cannot be recovered at runtime.
+    // Absent only for single-chip.
+    if (auto meshShapeAttr =
+            impl->getAttrOfType<ArrayAttr>(ttcore::g_deviceMeshShapeAttrName)) {
+      callArgs.push_back(
+          emitpy::OpaqueAttr::get(ctx, formatMeshShapeTuple(meshShapeAttr)));
+      callKwargs.push_back(StringAttr::get(ctx, "mesh_shape"));
+    }
     auto callOp = builder.create<emitpy::CallOpaqueOp>(
         impl.getLoc(), SmallVector<Type>(numResults, ttnnType),
         "utils.execute_cpu_hoisted_function", callOperands,

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -643,6 +643,8 @@ void createTTNNCommonToEmitCPipeline(
 //
 void createTTNNCommonToEmitPyPipeline(
     OpPassManager &pm, const TTNNCommonToEmitPyPipelineOptions &options) {
+  pm.addPass(mlir::tt::createCaptureMeshShapePass());
+
   auto &devicePm = pm.nest<ttcore::DeviceModuleOp>().nest<mlir::ModuleOp>();
 
   devicePm.addPass(createTTNNAdjustDeallocs());

--- a/test/ttmlir/EmitPy/cpu_hoisted_const_eval_multichip.mlir
+++ b/test/ttmlir/EmitPy/cpu_hoisted_const_eval_multichip.mlir
@@ -19,9 +19,10 @@
 // CHECK-DAG: ttir_cpu.add(
 // CHECK-DAG: ttir_cpu.subtract(
 
-// Each hoisted segment defers to the shard-by-shard helper, passing its body.
-// CHECK-DAG: utils.execute_cpu_hoisted_function({{.*}}, cpu_hoisted_const_eval_{{.*}}_impl)
-// CHECK-DAG: utils.execute_cpu_hoisted_function({{.*}}, cpu_hoisted_const_eval_{{.*}}_impl)
+// Each hoisted segment defers to the shard-by-shard helper, passing its body
+// and the device mesh shape.
+// CHECK-DAG: utils.execute_cpu_hoisted_function({{.*}}, cpu_hoisted_const_eval_{{.*}}_impl, mesh_shape=(1, 2))
+// CHECK-DAG: utils.execute_cpu_hoisted_function({{.*}}, cpu_hoisted_const_eval_{{.*}}_impl, mesh_shape=(1, 2))
 
 // The device-side const-eval function calls the first segment, performs the
 // all_gather on device, brings the result to host, then calls the second

--- a/tools/tt-alchemist/templates/python/local/utils.py
+++ b/tools/tt-alchemist/templates/python/local/utils.py
@@ -94,32 +94,39 @@ def load_tensor(file_path: str, layout, dtype, device, memory_config) -> ttnn.Te
 # CPU-hoisted segments are barrier-free local compute, so each device's shard is
 # computed independently on the host and the per-shard results are reassembled
 # into a multi-device tensor.
-def execute_cpu_hoisted_function(inputs, function):
+def execute_cpu_hoisted_function(inputs, function, mesh_shape=None):
     """Run a pure-torch CPU-hoisted body shard-by-shard over a mesh.
 
-    inputs:   list of ttnn.Tensor operands (device-resident, possibly sharded).
-    function: pure-torch callable mapping torch tensors -> torch tensor(s).
+    inputs:     list of ttnn.Tensor operands (device-resident, possibly sharded).
+    function:   pure-torch callable mapping torch tensors -> torch tensor(s).
+    mesh_shape: the device mesh grid (e.g. (4, 8)), or None. The compiler bakes
+                it in the target-module path, where the DeviceGetter singleton is
+                not populated. When None, try reading it from the DeviceGetter singleton
+                if available (the standalone path populates it by opening its own
+                device). Otherwise, None means single-chip.
     Returns a single ttnn.Tensor, or a tuple of them for multi-output bodies.
     """
 
     def _wrap_outputs(result):
         return result if isinstance(result, (list, tuple)) else (result,)
 
-    # The mesh device comes from the program context (the DeviceGetter
-    # singleton), not from the inputs: CPU-hoisted inputs have already been
-    # brought to host by the device program, so their .device() is None. This
-    # mirrors how the runtime obtains the mesh device from the ProgramContext.
-    mesh_device = DeviceGetter._instance
+    # Recover the mesh grid when the compiler did not bake it in: the standalone
+    # path opens its own device via the DeviceGetter singleton (which may be
+    # multi-device), so read the mesh from there.
+    if mesh_shape is None and DeviceGetter._instance is not None:
+        mesh_shape = DeviceGetter._instance.shape
 
-    # No mesh context: run the body once on the host and return host tensor(s).
-    if mesh_device is None:
+    # No mesh (single-chip): run the body once on the host.
+    if mesh_shape is None:
         torch_inputs = [ttnn.to_torch(tensor) for tensor in inputs]
         outputs = _wrap_outputs(function(*torch_inputs))
         host_outputs = [ttnn.from_torch(out) for out in outputs]
         return host_outputs[0] if len(host_outputs) == 1 else tuple(host_outputs)
 
-    mesh_shape = mesh_device.shape
-    num_shards = mesh_device.get_num_devices()
+    # Multi-chip: run the body shard-by-shard over the mesh.
+    mesh_dims = list(mesh_shape)
+    num_shards = math.prod(mesh_dims)
+    mesh_shape = ttnn.MeshShape(mesh_dims)
 
     # Split each input into per-device torch shards. get_device_tensors returns
     # one shard per device for a sharded tensor, or a single shard for an

--- a/tools/tt-alchemist/templates/python/local/utils.py
+++ b/tools/tt-alchemist/templates/python/local/utils.py
@@ -112,9 +112,9 @@ def execute_cpu_hoisted_function(inputs, function, mesh_shape=None):
 
     # Recover the mesh grid when the compiler did not bake it in: the standalone
     # path opens its own device via the DeviceGetter singleton (which may be
-    # multi-device), so read the mesh from there.
+    # multi-device), so read the mesh it was initialized with.
     if mesh_shape is None and DeviceGetter._instance is not None:
-        mesh_shape = DeviceGetter._instance.shape
+        mesh_shape = DeviceGetter._mesh_shape
 
     # No mesh (single-chip): run the body once on the host.
     if mesh_shape is None:


### PR DESCRIPTION
### Ticket
Closes #9092
### Problem description
Multi-chip CPU-hoisted functions crash in the EmitPy target-module path: `utils.execute_cpu_hoisted_function` reads the mesh from the DeviceGetter singleton, which is never populated when the device is supplied externally (for more info #9092). 
### What's changed
- New **CaptureMeshShape** pass (lib/Conversion/TTIRToEmitPy/CaptureMeshShape.cpp): a pre-pass for convertTTIRCPUToEmitPy. It reads the mesh shape from the `deviceOp` (before the TTNN→EmitPy conversion erases it) and stamps it as the `ttcore.device_mesh_shape` attribute on each forward CPU function. Relevant only for multichip scenarios.
- wrapAndNest (TTIRCPUToEmitPyPass.cpp): reads that attribute and emits it as the `mesh_shape=(…)` argument of the `execute_cpu_hoisted_function` call.
- `execute_cpu_hoisted_function` (utils.py): shards over a mesh with given `mesh_shape`. When `mesh_shape` is not given, it tries reading it from the DeviceGetter singleton. If neither the `mesh_shape` is present nor the DeviceGetter singleton is populated, it runs a single-chip scenario.
### Relevant runs
- [n300 dp](https://github.com/tenstorrent/tt-xla/actions/runs/29936971087)
- [glx tp](https://github.com/tenstorrent/tt-xla/actions/runs/29937030143) (this run is currently failing, but not for the previous reason, as we can see from the logs)
### Checklist
- [x] New/Existing tests provide coverage for changes

