### PR TITLE
[Optimizer] Reconcile op-model result dtypes instead of redefining declared ones (fixes #9115)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
@@ -125,6 +125,13 @@ private:
   /// Update function return types to match modified IR.
   void updateFunctionReturnTypes();
 
+  /// Backstop for updateFunctionReturnTypes: a function result's layout may
+  /// change, its element type may not. Casts the return operand back to the
+  /// declared element type if it diverged.
+  void reconcileReturnOperandDataType(func::ReturnOp returnOp,
+                                      unsigned operandIdx,
+                                      FunctionType declaredType);
+
   /// Backward pass: consolidate beam at fork points.
   /// Only runs when beamWidth > 1.
   void consolidateBeam();

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -81,6 +81,53 @@ static TTNNLayoutAttr getOutputLayoutForResult(const BeamCandidate &c,
   return c.configHint.outputLayout;
 }
 
+/// Returns `layout` with its scalar element type replaced, recomputing the
+/// physical layout for the new element size. Layouts that already carry the
+/// requested type are returned unchanged. Delegates the actual re-encoding to
+/// RankedTensorTypeFactory so element-type handling - including quantized types
+/// - lives in one place, and keeps only the encoding of its result.
+static TTNNLayoutAttr withScalarElementType(TTNNLayoutAttr layout,
+                                            llvm::ArrayRef<int64_t> tensorShape,
+                                            Type scalarElementType) {
+  if (!layout || layout.getScalarElementType() == scalarElementType) {
+    return layout;
+  }
+  RankedTensorType asTensorType =
+      RankedTensorType::get(tensorShape, layout.getScalarElementType(), layout);
+  return utils::getLayoutAttrFromTensor(utils::RankedTensorTypeFactory::create(
+      asTensorType, ttcore::elementTypeToDataType(scalarElementType)));
+}
+
+/// The op-model reports the result layout tt-metal actually produces, whose
+/// data type can differ from the one declared on the op result: ttnn.argmax
+/// really produces ui32 where the frontend declared si32. applyOpConfig adopts
+/// the real data type and reconciles it back to the declared one with a cast,
+/// so everything that reasons about the value a consumer sees - the input
+/// candidates, and the reshard sources validated against them - must use the
+/// declared data type. Layouts that differ only in memory or page layout are
+/// returned unchanged.
+static TTNNLayoutAttr withDeclaredDataType(TTNNLayoutAttr layout,
+                                           RankedTensorType declaredType) {
+  return withScalarElementType(layout, declaredType.getShape(),
+                               declaredType.getElementType());
+}
+
+/// Builds a ttnn.typecast that converts `value` to `targetElementType`, leaving
+/// every other property of its layout - buffer type, page layout, sharding -
+/// exactly as it is. A direct typecast rather than a ttnn.to_layout is
+/// deliberate: reconciling a data type never needs to move or re-page the
+/// tensor, and a typecast can be validated against the op-model and needs no
+/// later decomposition.
+static TypecastOp createDataTypeReconcilingCast(
+    RewriterBase &rewriter, mlir::TypedValue<RankedTensorType> value,
+    Type targetElementType, llvm::StringRef locSuffix) {
+  RankedTensorType targetType = utils::RankedTensorTypeFactory::create(
+      value.getType(), ttcore::elementTypeToDataType(targetElementType));
+  return rewriter.create<TypecastOp>(
+      ttmlir::utils::appendLocationSuffix(value.getLoc(), locSuffix),
+      targetType, value);
+}
+
 /// Returns an optional filter predicate that rejects invalid input layouts
 /// for a given op.  When the filter returns false, the candidate is removed.
 /// Returns nullptr when no filtering is needed (all layouts accepted).
@@ -709,8 +756,9 @@ void MemoryLayoutPropagation::addL1InterleavedFallbacks(
     if (candidates.size() >= maxCandidates) {
       break;
     }
-    TTNNLayoutAttr prodOut =
-        getOutputLayoutForResult((*producerBeam)[pIdx], resultIdx);
+    TTNNLayoutAttr prodOut = withDeclaredDataType(
+        getOutputLayoutForResult((*producerBeam)[pIdx], resultIdx),
+        inputTensorType);
     if (!prodOut || !prodOut.hasL1BufferType()) {
       continue;
     }
@@ -884,8 +932,9 @@ void MemoryLayoutPropagation::addReshardCandidates(
       // Validate the reshard is feasible for this producer candidate.
       TTNNLayoutAttr producerOutput;
       if (producerBeam) {
-        producerOutput =
-            getOutputLayoutForResult((*producerBeam)[pIdx], resultIdx);
+        producerOutput = withDeclaredDataType(
+            getOutputLayoutForResult((*producerBeam)[pIdx], resultIdx),
+            tensorType);
       } else {
         // Func args / unresolved producers: use the current IR layout.
         producerOutput = currentLayout;
@@ -946,7 +995,9 @@ MemoryLayoutPropagation::getInputCandidateSets(Operation *op) {
     if (producerBeam) {
       for (size_t k = 0; k < producerBeam->size() && k < beamWidth; ++k) {
         InputCandidate ic;
-        ic.layout = getOutputLayoutForResult((*producerBeam)[k], resultIdx);
+        ic.layout = withDeclaredDataType(
+            getOutputLayoutForResult((*producerBeam)[k], resultIdx),
+            tensorType);
         ic.producerCandidateIndex = k;
         ic.isReshard = false;
         if (ic.layout) {
@@ -1380,14 +1431,17 @@ void MemoryLayoutPropagation::applyToIR() {
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "applyToIR: applying configs for {0} ops in beam state",
                beamState.size());
-  // First pass: apply op configs.
+  // First pass: apply op configs. Collected up front because applyOpConfig can
+  // insert a reconciling cast right after the op it is configuring.
+  SmallVector<Operation *> configuredOps;
   func->walk([&](Operation *op) {
-    const BeamCandidate *chosen = getChosenCandidate(op);
-    if (!chosen) {
-      return;
+    if (getChosenCandidate(op)) {
+      configuredOps.push_back(op);
     }
-    applyOpConfig(op, *chosen);
   });
+  for (Operation *op : configuredOps) {
+    applyOpConfig(op, *getChosenCandidate(op));
+  }
 
   // Second pass: insert reshard ops.
   func->walk([&](Operation *op) {
@@ -1423,6 +1477,8 @@ void MemoryLayoutPropagation::applyOpConfig(Operation *op,
     return;
   }
 
+  IRRewriter rewriter(op->getContext());
+
   // Update all tensor results. For single-output ops this iterates once.
   // For multi-output ops (e.g. SplitQueryKeyValueAndSplitHeads), each result
   // gets its own layout from outputLayouts.
@@ -1449,6 +1505,32 @@ void MemoryLayoutPropagation::applyOpConfig(Operation *op,
     RankedTensorType newTensorType =
         RankedTensorType::get(tensorShape, newElementType, resultLayout);
     result.setType(newTensorType);
+
+    // Nothing observes the divergence for a dead result, so a cast there would
+    // only add IR (and a deallocate) for later passes to clean up.
+    if (newElementType == originalElementType || result.use_empty()) {
+      continue;
+    }
+
+    // The op-model's real result data type differs from the declared one (e.g.
+    // ttnn.argmax produces ui32 where the frontend declared si32). Adopting it
+    // silently would redefine the type every consumer - and, for a returned
+    // value, the program's public signature - was compiled against, which is
+    // what the runtime then refuses to reconcile (#9115). Keep the change local
+    // by typecasting back and rewiring the op's consumers through the cast.
+    rewriter.setInsertionPointAfter(op);
+    TypecastOp castOp = createDataTypeReconcilingCast(
+        rewriter, mlir::cast<mlir::TypedValue<RankedTensorType>>(result),
+        originalElementType, "_dtype_reconcile");
+    rewriter.replaceUsesWithIf(
+        result, castOp.getResult(), [&](OpOperand &operand) {
+          return operand.getOwner() != castOp.getOperation();
+        });
+
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "Reconciled op-model result dtype {0} back to declared {1} "
+                 "for {2}",
+                 newElementType, originalElementType, op->getName());
   }
 
   applyOpSpecificAttrs(op, candidate);
@@ -1528,21 +1610,59 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
 }
 
 void MemoryLayoutPropagation::updateFunctionReturnTypes() {
+  FunctionType funcType = func.getFunctionType();
   SmallVector<Type> funcResultTypes;
 
   func->walk([&](Operation *op) {
     if (op->getNumResults() == 0) {
       if (auto funcReturn = dyn_cast<func::ReturnOp>(op)) {
+        for (unsigned i = 0; i < funcReturn.getNumOperands(); ++i) {
+          reconcileReturnOperandDataType(funcReturn, i, funcType);
+        }
         funcResultTypes.append(funcReturn.getOperandTypes().begin(),
                                funcReturn.getOperandTypes().end());
       }
     }
   });
 
-  FunctionType funcType = func.getFunctionType();
   FunctionType newFuncType = FunctionType::get(
       func.getContext(), funcType.getInputs(), funcResultTypes);
   func.setType(newFuncType);
+}
+
+void MemoryLayoutPropagation::reconcileReturnOperandDataType(
+    func::ReturnOp returnOp, unsigned operandIdx, FunctionType declaredType) {
+  if (operandIdx >= declaredType.getNumResults()) {
+    return;
+  }
+  auto declared =
+      mlir::dyn_cast<RankedTensorType>(declaredType.getResult(operandIdx));
+  Value operand = returnOp.getOperand(operandIdx);
+  auto current = mlir::dyn_cast<RankedTensorType>(operand.getType());
+  if (!declared || !current ||
+      declared.getElementType() == current.getElementType()) {
+    return;
+  }
+
+  // A function result's layout is free to change - the runtime's toLayout
+  // reconciles buffer type, sharding and page layout when the tensor is handed
+  // to the next program. Its element type is not: changing it redefines the
+  // program's signature relative to every other program compiled against it,
+  // and the runtime is then asked for a device-resident pure-dtype cast it
+  // cannot perform (#9115). applyOpConfig already casts back where it adopts
+  // the op-model's data type, so this is a backstop for any other path.
+  func.emitWarning() << "layout propagation changed the element type of "
+                        "function result "
+                     << operandIdx << " from " << declared.getElementType()
+                     << " to " << current.getElementType()
+                     << "; inserting a reconciling cast";
+
+  IRRewriter rewriter(returnOp->getContext());
+  rewriter.setInsertionPoint(returnOp);
+  TypecastOp castOp = createDataTypeReconcilingCast(
+      rewriter, mlir::cast<mlir::TypedValue<RankedTensorType>>(operand),
+      declared.getElementType(), "_result_dtype_reconcile");
+  returnOp.setOperand(operandIdx, castOp.getResult());
 }
 
 } // namespace mlir::tt::ttnn

--- a/test/ttmlir/Dialect/TTNN/optimizer/argmax_result_dtype_reconcile.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/argmax_result_dtype_reconcile.mlir
@@ -1,0 +1,43 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=1" -o %t1 %s --mlir-print-local-scope
+// RUN: FileCheck %s --input-file=%t1
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" -o %t2 %s --mlir-print-local-scope
+// RUN: FileCheck %s --input-file=%t2
+
+// tt-metal's argmax really returns uint32 where the frontend declares si32, and
+// at optimization-level >= 1 no operand workaround declares that output
+// contract (ArgMaxRuleBook owns the input only). The greedy optimizer adopts
+// the op-model's real ui32 result, so it must also reconcile it back to the
+// declared si32 -- otherwise the ui32 escapes into the program's signature and
+// the runtime, handed that tensor as the next program's input, is asked for a
+// device-resident row-major pure-dtype cast it cannot perform. See #9115.
+// Workarounds stay enabled here: this is the shipping configuration.
+//
+// The reconciling cast is a direct ttnn.typecast rather than a ttnn.to_layout:
+// only the data type needs reconciling, and unlike a to_layout - which
+// OperationValidationAndFallback skips and TTNNDecomposeLayouts has to expand
+// later - a typecast is validated against the op-model right where it is
+// inserted.
+
+module {
+  func.func @add_argmax(%a: tensor<64x128xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}, %b: tensor<64x128xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<64xi32> {
+    // The declared si32 result element type survives into the signature.
+    // CHECK-LABEL: func.func @add_argmax
+    // CHECK-SAME: -> tensor<64xsi32
+    // argmax keeps the op-model's real ui32 result...
+    // CHECK: "ttnn.argmax"
+    // CHECK-SAME: -> tensor<64xui32
+    // ...and a direct typecast reconciles it back to si32 for its consumers.
+    // The CHECK-NOT pins the cast to be a typecast: no to_layout stands
+    // between argmax and it.
+    // CHECK-NOT: ttnn.to_layout
+    // CHECK: "ttnn.typecast"
+    // CHECK-SAME: tensor<64xui32
+    // CHECK-SAME: -> tensor<64xsi32
+    // CHECK: return
+    // CHECK-SAME: tensor<64xsi32
+    %0 = "ttir.add"(%a, %b) : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    %1 = "ttir.argmax"(%0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<64x128xbf16>) -> tensor<64xi32>
+    return %1 : tensor<64xi32>
+  }
+}


### PR DESCRIPTION
### What

The greedy layout optimizer no longer redefines an op result's declared data type.
Where the op-model reports a result data type that differs from the declared one,
`MemoryLayoutPropagation` keeps the real data type on the op result and inserts a
direct `ttnn.typecast` back to the declared type, rewiring the op's consumers
through it — so the divergence stays local and never leaks into consumers or the
function signature.

Fixes #9115.

### Why

`ttnn.argmax` really returns `uint32` while the frontend declares `si32`. Since
#9017 dropped `ArgMaxOp` from the with-optimizer workaround list, nothing declared
that output contract at `optimization-level >= 1`, so `applyOpConfig()` adopted the
op-model's `ui32` unconditionally and `updateFunctionReturnTypes()` rebuilt the
`FunctionType` around it. Ministral_8b's prefill program then returned
`tensor<32x1xui32>` where the decode program declared `si32`, and the runtime
`LOG_FATAL`s on the device-resident ROW_MAJOR pure-dtype cast that mismatch asks
for. See #9115 for the full RCA. The fix is systematic rather than ArgMax-only: any
op whose op-model dtype diverges from its declared dtype has the same failure mode.

### How

* `applyOpConfig()` still adopts the op-model's real data type — the IR has to
  describe what tt-metal produces — then inserts a `ttnn.typecast` back to the
  declared type after the op and rewires its other consumers through it. Skipped
  for dead results and for layouts that differ only in memory or page layout. A
  direct typecast (not a `ttnn.to_layout`) because reconciling a data type never
  needs to move or re-page the tensor, and a typecast is validated against the
  op-model where it is inserted.
* `updateFunctionReturnTypes()` keeps updating a function result's *layout* but
  never its element type; a divergence reaching it is diagnosed and cast back
  (backstop — `applyOpConfig()` should have handled it).
* Input candidates and reshard sources (`getInputCandidateSets()`,
  `addReshardCandidates()`, `addL1InterleavedFallbacks()`) reason about the
  **declared** data type, so reconciliation does not cascade into consumers.
* `applyToIR()`'s first pass collects its ops before configuring them, since
  `applyOpConfig()` can now insert an op right after the one it configures.
* New lit test `optimizer/argmax_result_dtype_reconcile.mlir`: checks the returned
  element type and the reconciling typecast at opt-1 and opt-2 with workarounds
  enabled (fails on `main`, passes here).

No workarounds code is touched: `revertOutputLayout()` /
`TTNNWorkaroundsPatterns.cpp` are unchanged, and there is no shared
`TransformUtils` helper — the cast is created in `MemoryLayoutPropagation`.

### Validation

Reproduced and validated on Wormhole n150 (compile-time only, no device needed);
`check-ttmlir`, the OpModel/optimizer unit tests and p150 CI pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
