### PR TITLE
Add d2m-jit to CI

### DIFF
--- a/.github/settings/optional-components.yml
+++ b/.github/settings/optional-components.yml
@@ -10,3 +10,6 @@ ttnn-jit-wheel:
   - tools/ttnn-jit/**
 ttnn-jit-nightly:
   - test/ttnn-jit/nightly/**
+d2m-jit-nightly:
+  - test/d2m-jit/**
+  - tools/d2m-jit/**

--- a/.github/settings/optional-components.yml
+++ b/.github/settings/optional-components.yml
@@ -10,6 +10,3 @@ ttnn-jit-wheel:
   - tools/ttnn-jit/**
 ttnn-jit-nightly:
   - test/ttnn-jit/nightly/**
-d2m-jit-nightly:
-  - test/d2m-jit/**
-  - tools/d2m-jit/**

--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -1,43 +1,4 @@
 [
-    { "runs-on": ["n150","n300","llmbox"],
-          "image": "speedy",
-              "script": "ttrt.sh", "args": ["run", "Silicon"] },
-
-    { "runs-on": ["n150","n300","llmbox"],
-          "image": "tracy",
-              "script": "ttrt.sh", "args": ["perf", "Silicon/TTNN/$RUNS_ON/perf"] },
-
-    { "runs-on": "n150", "image": "tracy", "script": "chisel.sh" },
-    { "runs-on": "n300", "image": "tracy", "script": "chisel.sh" },
-
-    { "runs-on": "n150",
-          "image": "tracy",
-              "script": "test-ttrt.sh" },
-
-    { "runs-on": "n150",
-          "image": "tracy",
-              "script": "pytest.sh", "args": "test/python/op_by_op" },
-
-    { "runs-on": "n150",   "image": "tracy",  "script": "pytest.sh", "args": "tools/explorer/test/run_tests.py", "reqs": "--force-reinstall $BUILD_DIR/bin/wheels/tt_adapter*.whl $BUILD_DIR/bin/wheels/ai_edge_model_explorer*.whl" },
-
-    { "runs-on": ["llmbox","n300","n150","p150"],
-          "image": "tracy",
-              "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt"], "autosplit": "builder" },
-
-    { "runs-on": "n150",   "image": "tracy",  "script": "op_model_ttrt.sh", "args": "perf" },
-    { "runs-on": "n150",   "image": "speedy",  "script": "op_model_ttrt.sh", "args": "run" },
-    { "runs-on": "n150",   "image": "speedy", "script": "op_model.sh" },
-
-    { "runs-on": "n150",   "image": "speedy", "script": "builder.sh", "args": [ "test/python/golden/optimizer", "", "require-opmodel" ] },
-    { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n150" },
-    { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/n150" },
-    { "runs-on": "n300",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n300" },
-    { "runs-on": "llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py" },
-    { "runs-on": "llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox/test_multiprocess_tracy.py", "reqs": "websockets" },
-    { "runs-on": "llmbox", "image": "speedy", "script": "ttrt.sh", "args": ["run", "Dialect/TTNN/trace/scenarios/llmbox", "--enable-program-cache", "--loops", "3"] },
-    { "runs-on": "n300",   "image": "tracy",  "script": "runtime_debug.sh" },
-    { "runs-on": "n150",   "image": "speedy",  "script": "ttnn_standalone.sh" },
-    { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },
     { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_jit.sh", "args": "nightly", "if": "ttnn-jit-nightly" },
     { "runs-on": ["n150","llmbox","p150"],   "image": "tracy",  "script": "ttnn_jit.sh" },
     { "runs-on": "n150",   "image": "tracy",  "script": "d2m_jit.sh", "args": "nightly", "if": "d2m-jit-nightly" },

--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -40,7 +40,6 @@
     { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },
     { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_jit.sh", "args": "nightly", "if": "ttnn-jit-nightly" },
     { "runs-on": ["n150","llmbox","p150"],   "image": "tracy",  "script": "ttnn_jit.sh" },
-    { "runs-on": "n150",   "image": "tracy",  "script": "d2m_jit.sh", "args": "nightly", "if": "d2m-jit-nightly" },
     { "runs-on": ["n150","p150"],   "image": "tracy",  "script": "d2m_jit.sh" },
     { "runs-on": "n150",   "image": "speedy",  "script": "alchemist.sh" },
     { "runs-on": "n150",   "image": "speedy",  "script": "emitc.sh"}

--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -40,6 +40,8 @@
     { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },
     { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_jit.sh", "args": "nightly", "if": "ttnn-jit-nightly" },
     { "runs-on": ["n150","llmbox","p150"],   "image": "tracy",  "script": "ttnn_jit.sh" },
+    { "runs-on": "n150",   "image": "tracy",  "script": "d2m_jit.sh", "args": "nightly", "if": "d2m-jit-nightly" },
+    { "runs-on": ["n150","p150"],   "image": "tracy",  "script": "d2m_jit.sh" },
     { "runs-on": "n150",   "image": "speedy",  "script": "alchemist.sh" },
     { "runs-on": "n150",   "image": "speedy",  "script": "emitc.sh"}
   ]

--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -1,4 +1,43 @@
 [
+    { "runs-on": ["n150","n300","llmbox"],
+          "image": "speedy",
+              "script": "ttrt.sh", "args": ["run", "Silicon"] },
+
+    { "runs-on": ["n150","n300","llmbox"],
+          "image": "tracy",
+              "script": "ttrt.sh", "args": ["perf", "Silicon/TTNN/$RUNS_ON/perf"] },
+
+    { "runs-on": "n150", "image": "tracy", "script": "chisel.sh" },
+    { "runs-on": "n300", "image": "tracy", "script": "chisel.sh" },
+
+    { "runs-on": "n150",
+          "image": "tracy",
+              "script": "test-ttrt.sh" },
+
+    { "runs-on": "n150",
+          "image": "tracy",
+              "script": "pytest.sh", "args": "test/python/op_by_op" },
+
+    { "runs-on": "n150",   "image": "tracy",  "script": "pytest.sh", "args": "tools/explorer/test/run_tests.py", "reqs": "--force-reinstall $BUILD_DIR/bin/wheels/tt_adapter*.whl $BUILD_DIR/bin/wheels/ai_edge_model_explorer*.whl" },
+
+    { "runs-on": ["llmbox","n300","n150","p150"],
+          "image": "tracy",
+              "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt"], "autosplit": "builder" },
+
+    { "runs-on": "n150",   "image": "tracy",  "script": "op_model_ttrt.sh", "args": "perf" },
+    { "runs-on": "n150",   "image": "speedy",  "script": "op_model_ttrt.sh", "args": "run" },
+    { "runs-on": "n150",   "image": "speedy", "script": "op_model.sh" },
+
+    { "runs-on": "n150",   "image": "speedy", "script": "builder.sh", "args": [ "test/python/golden/optimizer", "", "require-opmodel" ] },
+    { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n150" },
+    { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/n150" },
+    { "runs-on": "n300",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n300" },
+    { "runs-on": "llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py" },
+    { "runs-on": "llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox/test_multiprocess_tracy.py", "reqs": "websockets" },
+    { "runs-on": "llmbox", "image": "speedy", "script": "ttrt.sh", "args": ["run", "Dialect/TTNN/trace/scenarios/llmbox", "--enable-program-cache", "--loops", "3"] },
+    { "runs-on": "n300",   "image": "tracy",  "script": "runtime_debug.sh" },
+    { "runs-on": "n150",   "image": "speedy",  "script": "ttnn_standalone.sh" },
+    { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },
     { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_jit.sh", "args": "nightly", "if": "ttnn-jit-nightly" },
     { "runs-on": ["n150","llmbox","p150"],   "image": "tracy",  "script": "ttnn_jit.sh" },
     { "runs-on": "n150",   "image": "tracy",  "script": "d2m_jit.sh", "args": "nightly", "if": "d2m-jit-nightly" },

--- a/.github/test_scripts/d2m_jit.sh
+++ b/.github/test_scripts/d2m_jit.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e -o pipefail
+
+# Unlike ttnn-jit, d2m-jit ships as a plain python package under
+# build/python_packages (built by the `d2m-jit` CMake target on the tracy
+# flavor), so there is no wheel to download/install. env/activate already puts
+# build/python_packages on PYTHONPATH; set it explicitly anyway, and add the
+# tt-metal python paths plus test/d2m-jit so the suite's `runner`/`utils`
+# imports resolve under pytest.
+export PYTHONPATH="$BUILD_DIR/python_packages:$WORK_DIR/test/d2m-jit:$INSTALL_DIR/tt-metal/ttnn:$INSTALL_DIR/tt-metal:$PYTHONPATH"
+
+# The in-process runtime expects tt-metal at third_party/tt-metal/src/tt-metal.
+mkdir -p $WORK_DIR/third_party/tt-metal/src
+ln -sf $INSTALL_DIR/tt-metal $WORK_DIR/third_party/tt-metal/src/tt-metal
+
+# lit and pytest both emit junit xml; keep them in separate report files so one
+# does not clobber the other (both still match report_*.xml for collection).
+LIT_REPORT_PATH="${TEST_REPORT_PATH%.xml}_lit.xml"
+
+echo "Running d2m-jit tests (RUNS_ON=$RUNS_ON)..."
+if [ "$1" == "nightly" ]; then
+    # Full suite: FileCheck lit tests + every pytest module. Runs every nightly
+    # and on PRs that touch test/d2m-jit or tools/d2m-jit (d2m-jit-nightly
+    # component in .github/settings/optional-components.yml).
+    llvm-lit -v --xunit-xml-output "$LIT_REPORT_PATH" "$BUILD_DIR/test/d2m-jit/lit"
+    pytest -v "$WORK_DIR"/test/d2m-jit/test_*.py --junit-xml="$TEST_REPORT_PATH"
+else
+    # Always-on PR smoke: a single, device-generic eltwise kernel that exercises
+    # the build + in-process execution path on every runner.
+    pytest -v "$WORK_DIR/test/d2m-jit/test_simple.py" --junit-xml="$TEST_REPORT_PATH"
+fi
+
+# cleanup
+rm -rf $WORK_DIR/third_party/tt-metal

--- a/.github/test_scripts/d2m_jit.sh
+++ b/.github/test_scripts/d2m_jit.sh
@@ -19,6 +19,3 @@ echo "Running d2m-jit tests (RUNS_ON=$RUNS_ON)..."
 # Full suite: FileCheck lit tests + every pytest module. Runs on every PR.
 llvm-lit -v --xunit-xml-output "$LIT_REPORT_PATH" "$BUILD_DIR/test/d2m-jit/lit"
 pytest -v "$WORK_DIR"/test/d2m-jit/test_*.py --junit-xml="$TEST_REPORT_PATH"
-
-# cleanup
-rm -rf $WORK_DIR/third_party/tt-metal

--- a/.github/test_scripts/d2m_jit.sh
+++ b/.github/test_scripts/d2m_jit.sh
@@ -5,12 +5,6 @@
 
 set -e -o pipefail
 
-# Unlike ttnn-jit, d2m-jit ships as a plain python package under
-# build/python_packages (built by the `d2m-jit` CMake target on the tracy
-# flavor), so there is no wheel to download/install. env/activate already puts
-# build/python_packages on PYTHONPATH; set it explicitly anyway, and add the
-# tt-metal python paths plus test/d2m-jit so the suite's `runner`/`utils`
-# imports resolve under pytest.
 export PYTHONPATH="$BUILD_DIR/python_packages:$WORK_DIR/test/d2m-jit:$INSTALL_DIR/tt-metal/ttnn:$INSTALL_DIR/tt-metal:$PYTHONPATH"
 
 # The in-process runtime expects tt-metal at third_party/tt-metal/src/tt-metal.

--- a/.github/test_scripts/d2m_jit.sh
+++ b/.github/test_scripts/d2m_jit.sh
@@ -19,3 +19,6 @@ echo "Running d2m-jit tests (RUNS_ON=$RUNS_ON)..."
 # Full suite: FileCheck lit tests + every pytest module. Runs on every PR.
 llvm-lit -v --xunit-xml-output "$LIT_REPORT_PATH" "$BUILD_DIR/test/d2m-jit/lit"
 pytest -v "$WORK_DIR"/test/d2m-jit/test_*.py --junit-xml="$TEST_REPORT_PATH"
+
+# cleanup
+rm -rf $WORK_DIR/third_party/tt-metal

--- a/.github/test_scripts/d2m_jit.sh
+++ b/.github/test_scripts/d2m_jit.sh
@@ -16,17 +16,9 @@ ln -sf $INSTALL_DIR/tt-metal $WORK_DIR/third_party/tt-metal/src/tt-metal
 LIT_REPORT_PATH="${TEST_REPORT_PATH%.xml}_lit.xml"
 
 echo "Running d2m-jit tests (RUNS_ON=$RUNS_ON)..."
-if [ "$1" == "nightly" ]; then
-    # Full suite: FileCheck lit tests + every pytest module. Runs every nightly
-    # and on PRs that touch test/d2m-jit or tools/d2m-jit (d2m-jit-nightly
-    # component in .github/settings/optional-components.yml).
-    llvm-lit -v --xunit-xml-output "$LIT_REPORT_PATH" "$BUILD_DIR/test/d2m-jit/lit"
-    pytest -v "$WORK_DIR"/test/d2m-jit/test_*.py --junit-xml="$TEST_REPORT_PATH"
-else
-    # Always-on PR smoke: a single, device-generic eltwise kernel that exercises
-    # the build + in-process execution path on every runner.
-    pytest -v "$WORK_DIR/test/d2m-jit/test_simple.py" --junit-xml="$TEST_REPORT_PATH"
-fi
+# Full suite: FileCheck lit tests + every pytest module. Runs on every PR.
+llvm-lit -v --xunit-xml-output "$LIT_REPORT_PATH" "$BUILD_DIR/test/d2m-jit/lit"
+pytest -v "$WORK_DIR"/test/d2m-jit/test_*.py --junit-xml="$TEST_REPORT_PATH"
 
 # cleanup
 rm -rf $WORK_DIR/third_party/tt-metal

--- a/.github/workflows/call-build-release.yml
+++ b/.github/workflows/call-build-release.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         build: [
           { enable_op_model: "ON", enable_emitc: "ON", enable_alchemist_whl: "ON", name: "speedy" },
-          { enable_op_model: "ON", enable_perf: "ON", enable_runtime_debug: "ON", enable_explorer: "ON", enable_pykernel: "ON", enable_ttnn_jit: "ON", name: "tracy" }
+          { enable_op_model: "ON", enable_perf: "ON", enable_runtime_debug: "ON", enable_explorer: "ON", enable_pykernel: "ON", enable_ttnn_jit: "ON", enable_d2m_jit: "ON", name: "tracy" }
         ]
 
     name: Build ${{ matrix.build.name }} Release
@@ -112,6 +112,7 @@ jobs:
           -DTT_RUNTIME_ENABLE_PERF_TRACE=${{ matrix.build.enable_perf }} \
           -DTTMLIR_ENABLE_PYKERNEL=${{ matrix.build.enable_pykernel }} \
           -DTTMLIR_ENABLE_TTNN_JIT=${{ matrix.build.enable_ttnn_jit }} \
+          -DTTMLIR_ENABLE_D2M_JIT=${{ matrix.build.enable_d2m_jit }} \
           -DTTMLIR_ENABLE_STABLEHLO=ON \
           -DTTMLIR_ENABLE_OPMODEL=${{ matrix.build.enable_op_model }} \
           -DTTMLIR_ENABLE_ALCHEMIST_WHEEL=${{ matrix.build.enable_alchemist_whl }} \
@@ -129,6 +130,9 @@ jobs:
       shell: bash
       run: |
         source env/activate
+        # compile-ttmlir-tests depends on the d2m-jit target when
+        # TTMLIR_ENABLE_D2M_JIT=ON, so the d2m_jit python package lands in
+        # build/python_packages (archived below) for the d2m-jit test job.
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- compile-ttmlir-tests
 
     - name: Install

--- a/.github/workflows/call-build-release.yml
+++ b/.github/workflows/call-build-release.yml
@@ -130,9 +130,6 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        # compile-ttmlir-tests depends on the d2m-jit target when
-        # TTMLIR_ENABLE_D2M_JIT=ON, so the d2m_jit python package lands in
-        # build/python_packages (archived below) for the d2m-jit test job.
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- compile-ttmlir-tests
 
     - name: Install

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -145,7 +145,7 @@ jobs:
         rm -rf ttrt_results || true
         mkdir -p ttrt_results
         if [ "${{ matrix.build.runs-on }}" != "builder" ]; then
-          llvm-lit --filter-out="optimizer|ttnn-jit" --xunit-xml-output ${{ steps.strings.outputs.work-dir }}/test_reports/report_lit_${{matrix.build.runs-on}}_${{ matrix.build.image }}_${{strategy.job-index}}_${{job.check_run_id}}.xml \
+          llvm-lit --filter-out="optimizer|ttnn-jit|d2m-jit" --xunit-xml-output ${{ steps.strings.outputs.work-dir }}/test_reports/report_lit_${{matrix.build.runs-on}}_${{ matrix.build.image }}_${{strategy.job-index}}_${{job.check_run_id}}.xml \
             ${{ steps.strings.outputs.build-output-dir }}/test
         fi
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,6 +44,9 @@ endif()
 if(TTMLIR_ENABLE_TTNN_JIT AND MLIR_ENABLE_BINDINGS_PYTHON AND TTMLIR_ENABLE_BINDINGS_PYTHON)
     list(APPEND TTMLIR_TEST_DEPENDS ttnn-jit)
 endif()
+if(TTMLIR_ENABLE_D2M_JIT AND MLIR_ENABLE_BINDINGS_PYTHON AND TTMLIR_ENABLE_BINDINGS_PYTHON)
+    list(APPEND TTMLIR_TEST_DEPENDS d2m-jit)
+endif()
 
 # Add custom target to compile everything needed for tests but not execute it
 add_custom_target(compile-ttmlir-tests DEPENDS ${TTMLIR_TEST_DEPENDS})


### PR DESCRIPTION
Closes [#9108](https://github.com/tenstorrent/tt-mlir/issues/9108) 

## What

Adds the d2m-jit test suite to CI and runs the full suite on every PR.

Build side (tracy flavor):
- `call-build-release.yml`: build with `-DTTMLIR_ENABLE_D2M_JIT=ON`; `compile-ttmlir-tests` pulls in the `d2m-jit` target (see `test/CMakeLists.txt`), landing the python package in `build/python_packages`.
- `call-test.yml`: exclude `d2m-jit` from the generic lit run (they need hardware, serial execution, and the d2m-jit runtime env set up only by `d2m_jit.sh`).

Test side:
- `d2m_jit.sh`: sets up PYTHONPATH + the `third_party/tt-metal` symlink, then runs the FileCheck lit tests and every `test_*.py` pytest module.
- `tests.json`: one d2m-jit entry running the full suite on **n150 + p150**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)