### PR TITLE
[codegen] Fix l1SmallSize to mimic runtime

### DIFF
--- a/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
@@ -80,7 +80,7 @@ namespace ttnn {
 //
 class DeviceGetter {
 public:
-  static constexpr std::size_t l1SmallSize = 1 << 15; // 32kB
+  static constexpr std::size_t l1SmallSize = 1 << 16; // 64kB
   static constexpr std::size_t traceRegionSize = 0;
 
   static ttnn::MeshDevice *getInstance() {

--- a/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
@@ -80,7 +80,7 @@ namespace ttnn {
 //
 class DeviceGetter {
 public:
-  static constexpr std::size_t l1SmallSize = 1 << 15; // 32kB
+  static constexpr std::size_t l1SmallSize = 1 << 16; // 64kB
   static constexpr std::size_t traceRegionSize = 0;
 
   static ttnn::MeshDevice *getInstance() {

--- a/tools/tt-alchemist/templates/python/local/utils.py
+++ b/tools/tt-alchemist/templates/python/local/utils.py
@@ -9,7 +9,7 @@ class DeviceGetter:
     _instance = None
     _mesh_shape = None
     _fabric_config = None
-    l1_small_size = 1 << 15
+    l1_small_size = 1 << 16  # 64kB
 
     def __init__(self):
         raise RuntimeError("This is Singleton, invoke get_device() instead.")

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -109,7 +109,7 @@ namespace ttnn {
 //
 class DeviceGetter {
 public:
-  static constexpr std::size_t l1SmallSize = 1 << 15; // 32kB
+  static constexpr std::size_t l1SmallSize = 1 << 16; // 64kB
   static constexpr std::size_t traceRegionSize = 0;
 
   static ttnn::MeshDevice *getInstance() {


### PR DESCRIPTION
### Ticket
N/A
### Problem description
`l1SmallSize` used for codegen should have the same value as the constant used by the runtime. 
### What's changed
Changed `l1SmallSize` to `1 << 16` to mimic the runtime.

### Checklist
- [ ] New/Existing tests provide coverage for changes
