### PR TITLE
[Runtime] Cache TTMetal programs across repeated submissions

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -111,6 +111,7 @@ std::vector<uint32_t> getMeshShape(Device meshDevice);
 std::vector<int> getDeviceIds(Device meshDevice);
 size_t getNumHwCqs(Device meshDevice);
 bool isProgramCacheEnabled(Device meshDevice);
+size_t getNumProgramCacheEntries(Device meshDevice);
 void clearProgramCache(Device meshDevice);
 size_t getL1SmallSize(Device meshDevice);
 size_t getTraceRegionSize(Device meshDevice);

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -203,6 +203,7 @@ std::vector<uint32_t> getMeshOffset(Device meshDevice);
 std::vector<int> getDeviceIds(Device meshDevice);
 size_t getNumHwCqs(Device meshDevice);
 bool isProgramCacheEnabled(Device meshDevice);
+size_t getNumProgramCacheEntries(Device meshDevice);
 void clearProgramCache(Device meshDevice);
 size_t getL1SmallSize(Device meshDevice);
 size_t getTraceRegionSize(Device meshDevice);

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -172,6 +172,7 @@ std::vector<int> getDeviceIds(Device meshDevice);
 std::vector<int> getMappedDeviceIds(const std::vector<uint32_t> &meshShape);
 size_t getNumHwCqs(Device meshDevice);
 bool isProgramCacheEnabled(Device meshDevice);
+size_t getNumProgramCacheEntries(Device meshDevice);
 void clearProgramCache(Device meshDevice);
 size_t getL1SmallSize(Device meshDevice);
 size_t getTraceRegionSize(Device meshDevice);

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -780,6 +780,22 @@ bool isProgramCacheEnabled(Device meshDevice) {
       });
 }
 
+size_t getNumProgramCacheEntries(Device meshDevice) {
+  using RetType = size_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getNumProgramCacheEntries(meshDevice);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getNumProgramCacheEntries(meshDevice);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("getNumProgramCacheEntries",
+                                    HostRuntime::Distributed);
+      });
+}
+
 void clearProgramCache(Device meshDevice) {
   using RetType = void;
   DISPATCH_TO_CURRENT_RUNTIME(

--- a/runtime/lib/ttmetal/arguments.h
+++ b/runtime/lib/ttmetal/arguments.h
@@ -41,7 +41,8 @@ std::vector<std::uint32_t> processKernelArgs(
         *cbs,
     const DeviceAddressValidator &deviceAddressValidator,
     std::function<std::uint32_t(std::uint32_t)> createSemaphoreFn,
-    const std::unordered_map<std::uint32_t, Tensor> &hostBuffers) {
+    const std::unordered_map<std::uint32_t, Tensor> &hostBuffers,
+    const std::vector<std::uint32_t> *cachedArgs = nullptr) {
   std::vector<std::uint32_t> argsVec;
   if (args == nullptr || args->size() == 0) {
     return argsVec;
@@ -78,7 +79,6 @@ std::vector<std::uint32_t> processKernelArgs(
       break;
     }
     case target::metal::KernelArgType::KernelArgLocalSemaphore: {
-      LOG_ASSERT(createSemaphoreFn, "createSemaphoreFn is not set");
       const auto *arg = kernelArg->arg_as_KernelArgLocalSemaphore();
       LOG_ASSERT(arg->operand_idx() < argRefsType->size(),
                  "local semaphore operand_idx out of bounds ",
@@ -94,8 +94,17 @@ std::vector<std::uint32_t> processKernelArgs(
           "Local semaphore id referenced by kernel args is no longer alive "
           "or was never created ",
           logger::Buffer(local_sem_ref->global_id()));
-      argsVec.push_back(createSemaphoreFn(
-          localSemaphoresCache.at(local_sem_ref->global_id())));
+      if (cachedArgs) {
+        LOG_ASSERT(cachedArgs->size() > argsVec.size(),
+                   "Cached kernel arguments are incomplete");
+        // Local semaphore addresses belong to the materialized Program and
+        // must remain unchanged when its other arguments are refreshed.
+        argsVec.push_back(cachedArgs->at(argsVec.size()));
+      } else {
+        LOG_ASSERT(createSemaphoreFn, "createSemaphoreFn is not set");
+        argsVec.push_back(createSemaphoreFn(
+            localSemaphoresCache.at(local_sem_ref->global_id())));
+      }
       break;
     }
     case target::metal::KernelArgType::KernelArgNamedArgument: {
@@ -183,6 +192,13 @@ std::vector<std::uint32_t> processRuntimeArgs(Args &&...args) {
 template <typename... Args>
 std::vector<std::uint32_t> processCompileArgs(Args &&...args) {
   return processKernelArgs<true>(std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+std::vector<std::uint32_t>
+refreshRuntimeArgs(const std::vector<std::uint32_t> &cachedArgs,
+                   Args &&...args) {
+  return processKernelArgs<false>(std::forward<Args>(args)..., &cachedArgs);
 }
 
 } // namespace tt::runtime::ttmetal

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -27,7 +27,10 @@
 #include "ttmlir/Version.h"
 #include "types_generated.h"
 
+#include <algorithm>
 #include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -38,6 +41,47 @@ namespace tt_metal = ::tt::tt_metal;
 namespace distributed = ::tt::tt_metal::distributed;
 
 namespace {
+struct CachedKernelBinding {
+  tt_metal::KernelHandle handle;
+  tt_metal::CoreRangeSet coreRangeSet;
+  std::vector<std::uint32_t> commonRuntimeArgs;
+  std::vector<std::uint32_t> runtimeArgs;
+};
+
+struct CachedCircularBufferBinding {
+  tt_metal::CBHandle handle;
+  std::uint32_t bufferGlobalId;
+};
+
+struct CachedMeshWorkloadState {
+  std::vector<CachedKernelBinding> kernels;
+  std::vector<CachedCircularBufferBinding> circularBuffers;
+};
+
+using CachedMeshWorkload = tt_metal::program_cache::detail::CachedMeshWorkload<
+    CachedMeshWorkloadState>;
+
+bool hasDynamicCompileTimeBindings(
+    const target::metal::EnqueueProgramCommand *command) {
+  for (const target::metal::KernelConfig *kernelConfig :
+       *command->program()->kernels()) {
+    const auto *compileArgs = kernelConfig->args()->ct_args();
+    if (!compileArgs) {
+      continue;
+    }
+
+    for (const target::metal::KernelArg *kernelArg : *compileArgs) {
+      if (kernelArg->arg_type() ==
+              target::metal::KernelArgType::KernelArgBufferAddress ||
+          kernelArg->arg_type() ==
+              target::metal::KernelArgType::KernelArgGlobalSemaphore) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 class MCQExecutor {
 public:
   MCQExecutor(
@@ -45,7 +89,8 @@ public:
       const flatbuffers::Vector<
           flatbuffers::Offset<tt::target::metal::BufferRef>> *programInputs,
       const std::vector<Tensor> &inputs, common::DylibManager &&dylibManager,
-      bool blockingCQ);
+      bool blockingCQ, std::uint64_t binaryId, std::uint32_t programIndex,
+      std::uint32_t deviceProgramIndex);
 
   const std::vector<Tensor> &getOutputs() const { return outputs; }
 
@@ -71,6 +116,15 @@ private:
   void execute(const target::metal::CreateGlobalSemaphoreCommand *command);
   void execute(const target::metal::ResetGlobalSemaphoreCommand *command);
   void execute(const target::metal::CreateLocalSemaphoreCommand *command);
+
+  tt_metal::program_cache::detail::ProgramCacheKey
+  createProgramCacheKey(const target::metal::EnqueueProgramCommand *command,
+                        std::uint32_t commandIndex) const;
+  void refreshCachedMeshWorkload(
+      CachedMeshWorkload &cached,
+      const target::metal::EnqueueProgramCommand *command);
+  void enqueueMeshWorkload(distributed::MeshWorkload &workload,
+                           const char *loc);
 
   std::uint64_t generateUniqueProgramRuntimeId() {
     return nextProgramRuntimeId++;
@@ -98,7 +152,11 @@ private:
   const char *currentProgramName;
   DeviceAddressValidator deviceAddressValidator;
   common::DylibManager dylibManager;
+  std::uint64_t binaryId;
+  std::uint32_t programIndex;
+  std::uint32_t deviceProgramIndex;
   std::uint64_t nextProgramRuntimeId = 10000; // Start at a greppable number.
+  std::uint32_t nextEnqueueProgramIndex = 0;
 };
 } // namespace
 
@@ -107,10 +165,12 @@ MCQExecutor::MCQExecutor(
     const flatbuffers::Vector<flatbuffers::Offset<tt::target::metal::BufferRef>>
         *programInputs,
     const std::vector<Tensor> &inputs, common::DylibManager &&dylibManager,
-    bool blockingCQ)
+    bool blockingCQ, std::uint64_t binaryId, std::uint32_t programIndex,
+    std::uint32_t deviceProgramIndex)
     : meshDevice(meshDevice), blockingCQ(blockingCQ),
       deviceAddressValidator(meshDevice->get_devices().at(0)),
-      dylibManager(std::move(dylibManager)) {
+      dylibManager(std::move(dylibManager)), binaryId(binaryId),
+      programIndex(programIndex), deviceProgramIndex(deviceProgramIndex) {
   initMeshEvents.reserve(inputs.size());
 
   std::uint32_t inputIndex = 0;
@@ -356,11 +416,156 @@ void MCQExecutor::execute(
                                             command->ref()->initial_value());
 }
 
+tt_metal::program_cache::detail::ProgramCacheKey
+MCQExecutor::createProgramCacheKey(
+    const target::metal::EnqueueProgramCommand *command,
+    std::uint32_t commandIndex) const {
+  std::string canonical = "ttmlir.ttmetal:";
+  canonical += std::to_string(binaryId) + ":" + std::to_string(programIndex) +
+               ":" + std::to_string(deviceProgramIndex) + ":" +
+               std::to_string(commandIndex);
+
+  // A scalar compile argument changes the materialized kernel, while runtime
+  // scalars are refreshed in place on cache hits.
+  for (const target::metal::KernelConfig *kernelConfig :
+       *command->program()->kernels()) {
+    const auto *compileArgs = kernelConfig->args()->ct_args();
+    if (!compileArgs) {
+      continue;
+    }
+    for (const target::metal::KernelArg *kernelArg : *compileArgs) {
+      if (kernelArg->arg_type() !=
+          target::metal::KernelArgType::KernelArgScalar) {
+        continue;
+      }
+
+      const auto *arg = kernelArg->arg_as_KernelArgScalar();
+      LOG_ASSERT(command->arg_refs_type()->Get(arg->operand_idx()) ==
+                 target::metal::ArgRef::BufferRef);
+      const auto *buffer = reinterpret_cast<const target::metal::BufferRef *>(
+          command->arg_refs()->Get(arg->operand_idx()));
+      const MetalTensor &metalTensor =
+          hostBuffers.at(buffer->global_id())
+              .as<MetalTensor>(DeviceRuntime::TTMetal);
+      canonical += ":" + std::to_string(std::get<std::uint32_t>(metalTensor));
+    }
+  }
+
+  return {std::hash<std::string>{}(canonical), std::move(canonical)};
+}
+
+void MCQExecutor::refreshCachedMeshWorkload(
+    CachedMeshWorkload &cached,
+    const target::metal::EnqueueProgramCommand *command) {
+  auto &programs = cached.workload.get_programs();
+  LOG_ASSERT(programs.size() == 1,
+             "Cached non-fabric workloads must contain exactly one program");
+  tt_metal::Program &program = programs.begin()->second;
+  LOG_ASSERT(cached.shared_variables.kernels.size() ==
+                 command->program()->kernels()->size(),
+             "Cached kernel binding count mismatch");
+
+  std::function<std::uint32_t(std::uint32_t)> preserveLocalSemaphores;
+  for (std::size_t i = 0; i < cached.shared_variables.kernels.size(); ++i) {
+    const target::metal::KernelConfig *kernelConfig =
+        command->program()->kernels()->Get(i);
+    const CachedKernelBinding &binding = cached.shared_variables.kernels[i];
+
+    std::vector<std::uint32_t> commonRuntimeArgs = refreshRuntimeArgs(
+        binding.commonRuntimeArgs, kernelConfig->args()->crt_args(),
+        command->arg_refs_type(), command->arg_refs(), meshBuffers,
+        global_semaphores, local_semaphore_initializer, command->cbs(),
+        deviceAddressValidator, preserveLocalSemaphores, hostBuffers);
+    tt_metal::RuntimeArgsData &cachedCommonRuntimeArgs =
+        tt_metal::GetCommonRuntimeArgs(program, binding.handle);
+    LOG_ASSERT(cachedCommonRuntimeArgs.size() == commonRuntimeArgs.size(),
+               "Cached common runtime argument count mismatch");
+    std::copy(commonRuntimeArgs.begin(), commonRuntimeArgs.end(),
+              cachedCommonRuntimeArgs.data());
+
+    std::vector<std::uint32_t> runtimeArgs = refreshRuntimeArgs(
+        binding.runtimeArgs, kernelConfig->args()->rt_args(),
+        command->arg_refs_type(), command->arg_refs(), meshBuffers,
+        global_semaphores, local_semaphore_initializer, command->cbs(),
+        deviceAddressValidator, preserveLocalSemaphores, hostBuffers);
+    for (const tt_metal::CoreCoord core :
+         tt_metal::corerange_to_cores(binding.coreRangeSet)) {
+      tt_metal::RuntimeArgsData &cachedRuntimeArgs =
+          tt_metal::GetRuntimeArgs(program, binding.handle, core);
+      LOG_ASSERT(cachedRuntimeArgs.size() == runtimeArgs.size(),
+                 "Cached runtime argument count mismatch");
+      std::copy(runtimeArgs.begin(), runtimeArgs.end(),
+                cachedRuntimeArgs.data());
+    }
+  }
+
+  for (const CachedCircularBufferBinding &binding :
+       cached.shared_variables.circularBuffers) {
+    const auto &meshBuffer = meshBuffers.at(binding.bufferGlobalId);
+    tt_metal::UpdateDynamicCircularBufferAddress(
+        program, binding.handle, *meshBuffer->get_reference_buffer());
+  }
+}
+
+void MCQExecutor::enqueueMeshWorkload(distributed::MeshWorkload &workload,
+                                      const char *loc) {
+  if (perf::Env::get().enablePerfTrace) {
+    auto devices = meshDevice->get_devices();
+    auto meshShape = meshDevice->shape();
+
+    // All programs in a workload represent one serialized enqueue operation.
+    auto opId = generateUniqueProgramRuntimeId();
+    for (auto &[range, program] : workload.get_programs()) {
+      program.set_runtime_id(opId);
+      for (auto coord : range) {
+        size_t linearIdx = coord.to_linear_index(meshShape);
+        auto deviceId = devices[linearIdx]->id();
+        profiler::addProgramProfileHostMetadata(deviceId, program, loc);
+      }
+    }
+  }
+
+  distributed::EnqueueMeshWorkload(*mcq, workload, blockingCQ);
+
+  if (perf::Env::get().enablePerfTrace) {
+    ::tt::tt_metal::ReadMeshDeviceProfilerResults(*meshDevice);
+  }
+}
+
 void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
                           const char *loc, const char *debugInfo) {
   ZoneScopedN("EnqueueProgramCommand");
   LOG_TRACE(logger::LogRuntimeTTMetalCommand, "Executing program: ", loc, "\n",
             debugInfo);
+
+  const std::uint32_t commandIndex = nextEnqueueProgramIndex++;
+  auto &programCache = meshDevice->get_program_cache();
+
+  // Cached bindings describe one Program. Multi-device and fabric workloads
+  // need per-Program binding state before they can be refreshed safely. Buffer
+  // and global semaphore addresses baked into kernels can change between
+  // submissions, so those programs must be rebuilt.
+  const bool cacheEligible = programCache.is_enabled() &&
+                             meshDevice->num_devices() == 1 &&
+                             !command->fabric_connection_config() &&
+                             !hasDynamicCompileTimeBindings(command);
+  tt_metal::program_cache::detail::ProgramCacheKey programKey;
+  if (cacheEligible) {
+    programKey = createProgramCacheKey(command, commandIndex);
+    if (programCache.contains(programKey)) {
+      auto &cachedProgramFactory = programCache.get(programKey);
+      auto &cached =
+          cachedProgramFactory.cached_program.get<CachedMeshWorkload>();
+      refreshCachedMeshWorkload(cached, command);
+      enqueueMeshWorkload(cached.workload, loc);
+      return;
+    }
+
+    LOG_ASSERT(programCache.cache_misses_allowed(),
+               "TTMetal program cache miss occurred while misses are disabled");
+  }
+
+  CachedMeshWorkloadState cacheState;
 
   auto meshWorkload = distributed::MeshWorkload();
   auto deviceRange = distributed::MeshCoordinateRange(meshDevice->shape());
@@ -420,6 +625,12 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
       } else {
         tt_metal::SetRuntimeArgs(program, handle, coreRangeSet, rtArgsVec);
       }
+
+      if (cacheEligible) {
+        cacheState.kernels.push_back({handle, coreRangeSet,
+                                      std::move(commonRtArgsVec),
+                                      std::move(rtArgsVec)});
+      }
     }
 
     for (const target::metal::CBRef *cbRef : *command->cbs()) {
@@ -443,7 +654,12 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
           metalBuffer->circular_buffer_config()->core_range_set());
       tt_metal::CircularBufferConfig config =
           createCircularBufferConfig(cbRef, meshBuffers);
-      tt_metal::CreateCircularBuffer(program, coreRangeSet, config);
+      tt_metal::CBHandle handle =
+          tt_metal::CreateCircularBuffer(program, coreRangeSet, config);
+      if (cacheEligible) {
+        cacheState.circularBuffers.push_back(
+            {handle, cbRef->buffer_ref()->global_id()});
+      }
     }
 
     // fabric connected cores all have separate runtime args so we add a
@@ -457,26 +673,17 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
     }
   }
 
-  if (perf::Env::get().enablePerfTrace) {
-    auto devices = meshDevice->get_devices();
-    auto meshShape = meshDevice->shape();
-
-    // We use the same opId for all programs in the workload.
-    auto opId = generateUniqueProgramRuntimeId();
-    for (auto &[range, program] : meshWorkload.get_programs()) {
-      program.set_runtime_id(opId);
-      for (auto coord : range) {
-        size_t linearIdx = coord.to_linear_index(meshShape);
-        auto deviceId = devices[linearIdx]->id();
-        profiler::addProgramProfileHostMetadata(deviceId, program, loc);
-      }
-    }
-  }
-
-  distributed::EnqueueMeshWorkload(*mcq, meshWorkload, blockingCQ);
-
-  if (perf::Env::get().enablePerfTrace) {
-    ::tt::tt_metal::ReadMeshDeviceProfilerResults(*meshDevice);
+  if (cacheEligible) {
+    CachedMeshWorkload cached(std::move(meshWorkload), std::move(cacheState));
+    programCache.insert(programKey,
+                        tt_metal::program_cache::detail::CachedProgramFactory{
+                            std::move(cached), 0});
+    auto &cachedProgramFactory = programCache.get(programKey);
+    auto &cachedWorkload =
+        cachedProgramFactory.cached_program.get<CachedMeshWorkload>();
+    enqueueMeshWorkload(cachedWorkload.workload, loc);
+  } else {
+    enqueueMeshWorkload(meshWorkload, loc);
   }
 }
 
@@ -648,11 +855,14 @@ std::vector<Tensor>
 executeMeshDeviceProgram(distributed::MeshDevice *meshDevice,
                          const target::metal::DeviceProgram *program,
                          const std::vector<Tensor> &inputs,
-                         common::DylibManager &&dylibs) {
+                         common::DylibManager &&dylibs, std::uint64_t binaryId,
+                         std::uint32_t programIndex,
+                         std::uint32_t deviceProgramIndex) {
   LOG_ASSERT(program->command_queues()->size() == 1, "Only one MCQ supported");
 
   MCQExecutor executor(meshDevice, program->inputs(), inputs, std::move(dylibs),
-                       debug::Env::get().blockingCQ);
+                       debug::Env::get().blockingCQ, binaryId, programIndex,
+                       deviceProgramIndex);
   for (const target::metal::CommandQueue *cq : *program->command_queues()) {
     FrameMark;
     ZoneScoped;

--- a/runtime/lib/ttmetal/executor.h
+++ b/runtime/lib/ttmetal/executor.h
@@ -25,7 +25,9 @@ std::vector<Tensor>
 executeMeshDeviceProgram(::tt::tt_metal::distributed::MeshDevice *meshDevice,
                          const ::tt::target::metal::DeviceProgram *program,
                          const std::vector<Tensor> &inputs,
-                         common::DylibManager &&dylibs);
+                         common::DylibManager &&dylibs, std::uint64_t binaryId,
+                         std::uint32_t programIndex,
+                         std::uint32_t deviceProgramIndex);
 
 } // namespace tt::runtime::ttmetal
 

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -302,6 +302,12 @@ Device openMeshDevice(const MeshDeviceOptions &options) {
           meshConfig, l1SmallSize, traceRegionSize, options.numHWCQs,
           dispatchCoreType);
 
+  if (options.enableProgramCache) {
+    meshDevice->enable_program_cache();
+  } else {
+    meshDevice->disable_and_clear_program_cache();
+  }
+
   LOG_DEBUG("Device grid size = { ",
             meshDevice->compute_with_storage_grid_size().x, ", ",
             meshDevice->compute_with_storage_grid_size().y, " }");
@@ -413,6 +419,13 @@ bool isProgramCacheEnabled(Device meshDevice) {
       meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
           DeviceRuntime::TTMetal);
   return metalMeshDevice.get_program_cache().is_enabled();
+}
+
+size_t getNumProgramCacheEntries(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return metalMeshDevice.num_program_cache_entries();
 }
 
 void clearProgramCache(Device meshDevice) {
@@ -1078,7 +1091,8 @@ std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
 
     outputs = executeMeshDeviceProgram(deviceProgramMeshDevice[i].get(),
                                        deviceProgram, inputs,
-                                       common::DylibManager(fbb.dylibs()));
+                                       common::DylibManager(fbb.dylibs()),
+                                       executableHandle.id(), programIndex, i);
 
     LOG_ASSERT(outputs.size() == program->outputs()->size(),
                "Outputs size mismatch");

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -724,6 +724,12 @@ bool isProgramCacheEnabled(Device meshDevice) {
   return ttnnMeshDevice.get_program_cache().is_enabled();
 }
 
+size_t getNumProgramCacheEntries(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return ttnnMeshDevice.num_program_cache_entries();
+}
+
 void clearProgramCache(Device meshDevice) {
   ::ttnn::MeshDevice &ttnnMeshDevice =
       meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -43,6 +43,8 @@ void registerRuntimeBindings(nb::module_ &m) {
       .def("get_device_ids", &tt::runtime::getDeviceIds)
       .def("get_num_hw_cqs", &tt::runtime::getNumHwCqs)
       .def("is_program_cache_enabled", &tt::runtime::isProgramCacheEnabled)
+      .def("get_num_program_cache_entries",
+           &tt::runtime::getNumProgramCacheEntries)
       .def("clear_program_cache", &tt::runtime::clearProgramCache)
       .def("get_l1_small_size", &tt::runtime::getL1SmallSize)
       .def("get_trace_region_size", &tt::runtime::getTraceRegionSize)

--- a/runtime/python/runtime/stubs_macos.cpp
+++ b/runtime/python/runtime/stubs_macos.cpp
@@ -254,6 +254,7 @@ std::vector<std::uint32_t> getTensorStride(Tensor tensor) { __builtin_trap(); }
 std::uint32_t getTensorVolume(Tensor tensor) { __builtin_trap(); }
 size_t getTraceRegionSize(Device meshDevice) { __builtin_trap(); }
 bool isProgramCacheEnabled(Device meshDevice) { __builtin_trap(); }
+size_t getNumProgramCacheEntries(Device meshDevice) { __builtin_trap(); }
 void clearProgramCache(Device meshDevice) { __builtin_trap(); }
 bool isTensorAllocated(Tensor tensor) { __builtin_trap(); }
 void launchDistributedRuntime(const DistributedOptions &options) {

--- a/test/python/golden/d2m/test_program_cache.py
+++ b/test/python/golden/d2m/test_program_cache.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Optional
+
+import pytest
+import torch
+
+import _ttmlir_runtime as tt_runtime
+from builder.base.builder_apis import compile_ttir_to_flatbuffer
+from builder.base.builder_runtime import (
+    convert_input_layouts,
+    create_tensor,
+    program_outputs_as_dict,
+    runtime_dtype_to_torch_dtype,
+    runtime_str_dtype_to_torch_dtype,
+)
+from builder.base.builder_utils import Operand, Shape
+from builder.ttir.ttir_builder import TTIRBuilder
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+def _execute_add(device, fbb, lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    mesh_shape = device.get_mesh_shape()
+    inputs = [create_tensor({0: tensor}, mesh_shape) for tensor in (lhs, rhs)]
+    converted_inputs = convert_input_layouts(device, inputs, fbb=fbb, program_index=0)
+
+    runtime_outputs = tt_runtime.runtime.submit(device, fbb, 0, converted_inputs)
+    tt_runtime.runtime.wait(runtime_outputs)
+
+    output_desc = program_outputs_as_dict(fbb, 0)[0]["desc"]
+    output = torch.zeros(
+        output_desc["shape"],
+        dtype=runtime_str_dtype_to_torch_dtype(
+            output_desc["layout"]["memory_desc"]["data_type"]
+        ),
+    )
+    output_tensor = create_tensor({0: output}, mesh_shape)
+    output_shards = tt_runtime.runtime.to_host(runtime_outputs[0], untilize=True)
+    assert len(output_shards) == 1
+    tt_runtime.runtime.memcpy(output_tensor, output_shards[0])
+
+    data = torch.frombuffer(
+        bytearray(output_tensor.get_data_buffer()),
+        dtype=runtime_dtype_to_torch_dtype(output_tensor.get_dtype()),
+    ).reshape(output_tensor.get_shape())
+    tt_runtime.runtime.deallocate_tensor(runtime_outputs[0], force=True)
+    return data.clone()
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("force_compile_time_args", [False, True])
+def test_repeated_submission_with_dynamic_inputs(
+    target: str, force_compile_time_args: bool, request, device
+):
+    shape: Shape = (64, 64)
+    dtype = torch.float32
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, shape], [dtype, dtype])
+        def add(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.add(in0, in1, unit_attrs=unit_attrs)
+
+    _, capsule, _, _ = compile_ttir_to_flatbuffer(
+        module,
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+        custom_pipeline=(
+            "ttir-to-ttmetal-pipeline{force-compile-time-args=1}"
+            if force_compile_time_args
+            else None
+        ),
+    )
+    fbb = tt_runtime.binary.load_binary_from_capsule(capsule)
+
+    assert device.is_program_cache_enabled()
+    device.clear_program_cache()
+    assert device.get_num_program_cache_entries() == 0
+
+    cold_lhs = torch.full(shape, 0.25, dtype=dtype)
+    cold_rhs = torch.full(shape, 0.5, dtype=dtype)
+    cold_output = _execute_add(device, fbb, cold_lhs, cold_rhs)
+    torch.testing.assert_close(cold_output, cold_lhs + cold_rhs, atol=0.005, rtol=0.01)
+    cold_cache_entries = device.get_num_program_cache_entries()
+    assert cold_cache_entries > 0
+
+    # Normal lowering refreshes cached bindings. Forced compile-time lowering
+    # rebuilds programs whose kernels bake in allocation-dependent addresses,
+    # while address-independent programs in the command queue remain eligible.
+    warm_lhs = torch.linspace(-1.0, 1.0, shape[0] * shape[1], dtype=dtype).reshape(
+        shape
+    )
+    warm_rhs = torch.linspace(1.0, 2.0, shape[0] * shape[1], dtype=dtype).reshape(shape)
+    warm_output = _execute_add(device, fbb, warm_lhs, warm_rhs)
+    torch.testing.assert_close(warm_output, warm_lhs + warm_rhs, atol=0.005, rtol=0.01)
+    assert device.get_num_program_cache_entries() == cold_cache_entries

--- a/test/python/golden/d2m/test_scalar_rt_arg.py
+++ b/test/python/golden/d2m/test_scalar_rt_arg.py
@@ -130,9 +130,12 @@ def test_scalar_kernel_arg(target: str, request, device):
     capsule = ttmetal_to_flatbuffer_bin(module)
     fbb = tt_runtime.binary.load_binary_from_capsule(capsule)
 
-    scalar = tt_runtime.runtime.create_scalar_tensor(42)
-    outputs = tt_runtime.runtime.submit(device, fbb, 0, [scalar])
-    tt_runtime.runtime.wait(outputs)
+    device.clear_program_cache()
+    for value, expected_cache_entries in ((42, 1), (42, 1), (7, 2), (42, 2)):
+        scalar = tt_runtime.runtime.create_scalar_tensor(value)
+        outputs = tt_runtime.runtime.submit(device, fbb, 0, [scalar])
+        tt_runtime.runtime.wait(outputs)
+        assert device.get_num_program_cache_entries() == expected_cache_entries
 
 
 @pytest.mark.parametrize("target", ["ttnn"])


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The TTMetal flatbuffer runtime reconstructs every `Program` and `MeshWorkload` on each repeated submission, even when the binary, program, and enqueue operation are unchanged. `MeshDeviceOptions::enableProgramCache` was also not applied when opening a TTMetal mesh device.

### What changed
- Honor `enableProgramCache` for TTMetal mesh devices.
- Cache each eligible `MeshWorkload` by binary, program, device-program, enqueue ordinal, and scalar compile-time arguments.
- Refresh buffer-backed runtime arguments, common runtime arguments, and dynamic circular-buffer addresses on cache hits.
- Preserve local semaphore addresses owned by the cached `Program`.
- Rebuild only programs with compile-time buffer or global-semaphore addresses, since those addresses can change between submissions.
- Restrict caching to single-device, non-fabric workloads until cached bindings are tracked per `Program` in a multi-device workload.
- Expose program-cache entry counts through the runtime API so tests can assert hits and misses directly.
- Add device coverage for changing allocations and values, forced compile-time-address lowering, and compile-time scalar hit/miss sequences.

### Testing
- Rebased onto current `main` (`da6f1ce081`).
- Configured a Debug runtime build with runtime tests, StableHLO, TTNN JIT, and perf tracing enabled against pinned TT-Metal `5beed318d0f0d1c6212e605947fb0be80c9e0a1d`.
- `cmake --build build --target _ttmlir_runtime -j16`
- `pytest -q test/python/golden/d2m/test_program_cache.py test/python/golden/d2m/test_scalar_rt_arg.py::test_scalar_kernel_arg --sys-desc current.ttsys` (`3 passed`)
- `pre-commit` passed for every changed file.

### Checklist
- [x] New/Existing tests provide coverage for changes
